### PR TITLE
HINT_EXISTS_TAC

### DIFF
--- a/help/Docfiles/Tactic.HINT_EXISTS_TAC.doc
+++ b/help/Docfiles/Tactic.HINT_EXISTS_TAC.doc
@@ -1,0 +1,65 @@
+\DOC HINT_EXISTS_TAC.doc
+
+\TYPE {HINT_EXISTS_TAC : tactic}
+
+
+\SYNOPSIS
+Reduces an existentially quantified goal by finding a witness which, from the
+assumption list, satisfies at least partially the body of the existential.
+
+\DESCRIBE
+When applied to a goal {?x. t1 /\ ... /\ tn}, the tactic {HINT_EXISTS_TAC}
+looks for an assumption of the form {ti[u/x]}, where {i} belongs to {1..n},
+and reduces the goal by taking {u} as a witness for {x}.
+
+\FAILURE
+Fails unless the goal contains an assumption of the expected form.
+
+\EXAMPLE
+- The goal:
+{
+   b = 0, a < 1, c > 0 ?- ?x. x < 1
+}
+is turned by {HINT_EXISTS_TAC} into:
+{
+   b = 0, a < 1, c > 0 ?- a < 1
+}
+
+- However the tactic also allows to make progress if only one conjunct of the
+  existential is satisfied. For instance, the goal:
+{
+   b = 0, a < 1, c > 0 ?- ?x. x < 1 /\ x + x = c
+}
+is turned by {HINT_EXISTS_TAC} into:
+{
+   b = 0, a < 1, c > 0 ?- a < 1 /\ a + a = c
+}
+
+- The location of the conjunct does not matter, the goal:
+{
+   b = 0, a < 1, c > 0 ?- ?x. x + x = c /\ x < 1
+}
+is turned by {HINT_EXISTS_TAC} into:
+{
+   b = 0, a < 1, c > 0 ?- a + a = c /\ a < 1
+}
+
+- It can be convenient to chain the call to {HINT_EXISTS_TAC} with one to
+  {ASM_REWRITE_TAC} in order to remove automatically the satisfied conjunct:
+{
+   b = 0, a < 1, c > 0 ?- ?x. x + x = c /\ x < 1
+}
+is turned by {HINT_EXISTS_TAC THEN ASM_REWRITE_TAC[]} into:
+{
+   b = 0, a < 1, c > 0 ?- a + a = c
+}
+
+\USES
+Avoid providing a witness explicitly, in order to make the tactic script less
+fragile.
+
+
+\SEEALSO Tactic.EXISTS_TAC.
+
+
+\ENDDOC

--- a/src/1/Tactic.sig
+++ b/src/1/Tactic.sig
@@ -73,4 +73,5 @@ sig
   val DEEP_INTRO_TAC        : thm -> tactic
 
   val SELECT_ELIM_TAC       : tactic
+  val HINT_EXISTS_TAC       : tactic
 end;

--- a/src/1/Tactic.sml
+++ b/src/1/Tactic.sml
@@ -999,4 +999,29 @@ fun DEEP_INTRO_TAC th = DEEP_INTROk_TAC th ALL_TAC
 
 val SELECT_ELIM_TAC = DEEP_INTRO_TAC SELECT_ELIM_THM
 
+
+(*----------------------------------------------------------------------*
+ *  HINT_EXISTS_TAC                                                     *
+ *    instantiates an existential by using hints from the assumptions.  *
+ *----------------------------------------------------------------------*)
+
+fun HINT_EXISTS_TAC g =
+  let
+    val (hs,c) = g
+    val (v,c') = dest_exists c
+    val (vs,c') = strip_exists c'
+    fun hyp_match c h =
+      if exists (C mem vs) (free_vars c) then fail () else match_term c h
+    val (subs,_) = tryfind (C tryfind hs o hyp_match) (strip_conj c')
+    val witness =
+      case subs of
+         [] => v
+        |[{redex = u, residue = t}] =>
+            if u = v then t else failwith "HINT_EXISTS_TAC not applicable"
+        |_ => failwith "HINT_EXISTS_TAC not applicable"
+  in
+    EXISTS_TAC witness g
+  end;
+
+
 end (* Tactic *)


### PR DESCRIPTION
I added the tactic at the end of the src/1/Tactic.sml.

A few remarks:
- Michael, you mentionned something about writing a selftest but I did not see any part of 1/selftest.ml dedicated to the test of tactics
  => what would be the ideal place for this?
- I wrote a short Doc file: help/Docfiles/Tactic.HINT_EXISTS_TAC.doc
- To make it compile I had to do a slight change to the tactic's behaviour. For clarity, I recall this behaviour briefly.
  Given a goal of the form:
  # ?x. P x /\ Q x /\ R x
  1. ...
  2. ...
  3. Q t
  4. ....
  
  Applying HINT_EXISTS_TAC yields:
  # P t /\ Q t /\ R t
  1. ...
  2. ...
  3. Q t
  4. ....
  
  Now the change is as follows: In my original code, I was calling ASM_REWRITE_TAC in order to simplify the goal further as follows:
  # P t /\ R t
  1. ...
  2. ...
  3. Q t
  4. ....
  
  However, this introduces a dependency on Rewrite.sml (which itself depends on Tactic.sml), so I removed it.
  
  Comments:
  - this is actually probably a good thing since the ASM_REWRITE_TAC could have induced rewrites that were not wanted by the user
  - in addition I don't think that HINT_EXISTS_TAC had anything to do in Rewrite.sml
  - this is easily circumvented at the user level by defining a tactic which calls both tactics sequentially

-- Vincent Aravantinos vincent@encs.concordia.ca
