### PR TITLE
double 'the' removed

### DIFF
--- a/Manual/Guide/guide.tex
+++ b/Manual/Guide/guide.tex
@@ -860,7 +860,7 @@ the \ML\ identifier being documented.  The aim of the synopsis is not to give
 a full specification or description, but merely to allow the reader to decide
 at a glance whether this item may provide the functionality that he or she is
 looking for. If at all possible, this should fit on one line on an 80-column
-display. Unless clearly inappropriate, the synopsis should use the the third
+display. Unless clearly inappropriate, the synopsis should use the third
 person singular present tense, for example ``Solves any goal of the form
 \ldots'', ``Introduces an assumption \ldots'' or ``Performs the action
 corresponding to \ldots''. Consistency in this regard makes reading a lot of

--- a/Manual/Logic/semantics.tex
+++ b/Manual/Logic/semantics.tex
@@ -296,7 +296,7 @@ Q}_0$, and then to derive more complex rules from it.
 \label{soundness}
 
 \index{inference rules, of HOL logic@inference rules, of \HOL{} logic!formal semantics of}
-\emph{The rules of the the \HOL{} deductive system are {\em sound} for
+\emph{The rules of the \HOL{} deductive system are {\em sound} for
   the notion of satisfaction defined in Section~\ref{sequents}: for
   any instance of the rules of inference, if a (standard) model
   satisfies the hypotheses of the rule it also satisfies the

--- a/Manual/Tutorial/logic.tex
+++ b/Manual/Tutorial/logic.tex
@@ -160,7 +160,7 @@ For example, in the following case, the \HOL{} type checker used the known type 
 In the next two cases, the type of \ml{x} and \ml{y} cannot be
 deduced.
 (The default `scope' of type information for type checking is a single quotation, so a type in one quotation cannot affect the type-checking of another.
-Thus \ml{x} is not constrained to have the the type \ml{bool} in the second quotation.)
+Thus \ml{x} is not constrained to have the type \ml{bool} in the second quotation.)
 
 \begin{session}
 \begin{verbatim}

--- a/examples/acl2/lisp/obsolete/pprint-file.lisp
+++ b/examples/acl2/lisp/obsolete/pprint-file.lisp
@@ -7,7 +7,7 @@
 
 ; The following utility, pprint-file, takes an input file of forms and writes
 ; out a file of corresponding forms in user-level syntax.  In order to do this,
-; it applies ACL2's untranslate function to the the result of translating each
+; it applies ACL2's untranslate function to the result of translating each
 ; definition and theorem.  An optional argument controls whether or not first
 ; to evaluate the forms in the input file -- generally necessary for
 ; translation to work, but not if we are dealing with a file of built-ins.

--- a/examples/dev/Fact32/exor32.ml
+++ b/examples/dev/Fact32/exor32.ml
@@ -50,7 +50,7 @@ add_temporal_abstractions[XOR32_at];
 (* create an instance with a given size as a string (XOR32vInst), an         *)
 (* instance counter (XOR32vInst_count -- used to create unique names for     *)
 (* instances) and a function to print a HOL term ``XOR32(in1,in2,out)`` as   *)
-(* an instance, using the the type of ``out`` to compute the word width      *)
+(* an instance, using the type of ``out`` to compute the word width          *)
 (* needed to set parameter "size" in XOR32vDef (termToVerilog_XOR32).        *)
 (* These functions are added to a couple of global lists.                    *)
 (*****************************************************************************)

--- a/examples/dev/README
+++ b/examples/dev/README
@@ -770,7 +770,7 @@ add_temporal_abstractions[XOR32_at];
 (* create an instance with a given size as a string (XOR32vInst), an         *)
 (* instance counter (XOR32vInst_count -- used to create unique names for     *)
 (* instances) and a function to print a HOL term ``XOR32(in1,in2,out)`` as   *)
-(* an instance, using the the type of ``out`` to compute the word width      *)
+(* an instance, using the type of ``out`` to compute the word width          *)
 (* needed to set parameter "size" in XOR32vDef (termToVerilog_XOR32).        *)
 (* These functions are added to a couple of global lists.                    *)
 (*****************************************************************************)

--- a/examples/l3-machine-code/common/spec_databaseLib.sml
+++ b/examples/l3-machine-code/common/spec_databaseLib.sml
@@ -34,7 +34,7 @@ fun thm_eq thm1 thm2 = Term.aconv (Thm.concl thm1) (Thm.concl thm2)
 
     - proj_opt
 
-      Used to determine if the the current option setting is different from
+      Used to determine if the current option setting is different from
       "basic_opt".
 
     - closeness : ''opt -> ''opt -> int

--- a/examples/muddy/muddyC/buddy/src/bdd.h
+++ b/examples/muddy/muddyC/buddy/src/bdd.h
@@ -173,8 +173,8 @@ DESCR   {* The fields are \\[\baselineskip] \begin{tabular}{ll}
   {\bf Name}         & {\bf Number of } \\
   uniqueAccess & accesses to the unique node table \\
   uniqueChain  & iterations through the cache chains in the unique node table\\
-  uniqueHit    & entries actually found in the the unique node table \\
-  uniqueMiss   & entries not found in the the unique node table \\
+  uniqueHit    & entries actually found in the unique node table \\
+  uniqueMiss   & entries not found in the unique node table \\
   opHit        & entries found in the operator caches \\
   opMiss       & entries not found in the operator caches \\
   swapCount    & number of variable swaps in reordering \\

--- a/examples/muddy/muddyC/buddy/src/bvec.c
+++ b/examples/muddy/muddyC/buddy/src/bvec.c
@@ -179,7 +179,7 @@ SECTION {* bvec *}
 SHORT   {* build a boolean vector with BDD variables *}
 PROTO   {* bvec bvec_var(int bitnum, int offset, int step) *}
 DESCR   {* Builds a boolean vector with the BDD variables $v_1, \ldots,
-           v_n$ as the elements. Each variable will be the the variabled
+           v_n$ as the elements. Each variable will be the variabled
 	   numbered {\tt offset + N*step} where {\tt N} ranges from 0 to
 	   {\tt bitnum}-1.*}
 RETURN  {* The boolean vector (which is already reference counted) *}

--- a/examples/separationLogic/src/holfoot/EXAMPLES/vstte/vscomp1.hol
+++ b/examples/separationLogic/src/holfoot/EXAMPLES/vstte/vscomp1.hol
@@ -1,7 +1,7 @@
 (******************************************************************************)
 (* Holfoot can proof partial correctness of programs using separation logic.  *)
 (*                                                                            *)
-(* The entire proof is done using HOL 4. This includes not just the the       *)
+(* The entire proof is done using HOL 4. This includes not just the           *)
 (* proof of some verification conditions, but the whole proof. This includes  *)
 (* formal definitions of the programming and specification language as well   *)
 (* as verified inferences.                                                    *)

--- a/examples/separationLogic/src/holfoot/EXAMPLES/vstte/vscomp2.hol
+++ b/examples/separationLogic/src/holfoot/EXAMPLES/vstte/vscomp2.hol
@@ -1,7 +1,7 @@
 (******************************************************************************)
 (* Holfoot can proof partial correctness of programs using separation logic.  *)
 (*                                                                            *)
-(* The entire proof is done using HOL 4. This includes not just the the       *)
+(* The entire proof is done using HOL 4. This includes not just the           *)
 (* proof of some verification conditions, but the whole proof. This includes  *)
 (* formal definitions of the programming and specification language as well   *)
 (* as verified inferences.                                                    *)

--- a/examples/separationLogic/src/holfoot/EXAMPLES/vstte/vscomp3.hol
+++ b/examples/separationLogic/src/holfoot/EXAMPLES/vstte/vscomp3.hol
@@ -1,7 +1,7 @@
 (******************************************************************************)
 (* Holfoot can proof partial correctness of programs using separation logic.  *)
 (*                                                                            *)
-(* The entire proof is done using HOL 4. This includes not just the the       *)
+(* The entire proof is done using HOL 4. This includes not just the           *)
 (* proof of some verification conditions, but the whole proof. This includes  *)
 (* formal definitions of the programming and specification language as well   *)
 (* as verified inferences.                                                    *)

--- a/examples/separationLogic/src/holfoot/EXAMPLES/vstte/vscomp4.hol
+++ b/examples/separationLogic/src/holfoot/EXAMPLES/vstte/vscomp4.hol
@@ -1,7 +1,7 @@
 (******************************************************************************)
 (* Holfoot can proof partial correctness of programs using separation logic.  *)
 (*                                                                            *)
-(* The entire proof is done using HOL 4. This includes not just the the       *)
+(* The entire proof is done using HOL 4. This includes not just the           *)
 (* proof of some verification conditions, but the whole proof. This includes  *)
 (* formal definitions of the programming and specification language as well   *)
 (* as verified inferences.                                                    *)
@@ -24,7 +24,7 @@ val _ = HOL_Interactive.toggle_quietdec();
 
 
 (******************************************************************************)
-(* Define a predicates for boards                                              *)
+(* Define predicates for boards                                               *)
 (******************************************************************************)
 
 val IS_CONSISTENT_BOARD_REC_def = Define `

--- a/examples/separationLogic/src/holfoot/EXAMPLES/vstte/vscomp5.hol
+++ b/examples/separationLogic/src/holfoot/EXAMPLES/vstte/vscomp5.hol
@@ -1,7 +1,7 @@
 (******************************************************************************)
 (* Holfoot can proof partial correctness of programs using separation logic.  *)
 (*                                                                            *)
-(* The entire proof is done using HOL 4. This includes not just the the       *)
+(* The entire proof is done using HOL 4. This includes not just the           *)
 (* proof of some verification conditions, but the whole proof. This includes  *)
 (* formal definitions of the programming and specification language as well   *)
 (* as verified inferences.                                                    *)

--- a/examples/theorem-prover/milawa-prover/milawa_proofpScript.sml
+++ b/examples/theorem-prover/milawa-prover/milawa_proofpScript.sml
@@ -5366,7 +5366,7 @@ val init_thm = prove(
    (SIMP_TAC std_ss [milawa_initTheory.core_assum_thm]));
 
 
-(* relating the above results to the the main routine *)
+(* relating the above results to the main routine *)
 
 val define_safe_list_side_tm =
   milawa_initTheory.define_safe_list_side_def

--- a/help/Docfiles/PairRules.HALF_MK_PABS.doc
+++ b/help/Docfiles/PairRules.HALF_MK_PABS.doc
@@ -25,7 +25,7 @@ universally quantified equation, {HALF_MK_PABS} returns the theorem
 \FAILURE
 Fails unless the theorem is a singly paired universally quantified equation 
 whose left-hand side is a function applied to the quantified pair,
-or if any of the the variables in the quantified pair is free in that function.
+or if any of the variables in the quantified pair is free in that function.
 
 \SEEALSO
 Drule.HALF_MK_ABS, PairRules.PETA_CONV, PairRules.MK_PABS, PairRules.MK_PEXISTS.

--- a/src/datatype/mutrec/ConsThms.sml
+++ b/src/datatype/mutrec/ConsThms.sml
@@ -157,7 +157,7 @@ val conjuncts_list = map mk_all_conjuncts cons_var_newvar_list
 val filtered_list = filter (fn x => x <> []) conjuncts_list
 
 (* goals is a list, containining one goal for each type;
-   each goal says that the the constructors for that type are distinct *)
+   each goal says that the constructors for that type are distinct *)
 
 val goals = map list_mk_conj filtered_list
 

--- a/src/datatype/mutrec/MutRecDef.sml
+++ b/src/datatype/mutrec/MutRecDef.sml
@@ -789,7 +789,7 @@ fun joint_select_x ty_name =
  are all the variable arguments to the operators of the joint type.  The
  abs_args are the abstractions from the joint type to the specific new types
  and the proj_args are the projections from the sum_type to the individual
- result types the the mutually recursive functions being defined.
+ result types the mutually recursive functions being defined.
  exists_specl is the set of specializations for the conjuncts.
 *)
 

--- a/src/datatype/mutrec/Recftn.sml
+++ b/src/datatype/mutrec/Recftn.sml
@@ -443,7 +443,7 @@ open Rsyntax   (* use records *)
     (* replace_recursion actually does the job of replacing recursive calls
        (like (varcon_atpat ap)) with variables (like r) in definition
        given in order to make body of return function. It returns
-       the the modified term (which will be the body of our function) and
+       the modified term (which will be the body of our function) and
        the variables representing the recursions (in reverse order). The arg
        all_vars initially contains the args (which are variables) of the
        constructors; the recursive variables are added on as they

--- a/src/enumfset/fmapalScript.sml
+++ b/src/enumfset/fmapalScript.sml
@@ -1965,7 +1965,7 @@ by IMP_RES_TAC inter_merge_ORL THEN
 IMP_RES_THEN SUBST1_TAC bt_to_orl_ID_IMP THEN
 IMP_RES_TAC inter_merge_fmap);
 
-(* ********* Do the the corresponding stuff for diff_merge ******* *)
+(* ********* Do the corresponding stuff for diff_merge ******* *)
 
 val diff_merge = Define
 `(diff_merge cmp [] [] = []) /\

--- a/src/simp/src/congLib.sig
+++ b/src/simp/src/congLib.sig
@@ -17,7 +17,7 @@ sig
   * however is able to handle arbitrary congruences.
   *
   * This lib tries to provide this ability of the traverser to handle arbitrary
-  * congruences (or in fact preorders) to the the end user. Therefore, an
+  * congruences (or in fact preorders) to the end user. Therefore, an
   * interface similar to the interface of SimpLib is provided.
   *)
 

--- a/src/temporal/src/temporalLib.sml
+++ b/src/temporal/src/temporalLib.sml
@@ -269,7 +269,7 @@ fun temporal2hol truesig  = (--`\t:num.T`--)
 
 
 (* ****************************************************************************	*)
-(* 		Computing the the names of the variables 			*)
+(* 		Computing the names of the variables    		  	*)
 (* ****************************************************************************	*)
 
 fun var_names truesig          = []


### PR DESCRIPTION
This patch removes double 'the' from both LaTeX documentation and ML comments.
