### PR TITLE
Fixup tools-poly/configure.sml for OSX.

### DIFF
--- a/tools-poly/configure.sml
+++ b/tools-poly/configure.sml
@@ -6,9 +6,9 @@
 
      smart-configure
 
-   AND
+   AND CREATING THE FILE
 
-     config-override.
+     poly-includes.ML.
 
    ---------------------------------------------------------------------- *)
 
@@ -72,7 +72,7 @@ in
            val number = major * 100 + 10 * minor + point
          in
            (if number >= 551
-               then ["-lpthread", "-lm", "-ldl", "-lstdc++",
+               then ["-lpthread", "-lm", "-ldl", "-lstdc++", "-lgmp",
                      "-Wl,-no_pie"]
             else if number >= 550
                then ["-Wl,-no_pie"]


### PR DESCRIPTION
Added -lgmp to tools-poly/configure.sml for OSX. Fixed up comments to refer to
the correct override file for tools-poly/smart-configure.sml
