### PR TITLE
GEN_VALIDATE(_LT) - flag for adding new subgoals in any event

### DIFF
--- a/help/Docfiles/Tactical.GEN_VALIDATE.doc
+++ b/help/Docfiles/Tactical.GEN_VALIDATE.doc
@@ -1,0 +1,75 @@
+\DOC GEN_VALIDATE
+
+\TYPE {GEN_VALIDATE : bool -> tactic -> tactic}
+
+\SYNOPSIS
+Where a tactic requires assumptions to be in the goal, 
+add those assumptions as new subgoals.
+
+\DESCRIBE
+See {VALIDATE}, which is implemented as {GEN_VALIDATE true}.
+
+Suppose {tac} applied to the goal {(asl,g)} produces a justification that
+creates a theorem {A |- g'}.
+Then {GEN_VALIDATE false} adds new subgoals for members of {A},
+regardless of whether they are present in {asl}.
+
+\FAILURE
+Fails by design if {tac}, when applied to a goal,
+produces a proof which is invalid on account of proving
+a theorem whose conclusion differs from that of the goal.
+
+Also fails if {tac} fails when applied to the given goal.
+
+\EXAMPLE
+For example, where theorem {uthr'} is {[p', q] |- r} 
+
+{
+1 subgoal:
+val it =
+   
+r
+------------------------------------
+  0.  p
+  1.  q
+
+> e (VALIDATE (ACCEPT_TAC uthr')) ;
+OK..
+1 subgoal:
+val it =
+   
+p'
+------------------------------------
+  p
+:
+   proof
+} 
+but, instead of that,  
+{
+> e (GEN_VALIDATE false (ACCEPT_TAC uthr')) ;
+OK..
+2 subgoals:
+val it =
+   
+q
+------------------------------------
+  0.  p
+  1.  q
+
+
+p'
+------------------------------------
+  0.  p
+  1.  q
+}
+
+\USES
+Use {GEN_VALIDATE false} rather than {VALIDATE}
+when programming compound tactics if you want to know 
+what the resulting subgoals will be,
+ regardless of what the assumptions of the goal are.
+
+\SEEALSO
+Tactical.VALID, Tactical.VALIDATE
+
+\ENDDOC

--- a/help/Docfiles/Tactical.GEN_VALIDATE_LT.doc
+++ b/help/Docfiles/Tactical.GEN_VALIDATE_LT.doc
@@ -1,0 +1,42 @@
+\DOC GEN_VALIDATE_LT 
+
+\TYPE {GEN_VALIDATE_LT : bool -> list_tactic -> list_tactic}
+
+\SYNOPSIS
+Where a list-tactic requires assumptions to be in the goal, 
+add those assumptions as new subgoals.
+
+\DESCRIBE
+See {VALIDATE_LT}, which is implemented as {GEN_VALIDATE_LT true}.
+
+When list-tactic {ltac} is applied to a goal list {gl}
+it produces a new goal list {gl'} and a justification.
+When the justification is applied to a list {thl'} of theorems
+which are the new goals {gl'}, proved, it produces a list {thl}
+of theorems (which, for a valid list-tactic are the goals {gl}, proved).
+
+But {GEN_VALIDATE_LT false ltac} also returns extra subgoals corresponding to
+the assumptions of {thl}.
+
+See {GEN_VALIDATE} for more details.
+
+\FAILURE
+Fails by design if {ltac}, when applied to a goal list,
+produces a proof which is invalid on account of proving
+a theorem whose conclusion differs from that of the corresponding goal.
+
+Also fails if {ltac} fails when applied to the given goals.
+
+\USES
+Compared with {VALIDATE_LT ltac}, {GEN_VALIDATE_LT false ltac} can
+produces extra, unnecessary, subgoals.
+But since the subgoals produced are predictable, regardless of the assumptions
+of the goal, which may be useful when coding compound tactics.
+
+\SEEALSO
+Tactical.VALID, Tactical.VALID_LT, Tactical.VALIDATE,
+Tactical.VALIDATE_LT, Tactical.GEN_VALIDATE 
+
+\ENDDOC
+
+

--- a/help/Docfiles/Tactical.VALIDATE.doc
+++ b/help/Docfiles/Tactical.VALIDATE.doc
@@ -12,7 +12,7 @@ creates a theorem {A |- g'}.
 If {A} a not a subset of {asl}, then the tactic is invalid
 (and {VALID tac (asl,g)} fails, ie, raises an exception).
 But {VALIDATE tac (asl,g)} produces a subgoal list augmented by the 
-members of {asl} missing from {A}.
+members of {A} missing from {asl}.
 
 If {g'} differs from {g}, both {VALID tac (asl,g)} and {VALIDATE tac (asl,g)}
 fail.
@@ -97,6 +97,7 @@ which are not present but are capable of being proved,
 assumptions.
 
 \SEEALSO
-proofManagerLib.expand, Tactical.VALID, Tactical.SUBGOAL_THEN.
+proofManagerLib.expand, Tactical.VALID, Tactical.GEN_VALIDATE,
+Tactical.SUBGOAL_THEN.
 
 \ENDDOC

--- a/src/1/Tactical.sig
+++ b/src/1/Tactical.sig
@@ -41,6 +41,8 @@ sig
   val VALID_LT       : list_tactic -> list_tactic
   val VALIDATE       : tactic -> tactic
   val VALIDATE_LT    : list_tactic -> list_tactic
+  val GEN_VALIDATE       : bool -> tactic -> tactic
+  val GEN_VALIDATE_LT    : bool -> list_tactic -> list_tactic
   val EVERY          : tactic list -> tactic
   val FIRST          : tactic list -> tactic
   val MAP_EVERY      : ('a -> tactic) -> 'a list -> tactic


### PR DESCRIPTION
GEN_VALIDATE false is like VALIDATE, but adds subgoals for the assumptions
of the theorem produced by the justification, regardless of whether they
are among the assumptions of the goal.  Advantage of this is that
GEN_VALIDATE false (ACCEPT_TAC th) produces predictable subgoals,
which may help in coding compound tactics
