### PR TITLE
FreeBSD support

### DIFF
--- a/src/integer/testing/number.sh
+++ b/src/integer/testing/number.sh
@@ -1,3 +1,3 @@
-#! /bin/bash
+#!/bin/sh
 
 perl -e '$/ = "\n\n"; while (<>) { print $i++, " ", $_; }'

--- a/src/opentheory/logging/term2thm.cgi
+++ b/src/opentheory/logging/term2thm.cgi
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 case $REQUEST_METHOD in
 'POST')
 export PATH="$HOME/bin:$PATH"

--- a/tools-poly/configure.sml
+++ b/tools-poly/configure.sml
@@ -41,7 +41,7 @@ val OS :string            =
 
 val _ = PolyML.print_depth 0;
 
-val CC:string       = "gcc";      (* C compiler                       *)
+val CC:string       = "cc";       (* C compiler                       *)
 val GNUMAKE:string  = "make";     (* for bdd library and SMV          *)
 val DEPDIR:string   = ".HOLMK";   (* where Holmake dependencies kept  *)
 

--- a/tools/Holmake/Holmake_tools.sml
+++ b/tools/Holmake/Holmake_tools.sml
@@ -282,7 +282,7 @@ val nice_dir =
       | NONE => (fn s => s)
 
 fun xterm_log s =
-    ignore (OS.Process.system ("/bin/bash -c 'echo -ne \"\\033]0;" ^ s ^ "\\007\"'"))
+    ignore (OS.Process.system ("/bin/sh -c 'echo -ne \"\\033]0;" ^ s ^ "\\007\"'"))
 
 val terminal_log =
     if Systeml.isUnix then xterm_log

--- a/tools/configure.sml
+++ b/tools/configure.sml
@@ -41,7 +41,7 @@ val OS :string      =
 *)
 
 
-val CC:string       = "gcc";      (* C compiler                       *)
+val CC:string       = "cc";       (* C compiler                       *)
 val GNUMAKE:string  = "make";     (* for bdd library and SMV          *)
 val DEPDIR:string   = ".HOLMK";   (* where Holmake dependencies kept  *)
 

--- a/tools/mllex/Holmakefile
+++ b/tools/mllex/Holmakefile
@@ -10,7 +10,7 @@ OBJ_DEPS = $(if $(MOSMLC),mllex.uo mosmlmain.uo,mllex.sml poly-mllex.ML)
 $(OBJ): $(OBJ_DEPS)
 	$(if $(MOSMLC),$(MOSMLC) -o $@ $(OBJ_DEPS),\
              poly < poly-mllex.ML && \
-             gcc -o $@ mllex.o $(POLYLIBS) -lpolymain -lpolyml)
+             cc -o $@ mllex.o $(POLYLIBS) -lpolymain -lpolyml)
 
 mosmlmain.uo mosmlmain.ui: mosmlmain.sml mllex.ui
 	$(MOSMLC) -c mllex.ui $<

--- a/tools/quote-filter/Holmakefile
+++ b/tools/quote-filter/Holmakefile
@@ -7,7 +7,7 @@ all: quote-filter selftest
 quote-filter: $(DEPS)
 	$(if $(MOSMLC), $(HOLMOSMLC) -o quote-filter quote-filter.uo,\
            poly < poly-unquote.ML && \
-           gcc -o quote-filter unquote.o $(POLYLIBS) -lpolymain -lpolyml)
+           cc -o quote-filter unquote.o $(POLYLIBS) -lpolymain -lpolyml)
 
 filter.sml : filter
 	$(if $(MOSMLC),$(protect $(HOLDIR)/tools/mllex/mllex.exe),../mllex/mllex.exe) filter


### PR DESCRIPTION
instead of `/bin/bash`, we can use `/bin/sh`. Also, there is no deep need to use `gcc` directly, HOL compiles perfectly fine with clang (the default C compiler in FreeBSD).