### PR TITLE
add quantHeuristicsLib abbreviations to bossLib

### DIFF
--- a/help/Docfiles/bossLib.ASM_QI_TAC.doc
+++ b/help/Docfiles/bossLib.ASM_QI_TAC.doc
@@ -1,0 +1,14 @@
+\DOC ASM_QI_TAC
+
+\TYPE {ASM_QI_TAC : tactic}
+
+\SYNOPSIS
+Try to instantiate quantifiers with some default heuristics using also the assumptions..
+
+\DESCRIBE
+{ASM_QI_TAC} is short for {ASM_QUANT_INSTANTIATE_TAC [std_qp]}.
+
+\SEEALSO
+bossLib.QI_TAC, quantHeuristicsLib.ASM_QUANT_INSTANTIATE_TAC, quantHeuristicsLib.QUANT_INSTANTIATE_TAC.
+
+\ENDDOC

--- a/help/Docfiles/bossLib.GEN_EXISTS_TAC.doc
+++ b/help/Docfiles/bossLib.GEN_EXISTS_TAC.doc
@@ -1,0 +1,16 @@
+\DOC GEN_EXISTS_TAC
+
+\TYPE {GEN_EXISTS_TAC : string -> Parse.term Lib.frag list -> tactic}
+
+\SYNOPSIS
+Instantiate a quantifier at subposition.
+
+\DESCRIBE
+{GEN_EXISTS_TAC v_name i} tries to instantiate a quantifier for a variable with
+name {v_name} with {i}. It is short for {quantHeuristicsLib.QUANT_TAC [(v, i, [])]}.
+It can be seen as a generalisation of {Q.EXISTS_TAC}.
+
+\SEEALSO
+Tactic.EXISTS_TAC, quantHeuristicsLib.QUANT_TAC.
+
+\ENDDOC

--- a/help/Docfiles/bossLib.QI_TAC.doc
+++ b/help/Docfiles/bossLib.QI_TAC.doc
@@ -1,0 +1,14 @@
+\DOC QI_TAC
+
+\TYPE {QI_TAC : tactic}
+
+\SYNOPSIS
+Try to instantiate quantifiers with some default heuristics.
+
+\DESCRIBE
+{QI_TAC} is short for {QUANT_INSTANTIATE_TAC [std_qp]}.
+
+\SEEALSO
+bossLib.ASM_QI_TAC, quantHeuristicsLib.QUANT_INSTANTIATE_TAC, quantHeuristicsLib.ASM_QUANT_INSTANTIATE_TAC.
+
+\ENDDOC

--- a/help/Docfiles/bossLib.QI_ss.doc
+++ b/help/Docfiles/bossLib.QI_ss.doc
@@ -1,0 +1,14 @@
+\DOC QI_ss
+
+\TYPE {QI_ss : ssfrag}
+
+\SYNOPSIS
+Simpset-fragment for instantiating quantifiers with some default heuristics.
+
+\DESCRIBE
+{QI_ss} is short for {QUANT_INST_ss [std_qp]}.
+
+\SEEALSO
+bossLib.QI_TAC, quantHeuristicsLib.QUANT_INST_ss.
+
+\ENDDOC

--- a/src/boss/bossLib.sig
+++ b/src/boss/bossLib.sig
@@ -61,6 +61,7 @@ sig
   val old_arith_ss    : simpset
   val list_ss         : simpset
   val srw_ss          : unit -> simpset
+  val QI_ss           : ssfrag
   val ARITH_ss        : ssfrag            (* arithmetic d.p. + some rewrites *)
   val old_ARITH_ss    : ssfrag
   val type_rws        : hol_type -> thm list
@@ -90,6 +91,10 @@ sig
 
   val NO_STRIP_FULL_SIMP_TAC     : simpset -> thm list -> tactic
   val NO_STRIP_REV_FULL_SIMP_TAC : simpset -> thm list -> tactic
+
+  val QI_TAC     : tactic
+  val ASM_QI_TAC : tactic
+  val GEN_EXISTS_TAC : string -> Parse.term Lib.frag list -> tactic
 
   (* Call-by-value evaluation *)
   val EVAL           : term -> thm

--- a/src/boss/bossLib.sml
+++ b/src/boss/bossLib.sml
@@ -15,7 +15,7 @@ structure bossLib :> bossLib =
 struct
 
 open HolKernel Parse boolLib pairLib simpLib metisLib pred_setLib
-     boolSimps
+     boolSimps quantHeuristicsLib
 
 (* This makes the dependency on listTheory and optionTheory explicit.
    Without it, the theories can change, and bossLib won't get recompiled.
@@ -77,6 +77,10 @@ val EVAL           = computeLib.EVAL_CONV;
 val EVAL_RULE      = computeLib.EVAL_RULE
 val EVAL_TAC       = computeLib.EVAL_TAC
 
+val QI_TAC = quantHeuristicsLib.QUANT_INSTANTIATE_TAC [std_qp]
+val ASM_QI_TAC = quantHeuristicsLib.ASM_QUANT_INSTANTIATE_TAC [std_qp]
+fun GEN_EXISTS_TAC v i = quantHeuristicsLib.QUANT_TAC [(v, i, [])]
+
 val op && = simpLib.&&;
 
 (*---------------------------------------------------------------------------
@@ -94,6 +98,8 @@ val op && = simpLib.&&;
 local open sumTheory pred_setTheory
       infix ++
 in
+
+val QI_ss = quantHeuristicsLib.QUANT_INST_ss [std_qp]
 val pure_ss = pureSimps.pure_ss
 val bool_ss = boolSimps.bool_ss
 val std_ss = numLib.std_ss


### PR DESCRIPTION
As discussed in issue #282 this adds abbreviations for quantifier heuristic tools to bossLib. Hopefully, this helps promoting quantHeuristicsLib.