### PR TITLE
Monad

### DIFF
--- a/src/llist/llistScript.sml
+++ b/src/llist/llistScript.sml
@@ -810,11 +810,10 @@ val _ = export_rewrites ["LLENGTH_THM"]
 
 val LLENGTH_0 = Q.store_thm("LLENGTH_0[simp]",
   `(LLENGTH x = SOME 0) <=> (x = [||])`,
-  reverse EQ_TAC >- simp[LLENGTH_THM] >>
-  METIS_TAC[LLENGTH_THM,llist_CASES,
-            numeralTheory.numeral_distrib,
-            optionTheory.OPTION_MAP_EQ_SOME,
-            arithmeticTheory.NOT_SUC_LESS_EQ_0]);
+  llist_CASE_TAC ``x : 'a llist`` THEN
+  SIMP_TAC bool_ss [LLENGTH_THM, LCONS_NOT_NIL] THEN
+  Cases_on `LLENGTH t` THEN
+  SIMP_TAC std_ss [OPTION_MAP_DEF, NOT_SUC]) ;
 
 val LFINITE_HAS_LENGTH = store_thm(
   "LFINITE_HAS_LENGTH",

--- a/src/llist/llistScript.sml
+++ b/src/llist/llistScript.sml
@@ -352,20 +352,6 @@ val llist_Axiom_1ue = store_thm(
 
 val eq_imp_lem = Q.prove (`(p = q) ==> p ==> q`, DECIDE_TAC)  ;
 
-fun OPTION_CASES_TAC t = STRUCT_CASES_TAC (ISPEC t option_nchotomy);
-
-(* this rather horrible way of proceeding is because in the 
-  experimental kernel (build -expk) the step 
-  SIMP_TAC bool_ss [FUN_EQ_THM, GSYM FORALL_AND_THM]
-  turns \f. xxx = \f. yyy to !f'. xxx = yyy,
-  whereas the ordinary kernel gives !f. xxx = yyy *)
- 
-fun asgtac tac (asl, goal) = 
-  let val (lt, rt) = dest_eq goal ;
-    val (gx, oc) = dest_eq lt ;
-    val fx = rand (rator (rator oc)) ;
-  in tac (gx, fx) (asl, goal) end ;
-
 val llist_ue_Axiom = store_thm(
   "llist_ue_Axiom",
   ``!f : 'a -> ('a # 'b) option.
@@ -374,11 +360,11 @@ val llist_ue_Axiom = store_thm(
         (!x. LTL (g x) = OPTION_MAP (g o FST) (f x))``,
   MP_TAC llist_Axiom_1ue THEN
   MATCH_MP_TAC eq_imp_lem THEN
-  REPEAT (AP_TERM_TAC THEN 
-    SIMP_TAC bool_ss [FUN_EQ_THM, GSYM FORALL_AND_THM] THEN GEN_TAC) THEN
-  asgtac (fn (gx, fx) => REPEAT (STRIP_TAC ORELSE EQ_TAC) THEN
-    REPEAT (POP_ASSUM MP_TAC) THEN
-    OPTION_CASES_TAC fx THEN llist_CASE_TAC gx) THEN
+  AP_TERM_TAC THEN SIMP_TAC bool_ss [FUN_EQ_THM, GSYM FORALL_AND_THM] THEN 
+    Q.X_GEN_TAC `f` THEN
+  AP_TERM_TAC THEN SIMP_TAC bool_ss [FUN_EQ_THM] THEN Q.X_GEN_TAC `g` THEN
+  AP_TERM_TAC THEN SIMP_TAC bool_ss [FUN_EQ_THM] THEN GEN_TAC THEN
+  Cases_on `f x` THEN llist_CASE_TAC ``(g : 'a -> 'b llist) x`` THEN
   SIMP_TAC std_ss [OPTION_MAP_DEF, LHD_THM, LTL_THM, pair_CASE_def,
     LCONS_NOT_NIL, LCONS_11]) ;
 

--- a/src/llist/llistScript.sml
+++ b/src/llist/llistScript.sml
@@ -412,34 +412,18 @@ val llist_Axiom_1 = Q.store_thm
             case f x
              of NONE => LNIL
               | SOME (a,b) => LCONS b (g a)`,
- GEN_TAC THEN
- STRIP_ASSUME_TAC (SPEC_ALL llist_Axiom) THEN
- Q.EXISTS_TAC `g` THEN
- GEN_TAC THEN (REPEAT CASE_TAC) THENL [
-   METIS_TAC [LHD_EQ_NONE,optionTheory.OPTION_MAP_DEF],
-   SRW_TAC [][LHDTL_EQ_SOME]
- ]);
-
+  GEN_TAC THEN Q.EXISTS_TAC `LUNFOLD f` THEN
+  GEN_TAC THEN MATCH_ACCEPT_TAC LUNFOLD) ;
+  
 val llist_Axiom_1ue = store_thm(
   "llist_Axiom_1ue",
   ``!f. ?!g. !x. g x = case f x
                        of NONE => LNIL
                         | SOME (a,b) => b ::: g a``,
-  GEN_TAC THEN
-  STRIP_ASSUME_TAC
-    (SIMP_RULE bool_ss [EXISTS_UNIQUE_THM] (SPEC_ALL llist_ue_Axiom)) THEN
-  SIMP_TAC bool_ss [EXISTS_UNIQUE_THM] THEN CONJ_TAC THENL [
-    Q.EXISTS_TAC `g` THEN GEN_TAC THEN REPEAT CASE_TAC THENL [
-      METIS_TAC [LHD_EQ_NONE,optionTheory.OPTION_MAP_DEF],
-      SRW_TAC [][LHDTL_EQ_SOME]
-    ],
-    MAP_EVERY Q.X_GEN_TAC [`f1`, `f2`] THEN STRIP_TAC THEN
-    FIRST_X_ASSUM MATCH_MP_TAC THEN
-    ONCE_ASM_REWRITE_TAC [] THEN REPEAT STRIP_TAC THEN
-    `(f x = NONE) \/  (?a b. f x = SOME(a,b))`
-       by METIS_TAC [pairTheory.pair_CASES, optionTheory.option_CASES] THEN
-    POP_ASSUM SUBST1_TAC THEN SIMP_TAC (srw_ss()) []
-  ]);
+  SIMP_TAC bool_ss [EXISTS_UNIQUE_THM] THEN REPEAT STRIP_TAC 
+  THENL [
+    Q.EXISTS_TAC `LUNFOLD f` THEN GEN_TAC THEN MATCH_ACCEPT_TAC LUNFOLD,
+    IMP_RES_TAC LUNFOLD_UNIQUE THEN ASM_SIMP_TAC bool_ss [FUN_EQ_THM] ]) ;
 
 (* ----------------------------------------------------------------------
     Another consequence of the finality theorem is the principle of

--- a/src/llist/llistScript.sml
+++ b/src/llist/llistScript.sml
@@ -184,6 +184,14 @@ val llist_CASES = store_thm(
     SRW_TAC [][llist_repabs']
   ]);
 
+fun llist_CASE_TAC tm = STRUCT_CASES_TAC (SPEC tm llist_CASES) ;
+
+val LTL_HD_11 = Q.store_thm ("LTL_HD_11",
+  `(LTL_HD ll1 = LTL_HD ll2) ==> (ll1 = ll2)`,
+  llist_CASE_TAC ``ll1 : 'a llist`` THEN
+  llist_CASE_TAC ``ll2 : 'a llist`` THEN
+  ASM_SIMP_TAC std_ss [LTL_HD_LNIL, LTL_HD_LCONS]) ;
+
 val LHD_THM = store_thm(
   "LHD_THM",
   ``(LHD LNIL = NONE) /\ (!h t. LHD (LCONS h t) = SOME h)``,
@@ -301,6 +309,17 @@ val LUNFOLD_UNIQUE = Q.store_thm ("LUNFOLD_UNIQUE",
     SIMP_TAC std_ss [FUNPOW, llist_rep_LCONS, llist_rep_LNIL, NOT_SUC,
       pair_CASE_def, FUNPOW_BIND_NONE, OPTION_MAP_DEF, UNCURRY_VAR] THEN
     FIRST_ASSUM (MATCH_ACCEPT_TAC)) ;
+
+(* LUNFOLD is a sort of inverse to LTL_HD *)
+val lu1 = BETA_RULE 
+  (ISPECL [``LTL_HD``, ``(\x. x) : 'a llist -> 'a llist``] LUNFOLD_UNIQUE) ;
+
+val LUNFOLD_LTL_HD = Q.store_thm ("LUNFOLD_LTL_HD",
+  `LUNFOLD LTL_HD ll = ll`,
+  irule EQ_SYM THEN irule lu1 THEN
+  GEN_TAC THEN irule LTL_HD_11 THEN
+  Cases_on `LTL_HD x` THEN
+  SIMP_TAC std_ss [LTL_HD_LNIL, pair_CASE_def, LTL_HD_LCONS]) ;
 
 (*---------------------------------------------------------------------------*)
 (* Co-recursion theorem for lazy lists                                       *)


### PR DESCRIPTION
can do definition (rather than specification) of LUNFOLD using option monad functions; 
define LTL_HD as it's "inverse" to LUNFOLD