### PR TITLE
Make COND_CASES_TAC handle repeated use of guard properly

### DIFF
--- a/help/Docfiles/Tactic.COND_CASES_TAC.doc
+++ b/help/Docfiles/Tactic.COND_CASES_TAC.doc
@@ -14,8 +14,8 @@ i.e. a sub-term of the form {p=>u|v}, choosing one by its own criteria if there
 is more than one. It then induces a case split over {p} as follows:
 {
                              A ?- t
-    =======================================================  COND_CASES_TAC
-     A u {p} ?- t[u/(p=>u|v)]   A u {~p} ?- t[v/(p=>u|v)]]
+    ==============================================================  COND_CASES_TAC
+     A u {p} ?- t[u/(p=>u|v),T/p]   A u {~p} ?- t[v/(p=>u|v),F/p]
 }
 where {p} is not a constant, and the term {p=>u|v} is free in {t}.
 Note that it both enriches the assumptions and inserts the assumed value into

--- a/src/1/Tactic.sml
+++ b/src/1/Tactic.sml
@@ -449,12 +449,13 @@ fun GEN_COND_CASES_TAC P (asl, w) =
       val (cond, larm, rarm) = dest_cond cond
       val inst = INST_TYPE [Type.alpha |-> type_of larm] COND_CLAUSES
       val (ct, cf) = CONJ_PAIR (SPEC rarm (SPEC larm inst))
+      fun subst_tac th c = SUBST1_TAC th THEN SUBST1_TAC (SUBS [th] c)
    in
       DISJ_CASES_THEN2
         (fn th =>
-           SUBST1_TAC (EQT_INTRO th) THEN SUBST1_TAC ct THEN ASSUME_TAC th)
+           subst_tac (EQT_INTRO th) ct THEN ASSUME_TAC th)
         (fn th =>
-           SUBST1_TAC (EQF_INTRO th) THEN SUBST1_TAC cf THEN ASSUME_TAC th)
+           subst_tac (EQF_INTRO th) cf THEN ASSUME_TAC th)
         (SPEC cond EXCLUDED_MIDDLE)
         (asl, w)
    end


### PR DESCRIPTION
If a conditional's guard appears in one of the arms then `COND_CASES_TAC` fails to substitute the conditional:

    > COND_CASES_TAC ([], ``if x then f x else z``);
    <<HOL message: inventing new type variable names: 'a>>
    val it =
       ([([``x``],
          ``if T then f T else z``),
         ([``¬x``],
          ``if F then f F else z``)],
        fn): goal list * validation

This fixes it so that you end up with `f T` and `z`, respectively.  I also tried sticking strictly to the documentation (which would produce `f x`), but that breaks existing proofs.