### PR TITLE
Fix the ConseqConv documentation so that it matches the actual types

### DIFF
--- a/help/Docfiles/ConseqConv.EXT_CONSEQ_REWRITE_CONV.doc
+++ b/help/Docfiles/ConseqConv.EXT_CONSEQ_REWRITE_CONV.doc
@@ -1,7 +1,7 @@
 \DOC
 
 \BLTYPE
-EXT_CONSEQ_REWRITE_CONV : conv list -> thm list ->
+EXT_CONSEQ_REWRITE_CONV : (thm list -> conv) list -> thm list ->
                           (thm list * thm list * thm list) ->
                           directed_conseq_conv
 \ELTYPE

--- a/help/Docfiles/ConseqConv.EXT_DEPTH_CONSEQ_CONV.doc
+++ b/help/Docfiles/ConseqConv.EXT_DEPTH_CONSEQ_CONV.doc
@@ -1,8 +1,11 @@
 \DOC
 
 \BLTYPE
-EXT_DEPTH_CONSEQ_CONV : conseq_conv_congruence list -> int option ->
-                        bool -> directed_conseq_conv list ->
+EXT_DEPTH_CONSEQ_CONV : conseq_conv_congruence list ->
+                        depth_conseq_conv_cache_opt -> int option ->
+                        bool ->
+                        (bool * int option * (thm list -> directed_conseq_conv)) list ->
+                        thm list ->
                         directed_conseq_conv
 \ELTYPE
 
@@ -13,15 +16,15 @@ The general depth consequence conversion of which
 are just instantiations.
 
 \DESCRIBE
-{DEPTH_CONSEQ_CONV} and similar conversions are able apply a
+{DEPTH_CONSEQ_CONV} and similar conversions are able to apply a
 consequence conversion by breaking down the structure of a term using
 lemmata about {/\}, {\/}, {~}, {==>} and quantification.  Thereby,
 these conversions collect various amounts of context information.
 
 {EXT_DEPTH_CONSEQ_CONV} {congruence_list} {cache_opt} {step_opt}
-{redepth} {convL} is the conversion used by these other depth
-conversions. Its interface allows one to add to the given list of
-boolean combinations and thus allow the conversion of parts of
+{redepth} {convL} {context} is the conversion used by these other
+depth conversions. Its interface allows one to add to the given list
+of boolean combinations and thus allow the conversion of parts of
 user-defined predicates. This is done using {congruence_list}.
 However, let's consider the other parameters first: {cache_opt}
 determines which cache to use: {NONE} means no caching; a standard
@@ -37,6 +40,7 @@ applied at subpositions. Its entries consist of a flag, whether to
 apply the conversion before or after descending into subterms; the
 weight (i.e. the number of counted steps) for the conversion, and a
 function from the context (a list of theorems) to the conversion.
+{context} provides additional context that might be used.
 
 The first parameter {congruence_list} is a list of congruences that
 determine how to break down terms. Each element of this list has to be


### PR DESCRIPTION
It might also be good to update the documentation of `ConseqConv.EXT_CONSEQ_REWRITE_CONV` to explain what is the `thm list` that is passed as an argument to the "conversions" (I do not know the answer).