### PR TITLE
Add brackets to reduce sensitivity to equality looseness

### DIFF
--- a/examples/l3-machine-code/common/utilsLib.sml
+++ b/examples/l3-machine-code/common/utilsLib.sml
@@ -729,8 +729,8 @@ local
    val rule =
       Conv.CONV_RULE
          (Conv.CHANGED_CONV
-             (REWRITE_CONV [DECIDE ``(b ==> a) /\ (~b ==> a) = a``,
-                            DECIDE ``(~b ==> a) /\ (b ==> a) = a``]))
+             (REWRITE_CONV [DECIDE ``((b ==> a) /\ (~b ==> a)) = a``,
+                            DECIDE ``((~b ==> a) /\ (b ==> a)) = a``]))
    fun SMART_DISCH tm thm =
       let
          val l = Thm.hyp thm


### PR DESCRIPTION
This makes the library work when temp_tight_equality is in effect