### PR TITLE
tweak case expression pretty printing

### DIFF
--- a/src/parse/term_pp.sml
+++ b/src/parse/term_pp.sml
@@ -79,7 +79,13 @@ fun convert_case tm =
       end
 
 val prettyprint_cases = ref true;
+val prettyprint_cases_dt = ref false;
 val _ = register_btrace ("pp_cases", prettyprint_cases)
+val _ = register_btrace ("pp_cases_dt", prettyprint_cases_dt)
+
+fun prettyprint_cases_name () = if !prettyprint_cases_dt then "dtcase" else "case";
+
+
 
 (* ----------------------------------------------------------------------
     A flag controlling whether to print escaped syntax with a dollar
@@ -1900,7 +1906,7 @@ fun pp_term (G : grammar) TyG backend = let
                    in
                      p (block PP.CONSISTENT 0
                           (block PP.CONSISTENT 0
-                            (add_string "case" >> add_break(1,2) >>
+                            (add_string (prettyprint_cases_name ()) >> add_break(1,2) >>
                              pr_term split_on Top Top Top (decdepth depth) >>
                              add_break(1,0) >> add_string "of") >>
                            (if !pp_print_firstcasebar then

--- a/src/parse/testutils.sig
+++ b/src/parse/testutils.sig
@@ -2,6 +2,7 @@ signature testutils =
 sig
 
 val linewidth : int ref
+val really_die : bool ref
 val OK : unit -> unit
 val die : string -> 'a
 val tprint : string -> unit

--- a/src/parse/testutils.sml
+++ b/src/parse/testutils.sml
@@ -32,7 +32,8 @@ val boldgreen = checkterm "\027[32m\027[1m"
 val red = checkterm "\027[31m"
 val dim = checkterm "\027[2m"
 
-fun die s = (print (boldred s ^ "\n"); OS.Process.exit OS.Process.failure)
+val really_die = ref true;
+fun die s = (print (boldred s ^ "\n"); (if (!really_die) then OS.Process.exit OS.Process.failure else raise (Fail ("DIE:" ^ s))));
 fun OK () = print (boldgreen "OK" ^ "\n")
 
 fun unicode_off f = Feedback.trace ("Unicode", 0) f

--- a/src/pattern_matches/parsePMATCH.sml
+++ b/src/pattern_matches/parsePMATCH.sml
@@ -296,6 +296,7 @@ fun add_pmatch actions (G:'a) =
             [] => raise mk_HOL_ERR "parsePMATCH" "ADD_PMATCH"
                         "No existing case rules?"
           | c :: _ => #term_name c <> PMATCH_case_special
+    val _ = set_trace "pp_cases_dt" 1
     val G =
         if do_pm then rmtmtok {term_name = GrammarSpecials.core_case_special,
                                tok = "case"} G

--- a/src/pattern_matches/patternMatchesSyntax.sml
+++ b/src/pattern_matches/patternMatchesSyntax.sml
@@ -702,13 +702,9 @@ fun pmatch_printer
     fun pp_row (vars, pat, guard, rh) =
       let
         val (print_vars, print_unit) =
-            let val vs = FVL [vars] empty_tmset
-                val pvs0 = FVL [pat] empty_tmset
-                val pvs = HOLset.foldl
-                            (fn (v, acc) => if is_uscV v then acc
-                                            else HOLset.add(acc,v))
-                            empty_tmset
-                            pvs0
+            let fun get_real_vars t = HOLset.filter (fn v => not (is_uscV v orelse varname_starts_with_uscore v)) (FVL [t] empty_tmset)
+                val vs =  get_real_vars vars
+                val pvs = get_real_vars pat
             in
               if HOLset.isSubset(pvs,vs) andalso HOLset.isSubset(vs,pvs) then (false, false)
               else

--- a/src/pattern_matches/selftest.sml
+++ b/src/pattern_matches/selftest.sml
@@ -1,8 +1,10 @@
 open HolKernel Parse boolTheory boolLib pairTheory
 open constrFamiliesLib patternMatchesLib computeLib
 open quantHeuristicsLib simpLib boolSimps
+open testutils
 
 val hard_fail = true;
+val _ = really_die := true;
 val quiet = false;
 val _ = Parse.current_backend := PPBackEnd.vt100_terminal;
 
@@ -10,6 +12,7 @@ val _ = Parse.current_backend := PPBackEnd.vt100_terminal;
 
 set_trace "use pmatch_pp" 0
 val hard_fail = false;
+val _ = really_die := false;
 val quiet = false;
 val _ = Parse.current_backend := PPBackEnd.emacs_terminal;
 
@@ -498,7 +501,6 @@ val _ = run_test (``(4::3::l) : num list``, ``PMATCH ((4 :num)::(3 :num)::l)
     Parser
    ---------------------------------------------------------------------- *)
 
-open testutils
 val _ = patternMatchesLib.ENABLE_PMATCH_CASES ()
 fun pel2string [] = ""
   | pel2string (pLeft::rest) = "L" ^ pel2string rest
@@ -640,8 +642,18 @@ val _ = app shouldfail [
 
 val _ = app (raw_backend tpp) [
   "case x of 0 => 3 | SUC n => n",
+  "dtcase x of 0 => 3 | SUC n => n",
+  "(case x of 0 => 3 | SUC n => n) > 5",
+  "(dtcase x of 0 => 3 | SUC n => n) = 3",
+  "case SUC 5 of 0 => 3 | SUC n => n",
+  "dtcase SUC (SUC 5) of 0 => 3 | SUC n => n",
   "case x of 0 => 4 | SUC _ => 10",
   "case (x,y) of (NONE,_) => 10 | (SOME n,0) when n < 10 => 11",
   "case x of 0 => 3 | () .| n => 4 | x => 100",
-  "case x of NONE => 3 | () .| SOME n => n | SOME x => x + 1"
+  "case x of NONE => 3 | () .| SOME n => n | SOME x => x + 1",
+  "dtcase (x,y) of (NONE,z) => SUC z | (SOME n,z) => n",
+  "SUC (case x of 0 => 3 | SUC n => n)",
+  "SUC (dtcase x of 0 => 3 | SUC n => n)",
+  "case x of z .| 0 => z | SUC _ => 10",
+  "case x of (z,y) .| 0 => z | SUC _ => 10"
 ]

--- a/src/portableML/Redblackset.sig
+++ b/src/portableML/Redblackset.sig
@@ -27,6 +27,7 @@ val revapp       : ('item -> unit) -> 'item set -> unit
 val foldr        : ('item * 'b -> 'b) -> 'b -> 'item set -> 'b
 val foldl        : ('item * 'b -> 'b) -> 'b -> 'item set -> 'b
 val find         : ('item -> bool) -> 'item set -> 'item option
+val filter       : ('item -> bool) -> 'item set -> 'item set
 
 end
 

--- a/src/portableML/Redblackset.sml
+++ b/src/portableML/Redblackset.sml
@@ -395,4 +395,11 @@ struct
                 RED arg => BLACK arg
               | tree    => tree
           , n-1) end
+
+  fun filter p (set as (compare, _, _)) =
+      foldl (fn (e, acc) => if p e then add(acc,e)
+                            else acc)
+         (empty compare)
+         set
+
 end


### PR DESCRIPTION
- when PMATCH-case expression parsing is enabled, print tree-based case- expressions as "dtcase"
- if more than the variables used in the patter are bound, print all variables
- add parenthesis around PMATCH case expressions if necessary

I finally found the time to look at the pattern matches again. I ran into a few issues with pretty-printing / parsing. Since Michael Norrish is the expert for this code and since I also modify term_pp, I did not want to push directly to master. Thus, I create a pull request and would appreciate if anyone interested, esp. Michael could have a look.

@mn200 Could you please have a look, whether my changes make sense and either merge the pull request, tell me what to change or (if it is simpler) change it yourself?