### PR TITLE
mixing literals and constructor patterns

### DIFF
--- a/src/1/Pmatch.sml
+++ b/src/1/Pmatch.sml
@@ -386,7 +386,10 @@ fun mk_case0_heu (heu : pmatch_heuristic) ty_info ty_match FV range_ty =
                            " is a bad pattern (of var type?)")
      in
      if exists Literal.is_pure_literal col0 (* col0 has a literal *) then
-       let val other_var = fresh_var pty
+       let val is_lit_col = all (fn t => Literal.is_literal t orelse is_var t) col0
+           val _ = if is_lit_col then () else
+                   mk_case_fail "case expression mixes literals with non-literals."
+           val other_var = fresh_var pty
            val constructors = rev (mk_set (rev (filter (not o is_var) col0)))
                               @ [other_var]
            val arb = mk_arb range_ty


### PR DESCRIPTION
While looking at the description-manual during working on pull request #377, I noticed that it is currently possible to mix literals and constructor patterns within the same column of a pattern. The results are not as intended though, I believe. For example

``case x of 0 => 0 | 1 => 1 | SUC m => 2``

is compiled to (with pretty printing turned off)

``literal_case
    (λv.
       if v = 0 then 0
       else if v = 1 then 1
       else if v = SUC m then 2
       else ARB) x``

The pattern `SUC m` is handled as a value. `m` is a free variable of the resulting case expression. It is not - as most likely intended by the user - matched against `x`.

The problem is that this case expression mixes literals and constructor patterns. The description manual states explicitly that this is an unsupported case expression. I thought the parser would fail on such case expressions. I suspect that it did at some point. While looking through old versions, I could not find when this behaviour might have changed. 

Anyhow, this pulls adds such a check during pattern compilation now that prevents such patterns from being parsed. Since they were prohibited before and if used caused problems, this is OK with existing code.