### PR TITLE
Provide easy way to include case-equality theorems / issue #345

### DIFF
--- a/src/datatype/DatatypeSimps.sig
+++ b/src/datatype/DatatypeSimps.sig
@@ -55,6 +55,33 @@ val mk_type_exists_thm_tyinfo : tyinfo -> thm
 val mk_type_forall_thm_tyinfo : tyinfo -> thm
 val mk_type_quant_thms_tyinfo : tyinfo -> thm * thm
 
+
+(* mk_case_pred_elim_thm_tyinfo_or and
+   mk_case_pred_elim_thm_tyinfo_and generate an elimination theorem
+   for case-splits that are applied to a predicate.  There is a choice
+   to expand to either a disjunction or a conjunction. The most common
+   case is an equality used as this predicate. Therefore, the
+   specialised versions mk_case_eq_elim_thm_tyinfo_or and
+   mk_case_eq_elim_thm_tyinfo_and are provided as well.
+
+   |- !P M r1 r2. (P (case M of C1 => r1 | C2 x0 => r2 x0)) <=>
+      ((M = C1) ==> P r1) /\ (!x0. (M = C2 x0) ==> P (r2 x0))
+
+   |- !P M r1 r2. (P (case M of C1 => r1 | C2 x0 => r2 x0)) <=>
+      ((M = C1) /\ P r1) \/ (?x0. (M = C2 x0) /\ P (r2 x0))
+
+   |- !r M r1 r2. (case M of C1 => r1 | C2 x0 => r2 x0) = r <=>
+      ((M = C1) ==> r1 = r) /\ (!x0. (M = C2 x0) ==> (r2 x0 = r))
+
+   |- !r M r1 r2. ((case M of C1 => r1 | C2 x0 => r2 x0) = r) <=>
+      ((M = C1) /\ (r1 = r)) \/ (?x0. (M = C2 x0) /\ (r2 x0 = r))
+*)
+val mk_case_pred_elim_thm_tyinfo_or  : tyinfo -> thm
+val mk_case_eq_elim_thm_tyinfo_or    : tyinfo -> thm
+val mk_case_pred_elim_thm_tyinfo_and : tyinfo -> thm
+val mk_case_eq_elim_thm_tyinfo_and   : tyinfo -> thm
+
+
 (* mk_case_rand_thm_tyinfo, mk_case_rand_thm_tyinfo and
    mk_case_abs_thm_tyinfo provide theorems that are used for
    lifting case constants. Use carefully, since their application
@@ -106,6 +133,15 @@ val expand_type_quants_typeinfos_ss : tyinfo list -> ssfrag
 val expand_type_quants_ss : hol_type list -> ssfrag
 val expand_type_quants_stateful_ss : unit -> ssfrag
 
+(* elim case eq patterns and introduce disjunctions instead *)
+val elim_case_eq_or_typeinfos_ss : tyinfo list -> ssfrag
+val elim_case_eq_or_ss : hol_type list -> ssfrag
+val elim_case_eq_or_stateful_ss : unit -> ssfrag
+
+(* elim case eq patterns and introduce conjunctions instead *)
+val elim_case_eq_and_typeinfos_ss : tyinfo list -> ssfrag
+val elim_case_eq_and_ss : hol_type list -> ssfrag
+val elim_case_eq_and_stateful_ss : unit -> ssfrag
 
 (*---------------------------------------------------------------------------*)
 (* Rules                                                                     *)


### PR DESCRIPTION
Issue #345 reminded me of some work I had done in 2013 (see commit 3ecc5da6a9385cf854831db64a3999880c63bc6c). The library `DatatypeSimps` provides theorems and simpsets similar to the ones requested by issue #345. However, it did not implement the ones needed for #345. This pull requests extends `DatatypeSimps` accordingly.

This pull request adds `DatatypeSimps.elim_case_eq_or_stateful_ss` and `DatatypeSimps.elim_case_eq_and_stateful_ss` as well as several similar spirited functions. When eliminating case splits, one can introduce disjunctions or conjunctions

````
> SIMP_CONV (std_ss ++ DatatypeSimps.elim_case_eq_or_stateful_ss ()) [] 
     ``(option_CASE opt n f = v)``

val it =
   |- (option_CASE opt n f = v) <=>
   (opt = NONE) /\ (n = v) \/ ?x. (opt = SOME x) /\ (f x = v):
   thm
````

````
> SIMP_CONV (std_ss ++ DatatypeSimps.elim_case_eq_and_stateful_ss ()) [] 
     ``(option_CASE opt n f = v)``

val it =
   |- (option_CASE opt n f = v) <=>
   ((opt = NONE) ==> (n = v)) /\ !x. (opt = SOME x) ==> (f x = v):
   thm
````

I hope this addresses issue #345 .