### PR TITLE
Strongly reduce initial arguments of set_skip'd constants.

### DIFF
--- a/src/compute/src/clauses.sig
+++ b/src/compute/src/clauses.sig
@@ -21,6 +21,8 @@ sig
     | Abs of 'a dterm
 
   val is_skip : 'a * 'b fterm -> bool
+  val partition_skip : int option -> (term * 'b fterm) list ->
+                       (term * 'b fterm) list * (term * 'b fterm) list
   val inst_type_dterm : (hol_type,hol_type) subst * 'a dterm -> 'a dterm
 
 

--- a/src/compute/src/clauses.sml
+++ b/src/compute/src/clauses.sml
@@ -152,6 +152,15 @@ fun is_skip (_, CST {Skip=SOME n,Args,...}) = (n <= List.length Args)
   | is_skip _ = false
 ;
 
+fun partition_skip (SOME n) Args =
+  let val len = List.length Args in
+     if n <= len
+     then Lib.split_after (len - n) Args
+     else ([], Args)
+  end
+   | partition_skip NONE Args = ([], Args)
+;
+
 (*---------------------------------------------------------------------------
  * equation database
  * We should try to factorize the rules (cf discrimination nets)

--- a/src/compute/src/computeLib.sml
+++ b/src/compute/src/computeLib.sml
@@ -99,11 +99,11 @@ fun strong ((th, CLOS{Env,Term=Abs t}), stk) =
       strong (cbv_wk((thb, mk_clos(NEUTR :: Env, t)), stk'))
       end
   | strong (clos as (_,CLOS _), stk) = raise DEAD_CODE "strong"
-  | strong (hcl as (th,CST {Args,...}), stk) =
-      let val (th',stk') =
- 	if is_skip hcl then (th,stk)
- 	else foldl (push_in_stk snd) (th,stk) Args in
-      strong_up (th',stk')
+  | strong ((th,CST {Skip,Args,...}), stk) =
+      let val (argssk, argsrd) = partition_skip Skip Args
+          val (th',stk') = foldl (push_skip_stk snd) (th,stk) argssk
+          val (th'',stk'') = foldl (push_in_stk snd) (th',stk') argsrd in
+      strong_up (th'',stk'')
       end
   | strong ((th, NEUTR), stk) = strong_up (th,stk)
 

--- a/src/compute/src/compute_rules.sig
+++ b/src/compute/src/compute_rules.sig
@@ -19,6 +19,9 @@ val evaluate  : thm -> Thm.thm
 val push_in_stk :  ('a -> 'b) ->
       'a * (thm * ((thm->thm->thm) * (thm * 'b), 'c, 'd) stack) ->
             thm * ((thm->thm->thm) * (thm * 'b), 'c, 'd) stack
+val push_skip_stk :  ('a -> 'b) ->
+      'a * (thm * ('c, (thm->thm->thm) * bool * (thm * 'b), 'd) stack) ->
+            thm * ('c, (thm->thm->thm) * bool * (thm * 'b), 'd) stack
 val push_lam_in_stk :
       thm * ('a, 'b, thm->thm) stack ->
       thm * ('a, 'b, thm->thm) stack

--- a/src/compute/src/compute_rules.sml
+++ b/src/compute/src/compute_rules.sml
@@ -98,6 +98,12 @@ fun push_in_stk f (arg,(th,stk)) =
       end
 ;
 
+fun push_skip_stk f (arg,(th,stk)) =
+      let val (tha,thb,mka) = Mk_comb th in
+      (tha, Zrand{Rator=(Lib.C mka,true,(thb,f arg)), Ctx=stk})
+      end
+;
+
 fun push_lam_in_stk (th, stk) =
       let val (_,thb,mkl) = Mk_abs th in
       (thb, Zabs{Bvar=try_eta o mkl, Ctx=stk})


### PR DESCRIPTION
Makes strong reduction on record updates reduce values properly.
Fixes #267.