### PR TITLE
fixed docs for proofManagerLib.restore

### DIFF
--- a/help/Docfiles/proofManagerLib.restore.doc
+++ b/help/Docfiles/proofManagerLib.restore.doc
@@ -1,21 +1,21 @@
-\DOC Backup
+\DOC restore
 
-\TYPE {Backup : unit -> proof}
+\TYPE {restore : unit -> proof}
 
 \SYNOPSIS
 Restores the proof state of the last save point, undoing the effects of expansions after the save point.
 
 \DESCRIBE
-The function {Backup} is part of the subgoal package. A call to {Backup}
+The function {restore} is part of the subgoal package. A call to {restore}
 restores the proof state to the last save point (a proof state saved by
-{save}). If the current state is a save point then {Backup} clears the
+{save}). If the current state is a save point then {restore} clears the
 current save point and returns to the last save point. If there are no save
-points in the history, then {Backup} returns to the initial goal and is
+points in the history, then {restore} returns to the initial goal and is
 equivalent to {restart}. For a description of the subgoal package, see
 {set_goal}.
 
 \FAILURE
-The function {Backup} will fail only if no goalstack is being managed.
+The function {restore} will fail only if no goalstack is being managed.
 
 \USES
 Back tracking in a goal-directed proof to a user-defined save point.


### PR DESCRIPTION
Minor fix: in doc entry of proofManagerLib.restore, the command name "restore" was wrongly written as "Backup".