### PR TITLE
fixed parse_Z3_version() for 64-bit Z3

### DIFF
--- a/src/HolSmt/Z3.sml
+++ b/src/HolSmt/Z3.sml
@@ -44,12 +44,14 @@ structure Z3 = struct
       " -smt2 -file:"
       (Lib.K is_sat_file)
 
+  (* e.g. "Z3 version 4.5.0 - 64 bit" *)
   fun parse_Z3_version fname =
     let
       val instrm = TextIO.openIn fname
       val s = TextIO.inputAll instrm before TextIO.closeIn instrm
+      val tokens = String.tokens Char.isSpace s
     in
-      List.last (String.tokens Char.isSpace s)
+      List.nth (tokens, 2)
     end
 
   val Z3version =


### PR DESCRIPTION
Z3 4.x still works with HolSmtLib. However, 64-bit Z3 now has version strings like "Z3 version 4.5.0 - 64 bit". To correctly get the part "4.5.0" from both 32-bit and 64-bit Z3, I think we parse_Z3_version() should always get the 3rd space-separated token (instead of the last one).