### PR TITLE
Fixed doc for Tactical.PAT_ASSUM; added doc for Tactical.PAT_X_ASSUM

### DIFF
--- a/help/Docfiles/Tactical.PAT_ASSUM.doc
+++ b/help/Docfiles/Tactical.PAT_ASSUM.doc
@@ -4,7 +4,7 @@
 
 \SYNOPSIS
 Finds the first assumption that matches the term argument, applies
-the theorem tactic to it, and removes this assumption.
+the theorem tactic to it. The matching assumption is still kept in the assumption list.
 
 \KEYWORDS
 theorem-tactical, assumption.
@@ -53,8 +53,14 @@ This use of the tactic exploits higher order matching to
 match the RHS of the assumption, and the fact that {f} is effectively
 a local constant in the goal to find the correct assumption.
 
+\COMMENTS
+The behavior of PAT_ASSUM has been changed in Kananaskis 11.
+The old PAT_ASSUM (and qpat_assum, Q.PAT_ASSUM) was changed to include an extra _X_ (or _x_),
+indicating that the matching assumption is pulled out of the assumption list.
+The old name now provide a version that doesn't pull the assumption out of the list.
+
 \SEEALSO
-Tactical.ASSUM_LIST, Tactical.EVERY, Tactical.EVERY_ASSUM, Tactical.FIRST,
+Tactical.PAT_X_ASSUM, Tactical.ASSUM_LIST, Tactical.EVERY, Tactical.EVERY_ASSUM, Tactical.FIRST,
 Tactical.MAP_EVERY, Tactical.MAP_FIRST, Thm_cont.UNDISCH_THEN, Term.match_term.
 
 \ENDDOC

--- a/help/Docfiles/Tactical.PAT_X_ASSUM.doc
+++ b/help/Docfiles/Tactical.PAT_X_ASSUM.doc
@@ -1,0 +1,32 @@
+\DOC PAT_X_ASSUM
+
+\TYPE {PAT_X_ASSUM : term -> thm_tactic -> tactic}
+
+\SYNOPSIS
+Finds the first assumption that matches the term argument, applies
+the theorem tactic to it, and removes this assumption.
+
+\KEYWORDS
+theorem-tactical, assumption.
+
+\DESCRIBE
+The tactic
+{
+   PAT_X_ASSUM tm ttac ([A1, ..., An], g)
+}
+finds the first {Ai} which matches {tm} using higher-order
+pattern matching in the sense of {ho_match_term}.  Unless there is just
+one match otherwise, free variables in the pattern that are also free
+in the assumptions or the goal must not be bound by the match.  In
+effect, these variables are being treated as local constants.
+
+\FAILURE
+Fails if the term doesn't match any of the assumptions, or if the
+theorem-tactic fails when applied to the first assumption that does
+match the term.
+
+\SEEALSO
+Tactical.PAT_ASSUM, Tactical.ASSUM_LIST, Tactical.EVERY, Tactical.EVERY_ASSUM, Tactical.FIRST,
+Tactical.MAP_EVERY, Tactical.MAP_FIRST, Thm_cont.UNDISCH_THEN, Term.match_term.
+
+\ENDDOC


### PR DESCRIPTION
Hi,

I fixed doc for Tactical.PAT_ASSUM and then added a new doc entry for Tactical.PAT_X_ASSUM. Words are all taken from this link: (but feel free to make any change, as I'm not a native English speaker)

https://github.com/HOL-Theorem-Prover/HOL/commit/fa81d70b67a61d6eddc6a517f968594c21be384d

[reference.pdf](https://github.com/HOL-Theorem-Prover/HOL/files/709420/reference.pdf)

The resulting PDF seems good. (PAT_ASSUM is at page 748; PAT_X_ASSUM is at page 750)