### PR TITLE
Drop 'use' from decompile.py.

### DIFF
--- a/examples/machine-code/graph/decompile.py
+++ b/examples/machine-code/graph/decompile.py
@@ -49,7 +49,7 @@ elf = os.path.abspath(args.filename)
 output_file = os.path.abspath(args.filename + '_output.txt')
 
 ml_input = """
-use "writerLib"; load "decompileLib";
+load "decompileLib";
 val _ = decompileLib.decomp "{0}" {1} "{2}";
 """
 


### PR DESCRIPTION
The 'use' statement doesn't seem to work at the moment, probably as a result of
64584544a4b1 but unconfirmed. In any case, it also doesn't seem to
be necessary.