### PR TITLE
implement simple quantifier heuristics

### DIFF
--- a/Manual/Description/QuantHeuristics.tex
+++ b/Manual/Description/QuantHeuristics.tex
@@ -239,6 +239,16 @@ problematic. Therefore, the simplifier and Metis are used to prove
 the validity of the explicitly given instantiations. This succeeds
 only for simple examples.
 
+\subsection{Simple Quantifier Heuristics}
+
+The full quantifier heuristics described above are powerful and very flexible.
+However, they are sometimes slow.
+The unwind library\footnote{see \texttt{src/simp/src/Unwind.sml}} on the other hand is limited, but fast.
+The simple version of the quantifier heuristics fills the gap in the middle.
+They just search for gap guesses without any free variables.
+Moreover, slow operations like recombining or automatically looking up datatype information is omitted.
+As a result, the conversion \texttt{SIMPLE\_QUANT\_INSTANTIATE\_CONV} (and corresponding \texttt{SIMPLE\_QUANT\_INST\_ss}) is nearly as fast as the corresponding unwind conversions.
+However, it supports more complicated syntax. Moreover, there is support for quantifiers, pairs, list and much more. 
 
 \subsection{Quantifier Heuristic Parameters}\label{quantHeu-subsec-qps}
 

--- a/help/Docfiles/bossLib.SQI_ss.doc
+++ b/help/Docfiles/bossLib.SQI_ss.doc
@@ -1,0 +1,10 @@
+\DOC SQI_ss
+
+\TYPE {SQI_ss : simpLib.ssfrag}
+
+\SYNOPSIS
+A synonym for {quantHeuristicsLib.SIMPLE_QUANT_INST_ss}.
+
+\SEEALSO
+quantHeuristicsLib.SIMPLE_QUANT_INST_ss.
+\ENDDOC

--- a/help/Docfiles/quantHeuristicsLib.SIMPLE_QUANT_INSTANTIATE_CONV.doc
+++ b/help/Docfiles/quantHeuristicsLib.SIMPLE_QUANT_INSTANTIATE_CONV.doc
@@ -1,0 +1,41 @@
+\DOC SIMPLE_QUANT_INSTANTIATE_CONV
+
+\TYPE {SIMPLE_QUANT_INSTANTIATE_CONV : conv}
+
+\SYNOPSIS
+A conversion for instantiating quantifiers. In contrast to
+{quantHeuristicsLib.QUANT_INSTANTIATE_CONV} it only searches for gap
+guesses without free variables. As a result, it is much less powerful,
+but also much faster than {quantHeuristicsLib.QUANT_INSTANTIATE_CONV}.
+
+\FAILURE
+If no instantiation could be found.
+
+\EXAMPLE
+{
+> SIMPLE_QUANT_INSTANTIATE_CONV ``?x. P x /\ (x = 5)``
+|- (?x. P x /\ (x = 5)) <=> P 5 /\ (5 = 5):
+
+> SIMPLE_QUANT_INSTANTIATE_CONV ``!x. (x = 5) ==> P x``
+|- (!x. (x = 5) ==> P x) <=> (5 = 5) ==> P 5:
+
+> SIMPLE_QUANT_INSTANTIATE_CONV ``!x. Q x ==> !z. Z z /\ (x = 5) ==> P x z``
+|- (!x. Q x ==> !z. Z z /\ (x = 5) ==> P x z) <=>
+   Q 5 ==> !z. Z z /\ (5 = 5) ==> P 5 z:
+
+> SIMPLE_QUANT_INSTANTIATE_CONV ``!x. ((3, x, y) = zxy) ==> P x``
+|- (!x. ((3,x,y) = zxy) ==> P x) <=>
+   ((3,FST (SND zxy),y) = zxy) ==> P (FST (SND zxy)):
+
+> SIMPLE_QUANT_INSTANTIATE_CONV ``some x. (x = 2) /\ P x``
+|- (some x. (x = 2) /\ P x) = if (2 = 2) /\ P 2 then SOME 2 else NONE:
+
+> SIMPLE_QUANT_INSTANTIATE_CONV ``?x1 x2 x3. P x1 x2 /\ (x2::x1::l = 3::(f x3)::l')``
+|- (?x1 x2 x3. P x1 x2 /\ (x2::x1::l = 3::f x3::l')) <=>
+   ?x2 x3. P (f x3) x2 /\ (x2::f x3::l = 3::f x3::l'):
+}
+
+\SEEALSO
+quantHeuristicsLib.QUANT_INSTANTIATE_CONV, unwind.UNWIND_EXISTS_CONV, unwind.UNWIND_FORALL_CONV,
+quantHeuristicsLib.SIMPLE_QUANT_INST_ss, bossLib.SQI_ss.
+\ENDDOC

--- a/help/Docfiles/quantHeuristicsLib.SIMPLE_QUANT_INST_ss.doc
+++ b/help/Docfiles/quantHeuristicsLib.SIMPLE_QUANT_INST_ss.doc
@@ -1,0 +1,10 @@
+\DOC SIMPLE_QUANT_INST_ss
+
+\TYPE {SIMPLE_QUANT_INST_ss : simpLib.ssfrag}
+
+\SYNOPSIS
+A simpset fragment corresponding to {quantHeuristicsLib.SIMPLE_QUANT_INSTANTIATE_CONV}.
+
+\SEEALSO
+quantHeuristicsLib.SIMPLE_QUANT_INSTANTIATE_CONV, bossLib.SQI_ss.
+\ENDDOC

--- a/src/boss/bossLib.sig
+++ b/src/boss/bossLib.sig
@@ -67,6 +67,7 @@ sig
   val list_ss         : simpset
   val srw_ss          : unit -> simpset
   val QI_ss           : ssfrag
+  val SQI_ss          : ssfrag
   val ARITH_ss        : ssfrag            (* arithmetic d.p. + some rewrites *)
   val old_ARITH_ss    : ssfrag
   val type_rws        : hol_type -> thm list

--- a/src/boss/bossLib.sml
+++ b/src/boss/bossLib.sml
@@ -105,6 +105,7 @@ local open sumTheory pred_setTheory
 in
 
 val QI_ss = quantHeuristicsLib.QUANT_INST_ss [std_qp]
+val SQI_ss = quantHeuristicsLib.SIMPLE_QUANT_INST_ss
 val pure_ss = pureSimps.pure_ss
 val bool_ss = boolSimps.bool_ss
 val std_ss = numLib.std_ss ++ PMATCH_SIMP_ss

--- a/src/quantHeuristics/doc/quantHeu.tex
+++ b/src/quantHeuristics/doc/quantHeu.tex
@@ -1076,6 +1076,17 @@ the validity of the explicitly given instantiations. This succeeds
 usually only for simple examples.
 
 
+\subsection{Simple Quantifier Heuristics}\label{subsec_simple}
+
+The full quantifier heuristics described above are powerful and very flexible.
+However, they are sometimes slow.
+The unwind library\footnote{see \texttt{src/simp/src/Unwind.sml}} on the other hand is limited, but fast.
+The simple version of the quantifier heuristics fills the gap in the middle.
+They just search for gap guesses without any free variables.
+Moreover, slow operations like recombining or automatically looking up datatype information is omitted.
+As a result, the conversion \texttt{SIMPLE\_QUANT\_INSTANTIATE\_CONV} (and corresponding \texttt{SIMPLE\_QUANT\_INST\_ss}) is nearly as fast as the corresponding unwind conversions.
+However, it supports more complicated syntax. Moreover, there is support for quantifiers, pairs, list and much more. 
+
 \section{Quantifier Heuristic Parameters}\label{sec_qps}
 
 Quantifier heuristic parameters play a similar role for the quantifier
@@ -1348,7 +1359,6 @@ at the source code and contact Thomas Tuerk
 \texttt{heuristics\_qp} and \texttt{top\_heuristics\_qp} provide
 interfaces to add user defined heuristics to a quantifier heuristics
 parameter.
-
 
 \chapter{Conclusion}\label{sec_conclusion}
 

--- a/src/quantHeuristics/quantHeuristicsLib.sig
+++ b/src/quantHeuristics/quantHeuristicsLib.sig
@@ -13,6 +13,7 @@ sig
   val QUANT_INST_ss        : quant_param list -> simpLib.ssfrag;
   val FAST_QUANT_INST_ss   : quant_param list -> simpLib.ssfrag;
   val EXPAND_QUANT_INST_ss : quant_param list -> simpLib.ssfrag;
+  val SIMPLE_QUANT_INST_ss : simpLib.ssfrag;
 
   (* Tactics *)
   val QUANT_INSTANTIATE_TAC          : quant_param list -> tactic;
@@ -20,11 +21,13 @@ sig
   val FAST_QUANT_INSTANTIATE_TAC     : quant_param list -> tactic;
   val FAST_ASM_QUANT_INSTANTIATE_TAC : quant_param list -> tactic;
   val QUANT_INSTANTIATE_CONSEQ_TAC   : quant_param list -> tactic;
+  val SIMPLE_QUANT_INSTANTIATE_TAC   : tactic;
 
   (* Conversions *)
-  val QUANT_INSTANTIATE_CONV      : quant_param list -> conv;
-  val NORE_QUANT_INSTANTIATE_CONV : quant_param list -> conv;
-  val FAST_QUANT_INSTANTIATE_CONV : quant_param list -> conv;
+  val QUANT_INSTANTIATE_CONV        : quant_param list -> conv;
+  val NORE_QUANT_INSTANTIATE_CONV   : quant_param list -> conv;
+  val FAST_QUANT_INSTANTIATE_CONV   : quant_param list -> conv;
+  val SIMPLE_QUANT_INSTANTIATE_CONV : conv;
 
   (* Conversions that do a case split in order to instantiate quantifiers,
      if no equivalence can be proved. Be careful, this will blow up the term size! *)

--- a/src/quantHeuristics/quantHeuristicsLib.sml
+++ b/src/quantHeuristics/quantHeuristicsLib.sml
@@ -1,6 +1,6 @@
 structure quantHeuristicsLib :> quantHeuristicsLib =
 struct
 
-open quantHeuristicsLibBase quantHeuristicsLibParameters quantHeuristicsLibFunRemove
+open quantHeuristicsLibBase quantHeuristicsLibSimple quantHeuristicsLibParameters quantHeuristicsLibFunRemove 
 
 end

--- a/src/quantHeuristics/quantHeuristicsLibSimple.sig
+++ b/src/quantHeuristics/quantHeuristicsLibSimple.sig
@@ -1,0 +1,96 @@
+signature quantHeuristicsLibSimple =
+sig
+  include Abbrev
+
+  (************************************)
+  (* Main functionality               *)
+  (************************************)
+
+  (* SIMPLE_QUANT_INSTANTIATE_CONV implements functionality for
+     finding GAP guesses fast. Moreover, the found instantiations may
+     not contain free variables. As such, the functionality is similar
+     to Unwind. It allows more syntax than Unwind and can be
+     extended. It is much faster than the general quantifier
+     instantiations heuristics, but also far less powerful. *)
+
+  val SIMPLE_QUANT_INSTANTIATE_CONV   : conv
+  val SIMPLE_QUANT_INST_ss            : simpLib.ssfrag
+  val SIMPLE_QUANT_INSTANTIATE_TAC    : tactic
+
+  val SIMPLE_EXISTS_INSTANTIATE_CONV  : conv
+  val SIMPLE_FORALL_INSTANTIATE_CONV  : conv
+  val SIMPLE_UEXISTS_INSTANTIATE_CONV : conv
+  val SIMPLE_SOME_INSTANTIATE_CONV    : conv
+  val SIMPLE_SELECT_INSTANTIATE_CONV  : conv
+
+
+
+  (************************************)
+  (* Extensions                       *)
+  (************************************)
+
+  (* A simple_guess_seaech_fun is a function that searches a guess. Given a
+
+     - avoid : a set of variables to avoid in the instantiation
+     - ty    : search a guess for either universal or existential quantification
+     - v     : variable to search an instance for
+     - tm    : a term to search an instantiation in
+
+     it (if it succeeds) results in a theorem of the form
+
+       |- SIMPLE_GUESS_EXISTS v i tm
+
+     or
+
+       |- SIMPLE_GUESS_FORALL v i tm
+
+     depending on the value of ty. Moreover i does not contain any variable from avoid.
+
+     Having an additional callback argument to search guesses for subterms is also useful.
+     combine_sgsfwcs then allows combining a list of such search functions with callback
+     into a single search function.
+  *)
+
+  datatype simple_guess_type = sgty_exists | sgty_forall
+  type simple_guess_search_fun = term HOLset.set -> simple_guess_type -> term -> term -> thm
+  type simple_guess_search_fun_with_callback = simple_guess_search_fun -> simple_guess_search_fun
+
+  val combine_sgsfwcs : simple_guess_search_fun_with_callback list -> simple_guess_search_fun
+
+  (* search functions for common operations *)
+  val sgsfwc_eq     : simple_guess_search_fun_with_callback (* v = _ / _ = v *)
+  val sgsfwc_eq_var : simple_guess_search_fun_with_callback (* v *)
+  val sgsfwc_neg    : simple_guess_search_fun_with_callback (* ~ _ *)
+  val sgsfwc_and    : simple_guess_search_fun_with_callback (* _ /\ _ *)
+  val sgsfwc_or     : simple_guess_search_fun_with_callback (* _ \/ _ *)
+  val sgsfwc_imp    : simple_guess_search_fun_with_callback (* _ ==> _ *)
+  val sgsfwc_forall : simple_guess_search_fun_with_callback (* !z. _ *)
+  val sgsfwc_exists : simple_guess_search_fun_with_callback (* ?z. _ *)
+
+  (* to find guesses for equations, a function can also be applied to
+     both sides of the equation first. For example, to find guesses
+     for "x" in "(x, y) = f z" it might be useful to apply "FST" to
+     both sides. This is done by "sgsfwc_eq_fun". It gets a list of
+     functions to try. Entries of this list are triples containing the
+     function to apply, a check when to apply and a theorem about how
+     to rewrite in case the check succeeds.  For FST the entries would
+     look like: (``FST``, pairSyntax.is_pair, pairTheory.FST). *)
+  val sgsfwc_eq_fun : (term * (term -> bool) * thm) list -> (* ?z. _ = _ *)
+                      simple_guess_search_fun_with_callback
+
+  (* List of eq_funs for pairs, lists, options and sum types. *)
+  val default_eq_funs : (term * (term -> bool) * thm) list
+
+  val default_sgsfwcs : simple_guess_search_fun_with_callback list
+
+  (* Generalised conversions that allow specifying which search functions to use *)
+  val SIMPLE_EXISTS_INSTANTIATE_CONV_GEN  : simple_guess_search_fun_with_callback list -> conv
+  val SIMPLE_FORALL_INSTANTIATE_CONV_GEN  : simple_guess_search_fun_with_callback list -> conv
+  val SIMPLE_UEXISTS_INSTANTIATE_CONV_GEN : simple_guess_search_fun_with_callback list -> conv
+  val SIMPLE_SOME_INSTANTIATE_CONV_GEN    : simple_guess_search_fun_with_callback list -> conv
+  val SIMPLE_SELECT_INSTANTIATE_CONV_GEN  : simple_guess_search_fun_with_callback list -> conv
+
+  val SIMPLE_QUANT_INSTANTIATE_CONV_GEN   : simple_guess_search_fun_with_callback list -> conv
+  val SIMPLE_QUANT_INST_GEN_ss            : simple_guess_search_fun_with_callback list -> simpLib.ssfrag
+
+end

--- a/src/quantHeuristics/quantHeuristicsLibSimple.sml
+++ b/src/quantHeuristics/quantHeuristicsLibSimple.sml
@@ -1,0 +1,362 @@
+(*=====================================================================  *)
+(* FILE          : quantHeuristicsLibSimple.sml                          *)
+(* DESCRIPTION   : simple and fast way to find guesses, this is closer   *)
+(*                 to unwind than to the full search of quantifier       *)
+(*                 heuristics                                            *)
+(*                                                                       *)
+(* AUTHORS       : Thomas Tuerk                                          *)
+(* DATE          : February 2017                                         *)
+(* ===================================================================== *)
+
+
+structure quantHeuristicsLibSimple :> quantHeuristicsLibSimple =
+struct
+
+(*
+loadPath :=
+            (concat [Globals.HOLDIR, "/src/quantHeuristics"])::
+            !loadPath;
+
+map load ["quantHeuristicsTheory"];
+*)
+
+open HolKernel Parse boolLib Drule
+     quantHeuristicsTheory pairTools
+
+
+val std_ss = numLib.std_ss
+
+
+(**************************************)
+(* Basic types                        *)
+(**************************************)
+
+datatype simple_guess_type = sgty_forall | sgty_exists
+
+type simple_guess_search_fun =
+  term set ->          (* vars to avoid *)
+  simple_guess_type -> (* which type of guess should be searched *)
+  term ->              (* var to search a guess for *)
+  term ->              (* term to search in *)
+  thm;                 (* found thm *)
+
+type simple_guess_search_fun_with_callback =
+  simple_guess_search_fun -> simple_guess_search_fun
+
+
+(***************************************)
+(* Auxiliary function                  *)
+(***************************************)
+
+fun not_uses_avoid_vars avoid tm = let
+  val s1 = FVL [tm] empty_tmset
+  val s2 = HOLset.intersection (s1, avoid)
+in
+  HOLset.isEmpty s2
+end
+
+fun inst_vi v i thm = let
+  val ty = type_of v
+  val thm' = INST_TYPE [alpha |-> ty] thm
+in
+  SPEC i (SPEC v thm')
+end
+
+fun dest_simple_guess_thm thm = let
+  val tt = concl thm
+  val (tt, P) = dest_comb tt
+  val (tt, i) = dest_comb tt
+  val (tt, v) = dest_comb tt
+in
+  (tt, v, i, P)
+end
+
+fun inst_guess gi es thm = let
+  val (_, v, i, _) = dest_simple_guess_thm gi
+  val thm' = inst_vi v i thm
+  val thm'' = SPECL es thm'
+in
+  MP thm'' gi
+end
+
+val select_some      = prim_mk_const {Name = "some", Thy = "option"}
+val dest_select_some = dest_binder select_some (ERR "dest_select_some" "not a \"some x. _\"")
+
+(***************************************)
+(* search functions                    *)
+(***************************************)
+
+fun sgsfwc_eq_var sys avoid sgty_forall v tm = failwith "sgsfwc_eq_var: only works for exists"
+  | sgsfwc_eq_var sys avoid sgty_exists v tm = (
+      if (aconv v tm) then
+        SPEC v (SIMPLE_GUESS_EXISTS_EQ_T)
+      else failwith "sgsfwc_eq_var: not eq v"
+    )
+
+fun sgsfwc_eq (sys : simple_guess_search_fun) avoid sgty_forall v tm =
+    failwith "sgsfwc_eq: only works for exists"
+  | sgsfwc_eq sys avoid sgty_exists v tm = let
+      val (tm1, tm2) = dest_eq tm in
+        if (aconv v tm1) andalso not_uses_avoid_vars avoid tm2 then
+          inst_vi v tm2 SIMPLE_GUESS_EXISTS_EQ_1
+        else if (aconv v tm2) andalso not_uses_avoid_vars avoid tm1 then
+          inst_vi v tm1 SIMPLE_GUESS_EXISTS_EQ_2
+        else failwith "sgty_eq"
+      end;
+
+fun sgsfwc_neg (sys : simple_guess_search_fun) avoid sgty v tm =
+    let
+      val tm' = dest_neg tm
+      val (sgty', thm) = case sgty of
+          sgty_exists => (sgty_forall, SIMPLE_GUESS_EXISTS_NEG)
+        | sgty_forall => (sgty_exists, SIMPLE_GUESS_FORALL_NEG)
+      val g = sys avoid sgty' v tm'
+    in inst_guess g [tm'] thm end
+
+fun sgsfwc_and (sys : simple_guess_search_fun) avoid sgty_forall v tm =
+    failwith "sgsfwc_and: only works for exists"
+  | sgsfwc_and sys avoid sgty_exists v tm = let
+      val (tm1, tm2) = dest_conj tm in
+        let
+          val g1 = sys avoid sgty_exists v tm1
+        in inst_guess g1 [tm1, tm2] SIMPLE_GUESS_EXISTS_AND_1 end
+        handle HOL_ERR _ =>
+        let
+          val g2 = sys avoid sgty_exists v tm2
+        in inst_guess g2 [tm1, tm2] SIMPLE_GUESS_EXISTS_AND_2 end
+        handle HOL_ERR _ => failwith "sgsfwc_and"
+      end;
+
+fun sgsfwc_or (sys : simple_guess_search_fun) avoid sgty_exists v tm =
+    failwith "sgsfwc_or: only works for forall"
+  | sgsfwc_or sys avoid sgty_forall v tm = let
+      val (tm1, tm2) = dest_disj tm in
+        let
+          val g1 = sys avoid sgty_forall v tm1
+        in inst_guess g1 [tm1, tm2] SIMPLE_GUESS_FORALL_OR_1 end
+        handle HOL_ERR _ =>
+        let
+          val g2 = sys avoid sgty_forall v tm2
+        in inst_guess g2 [tm1, tm2] SIMPLE_GUESS_FORALL_OR_2 end
+        handle HOL_ERR _ => failwith "sgsfwc_or"
+      end;
+
+fun sgsfwc_imp (sys : simple_guess_search_fun) avoid sgty_exists v tm =
+    failwith "sgsfwc_imp: only works for forall"
+  | sgsfwc_imp sys avoid sgty_forall v tm = let
+      val (tm1, tm2) = dest_imp_only tm in
+        let
+          val g1 = sys avoid sgty_exists v tm1
+        in inst_guess g1 [tm1, tm2] SIMPLE_GUESS_FORALL_IMP_1 end
+        handle HOL_ERR _ =>
+        let
+          val g2 = sys avoid sgty_forall v tm2
+        in inst_guess g2 [tm1, tm2] SIMPLE_GUESS_FORALL_IMP_2 end
+        handle HOL_ERR _ => failwith "sgsfwc_or"
+      end;
+
+fun sgsfwc_forall (sys : simple_guess_search_fun) avoid sgty v tm =
+    let
+      val (v', tm') = dest_forall tm
+      val avoid' = HOLset.add (avoid, v')
+      val g0 = sys avoid' sgty v tm'
+      val g1 = GEN v' g0
+      val thm0 = case sgty of
+          sgty_exists => SIMPLE_GUESS_EXISTS_FORALL
+        | sgty_forall => SIMPLE_GUESS_FORALL_FORALL
+      val (_, v, i, _) = dest_simple_guess_thm g0
+      val thm' = HO_MATCH_MP thm0 g1
+    in thm' end;
+
+fun sgsfwc_exists (sys : simple_guess_search_fun) avoid sgty v tm =
+    let
+      val (v', tm') = dest_exists tm
+      val avoid' = HOLset.add (avoid, v')
+      val g0 = sys avoid' sgty v tm'
+      val g1 = GEN v' g0
+      val thm0 = case sgty of
+          sgty_exists => SIMPLE_GUESS_EXISTS_EXISTS
+        | sgty_forall => SIMPLE_GUESS_FORALL_EXISTS
+      val (_, v, i, _) = dest_simple_guess_thm g0
+      val thm' = HO_MATCH_MP thm0 g1
+    in thm' end;
+
+
+fun sgsfwc_eq_fun_aux (sys : simple_guess_search_fun) avoid v (tm1, tm2) (f, cond, rewr) =
+  if (not (cond tm1 orelse cond tm2)) then failwith "sgsfwc_fun_aux: cond failed" else
+  let
+    val tm1' = mk_icomb (f, tm1)
+    val tm1'_eq = REWR_CONV rewr tm1' handle HOL_ERR _ => REFL tm1'
+    val tm2' = mk_icomb (f, tm2)
+    val tm2'_eq = REWR_CONV rewr tm2' handle HOL_ERR _ => REFL tm2'
+
+    val tm' = mk_eq (tm1', tm2')
+    val tm'_eq = (LHS_CONV (K tm1'_eq) THENC RHS_CONV (K tm2'_eq)) tm'
+    val tm'' = rhs (concl tm'_eq)
+
+    val g = sys avoid sgty_exists v tm''
+    val g' = CONV_RULE (RAND_CONV (K (GSYM tm'_eq))) g
+  in
+    MATCH_MP SIMPLE_GUESS_EXISTS_EQ_FUN g'
+  end
+
+fun sgsfwc_eq_fun l (sys : simple_guess_search_fun) avoid sgty_forall v tm =
+    failwith "sgsfwc_eq_fun: only works for exists"
+  | sgsfwc_eq_fun l (sys : simple_guess_search_fun) avoid sgty_exists v tm =
+    let
+      val (tm1, tm2) = dest_eq tm
+    in
+      tryfind (sgsfwc_eq_fun_aux sys avoid v (tm1, tm2)) l
+    end;
+
+val default_eq_funs = [
+  (``FST``, pairSyntax.is_pair, pairTheory.FST),
+  (``SND``, pairSyntax.is_pair, pairTheory.SND),
+  (``HD``, listSyntax.is_cons, listTheory.HD),
+  (``TL``, listSyntax.is_cons, listTheory.TL),
+  (``THE``, optionSyntax.is_some, optionTheory.THE_DEF),
+  (``OUTL``, sumSyntax.is_inl, sumTheory.OUTL),
+  (``OUTR``, sumSyntax.is_inr, sumTheory.OUTR)]
+
+
+fun combine_sgsfwcs (wc_l : simple_guess_search_fun_with_callback list)
+  avoid ty v tm =
+  Lib.tryfind (fn wc => wc (combine_sgsfwcs wc_l) avoid ty v tm) wc_l
+
+val default_sgsfwcs : simple_guess_search_fun_with_callback list = [
+  sgsfwc_and,
+  sgsfwc_or,
+  sgsfwc_imp,
+  sgsfwc_neg,
+  sgsfwc_eq,
+  sgsfwc_eq_var,
+  sgsfwc_forall,
+  sgsfwc_exists,
+  sgsfwc_eq_fun default_eq_funs];
+
+val sys = combine_sgsfwcs default_sgsfwcs
+
+(***************************************)
+(* top level functions                 *)
+(***************************************)
+
+fun MOVE_TO_LAST_EXISTS_CONV c t =
+  ((SWAP_EXISTS_CONV THENC QUANT_CONV
+    (MOVE_TO_LAST_EXISTS_CONV c)) ORELSEC c) t
+
+fun SIMPLE_EXISTS_INSTANTIATE_CONV_GEN wcl tm = let
+  val (vl, b_tm) = strip_exists tm
+  val (v, vl') = case vl of [] => failwith "SIMPLE_EXISTS_INSTANTIATE_CONV: no exists"
+                          | (v :: vl') => (v, vl')
+  val avoid = HOLset.singleton Term.compare v
+  val guess = combine_sgsfwcs wcl avoid sgty_exists v b_tm
+
+  val thm0 = HO_MATCH_MP SIMPLE_GUESS_EXISTS_THM (GEN v guess)
+  val thm1 = MOVE_TO_LAST_EXISTS_CONV (K thm0) tm
+in
+  thm1
+end
+
+val SIMPLE_EXISTS_INSTANTIATE_CONV = SIMPLE_EXISTS_INSTANTIATE_CONV_GEN default_sgsfwcs
+
+
+fun MOVE_TO_LAST_FORALL_CONV c t =
+  ((SWAP_FORALL_CONV THENC QUANT_CONV
+    (MOVE_TO_LAST_FORALL_CONV c)) ORELSEC c) t
+
+
+fun SIMPLE_FORALL_INSTANTIATE_CONV_GEN wcl tm = let
+  val (vl, b_tm) = strip_forall tm
+  val (v, vl') = case vl of [] => failwith "SIMPLE_FORALL_INSTANTIATE_CONV: no forall"
+                          | (v :: vl') => (v, vl')
+  val avoid = HOLset.singleton Term.compare v
+  val guess = combine_sgsfwcs wcl avoid sgty_forall v b_tm
+
+  val thm0 = HO_MATCH_MP SIMPLE_GUESS_FORALL_THM (GEN v guess)
+  val thm1 = MOVE_TO_LAST_FORALL_CONV (K thm0) tm
+in
+  thm1
+end;
+
+val SIMPLE_FORALL_INSTANTIATE_CONV = SIMPLE_FORALL_INSTANTIATE_CONV_GEN default_sgsfwcs;
+
+
+fun SIMPLE_UEXISTS_INSTANTIATE_CONV_GEN wcl tm = let
+  val (v, b_tm) = dest_exists1 tm
+  val avoid = HOLset.singleton Term.compare v
+  val guess = combine_sgsfwcs wcl avoid sgty_exists v b_tm
+
+  val thm0 = HO_MATCH_MP SIMPLE_GUESS_UEXISTS_THM (GEN v guess)
+in
+  thm0
+end;
+
+val SIMPLE_UEXISTS_INSTANTIATE_CONV = SIMPLE_UEXISTS_INSTANTIATE_CONV_GEN default_sgsfwcs;
+
+
+fun SIMPLE_SOME_INSTANTIATE_CONV_GEN wcl tm = let
+  val (v, b_tm) = dest_select_some tm
+  val avoid = HOLset.singleton Term.compare v
+  val guess = combine_sgsfwcs wcl avoid sgty_exists v b_tm
+
+  val thm0 = HO_MATCH_MP SIMPLE_GUESS_SOME_THM (GEN v guess)
+in
+  thm0
+end
+
+val SIMPLE_SOME_INSTANTIATE_CONV = SIMPLE_SOME_INSTANTIATE_CONV_GEN default_sgsfwcs;
+
+
+fun SIMPLE_SELECT_INSTANTIATE_CONV_GEN wcl tm = let
+  val (v, b_tm) = dest_select tm
+  val avoid = HOLset.singleton Term.compare v
+  val guess = combine_sgsfwcs wcl avoid sgty_exists v b_tm
+
+  val thm0 = HO_MATCH_MP SIMPLE_GUESS_SELECT_THM (GEN v guess)
+in
+  thm0
+end
+
+val SIMPLE_SELECT_INSTANTIATE_CONV = SIMPLE_SELECT_INSTANTIATE_CONV_GEN default_sgsfwcs;
+
+
+fun SIMPLE_QUANT_INSTANTIATE_CONV_GEN wcl = FIRST_CONV [
+  SIMPLE_EXISTS_INSTANTIATE_CONV_GEN wcl,
+  SIMPLE_FORALL_INSTANTIATE_CONV_GEN wcl,
+  SIMPLE_UEXISTS_INSTANTIATE_CONV_GEN wcl,
+  SIMPLE_SOME_INSTANTIATE_CONV_GEN wcl,
+  SIMPLE_SELECT_INSTANTIATE_CONV_GEN wcl]
+
+val SIMPLE_QUANT_INSTANTIATE_CONV =
+  SIMPLE_QUANT_INSTANTIATE_CONV_GEN default_sgsfwcs
+
+val SIMPLE_QUANT_INSTANTIATE_TAC =
+  CONV_TAC (TOP_DEPTH_CONV SIMPLE_QUANT_INSTANTIATE_CONV)
+
+fun SIMPLE_QUANT_INST_GEN_ss wcl = simpLib.SSFRAG
+  {name=SOME "SIMPLE_QUANT_INSTANTIATE_GEN",
+   convs=[{name="SIMPLE_EXISTS_INSTANTIATE_CONV_GEN",
+           trace=1,
+           key=SOME ([],``?x:'a. P``),
+           conv=K (K (SIMPLE_EXISTS_INSTANTIATE_CONV_GEN wcl))},
+          {name="SIMPLE_FORALL_INSTANTIATE_CONV_GEN",
+           trace=1,
+           key=SOME ([],``!x:'a. P``),
+           conv=K (K (SIMPLE_FORALL_INSTANTIATE_CONV_GEN wcl))},
+          {name="SIMPLE_UEXISTS_INSTANTIATE_CONV_GEN",
+           trace=1,
+           key=SOME ([],``?!x:'a. P``),
+           conv=K (K (SIMPLE_UEXISTS_INSTANTIATE_CONV_GEN wcl))},
+          {name="SIMPLE_SOME_INSTANTIATE_CONV_GEN",
+           trace=1,
+           key=SOME ([],``some (x:'a). P``),
+           conv=K (K (SIMPLE_SOME_INSTANTIATE_CONV_GEN wcl))},
+          {name="SIMPLE_SELECT_INSTANTIATE_CONV_GEN",
+           trace=1,
+           key=SOME ([],``@x:'a. P``),
+           conv=K (K (SIMPLE_SELECT_INSTANTIATE_CONV_GEN wcl))}],
+   rewrs=[],filter=NONE,ac=[],dprocs=[],congs=[]};
+
+val SIMPLE_QUANT_INST_ss = SIMPLE_QUANT_INST_GEN_ss default_sgsfwcs;
+
+end

--- a/src/quantHeuristics/quantHeuristicsScript.sml
+++ b/src/quantHeuristics/quantHeuristicsScript.sml
@@ -734,6 +734,152 @@ val IMP_NEG_CONTRA = store_thm("IMP_NEG_CONTRA",
 val DISJ_IMP_INTRO  = store_thm ("DISJ_IMP_INTRO",
   ``(!x. P x \/ Q x) ==> ((~(P y) ==> Q y) /\ (~(Q y) ==> P y))``, PROVE_TAC[])
 
+
+(******************************************************************************)
+(* Simple GUESSES                                                             *)
+(******************************************************************************)
+
+val SIMPLE_GUESS_EXISTS_def = Define `
+    SIMPLE_GUESS_EXISTS (v : 'a) (i : 'a) (P : bool) =
+      (P ==> (v = i))`
+
+val SIMPLE_GUESS_EXISTS_ALT_DEF = store_thm ("SIMPLE_GUESS_EXISTS_ALT_DEF",
+  ``(!v. SIMPLE_GUESS_EXISTS (v:'a) i (P v)) <=> (
+    GUESS_EXISTS_GAP ((K i):(unit -> 'a)) (\v. P v))``,
+SIMP_TAC std_ss [SIMPLE_GUESS_EXISTS_def, GUESS_EXISTS_GAP_def]);
+
+
+val SIMPLE_GUESS_FORALL_def = Define `
+    SIMPLE_GUESS_FORALL (v : 'a) (i : 'a) (P : bool) =
+      (~P ==> (v = i))`
+
+val SIMPLE_GUESS_FORALL_ALT_DEF = store_thm ("SIMPLE_GUESS_FORALL_ALT_DEF",
+  ``(!v. SIMPLE_GUESS_FORALL (v:'a) i (P v)) <=> (
+    GUESS_FORALL_GAP ((K i):(unit -> 'a)) (\v. P v))``,
+SIMP_TAC std_ss [SIMPLE_GUESS_FORALL_def, GUESS_FORALL_GAP_def]);
+
+val SIMPLE_GUESS_FORALL_THM = store_thm ("SIMPLE_GUESS_FORALL_THM",
+  ``!i P. (!v. SIMPLE_GUESS_FORALL v i (P v)) ==>
+    ((!v. P v) <=> (P i))``,
+REWRITE_TAC [SIMPLE_GUESS_FORALL_def] THEN
+METIS_TAC[])
+
+val SIMPLE_GUESS_EXISTS_THM = store_thm ("SIMPLE_GUESS_EXISTS_THM",
+  ``!i P. (!v. SIMPLE_GUESS_EXISTS v i (P v)) ==>
+    ((?v. P v) <=> (P i))``,
+REWRITE_TAC [SIMPLE_GUESS_EXISTS_def] THEN
+METIS_TAC[])
+
+val SIMPLE_GUESS_UEXISTS_THM = store_thm ("SIMPLE_GUESS_UEXISTS_THM",
+  ``!i P.
+    (!v. SIMPLE_GUESS_EXISTS v i (P v)) ==>
+    ((?!v. P v) <=> (P i))``,
+SIMP_TAC std_ss [SIMPLE_GUESS_EXISTS_def, EXISTS_UNIQUE_THM] THEN
+METIS_TAC[])
+
+val SIMPLE_GUESS_SELECT_THM = store_thm ("SIMPLE_GUESS_SELECT_THM",
+  ``!i P.
+    (!v. SIMPLE_GUESS_EXISTS v i (P v)) ==>
+    ((@v. P v) = if P i then i else (@v. F))``,
+SIMP_TAC std_ss [SIMPLE_GUESS_EXISTS_def] THEN
+REPEAT STRIP_TAC THEN
+Cases_on `P i` THEN ASM_REWRITE_TAC [] THENL [
+  SELECT_ELIM_TAC THEN
+  METIS_TAC[],
+
+  `!v. P v = F` by METIS_TAC[] THEN
+  ASM_REWRITE_TAC[]
+])
+
+
+val SIMPLE_GUESS_SOME_THM = store_thm ("SIMPLE_GUESS_SOME_THM",
+  ``!i P.
+    (!v. SIMPLE_GUESS_EXISTS v i (P v)) ==>
+    ((some v. P v) = (if P i then SOME i else NONE))``,
+
+SIMP_TAC std_ss [SIMPLE_GUESS_EXISTS_def, some_def] THEN
+REPEAT STRIP_TAC THEN
+Cases_on `?v. P v` THEN (
+  ASM_REWRITE_TAC [] THEN
+  METIS_TAC[]
+))
+
+val SIMPLE_GUESS_TAC =
+  SIMP_TAC std_ss [SIMPLE_GUESS_FORALL_def, SIMPLE_GUESS_EXISTS_def] THEN METIS_TAC[];
+
+val SIMPLE_GUESS_EXISTS_EQ_1 = store_thm ("SIMPLE_GUESS_EXISTS_EQ_1",
+  ``!v:'a i. SIMPLE_GUESS_EXISTS v i (v = i)``,
+  SIMPLE_GUESS_TAC)
+
+val SIMPLE_GUESS_EXISTS_EQ_2 = store_thm ("SIMPLE_GUESS_EXISTS_EQ_2",
+  ``!v:'a i. SIMPLE_GUESS_EXISTS v i (i = v)``,
+  SIMPLE_GUESS_TAC)
+
+val SIMPLE_GUESS_EXISTS_EQ_T = store_thm ("SIMPLE_GUESS_EXISTS_EQ_T",
+  ``!v. SIMPLE_GUESS_EXISTS v T v``,
+  SIMPLE_GUESS_TAC)
+
+val SIMPLE_GUESS_FORALL_NEG = store_thm ("SIMPLE_GUESS_FORALL_NEG",
+  ``!v:'a i P. SIMPLE_GUESS_EXISTS v i P ==> SIMPLE_GUESS_FORALL v i (~P)``,
+  SIMPLE_GUESS_TAC
+)
+
+val SIMPLE_GUESS_EXISTS_NEG = store_thm ("SIMPLE_GUESS_EXISTS_NEG",
+  ``!v:'a i P. SIMPLE_GUESS_FORALL v i P ==> SIMPLE_GUESS_EXISTS v i (~P)``,
+  SIMPLE_GUESS_TAC
+)
+
+val SIMPLE_GUESS_FORALL_OR_1 = store_thm ("SIMPLE_GUESS_FORALL_OR_1",
+  ``!v:'a i P1 P2. SIMPLE_GUESS_FORALL v i P1 ==> SIMPLE_GUESS_FORALL v i (P1 \/ P2)``,
+  SIMPLE_GUESS_TAC);
+
+val SIMPLE_GUESS_FORALL_OR_2 = store_thm ("SIMPLE_GUESS_FORALL_OR_2",
+  ``!v:'a i P1 P2. SIMPLE_GUESS_FORALL v i P2 ==> SIMPLE_GUESS_FORALL v i (P1 \/ P2)``,
+  SIMPLE_GUESS_TAC);
+
+val SIMPLE_GUESS_EXISTS_AND_1 = store_thm ("SIMPLE_GUESS_EXISTS_AND_1",
+  ``!v:'a i P1 P2. SIMPLE_GUESS_EXISTS v i P1 ==> SIMPLE_GUESS_EXISTS v i (P1 /\ P2)``,
+  SIMPLE_GUESS_TAC);
+
+val SIMPLE_GUESS_EXISTS_AND_2 = store_thm ("SIMPLE_GUESS_EXISTS_AND_2",
+  ``!v:'a i P1 P2. SIMPLE_GUESS_EXISTS v i P2 ==> SIMPLE_GUESS_EXISTS v i (P1 /\ P2)``,
+  SIMPLE_GUESS_TAC);
+
+val SIMPLE_GUESS_EXISTS_EXISTS = store_thm ("SIMPLE_GUESS_EXISTS_EXISTS",
+  ``!v:'a i P. (!v2. SIMPLE_GUESS_EXISTS v i (P v2)) ==>
+               SIMPLE_GUESS_EXISTS v i (?v2. P v2)``,
+  SIMPLE_GUESS_TAC)
+
+val SIMPLE_GUESS_EXISTS_FORALL = store_thm ("SIMPLE_GUESS_EXISTS_FORALL",
+  ``!v:'a i P. (!v2. SIMPLE_GUESS_EXISTS v i (P v2)) ==>
+               SIMPLE_GUESS_EXISTS v i (!v2. P v2)``,
+  SIMPLE_GUESS_TAC)
+
+val SIMPLE_GUESS_FORALL_EXISTS = store_thm ("SIMPLE_GUESS_FORALL_EXISTS",
+  ``!v:'a i P. (!v2. SIMPLE_GUESS_FORALL v i (P v2)) ==>
+               SIMPLE_GUESS_FORALL v i (?v2. P v2)``,
+  SIMPLE_GUESS_TAC)
+
+val SIMPLE_GUESS_FORALL_FORALL = store_thm ("SIMPLE_GUESS_FORALL_FORALL",
+  ``!v i P. (!v2. SIMPLE_GUESS_FORALL v i (P v2)) ==>
+            SIMPLE_GUESS_FORALL v i (!v2. P v2)``,
+  SIMPLE_GUESS_TAC)
+
+val SIMPLE_GUESS_FORALL_IMP_1 = store_thm ("SIMPLE_GUESS_FORALL_IMP_1",
+  ``!v:'a i P1 P2. SIMPLE_GUESS_EXISTS v i P1 ==> SIMPLE_GUESS_FORALL v i (P1 ==> P2)``,
+  SIMPLE_GUESS_TAC);
+
+val SIMPLE_GUESS_FORALL_IMP_2 = store_thm ("SIMPLE_GUESS_FORALL_IMP_2",
+  ``!v:'a i P1 P2. SIMPLE_GUESS_FORALL v i P2 ==> SIMPLE_GUESS_FORALL v i (P1 ==> P2)``,
+  SIMPLE_GUESS_TAC);
+
+val SIMPLE_GUESS_EXISTS_EQ_FUN = store_thm ("SIMPLE_GUESS_EXISTS_EQ_FUN",
+  ``!v:'a i t1 t2 f.
+      SIMPLE_GUESS_EXISTS v i (f t1 = f t2) ==>
+      SIMPLE_GUESS_EXISTS v i (t1 = t2)``,
+  SIMPLE_GUESS_TAC)
+
+
 (******************************************************************************)
 (* Removing functions under quantifiers                                       *)
 (******************************************************************************)

--- a/src/quantHeuristics/selftest.sml
+++ b/src/quantHeuristics/selftest.sml
@@ -321,4 +321,54 @@ val qh_testCases_context2 =
 val _ = map (qh_test_context2 hard_fail quiet) qh_testCases_context2;
 
 
+(******************************************************************************)
+(* simple tests                                                               *)
+(******************************************************************************)
+
+val qh_test_simple = test_conv "SIMPLE_QUANT_INSTANTIATE_CONV" SIMPLE_QUANT_INSTANTIATE_CONV
+
+val qh_testCases_simple =
+  [(``!x. (P x /\ (x = 5) /\ Q x) ==> Z x``, SOME ``(P 5 /\ (5 = 5) /\ Q 5) ==> Z 5``),
+
+   (``?x. (P x /\ (x = 5) /\ Q x)``, SOME ``(P 5 /\ (5 = 5) /\ Q 5)``),
+
+   (``!x. (P x \/ ~(x = 5) \/ Q x)``, SOME ``(P 5 \/ ~(5 = 5) \/ Q 5)``),
+
+   (``?x. (P x /\ x)``, SOME ``P T /\ T``),
+   (``!x. (P x \/ ~x)``, SOME ``P T \/ ~T``),
+
+   (``?x. (x = 5)``, SOME ``5 = 5``),
+   (``!x. ~(5 = x)``, SOME ``~(5 = 5)``),
+
+   (``?!x. (P x /\ (x = 5) /\ Q x)``, SOME ``(P 5 /\ (5 = 5) /\ Q 5)``),
+
+   (``some x. (P x /\ (x = 5) /\ Q x)``, SOME ``if (P 5 /\ (5 = 5) /\ Q 5) then SOME 5 else NONE``),
+
+   (``@x. (P x /\ (x = 5) /\ Q x)``, SOME ``if (P 5 /\ (5 = 5) /\ Q 5) then 5 else @x. F``),
+
+
+   (``!x y z. (P x \/ ~(x = f y z) \/ Q x)``, SOME ``!y:'b z:'c. (P (f y z) \/ ~(f y z = f y z) \/ Q (f y z))``),
+
+
+   (``?x. (P x /\ (5 = x) /\ Q x)``, SOME ``(P 5 /\ (5 = 5) /\ Q 5)``),
+   (``?x. (P x /\ (!z:'a. (5 = x) /\ Q x z))``, SOME ``(P 5 /\ (!z:'a. (5 = 5) /\ Q 5 z))``),
+   (``?x. (P x /\ (?z:'a. (5 = x) /\ Q x z))``, SOME ``(P 5 /\ (?z:'a. (5 = 5) /\ Q 5 z))``),
+
+   (``!x. ~(P x /\ (5 = x) /\ Q x)``, SOME ``~(P 5 /\ (5 = 5) /\ Q 5)``),
+   (``!x. ~(P x /\ (!z:'a. (5 = x) /\ Q x z))``, SOME ``~(P 5 /\ (!z:'a. (5 = 5) /\ Q 5 z))``),
+   (``!x. ~(P x /\ (?z:'a. (5 = x) /\ Q x z))``, SOME ``~(P 5 /\ (?z:'a. (5 = 5) /\ Q 5 z))``),
+
+   (``?x. (x, y) = (X:('a # 'b))``, SOME ``(FST X, y) = (X:('a # 'b))``),
+   (``?x. ((y, x) = (X:('a # 'b)))``, SOME ``(y, SND X) = (X:('a # 'b))``),
+   (``?x. ((3, (y:'a, x:'b), z:'c)) = X``, SOME ``((3,(y:'a,SND (FST (SND X))),z:'c) = X)``),
+   (``?x. (3::4::l = y::x::l')``, SOME ``(3::4::l = y::4::l')``),
+   (``?l'. (3::4::l = y::x::l')``, SOME ``(3::4::l = y::x::l)``),
+   (``?y. (3::4::l = y::x::l')``, SOME ``(3::4::l = 3::x::l')``),
+   (``?x. (SOME x = f)``, SOME ``(SOME (THE f) = f)``)
+]
+
+
+val _ = map (qh_test_simple hard_fail quiet) qh_testCases_simple;
+
+
 val _ = Process.exit Process.success;


### PR DESCRIPTION
The quantifier heuristics library is powerful, but often slow. The unwind conversions are fast, but have serious restrictions. This commits adds simple quantifier heuristics. They are based on the techniques
developed for quantifier heuristics library, but only search gap guesses that don't contain free variables. Some very limited experiments suggest that it is similarly fast as unwind. It can handle all the cases unwind can handle. However, it supports also a much richer syntax. Moreover, it can instantiate in addition to universal and existential quantifiers also unique existential quantifiers, eliminate select and some. Moreover, it knows about pairs and lists.

Perhaps this is useful for #341. This pull request also adds a new simpset fragment `SQI_ss` to bossLib.

I'm a bit uncertain how to do this. I need support for instantiating quantifiers fast while using information about pairs for the PMATCH pattern matching automation. I was looking into adding this on top of existing unwind implementations. However, `simpLib/Unwind` is in the build sequence before pairs. Moreover, I found it fiddly to adapt and it results in a less powerful tool than the much easier to implement it based on quantifier heuristics. However, this now adds some kind of duplication, since the resulting tool is rather similar to unwind. 

@mn200 and whoever else is interested in this: do you think this duplication is an issue? 