### PR TITLE
fix bug in case expression pretty printer

### DIFF
--- a/src/1/Pmatch.sml
+++ b/src/1/Pmatch.sml
@@ -656,14 +656,13 @@ local fun dest tybase (pat,rhs) =
           in if is_eq exp
              then let val (v,e) = dest_eq exp
                       val fvs = free_vars v
-                      val pat0 = if is_var v then subst [v |-> e] pat
-                                             else e (* fails if pat ~= v *)
                       (* val theta = fst (Term.match_term v e) handle HOL_ERR _ => [] *)
                   in if null (subtract fvs patvars) andalso null (free_vars e)
+                        andalso is_var v
                         (* andalso null_intersection fvs (free_vars (hd rhsides)) *)
                      then flatten
                             (map (dest tybase)
-                               (zip [pat0, pat] rhsides))
+                               (zip [subst [v |-> e] pat, pat] rhsides))
                      else [(pat,rhs)]
                   end
              else let val fvs = free_vars exp


### PR DESCRIPTION
As reported by Anthony (see issue #400) there is a bug in the pretty printer for case expressions. This commit is an attempt to fix it.

In case a sub-casesplit is splitting on not a pattern variable then stop the merging of patterns. A comment said this should be the case already, but this did not work. There is also a related bug in the translation of decision tree to PMATCH case expressions, which is not fixed by this commit.