### PR TITLE
Make parser prefer charset64 alphabets in regexp example

### DIFF
--- a/examples/formal-languages/regular/regexp_compilerScript.sml
+++ b/examples/formal-languages/regular/regexp_compilerScript.sml
@@ -6,6 +6,8 @@ open optionTheory pairTheory relationTheory arithmeticTheory
      finite_mapTheory vec_mapTheory charset64Theory regexpTheory
 ;
 
+val _ = Parse.bring_to_front_overload "ALPHABET" {Thy="charset64",Name="ALPHABET"};
+val _ = Parse.bring_to_front_overload "alphabet_size" {Thy="charset64",Name="alphabet_size"};
 val _ = numLib.prefer_num();
 
 fun pat_elim q = Q.PAT_X_ASSUM q (K ALL_TAC);


### PR DESCRIPTION
...or else some proofs break in regexp_compilerScript.sml