### PR TITLE
[example] a formalization of process algebra CCS (ported from HOL88)

### DIFF
--- a/examples/CCS/CCSLib.sig
+++ b/examples/CCS/CCSLib.sig
@@ -1,0 +1,47 @@
+(*
+ * Copyright 1991-1995  University of Cambridge (Author: Monica Nesi)
+ * Copyright 2016-2017  University of Bologna   (Author: Chun Tian)
+ *)
+
+signature CCSLib =
+sig
+  include Abbrev
+
+  val PAT_X_ASSUM		: term -> thm_tactic -> tactic
+  val fix			: Q.tmquote list -> tactic
+  val set			: Q.tmquote list -> tactic
+  val take			: Q.tmquote list -> tactic
+  val //			: tactic -> tactic
+
+  val add_rules_for_ccs_terms	: unit -> unit
+  val remove_rules_for_ccs_terms: unit -> unit
+
+  val ONCE_REWRITE_RHS_RULE	: thm list -> thm -> thm
+  val PURE_REWRITE_RHS_RULE	: thm list -> thm -> thm
+  val REWRITE_RHS_RULE		: thm list -> thm -> thm
+  val ONCE_REWRITE_RHS_TAC	: thm list -> tactic
+  val REWRITE_RHS_TAC		: thm list -> tactic
+  val ONCE_REWRITE_LHS_RULE	: thm list -> thm -> thm
+  val PURE_REWRITE_LHS_RULE	: thm list -> thm -> thm
+  val REWRITE_LHS_RULE		: thm list -> thm -> thm
+  val ONCE_REWRITE_LHS_TAC	: thm list -> tactic
+  val REWRITE_LHS_TAC		: thm list -> tactic
+  val ONCE_ASM_REWRITE_LHS_RULE	: thm list -> thm -> thm
+  val ONCE_ASM_REWRITE_LHS_TAC	: thm list -> tactic
+  val SWAP_FORALL_CONV		: term -> thm
+  val STRIP_FORALL_RULE		: (thm -> thm) -> thm -> thm
+  val EQ_IMP_LR			: thm -> thm
+  val EQ_IMP_RL			: thm -> thm
+  val lconcl			: thm -> term
+  val rconcl			: thm -> term
+
+  val args_thm			: thm -> term * term
+  val lhs_tm			: thm -> term
+  val rhs_tm			: thm -> term
+  val args_equiv		: term -> term * term * term
+  val elim			: term -> term list -> term list
+  val list_apply_tac		: ('a -> tactic) -> 'a list -> tactic list
+
+end
+
+(* last updated: May 14, 2017 *)

--- a/examples/CCS/CCSLib.sml
+++ b/examples/CCS/CCSLib.sml
@@ -1,0 +1,195 @@
+(*
+ * Copyright 1991-1995  University of Cambridge (Author: Monica Nesi)
+ * Copyright 2016-2017  University of Bologna   (Author: Chun Tian)
+ *)
+
+structure CCSLib :> CCSLib =
+struct
+
+open HolKernel Parse boolLib bossLib;
+
+(******************************************************************************)
+(*                                                                            *)
+(*            Backward compatibility and utility tactic/tacticals             *)
+(*                                                                            *)
+(******************************************************************************)
+
+local
+    val PAT_X_ASSUM = PAT_ASSUM;
+    val qpat_x_assum = Q.PAT_ASSUM;
+    open Tactical
+in
+    (* Backward compatibility with Kananaskis 11 *)
+    val PAT_X_ASSUM = PAT_X_ASSUM;
+    val qpat_x_assum = qpat_x_assum;
+
+    (* Tacticals for better expressivity *)
+    fun fix  ts = MAP_EVERY Q.X_GEN_TAC ts;	(* from HOL Light *)
+    fun set  ts = MAP_EVERY Q.ABBREV_TAC ts;	(* from HOL mizar mode *)
+    fun take ts = MAP_EVERY Q.EXISTS_TAC ts;	(* from HOL mizar mode *)
+    val op // = op REPEAT			(* from Matita *)
+end;
+
+(******************************************************************************)
+(*                                                                            *)
+(*                      Minimal grammar support for CCS                       *)
+(*                                                                            *)
+(******************************************************************************)
+
+fun add_rules_for_ccs_terms () = let
+in
+    add_rule { term_name = "TRANS", fixity = Infix (NONASSOC, 450),
+	pp_elements = [ BreakSpace(1,0), TOK "--", HardSpace 0, TM, HardSpace 0, TOK "->",
+			BreakSpace(1,0) ],
+	paren_style = OnlyIfNecessary,
+	block_style = (AroundEachPhrase, (PP.CONSISTENT, 0)) };
+
+    add_rule { term_name = "WEAK_TRANS", fixity = Infix (NONASSOC, 450),
+	pp_elements = [ BreakSpace(1,0), TOK "==", HardSpace 0, TM, HardSpace 0, TOK "=>>",
+			BreakSpace(1,0) ],
+	paren_style = OnlyIfNecessary,
+	block_style = (AroundEachPhrase, (PP.CONSISTENT, 0)) };
+
+    overload_on ("+", ``sum``); (* priority: 500 *)
+
+    set_mapped_fixity { fixity = Infix(LEFT, 600), tok = "||", term_name = "par" };
+
+    add_rule { term_name = "prefix", fixity = Infix(RIGHT, 700),
+	pp_elements = [ BreakSpace(0,0), TOK "..", BreakSpace(0,0) ],
+	paren_style = OnlyIfNecessary,
+	block_style = (AroundSamePrec, (PP.CONSISTENT, 0)) }
+end;
+
+fun remove_rules_for_ccs_terms () = let
+in
+    remove_rules_for_term	"prefix";
+    remove_rules_for_term	"par";
+    clear_overloads_on		"sum";
+    remove_rules_for_term	"TRANS";
+    remove_rules_for_term	"WEAK_TRANS"
+end;
+
+(******************************************************************************)
+(*                                                                            *)
+(*         Basic rules and tactics for particular forms of rewriting          *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Rule for rewriting only the right-hand side on an equation once. *)
+val ONCE_REWRITE_RHS_RULE =
+    GEN_REWRITE_RULE (RAND_CONV o ONCE_DEPTH_CONV) empty_rewrites;
+
+(* Rule for rewriting only the right-hand side on an equation (pure version). *)
+val PURE_REWRITE_RHS_RULE =
+    GEN_REWRITE_RULE (RAND_CONV o TOP_DEPTH_CONV) empty_rewrites;
+
+(* Rule for rewriting only the right-hand side on an equation
+   (basic rewrites included) *)
+val REWRITE_RHS_RULE =
+    GEN_REWRITE_RULE (RAND_CONV o TOP_DEPTH_CONV) (implicit_rewrites ());
+
+(* Tactic for rewriting only the right-hand side on an equation once. *)
+val ONCE_REWRITE_RHS_TAC =
+    GEN_REWRITE_TAC (RAND_CONV o ONCE_DEPTH_CONV) empty_rewrites; 
+
+(* Tactic for rewriting only the right-hand side on an equation. *)
+val REWRITE_RHS_TAC =
+    GEN_REWRITE_TAC (RAND_CONV o TOP_DEPTH_CONV) (implicit_rewrites ());
+
+(* Rule for rewriting only the left-hand side on an equation once. *)
+val ONCE_REWRITE_LHS_RULE =
+    GEN_REWRITE_RULE (RATOR_CONV o ONCE_DEPTH_CONV) empty_rewrites;
+
+(* Rule for rewriting only the left-hand side on an equation (pure version). *)
+val PURE_REWRITE_LHS_RULE =
+    GEN_REWRITE_RULE (RATOR_CONV o TOP_DEPTH_CONV) empty_rewrites;
+
+(* Rule for rewriting only the left-hand side on an equation
+   (basic rewrites included). *)
+val REWRITE_LHS_RULE =
+    GEN_REWRITE_RULE (RATOR_CONV o TOP_DEPTH_CONV) (implicit_rewrites ());
+
+(* Tactic for rewriting only the left-hand side on an equation once. *)
+val ONCE_REWRITE_LHS_TAC =
+    GEN_REWRITE_TAC (RATOR_CONV o ONCE_DEPTH_CONV) empty_rewrites;
+
+(* Tactic for rewriting only the left-hand side on an equation. *)
+val REWRITE_LHS_TAC =
+    GEN_REWRITE_TAC (RATOR_CONV o TOP_DEPTH_CONV) (implicit_rewrites ());
+
+(* Rule for rewriting only the left-hand side of an equation once with the
+   assumptions. *)
+fun ONCE_ASM_REWRITE_LHS_RULE thl th =
+    ONCE_REWRITE_LHS_RULE ((map ASSUME (hyp th)) @ thl) th;
+
+(* Tactic for rewriting only the left-hand side of an equation once with the
+   assumptions. *)
+fun ONCE_ASM_REWRITE_LHS_TAC thl =
+    ASSUM_LIST (fn asl => ONCE_REWRITE_LHS_TAC (asl @ thl));
+
+(* Conversion to swap two universally quantified variables. *)
+fun SWAP_FORALL_CONV tm = let
+    val (v1, body) = dest_forall tm;
+    val v2 = fst (dest_forall body);
+    val tl1 = [v1, v2] and tl2 = [v2, v1];
+    val th1 = GENL tl2 (SPECL tl1 (ASSUME tm));
+    val th2 = GENL tl1 (SPECL tl2 (ASSUME (concl th1)))
+in
+    IMP_ANTISYM_RULE (DISCH_ALL th1) (DISCH_ALL th2)
+end;
+
+(* provided by Michael Norrish *)
+fun STRIP_FORALL_RULE f th =
+  let
+      val (vs, _) = strip_forall (concl th)
+  in
+      GENL vs (f (SPEC_ALL th))
+  end;
+
+(* The rule EQ_IMP_LR returns the implication from left to right of a given
+   equational theorem. *)
+val EQ_IMP_LR = STRIP_FORALL_RULE (fst o EQ_IMP_RULE);
+
+(* The rule EQ_IMP_RL returns the implication from right to left of a given
+   equational theorem. *)
+val EQ_IMP_RL = STRIP_FORALL_RULE (snd o EQ_IMP_RULE);
+
+(* Functions to get the left and right hand side of the equational conclusion
+   of a theorem. *)
+val lconcl = fst o dest_eq o concl o SPEC_ALL;
+val rconcl = snd o dest_eq o concl o SPEC_ALL;
+
+(* Define args_thm as a function that, given a theorem |- f t1 t2, returns (t1, t2). *)
+fun args_thm thm = let
+    val (f, [t1, t2]) = strip_comb (concl thm)
+in
+    (t1, t2)
+end;
+
+fun lhs_tm thm = (fst o args_thm) thm;
+fun rhs_tm thm = (snd o args_thm) thm;
+
+(* Define args_equiv as a function that, given a tm "p t1 t2", returns (p, t1, t2) *)
+fun args_equiv tm = let
+    val (p, [t1, t2]) = strip_comb tm
+in
+    (p, t1, t2)
+end;
+
+(* Auxiliary functions (on lists and terms) to find repeated occurrences of a
+   summand to be then deleted by applying the idempotence law for summation. *)
+local
+    fun helper (h:term, nil) = nil
+      | helper (h, t::l) = if h = t then l else t :: (helper (h, l))
+in
+    fun elim h l = helper (h, l)
+end;
+
+(* Function for applying a list of tactics to a list of subgoals. *)
+fun list_apply_tac _ [] = []
+  | list_apply_tac (f: 'a -> tactic) (actl : 'a list) : tactic list =
+    (f (hd actl)) :: (list_apply_tac f (tl actl));
+
+end (* struct *)
+
+(* last updated: May 7, 2017 *)

--- a/examples/CCS/CCSScript.sml
+++ b/examples/CCS/CCSScript.sml
@@ -1,0 +1,763 @@
+(*
+ * Copyright 1991-1995  University of Cambridge (Author: Monica Nesi)
+ * Copyright 2016-2017  University of Bologna   (Author: Chun Tian)
+ *)
+
+open HolKernel Parse boolLib bossLib;
+
+open stringTheory pred_setTheory IndDefRules CCSLib;
+
+val _ = new_theory "CCS";
+
+(******************************************************************************)
+(*                                                                            *)
+(*              Syntax of pure CCS (string based formalization)               *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Define the set of labels as the union of names (`in`) (strings) and
+   co-names (`out`) (complement of names) *)
+val _ = Datatype `Label = name string | coname string`;
+
+(* Define structural induction on labels   
+   |- ∀P. (∀s. P (name s)) ∧ (∀s. P (coname s)) ⇒ ∀L. P L
+ *)
+val Label_induction = TypeBase.induction_of ``:Label``;
+
+(* The structural cases theorem for the type Label
+   |- ∀LL. (∃s. LL = name s) ∨ ∃s. LL = coname s
+ *)
+val Label_nchotomy = TypeBase.nchotomy_of ``:Label``;
+
+(* The distinction and injectivity theorems for the type Label
+   |- ∀a' a. name a ≠ coname a'
+   |- (∀a a'. (name a = name a') ⇔ (a = a')) ∧
+       ∀a a'. (coname a = coname a') ⇔ (a = a')
+ *)
+val Label_distinct = TypeBase.distinct_of ``:Label``;
+val Label_distinct' = save_thm ("Label_distinct'", GSYM Label_distinct);
+
+val Label_not_eq = save_thm (
+   "Label_not_eq",
+    STRIP_FORALL_RULE EQF_INTRO Label_distinct);
+
+val Label_not_eq' = save_thm (
+   "Label_not_eq'",
+    STRIP_FORALL_RULE (PURE_REWRITE_RULE [SYM_CONV ``name s = coname s'``])
+		      Label_not_eq);
+
+val Label_11 = TypeBase.one_one_of ``:Label``;
+
+(* Define the set of actions as the union of the internal action tau and the labels. *)
+val _ = Datatype `Action = tau | label Label`;
+val _ = Unicode.unicode_version { u = UnicodeChars.tau, tmnm = "tau"};
+
+(* The compact representation for (visible) input and output actions, suggested by Michael Norrish *)
+val _ = overload_on ("In", ``\a. label (name a)``);
+val _ = overload_on ("Out", ``\a. label (coname a)``);
+
+(* Define structural induction on actions
+   |- ∀P. P tau ∧ (∀L. P (label L)) ⇒ ∀A. P A 
+ *)
+val Action_induction = TypeBase.induction_of ``:Action``;
+
+(* The structural cases theorem for the type Action
+   |- ∀AA. (AA = tau) ∨ ∃L. AA = label L
+ *)
+val Action_nchotomy = TypeBase.nchotomy_of ``:Action``;
+
+(* The distinction and injectivity theorems for the type Action
+   |- ∀a. tau ≠ label a
+   |- ∀a a'. (label a = label a') ⇔ (a = a')
+ *)
+val Action_distinct = TypeBase.distinct_of ``:Action``;
+val Action_distinct_label = save_thm ("Action_distinct_label", GSYM Action_distinct);
+val Action_11 = TypeBase.one_one_of ``:Action``;
+
+(* |- ∀A. A ≠ tau ⇒ ∃L. A = label L *)
+val Action_not_tau_is_Label = save_thm ("Action_not_tau_is_Label",
+    GEN ``A :Action`` (DISJ_IMP (SPEC ``A :Action`` Action_nchotomy)));
+
+(* Extract the label from a visible action, LABEL: Action -> Label. *)
+val    LABEL_def = Define `    LABEL (label l) = l`;
+val IS_LABEL_def = Define `(IS_LABEL (label l) = T) /\
+			   (IS_LABEL tau       = F)`;
+val _ = export_rewrites ["LABEL_def", "IS_LABEL_def"];
+
+(* Define the complement of a label, COMPL: Label -> Label. *)
+val COMPL_LAB_def = Define `(COMPL_LAB (name s) = (coname s)) /\
+			    (COMPL_LAB (coname s) = (name s))`;
+
+val _ = overload_on ("COMPL", ``COMPL_LAB``);
+val _ = export_rewrites ["COMPL_LAB_def"];
+
+val coname_COMPL = store_thm ("coname_COMPL", 
+  ``!s. coname s = COMPL (name s)``,
+    REWRITE_TAC [COMPL_LAB_def]);
+
+val COMPL_COMPL_LAB = store_thm (
+   "COMPL_COMPL_LAB", ``!(l :Label). COMPL_LAB (COMPL_LAB l) = l``,
+    Induct >> REWRITE_TAC [COMPL_LAB_def]);
+
+(* Extend the complement to actions, COMPL_ACT: Action -> Action. *)
+val COMPL_ACT_def = Define `
+   (COMPL_ACT (label l) = label (COMPL l)) /\
+   (COMPL_ACT tau = tau)`;
+
+val _ = overload_on ("COMPL", ``COMPL_ACT``);
+val _ = export_rewrites ["COMPL_ACT_def"];
+
+val COMPL_COMPL_ACT = store_thm (
+   "COMPL_COMPL_ACT", ``!(a :Action). COMPL_ACT (COMPL_ACT a) = a``,
+    Induct
+ >| [ REWRITE_TAC [COMPL_ACT_def],
+      REWRITE_TAC [COMPL_ACT_def, COMPL_COMPL_LAB] ]);
+
+(* Auxiliary theorem about complementary labels. *)
+val COMPL_THM = store_thm ("COMPL_THM",
+  ``!l s. (~(l = name s) ==> ~(COMPL l = coname s)) /\
+	  (~(l = coname s) ==> ~(COMPL l = name s))``,
+    Induct_on `l`
+ >| [ (* case 1 *)
+      REPEAT GEN_TAC >> CONJ_TAC >|
+      [ REWRITE_TAC [Label_11, COMPL_LAB_def],
+        REWRITE_TAC [Label_distinct, COMPL_LAB_def, Label_distinct'] ] ,
+      (* case 2 *)
+      REPEAT GEN_TAC >> CONJ_TAC >|
+      [ REWRITE_TAC [Label_distinct, COMPL_LAB_def, Label_distinct'],
+        REWRITE_TAC [Label_11, COMPL_LAB_def] ] ]);
+
+val Is_Relabeling_def = Define `
+    Is_Relabeling (f: Label -> Label) = (!s. f (coname s) = COMPL (f (name s)))`;
+
+val EXISTS_Relabeling = store_thm ("EXISTS_Relabeling", ``?f. Is_Relabeling f``,
+    Q.EXISTS_TAC `\a. a`
+ >> PURE_ONCE_REWRITE_TAC [Is_Relabeling_def]
+ >> BETA_TAC
+ >> REWRITE_TAC [COMPL_LAB_def]);
+
+(* Relabeling_TY_DEF =
+   |- ∃rep. TYPE_DEFINITION Is_Relabeling rep
+ *)
+val Relabeling_TY_DEF = new_type_definition ("Relabeling", EXISTS_Relabeling);
+
+(* Relabeling_ISO_DEF =
+   |- (∀a. ABS_Relabeling (REP_Relabeling a) = a) ∧
+       ∀r. Is_Relabeling r ⇔ (REP_Relabeling (ABS_Relabeling r) = r)
+ *)
+val Relabeling_ISO_DEF = define_new_type_bijections
+			      { ABS  = "ABS_Relabeling",
+				REP  = "REP_Relabeling",
+				name = "Relabeling_ISO_DEF",
+				tyax =  Relabeling_TY_DEF };
+
+(* ABS_Relabeling_one_one =
+   |- ∀r r'.
+      Is_Relabeling r ⇒ Is_Relabeling r' ⇒
+      ((ABS_Relabeling r = ABS_Relabeling r') ⇔ (r = r'))
+
+   ABS_Relabeling_onto =
+   |- ∀a. ∃r. (a = ABS_Relabeling r) ∧ Is_Relabeling r
+
+   REP_Relabeling_one_one =
+   |- ∀a a'. (REP_Relabeling a = REP_Relabeling a') ⇔ (a = a')
+
+   REP_Relabeling_onto =
+   |- ∀r. Is_Relabeling r ⇔ ∃a. r = REP_Relabeling a
+ *)
+val [ABS_Relabeling_one_one,
+     ABS_Relabeling_onto,
+     REP_Relabeling_one_one,
+     REP_Relabeling_onto] =
+    map (fn f => f Relabeling_ISO_DEF)
+	[prove_abs_fn_one_one,
+	 prove_abs_fn_onto,
+	 prove_rep_fn_one_one,
+	 prove_rep_fn_onto];
+
+val REP_Relabeling_THM = store_thm ("REP_Relabeling_THM",
+  ``!rf: Relabeling. Is_Relabeling (REP_Relabeling rf)``,
+    GEN_TAC
+ >> REWRITE_TAC [REP_Relabeling_onto]
+ >> Q.EXISTS_TAC `rf`
+ >> REWRITE_TAC []);
+
+(* Relabeling labels is extended to actions by renaming tau as tau. *)
+val relabel_def = Define `(relabel (rf: Relabeling) tau = tau) /\
+			  (relabel rf (label l) = label (REP_Relabeling rf l))`;
+
+(* If the renaming of an action is a label, that action is a label. *)
+val Relab_label = prove (``!rf u l. (relabel rf u = label l) ==> ?l'. u = label l'``,
+    Induct_on `u`
+ >- REWRITE_TAC [relabel_def, Action_distinct]
+ >> REWRITE_TAC [relabel_def]
+ >> REPEAT STRIP_TAC
+ >> Q.EXISTS_TAC `L`
+ >> REWRITE_TAC []);
+
+(* If the renaming of an action is tau, that action is tau. *)
+val Relab_tau = prove (``!rf u. (relabel rf u = tau) ==> (u = tau)``,
+    Induct_on `u`
+ >> REWRITE_TAC [relabel_def, Action_distinct_label]);
+
+(* Apply_Relab: ((Label # Label) list) -> Label -> Label
+   (SND of any pair is a name, FST can be either name or coname)
+ *)
+val Apply_Relab_def = Define `
+   (Apply_Relab ([]: (Label # Label) list) l = l) /\
+   (Apply_Relab (CONS (newold: Label # Label) ls) l =
+	  if (SND newold = l)         then (FST newold)
+     else if (COMPL (SND newold) = l) then (COMPL (FST newold))
+     else (Apply_Relab ls l))`;
+
+val Apply_Relab_COMPL_THM = store_thm ("Apply_Relab_COMPL_THM",
+  ``!labl s. Apply_Relab labl (coname s) = COMPL (Apply_Relab labl (name s))``,
+    Induct
+ >- REWRITE_TAC [Apply_Relab_def, COMPL_LAB_def]
+ >> REPEAT GEN_TAC
+ >> REWRITE_TAC [Apply_Relab_def]
+ >> COND_CASES_TAC
+ >- ASM_REWRITE_TAC [Label_distinct', COMPL_LAB_def, COMPL_COMPL_LAB]
+ >> ASM_CASES_TAC ``SND (h :Label # Label) = name s``
+ >- ASM_REWRITE_TAC [COMPL_LAB_def]
+ >> IMP_RES_TAC COMPL_THM
+ >> ASM_REWRITE_TAC []);
+
+val IS_RELABELING = store_thm (
+   "IS_RELABELING" ,``!labl. Is_Relabeling (Apply_Relab labl)``,
+    Induct
+ >- REWRITE_TAC [Is_Relabeling_def, Apply_Relab_def, COMPL_LAB_def]
+ >> GEN_TAC
+ >> REWRITE_TAC [Is_Relabeling_def, Apply_Relab_def]
+ >> GEN_TAC
+ >> COND_CASES_TAC
+ >- ASM_REWRITE_TAC [Label_distinct', COMPL_LAB_def, COMPL_COMPL_LAB]
+ >> ASM_CASES_TAC ``SND (h :Label # Label) = name s``
+ >- ASM_REWRITE_TAC [COMPL_LAB_def]
+ >> IMP_RES_TAC COMPL_THM
+ >> ASM_REWRITE_TAC [Apply_Relab_COMPL_THM]);
+
+(* Defining a relabelling function through substitution-like notation.
+   RELAB: (Label # Label)list -> Relabeling
+ *)
+val RELAB_def = Define `RELAB labl = ABS_Relabeling (Apply_Relab labl)`;
+
+(* Define the type of (pure) CCS agent expressions. *)
+val _ = Datatype `CCS = nil
+		      | var string
+		      | prefix Action CCS
+		      | sum CCS CCS
+		      | par CCS CCS
+		      | restr (Label set) CCS
+		      | relab CCS Relabeling
+		      | rec string CCS`;
+
+(* compact representation for single-action restriction *)
+val _ = overload_on ("nu", ``\n P. restr {name n} P``);
+val _ = overload_on ("nu", ``restr``);
+
+val _ = Unicode.unicode_version { u = UnicodeChars.nu, tmnm = "nu" };
+
+val _ = overload_on ("+", ``sum``); (* priority: 500 *)
+val _ = set_mapped_fixity { fixity = Infix(LEFT, 600), tok = "||", term_name = "par" };
+val _ =
+    add_rule { term_name = "prefix", fixity = Infix(RIGHT, 700),
+	pp_elements = [ BreakSpace(0,0), TOK "..", BreakSpace(0,0) ],
+	paren_style = OnlyIfNecessary,
+	block_style = (AroundSamePrec, (PP.CONSISTENT, 0)) };
+
+(* Define structural induction on CCS agent expressions. *)
+val CCS_induct = TypeBase.induction_of ``:CCS``;
+
+(* The structural cases theorem for the type CCS. *)
+val CCS_cases = TypeBase.nchotomy_of ``:CCS``;
+
+(* Prove that the constructors of the type CCS are distinct. *)
+val CCS_distinct = TypeBase.distinct_of ``:CCS``;
+
+local
+    val thm = CONJUNCTS CCS_distinct;
+    val CCS_distinct_LIST = thm @ (map GSYM thm);
+in
+    val CCS_distinct' = save_thm ("CCS_distinct'", LIST_CONJ CCS_distinct_LIST);
+end
+
+(* Prove that the constructors of the type CCS are one-to-one. *)
+val CCS_11 = TypeBase.one_one_of ``:CCS``;
+
+(* Given any agent expression, define the substitution of an agent expression
+   E' for an agent variable X.
+
+   This works under the hypothesis that the Barendregt convention holds. *)
+val CCS_Subst_def = Define `
+   (CCS_Subst nil	   E' X = nil) /\
+   (CCS_Subst (prefix u E) E' X = prefix u (CCS_Subst E E' X)) /\
+   (CCS_Subst (sum E1 E2)  E' X = sum (CCS_Subst E1 E' X)
+				      (CCS_Subst E2 E' X)) /\
+   (CCS_Subst (par E1 E2)  E' X = par (CCS_Subst E1 E' X)
+				      (CCS_Subst E2 E' X)) /\
+   (CCS_Subst (restr L E)  E' X = restr L (CCS_Subst E E' X)) /\
+   (CCS_Subst (relab E f)  E' X = relab   (CCS_Subst E E' X) f) /\
+   (CCS_Subst (var Y)      E' X = if (Y = X) then E' else (var Y)) /\ 
+   (CCS_Subst (rec Y E)    E' X = if (Y = X) then (rec Y E)
+					     else (rec Y (CCS_Subst E E' X)))`;
+
+(* Note that in the rec clause, if Y = X then all occurrences of Y in E are X 
+   and bound, so there exist no free variables X in E to be replaced with E'.
+   Hence, the term rec Y E is returned. *)
+
+(* Define an arbitrary CCS agent. This finished porting of syntax.ml *)
+val ARB'_def = Define `ARB' = @x:CCS. T`;
+
+(* |- !t1 t2. ((T => t1 | t2) = t1) /\ ((F => t1 | t2) = t2) *)
+val CCS_COND_CLAUSES = save_thm (
+   "CCS_COND_CLAUSES", INST_TYPE [``:'a`` |-> ``:CCS``] COND_CLAUSES);
+
+(******************************************************************************)
+(*                                                                            *)
+(*            Definition of the transition relation for pure CCS              *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Inductive definition of the transition relation TRANS for CCS.
+   TRANS: Action -> CCS -> CCS -> bool
+ *)
+val (TRANS_rules, TRANS_ind, TRANS_cases) = Hol_reln `
+    (!E u. TRANS (prefix u E) u E) /\					(* PREFIX *)
+    (!E u E1 E'. TRANS E u E1 ==> TRANS (sum E E') u E1) /\		(* SUM1 *)
+    (!E u E1 E'. TRANS E u E1 ==> TRANS (sum E' E) u E1) /\		(* SUM2 *)
+    (!E u E1 E'. TRANS E u E1 ==> TRANS (par E E') u (par E1 E')) /\	(* PAR1 *)
+    (!E u E1 E'. TRANS E u E1 ==> TRANS (par E' E) u (par E' E1)) /\	(* PAR2 *)
+    (!E l E1 E' E2.
+		 TRANS E (label l) E1 /\ TRANS E' (label (COMPL l)) E2
+	     ==> TRANS (par E E') tau (par E1 E2)) /\			(* PAR3 (COM) *)
+    (!E u E' l L. 
+		 TRANS E u E' /\ ((u = tau) \/
+				  ((u = label l) /\ (~(l IN L)) /\ (~((COMPL l) IN L))))
+	     ==> TRANS (restr L E) u (restr L E')) /\			(* RESTR *)
+    (!E u E' rf. TRANS E u E'
+	     ==> TRANS (relab E rf) (relabel rf u) (relab E' rf)) /\	(* RELAB *)
+    (!E u X E1.  TRANS (CCS_Subst E (rec X E) X) u E1
+	     ==> TRANS (rec X E) u E1)`;				(* REC (CONS) *)
+
+val _ =
+    add_rule { term_name = "TRANS", fixity = Infix (NONASSOC, 450),
+	pp_elements = [ BreakSpace(1,0), TOK "--", HardSpace 0, TM, HardSpace 0, TOK "->",
+			BreakSpace(1,0) ],
+	paren_style = OnlyIfNecessary,
+	block_style = (AroundEachPhrase, (PP.CONSISTENT, 0)) };
+
+(* The rules for the transition relation TRANS as individual theorems. *)
+val [PREFIX, SUM1, SUM2, PAR1, PAR2, PAR3, RESTR, RELAB, REC] =
+    map (fn (s, thm) => save_thm (s, thm))
+        (combine (["PREFIX", "SUM1", "SUM2", "PAR1", "PAR2", "PAR3", "RESTR", "RELAB", "REC"],
+                  CONJUNCTS TRANS_rules));
+
+(* Tactics for proofs about the transition relation TRANS, re-defined in CCSSimps *)
+val [PREFIX_TAC, SUM1_TAC, SUM2_TAC,
+     PAR1_TAC, PAR2_TAC, PAR3_TAC,
+     RESTR_TAC, RELAB_TAC, REC_TAC] = map RULE_TAC (CONJUNCTS TRANS_rules);
+
+(* The process nil has no transitions.
+   |- ∀u E. ¬TRANS nil u E
+ *)
+val NIL_NO_TRANS = save_thm ("NIL_NO_TRANS",
+  ((GEN ``u :Action``) o
+   (GEN ``E: CCS``) o
+   (REWRITE_RULE [CCS_distinct]))
+      (SPECL [``nil``, ``u :Action``, ``E :CCS``] TRANS_cases));
+
+(* |- ∀u E. nil --u-> E ⇔ F *)
+val NIL_NO_TRANS_EQF = save_thm (
+   "NIL_NO_TRANS_EQF",
+  ((GEN ``u :Action``) o
+   (GEN ``E: CCS``) o EQF_INTRO o SPEC_ALL) NIL_NO_TRANS);
+
+(* Prove that if a process can do an action, then the process is not nil.
+   |- ∀E u E'. TRANS E u E' ⇒ E ≠ nil:
+ *)
+val TRANS_IMP_NO_NIL = store_thm ("TRANS_IMP_NO_NIL",
+  ``!E u E'. TRANS E u E' ==> ~(E = nil)``,
+    HO_MATCH_MP_TAC TRANS_ind
+ >> REWRITE_TAC [CCS_distinct']);
+
+(* Above theorem can be proved without using TRANS_ind *)
+val TRANS_IMP_NO_NIL' = store_thm ("TRANS_IMP_NO_NIL'",
+  ``!E u E'. TRANS E u E' ==> ~(E = nil)``,
+    REPEAT GEN_TAC
+ >> ONCE_REWRITE_TAC [TRANS_cases]
+ >> REPEAT STRIP_TAC
+ >> PROVE_TAC [CCS_distinct']);
+
+(* An agent variable has no transitions.
+   |- !X u E'. ~TRANS (var X) u E'
+ *)
+val VAR_NO_TRANS = save_thm ("VAR_NO_TRANS",
+  ((GEN ``X :string``) o
+   (GEN ``u :Action``) o
+   (GEN ``E :CCS``) o
+   (REWRITE_RULE [CCS_distinct', CCS_11]) o
+   (SPECL [``var X``, ``u :Action``, ``E: CCS``]))
+      TRANS_cases);
+
+(* |- !u E u' E'. TRANS (prefix u E) u' E' = (u' = u) /\ (E' = E) *)
+val TRANS_PREFIX_EQ = save_thm ("TRANS_PREFIX_EQ",
+  ((GEN ``u :Action``) o
+   (GEN ``E :CCS``) o
+   (GEN ``u' :Action``) o
+   (GEN ``E' :CCS``) o
+   (ONCE_REWRITE_RHS_RULE [EQ_SYM_EQ]) o
+   SPEC_ALL o
+   (REWRITE_RULE [CCS_distinct', CCS_11]) o
+   (SPECL [``prefix u E``, ``u' :Action``, ``E' :CCS``]))
+      TRANS_cases);
+
+(* |- ∀u E u' E'. u..E --u'-> E' ⇒ (u' = u) ∧ (E' = E) *)
+val TRANS_PREFIX = save_thm ("TRANS_PREFIX", EQ_IMP_LR TRANS_PREFIX_EQ);
+
+(******************************************************************************)
+(*                                                                            *)
+(*                The transitions of a binary summation                       *)
+(*                                                                            *)
+(******************************************************************************)
+
+val SUM_cases_EQ = save_thm ("SUM_cases_EQ",
+    GENL [``D :CCS``, ``D' :CCS``, ``u :Action``, ``D'' :CCS``]
+	 (REWRITE_RULE [CCS_distinct', CCS_11]
+		       (SPECL [``sum D D'``, ``u :Action``, ``D'' :CCS``] TRANS_cases)));
+
+val SUM_cases = save_thm ("SUM_cases", EQ_IMP_LR SUM_cases_EQ);
+
+val TRANS_SUM_EQ = store_thm ("TRANS_SUM_EQ",
+  ``!E E' u E''. TRANS (sum E E') u E'' = TRANS E u E'' \/ TRANS E' u E''``, 
+    REPEAT GEN_TAC
+ >> EQ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      DISCH_TAC \\
+      IMP_RES_TAC SUM_cases \\
+      ASM_REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      STRIP_TAC >| [SUM1_TAC, SUM2_TAC] \\
+      ASM_REWRITE_TAC [] ]);
+
+(* for CCS_TRANS_CONV *)
+val TRANS_SUM_EQ' = store_thm (
+   "TRANS_SUM_EQ'",
+  ``!E1 E2 u E. TRANS (sum E1 E2) u E = TRANS E1 u E \/ TRANS E2 u E``, 
+    REWRITE_TAC [TRANS_SUM_EQ]);
+
+val TRANS_SUM = save_thm ("TRANS_SUM", EQ_IMP_LR TRANS_SUM_EQ);
+
+val TRANS_COMM_EQ = store_thm ("TRANS_COMM_EQ",
+  ``!E E' E'' u. TRANS (sum E E') u E'' = TRANS (sum E' E) u E''``,
+    REPEAT GEN_TAC
+ >> EQ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      DISCH_TAC \\
+      IMP_RES_TAC TRANS_SUM >|
+      [ SUM2_TAC, SUM1_TAC ] \\
+      ASM_REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      DISCH_TAC \\
+      IMP_RES_TAC TRANS_SUM >|
+      [ SUM2_TAC, SUM1_TAC ] \\
+      ASM_REWRITE_TAC [] ]);
+
+val TRANS_ASSOC_EQ = store_thm ("TRANS_ASSOC_EQ",
+  ``!E E' E'' E1 u. TRANS (sum (sum E E') E'') u E1 = TRANS (sum E (sum E' E'')) u E1``,
+    REPEAT GEN_TAC
+ >> EQ_TAC
+ >| [ (* goal 1 (of 2) *)
+      DISCH_TAC \\
+      IMP_RES_TAC TRANS_SUM >|
+      [ (* goal 1.1 (of 2) *)
+	IMP_RES_TAC TRANS_SUM >| (* 4 sub-goals here *)
+        [ SUM1_TAC,
+	  SUM1_TAC,
+	  SUM2_TAC >> SUM1_TAC,
+	  SUM2_TAC >> SUM1_TAC ] \\
+        ASM_REWRITE_TAC [],
+	(* goal 1.2 (of 2) *)
+        SUM2_TAC >> SUM2_TAC \\
+        ASM_REWRITE_TAC [] ],
+      (* goal 2 (of 2) *)
+      DISCH_TAC \\
+      IMP_RES_TAC TRANS_SUM >|
+      [ SUM1_TAC >> SUM1_TAC \\
+        ASM_REWRITE_TAC [],
+        IMP_RES_TAC TRANS_SUM >| (* 4 sub-goals here *)
+        [ SUM1_TAC >> SUM1_TAC,
+	  SUM1_TAC >> SUM2_TAC,
+	  SUM2_TAC,
+	  SUM2_TAC ] \\
+	ASM_REWRITE_TAC [] ] ]);
+
+val TRANS_ASSOC_RL = save_thm (
+   "TRANS_ASSOC_RL", EQ_IMP_RL TRANS_ASSOC_EQ);
+
+val TRANS_SUM_NIL_EQ = store_thm (
+   "TRANS_SUM_NIL_EQ",
+  ``!E u E'. TRANS (sum E nil) u E' = TRANS E u E'``,
+    REPEAT GEN_TAC
+ >> EQ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      DISCH_TAC \\
+      IMP_RES_TAC TRANS_SUM \\
+      IMP_RES_TAC NIL_NO_TRANS,
+      (* goal 2 (of 2) *)
+      DISCH_TAC \\
+      SUM1_TAC >> ASM_REWRITE_TAC [] ]);   
+
+(* |- ∀E u E'. E + nil --u-> E' ⇒ E --u-> E' *)
+val TRANS_SUM_NIL = save_thm ("TRANS_SUM_NIL", EQ_IMP_LR TRANS_SUM_NIL_EQ);
+
+val TRANS_P_SUM_P_EQ = store_thm ("TRANS_P_SUM_P_EQ",
+  ``!E u E'. TRANS (sum E E) u E' = TRANS E u E'``,
+    REPEAT GEN_TAC
+ >> EQ_TAC
+ >| [ DISCH_TAC \\
+      IMP_RES_TAC TRANS_SUM,
+      DISCH_TAC \\
+      SUM1_TAC >> ASM_REWRITE_TAC [] ]);
+
+val TRANS_P_SUM_P = save_thm ("TRANS_P_SUM_P", EQ_IMP_LR TRANS_P_SUM_P_EQ);
+
+val PAR_cases_EQ = save_thm ("PAR_cases_EQ",
+    GENL [``D :CCS``, ``D' :CCS``, ``u :Action``, ``D'' :CCS``]
+	 (REWRITE_RULE [CCS_distinct', CCS_11]
+		       (SPECL [``par D D'``, ``u :Action``, ``D'' :CCS``] TRANS_cases)));
+
+val PAR_cases = save_thm ("PAR_cases", EQ_IMP_LR PAR_cases_EQ);
+
+(* NOTE: the shape of this theorem can be easily got from above definition by replacing
+         REWRITE_RULE to SIMP_RULE, however the inner existential variable (E1) has a
+         different name. *)
+val TRANS_PAR_EQ = store_thm ("TRANS_PAR_EQ",
+  ``!E E' u E''. TRANS (par E E') u E'' =
+		 (?E1. (E'' = par E1 E') /\ TRANS E u E1) \/
+		 (?E1. (E'' = par E E1) /\ TRANS E' u E1) \/
+		 (?E1 E2 l. (u = tau) /\ (E'' = par E1 E2) /\
+			    TRANS E (label l) E1 /\ TRANS E' (label (COMPL l)) E2)``,
+    REPEAT GEN_TAC
+ >> EQ_TAC (* two goals here *)
+ >| [ (* case 1 (LR) *)
+      STRIP_TAC \\
+      IMP_RES_TAC PAR_cases >| (* 3 sub-goals here *)
+      [ (* goal 1.1 *)
+	DISJ1_TAC \\
+	Q.EXISTS_TAC `E1` >> ASM_REWRITE_TAC [],
+	(* goal 1.2 *)
+	DISJ2_TAC \\
+	DISJ1_TAC \\
+	Q.EXISTS_TAC `E1` >> ASM_REWRITE_TAC [],
+	(* goal 1.3 *)
+	DISJ2_TAC \\
+	DISJ2_TAC \\
+	take [`E1`, `E2`, `l`] \\
+	ASM_REWRITE_TAC [] ],
+      (* case 2 (RL) *)
+      STRIP_TAC (* 3 sub-goals here, but they share the first and last steps *)
+   >> ASM_REWRITE_TAC []
+   >| [ PAR1_TAC, PAR2_TAC, PAR3_TAC ]
+   >> ASM_REWRITE_TAC [] ]);
+
+val TRANS_PAR = save_thm ("TRANS_PAR", EQ_IMP_LR TRANS_PAR_EQ);
+
+val TRANS_PAR_P_NIL = store_thm ("TRANS_PAR_P_NIL",
+  ``!E u E'. TRANS (par E nil) u E' ==> (?E''. TRANS E u E'' /\ (E' = par E'' nil))``,
+    REPEAT STRIP_TAC
+ >> IMP_RES_TAC TRANS_PAR
+ >| [ Q.EXISTS_TAC `E1` >> ASM_REWRITE_TAC [],
+      IMP_RES_TAC NIL_NO_TRANS,
+      IMP_RES_TAC NIL_NO_TRANS ]);
+
+val TRANS_PAR_NO_SYNCR = store_thm ("TRANS_PAR_NO_SYNCR",
+  ``!l l'. ~(l = COMPL l') ==>
+	   (!E E' E''. ~(TRANS (par (prefix (label l) E) (prefix (label l') E')) tau E''))``,
+    REPEAT STRIP_TAC
+ >> IMP_RES_TAC TRANS_PAR
+ >| [ IMP_RES_TAC TRANS_PREFIX >> IMP_RES_TAC Action_distinct,
+      IMP_RES_TAC TRANS_PREFIX >> IMP_RES_TAC Action_distinct,
+      IMP_RES_TAC TRANS_PREFIX >> IMP_RES_TAC Action_11 \\
+      CHECK_ASSUME_TAC
+        (REWRITE_RULE [SYM (ASSUME ``(l'': Label) = l``),
+		       SYM (ASSUME ``COMPL (l'' :Label) = l'``), COMPL_COMPL_LAB]
+		      (ASSUME ``~(l = COMPL (l' :Label))``)) \\
+      RW_TAC bool_ss [] ]);
+
+val RESTR_cases_EQ = save_thm ("RESTR_cases_EQ",
+    GENL [``D :CCS``, ``L :Label set``, ``u: Action``, ``D' :CCS``]
+	 (REWRITE_RULE [CCS_distinct', CCS_11, Action_distinct, Action_11]
+		       (SPECL [``restr L D``, ``u :Action``, ``D' :CCS``]
+			      TRANS_cases)));
+
+val RESTR_cases = save_thm ("RESTR_cases", EQ_IMP_LR RESTR_cases_EQ);
+
+val TRANS_RESTR_EQ = store_thm ("TRANS_RESTR_EQ",
+  ``!E L u E'.
+     TRANS (restr L E) u E' = 
+     (?E'' l. (E' = restr L E'') /\ TRANS E u E'' /\
+	      ((u = tau) \/ ((u = label l) /\ ~(l IN L) /\ ~((COMPL l) IN L))))``,
+  let val a1 = ASSUME ``u = tau``
+      and a2 = ASSUME ``u = label l``
+      and a3 = ASSUME ``TRANS E'' u E'''``
+      and a4 = ASSUME ``TRANS E u E''``
+  in
+    REPEAT GEN_TAC
+ >> EQ_TAC >| (* two goals here *)
+    [ (* case 1 (LR) *)
+      STRIP_TAC \\
+      IMP_RES_TAC RESTR_cases \\ (* two sub-goals here, first two steps are shared *)
+      Q.EXISTS_TAC `E'''` \\
+      Q.EXISTS_TAC `l` >|
+      [ (* goal 1.1 *)
+	ASM_REWRITE_TAC [REWRITE_RULE [a1] a3],
+	(* goal 1.2 *)
+	ASM_REWRITE_TAC [REWRITE_RULE [a2] a3] ],
+      (* case 2 (RL) *)
+      STRIP_TAC >|			(* two sub-goals here *)
+      [ (* sub-goal 2.1 *)
+	ASM_REWRITE_TAC [] \\
+	RESTR_TAC \\
+	ASM_REWRITE_TAC [REWRITE_RULE [a1] a4],
+	(* sub-goal 2.2 *)
+	ASM_REWRITE_TAC [] \\
+	RESTR_TAC \\
+	ASM_REWRITE_TAC [REWRITE_RULE [a2] a4] ] ]
+  end);
+
+val TRANS_RESTR = save_thm ("TRANS_RESTR", EQ_IMP_LR TRANS_RESTR_EQ);
+
+val TRANS_P_RESTR = store_thm ("TRANS_P_RESTR",
+  ``!E u E' L. TRANS (restr L E) u (restr L E') ==> TRANS E u E'``,
+  let
+      val thm = REWRITE_RULE [CCS_11] (ASSUME ``restr L E' = restr L E''``)
+  in
+      REPEAT STRIP_TAC \\
+      IMP_RES_TAC TRANS_RESTR >| (* 2 sub-goals here *)
+      [ FILTER_ASM_REWRITE_TAC (fn t => not (t = ``u = tau``)) [thm],
+        FILTER_ASM_REWRITE_TAC (fn t => not (t = ``u = label l``)) [thm] ]
+  end);
+
+val RESTR_NIL_NO_TRANS = store_thm ("RESTR_NIL_NO_TRANS",
+  ``!L u E. ~(TRANS (restr L nil) u E)``,
+    REPEAT STRIP_TAC
+ >> IMP_RES_TAC TRANS_RESTR (* two sub-goals here, but same proofs *)
+ >> IMP_RES_TAC NIL_NO_TRANS);
+
+val TRANS_IMP_NO_RESTR_NIL = store_thm ("TRANS_IMP_NO_RESTR_NIL",
+  ``!E u E'. TRANS E u E' ==> !L. ~(E = restr L nil)``,
+    REPEAT STRIP_TAC
+ >> ASSUME_TAC (REWRITE_RULE [ASSUME ``E = restr L nil``]
+			     (ASSUME ``TRANS E u E'``))
+ >> IMP_RES_TAC RESTR_NIL_NO_TRANS);
+
+val TRANS_RESTR_NO_NIL = store_thm ("TRANS_RESTR_NO_NIL",
+  ``!E L u E'. TRANS (restr L E) u (restr L E') ==> ~(E = nil)``,
+    REPEAT STRIP_TAC
+ >> IMP_RES_TAC TRANS_RESTR
+ >> ASSUME_TAC (REWRITE_RULE [ASSUME ``E = nil``]
+			     (ASSUME ``TRANS E u E''``))
+ >> IMP_RES_TAC NIL_NO_TRANS);
+
+val RESTR_LABEL_NO_TRANS = store_thm ("RESTR_LABEL_NO_TRANS",
+  ``!l L. (l IN L) \/ ((COMPL l) IN L) ==>
+	  (!E u E'. ~(TRANS (restr L (prefix (label l) E)) u E'))``,
+    REPEAT STRIP_TAC (* 2 goals here *)
+ >| [ (* goal 1 *)
+      IMP_RES_TAC TRANS_RESTR >| (* 2 sub-goals here *)
+      [ (* goal 1.1 *)
+	IMP_RES_TAC TRANS_PREFIX \\
+	CHECK_ASSUME_TAC
+	  (REWRITE_RULE [ASSUME ``u = tau``, Action_distinct]
+			(ASSUME ``u = label l``)),
+	(* goal 1.2 *)
+	IMP_RES_TAC TRANS_PREFIX \\
+	CHECK_ASSUME_TAC
+	  (MP (REWRITE_RULE
+		[REWRITE_RULE [ASSUME ``u = label l'``, Action_11]
+			      (ASSUME ``u = label l``)]
+		(ASSUME ``~((l':Label) IN L)``))
+	      (ASSUME ``(l:Label) IN L``)) ],
+      (* goal 2 *)
+      IMP_RES_TAC TRANS_RESTR >| (* 2 sub-goals here *)
+      [ (* goal 2.1 *)
+	IMP_RES_TAC TRANS_PREFIX \\
+	CHECK_ASSUME_TAC
+	  (REWRITE_RULE [ASSUME ``u = tau``, Action_distinct]
+			(ASSUME ``u = label l``)),
+	(* goal 2.2 *)        
+	IMP_RES_TAC TRANS_PREFIX \\
+	CHECK_ASSUME_TAC
+	  (MP (REWRITE_RULE
+		[REWRITE_RULE [ASSUME ``u = label l'``, Action_11]
+			      (ASSUME ``u = label l``)]
+		(ASSUME ``~((COMPL (l':Label)) IN L)``))
+	      (ASSUME ``(COMPL (l:Label)) IN L``)) ] ]);
+
+val RELAB_cases_EQ = save_thm ("RELAB_cases_EQ",
+    GEN_ALL (REWRITE_RULE [CCS_distinct', CCS_11] (SPEC ``relab E rf`` TRANS_cases)));
+
+val RELAB_cases = save_thm ("RELAB_cases", EQ_IMP_LR RELAB_cases_EQ);
+
+val TRANS_RELAB_EQ = store_thm ("TRANS_RELAB_EQ",
+  ``!E rf u E'. TRANS (relab E rf) u E' =
+		(?u' E''. (u = relabel rf u') /\ 
+			  (E' = relab E'' rf) /\ TRANS E u' E'')``,
+    REPEAT GEN_TAC
+ >> EQ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      DISCH_TAC	\\
+      IMP_RES_TAC RELAB_cases \\
+      take [`u'`, `E'''`] >> ASM_REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      STRIP_TAC \\
+      PURE_ONCE_ASM_REWRITE_TAC [] \\
+      RELAB_TAC \\
+      PURE_ONCE_ASM_REWRITE_TAC [] ]);
+
+val TRANS_RELAB = save_thm ("TRANS_RELAB", EQ_IMP_LR TRANS_RELAB_EQ);
+
+val TRANS_RELAB_labl = save_thm ("TRANS_RELAB_labl",
+    GEN_ALL (Q.SPECL [`E`, `RELAB labl`] TRANS_RELAB));
+
+val RELAB_NIL_NO_TRANS = store_thm ("RELAB_NIL_NO_TRANS",
+  ``!rf u E. ~(TRANS (relab nil rf) u E)``,
+    REPEAT STRIP_TAC
+ >> IMP_RES_TAC TRANS_RELAB
+ >> IMP_RES_TAC NIL_NO_TRANS);
+
+(* |- ∀labl' labl.
+     (RELAB labl' = RELAB labl) ⇔ (Apply_Relab labl' = Apply_Relab labl)
+ *)
+val APPLY_RELAB_THM = save_thm ("APPLY_RELAB_THM",
+    GEN_ALL
+      (REWRITE_RULE [GSYM RELAB_def]
+	(MATCH_MP (MATCH_MP ABS_Relabeling_one_one
+			    (Q.SPEC `labl` IS_RELABELING))
+		  (Q.SPEC `labl` IS_RELABELING))));
+
+val REC_cases_EQ = save_thm ("REC_cases_EQ",
+    GENL [``X :string``, ``E :CCS``, ``u :Action``, ``E'' :CCS``]
+	 (SPECL [``u :Action``, ``E'' :CCS``]
+		(REWRITE_RULE [CCS_distinct', CCS_11] (SPEC ``rec X E`` TRANS_cases))));
+
+val REC_cases = save_thm ("REC_cases", EQ_IMP_LR REC_cases_EQ);
+
+val TRANS_REC_EQ = store_thm ("TRANS_REC_EQ",
+  ``!X E u E'. TRANS (rec X E) u E' = TRANS (CCS_Subst E (rec X E) X) u E'``,
+    REPEAT GEN_TAC
+ >> EQ_TAC
+ >| [ (* goal 1 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [REC_cases_EQ] \\
+      REPEAT STRIP_TAC \\
+      PURE_ASM_REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [REC] ]);
+
+val TRANS_REC = save_thm ("TRANS_REC", EQ_IMP_LR TRANS_REC_EQ);
+
+val _ = export_theory ();
+val _ = DB.html_theory "CCS";
+
+(* last updated: May 14, 2017 *)

--- a/examples/CCS/CCSSimps.sig
+++ b/examples/CCS/CCSSimps.sig
@@ -1,0 +1,28 @@
+(*
+ * Copyright 1991-1995  University of Cambridge (Author: Monica Nesi)
+ * Copyright 2016-2017  University of Bologna   (Author: Chun Tian)
+ *)
+
+signature CCSSimps =
+sig
+  include Abbrev
+
+  val PAR1_TAC			: tactic
+  val PAR2_TAC			: tactic
+  val PAR3_TAC			: tactic
+  val PREFIX_TAC		: tactic
+  val REC_TAC			: tactic
+  val RELAB_TAC			: tactic
+  val RESTR_TAC			: tactic
+  val SUM1_TAC			: tactic
+  val SUM2_TAC			: tactic
+  val eqf_elim			: thm -> thm
+
+  val strip_trans		: thm -> (term * term) list
+
+  val CCS_TRANS_CONV		: conv
+  val CCS_TRANS			: term -> thm * (term * term) list
+
+end
+
+(* last updated: May 15, 2017 *)

--- a/examples/CCS/CCSSimps.sml
+++ b/examples/CCS/CCSSimps.sml
@@ -1,0 +1,636 @@
+(*
+ * Copyright 1991-1995  University of Cambridge (Author: Monica Nesi)
+ * Copyright 2016-2017  University of Bologna   (Author: Chun Tian)
+ *)
+
+structure CCSSimps :> CCSSimps =
+struct
+
+open HolKernel Parse boolLib bossLib;
+open IndDefRules;
+open CCSLib CCSTheory CCSSyntax;
+
+(******************************************************************************)
+(*                                                                            *)
+(*        Conversion for computing the transitions of a pure CCS agent        *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Old tactics for proofs about the transition relation TRANS.
+
+   NOT RECOMMENDED. NOTES:
+   - PAR3_TAC has different effects with (MATCH_MP_TAC PAR3),
+   - RESTR_TAC has different effects with (MATCH_MP_TAC RESTR).
+ *)
+val [PREFIX_TAC, SUM1_TAC, SUM2_TAC,
+     PAR1_TAC, PAR2_TAC, PAR3_TAC,
+     RESTR_TAC, RELAB_TAC, REC_TAC] = map RULE_TAC (CONJUNCTS TRANS_rules);
+
+(* Source Level Debugging in Poly/ML
+
+ trace true;
+ PolyML.Compiler.debug := true;
+ open PolyML.Debug;
+ breakIn "CCS_TRANS_CONV";
+
+ clearIn "CCS_TRANS_CONV";
+
+Tracing program execution
+
+    val trace = fn : bool -> unit
+
+Breakpoints
+
+    val breakAt = fn : string * int -> unit
+    val breakIn = fn : string -> unit
+    val breakEx = fn : exn -> unit
+    val clearAt = fn : string * int -> unit
+    val clearIn = fn : string -> unit
+    val clearEx = fn : exn -> unit
+
+Single Stepping and Continuing
+
+    val continue = fn : unit -> unit
+    val step = fn : unit -> unit
+    val stepOver = fn : unit -> unit
+    val stepOut = fn : unit -> unit
+
+Examining and Traversing the Stack
+
+    val up = fn : unit -> unit
+    val down = fn : unit -> unit
+    val dump = fn : unit -> unit
+    val variables = fn : unit -> unit
+ *)
+
+fun eqf_elim thm = let
+    val concl = (rconcl thm) handle HOL_ERR _ => ``F``
+in
+    if concl = ``F`` then
+	STRIP_FORALL_RULE EQF_ELIM thm
+    else
+	thm
+end;
+
+(* Conversion for executing the operational semantics. *)
+local
+    val list2_pair = fn [x, y] => (x, y);
+    val f = (fn c => map (snd o dest_eq) (strip_conj c));
+in
+
+fun strip_trans (thm) = let
+    val concl = (rconcl thm) handle HOL_ERR _ => ``F``
+in
+    if concl = ``F`` then []
+    else
+	map (list2_pair o f) (strip_disj concl)
+end;
+
+fun CCS_TRANS_CONV tm =
+
+(* case 1: nil *)
+  if is_nil tm then
+      NIL_NO_TRANS_EQF
+
+(* case 2: prefix *)
+  else if is_prefix tm then
+      let val (u, P) = args_prefix tm
+      in
+	  SPECL [u, P] TRANS_PREFIX_EQ
+      end
+
+(* case 3: sum *)
+  else if is_sum tm then
+      let val (P1, P2) = args_sum tm;
+	  val thm1 = CCS_TRANS_CONV P1
+	  and thm2 = CCS_TRANS_CONV P2
+      in
+	  REWRITE_RULE [thm1, thm2] (SPECL [P1, P2] TRANS_SUM_EQ')
+      end
+
+(* case 4: restr *)
+  else if is_restr tm then
+      let fun extr_acts [] _ = []
+	    | extr_acts actl L = let
+		val act = hd actl
+	    in
+		if is_tau act then
+		    act :: (extr_acts (tl actl) L)
+		else
+		    let val l = arg_action act;
+			val thml = Label_IN_CONV l L
+		    in
+			if (rconcl thml = ``T``) then
+			    extr_acts (tl actl) L
+			else
+			    let	val thmlc = Label_IN_CONV 
+					      (rconcl (REWRITE_CONV [COMPL_LAB_def] ``COMPL ^l``)) L
+			    in
+				if (rconcl thmlc = ``T``) then
+				    extr_acts (tl actl) L
+				else
+				    act :: (extr_acts (tl actl) L)
+			    end (* val thmlc *)
+		    end (* val l *)
+	    end; (* val act *)
+	  val (P, L) = args_restr tm;
+	  val thm = CCS_TRANS_CONV P
+      in
+	  if (rconcl thm = ``F``) then
+	      prove (``!u E. TRANS ^tm u E = F``,
+(** PROOF BEGIN ***************************************************************)
+    REPEAT GEN_TAC
+ >> EQ_TAC
+ >| [ (* goal 1 *)
+      DISCH_TAC \\
+      IMP_RES_TAC TRANS_RESTR \\
+      IMP_RES_TAC thm,
+      (* goal 2 *)
+      REWRITE_TAC [] ])
+(****************************************************************** Q. E. D. **)
+	  else
+	      let val dl = strip_disj (rconcl thm);
+		  val actl = map (snd o dest_eq o hd o strip_conj o hd o strip_disj) dl;
+		  val actl_not = extr_acts actl L
+	      in
+		  if (null actl_not) then
+		      prove (``!u E. TRANS ^tm u E = F``,
+(** PROOF BEGIN ***************************************************************)
+    REPEAT GEN_TAC >> EQ_TAC
+ >| [ (* goal 1 *)
+      STRIP_TAC \\
+      IMP_RES_TAC TRANS_RESTR >|
+      [ (* goal 1.1 *)
+	IMP_RES_TAC thm >|
+	(list_apply_tac
+	  (fn a => CHECK_ASSUME_TAC
+		     (REWRITE_RULE [ASSUME ``u = tau``, Action_distinct]
+				   (ASSUME ``u = ^a``))) actl),
+	(* goal 1.2 *)
+	IMP_RES_TAC thm >|
+	(list_apply_tac
+	  (fn a => ASSUME_TAC (REWRITE_RULE [ASSUME ``u = label l``, Action_11]
+					    (ASSUME ``u = ^a``)) \\
+		   CHECK_ASSUME_TAC
+		     (REWRITE_RULE [ASSUME ``l = ^(arg_action a)``,
+				    Label_IN_CONV (arg_action a) L]
+				   (ASSUME ``~(l:Label IN ^L)``)) \\
+		   CHECK_ASSUME_TAC
+		     (REWRITE_RULE [ASSUME ``l = ^(arg_action a)``, COMPL_LAB_def,
+				    Label_IN_CONV
+					(rconcl (REWRITE_CONV [COMPL_LAB_def]
+							      ``COMPL ^(arg_action a)``)) L]
+				   (ASSUME ``~((COMPL l:Label) IN ^L)``))) actl) ],
+      (* goal 2 *)
+      REWRITE_TAC [] ])
+(****************************************************************** Q. E. D. **)
+		  else (* actl_not is not empty => the list of pairs lp is not empty as well *)
+		      let fun build_disj lp L =
+			    let val (u, p) = hd lp in
+				if (null (tl lp)) then
+				    mk_conj (``u = ^u``, ``E = ^(mk_restr (p, L))``)
+				else
+				    mk_disj (mk_conj (``u = ^u``, ``E = ^(mk_restr (p, L))``),
+					     build_disj (tl lp) L)
+			    end;
+			  val lp = map (list2_pair o f)
+				       (filter (fn c =>
+						   mem ((snd o dest_eq o hd o strip_conj
+								       o hd o strip_disj) c)
+						       actl_not) dl);
+			  val dsjt = build_disj lp L
+		      in
+			  prove (``!u E. TRANS ^tm u E = ^dsjt``,
+(** PROOF BEGIN ***************************************************************)
+    REPEAT GEN_TAC >> EQ_TAC
+ >| [ (* goal 1 *)
+      DISCH_TAC >> IMP_RES_TAC TRANS_RESTR >|
+      [ (* goal 1.1 *)
+	IMP_RES_TAC thm >|
+	(list_apply_tac
+	  (fn a => CHECK_ASSUME_TAC (REWRITE_RULE [ASSUME ``u = tau``, Action_distinct]
+						  (ASSUME ``u = ^a``)) \\
+		   ASM_REWRITE_TAC []) actl),
+	(* goal 1.2 *)        
+	IMP_RES_TAC thm >|
+	(list_apply_tac
+	  (fn a => if is_tau a then
+	  	       ASSUME_TAC (REWRITE_RULE [ASSUME ``u = label l``, Action_11]
+						(ASSUME ``u = ^a``)) \\
+		       ASM_REWRITE_TAC []
+		   else
+		       ASSUME_TAC (REWRITE_RULE [ASSUME ``u = label l``, Action_11]
+						(ASSUME ``u = ^a``)) \\
+		       CHECK_ASSUME_TAC
+		         (REWRITE_RULE [ASSUME ``l = ^(arg_action a)``,
+					Label_IN_CONV (arg_action a) L]
+				       (ASSUME ``~(l:Label IN ^L)``)) \\
+		       CHECK_ASSUME_TAC
+		         (REWRITE_RULE
+			      [ASSUME ``l = ^(arg_action a)``, COMPL_LAB_def,
+			       Label_IN_CONV
+				 (rconcl (REWRITE_CONV [COMPL_LAB_def] ``COMPL ^(arg_action a)``)) L]
+			      (ASSUME ``~((COMPL l:Label) IN ^L)``)) \\
+		       ASM_REWRITE_TAC []) actl) ],
+      (* goal 2 *)
+      STRIP_TAC >|
+      (list_apply_tac
+        (fn (a, P) =>
+	    REWRITE_TAC [ASSUME ``u = ^a``,
+			 ASSUME ``E = restr ^L ^P``] \\
+	    MATCH_MP_TAC RESTR \\
+            (if is_tau a then
+		 ASM_REWRITE_TAC [thm]
+	     else
+		 EXISTS_TAC (arg_action a) \\
+		 ASM_REWRITE_TAC
+		     [thm, COMPL_LAB_def,
+		      Label_IN_CONV (arg_action a) L,
+		      Label_IN_CONV (rconcl (REWRITE_CONV [COMPL_LAB_def]
+						``COMPL ^(arg_action a)``)) L]))
+	lp) ]) (* prove *)
+(****************************************************************** Q. E. D. **)
+		      end (* let: build_disj *)
+	      end (* let: dl *)
+      end (* let: extr_acts *)
+
+(* case 5: relab *)
+  else if is_relab tm then
+      let val (P, rf) = args_relab tm;
+	  val thm = CCS_TRANS_CONV P
+      in
+	  if (rconcl thm = ``F``) then
+	      prove (``!u E. TRANS ^tm u E = F``,
+(** PROOF BEGIN ***************************************************************)
+    REPEAT GEN_TAC
+ >> EQ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      DISCH_TAC \\
+      IMP_RES_TAC TRANS_RELAB \\
+      IMP_RES_TAC thm,
+      (* goal 2 (of 2) *)
+      REWRITE_TAC [] ])
+(****************************************************************** Q. E. D. **)
+	  else (* ~(rconcl thm = "F") implies  dl is not empty *)
+	      let fun relab_act [] _ = []
+		    | relab_act actl labl = let
+			val act = hd actl;
+			val thm_act =
+			    REWRITE_RHS_RULE [relabel_def, Apply_Relab_def,
+					      Label_distinct, Label_distinct', Label_11,
+					      COMPL_LAB_def, COMPL_COMPL_LAB]
+					     (REFL ``relabel (Apply_Relab ^labl) ^act``);
+			val thm_act' = RELAB_EVAL_CONV (rconcl thm_act)
+		    in
+			(TRANS thm_act thm_act') :: (relab_act (tl actl) labl)
+		    end;
+		  fun build_disj_relab rlp rf =
+		    let val (u, p) = hd rlp
+		    in
+			if (null (tl rlp)) then
+			    mk_conj (``u = ^u``, ``E = ^(mk_relab (p, rf))``)
+			else
+			    mk_disj (mk_conj (``u = ^u``, ``E = ^(mk_relab (p, rf))``),
+				     build_disj_relab (tl rlp) rf)
+		    end;
+		  val dl = strip_disj (rconcl thm);
+		  val actl = map (snd o dest_eq o hd o strip_conj) dl
+		  and labl = arg_relabelling rf;
+		  val thml = relab_act actl labl;
+		  val rlp = combine (map rconcl thml, map (snd o list2_pair o f) dl);
+		  val disjt = build_disj_relab rlp rf
+	      in
+		  prove (``!u E. TRANS ^tm u E = ^disjt``,
+(** PROOF BEGIN ***************************************************************)
+    REPEAT GEN_TAC
+ >> EQ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      DISCH_TAC \\
+      IMP_RES_TAC TRANS_RELAB \\
+      IMP_RES_TAC thm >|
+      (list_apply_tac
+        (fn (a, thm_act) =>
+            REWRITE_TAC [REWRITE_RULE [ASSUME ``u' = ^a``, thm_act]
+			    (REWRITE_RULE [SYM (ASSUME ``RELAB ^labl = RELAB labl``)]
+				(ASSUME ``u = relabel (Apply_Relab labl) u'``))] \\
+	    ASM_REWRITE_TAC [])
+	(combine (actl, thml))),
+      (* goal 2 (of 2) *)
+      STRIP_TAC >|
+      (list_apply_tac 
+        (fn ((a, P), thm_act) =>
+            REWRITE_TAC [ONCE_REWRITE_RULE [SYM thm_act]
+					   (ASSUME ``u = ^a``),
+			 ASSUME ``E = relab ^P ^rf``] \\
+	    RELAB_TAC \\
+	    REWRITE_TAC [thm])
+	(combine (rlp, thml))) ])
+(****************************************************************** Q. E. D. **)
+	      end (* fun relab_act *)
+      end (* val (P, rf) *)
+
+(* case 6: par *)
+  else if is_par tm then
+      let fun build_disj1 dl P =
+	    let val (u, p) = hd dl
+	    in
+		if (null (tl dl)) then
+		    mk_conj (``u = ^u``, ``E = ^(mk_par (p, P))``)
+		else
+		    mk_disj (mk_conj (``u = ^u``, ``E = ^(mk_par (p, P))``),
+			     build_disj1 (tl dl) P)
+	    end;
+	  fun build_disj2 dl P =
+	    let val (u, p) = hd dl
+	    in
+		if (null (tl dl)) then
+		    mk_conj (``u = ^u``, ``E = ^(mk_par (P, p))``)
+		else
+		    mk_disj (mk_conj (``u = ^u``, ``E = ^(mk_par (P, p))``),
+			     build_disj2 (tl dl) P)
+	    end;
+	  fun build_disj_tau _ [] = ``F``
+	    | build_disj_tau  p syncl = let
+		val (_, p') = hd syncl
+	    in
+		mk_disj (mk_conj (``u = tau``, ``E = ^(mk_par (p, p'))``),
+			 build_disj_tau p (tl syncl))
+	    end;
+	  fun act_sync [] _ = []
+	    | act_sync dl1 dl2 = let
+		val (act, p) = hd dl1;
+		val syncl = filter (fn (a, p) =>
+				       a = (if is_tau act then
+						act
+					    else
+						rconcl (REWRITE_CONV [COMPL_ACT_def, COMPL_LAB_def]
+								    ``COMPL_ACT ^act``)))
+				   dl2
+	    in
+		if (null syncl) then
+		    act_sync (tl dl1) dl2
+		else
+                    act :: (act_sync (tl dl1) dl2)
+	    end;
+	  fun build_sync dl1 dl2 =
+	    let val (act, p) = hd dl1;
+		val syncl = filter (fn (a, p) =>
+				       a = (if is_tau act then
+						act
+					    else
+						rconcl (REWRITE_CONV [COMPL_ACT_def, COMPL_LAB_def]
+								    ``COMPL_ACT ^act``)))
+				   dl2
+	    in
+		if (null (tl dl1)) then
+		    build_disj_tau p syncl
+		else
+		    mk_disj (build_disj_tau p syncl, build_sync (tl dl1) dl2)
+	    end;
+	  val (P1, P2) = args_par tm;
+	  val thm1 = CCS_TRANS_CONV P1
+	  and thm2 = CCS_TRANS_CONV P2
+      in
+	  if (rconcl thm1 = ``F``) andalso (rconcl thm2 = ``F``) then
+	      prove (``!u E. TRANS ^tm u E = F``,
+(** PROOF BEGIN ***************************************************************)
+    REPEAT GEN_TAC
+ >> EQ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 *)
+      DISCH_TAC \\
+      IMP_RES_TAC TRANS_PAR >| (* 3 sub-goals here *)
+      [ IMP_RES_TAC thm1, IMP_RES_TAC thm2, IMP_RES_TAC thm1 ],
+      (* goal 2 *)
+      REWRITE_TAC [] ])
+(****************************************************************** Q. E. D. **)
+	  else if (rconcl thm1 = ``F``) then
+	      let val dl2 = map (list2_pair o f) (strip_disj (rconcl thm2));
+		  val actl2 = map fst dl2
+		  and disj_nosync = build_disj2 dl2 P1
+	      in
+		  prove (``!u E. TRANS ^tm u E = ^disj_nosync``,
+(** PROOF BEGIN ***************************************************************)
+    REPEAT GEN_TAC
+ >> EQ_TAC
+ >| [ (* goal 1 (of 2) *)
+      DISCH_TAC \\
+      IMP_RES_TAC TRANS_PAR >| (* 3 sub-goals here *)
+      [ IMP_RES_TAC thm1,
+        IMP_RES_TAC thm2 >> ASM_REWRITE_TAC [],
+        IMP_RES_TAC thm1 ],
+      (* goal 2 (of 2) *)
+      STRIP_TAC >|
+      (list_apply_tac
+        (fn a => ASM_REWRITE_TAC [] >> PAR2_TAC \\
+		 REWRITE_TAC [GEN_ALL thm2]) actl2) ])
+(****************************************************************** Q. E. D. **)
+	      end
+	  else if (rconcl thm2 = ``F``) then
+	      let val dl1 = map (list2_pair o f) (strip_disj (rconcl thm1));
+		  val actl1 = map fst dl1
+		  and disj_nosync = build_disj1 dl1 P2
+	      in
+		  prove (``!u E. TRANS ^tm u E = ^disj_nosync``,
+(** PROOF BEGIN ***************************************************************)
+    REPEAT GEN_TAC
+ >> EQ_TAC
+ >| [ (* goal 1 (of 2) *)
+      DISCH_TAC \\
+      IMP_RES_TAC TRANS_PAR >|
+      [ IMP_RES_TAC thm1 >> ASM_REWRITE_TAC [],
+        IMP_RES_TAC thm2,
+        IMP_RES_TAC thm2 ],
+      (* goal 2 (of 2) *)
+      STRIP_TAC >|
+      (list_apply_tac
+	(fn a => ASM_REWRITE_TAC [] >> PAR1_TAC \\
+		 REWRITE_TAC [GEN_ALL thm1]) actl1) ])
+(****************************************************************** Q. E. D. **)
+	      end
+	  else (* ~(rconcl thm1 = "F") and ~(rconcl thm2 = "F") => dl1 and dl2 are not empty *)
+	      let val [dl1, dl2] = map ((map (list2_pair o f)) o strip_disj o rconcl)
+				       [thm1, thm2];
+		  val [actl1, actl2] = map (map fst) [dl1, dl2]
+		  and disj_nosync = mk_disj (build_disj1 dl1 P2, build_disj2 dl2 P1)
+		  and disj_sync = rconcl (QCONV (REWRITE_CONV []) (build_sync dl1 dl2))
+	      in
+		  if (disj_sync = ``F``) then
+		      prove (``!u E. TRANS ^tm u E = ^disj_nosync``,
+(** PROOF BEGIN ***************************************************************)
+    REPEAT GEN_TAC
+ >> EQ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      DISCH_TAC \\
+      IMP_RES_TAC TRANS_PAR >| (* 3 sub-goals here *)
+      [ IMP_RES_TAC thm1 >> ASM_REWRITE_TAC [],
+        IMP_RES_TAC thm2 >> ASM_REWRITE_TAC [],
+        IMP_RES_TAC thm1 \\
+        IMP_RES_TAC thm2 >|
+        (list_apply_tac
+	  (fn a =>
+	      if is_tau (hd actl1) then
+	      	  IMP_RES_TAC Action_distinct_label
+              else
+		  let val eq = REWRITE_RULE [REWRITE_RULE [Action_11]
+							  (ASSUME ``label l = ^(hd actl1)``),
+					     COMPL_LAB_def]
+					    (ASSUME ``label (COMPL l:Label) = ^a``)
+		  in
+		      CHECK_ASSUME_TAC
+			  (REWRITE_RULE [eq] (Action_EQ_CONV (concl eq)))
+		  end) actl2) ],
+      (* goal 2 (of 2) *)
+      STRIP_TAC >| (* as many as the number of the summands *)
+      (list_apply_tac
+	(fn a => ASM_REWRITE_TAC [] >> PAR1_TAC \\
+		 REWRITE_TAC [GEN_ALL thm1]) actl1) @ 
+      (list_apply_tac
+	(fn a => ASM_REWRITE_TAC [] >> PAR2_TAC \\
+		 REWRITE_TAC [GEN_ALL thm2]) actl2) @
+      (list_apply_tac
+        (fn a => ASM_REWRITE_TAC [] \\
+		 MATCH_MP_TAC PAR3 \\
+		 EXISTS_TAC (arg_action a) \\
+		 REWRITE_TAC [COMPL_LAB_def, GEN_ALL thm1, GEN_ALL thm2])
+        (act_sync dl1 dl2)) ])
+(****************************************************************** Q. E. D. **)
+		  else
+		      prove (``!u E. TRANS ^tm u E = ^(mk_disj (disj_nosync, disj_sync))``,
+(** PROOF BEGIN ***************************************************************)
+    REPEAT GEN_TAC
+ >> EQ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      DISCH_TAC \\
+      IMP_RES_TAC TRANS_PAR >| (* 3 sub-goals here *)
+      [ IMP_RES_TAC thm1 >> ASM_REWRITE_TAC [],
+        IMP_RES_TAC thm2 >> ASM_REWRITE_TAC [],
+        IMP_RES_TAC thm1 >> IMP_RES_TAC thm2 >> ASM_REWRITE_TAC [] ],
+      (* goal 2 (of 2) *)
+      STRIP_TAC >| (* as many as the number of the summands *)
+      (list_apply_tac (* goal 2.1 *)
+	(fn a => ASM_REWRITE_TAC [] >> PAR1_TAC \\
+		 REWRITE_TAC [GEN_ALL thm1]) actl1) @
+      (list_apply_tac (* goal 2.2 *)
+	(fn a => ASM_REWRITE_TAC [] >> PAR2_TAC \\
+		 REWRITE_TAC [GEN_ALL thm2]) actl2) @
+      (list_apply_tac (* goal 2.3 *)
+	(fn a => ASM_REWRITE_TAC [] \\
+		 MATCH_MP_TAC PAR3 \\
+		 EXISTS_TAC (arg_action a) \\
+		 REWRITE_TAC [COMPL_LAB_def, GEN_ALL thm1, GEN_ALL thm2])
+        (act_sync dl1 dl2)) ])
+(****************************************************************** Q. E. D. **)
+	      end (* val [dl1, dl2] *)
+      end (* fun build_disj1 *)
+
+(* case 7: rec *)
+  else if is_rec tm then
+      let val (X, P) = args_rec tm;
+	  val thmS = SIMP_CONV (srw_ss ()) [CCS_Subst_def] ``CCS_Subst ^P ^tm ^X``;
+	  val thm = CCS_TRANS_CONV (rconcl thmS)
+      in
+	  GEN_ALL (REWRITE_CONV [TRANS_REC_EQ, thmS, thm] ``TRANS ^tm u E``)
+      end (* val (X, P) *)
+  else (* no need to distinguish on (rconcl thm) *)
+      failwith "CCS_TRANS_CONV";
+
+(** CCS_TRANS returns both a theorem and a list of CCS transitions **)
+fun CCS_TRANS tm =
+  let val thm = CCS_TRANS_CONV tm;
+      val trans = strip_trans thm
+  in
+      (eqf_elim thm, trans)
+  end;
+
+end; (* local *)
+
+(******************************************************************************)
+(*                                                                            *)
+(*                       Test cases for CCS_TRANS_CONV                        *)
+(*                                                                            *)
+(******************************************************************************)
+(*
+
+ 1. (ν a) (a.0 | `a.0)
+   CCS_TRANS_CONV ``(restr {name "a"}) (label (name "a")..nil || label (coname "a")..nil)``
+
+   |- ∀u E.
+     ν {name "a"} (label (name "a")..nil || label (coname "a")..nil) --u->
+     E ⇔ (u = τ) ∧ (E = ν {name "a"} (nil || nil))
+
+ 2. a.0 | `a.0
+   CCS_TRANS_CONV
+	 ``par (prefix (label (name "a")) nil)
+	       (prefix (label (coname "a")) nil)``
+
+   |- ∀u E.
+     label (name "a")..nil || label (coname "a")..nil --u-> E ⇔
+     ((u = label (name "a")) ∧ (E = nil || label (coname "a")..nil) ∨
+      (u = label (coname "a")) ∧ (E = label (name "a")..nil || nil)) ∨
+     (u = τ) ∧ (E = nil || nil)
+
+ 3. nil | nil
+   CCS_TRANS_CONV ``par nil nil``
+
+   |- ∀u E. nil || nil --u-> E ⇔ F
+
+ 4. (ν a) (nil | nil)
+   CCS_TRANS_CONV ``restr { name "a" } (par nil nil)``
+
+   |- ∀u E. ν {name "a"} (nil || nil) --u-> E ⇔ F:
+
+ 5. a.b.0 + b.a.0
+   CCS_TRANS_CONV ``label (name "a")..label (name "b")..nil +
+		    label (name "b")..label (name "a")..nil``
+
+   |- ∀u E''.
+     label (name "a")..label (name "b")..nil +
+     label (name "b")..label (name "a")..nil
+     --u->
+     E'' ⇔
+     (u = label (name "a")) ∧ (E'' = label (name "b")..nil) ∨
+     (u = label (name "b")) ∧ (E'' = label (name "a")..nil)
+
+ 6. (nu a)(a.0|`a.0) | a.0
+   CCS_TRANS_CONV ``(restr {name "a"} (label (name "a")..nil || label (coname "a")..nil)) ||
+		    (label (name "a")..nil)``
+
+   |- ∀u E.
+     ν {name "a"} (label (name "a")..nil || label (coname "a")..nil) ||
+     label (name "a")..nil
+     --u->
+     E ⇔
+     (u = τ) ∧
+     (E = ν {name "a"} (nil || nil) || label (name "a")..nil) ∨
+     (u = label (name "a")) ∧
+     (E =
+      ν {name "a"} (label (name "a")..nil || label (coname "a")..nil) ||
+      nil)
+
+ 7. CCS_TRANS_CONV
+	``rec "VM" (In "coin"..(In "ask-esp"..rec "VM1" (Out "esp-coffee"..var "VM") +
+			        In "ask-am"..rec "VM2" (Out "am-coffee"..var "VM")))``
+
+   |- ∀u E.
+     rec "VM1"
+       (Out "esp-coffee"
+        ..
+        rec "VM"
+          (In "coin"
+           ..
+           (In "ask-esp"..rec "VM1" (Out "esp-coffee"..var "VM") +
+            In "ask-am"..rec "VM2" (Out "am-coffee"..var "VM"))))
+     --u->
+     E ⇔
+     (u = Out "esp-coffee") ∧
+     (E =
+      rec "VM"
+        (In "coin"
+         ..
+         (In "ask-esp"..rec "VM1" (Out "esp-coffee"..var "VM") +
+          In "ask-am"..rec "VM2" (Out "am-coffee"..var "VM"))))
+ *)
+
+end (* struct *)
+
+(* last updated: May 15, 2017 *)

--- a/examples/CCS/CCSSyntax.sig
+++ b/examples/CCS/CCSSyntax.sig
@@ -1,0 +1,63 @@
+(*
+ * Copyright 1991-1995  University of Cambridge (Author: Monica Nesi)
+ * Copyright 2016-2017  University of Bologna   (Author: Chun Tian)
+ *)
+
+signature CCSSyntax =
+sig
+  include Abbrev
+
+  val args_label		: term -> term * term
+  val arg_name			: term -> term
+  val arg_coname		: term -> term
+  val arg_action		: term -> term
+  val arg_compl			: term -> term
+  val arg_relabelling		: term -> term
+  val arg_ccs_var		: term -> term
+  val args_prefix		: term -> term * term
+  val args_sum			: term -> term * term
+  val args_par			: term -> term * term
+  val args_restr		: term -> term * term
+  val args_relab		: term -> term * term
+  val args_rec			: term -> term * term
+
+  val is_name			: term -> bool
+  val is_coname			: term -> bool
+  val is_label			: term -> bool
+  val is_tau			: term -> bool
+  val is_compl			: term -> bool
+  val is_nil			: term -> bool
+  val is_ccs_var		: term -> bool
+  val is_prefix			: term -> bool
+  val is_sum			: term -> bool
+  val is_par			: term -> bool
+  val is_restr			: term -> bool
+  val is_relab			: term -> bool
+  val is_rec			: term -> bool
+
+  val mk_name			: term -> term
+  val mk_coname			: term -> term
+  val mk_label			: term -> term
+  val mk_ccs_var		: term -> term
+  val mk_prefix			: term * term -> term
+  val mk_sum			: term * term -> term
+  val mk_par			: term * term -> term
+  val mk_restr			: term * term -> term
+  val mk_relab			: term * term -> term
+  val mk_rec			: term * term -> term
+
+  val flat_sum			: term -> term list
+  val ladd			: term -> term list -> term list
+  val FIND_SMD			: term list -> term -> term list -> term -> term list * term list
+  val build_sum			: term list -> term
+  val sum_to_fun		: term list -> term -> term -> term
+
+  val Label_EQ_CONV		: conv
+  val Label_IN_CONV		: term -> conv
+  val Action_EQ_CONV		: conv
+  val Action_IN_CONV		: term -> conv
+  val RELAB_EVAL_CONV		: conv
+
+end
+
+(* last updated: May 14, 2017 *)

--- a/examples/CCS/CCSSyntax.sml
+++ b/examples/CCS/CCSSyntax.sml
@@ -1,0 +1,260 @@
+(*
+ * Copyright 1991-1995  University of Cambridge (Author: Monica Nesi)
+ * Copyright 2016-2017  University of Bologna   (Author: Chun Tian)
+ *)
+
+structure CCSSyntax :> CCSSyntax =
+struct
+
+open HolKernel Parse boolLib bossLib;
+open stringLib PFset_conv;
+open CCSLib CCSTheory;
+
+(******************************************************************************)
+(*                                                                            *)
+(*            Auxiliary ML functions for dealing with CCS syntax              *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Define the destructors related to the constructors of the type Label. *)
+fun args_label l = let
+    val (opn, s) = dest_comb l
+in
+    if (opn = ``name``) orelse (opn = ``coname``)
+    then (opn, s) else (failwith "term not a CCS label")
+end;
+
+fun arg_name l = let
+    val (opn, s) = dest_comb l
+in
+    if (opn = ``name``) then s
+    else (failwith "term not a CCS name")
+end;
+
+fun arg_coname l = let
+    val (opn, s) = dest_comb l
+in
+    if (opn = ``coname``) then s
+    else (failwith "term not a CCS co-name")
+end;
+
+(* Define the destructors related to the constructors of the type Action. *)
+fun arg_action u = let
+    val (opn, l) = dest_comb u
+in 
+    if (opn = ``label``) then l
+    else (failwith "term not a CCS action(label)")
+end;
+
+(* Define the destructor related to the operator COMPL. *)
+fun arg_compl l = let
+    val (opn, x) = dest_comb l
+in
+    if (opn = ``COMPL``) then x
+    else (failwith "term not complement of a CCS label")
+end;
+
+(* Define the destructor related to the type Relabelling. *)
+fun arg_relabelling rf = let
+    val (opn, strl) = dest_comb rf
+in
+    if (opn = ``RELAB``) then strl
+    else (failwith "term not a CCS relabelling")
+end;
+
+(* Define the destructors related to the constructors of the type CCS. *)
+fun arg_ccs_var tm = let
+    val (opn, X) = dest_comb tm
+in
+    if (opn = ``var``) then X
+    else (failwith "term not a CCS variable")
+end;
+
+fun args_prefix tm = let
+    val (opn, [u, P]) = strip_comb tm
+in 
+    if (opn = ``prefix``) then (u, P)
+    else (failwith "term not CCS prefix")
+end;
+
+fun args_sum tm = let
+    val (opn, [P1, P2]) = strip_comb tm
+in
+    if (opn = ``sum``) then (P1, P2)
+    else (failwith "term not CCS summation")
+end;
+
+fun args_par tm = let
+    val (opn, [P1, P2]) = strip_comb tm
+in
+    if (opn = ``par``) then (P1, P2)
+    else (failwith "term not CCS parallel")
+end;
+
+fun args_restr tm = let
+    val (opn, [lset, P]) = strip_comb tm
+in
+    if (opn = ``restr``) then (P, lset)
+    else (failwith "term not CCS restriction")
+end;
+
+fun args_relab tm = let
+    val (opn, [P, f]) = strip_comb tm
+in
+    if (opn = ``relab``) then (P, f)
+    else (failwith "term not CCS relabelling")
+end; 
+
+fun args_rec tm = let
+    val (opn, [X, E]) = strip_comb tm
+in
+    if (opn = ``rec``) then (X, E)
+    else (failwith "term not CCS recursion")
+end;
+
+(* Define predicates related to the destructors above. *)
+val is_name		= can arg_name;
+val is_coname		= can arg_coname;
+val is_label		= can arg_action;
+val is_tau		= fn u => (u = ``tau``);
+val is_compl		= can arg_compl;
+val is_nil		= fn tm => (tm = ``nil``);
+val is_ccs_var		= can arg_ccs_var;
+val is_prefix		= can args_prefix;
+val is_sum		= can args_sum;
+val is_par		= can args_par;
+val is_restr		= can args_restr;
+val is_relab		= can args_relab;
+val is_rec		= can args_rec;
+
+(* Define construction of CCS terms. *)
+fun mk_name    s	= ``name ^s``;
+fun mk_coname  s	= ``coname ^s``;
+fun mk_label   l	= ``label ^l``;
+fun mk_ccs_var X	= ``var ^X``;
+fun mk_prefix (u, P)	= ``prefix ^u ^P``;
+fun mk_sum    (P1, P2)	= ``sum ^P1 ^P2``;
+fun mk_par    (P1, P2)	= ``par ^P1 ^P2``;
+fun mk_restr  (P, lset)	= ``restr ^lset ^P``;
+fun mk_relab  (P, f)	= ``relab ^P ^f``;
+fun mk_rec    (X, E)	= ``rec ^X ^E``;
+
+(* Define flattening of a CCS summation. *)
+fun flat_sum tm =
+  if not (is_sum tm) then [tm]
+  else let val (t1, t2) = args_sum tm in
+	   append (flat_sum t1) (flat_sum t2)
+       end;
+
+fun ladd x l =
+  if (null l) then [x] else [mk_sum (x, hd l)];
+
+local
+    fun helper (prima, mark, dopo, exp) =
+      if (exp = mark) then
+	  (prima, dopo)
+      else if is_sum exp then
+	  let val (a, b) = args_sum exp
+	  in if (b = mark) then ([a], dopo)
+	     else helper (prima, mark, (ladd b dopo), a)
+	  end
+      else (failwith "FIND_SMD")
+in
+    fun FIND_SMD prima mark dopo exp = helper (prima, mark, dopo, exp)
+end;
+
+(* Given a list of terms, the function build_sum builds a CCS term which is
+   the summation of the terms in the list (associating to the right). *)
+fun build_sum nil = ``nil``
+  | build_sum [t] = t
+  | build_sum (t::l) = mk_sum (t, build_sum l);
+
+(* Given a list of summands sumL and an instance ARBtm of the term ARB': CCS,
+   the function sum_to_fun sumL ARBtm n returns a function which associates
+   each summand to its index, starting from index n. *)
+fun sum_to_fun [] ARBtm n = ARBtm
+  | sum_to_fun sumL ARBtm n =
+    ``if (x = ^n) then ^(hd sumL) else ^(sum_to_fun (tl sumL) ARBtm ``SUM ^n``)``;
+
+(******************************************************************************)
+(*                                                                            *)
+(*            Auxiliary ML functions for dealing with CCS syntax              *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Conversion that implements a decision procedure for equality of labels. *)
+fun Label_EQ_CONV lab_eq = let
+    val (l1, l2) = dest_eq lab_eq;
+    val (op1, s1) = args_label l1
+    and (op2, s2) = args_label l2
+in
+    if (op1 = op2) then
+	let val thm = string_EQ_CONV ``^s1 = ^s2`` in 
+	    if (op1 = ``name``) then
+		TRANS (SPECL [s1, s2] (CONJUNCT1 Label_11)) thm
+	    else
+		TRANS (SPECL [s1, s2] (CONJUNCT2 Label_11)) thm
+	end
+    else if (op1 = ``name``) andalso
+	    (op2 = ``coname``) then (* not (op1 = op2) *)
+	SPECL [s1, s2] Label_not_eq (* (op1 = "coname") & (op2 = "name") *)
+    else
+	SPECL [s1, s2] Label_not_eq'
+end;
+
+(* Conversion that proves/disproves membership of a label to a set of labels. *)
+fun Label_IN_CONV l L = IN_CONV Label_EQ_CONV ``^l IN ^L``;
+
+(* Conversion that implements a decision procedure for equality of actions. *)
+fun Action_EQ_CONV act_eq = let
+    val (u1, u2) = dest_eq act_eq
+in
+    if (is_tau u1 andalso is_tau u2) then
+	EQT_INTRO (REFL u1)
+    else if (is_tau u1 andalso is_label u2) then
+	EQF_INTRO (SPEC (arg_action u2) Action_distinct)
+    else if (is_label u1 andalso is_tau u2) then
+	EQF_INTRO (SPEC (arg_action u1) Action_distinct_label)
+    else
+	let val l1 = arg_action u1 (* u1, u2 are both labels *)
+	    and l2 = arg_action u2;
+	    val (op1, s1) = args_label l1 
+	    and (op2, s2) = args_label l2
+	    and thm = Label_EQ_CONV ``^l1 = ^l2``
+	in
+	    if (op1 = op2) then
+		if (op1 = ``name``) then
+		    TRANS (SPECL [``name ^s1``, ``name ^s2``] Action_11) thm
+		else
+		    TRANS (SPECL [``coname ^s1``, ``coname ^s2``] Action_11) thm
+	    else if (op1 = ``name``) andalso (op2 = ``coname``) then (* not (op1 = op2) *)
+		TRANS (SPECL [``name ^s1``, ``coname ^s2``] Action_11)
+		      (SPECL [s1, s2] Label_not_eq)
+	    else (* (op1 = "coname") & (op2 = "name") *)
+		TRANS (SPECL [``coname ^s1``, ``name ^s2``] Action_11)
+		      (SPECL [s1, s2] Label_not_eq')
+	end
+end;
+
+(* Conversion that proves/disproves membership of an action to a set of actions. *)
+fun Action_IN_CONV u A = IN_CONV Action_EQ_CONV ``^u IN ^A``;
+
+(* Conversion for evaluating a relabelling function fc (in conditional form). *)
+fun RELAB_EVAL_CONV fc = let
+    val c = snd (dest_comb fc)
+in
+    if is_cond c then
+	let val (b, l, r) = dest_cond c;
+	    val (s1, s2) = dest_eq b;
+	    val thm = string_EQ_CONV ``^s1 = ^s2``;
+	    val thm' = REWRITE_RHS_RULE [thm] (REFL fc)
+	in
+	    TRANS thm' (RELAB_EVAL_CONV (rconcl thm'))
+	end
+    else
+	REFL fc
+end;
+
+end (* struct *)
+
+(* last updated: May 14, 2017 *)

--- a/examples/CCS/ExampleScript.sml
+++ b/examples/CCS/ExampleScript.sml
@@ -1,0 +1,444 @@
+(*
+ * Copyright 2016-2017  University of Bologna   (Author: Chun Tian)
+ *)
+
+open HolKernel Parse boolLib bossLib;
+
+open listTheory stringTheory pred_setTheory relationTheory;
+open CCSLib CCSTheory CCSSyntax CCSSimps;
+open StrongEQTheory StrongEQLib StrongLawsTheory WeakEQTheory;
+
+val _ = new_theory "Example";
+
+(******************************************************************************)
+(*                                                                            *)
+(*                     The coffee machine model                               *)
+(*                                                                            *)
+(******************************************************************************)
+
+val VM = ``rec "VM" (In "coin"..(In "ask-esp"..rec "VM1" (Out "esp-coffee"..var "VM") +
+				 In "ask-am"..rec "VM2" (Out "am-coffee"..var "VM")))``;
+
+(* ex1 =
+|- label (name "a")..label (name "b")..nil +
+   label (name "b")..label (name "a")..nil
+   -label (name "a")->
+   label (name "b")..nil
+ *)
+local
+    val t1 = SPEC ``label (name "a")`` (SPEC ``prefix (label (name "b")) nil`` PREFIX)
+    and t2 = SPECL [``prefix (label (name "a")) (prefix (label (name "b")) nil)``,
+		    ``label (name "a")``,
+		    ``prefix (label (name "b")) nil``,
+		    ``prefix (label (name "b")) (prefix (label (name "a")) nil)``]
+		   SUM1;
+in
+    val ex1 = save_thm ("ex1", MP t2 t1)
+end;
+
+local
+    val t1 = SPECL [``prefix (label (name "b")) nil``, ``label (name "a")``] PREFIX;
+    val t2 = MATCH_MP SUM1 t1
+in
+    val ex1' = save_thm ("ex1'", SPEC ``prefix (label (name "b")) (prefix (label (name "a")) nil)`` t2)
+end;
+
+(* (a.b.0 + b.a.0) --a-> (b.0) *)
+val ex1'' = store_thm ("ex1''",
+  ``TRANS (In "a"..In "b"..nil + In "b"..In "a"..nil)
+	  (In "a")
+	  (In "b"..nil)``,
+    MATCH_MP_TAC SUM1
+ >> rw [PREFIX]);
+
+(* (a.b.0 + b.a.0) --b-> (a.0) *)
+val ex2 = store_thm ("ex2",
+  ``TRANS (sum (prefix (label (name "a")) (prefix (label (name "b")) nil))
+               (prefix (label (name "b")) (prefix (label (name "a")) nil)))
+	  (label (name "b"))
+	  (prefix (label (name "a")) nil)``,
+    MATCH_MP_TAC SUM2
+ >> REWRITE_TAC [PREFIX]);
+
+(* prove: (nu c)(a.c.0 | (`a.0 + c.0)) --tau-> (nu c)(c.0 | 0), using TRANS rules:
+   PREFIX, SUM1, SUM2, PAR1, PAR2, PAR3, RESTR *)
+val ex3 = store_thm ("ex3",
+  ``TRANS (restr { name "c" }
+		 (par (prefix (label (name "a"))
+			      (prefix (label (name "c")) nil))
+		      (sum (prefix (label (coname "a")) nil)
+			   (prefix (label (name "c")) nil))))
+	  tau
+	  (restr { name "c" }
+		 (par (prefix (label (name "c")) nil) nil))``,
+    MATCH_MP_TAC RESTR
+ >> RW_TAC std_ss []
+ >> MATCH_MP_TAC PAR3
+ >> EXISTS_TAC ``name "a"``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >- REWRITE_TAC [PREFIX]
+ >> MATCH_MP_TAC SUM1
+ >> REWRITE_TAC [PREFIX, COMPL_LAB_def]);
+
+(* prove: (nu c)(a.c.0 | (b.0+c.0)) --b-> (nu c)(a.c.0|0) *)
+val ex4 = store_thm ("ex4",
+  ``TRANS (restr { name "c" }
+		 (par (prefix (label (name "a"))
+			      (prefix (label (name "c")) nil))
+		      (sum (prefix (label (name "b")) nil)
+			   (prefix (label (name "c")) nil))))
+	  (label (name "b"))
+	  (restr { name "c" }
+		 (par (prefix (label (name "a"))
+			      (prefix (label (name "c")) nil))
+		      nil))``,
+    MATCH_MP_TAC RESTR
+ >> RW_TAC std_ss [CHR_11, COMPL_LAB_def, IN_SING]
+ >> MATCH_MP_TAC PAR2
+ >> MATCH_MP_TAC SUM1
+ >> REWRITE_TAC [PREFIX]);
+
+(* prove: (a.0 | `a.0)|0 --tau-> (0|0)|0 *)
+val ex5 = store_thm ("ex5",
+  ``TRANS (par (par (prefix (label (name "a")) nil)
+		    (prefix (label (coname "a")) nil))
+	       nil)
+	  tau
+          (par (par nil nil) nil)``,
+    MATCH_MP_TAC PAR1
+ >> MATCH_MP_TAC PAR3
+ >> EXISTS_TAC ``name "a"``
+ >> RW_TAC std_ss [COMPL_LAB_def] (* two sub-goals *)
+ >| [ REWRITE_TAC [PREFIX],
+      REWRITE_TAC [PREFIX] ]);
+
+(* prove: (nu c)(a.c.0 | b.0) --tau-> (nu c)(c.0 | 0) is not derivable *)
+val ex6 = store_thm ("ex6",
+  ``~TRANS (restr { name "c" }
+		  (par (prefix (label (name "a"))
+			       (prefix (label (name "c")) nil))
+		       (prefix (label (name "b")) nil)))
+	   tau
+	   (restr { name "c" }
+		  (par (prefix (label (name "c")) nil) nil))``,
+    ONCE_REWRITE_TAC [TRANS_cases] (* step 1: remove outside restr *)
+ >> RW_TAC std_ss [CCS_distinct]
+ >> ONCE_REWRITE_TAC [TRANS_cases] (* step 2: remove par *)
+ >> RW_TAC std_ss [CCS_distinct]
+ >> Q.SPEC_TAC (`l`, `l`)
+ >> Cases_on `l` (* 2 sub-goals divided by names and conames of `l` *)
+ >| [ DISJ2_TAC \\
+      ONCE_REWRITE_TAC [TRANS_cases] \\
+      RW_TAC std_ss [CCS_distinct, COMPL_LAB_def, Label_distinct],
+      REWRITE_TAC [COMPL_LAB_def] \\
+      DISJ1_TAC \\
+      ONCE_REWRITE_TAC [TRANS_cases] \\
+      RW_TAC std_ss [CCS_distinct, COMPL_LAB_def, Label_distinct] ]);
+
+(* prove: (nu a)(a.0 | `a.0) --a-> (nu a)(0 | `a.0) is not derivable *)
+val ex7 = store_thm ("ex7",
+  ``~TRANS (restr { name "a" }
+		  (par (prefix (label (name "a")) nil)
+		       (prefix (label (coname "a")) nil)))
+	   (label (name "a"))
+	   (restr { name "a" }
+		  (par nil (prefix (label (coname "a")) nil)))``,
+    ONCE_REWRITE_TAC [TRANS_cases] (* step 1: remove outside restr *)
+ >> RW_TAC std_ss [CCS_distinct]
+ >> RW_TAC std_ss [COMPL_LAB_def, IN_SING]);
+
+(* A root of unknown LTS, (a.nil | `a.nil) *)
+val r1 = ``par (prefix (label (name "a")) nil) (prefix (label (coname "a")) nil)``;
+
+val r1_has_trans = store_thm ("r1_has_trans", ``?l G. TRANS ^r1 l G``,
+    ONCE_REWRITE_TAC [TRANS_cases]
+ >> RW_TAC std_ss [CCS_distinct]
+ >> ONCE_REWRITE_TAC [TRANS_cases]
+ >> RW_TAC std_ss [CCS_distinct, COMPL_LAB_def]
+(* 3 possible cases here:
+∃l G.
+  (G = par nil (prefix (label (coname "a")) nil)) ∧ (label (name "a") = l) ∨
+  (G = par (prefix (label (name "a")) nil) nil) ∧ (label (coname "a") = l) ∨
+  (l = tau) ∧ (G = par nil nil)
+*)
+ >> EXISTS_TAC ``tau``
+ >> EXISTS_TAC ``par nil nil``
+ >> RW_TAC std_ss []);
+
+(* above theorem indicates three possible transitions from r1 *)
+val r1_s1 = ``par nil (prefix (label (coname "a")) nil)``; (* with label a *)
+val r1_s2 = ``par (prefix (label (name "a")) nil) nil``;   (* with label co_a *)
+val r1_s3 = ``par nil nil``;				   (* with label tau *)
+
+(* two commonly used labels *)
+val a    = ``label (name "a")``;
+val co_a = ``label (coname "a")``;
+
+(* proofs for three possible transitions *)
+val r1_trans_1 = store_thm ("r1_trans_1", ``TRANS ^r1 ^a ^r1_s1``,
+    MATCH_MP_TAC PAR1
+ >> REWRITE_TAC [PREFIX]);
+
+val r1_trans_2 = store_thm ("r1_trans_2", ``TRANS ^r1 ^co_a ^r1_s2``,
+    MATCH_MP_TAC PAR2
+ >> REWRITE_TAC [PREFIX]);
+
+val r1_trans_3 = store_thm ("r1_trans_3", ``TRANS ^r1 tau ^r1_s3``,
+    MATCH_MP_TAC PAR3
+ >> EXISTS_TAC ``name "a"``
+ >> REWRITE_TAC [PREFIX, COMPL_LAB_def]);
+
+(* finally, there's a proof showing that no other transitions are possible *)
+val r1_has_no_other_trans = store_thm (
+   "r1_has_no_other_trans",
+  ``~?l G. ~((G = ^r1_s1) /\ (l = ^a) \/
+	     (G = ^r1_s2) /\ (l = ^co_a) \/
+	     (G = ^r1_s3) /\ (l = tau)) /\ TRANS ^r1 l G``,
+    ONCE_REWRITE_TAC [TRANS_cases]
+ >> RW_TAC std_ss [CCS_distinct]
+ >> ONCE_REWRITE_TAC [TRANS_cases]
+ >> RW_TAC std_ss [CCS_distinct, COMPL_LAB_def]
+ >> METIS_TAC []);
+
+(* then we have to prove both s1 and s2 have single transition to this last status *)
+local
+    val t = ONCE_REWRITE_TAC [TRANS_cases] \\
+	    RW_TAC std_ss [CCS_distinct] \\
+	    ONCE_REWRITE_TAC [TRANS_cases] \\
+	    RW_TAC std_ss [CCS_distinct] \\
+	    METIS_TAC []
+in
+    val r1_s1_has_trans = store_thm ("r1_s1_has_trans", ``?l G. TRANS ^r1_s1 l G``, t)
+    and r1_s2_has_trans = store_thm ("r1_s1_has_trans", ``?l G. TRANS ^r1_s2 l G``, t)
+    and r1_s1_has_no_other_trans = store_thm (
+       "r1_s1_has_no_other_trans",
+      ``~?l G. ~((G = par nil nil) /\ (l = ^co_a)) /\ TRANS ^r1_s1 l G``, t)
+    and r1_s2_has_no_other_trans = store_thm (
+       "r1_s2_has_no_other_trans",
+      ``~?l G. ~((G = par nil nil) /\ (l = ^a)) /\ TRANS ^r1_s2 l G``, t)
+end;
+
+val par_nils_no_trans = store_thm (
+   "par_nils_no_trans", ``!l G. ~TRANS (par nil nil) l G``,
+    ONCE_REWRITE_TAC [TRANS_cases]
+ >> RW_TAC std_ss [CCS_distinct] (* 3 sub-goals sharing the same tacticals *)
+ >> ONCE_REWRITE_TAC [TRANS_cases]
+ >> RW_TAC std_ss [CCS_distinct, COMPL_LAB_def, Label_distinct]);
+
+val r2 = ``restr { name "a" }
+		 (par (prefix (label (name "a")) nil)
+		      (prefix (label (coname "a")) nil))``;
+
+val r2_has_trans = store_thm ("r2_has_trans", ``?l G. TRANS ^r2 l G``,
+    ONCE_REWRITE_TAC [TRANS_cases]
+ >> RW_TAC std_ss [CCS_distinct]	(* restr removed *)
+ >> ONCE_REWRITE_TAC [TRANS_cases]
+ >> RW_TAC std_ss [CCS_distinct]	(* par rewrited into 3 possible cases *)
+ >> ONCE_REWRITE_TAC [TRANS_cases]
+ >> RW_TAC std_ss [CCS_distinct, Label_distinct, COMPL_LAB_def]
+(*
+∃l E' l'.
+  ((E' = par nil (prefix (label (coname "a")) nil)) ∧
+   (label (name "a") = l) ∨
+   (E' = par (prefix (label (name "a")) nil) nil) ∧
+   (label (coname "a") = l) ∨ (l = tau) ∧ (E' = par nil nil)) ∧
+  ((l = tau) ∨ (l = label l') ∧ l' ∉ {name "a"} ∧ COMPL l' ∉ {name "a"})
+*)
+ >> EXISTS_TAC ``tau``		(* for l *)
+ >> EXISTS_TAC ``par nil nil``	(* for G *)
+ >> RW_TAC std_ss [Label_distinct]);
+
+(* above theorem indicates that (G = par nil nil) and (l = tau) are the only solution
+   (with restrictions on G), now we prove that (G = restr (par nil nil) { name "a" })
+   and (l = tau) are the actual transition. *)
+val r2_trans = store_thm ("r2_trans",
+  ``TRANS ^r2 tau (restr { name "a" } (par nil nil) )``,
+    MATCH_MP_TAC RESTR
+ >> RW_TAC std_ss [Label_distinct]
+ >> MATCH_MP_TAC PAR3
+ >> EXISTS_TAC ``name "a"``
+ >> REWRITE_TAC [PREFIX, COMPL_LAB_def]);
+
+(* above theorem indicates that (G = par nil nil) and (l = tau) are the only solution
+   (after removing the restr), now we prove there's no others. It's incredibly hard! *)
+val r2_has_no_other_trans = store_thm (
+   "r2_has_no_other_trans",
+  ``~?l G. ~((l = tau) /\ (G = restr { name "a" } (par nil nil))) /\ TRANS ^r2 l G``,
+    CCONTR_TAC
+ >> POP_ASSUM (MP_TAC o (ONCE_REWRITE_RULE [DECIDE ``!t:bool. ~ ~t = t``]))
+ >> PURE_ONCE_REWRITE_TAC [TRANS_cases]
+ >> DISCH_TAC
+ >> FULL_SIMP_TAC std_ss [CCS_distinct, CCS_11] (* 4 sub-goals here, first one is easy *)
+ >- RW_TAC std_ss [] (* rest 3 sub-goals *)
+ >| [ (* case 1 *)
+      PAT_X_ASSUM ``TRANS E l E'`` (ASSUME_TAC o (ONCE_REWRITE_RULE [TRANS_cases])) \\
+      FULL_SIMP_TAC std_ss [CCS_distinct, CCS_11] (* 3 sub-goals here, last one is easy *)
+      >| [ (* case 1.1 *)
+	   POP_ASSUM (ASSUME_TAC o (ONCE_REWRITE_RULE [TRANS_cases])) \\
+	   FULL_SIMP_TAC std_ss [CCS_distinct, CCS_11] \\
+	   `l' = name "a"` by PROVE_TAC [Action_11] \\
+	   PROVE_TAC [IN_SING],
+	   (* case 1.2 *)
+	   POP_ASSUM (ASSUME_TAC o (ONCE_REWRITE_RULE [TRANS_cases])) \\
+	   FULL_SIMP_TAC std_ss [CCS_distinct, CCS_11] \\
+	   `l' = coname "a"` by PROVE_TAC [Action_11] \\
+	   `COMPL l' = name "a"` by PROVE_TAC [COMPL_LAB_def] \\
+	   PROVE_TAC [IN_SING],
+	   (* case 1.3 *)
+	   PROVE_TAC [Action_11] ],
+      (* case 2 *)
+      PAT_X_ASSUM ``TRANS E l E'`` (ASSUME_TAC o (ONCE_REWRITE_RULE [TRANS_cases])) \\
+      FULL_SIMP_TAC std_ss [CCS_distinct, CCS_11] (* 3 sub-goals here *)
+      >| [ (* case 2.1 *)
+	   POP_ASSUM (ASSUME_TAC o (ONCE_REWRITE_RULE [TRANS_cases])) \\
+	   FULL_SIMP_TAC std_ss [CCS_distinct, CCS_11] \\
+	   PROVE_TAC [Action_distinct],
+	   (* case 2.2 *)
+	   POP_ASSUM (ASSUME_TAC o (ONCE_REWRITE_RULE [TRANS_cases])) \\
+	   FULL_SIMP_TAC std_ss [CCS_distinct, CCS_11] \\
+	   PROVE_TAC [Action_distinct],
+	   (* case 2.3 *)
+	   POP_ASSUM (MP_TAC o (ONCE_REWRITE_RULE [TRANS_cases])) \\
+	   FULL_SIMP_TAC std_ss [CCS_distinct, CCS_11] \\
+	   POP_ASSUM (MP_TAC o (ONCE_REWRITE_RULE [TRANS_cases])) \\
+	   FULL_SIMP_TAC std_ss [CCS_distinct, CCS_11] ],
+      (* case 3 *)
+      PAT_X_ASSUM ``TRANS E l E'`` (ASSUME_TAC o (ONCE_REWRITE_RULE [TRANS_cases])) \\
+      FULL_SIMP_TAC std_ss [CCS_distinct, CCS_11] (* 3 sub-goals here, last one is easy *)
+      >| [ (* case 3.1 *)
+	   POP_ASSUM (ASSUME_TAC o (ONCE_REWRITE_RULE [TRANS_cases])) \\
+	   FULL_SIMP_TAC std_ss [CCS_distinct, CCS_11] \\
+	   `l' = name "a"` by PROVE_TAC [Action_11] \\
+	   PROVE_TAC [IN_SING],
+	   (* case 3.2 *)
+	   POP_ASSUM (ASSUME_TAC o (ONCE_REWRITE_RULE [TRANS_cases])) \\
+	   FULL_SIMP_TAC std_ss [CCS_distinct, CCS_11] \\
+	   `l' = coname "a"` by PROVE_TAC [Action_11] \\
+	   `COMPL l' = name "a"` by PROVE_TAC [COMPL_LAB_def] \\
+	   PROVE_TAC [IN_SING],
+	   (* case 3.3 *)
+	   PROVE_TAC [Action_distinct] ] ]);
+
+(* (nu a)(0 | 0) *)
+val r2_final = ``restr { name "a" } (par nil nil)``;
+
+val r2_final_no_trans = store_thm (
+   "r2_final_no_trans", ``!l G. ~TRANS ^r2_final l G``,
+    ONCE_REWRITE_TAC [TRANS_cases]
+ >> RW_TAC std_ss [CCS_distinct, CCS_11]
+ >> SIMP_TAC std_ss [par_nils_no_trans]);
+
+(* we define r3 on top of r2 *)
+val r3 = ``par ^r2 (prefix (label (name "a")) nil)``;
+
+(* for two transitions from r3, we construct the transitions in forward way, using previous results *)
+
+(* r3_trans_1 =
+   |- TRANS
+     (par
+        (restr {name "a"}
+           (par (prefix (label (name "a")) nil)
+              (prefix (label (coname "a")) nil)))
+        (prefix (label (name "a")) nil))
+     (label (name "a"))
+     (par
+        (restr {name "a"}
+           (par (prefix (label (name "a")) nil)
+              (prefix (label (coname "a")) nil))) nil):
+ r3_trans_2' =
+   |- TRANS
+     (par (restr {name "a"} (par nil nil))
+        (prefix (label (name "a")) nil))
+     (label (name "a"))
+     (par (restr {name "a"} (par nil nil)) nil)
+ *)
+local
+    val t1 = SPECL [``nil``, ``label (name "a")``] PREFIX;
+    val t2 = MATCH_MP PAR2 t1;
+in
+    val r3_trans_1 = SPEC r2 t2
+    and r3_trans_2' = SPEC r2_final t2
+end;
+
+(* r3_trans_1' =
+   |- TRANS
+     (par
+        (restr {name "a"}
+           (par (prefix (label (name "a")) nil)
+              (prefix (label (coname "a")) nil))) nil)
+     tau
+     (par (restr {name "a"} (par nil nil)) nil)
+
+   r3_trans_2 =
+   |- TRANS
+     (par
+        (restr {name "a"}
+           (par (prefix (label (name "a")) nil)
+              (prefix (label (coname "a")) nil)))
+        (prefix (label (name "a")) nil))
+     tau
+     (par (restr {name "a"} (par nil nil))
+        (prefix (label (name "a")) nil))
+ *)
+local
+    val t1 = MATCH_MP PAR1 r2_trans;
+in
+    val r3_trans_1' = SPEC ``nil`` t1;
+    val r3_trans_2 = SPEC ``prefix (label (name "a")) nil`` t1;
+end;
+
+(******************************************************************************)
+(*                                                                            *)
+(*           Re-worked exercises using the new CCS_TRANS function             *)
+(*                                                                            *)
+(******************************************************************************)
+
+local
+    val (temp_A, trans) = CCS_TRANS ``label (name "a")..nil || label (coname "a")..nil``;
+    val nodes = map (fn (l, s) => CCS_TRANS s) trans;
+in
+  val ex_A = save_thm ("ex_A", temp_A);
+  val [ex_A1, ex_A2, ex_A3] = map (fn (n, (thm, _)) => save_thm (n, thm))
+				(combine (["ex_A1", "ex_A2", "ex_A3"], nodes))
+end;
+
+local
+    val (temp_B, trans) = CCS_TRANS ``restr {name "a"} (label (name "a")..nil || label (coname "a")..nil)``;
+    val nodes = map (fn (l, s) => CCS_TRANS s) trans;
+in
+  val ex_B = save_thm ("ex_B", temp_B);
+  val [ex_B0] = map (fn (n, (thm, _)) => save_thm (n, thm))
+		    (combine (["ex_B0"], nodes))
+end;
+
+local
+    val (temp_C, trans) =
+	CCS_TRANS ``(restr {name "a"} (label (name "a")..nil || label (coname "a")..nil)) ||
+		    (label (name "a")..nil)``;
+    val nodes = map (fn (l, s) => CCS_TRANS s) trans;
+in
+  val ex_C = save_thm ("ex_C", temp_C);
+  val [ex_C1, ex_C2] = map (fn (n, (thm, _)) => save_thm (n, thm))
+			   (combine (["ex_C1", "ex_C2"], nodes))
+end;
+
+val _ = export_theory ();
+val _ = DB.html_theory "Example";
+
+(* Emit theory books in TeX *)
+if (OS.FileSys.isDir "../papers" handle e => false) then
+    let in
+	OS.FileSys.remove "../papers/references.tex" handle e => {};
+	OS.FileSys.remove "../papers/HOLCCS.tex" handle e => {};
+	OS.FileSys.remove "../papers/HOLStrongEQ.tex" handle e => {};
+	OS.FileSys.remove "../papers/HOLStrongLaws.tex" handle e => {};
+	OS.FileSys.remove "../papers/HOLWeakEQ.tex" handle e => {};
+	OS.FileSys.remove "../papers/HOLExample.tex" handle e => {};
+
+	EmitTeX.print_theories_as_tex_doc
+	    ["CCS", "StrongEQ", "StrongLaws", "WeakEQ", "Example"] "../papers/references"
+    end
+else
+    {};
+
+(* last updated: May 14, 2017 *)

--- a/examples/CCS/StrongEQLib.sig
+++ b/examples/CCS/StrongEQLib.sig
@@ -1,0 +1,31 @@
+(*
+ * Copyright 1991-1995  University of Cambridge (Author: Monica Nesi)
+ * Copyright 2016-2017  University of Bologna   (Author: Chun Tian)
+ *)
+
+signature StrongEQLib =
+sig
+  include Abbrev
+
+  val S_SYM			: thm -> thm
+  val S_TRANS			: thm -> thm -> thm
+  val S_ALL_CONV		: conv
+  val S_THENC			: conv * conv -> conv
+  val S_ORELSEC			: conv * conv -> conv
+  val S_REPEATC			: conv -> conv
+  val S_LHS_CONV_TAC		: conv -> tactic
+  val S_RHS_CONV_TAC		: conv -> tactic
+  val S_SUB_CONV		: conv -> conv
+  val S_TOP_DEPTH_CONV		: conv -> conv
+  val S_DEPTH_CONV		: conv -> conv
+  val S_SUBST			: thm -> term -> thm
+  val S_LHS_SUBST1_TAC		: thm -> tactic
+  val S_LHS_SUBST_TAC		: thm list -> tactic
+  val S_RHS_SUBST1_TAC		: thm -> tactic
+  val S_RHS_SUBST_TAC		: thm list -> tactic
+  val S_SUBST1_TAC		: thm -> tactic
+  val S_SUBST_TAC		: thm list -> tactic
+
+end
+
+(* last updated: May 14, 2017 *)

--- a/examples/CCS/StrongEQLib.sml
+++ b/examples/CCS/StrongEQLib.sml
@@ -1,0 +1,233 @@
+(*
+ * Copyright 1991-1995  University of Cambridge (Author: Monica Nesi)
+ * Copyright 2016-2017  University of Bologna   (Author: Chun Tian)
+ *)
+
+structure StrongEQLib :> StrongEQLib =
+struct
+
+open HolKernel Parse boolLib bossLib;
+open stringLib PFset_conv IndDefRules;
+open CCSLib CCSTheory CCSSyntax
+open StrongEQTheory;
+
+infixr 0 S_THENC S_ORELSEC;
+
+(******************************************************************************)
+(*                                                                            *)
+(*        Basic functions and conversions for rewriting with                  *)
+(*          the CCS laws for strong equivalence (basic_fun.ml)                *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Define S_SYM such that, when given a theorem A |- STRONG_EQUIV t1 t2,
+   returns the theorem A |- STRONG_EQUIV t2 t1. *)
+fun S_SYM thm = MATCH_MP STRONG_EQUIV_SYM thm;
+
+(* Define S_TRANS such that, when given the theorems thm1 and thm2, applies
+   STRONG_EQUIV_TRANS on them, if possible. *)
+fun S_TRANS thm1 thm2 =
+    if rhs_tm thm1 = lhs_tm thm2 then
+       MATCH_MP STRONG_EQUIV_TRANS (CONJ thm1 thm2)
+    else
+       failwith "transitivity of strong equivalence not applicable";
+
+(* When applied to a term "t: CCS", the conversion S_ALL_CONV returns the
+   theorem: |- STRONG_EQUIV t t *)
+fun S_ALL_CONV t = SPEC t STRONG_EQUIV_REFL;
+
+fun op S_THENC ((c1, c2) :conv * conv) :conv =
+  fn t => let
+      val thm1 = c1 t;
+      val thm2 = c2 (rhs_tm thm1)
+  in
+      S_TRANS thm1 thm2
+  end;
+
+fun op S_ORELSEC ((c1, c2) :conv * conv) :conv =
+  fn t => c1 t handle HOL_ERR _ => c2 t;
+
+fun S_REPEATC (c :conv) (t :term) :thm =
+  ((c S_THENC (S_REPEATC c)) S_ORELSEC S_ALL_CONV) t;
+
+(* Convert a conversion for the application of the laws for STRONG_EQUIV to a tactic. *)
+fun S_LHS_CONV_TAC (c :conv) :tactic =
+  fn (asl, w) => let
+      val (opt, t1, t2) = args_equiv w
+  in
+      if (opt = ``STRONG_EQUIV``) then
+	  let val thm = c t1;
+	      val (t1', t') = args_thm thm (* t1' = t1 *)
+	  in
+	      if (t' = t2) then
+		  ([], fn [] => S_TRANS thm (SPEC t' STRONG_EQUIV_REFL))
+	      else
+		  ([(asl, ``STRONG_EQUIV ^t' ^t2``)],
+		   fn [thm'] => S_TRANS thm thm')
+	  end
+      else
+	  failwith "the goal is not a STRONG_EQUIV relation"
+  end;
+
+fun S_RHS_CONV_TAC (c : conv) : tactic =
+  fn (asl, w) => let 
+      val (opt, t1, t2) = args_equiv w
+  in
+      if (opt = ``STRONG_EQUIV``) then
+	  let val thm = c t2;
+	      val (t2', t'') = args_thm thm (* t2' = t2 *)
+	  in
+	      if (t'' = t1) then
+		  ([], fn [] => S_SYM thm)
+	      else
+		  ([(asl, ``STRONG_EQUIV ^t1 ^t''``)],
+		   fn [thm'] => S_TRANS thm' (S_SYM thm))
+	  end
+      else
+	  failwith "the goal is not a STRONG_EQUIV relation"
+  end;
+
+(******************************************************************************)
+(*                                                                            *)
+(* Basic conversions and tactics for applying the laws for strong equivalence *)
+(*                                                                            *)
+(******************************************************************************)
+
+fun S_SUB_CONV (c :conv) tm =
+  if is_prefix tm then
+      let val (u, P) = args_prefix tm;
+	  val thm = c P
+      in
+	  SPEC u (MATCH_MP STRONG_EQUIV_SUBST_PREFIX thm)
+      end
+  else if is_sum tm then
+      let val (t1, t2) = args_sum tm;
+	  val thm1 = c t1
+	  and thm2 = c t2
+      in
+	  MATCH_MP STRONG_EQUIV_PRESD_BY_SUM (CONJ thm1 thm2)
+      end
+  else if is_par tm then
+      let val (t1, t2) = args_par tm;
+	  val thm1 = c t1
+	  and thm2 = c t2
+      in
+	  MATCH_MP STRONG_EQUIV_PRESD_BY_PAR (CONJ thm1 thm2)
+      end
+  else if is_restr tm then
+      let val (P, L) = args_restr tm;
+	  val thm = c P
+      in
+	  SPEC L (MATCH_MP STRONG_EQUIV_SUBST_RESTR thm)
+      end
+  else if is_relab tm then
+      let val (P, rf) = args_relab tm;
+	  val thm = c P
+      in
+	  SPEC rf (MATCH_MP STRONG_EQUIV_SUBST_RELAB thm)
+      end
+  else
+      S_ALL_CONV tm;
+
+fun S_DEPTH_CONV (c :conv) t =
+  S_SUB_CONV ((S_DEPTH_CONV c) S_THENC (S_REPEATC c)) t;
+
+fun S_TOP_DEPTH_CONV (c :conv) t =
+   ((S_REPEATC c) S_THENC
+    (S_SUB_CONV (S_TOP_DEPTH_CONV c)) S_THENC
+    ((c S_THENC (S_TOP_DEPTH_CONV c)) S_ORELSEC S_ALL_CONV))
+   t;
+
+(* Define the function S_SUBST for substitution in STRONG_EQUIV terms. *)
+fun S_SUBST thm tm : thm = let
+    val (ti, ti') = args_thm thm
+in
+    if (tm = ti) then thm
+    else if is_prefix tm then
+	let val (u, t) = args_prefix tm;
+	    val thm1 = S_SUBST thm t
+	in
+	    SPEC u (MATCH_MP STRONG_EQUIV_SUBST_PREFIX thm1)
+	end
+    else if is_sum tm then
+	let val (t1, t2) = args_sum tm;
+	    val thm1 = S_SUBST thm t1
+	    and thm2 = S_SUBST thm t2
+	in
+	    MATCH_MP STRONG_EQUIV_PRESD_BY_SUM (CONJ thm1 thm2)
+	end
+    else if is_par tm then
+	let val (t1, t2) = args_par tm;
+	    val thm1 = S_SUBST thm t1
+	    and thm2 = S_SUBST thm t2
+	in
+	    MATCH_MP STRONG_EQUIV_PRESD_BY_PAR (CONJ thm1 thm2)
+	end
+    else if is_restr tm then
+	let val (t, L) = args_restr tm;
+	    val thm1 = S_SUBST thm t
+	in
+	    SPEC L (MATCH_MP STRONG_EQUIV_SUBST_RESTR thm1)
+	end
+    else if is_relab tm then
+	let val (t, rf) = args_relab tm;
+	    val thm1 = S_SUBST thm t
+	in
+	    SPEC rf (MATCH_MP STRONG_EQUIV_SUBST_RELAB thm1)
+	end
+    else
+	S_ALL_CONV tm
+end;
+
+(* Define the tactic S_LHS_SUBST1_TAC: thm_tactic which substitutes a theorem
+   in the left-hand side of a strong equivalence. *)
+fun S_LHS_SUBST1_TAC thm : tactic =
+  fn (asl, w) => let
+      val (opt, t1, t2) = args_equiv w
+  in
+      if (opt = ``STRONG_EQUIV``) then
+	  let val thm' = S_SUBST thm t1;
+	      val (t1', t') = args_thm thm' (* t1' = t1 *)
+	  in
+	      if (t' = t2) then
+		  ([], fn [] => S_TRANS thm' (SPEC t' STRONG_EQUIV_REFL))
+	      else
+		  ([(asl, ``STRONG_EQUIV ^t' ^t2``)], fn [thm''] => S_TRANS thm' thm'')
+	  end
+      else
+	  failwith "the goal is not a STRONG_EQUIV relation"
+  end;
+
+(* The tactic S_LHS_SUBST_TAC substitutes a list of theorems in the left-hand
+   side of a strong equivalence. *)
+fun S_LHS_SUBST_TAC thmlist = EVERY (map S_LHS_SUBST1_TAC thmlist);
+
+(* The tactic S_RHS_SUBST1_TAC substitutes a theorem in the right-hand side of
+   a strong equivalence. *)
+fun S_RHS_SUBST1_TAC thm =
+    REPEAT GEN_TAC
+ >> RULE_TAC STRONG_EQUIV_SYM
+ >> S_LHS_SUBST1_TAC thm
+ >> RULE_TAC STRONG_EQUIV_SYM;
+
+(* The tactic S_RHS_SUBST_TAC substitutes a list of theorems in the right-hand
+   side of a strong equivalence. *)
+fun S_RHS_SUBST_TAC thmlist =
+    REPEAT GEN_TAC
+ >> RULE_TAC STRONG_EQUIV_SYM
+ >> S_LHS_SUBST_TAC thmlist
+ >> RULE_TAC STRONG_EQUIV_SYM;
+
+(* The tactic S_SUBST1_TAC (S_SUBST_TAC) substitutes a (list of) theorem(s) in
+   both sides of a strong equivalence. *)
+fun S_SUBST1_TAC thm =
+    S_LHS_SUBST1_TAC thm
+ >> S_RHS_SUBST1_TAC thm;
+
+fun S_SUBST_TAC thmlist =
+    S_LHS_SUBST_TAC thmlist
+ >> S_RHS_SUBST_TAC thmlist;
+
+end (* struct *)
+
+(* last updated: May 14, 2017 *)

--- a/examples/CCS/StrongEQScript.sml
+++ b/examples/CCS/StrongEQScript.sml
@@ -1,0 +1,763 @@
+(*
+ * Copyright 1991-1995  University of Cambridge (Author: Monica Nesi)
+ * Copyright 2016-2017  University of Bologna   (Author: Chun Tian)
+ *)
+
+open HolKernel Parse boolLib bossLib;
+
+open stringTheory pred_setTheory pairTheory relationTheory;
+open CCSLib CCSTheory;
+
+val _ = new_theory "StrongEQ";
+
+(******************************************************************************)
+(*                                                                            *)
+(*    Operational definition of strong equivalence for CCS (strong_sem.ml)    *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Define the strong bisimulation relation on CCS processes. *)
+val STRONG_BISIM = new_definition (
+   "STRONG_BISIM",
+  ``STRONG_BISIM (Bsm: CCS -> CCS -> bool) =
+       (!E E'.
+          Bsm E E' ==>
+          (!u.
+           (!E1. TRANS E u E1 ==> 
+                 ?E2. TRANS E' u E2 /\ Bsm E1 E2) /\
+           (!E2. TRANS E' u E2 ==> 
+                 ?E1. TRANS E u E1 /\ Bsm E1 E2)))``);
+
+(* The identity relation is a strong bisimulation. *)
+val IDENTITY_STRONG_BISIM = store_thm (
+   "IDENTITY_STRONG_BISIM",
+  ``STRONG_BISIM (\x y. x = y)``,
+    PURE_ONCE_REWRITE_TAC [STRONG_BISIM]
+ >> BETA_TAC
+ >> REPEAT STRIP_TAC (* 2 sub-goals *)
+ >| [ (* goal 1 *)
+      ASSUME_TAC (REWRITE_RULE [ASSUME ``E: CCS = E'``]
+			       (ASSUME ``TRANS E u E1``)) \\
+      EXISTS_TAC ``E1: CCS`` \\
+      ASM_REWRITE_TAC [] ,
+      (* goal 2 *)
+      PURE_ONCE_ASM_REWRITE_TAC [] \\
+      EXISTS_TAC ``E2: CCS`` \\
+      ASM_REWRITE_TAC [] ]);
+
+(* The converse of a strong bisimulation is a strong bisimulation. *)
+val CONVERSE_STRONG_BISIM = store_thm (
+   "CONVERSE_STRONG_BISIM",
+  ``!Bsm. STRONG_BISIM Bsm ==> STRONG_BISIM (\x y. Bsm y x)``,
+    GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_BISIM]
+ >> BETA_TAC
+ >> REPEAT STRIP_TAC (* 2 sub-goals here *)
+ >> RES_TAC (* enrich assumptions *)
+ >| [ EXISTS_TAC ``E1': CCS``,
+      EXISTS_TAC ``E2': CCS`` ]
+ >> ASM_REWRITE_TAC []);
+
+(* The composition of two strong bisimulations is a strong bisimulation. *)
+val COMP_STRONG_BISIM = store_thm (
+   "COMP_STRONG_BISIM",
+      ``!Bsm1 Bsm2. 
+         STRONG_BISIM Bsm1 /\ STRONG_BISIM Bsm2 ==>
+         STRONG_BISIM (\x z. ?y. Bsm1 x y /\ Bsm2 y z)``,
+    REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_BISIM]
+ >> BETA_TAC
+ >> REPEAT STRIP_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      IMP_RES_TAC 
+        (MP (SPECL [``E: CCS``, ``y: CCS``]
+            (ASSUME 
+             ``!E E'.
+               Bsm1 E E' ==>
+               (!u.
+                (!E1. TRANS E u E1 ==> (?E2. TRANS E' u E2 /\ Bsm1 E1 E2)) /\
+                (!E2. TRANS E' u E2 ==> (?E1. TRANS E u E1 /\ Bsm1 E1 E2)))``))
+          (ASSUME ``(Bsm1: CCS -> CCS -> bool) E y``)) \\
+      IMP_RES_TAC 
+        (MP (SPECL [``y: CCS``, ``E': CCS``] 
+            (ASSUME 
+             ``!E E'.
+               Bsm2 E E' ==>
+               (!u.
+                (!E1. TRANS E u E1 ==> (?E2. TRANS E' u E2 /\ Bsm2 E1 E2)) /\
+                (!E2. TRANS E' u E2 ==> (?E1. TRANS E u E1 /\ Bsm2 E1 E2)))``))
+          (ASSUME ``(Bsm2: CCS -> CCS -> bool) y E'``)) \\
+      EXISTS_TAC ``E2': CCS`` >> ASM_REWRITE_TAC [] \\
+      EXISTS_TAC ``E2: CCS`` >> ASM_REWRITE_TAC [] ,
+      (* goal 2 (of 2) *)
+      IMP_RES_TAC
+        (MP (SPECL [``y: CCS``, ``E': CCS``]
+            (ASSUME 
+             ``!E E'.
+               Bsm2 E E' ==>
+               (!u.
+                (!E1. TRANS E u E1 ==> (?E2. TRANS E' u E2 /\ Bsm2 E1 E2)) /\
+                (!E2. TRANS E' u E2 ==> (?E1. TRANS E u E1 /\ Bsm2 E1 E2)))``))
+          (ASSUME ``(Bsm2: CCS -> CCS -> bool) y E'``)) \\
+      IMP_RES_TAC
+        (MP (SPECL [``E: CCS``, ``y: CCS``]
+            (ASSUME 
+             ``!E E'.
+               Bsm1 E E' ==>
+               (!u.
+                (!E1. TRANS E u E1 ==> (?E2. TRANS E' u E2 /\ Bsm1 E1 E2)) /\
+                (!E2. TRANS E' u E2 ==> (?E1. TRANS E u E1 /\ Bsm1 E1 E2)))``))
+          (ASSUME ``(Bsm1: CCS -> CCS -> bool) E y``)) \\
+      EXISTS_TAC ``E1': CCS`` >> ASM_REWRITE_TAC [] \\
+      EXISTS_TAC ``E1: CCS`` >> ASM_REWRITE_TAC [] ]);
+
+(* The union of two strong bisimulations is a strong bisimulation. *)
+val UNION_STRONG_BISIM = store_thm (
+   "UNION_STRONG_BISIM",
+      ``!Bsm1 Bsm2. 
+         STRONG_BISIM Bsm1 /\ STRONG_BISIM Bsm2 ==>  
+         STRONG_BISIM (\x y. Bsm1 x y \/ Bsm2 x y)``,
+    REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_BISIM]
+ >> BETA_TAC 
+ >> REPEAT STRIP_TAC (* 4 sub-goals here *)
+ >> RES_TAC
+ >| [ EXISTS_TAC ``E2: CCS``,
+      EXISTS_TAC ``E1: CCS``,
+      EXISTS_TAC ``E2: CCS``,
+      EXISTS_TAC ``E1: CCS``]
+ >> ASM_REWRITE_TAC []);
+
+(* Define the strong equivalence relation for CCS processes.
+
+   Two states E and E' are bisimilar (or bisimulation equivalent, denoted E ~ E',
+   if there exists a bisimulation R such that (E, E') IN R.
+ *)
+val STRONG_EQUIV = new_definition (
+   "STRONG_EQUIV",
+  ``STRONG_EQUIV E E' = (?Bsm. Bsm E E' /\ STRONG_BISIM Bsm)``);
+
+val _ = set_mapped_fixity { fixity = Infix (NONASSOC, 450),
+			    tok = "~~", term_name = "STRONG_EQUIV" };
+
+val _ = Unicode.unicode_version { u = UTF8.chr 0x223C, tmnm = "STRONG_EQUIV"};
+val _ = TeX_notation { hol = UTF8.chr 0x223C,
+                       TeX = ("\\HOLTokenStrongEquiv", 1) }
+
+(* Strong equivalence is a reflexive relation. *)
+val STRONG_EQUIV_REFL = store_thm (
+   "STRONG_EQUIV_REFL", ``!E. STRONG_EQUIV E E``,
+    GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC ``\x y: CCS. x = y``
+ >> BETA_TAC
+ >> REWRITE_TAC [IDENTITY_STRONG_BISIM]);
+
+(* Strong equivalence is a symmetric relation. *)
+val STRONG_EQUIV_SYM = store_thm (
+   "STRONG_EQUIV_SYM",
+  ``!E E'. STRONG_EQUIV E E' ==> STRONG_EQUIV E' E``,
+    REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> REPEAT STRIP_TAC
+ >> EXISTS_TAC ``\x y. (Bsm: CCS -> CCS -> bool) y x``
+ >> BETA_TAC
+ >> IMP_RES_TAC CONVERSE_STRONG_BISIM
+ >> ASM_REWRITE_TAC [] );
+
+(* Strong equivalence is a transitive relation. *)
+val STRONG_EQUIV_TRANS = store_thm (
+   "STRONG_EQUIV_TRANS",
+      ``!E E' E''. 
+         STRONG_EQUIV E E' /\ STRONG_EQUIV E' E'' ==> STRONG_EQUIV E E''``,
+    REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> REPEAT STRIP_TAC
+ >> EXISTS_TAC ``\x z. ?y. (Bsm: CCS -> CCS -> bool) x y /\
+                           (Bsm': CCS -> CCS -> bool) y z``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ BETA_TAC \\
+      EXISTS_TAC ``E': CCS`` \\
+      ASM_REWRITE_TAC [], 
+      IMP_RES_TAC COMP_STRONG_BISIM ]);
+
+(* Syntactic equivalence implies strong equivalence. *)
+val EQUAL_IMP_STRONG_EQUIV = store_thm (
+   "EQUAL_IMP_STRONG_EQUIV",
+      ``!E E'. (E = E') ==> STRONG_EQUIV E E'``,
+    REPEAT STRIP_TAC
+ >> PURE_ASM_REWRITE_TAC [STRONG_EQUIV_REFL]);
+
+(* Definition 3, page 91 in Milner's book. *)
+val STRONG_EQUIV' = new_definition (
+   "STRONG_EQUIV'",
+  ``STRONG_EQUIV' E E' =
+        (!u.
+         (!E1. TRANS E u E1 ==> 
+               (?E2. TRANS E' u E2 /\ STRONG_EQUIV E1 E2)) /\
+         (!E2. TRANS E' u E2 ==> 
+               (?E1. TRANS E u E1 /\ STRONG_EQUIV E1 E2)))``); 
+
+(* Strong equivalence implies the new relation. *)
+val STR_EQUIV_IMP_STR_EQUIV' = store_thm (
+   "STR_EQUIV_IMP_STR_EQUIV'",
+      ``!E E'. STRONG_EQUIV E E' ==> STRONG_EQUIV' E E'``,
+    REPEAT GEN_TAC
+ >> REWRITE_TAC [STRONG_EQUIV', STRONG_EQUIV]
+ >> REPEAT STRIP_TAC (* 2 sub-goals *)
+ >> IMP_RES_TAC
+      (MP (SPEC_ALL
+           (EQ_MP (SPEC ``Bsm: CCS -> CCS -> bool`` STRONG_BISIM)
+                  (ASSUME ``STRONG_BISIM Bsm``)))
+          (ASSUME ``(Bsm: CCS -> CCS -> bool) E E'``))
+ >| [ EXISTS_TAC ``E2: CCS``,
+      EXISTS_TAC ``E1: CCS`` ]
+ >> ASM_REWRITE_TAC []
+ >> EXISTS_TAC ``Bsm: CCS -> CCS -> bool``
+ >> ASM_REWRITE_TAC [] ); 
+
+(* Lemma 3, page 91 in Milner's book
+   the new relation STRONG_EQUIV' is a strong bisimulation. *)
+val STRONG_EQUIV_IS_STRONG_BISIM = store_thm (
+   "STRONG_EQUIV_IS_STRONG_BISIM",
+  ``STRONG_BISIM STRONG_EQUIV'``,
+    PURE_ONCE_REWRITE_TAC [STRONG_BISIM]
+ >> REPEAT STRIP_TAC (* 2 sub-goals here *)
+ >> IMP_RES_TAC 
+       (EQ_MP (SPECL [``E: CCS``, ``E': CCS``] STRONG_EQUIV')
+              (ASSUME ``STRONG_EQUIV' E E'``))
+ >| [ EXISTS_TAC ``E2: CCS``,
+      EXISTS_TAC ``E1: CCS`` ]
+ >> IMP_RES_TAC STR_EQUIV_IMP_STR_EQUIV'
+ >> ASM_REWRITE_TAC []);
+
+(* The new relation implies strong equivalence. *)
+val STR_EQUIV'_IMP_STR_EQUIV = store_thm (
+   "STR_EQUIV'_IMP_STR_EQUIV",
+      ``!E E'. STRONG_EQUIV' E E' ==> STRONG_EQUIV E E'``,
+    REPEAT STRIP_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC ``STRONG_EQUIV'``
+ >> ASM_REWRITE_TAC [STRONG_EQUIV_IS_STRONG_BISIM]);
+
+(* equivalence theorems used for rewriting *)
+val STR_EQUIV'_TO_STR_EQUIV = store_thm (
+   "STR_EQUIV'_TO_STR_EQUIV",
+      ``!E E'. STRONG_EQUIV' E E' = STRONG_EQUIV E E'``,
+    REPEAT GEN_TAC
+ >> EQ_TAC (* 2 sub-goals here *)
+ >| [ REWRITE_TAC [STR_EQUIV'_IMP_STR_EQUIV],
+      REWRITE_TAC [STR_EQUIV_IMP_STR_EQUIV'] ]);
+
+(* the other direction *)
+val STR_EQUIV_TO_STR_EQUIV' = save_thm (
+   "STR_EQUIV_TO_STR_EQUIV'", GSYM STR_EQUIV'_TO_STR_EQUIV);
+
+(* Prop. 4, page 91: strong equivalence satisfies property [*] *)
+val PROPERTY_STAR = store_thm (
+   "PROPERTY_STAR",
+      ``!E E'. STRONG_EQUIV E E' =
+         (!u.
+           (!E1. TRANS E u E1 ==>
+                 (?E2. TRANS E' u E2 /\ STRONG_EQUIV E1 E2)) /\
+           (!E2. TRANS E' u E2 ==>
+                 (?E1. TRANS E u E1 /\ STRONG_EQUIV E1 E2)))``,
+    REPEAT GEN_TAC
+ >> EQ_TAC (* 2 sub-goals here *)
+ >| [ PURE_ONCE_REWRITE_TAC 
+        [ONCE_REWRITE_RULE [STRONG_EQUIV'] STR_EQUIV_IMP_STR_EQUIV'],
+      PURE_ONCE_REWRITE_TAC 
+        [ONCE_REWRITE_RULE [STRONG_EQUIV'] STR_EQUIV'_IMP_STR_EQUIV] ]);
+
+val PROPERTY_STAR_LR = save_thm (
+   "PROPERTY_STAR_LR", EQ_IMP_LR PROPERTY_STAR);
+
+(* Strong equivalence is substitutive under prefix operator. *)
+val STRONG_EQUIV_SUBST_PREFIX = store_thm (
+   "STRONG_EQUIV_SUBST_PREFIX",
+      ``!E E'. 
+         STRONG_EQUIV E E' ==> !u. STRONG_EQUIV (prefix u E) (prefix u E')``,
+    REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC 
+      [SPECL [``prefix u E``, ``prefix u E'``] PROPERTY_STAR]
+ >> REPEAT STRIP_TAC (* 2 sub-goals here *)
+ >| [ EXISTS_TAC ``E': CCS``,
+      EXISTS_TAC ``E: CCS``]
+ >> IMP_RES_TAC TRANS_PREFIX
+ >> ASM_REWRITE_TAC [PREFIX]);
+
+(* Strong equivalence is preserved by binary summation. *)
+val STRONG_EQUIV_PRESD_BY_SUM = store_thm (
+   "STRONG_EQUIV_PRESD_BY_SUM",
+      ``!E1 E1' E2 E2'.
+         STRONG_EQUIV E1 E1' /\ STRONG_EQUIV E2 E2' ==>
+         STRONG_EQUIV (sum E1 E2) (sum E1' E2')``,
+    REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [PROPERTY_STAR]
+ >> REPEAT STRIP_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 *)
+      IMP_RES_TAC TRANS_SUM \\ (* 2 sub-goals here *)
+      RES_TAC \\
+      EXISTS_TAC ``E2'': CCS`` \\
+      ASM_REWRITE_TAC []
+      >| [ MATCH_MP_TAC SUM1, MATCH_MP_TAC SUM2 ] \\
+      ASM_REWRITE_TAC [],
+      (* goal 2 *)
+      IMP_RES_TAC TRANS_SUM \\ (* 2 sub-goals here *)
+      RES_TAC \\
+      EXISTS_TAC ``E1'': CCS`` \\
+      ASM_REWRITE_TAC []
+      >| [ MATCH_MP_TAC SUM1, MATCH_MP_TAC SUM2] \\
+      ASM_REWRITE_TAC [] ]);
+
+(* Strong equivalence is substitutive under summation operator on the right.
+   |- !E E'. STRONG_EQUIV E E' ==> (!E''. STRONG_EQUIV (sum E E'') (sum E' E''))
+ *)
+val STRONG_EQUIV_SUBST_SUM_R = save_thm (
+   "STRONG_EQUIV_SUBST_SUM_R",
+      GEN_ALL
+       (DISCH_ALL
+        (GEN_ALL
+         (UNDISCH
+          (REWRITE_RULE [STRONG_EQUIV_REFL]
+           (DISCH_ALL
+            (MATCH_MP STRONG_EQUIV_PRESD_BY_SUM 
+             (CONJ (ASSUME ``STRONG_EQUIV E E'``)
+                   (ASSUME ``STRONG_EQUIV E'' E''``)))))))));
+
+(* Strong equivalence is substitutive under summation operator on the left.
+   |- !E E'. STRONG_EQUIV E E' ==> (!E''. STRONG_EQUIV (sum E'' E) (sum E'' E'))
+ *)
+val STRONG_EQUIV_SUBST_SUM_L = save_thm (
+   "STRONG_EQUIV_SUBST_SUM_L",
+      GEN_ALL
+       (DISCH_ALL
+        (GEN_ALL
+         (UNDISCH
+          (REWRITE_RULE [STRONG_EQUIV_REFL]
+           (DISCH_ALL
+            (MATCH_MP STRONG_EQUIV_PRESD_BY_SUM 
+             (CONJ (ASSUME ``STRONG_EQUIV E'' E''``)
+                   (ASSUME ``STRONG_EQUIV E E'``)))))))));
+
+(* Strong equivalence is preserved by parallel composition. *)
+val STRONG_EQUIV_PRESD_BY_PAR = store_thm (
+   "STRONG_EQUIV_PRESD_BY_PAR",
+      ``!E1 E1' E2 E2'.
+         STRONG_EQUIV E1 E1' /\ STRONG_EQUIV E2 E2' ==>
+         STRONG_EQUIV (par E1 E2) (par E1' E2')``,
+    REPEAT STRIP_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC
+       ``\x y.
+         (?F1 F2 F3 F4.
+           (x = par F1 F3) /\ (y = par F2 F4) /\
+           STRONG_EQUIV F1 F2 /\ STRONG_EQUIV F3 F4)``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC \\
+      take [`E1`, `E1'`, `E2`, `E2'`] \\
+      ASM_REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 2.1 (of 2) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E = par F1 F3``]
+                            (ASSUME ``TRANS E u E1''``)) \\
+        IMP_RES_TAC TRANS_PAR >| (* 3 sub-goals here *)
+        [ (* goal 2.1.1 (of 3) *)
+          IMP_RES_TAC (MATCH_MP PROPERTY_STAR_LR 
+				(ASSUME ``STRONG_EQUIV F1 F2``)) \\
+          EXISTS_TAC ``par E2'' F4`` \\
+          ASM_REWRITE_TAC [] \\
+          CONJ_TAC >| (* 2 sub-goals here *)
+          [ (* goal 2.1.1.1 (of 2) *)
+            MATCH_MP_TAC PAR1 \\
+            PURE_ONCE_ASM_REWRITE_TAC [],
+            (* goal 2.1.1.2 (of 2) *)
+            take [`E1'''`, `E2''`, `F3`, `F4`] \\
+            ASM_REWRITE_TAC [] ],
+          (* goal 2.1.2 (of 3) *)
+          IMP_RES_TAC (MATCH_MP PROPERTY_STAR_LR 
+                       (ASSUME ``STRONG_EQUIV F3 F4``)) \\
+          EXISTS_TAC ``par F2 E2''`` \\
+          ASM_REWRITE_TAC [] \\
+          CONJ_TAC >| (* 2 sub-goals here *)
+          [ (* goal 2.1.2.1 (of 2) *)
+            MATCH_MP_TAC PAR2 >> PURE_ONCE_ASM_REWRITE_TAC [],
+            (* goal 2.1.2.2 (of 2) *)
+            take [`F1`, `F2`, `E1'''`, `E2''`] \\
+            ASM_REWRITE_TAC [] ],
+          (* goal 2.1.3 (of 3) *)
+          IMP_RES_TAC (MATCH_MP PROPERTY_STAR_LR 
+                       (ASSUME ``STRONG_EQUIV F1 F2``)) \\
+          IMP_RES_TAC (MATCH_MP PROPERTY_STAR_LR 
+                       (ASSUME ``STRONG_EQUIV F3 F4``)) \\
+          EXISTS_TAC ``par E2''' E2''''`` \\
+          ASM_REWRITE_TAC [] \\
+          CONJ_TAC >| (* 2 sub-goals here *)
+          [ (* goal 2.1.3.1 (of 2) *)
+            MATCH_MP_TAC PAR3 \\
+            EXISTS_TAC ``l: Label`` \\
+            ASM_REWRITE_TAC [],
+            (* goal 2.1.3.2 (of 2) *)
+            take [`E1'''`, `E2'''`, `E2''`, `E2''''`] \\
+            ASM_REWRITE_TAC [] ] ], 
+         (* goal 2.2 (of 2) *)
+         ASSUME_TAC
+           (REWRITE_RULE [ASSUME ``E' = par F2 F4``]
+                 (ASSUME ``TRANS E' u E2''``)) \\
+         IMP_RES_TAC TRANS_PAR >| (* 3 sub-goals here *)
+         [ (* goal 2.2.1 (of 3) *)
+           IMP_RES_TAC (MATCH_MP PROPERTY_STAR_LR 
+                        (ASSUME ``STRONG_EQUIV F1 F2``)) \\
+           EXISTS_TAC ``par E1''' F3`` \\
+           ASM_REWRITE_TAC [] \\
+           CONJ_TAC >| (* 2 sub-goals here *)
+           [ (* goal 2.2.1.1 (of 2) *)
+             MATCH_MP_TAC PAR1 \\
+             PURE_ONCE_ASM_REWRITE_TAC [],
+             (* goal 2.2.1.2 (of 2) *)
+             take [`E1'''`, `E1''`, `F3`, `F4`] \\
+             ASM_REWRITE_TAC [] ],
+           (* goal 2.2.2 (of 3) *)
+           IMP_RES_TAC (MATCH_MP PROPERTY_STAR_LR 
+                        (ASSUME ``STRONG_EQUIV F3 F4``)) \\
+           EXISTS_TAC ``par F1 E1'''`` \\
+           ASM_REWRITE_TAC [] \\
+           CONJ_TAC >| (* 2 sub-goals here *)
+           [ (* goal 2.2.2.1 (of 2) *)
+             MATCH_MP_TAC PAR2 \\
+             PURE_ONCE_ASM_REWRITE_TAC [],
+             (* goal 2.2.2.2 (of 2) *)
+             take [`F1`, `F2`, `E1'''`, `E1''`] \\
+             ASM_REWRITE_TAC [] ],
+           (* goal 2.2.3 (of 3) *)
+           IMP_RES_TAC (MATCH_MP PROPERTY_STAR_LR
+                        (ASSUME ``STRONG_EQUIV F1 F2``)) \\
+           IMP_RES_TAC (MATCH_MP PROPERTY_STAR_LR 
+                        (ASSUME ``STRONG_EQUIV F3 F4``)) \\
+           EXISTS_TAC ``par E1''' E1''''`` \\
+           ASM_REWRITE_TAC [] \\
+           CONJ_TAC >| (* 2 sub-goals here *)
+           [ (* goal 2.2.3.1 (of 2) *)
+             MATCH_MP_TAC PAR3 \\
+             EXISTS_TAC ``l: Label`` \\
+             ASM_REWRITE_TAC [],
+             (* goal 2.2.3.2 (of 2) *)
+             take [`E1'''`, `E1''`, `E1''''`, `E2'''`] \\ 
+             ASM_REWRITE_TAC [] ] ] ] ]);
+
+(* Strong equivalence is substitutive under parallel operator on the right:
+   |- !E E'. STRONG_EQUIV E E' ==> (!E''. STRONG_EQUIV (par E E'') (par E' E''))
+ *)
+val STRONG_EQUIV_SUBST_PAR_R = save_thm (
+   "STRONG_EQUIV_SUBST_PAR_R",
+      GEN_ALL
+       (DISCH_ALL
+        (GEN_ALL
+         (UNDISCH
+          (REWRITE_RULE [STRONG_EQUIV_REFL]
+           (DISCH_ALL
+            (MATCH_MP STRONG_EQUIV_PRESD_BY_PAR
+             (CONJ (ASSUME ``STRONG_EQUIV E E'``)
+                   (ASSUME ``STRONG_EQUIV E'' E''``)))))))));
+
+(* Strong equivalence is substitutive under parallel operator on the left:
+   |- !E E'. STRONG_EQUIV E E' ==> (!E''. STRONG_EQUIV (par E'' E) (par E'' E'))
+ *)
+val STRONG_EQUIV_SUBST_PAR_L = save_thm (
+   "STRONG_EQUIV_SUBST_PAR_L",
+      GEN_ALL
+       (DISCH_ALL
+        (GEN_ALL
+         (UNDISCH
+          (REWRITE_RULE [STRONG_EQUIV_REFL]
+           (DISCH_ALL
+            (MATCH_MP STRONG_EQUIV_PRESD_BY_PAR 
+             (CONJ (ASSUME ``STRONG_EQUIV E'' E''``)
+                   (ASSUME ``STRONG_EQUIV E E'``)))))))));
+
+(* Strong equivalence is substitutive under restriction operator. *)
+val STRONG_EQUIV_SUBST_RESTR = store_thm (
+   "STRONG_EQUIV_SUBST_RESTR",
+      ``!E E'. 
+         STRONG_EQUIV E E' ==> 
+         (!L. STRONG_EQUIV (restr L E) (restr L E'))``,
+    REPEAT STRIP_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC ``\x y. ?E1 E2 L'. (x = restr L' E1) /\ (y = restr L' E2) /\ 
+                                    STRONG_EQUIV E1 E2``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC \\
+      take [`E`, `E'`, `L`] \\
+      ASM_REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC \\ 
+      REPEAT STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 2.1 (of 2) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E'' = restr L' E1``]
+                            (ASSUME ``TRANS E'' u E1'``)) \\ 
+        IMP_RES_TAC TRANS_RESTR >| (* 2 sub-goals here *)
+        [ (* goal 2.1.1 (of 2) *)
+          IMP_RES_TAC (MATCH_MP PROPERTY_STAR_LR  
+                       (ASSUME ``STRONG_EQUIV E1 E2``)) \\ 
+          EXISTS_TAC ``restr L' E2'`` \\
+          CONJ_TAC >| (* 2 sub-goals here *)
+          [ (* goal 2.1.1.1 (of 2) *)
+            ASM_REWRITE_TAC [] \\
+            MATCH_MP_TAC RESTR \\
+            REWRITE_TAC [REWRITE_RULE [ASSUME ``u = tau``]
+                               (ASSUME ``TRANS E2 u E2'``)],
+            (* goal 2.1.1.2 (of 2) *)
+            take [`E''''`, `E2'`, `L'`] \\
+            ASM_REWRITE_TAC [] ],
+          (* goal 2.1.2 (of 2) *)
+          IMP_RES_TAC (MATCH_MP PROPERTY_STAR_LR  
+                       (ASSUME ``STRONG_EQUIV E1 E2``)) \\
+          EXISTS_TAC ``restr L' E2'`` \\ 
+          CONJ_TAC >| (* 2 sub-goals here *)
+          [ (* goal 2.1.2.1 (of 2) *)
+            ASM_REWRITE_TAC [] \\
+            MATCH_MP_TAC RESTR \\
+            EXISTS_TAC ``l: Label`` \\
+            ASM_REWRITE_TAC [REWRITE_RULE [ASSUME ``u = label l``]
+                                   (ASSUME ``TRANS E2 u E2'``)],
+            (* goal 2.1.2.2 (of 2) *)
+            take [`E''''`, `E2'`, `L'`] \\
+            ASM_REWRITE_TAC [] ] ],  
+          (* goal 2.2 (of 2) *)
+          ASSUME_TAC (REWRITE_RULE [ASSUME ``E''' = restr L' E2``]
+				   (ASSUME ``TRANS E''' u E2'``)) \\ 
+          IMP_RES_TAC TRANS_RESTR >| (* 2 sub-goals here *)
+          [ (* goal 2.2.1 (of 2) *)
+            IMP_RES_TAC (MATCH_MP PROPERTY_STAR_LR
+				  (ASSUME ``STRONG_EQUIV E1 E2``)) \\ 
+            EXISTS_TAC ``restr L' E1'`` \\ 
+            CONJ_TAC >| (* 2 sub-goals here *)
+            [ (* goal 2.2.1.1 (of 2) *)
+              ASM_REWRITE_TAC [] \\
+              MATCH_MP_TAC RESTR \\
+              REWRITE_TAC [REWRITE_RULE [ASSUME ``u = tau``]
+					(ASSUME ``TRANS E1 u E1'``)],
+              (* goal 2.2.1.2 (of 2) *)
+              take [`E1'`, `E''''`, `L'`] \\
+              ASM_REWRITE_TAC [] ],  
+           (* goal 2.2.2 (of 2) *)
+           IMP_RES_TAC (MATCH_MP PROPERTY_STAR_LR  
+				 (ASSUME ``STRONG_EQUIV E1 E2``)) \\ 
+           EXISTS_TAC ``restr L' E1'`` \\ 
+           CONJ_TAC >| (* 2 sub-goals here *)
+           [ (* goal 2.2.2.1 (of 2) *)
+             ASM_REWRITE_TAC [] \\
+             MATCH_MP_TAC RESTR \\
+             EXISTS_TAC ``l: Label`` \\
+             ASM_REWRITE_TAC [REWRITE_RULE [ASSUME ``u = label l``]
+					   (ASSUME ``TRANS E1 u E1'``)],
+             (* goal 2.2.2.2 (of 2) *)
+             take [`E1'`, `E''''`, `L'`] \\
+             ASM_REWRITE_TAC [] ] ] ] ]);
+
+(* Strong equivalence is substitutive under relabelling operator. *)
+val STRONG_EQUIV_SUBST_RELAB = store_thm (
+   "STRONG_EQUIV_SUBST_RELAB",
+      ``!E E'.
+         STRONG_EQUIV E E' ==>
+         (!rf. STRONG_EQUIV (relab E rf) (relab E' rf))``,
+    REPEAT STRIP_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC ``\x y. ?E1 E2 rf'. (x = relab E1 rf') /\ (y = relab E2 rf') /\
+                                   STRONG_EQUIV E1 E2``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC \\
+      take [`E`, `E'`, `rf`] \\
+      ASM_REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 2.1 (of 2) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E'' = relab E1 rf'``]
+				 (ASSUME ``TRANS E'' u E1'``)) \\
+        IMP_RES_TAC TRANS_RELAB \\
+        IMP_RES_TAC (MATCH_MP PROPERTY_STAR_LR
+			      (ASSUME ``STRONG_EQUIV E1 E2``)) \\
+        EXISTS_TAC ``relab E2' rf'`` \\
+        CONJ_TAC >| (* 2 sub-goals here *)
+        [ (* goal 2.1.1 (of 2) *)
+          ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC RELAB \\
+          PURE_ONCE_ASM_REWRITE_TAC [],
+          (* goal 2.1.2 (of 2) *)
+          take [`E''''`, `E2'`, `rf'`] \\
+          ASM_REWRITE_TAC [] ],
+        (* goal 2.2 (of 2) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E''' = relab E2 rf'``]
+				 (ASSUME ``TRANS E''' u E2'``)) \\
+        IMP_RES_TAC TRANS_RELAB \\ 
+        IMP_RES_TAC (MATCH_MP PROPERTY_STAR_LR  
+			      (ASSUME ``STRONG_EQUIV E1 E2``)) \\
+        EXISTS_TAC ``relab E1' rf'`` \\
+        CONJ_TAC >| (* 2 sub-goals here *)
+        [ (* goal 2.2.1 (of 2) *)
+          ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC RELAB \\
+          PURE_ONCE_ASM_REWRITE_TAC [],
+          (* goal 2.2.2 (of 2) *)
+          take [`E1'`, `E''''`, `rf'`] \\
+          ASM_REWRITE_TAC [] ] ] ]);
+
+(******************************************************************************)
+(*                                                                            *)
+(*   A new definition of STRONG_EQUIV based on HOL's coinductive relation     *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Obsevations:
+   1. STRONG_EQ_cases ==> STRONG_EQ_rules (by EQ_IMP_LR)
+   2. STRONG_EQ_cases is the same as PROPERTY_STAR
+   3. STRONG_EQ_coind is new (the co-induction principle)
+ *)
+val (STRONG_EQ_rules, STRONG_EQ_coind, STRONG_EQ_cases) = Hol_coreln `
+    (!E E'.
+       (!u.
+         (!E1. TRANS E u E1 ==> 
+               (?E2. TRANS E' u E2 /\ STRONG_EQ E1 E2)) /\
+         (!E2. TRANS E' u E2 ==> 
+               (?E1. TRANS E u E1 /\ STRONG_EQ E1 E2))) ==> STRONG_EQ E E')`;
+
+(* Strong equivalence implies the new relation. *)
+val STR_EQUIV_IMP_STR_EQ = store_thm (
+   "STR_EQUIV_IMP_STR_EQ",
+      ``!E E'. STRONG_EQUIV E E' ==> STRONG_EQ E E'``,
+    HO_MATCH_MP_TAC STRONG_EQ_coind (* co-induction principle used here! *)
+ >> REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [GSYM PROPERTY_STAR]
+ >> RW_TAC bool_ss []);
+
+val STR_EQ_IS_STR_BISIM = store_thm (
+   "STR_EQ_IS_STR_BISIM",
+  ``STRONG_BISIM STRONG_EQ``,
+    PURE_ONCE_REWRITE_TAC [STRONG_BISIM]
+ >> PURE_ONCE_REWRITE_TAC [GSYM STRONG_EQ_cases]
+ >> RW_TAC bool_ss []);
+
+(* The new relation implies strong equivalence. *)
+val STR_EQ_IMP_STR_EQUIV = store_thm (
+   "STR_EQ_IMP_STR_EQUIV",
+      ``!E E'. STRONG_EQ E E' ==> STRONG_EQUIV E E'``,
+    REPEAT STRIP_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC ``STRONG_EQ``
+ >> ASM_REWRITE_TAC [STR_EQ_IS_STR_BISIM]);
+
+(* Now we have equivalence theorem used for rewriting:
+   |- ∀E E'. STRONG_EQ E E' ⇔ E ~~ E'
+ *)
+val STR_EQ_TO_STR_EQUIV = store_thm (
+   "STR_EQ_TO_STR_EQUIV",
+      ``!E E'. STRONG_EQ E E' = STRONG_EQUIV E E'``,
+    REPEAT GEN_TAC
+ >> EQ_TAC (* 2 sub-goals here *)
+ >| [ REWRITE_TAC [STR_EQ_IMP_STR_EQUIV],
+      REWRITE_TAC [STR_EQUIV_IMP_STR_EQ] ]);
+
+(* The other direction:
+   |- ∀E E'. E ~~ E' ⇔ STRONG_EQ E E'
+ *)
+val STR_EQUIV_TO_STR_EQ = save_thm (
+   "STR_EQUIV_TO_STR_EQ", GSYM STR_EQ_TO_STR_EQUIV);
+
+(* The co-induction principle for STRONG_EQUIV, generated from STRONG_EQ_coind *)
+val STRONG_EQUIV_coind = store_thm (
+   "STRONG_EQUIV_coind",
+  ``!R.
+     (!E E'.
+        R E E' ==>
+        (!u.
+          (!E1. TRANS E u E1 ==> ?E2. TRANS E' u E2 /\ R E1 E2) /\
+          (!E2. TRANS E' u E2 ==> ?E1. TRANS E u E1 /\ R E1 E2))) ==>
+      !E E'. R E E' ==> STRONG_EQUIV E E'``,
+    REWRITE_TAC [STR_EQUIV_TO_STR_EQ]
+ >> GEN_TAC
+ >> DISCH_TAC
+ >> HO_MATCH_MP_TAC STRONG_EQ_coind
+ >> ASM_REWRITE_TAC []);
+
+(******************************************************************************)
+(*                                                                            *)
+(*                Additional theorems of STRONG_EQUIV                         *)
+(*                                                                            *)
+(******************************************************************************)
+
+val BIGUNION_BISIM_def = Define `
+    BIGUNION_BISIM = CURRY (BIGUNION { UNCURRY R | STRONG_BISIM R })`;
+
+(* STRONG_EQUIV is the union of all STRONG_BISIMs *)
+val STRONG_EQUIV_IS_BIGUNION_BISIM = store_thm (
+   "STRONG_EQUIV_IS_BIGUNION_BISIM",
+  ``!E E'. STRONG_EQUIV E E' = BIGUNION_BISIM E E'``,
+    REWRITE_TAC [BIGUNION_BISIM_def]
+ >> REPEAT GEN_TAC
+ >> REWRITE_TAC [CURRY_DEF]
+ >> ONCE_REWRITE_RHS_TAC [GSYM SPECIFICATION]
+ >> REWRITE_TAC [IN_BIGUNION]
+ >> REWRITE_TAC [GSPECIFICATION]
+ >> BETA_TAC
+ >> REWRITE_TAC [PAIR_EQ]
+ >> REWRITE_TAC [SPECIFICATION]
+ >> REWRITE_TAC [STRONG_EQUIV]
+ >> EQ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      REPEAT STRIP_TAC \\
+      EXISTS_TAC ``UNCURRY (Bsm :CCS -> CCS -> bool)`` \\
+      REWRITE_TAC [UNCURRY] \\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ ASM_REWRITE_TAC [],
+        EXISTS_TAC ``(Bsm :CCS -> CCS -> bool)`` \\
+        ASM_REWRITE_TAC [] ],
+      (* goal 2 (of 2) *)
+      REPEAT STRIP_TAC \\
+      EXISTS_TAC ``x :CCS -> CCS -> bool`` \\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ PAT_X_ASSUM ``(s :CCS # CCS -> bool) ((E :CCS), (E' :CCS))`` MP_TAC \\
+        ASM_REWRITE_TAC [UNCURRY],
+        ASM_REWRITE_TAC [] ] ]);
+
+val STRONG_EQUIV_IS_BIGUNION_BISIM' = store_thm (
+   "STRONG_EQUIV_IS_BIGUNION_BISIM'",
+  ``STRONG_EQUIV = BIGUNION_BISIM``,
+    REWRITE_TAC [FUN_EQ_THM, STRONG_EQUIV_IS_BIGUNION_BISIM]);
+
+(* forward way: |- STRONG_EQUIV = BIGUNION_BISIM *)
+val STRONG_EQUIV_IS_BIGUNION_BISIM'' = save_thm (
+   "STRONG_EQUIV_IS_BIGUNION_BISIM''",
+    EXT (GEN ``E: CCS``
+	  (EXT (SPEC ``E: CCS`` STRONG_EQUIV_IS_BIGUNION_BISIM))));
+
+val STRONG_EQUIV_EQ_BIGUNION_BISIM = store_thm (
+   "STRONG_EQUIV_EQ_BIGUNION_BISIM",
+  ``STRONG_EQUIV = CURRY (BIGUNION { UNCURRY R | STRONG_BISIM R })``,
+    REWRITE_TAC [STRONG_EQUIV_IS_BIGUNION_BISIM'',
+		 BIGUNION_BISIM_def]);
+
+(* Define the strong bisimulation relation up to STRONG_EQUIV *)
+val STRONG_BISIM_UPTO = new_definition (
+   "STRONG_BISIM_UPTO",
+  ``STRONG_BISIM_UPTO (Bsm: CCS -> CCS -> bool) =
+       (!E E'.
+          Bsm E E' ==>
+          (!u.
+           (!E1. TRANS E u E1 ==> 
+                 ?E2. TRANS E' u E2 /\ (STRONG_EQUIV O Bsm O STRONG_EQUIV) E1 E2) /\
+           (!E2. TRANS E' u E2 ==> 
+                 ?E1. TRANS E u E1 /\ (STRONG_EQUIV O Bsm O STRONG_EQUIV) E1 E2)))``);
+
+val _ = export_theory ();
+val _ = DB.html_theory "StrongEQ";
+
+(* last updated: May 14, 2017 *)

--- a/examples/CCS/StrongLawsLib.sig
+++ b/examples/CCS/StrongLawsLib.sig
@@ -1,0 +1,38 @@
+(*
+ * Copyright 1991-1995  University of Cambridge (Author: Monica Nesi)
+ * Copyright 2016-2017  University of Bologna   (Author: Chun Tian)
+ *)
+
+signature StrongLawsLib =
+sig
+  include Abbrev
+
+  val STRONG_SUM_ASSOC_CONV	: conv
+  val STRONG_SUM_NIL_CONV	: conv
+  val STRONG_FIND_IDEMP		: term -> term list -> thm
+  val STRONG_SUM_IDEMP_CONV	: conv
+  val STRONG_RESTR_ELIM_CONV	: conv
+  val STRONG_RELAB_ELIM_CONV	: conv
+  val COND_EVAL_CONV		: conv
+  val BETA_COND_CONV		: conv
+  val IS_PREFIX_CHECK		: term -> term -> term -> thm
+  val STRONG_PAR_NIL_CONV	: conv
+  val STRONG_NIL_SUM_PAR_CONV	: conv
+  val PREFIX_EXTRACT		: conv
+  val SIMPLIFY_CONV		: conv
+  val ALL_SYNC_CONV		: term -> term -> term -> term -> thm
+  val STRONG_PAR_SUM_CONV	: conv
+  val STRONG_PAR_PREFIX_CONV	: term * term -> term * term -> thm
+  val STRONG_PAR_ELIM_CONV	: conv
+  val STRONG_EXP_THM_CONV	: conv
+  val STRONG_REC_UNF_CONV	: conv
+  val STRONG_REC_FOLD_CONV	: conv
+  val STRONG_PAR_ELIM_TAC	: tactic
+  val STRONG_REC_UNF_TAC	: tactic
+  val STRONG_RELAB_ELIM_TAC	: tactic
+  val STRONG_RESTR_ELIM_TAC	: tactic
+  val STRONG_SUM_IDEMP_TAC	: tactic
+  val STRONG_SUM_NIL_TAC	: tactic
+  val STRONG_EXP_THM_TAC	: tactic
+
+end

--- a/examples/CCS/StrongLawsLib.sml
+++ b/examples/CCS/StrongLawsLib.sml
@@ -1,0 +1,455 @@
+(*
+ * Copyright 1991-1995  University of Cambridge (Author: Monica Nesi)
+ * Copyright 2016-2017  University of Bologna   (Author: Chun Tian)
+ *)
+
+structure StrongLawsLib :> StrongLawsLib =
+struct
+
+open HolKernel Parse boolLib bossLib;
+open prim_recTheory arithmeticTheory numTheory numLib;
+open stringLib PFset_conv IndDefRules listSyntax;
+open CCSLib CCSTheory CCSSyntax CCSSimps;
+open StrongEQTheory StrongEQLib StrongLawsTheory;
+
+infixr 0 S_THENC S_ORELSEC;
+
+(******************************************************************************)
+(*                                                                            *)
+(*       Conversions for the summation operator and strong equivalence        *)
+(*                                                                            *)
+(******************************************************************************)
+
+fun STRONG_SUM_ASSOC_CONV tm = let
+    val (a,b) = args_sum tm
+in
+    if is_sum b then
+	let val (b1, b2) = args_sum b;
+	    val thm = SPECL [a, b1, b2] STRONG_SUM_ASSOC_L;
+	    val thm' = STRONG_SUM_ASSOC_CONV (rhs_tm thm)
+	in
+	    S_TRANS thm thm'
+	end
+    else if is_sum a then
+	let val thm'' = STRONG_SUM_ASSOC_CONV a
+	in
+	    SPEC b (MATCH_MP STRONG_EQUIV_SUBST_SUM_R thm'')
+	end
+    else
+	SPEC tm STRONG_EQUIV_REFL
+end;
+
+(* Conversion for the application of STRONG_SUM_IDENT(_L/R). *)
+fun STRONG_SUM_NIL_CONV tm =
+  if is_sum tm then
+    let
+	val (t1, t2) = args_sum tm
+    in
+	if is_nil t1 then
+	    SPEC t2 STRONG_SUM_IDENT_L
+	else if is_nil t2 then
+	    SPEC t1 STRONG_SUM_IDENT_R
+	else
+	    failwith "STRONG_SUM_NIL_CONV"
+    end
+  else
+      failwith "STRONG_SUM_NIL_CONV";
+
+(* Find repeated occurrences of a summand to be then deleted by applying
+   STRONG_SUM_IDEMP. *)
+fun STRONG_FIND_IDEMP tm l = let
+    val h::t = l
+in
+    if (null t) then
+	failwith "term not a CCS summation"
+    else
+	let val tm' = fst (args_sum tm)
+	in
+	    if (mem h t) then
+		let val (l1, l2) = FIND_SMD [] h [] tm'
+		in 
+		    if (null l2) then
+			if (null l1) then
+			    SPEC h STRONG_SUM_IDEMP
+			else
+			    let val y = hd l1
+			    in
+				S_TRANS (SPECL [y, h, h] STRONG_SUM_ASSOC_R)
+					(SPEC y (MP (SPECL [mk_sum (h, h), h] STRONG_EQUIV_SUBST_SUM_R)
+						    (SPEC h STRONG_SUM_IDEMP)))
+			    end
+		    else
+			let val thm1 = 
+				if (null l1) then
+				    S_TRANS (S_SYM (STRONG_SUM_ASSOC_CONV
+							(mk_sum (mk_sum (h, hd l2), h))))
+					    (SPECL [h, hd l2] STRONG_SUM_MID_IDEMP)
+				else
+				    S_TRANS (S_SYM (STRONG_SUM_ASSOC_CONV
+							(mk_sum (mk_sum (mk_sum (hd l1, h), hd l2), h))))
+					    (SPECL [hd l1, h, hd l2] STRONG_LEFT_SUM_MID_IDEMP)
+			in
+			    S_TRANS thm1 (STRONG_SUM_ASSOC_CONV (snd (args_thm thm1)))
+			end
+		end
+	    else
+		let val thm' = STRONG_FIND_IDEMP tm' t
+		in  
+		    SPEC h (MATCH_MP STRONG_EQUIV_SUBST_SUM_R thm')
+		end
+	end
+end;
+
+(* Conversion for the application of STRONG_SUM_IDEMP. *)
+fun STRONG_SUM_IDEMP_CONV tm =
+  if is_sum tm then
+      let val thm = STRONG_SUM_ASSOC_CONV tm;
+	  val t1 = rhs_tm thm;
+	  val thm' = STRONG_FIND_IDEMP t1 (rev (flat_sum t1))
+      in
+	  S_TRANS thm thm'
+      end
+  else
+      failwith "STRONG_SUM_IDEMP_CONV";
+
+(******************************************************************************)
+(*                                                                            *)
+(*       Conversions for the restriction operator and strong equivalence      *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Conversion for the application of the laws for the restriction operator. *)
+fun STRONG_RESTR_ELIM_CONV tm =
+  if is_restr tm then
+      let val (P, L) = args_restr tm
+      in
+	  if (is_nil P) then
+	      SPEC L STRONG_RESTR_NIL
+	  else if (is_sum P) then
+	      let val (P1, P2) = args_sum P in
+		  SPECL [P1, P2, L] STRONG_RESTR_SUM
+	      end
+	  else if (is_prefix P) then
+	      let val (u, P') = args_prefix P in
+		  if (is_tau u) then
+		      SPECL [P', L] STRONG_RESTR_PREFIX_TAU
+		  else
+		      let val l = arg_action u;
+			  val thm = Label_IN_CONV l L
+		      in
+			  if (rconcl thm = ``T``) then
+			      SPEC P' (MP (SPECL [l, L] STRONG_RESTR_PR_LAB_NIL)
+					  (DISJ1 (EQT_ELIM thm) ``COMPL ^l IN ^L``))
+			  else
+			      let val thmc = REWRITE_RHS_RULE [COMPL_LAB_def] (REFL ``COMPL ^l``);
+				  val thm' = Label_IN_CONV (rconcl thmc) L
+			      in
+				  if (rconcl thm' = ``T``) then
+				      SPEC P' (MP (ONCE_REWRITE_RULE [COMPL_LAB_def]
+							(SPECL [l, L] STRONG_RESTR_PR_LAB_NIL))
+						  (DISJ2 ``^l IN ^L`` (EQT_ELIM thm')))
+				  else
+				      SPEC P' (MP (ONCE_REWRITE_RULE [COMPL_LAB_def]
+							(SPECL [l, L] STRONG_RESTR_PREFIX_LABEL))
+						  (CONJ (EQF_ELIM thm) (EQF_ELIM thm')))
+			      end
+		      end
+	      end
+	  else
+	      failwith "STRONG_RESTR_ELIM_CONV"
+      end
+  else	       
+      failwith "STRONG_RESTR_ELIM_CONV"; 
+
+(******************************************************************************)
+(*                                                                            *)
+(*      Conversions for the relabelling operator and strong equivalence       *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Conversion for the application of the laws for the relabelling operator. *)
+fun STRONG_RELAB_ELIM_CONV tm =
+  if is_relab tm then
+      let val (P, rf) = args_relab tm
+      in
+	  if (is_nil P) then
+	      SPEC rf STRONG_RELAB_NIL
+	  else if (is_sum P) then
+	      let val (P1, P2) = args_sum P in
+		  SPECL [P1, P2, rf] STRONG_RELAB_SUM
+	      end
+	  else if (is_prefix P) then
+	      let val (u, P') = args_prefix P
+		  and labl = arg_relabelling rf;
+		  val thm_act = REWRITE_RHS_RULE
+				    [relabel_def, Apply_Relab_def,
+				     Label_distinct, Label_distinct', Label_11,
+				     COMPL_LAB_def, COMPL_COMPL_LAB]
+				    (REFL ``relabel (Apply_Relab ^labl) ^u``);
+		  val thm_act' = RELAB_EVAL_CONV (rconcl thm_act)
+	      in
+		  ONCE_REWRITE_RULE [TRANS thm_act thm_act']
+				    (SPECL [u, P', labl] STRONG_RELAB_PREFIX)
+	      end
+	  else
+	      failwith "STRONG_RELAB_ELIM_CONV"
+      end
+  else
+      failwith "STRONG_RELAB_ELIM_CONV";
+
+(******************************************************************************)
+(*                                                                            *)
+(*       Conversions for the parallel operator and strong equivalence         *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Conversion to evaluate conditionals involving numbers. *)
+fun COND_EVAL_CONV (c :term) :thm =
+  if is_cond c then
+      let val (b, l, r) = dest_cond c;
+	  val thm1 = num_CONV b
+	  and thm2 = ISPECL [l, r] CCS_COND_CLAUSES
+      in
+	  if (rconcl thm1) = ``T`` then
+	      SUBS [SYM thm1] (CONJUNCT1 thm2)
+	  else
+	      TRANS (SUBS [SYM thm1] (CONJUNCT2 thm2)) (COND_EVAL_CONV r)
+      end
+  else
+      REFL c;
+
+val BETA_COND_CONV = BETA_CONV THENC COND_EVAL_CONV;
+
+(* Conversion that checks that, for all k <= n, the agents given by the
+   function f are prefixed agents. *)
+fun IS_PREFIX_CHECK k n f = prove (
+  ``!^k. ^k <= ^n ==> Is_Prefix (^f ^k)``,
+    GEN_TAC
+ >> REWRITE_TAC [LESS_OR_EQ, LESS_THM, NOT_LESS_0]
+ >> BETA_TAC
+ >> STRIP_TAC
+ >> ASM_REWRITE_TAC [INV_SUC_EQ, NOT_SUC, SUC_NOT, PREF_IS_PREFIX]);
+
+(* Conversion for deleting nil subterms by means of the identity laws for the
+   parallel operator. *)
+fun STRONG_PAR_NIL_CONV tm =
+  if is_par tm then
+      let val (P, Q) = args_par tm
+      in
+	  if is_nil P then SPEC Q STRONG_PAR_IDENT_L
+	  else if is_nil Q then SPEC P STRONG_PAR_IDENT_R
+	  else 
+	      failwith "STRONG_PAR_NIL_CONV"
+      end
+  else
+      failwith "STRONG_PAR_NIL_CONV";
+
+(* Conversion for deleting nil subterms by means of the identity laws for the
+   parallel and summation operators. *)
+fun STRONG_NIL_SUM_PAR_CONV tm =
+  if is_par tm then
+      let val (P, Q) = args_par tm
+      in
+	  if is_nil P then
+	      SPEC Q STRONG_PAR_IDENT_L
+	  else if is_nil Q then
+	      SPEC P STRONG_PAR_IDENT_R
+	  else
+	      failwith "STRONG_NIL_SUM_PAR_CONV"
+      end
+  else if is_sum tm then
+      let val (P, Q) = args_sum tm
+      in
+	  if is_nil P then
+	      SPEC Q STRONG_SUM_IDENT_L
+	  else if is_nil Q then
+	      SPEC P STRONG_SUM_IDENT_R
+	  else
+	      failwith "STRONG_NIL_SUM_PAR_CONV"
+      end
+  else
+      failwith "STRONG_NIL_SUM_PAR_CONV";
+
+(* Conversion for extracting the prefixed action and the prefixed process by
+   applying PREF_ACT and PREF_PROC, respectively. *)
+fun PREFIX_EXTRACT tm = let
+    val (opr, opd) = dest_comb tm;
+    val (act, proc) = args_prefix opd
+in 
+    if (opr = ``PREF_ACT``) then
+	SPECL [act, proc] PREF_ACT_def
+    else if (opr = ``PREF_PROC``) then
+	SPECL [act, proc] PREF_PROC_def
+    else
+	failwith "PREFIX_EXTRACT"
+end;
+
+(* Conversion for simplifying a summation term. *)
+val SIMPLIFY_CONV =
+    (DEPTH_CONV BETA_COND_CONV) THENC (DEPTH_CONV PREFIX_EXTRACT);
+
+(* Conversion to compute the synchronizing summands. *)
+fun ALL_SYNC_CONV f n1 f' n2 =
+  let val c1 = REWRITE_CONV [ALL_SYNC_def] ``ALL_SYNC ^f ^n1 ^f' ^n2``;
+      val c2 = TRANS c1 (SIMPLIFY_CONV (rconcl c1));
+      val c3 = TRANS c2 (REWRITE_CONV [SYNC_def] (rconcl c2));
+      val c4 = TRANS c3 (SIMPLIFY_CONV (rconcl c3));
+      val c5 = TRANS c4 (REWRITE_CONV [LABEL_def, COMPL_LAB_def, Action_distinct_label,  
+                                       Label_distinct, Label_distinct', Label_11]
+				      (rconcl c4))
+  in
+      TRANS c5 (REWRITE_RHS_RULE [] (DEPTH_CONV string_EQ_CONV (rconcl c5)))
+  end;
+
+(* Conversion for the application of the law for the parallel operator in the
+   general case of at least one summation agent in parallel. *)
+fun STRONG_PAR_SUM_CONV tm = let
+    fun comp_fun tm =
+      let val thm = REWRITE_RHS_RULE [CCS_SIGMA_def] ((DEPTH_CONV BETA_CONV) tm);
+	  val thm' = REWRITE_RHS_RULE [INV_SUC_EQ, NOT_SUC, SUC_NOT, PREF_ACT_def, PREF_PROC_def]
+				      ((DEPTH_CONV BETA_CONV) (rconcl thm))
+      in TRANS thm thm' end;
+    val (ls1, ls2) = (fn (x, y) => (flat_sum x, flat_sum y)) (args_par tm)
+    and (P1, P2) = args_par tm;
+    val ARBtm = inst [``:'a`` |-> ``:CCS``] ``ARB: 'a``;
+    val f = ``\x: num. ^(sum_to_fun ls1 ARBtm ``0: num``)``
+    and f' = ``\x: num. ^(sum_to_fun ls2 ARBtm ``0: num``)``
+    and [n1, n2] = map (term_of_int o length) [ls1, ls2];
+    val [thm1, thm2] =
+	map (fn t => REWRITE_RULE [INV_SUC_EQ, NOT_SUC, SUC_ID]
+				  (BETA_RULE (REWRITE_CONV [CCS_SIGMA_def] t)))
+            [``SIGMA ^f ^n1``, ``SIGMA ^f' ^n2``]
+    and thmp1 = IS_PREFIX_CHECK ``i: num`` n1 f
+    and thmp2 = IS_PREFIX_CHECK ``j: num`` n2 f'
+    and [thmc1, thmc2] =
+        map comp_fun
+            [``SIGMA (\i. prefix (PREF_ACT (^f i))
+				 (par (PREF_PROC (^f i)) (SIGMA ^f' ^n2))) ^n1``,
+             ``SIGMA (\j. prefix (PREF_ACT (^f' j))
+				 (par (SIGMA ^f ^n1) (PREF_PROC (^f' j)))) ^n2``]
+    and thm_sync = ALL_SYNC_CONV f n1 f' n2;
+    val thmt =
+	REWRITE_RULE [thmc1, thmc2, thm_sync]
+		     (MATCH_MP (SPECL [f, n1, f', n2] STRONG_PAR_LAW)
+			       (CONJ thmp1 thmp2))
+in
+    if is_prefix P1 then
+	let val thma' = S_SUBST (STRONG_SUM_ASSOC_CONV P2) ``par ^P1 ^P2``
+	in 
+	    S_TRANS thma' (REWRITE_LHS_RULE [thm1, thm2] thmt)
+	end
+    else if is_prefix P2 then
+	let val thma' = S_SUBST (STRONG_SUM_ASSOC_CONV P1) ``par ^P1 ^P2``
+	in 
+	    S_TRANS thma' (REWRITE_LHS_RULE [thm1, thm2] thmt)
+	end
+    else
+	let val thma = S_SUBST (STRONG_SUM_ASSOC_CONV P1) ``par ^P1 ^P2``;
+	    val thma' = S_TRANS thma
+				(S_SUBST (STRONG_SUM_ASSOC_CONV P2) (rhs_tm thma))
+	in
+	    S_TRANS thma' (REWRITE_LHS_RULE [thm1, thm2] thmt)
+	end
+end;
+
+(* Conversion for the application of the laws for the parallel operator in the
+   particular case of two prefixed agents in parallel. *)
+fun STRONG_PAR_PREFIX_CONV (u, P) (v, Q) =
+  if is_tau u andalso is_tau v then
+      SPECL [P, Q] STRONG_PAR_TAU_TAU
+  else
+      if is_tau u then
+	  SPECL [P, v, Q] STRONG_PAR_TAU_PREF
+      else if is_tau v then
+	  SPECL [u, P, Q] STRONG_PAR_PREF_TAU
+      else
+	  let val [l1, l2] = map arg_action [u, v];
+	      val thmc = REWRITE_RHS_RULE [COMPL_LAB_def] (REFL ``^l1 = COMPL ^l2``)
+	  in
+	      if (rconcl thmc = ``T``) then (* synchronization between l1 and l2 *)
+		  SPECL [P, Q] (MP (SPECL [l1, l2] STRONG_PAR_PREF_SYNCR)
+				   (EQT_ELIM thmc))
+	      else (* no synchronization between l1 and l2 *)
+		  let val thm_lab = TRANS thmc (Label_EQ_CONV (rconcl thmc)) in  
+		      SPECL [P, Q] (MP (SPECL [l1, l2] STRONG_PAR_PREF_NO_SYNCR)
+				       (EQF_ELIM thm_lab))
+		  end
+	  end;
+
+(* Conversion for the application of the laws for the parallel operator. *)
+fun STRONG_PAR_ELIM_CONV tm =
+  if is_par tm then
+      let val (P1, P2) = args_par tm
+      in
+	  if (is_prefix P1 andalso is_prefix P2) then
+	      let val thm = STRONG_PAR_PREFIX_CONV (args_prefix P1) (args_prefix P2) in
+		  S_TRANS thm (S_DEPTH_CONV STRONG_NIL_SUM_PAR_CONV (rhs_tm thm))
+	      end
+	  else if (is_sum P1 andalso is_prefix P2) orelse
+		  (is_prefix P1 andalso is_sum P2) orelse
+		  (is_sum P1 andalso is_sum P2) then
+	      let val thm = STRONG_PAR_SUM_CONV tm in
+		  S_TRANS thm (S_DEPTH_CONV STRONG_NIL_SUM_PAR_CONV (rhs_tm thm))
+	      end
+	  else
+	      failwith "STRONG_PAR_ELIM_CONV"
+      end
+  else
+      failwith "STRONG_PAR_ELIM_CONV";
+
+(* Conversion for applying the expansion theorem (parallel and restriction
+   operators). *)
+val STRONG_EXP_THM_CONV =
+    (S_DEPTH_CONV STRONG_PAR_ELIM_CONV) S_THENC
+    (S_TOP_DEPTH_CONV STRONG_RESTR_ELIM_CONV) S_THENC
+    (S_DEPTH_CONV STRONG_SUM_NIL_CONV);
+
+(******************************************************************************)
+(*                                                                            *)
+(*       Conversions for the recursion operator and strong equivalence        *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Conversion for applying the unfolding law for the recursion operator. *)
+fun STRONG_REC_UNF_CONV rtm =
+  if is_rec rtm then
+      let val (X, E) = args_rec rtm in
+	  REWRITE_RULE [CCS_Subst_def] (SPECL [X, E] STRONG_UNFOLDING)
+      end
+  else
+      failwith "STRONG_REC_UNF_CONV: no recursive terms";
+
+(* Conversion for folding a recursive term. *)
+fun STRONG_REC_FOLD_CONV rtm =
+  if is_rec rtm then
+      let val (X, E) = args_rec rtm in
+	  S_SYM (REWRITE_RULE [CCS_Subst_def] (SPECL [X, E] STRONG_UNFOLDING))
+      end
+  else
+      failwith "STRONG_REC_FOLD_CONV: no recursive terms";
+
+(******************************************************************************)
+(*                                                                            *)
+(*           Tactics for applying the laws for strong equivalence             *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Tactics for the application of the laws for STRONG_EQUIV on the left-hand
+   side of a strong equivalence. *)
+val [STRONG_SUM_IDEMP_TAC,
+     STRONG_SUM_NIL_TAC,
+     STRONG_RELAB_ELIM_TAC,
+     STRONG_RESTR_ELIM_TAC,
+     STRONG_PAR_ELIM_TAC,
+     STRONG_REC_UNF_TAC] = map (S_LHS_CONV_TAC o S_DEPTH_CONV)  
+                                [STRONG_SUM_IDEMP_CONV,
+                                 STRONG_SUM_NIL_CONV,
+                                 STRONG_RELAB_ELIM_CONV,
+                                 STRONG_RESTR_ELIM_CONV,
+                                 STRONG_PAR_ELIM_CONV,
+                                 STRONG_REC_UNF_CONV];
+
+(* Tactic for applying the expansion theorem. *)
+val STRONG_EXP_THM_TAC = S_LHS_CONV_TAC STRONG_EXP_THM_CONV;
+
+end (* struct *)

--- a/examples/CCS/StrongLawsScript.sml
+++ b/examples/CCS/StrongLawsScript.sml
@@ -1,0 +1,1999 @@
+(*
+ * Copyright 1991-1995  University of Cambridge (Author: Monica Nesi)
+ * Copyright 2016-2017  University of Bologna   (Author: Chun Tian)
+ *)
+
+open HolKernel Parse boolLib bossLib;
+
+open stringTheory pred_setTheory prim_recTheory arithmeticTheory relationTheory;
+open CCSLib CCSTheory StrongEQTheory StrongEQLib;
+
+val _ = new_theory "StrongLaws";
+
+(******************************************************************************)
+(*                                                                            *)
+(*  Basic laws of strong equivalence for the sum operator (sum_strong_laws)   *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Prove STRONG_SUM_IDENT_R: |- !E. STRONG_EQUIV (sum E nil) E *)
+val STRONG_SUM_IDENT_R = store_thm (
+   "STRONG_SUM_IDENT_R",``!E. STRONG_EQUIV (sum E nil) E``,
+    GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC
+       ``\x y. (x = y) \/ (?E'. (x = sum E' nil) /\ (y = E'))``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC \\
+      DISJ2_TAC \\
+      EXISTS_TAC ``E: CCS`` \\
+      REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 4 sub-goals here *)
+      [ (* goal 2.1 (of 4) *)
+        EXISTS_TAC ``E1: CCS`` \\
+        ASM_REWRITE_TAC [REWRITE_RULE [ASSUME ``E: CCS = E'``]
+                                 (ASSUME ``TRANS E u E1``)],
+        (* goal 2.2 (of 4) *)
+        EXISTS_TAC ``E2: CCS`` \\
+        ASM_REWRITE_TAC [],
+        (* goal 2.3 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E = sum E'' nil``]
+                            (ASSUME ``TRANS E u E1``)) \\
+        IMP_RES_TAC TRANS_SUM_NIL \\
+        EXISTS_TAC ``E1: CCS`` \\
+        ASM_REWRITE_TAC [],
+        (* goal 2.4 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E': CCS = E''``]
+                            (ASSUME ``TRANS E' u E2``)) \\
+        EXISTS_TAC ``E2: CCS`` \\
+        ASM_REWRITE_TAC [] \\
+        MATCH_MP_TAC SUM1 \\
+        PURE_ONCE_ASM_REWRITE_TAC [] ] ]);
+
+(* Prove STRONG_SUM_IDEMP: |- !E. STRONG_EQUIV (sum E E) E *)
+val STRONG_SUM_IDEMP = store_thm (
+   "STRONG_SUM_IDEMP", ``!E. STRONG_EQUIV (sum E E) E``,
+    GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC
+       ``\x y. (x = y) \/ (?E'. (x = sum E' E') /\ (y = E'))``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC \\
+      DISJ2_TAC \\
+      EXISTS_TAC ``E: CCS`` \\
+      REWRITE_TAC [],
+      (* goal 2 (of 2) *)  
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 4 sub-goals here *)
+      [ (* goal 2.1 (of 4) *)
+        EXISTS_TAC ``E1: CCS`` \\
+        ASM_REWRITE_TAC [REWRITE_RULE [ASSUME ``E: CCS = E'``]
+                                 (ASSUME ``TRANS E u E1``)],
+        (* goal 2.2 (of 4) *)
+        EXISTS_TAC ``E2: CCS`` \\
+        ASM_REWRITE_TAC [],
+        (* goal 2.3 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E = sum E'' E''``]
+                            (ASSUME ``TRANS E u E1``)) \\
+        IMP_RES_TAC TRANS_P_SUM_P \\
+        EXISTS_TAC ``E1: CCS`` \\
+        ASM_REWRITE_TAC [],
+        (* goal 2.4 (of 4) *)
+        EXISTS_TAC ``E2: CCS`` \\
+        ASM_REWRITE_TAC [] \\
+        MATCH_MP_TAC SUM1 \\
+        PURE_ONCE_REWRITE_TAC [REWRITE_RULE [ASSUME ``E': CCS = E''``]
+                                       (ASSUME ``TRANS E' u E2``)] ] ]);
+
+(* Prove STRONG_SUM_COMM: |- !E E'. STRONG_EQUIV(sum E E') (sum E' E) *)
+val STRONG_SUM_COMM = store_thm (
+   "STRONG_SUM_COMM", ``!E E'. STRONG_EQUIV (sum E E') (sum E' E)``,
+    REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC
+       ``\x y. (x = y) \/ (?E1 E2. (x = sum E1 E2) /\ (y = sum E2 E1))``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC \\
+      DISJ2_TAC \\
+      EXISTS_TAC ``E: CCS`` \\
+      EXISTS_TAC ``E': CCS`` \\
+      REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 4 sub-goals here *)
+      [ (* goal 2.1 (of 4) *)
+        EXISTS_TAC ``E1: CCS`` \\
+        ASM_REWRITE_TAC [REWRITE_RULE [ASSUME ``E: CCS = E'``]
+                                 (ASSUME ``TRANS E u E1``)],
+        (* goal 2.2 (of 4) *)
+        EXISTS_TAC ``E2: CCS`` \\
+        ASM_REWRITE_TAC [],
+        (* goal 2.3 (of 4) *)
+        EXISTS_TAC ``E1': CCS`` \\
+        ASM_REWRITE_TAC [REWRITE_RULE [ASSUME ``E = sum E1 E2``] 
+                                 (ASSUME ``TRANS E u E1'``),
+                         TRANS_COMM_EQ],
+        (* goal 2.4 (of 4) *)
+        EXISTS_TAC ``E2': CCS`` \\
+        ASM_REWRITE_TAC [REWRITE_RULE [ASSUME ``E' = sum E2 E1``] 
+                                 (ASSUME ``TRANS E' u E2'``),
+                         TRANS_COMM_EQ] ] ]);
+
+(* Prove STRONG_SUM_IDENT_L: |- !E. STRONG_EQUIV (sum nil E) E *)
+val STRONG_SUM_IDENT_L = save_thm (
+   "STRONG_SUM_IDENT_L",
+    GEN ``E: CCS``
+       (S_TRANS (SPECL [``nil``, ``E: CCS``] STRONG_SUM_COMM)
+                (SPEC ``E: CCS`` STRONG_SUM_IDENT_R)));
+
+val STRONG_SUM_ASSOC_R = store_thm (
+   "STRONG_SUM_ASSOC_R",
+      ``!E E' E''.
+         STRONG_EQUIV (sum (sum E E') E'') (sum E (sum E' E''))``,
+    REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC
+      ``\x y. (x = y) \/ (?E1 E2 E3. (x = sum (sum E1 E2) E3) /\
+                                     (y = sum E1 (sum E2 E3)))``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC \\
+      DISJ2_TAC \\
+      take [`E`, `E'`, `E''`] \\
+      REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 4 sub-goals *)
+      [ (* goal 2.1 (of 4) *)
+        EXISTS_TAC ``E1: CCS`` \\
+        ASM_REWRITE_TAC [REWRITE_RULE [ASSUME ``E: CCS = E'``]
+                                 (ASSUME ``TRANS E u E1``)],
+        (* goal 2.2 (of 4) *)
+        EXISTS_TAC ``E2: CCS`` \\
+        ASM_REWRITE_TAC [],
+        (* goal 2.3 (of 4) *)
+        EXISTS_TAC ``E1': CCS`` \\
+        ASM_REWRITE_TAC [] \\
+        ASM_REWRITE_TAC [REWRITE_RULE [ASSUME ``E = sum (sum E1 E2) E3``]
+                                 (ASSUME ``TRANS E u E1'``),
+                         SYM (SPEC_ALL TRANS_ASSOC_EQ)],
+        (* goal 2.4 (of 4) *)
+        EXISTS_TAC ``E2': CCS`` \\
+        ASM_REWRITE_TAC [REWRITE_RULE [ASSUME ``E' = sum E1 (sum E2 E3)``]
+                                 (ASSUME ``TRANS E' u E2'``),
+                         TRANS_ASSOC_EQ] ] ]);
+
+(* STRONG_SUM_ASSOC_L:
+   |- !E E' E''. STRONG_EQUIV (sum E (sum E' E'')) (sum (sum E E') E'')
+ *)
+val STRONG_SUM_ASSOC_L = save_thm (
+   "STRONG_SUM_ASSOC_L",
+    STRIP_FORALL_RULE S_SYM STRONG_SUM_ASSOC_R);
+
+(* STRONG_SUM_MID_IDEMP:
+   |- !E E'. STRONG_EQUIV (sum (sum E E') E) (sum E' E)
+ *)
+val STRONG_SUM_MID_IDEMP = save_thm (
+   "STRONG_SUM_MID_IDEMP",
+    GEN ``E: CCS``
+     (GEN ``E': CCS``
+       (S_TRANS
+        (SPEC ``E: CCS``
+         (MATCH_MP STRONG_EQUIV_SUBST_SUM_R
+          (SPECL [``E: CCS``, ``E': CCS``] STRONG_SUM_COMM)))
+        (S_TRANS
+         (SPECL [``E': CCS``, ``E: CCS``, ``E: CCS``] STRONG_SUM_ASSOC_R)
+         (SPEC ``E': CCS``
+          (MATCH_MP STRONG_EQUIV_SUBST_SUM_L
+           (SPEC ``E: CCS`` STRONG_SUM_IDEMP)))))));
+
+(* STRONG_LEFT_SUM_MID_IDEMP:
+   |- !E E' E''. STRONG_EQUIV (sum (sum (sum E E') E'') E') (sum (sum E E'') E')
+ *)
+val STRONG_LEFT_SUM_MID_IDEMP = save_thm (
+   "STRONG_LEFT_SUM_MID_IDEMP",
+  ((GEN ``E: CCS``) o
+   (GEN ``E': CCS``) o
+   (GEN ``E'': CCS``))
+      (S_TRANS
+        (S_TRANS
+         (SPEC ``E': CCS``
+          (MATCH_MP STRONG_EQUIV_SUBST_SUM_R
+           (SPEC ``E'': CCS``
+            (MATCH_MP STRONG_EQUIV_SUBST_SUM_R
+             (SPECL [``E: CCS``, ``E': CCS``] STRONG_SUM_COMM)))))
+         (SPEC ``E': CCS``
+          (MATCH_MP STRONG_EQUIV_SUBST_SUM_R
+           (SPECL [``E': CCS``, ``E: CCS``, ``E'': CCS``] STRONG_SUM_ASSOC_R))))
+        (SPECL [``E': CCS``, ``sum E E''``] STRONG_SUM_MID_IDEMP)));
+
+(******************************************************************************)
+(*                                                                            *)
+(*  Basic laws of strong equivalence for the par operator (par_strong_laws)   *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Prove STRONG_PAR_IDENT_R: |- !E. STRONG_EQUIV (par E nil) E *)
+val STRONG_PAR_IDENT_R = store_thm (
+   "STRONG_PAR_IDENT_R", ``!E. STRONG_EQUIV (par E nil) E``,
+    GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC ``\x y. (?E'. (x = par E' nil) /\ (y = E'))``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC \\
+      EXISTS_TAC ``E: CCS`` \\
+      REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 2.1 (of 2) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E = par E'' nil``]
+				 (ASSUME ``TRANS E u E1``)) \\
+        IMP_RES_TAC TRANS_PAR_P_NIL \\
+        EXISTS_TAC ``E''': CCS`` \\
+        ASM_REWRITE_TAC [] \\
+        EXISTS_TAC ``E''': CCS`` \\
+        ASM_REWRITE_TAC [],
+        (* goal 2.2 (of 2) *)
+        EXISTS_TAC ``par E2 nil`` \\
+        CONJ_TAC >| (* 2 sub-goals here *)
+        [ (* goal 2.2.1 (of 2) *)
+          PURE_ONCE_ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC PAR1 \\
+          ASSUME_TAC (REWRITE_RULE [ASSUME ``E': CCS = E''``]
+				   (ASSUME ``TRANS E' u E2``)) \\    
+          PURE_ONCE_ASM_REWRITE_TAC [],
+          (* goal 2.2.2 (of 2) *)
+          EXISTS_TAC ``E2: CCS`` \\
+          REWRITE_TAC [] ] ] ]);
+
+val STRONG_PAR_COMM = store_thm (
+   "STRONG_PAR_COMM", ``!E E'. STRONG_EQUIV (par E E') (par E' E)``,
+    REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC ``\x y. (?E1 E2. (x = par E1 E2) /\ (y = par E2 E1))``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC \\
+      take [`E`, `E'`] >> REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 2.1 (of 2) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E = par E1 E2``]
+                           (ASSUME ``TRANS E u E1'``)) \\
+        IMP_RES_TAC TRANS_PAR >| (* 3 sub-goals here *)
+        [ (* goal 2.1.1 (of 3) *)
+          EXISTS_TAC ``par E2 E1''`` \\
+          ASM_REWRITE_TAC [] \\
+          CONJ_TAC >| (* 2 sub-goals here *)
+          [ (* goal 2.1.1.1 (of 2) *)
+            MATCH_MP_TAC PAR2 \\
+            PURE_ONCE_ASM_REWRITE_TAC [],
+            (* goal 2.1.1.2 (of 2) *)
+            take [`E1''`, `E2`] \\
+            REWRITE_TAC [] ],
+          (* goal 2.1.2 (of 3) *)
+          EXISTS_TAC ``par E1'' E1`` \\
+          ASM_REWRITE_TAC [] \\
+          CONJ_TAC >| (* 2 sub-goals *)
+          [ (* goal 2.1.2.1 (of 2) *)
+            MATCH_MP_TAC PAR1 \\
+            PURE_ONCE_ASM_REWRITE_TAC [],
+            (* goal 2.1.2.2 (of 2) *)
+            take [`E1`, `E1''`] \\
+            REWRITE_TAC [] ],
+          (* goal 2.1.3 (of 3) *)
+          EXISTS_TAC ``par E2' E1''`` \\
+          ASM_REWRITE_TAC [] \\
+          CONJ_TAC >| (* 2 sub-goals here *)
+          [ (* goal 2.1.3.1 (of 2) *)
+            MATCH_MP_TAC PAR3 \\
+            EXISTS_TAC ``COMPL (l :Label)`` \\
+            ASM_REWRITE_TAC [COMPL_COMPL_LAB],
+            (* goal 2.1.3.2 (of 2) *)
+            take [`E1''`, `E2'`] \\
+            REWRITE_TAC [] ] ],
+         (* goal 2.2 (of 2) *)
+         ASSUME_TAC (REWRITE_RULE [ASSUME ``E' = par E2 E1``]
+                            (ASSUME ``TRANS E' u E2'``)) \\
+         IMP_RES_TAC TRANS_PAR >| (* 3 sub-goals here *)
+         [ (* goal 2.2.1 (of 3) *)
+           EXISTS_TAC ``par E1 E1'`` \\
+           ASM_REWRITE_TAC [] \\
+           CONJ_TAC >| (* 2 sub-goals here *)
+           [ (* goal 2.2.1.1 (of 2) *)
+             MATCH_MP_TAC PAR2 \\
+             PURE_ONCE_ASM_REWRITE_TAC [],
+             (* goal 2.2.1.2 (of 2) *)
+             take [`E1: CCS`, `E1'`] \\
+             REWRITE_TAC [] ],
+           (* goal 2.2.2 (of 3) *)
+           EXISTS_TAC ``par E1' E2`` \\
+           ASM_REWRITE_TAC [] \\
+           CONJ_TAC >| (* 2 sub-goals here *)
+           [ (* goal 2.2.2.1 (of 2) *)
+             MATCH_MP_TAC PAR1 \\
+             PURE_ONCE_ASM_REWRITE_TAC [],
+             (* goal 2.2.2.2 (of 2) *)
+             take [`E1'`, `E2`] \\
+             REWRITE_TAC [] ],
+           (* goal 2.2.3 (of 3) *)
+           EXISTS_TAC ``par E2'' E1'`` \\
+           ASM_REWRITE_TAC [] \\
+           CONJ_TAC >| (* 2 sub-goals *)
+           [ (* goal 2.2.3.1 (of 2) *)
+             MATCH_MP_TAC PAR3 \\
+             EXISTS_TAC ``COMPL (l :Label)`` \\
+             ASM_REWRITE_TAC [COMPL_COMPL_LAB],
+             (* goal 2.2.3.2 (of 2) *)
+             take [`E2''`, `E1'`] \\
+             REWRITE_TAC [] ] ] ] ]);
+
+(* STRONG_PAR_IDENT_L: |- !E. STRONG_EQUIV (par nil E) E *)
+val STRONG_PAR_IDENT_L = save_thm (
+   "STRONG_PAR_IDENT_L",
+    GEN_ALL
+       (S_TRANS (SPECL [``nil``, ``E: CCS``] STRONG_PAR_COMM) 
+                (SPEC ``E: CCS`` STRONG_PAR_IDENT_R)));
+
+val STRONG_PAR_ASSOC = store_thm (
+   "STRONG_PAR_ASSOC",
+      ``!E E' E''. STRONG_EQUIV (par (par E E') E'') (par E (par E' E''))``,
+    REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC
+      ``\x y. (?E1 E2 E3.
+               (x = par (par E1 E2) E3) /\ (y = par E1 (par E2 E3)))``
+ >> CONJ_TAC (* 2 sub-goals *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC \\
+      take [`E`, `E'`, `E''`] \\
+      REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 2.1 (of 2) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E = par (par E1 E2) E3``]
+                            (ASSUME ``TRANS E u E1'``)) \\
+        IMP_RES_TAC TRANS_PAR >| (* 3 sub-goals *)
+        [ (* goal 2.1.1 (of 3) *)
+          STRIP_ASSUME_TAC
+            (MATCH_MP TRANS_PAR (ASSUME ``TRANS (par E1 E2) u E1''``)) >| (* 3 sub-goals here *)
+          [ (* goal 2.1.1.1 (of 3) *)
+            EXISTS_TAC ``par E1''' (par E2 E3)`` \\
+            ASM_REWRITE_TAC [] \\
+            CONJ_TAC >| (* 2 sub-goals here *)
+            [ (* goal 2.1.1.1.1 (of 2) *)
+              MATCH_MP_TAC PAR1 \\
+              PURE_ONCE_ASM_REWRITE_TAC [],
+              (* goal 2.1.1.1.2 (of 2) *)
+              take [`E1'''`, `E2`, `E3`] \\
+              ASM_REWRITE_TAC [] ],
+            (* goal 2.1.1.2 (of 3) *)
+            EXISTS_TAC ``par E1 (par E1''' E3)`` \\
+            ASM_REWRITE_TAC [] \\
+            CONJ_TAC >| (* 2 sub-goals here *)
+            [ (* goal 2.1.1.2.1 (of 2) *)
+              MATCH_MP_TAC PAR2 \\
+              MATCH_MP_TAC PAR1 \\
+              PURE_ONCE_ASM_REWRITE_TAC [],
+              (* goal 2.1.1.2.2 (of 2) *)
+              take [`E1`, `E1'''`, `E3`] \\
+              ASM_REWRITE_TAC [] ],
+            (* goal 2.1.1.3 (of 3) *)
+            EXISTS_TAC ``par E1'''(par E2' E3)`` \\
+            ASM_REWRITE_TAC [] \\
+            CONJ_TAC >| (* 2 sub-goals here *)
+            [ (* goal 2.1.1.3.1 (of 2) *)
+              MATCH_MP_TAC PAR3 \\
+              EXISTS_TAC ``l: Label`` \\
+              ASM_REWRITE_TAC [] \\
+              MATCH_MP_TAC PAR1 \\
+              PURE_ONCE_ASM_REWRITE_TAC [],
+              (* goal 2.1.1.3.2 (of 2) *)
+              take [`E1'''`, `E2'`, `E3`] \\
+              ASM_REWRITE_TAC [] ] ],
+          (* goal 2.1.2 (of 3) *)
+          EXISTS_TAC ``par E1 (par E2 E1'')`` \\
+          CONJ_TAC >| (* 2 sub-goals *)
+          [ (* goal 2.1.2.1 (of 2) *)
+            PURE_ONCE_ASM_REWRITE_TAC [] \\
+            MATCH_MP_TAC PAR2 \\
+            MATCH_MP_TAC PAR2 \\
+            PURE_ONCE_ASM_REWRITE_TAC [],
+            (* goal 2.1.2.2 (of 2) *)
+            take [`E1`, `E2`, `E1''`] \\
+            ASM_REWRITE_TAC [] ],
+          (* goal 2.1.3 (of 3) *)
+          STRIP_ASSUME_TAC (* 3 sub-goals here *)
+            (MATCH_MP TRANS_PAR
+		      (ASSUME ``TRANS (par E1 E2) (label l) E1''``)) >|
+          [ (* goal 2.1.3.1 (of 3) *)
+            EXISTS_TAC ``par E1'''(par E2 E2')`` \\
+            ASM_REWRITE_TAC [] \\
+            CONJ_TAC >| (* 2 sub-goals here *)
+            [ (* goal 2.1.3.1.1 (of 2) *)
+              MATCH_MP_TAC PAR3 \\
+              EXISTS_TAC ``l: Label`` \\
+              ASM_REWRITE_TAC [] \\
+              MATCH_MP_TAC PAR2 \\
+              PURE_ONCE_ASM_REWRITE_TAC [],
+              (* goal 2.1.3.1.2 (of 2) *)
+              take [`E1'''`, `E2`, `E2'`] \\
+              ASM_REWRITE_TAC [] ],
+            (* goal 2.1.3.2 (of 3) *)
+            EXISTS_TAC ``par E1(par E1''' E2')`` \\
+            ASM_REWRITE_TAC [] \\
+            CONJ_TAC >| (* 2 sub-goals *)
+            [ (* goal 2.1.3.2.1 (of 2) *)
+              MATCH_MP_TAC PAR2 \\
+              MATCH_MP_TAC PAR3 \\
+              EXISTS_TAC ``l: Label`` \\
+              ASM_REWRITE_TAC [],
+              (* goal 2.1.3.2.2 (of 2) *)
+              take [`E1`, `E1'''`, `E2'`] \\
+              ASM_REWRITE_TAC [] ],
+            (* goal 2.1.3.3 (of 3) *)
+            IMP_RES_TAC Action_distinct_label ] ], 
+         (* goal 2.2 (of 2) *)
+         ASSUME_TAC (REWRITE_RULE [ASSUME ``E' = par E1(par E2 E3)``] 
+                            (ASSUME ``TRANS E' u E2'``)) \\
+         IMP_RES_TAC TRANS_PAR >| (* 3 sub-goals here *)
+         [ (* goal 2.2.1 (of 3) *)
+           EXISTS_TAC ``par (par E1' E2) E3`` >> ASM_REWRITE_TAC [] \\
+           CONJ_TAC >| (* 2 sub-goals here *)
+           [ (* goal 2.2.1.1 (of 2) *)
+             MATCH_MP_TAC PAR1 \\
+             MATCH_MP_TAC PAR1 \\
+             PURE_ONCE_ASM_REWRITE_TAC [],
+             (* goal 2.2.1.2 (of 2) *)
+             take [`E1'`, `E2: CCS`, `E3: CCS`] \\
+             ASM_REWRITE_TAC [] ],
+           (* goal 2.2.2 (of 3) *)
+           STRIP_ASSUME_TAC (* 3 sub-goals here *)
+             (MATCH_MP TRANS_PAR
+		       (ASSUME ``TRANS (par E2 E3) u E1'``)) >|
+           [ (* goal 2.2.2.1 (of 3) *)
+             EXISTS_TAC ``par (par E1 E1'') E3`` \\
+             ASM_REWRITE_TAC [] \\
+             CONJ_TAC >| (* 2 sub-goals *)
+             [ (* goal 2.2.2.1.1 (of 2) *)
+               MATCH_MP_TAC PAR1 \\
+               MATCH_MP_TAC PAR2 \\
+               PURE_ONCE_ASM_REWRITE_TAC [],
+               (* goal 2.2.2.1.2 (of 2) *)
+               take [`E1`, `E1''`, `E3`] \\
+               ASM_REWRITE_TAC [] ],
+             (* goal 2.2.2.2 (of 3) *)
+             EXISTS_TAC ``par (par E1 E2) E1''`` \\
+             ASM_REWRITE_TAC [] \\
+             CONJ_TAC >|
+             [ MATCH_MP_TAC PAR2 \\
+               PURE_ONCE_ASM_REWRITE_TAC [],
+               take [`E1`, `E2`, `E1''`] \\
+               ASM_REWRITE_TAC [] ],
+             (* goal 2.2.2.3 (of 3) *)
+             EXISTS_TAC ``par (par E1 E1'') E2''`` \\
+             ASM_REWRITE_TAC [] \\
+             CONJ_TAC >| (* 2 sub-goals here *)
+             [ (* goal 2.2.2.3.1 (of 2) *)
+               MATCH_MP_TAC PAR3 \\
+               EXISTS_TAC ``l: Label`` \\
+               ASM_REWRITE_TAC [] \\
+               MATCH_MP_TAC PAR2 \\
+               PURE_ONCE_ASM_REWRITE_TAC [],
+               (* goal 2.2.2.3.2 (of 2) *)
+               take [`E1`, `E1''`, `E2''`] \\
+               ASM_REWRITE_TAC [] ] ],
+           (* goal 2.2.3 (of 3) *)
+           STRIP_ASSUME_TAC (* 3 sub-goals here *)
+             (MATCH_MP TRANS_PAR
+		       (ASSUME ``TRANS (par E2 E3) (label (COMPL l)) E2''``)) >|
+           [ (* goal 2.2.3.1 (of 3) *)
+             EXISTS_TAC ``par (par E1' E1'') E3`` \\
+             ASM_REWRITE_TAC [] \\
+             CONJ_TAC >| (* 2 sub-goals *)
+             [ (* goal 2.2.3.1.1 *)
+               MATCH_MP_TAC PAR1 \\
+               MATCH_MP_TAC PAR3 \\
+               EXISTS_TAC ``l: Label`` \\
+               ASM_REWRITE_TAC [],
+               (* goal 2.2.3.1.2 *)
+               take [`E1'`, `E1''`, `E3`] \\
+               ASM_REWRITE_TAC [] ],
+             (* goal 2.2.3.2 (of 3) *)
+             EXISTS_TAC ``par (par E1' E2) E1''`` \\
+             ASM_REWRITE_TAC [] \\
+             CONJ_TAC >| (* 2 sub-goals here *)
+             [ (* goal 2.2.3.2.1 (of 2) *)
+               MATCH_MP_TAC PAR3 \\
+               EXISTS_TAC ``l: Label`` \\
+               ASM_REWRITE_TAC [] \\
+               MATCH_MP_TAC PAR1 >> PURE_ONCE_ASM_REWRITE_TAC [],
+               (* goal 2.2.3.2.2 (of 2) *)
+               take [`E1'`, `E2`, `E1''`] \\
+               ASM_REWRITE_TAC [] ],
+             (* goal 2.2.3.3 (of 3) *)
+             IMP_RES_TAC Action_distinct_label] ] ] ]);
+
+val STRONG_PAR_PREF_TAU = store_thm (
+   "STRONG_PAR_PREF_TAU",
+      ``!u E E'. 
+         STRONG_EQUIV 
+         (par (prefix u E) (prefix tau E'))
+         (sum (prefix u (par E (prefix tau E')))
+              (prefix tau (par (prefix u E) E')))``,
+    REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC
+       ``\x y. (x = y) \/ 
+              (?u' E1 E2. (x = par (prefix u' E1) (prefix tau E2)) /\
+                          (y = sum (prefix u' (par E1 (prefix tau E2)))
+                                   (prefix tau (par (prefix u' E1) E2))))``
+ >> CONJ_TAC (* 2 sub-goals *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC \\
+      DISJ2_TAC \\
+      take [`u`, `E`, `E'`] \\
+      REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 4 sub-goals *)
+      [ (* goal 2.1 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E: CCS = E'``]
+				 (ASSUME ``TRANS E u E1``)) \\
+        EXISTS_TAC ``E1: CCS`` \\
+        ASM_REWRITE_TAC [],
+        (* goal 2.2 (of 4) *)
+        EXISTS_TAC ``E2: CCS`` \\
+        ASM_REWRITE_TAC [],
+        (* goal 2.3 (of 4) *)
+        EXISTS_TAC ``E1': CCS`` \\
+        ASM_REWRITE_TAC [] \\
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E = par (prefix u' E1) (prefix tau E2)``]
+				 (ASSUME ``TRANS E u E1'``)) \\
+        IMP_RES_TAC TRANS_PAR >| (* 3 sub-goals *)
+        [ (* goal 2.3.1 (of 3) *)
+          IMP_RES_TAC TRANS_PREFIX \\
+          MATCH_MP_TAC SUM1 \\
+          ASM_REWRITE_TAC [PREFIX],
+          (* goal 2.3.2 (of 3) *)
+          IMP_RES_TAC TRANS_PREFIX \\
+          MATCH_MP_TAC SUM2 \\
+          ASM_REWRITE_TAC [PREFIX],
+          (* goal 2.3.3 (of 3) *)
+          IMP_RES_TAC TRANS_PREFIX \\
+          IMP_RES_TAC Action_distinct_label ],
+        (* goal 2.4 (of 4) *)
+        EXISTS_TAC ``E2': CCS`` \\
+        ASM_REWRITE_TAC [] \\
+        ASSUME_TAC (REWRITE_RULE
+                     [ASSUME ``E' = sum (prefix u' (par E1 (prefix tau E2)))
+                                        (prefix tau (par (prefix u' E1) E2))``]
+                     (ASSUME ``TRANS E' u E2'``)) \\
+        IMP_RES_TAC TRANS_SUM >| (* 2 sub-goals here *)
+        [ (* goal 2.4.1 (of 2) *)
+          IMP_RES_TAC TRANS_PREFIX \\
+          PURE_ONCE_ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC PAR1 \\
+          REWRITE_TAC [PREFIX],
+          (* goal 2.4.2 (of 2) *)
+          IMP_RES_TAC TRANS_PREFIX \\
+          PURE_ONCE_ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC PAR2 \\
+          REWRITE_TAC [PREFIX] ] ] ]);
+
+(* Prove STRONG_PAR_TAU_PREF:
+   |- !E u E'.
+       STRONG_EQUIV
+        (par (prefix tau E) (prefix u E'))
+        (sum (prefix tau (par E (prefix u E')))
+             (prefix u (par (prefix tau E) E')))
+ *)
+val STRONG_PAR_TAU_PREF = save_thm (
+   "STRONG_PAR_TAU_PREF",
+  ((GEN ``E: CCS``) o
+   (GEN ``u: Action``) o
+   (GEN ``E': CCS``))
+      (S_TRANS
+        (S_TRANS
+          (S_TRANS
+            (SPECL [``prefix tau E``, ``prefix u E'``] STRONG_PAR_COMM)
+            (SPECL [``u: Action``, ``E': CCS``, ``E: CCS``] STRONG_PAR_PREF_TAU))
+          (SPECL [``prefix u(par E'(prefix tau E))``,
+                  ``prefix tau(par(prefix u E')E)``] STRONG_SUM_COMM))
+        (MATCH_MP STRONG_EQUIV_PRESD_BY_SUM
+         (CONJ (SPEC ``tau``
+                (MATCH_MP STRONG_EQUIV_SUBST_PREFIX
+                 (SPECL [``prefix u E'``, ``E: CCS``] STRONG_PAR_COMM)))
+               (SPEC ``u: Action``
+                (MATCH_MP STRONG_EQUIV_SUBST_PREFIX
+                 (SPECL [``E': CCS``, ``prefix tau E``] STRONG_PAR_COMM)))))));
+
+(* Prove STRONG_PAR_TAU_TAU:
+   |- ∀E E'. τ..E || τ..E' ~ τ..(E || τ..E') + τ..(τ..E || E')
+ *)
+val STRONG_PAR_TAU_TAU = save_thm (
+   "STRONG_PAR_TAU_TAU", SPEC ``tau`` STRONG_PAR_PREF_TAU);
+
+(* Prove STRONG_PAR_PREF_NO_SYNCR:
+   |- ∀l l'.
+     l ≠ COMPL l' ⇒
+     ∀E E'.
+       label l..E || label l'..E' ~
+       label l..(E || label l'..E') + label l'..(label l..E || E')
+ *)
+val STRONG_PAR_PREF_NO_SYNCR = store_thm (
+   "STRONG_PAR_PREF_NO_SYNCR",
+      ``!l l'.
+         ~(l = COMPL l') ==>
+         (!E E'.
+           STRONG_EQUIV
+           (par (prefix (label l) E) (prefix (label l') E'))
+           (sum (prefix (label l) (par E (prefix (label l') E')))
+                (prefix (label l') (par (prefix (label l) E) E'))))``,
+    REPEAT STRIP_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC
+       ``\x y. (x = y) \/
+               (?l1 l2 E1 E2. ~(l1 = COMPL l2) /\  
+               (x = par (prefix (label l1) E1) (prefix (label l2) E2)) /\
+               (y = sum (prefix (label l1) (par E1 (prefix (label l2) E2))) 
+                        (prefix (label l2) (par (prefix (label l1) E1) E2))))`` 
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC \\
+      DISJ2_TAC \\
+      take [`l`, `l'`, `E`, `E'`] \\
+      ASM_REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 4 sub-goals here *)
+      [ (* goal 2.1 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E: CCS = E'``]
+				 (ASSUME ``TRANS E u E1``)) \\
+        EXISTS_TAC ``E1: CCS`` >> ASM_REWRITE_TAC [],
+        (* goal 2.2 (of 4) *)
+        EXISTS_TAC ``E2: CCS`` >> ASM_REWRITE_TAC [],
+        (* goal 2.3 (of 4) *)
+        EXISTS_TAC ``E1': CCS`` >> ASM_REWRITE_TAC [] \\
+        ASSUME_TAC (REWRITE_RULE
+                     [ASSUME ``E = par (prefix (label l1) E1) (prefix (label l2) E2)``]
+                            (ASSUME ``TRANS E u E1'``)) \\
+        IMP_RES_TAC TRANS_PAR >| (* 3 sub-goals here *)
+        [ (* goal 2.3.1 (of 3) *)
+          MATCH_MP_TAC SUM1 >> IMP_RES_TAC TRANS_PREFIX >> ASM_REWRITE_TAC [PREFIX],
+          (* goal 2.3.2 (of 3) *)
+          MATCH_MP_TAC SUM2 >> IMP_RES_TAC TRANS_PREFIX >> ASM_REWRITE_TAC [PREFIX],
+          (* goal 2.3.3 (of 3) *)
+          IMP_RES_TAC TRANS_PAR_NO_SYNCR \\
+          ASSUME_TAC (REWRITE_RULE [ASSUME ``u = tau``] 
+                      (ASSUME ``TRANS (par (prefix (label l1) E1)
+                                           (prefix (label l2) E2)) u E1'``)) \\
+          RES_TAC ],
+        (* goal 2.4 (of 4) *)
+        EXISTS_TAC ``E2': CCS`` \\
+        ASM_REWRITE_TAC [] \\
+        ASSUME_TAC (REWRITE_RULE
+			[ASSUME ``E' = sum 
+                             (prefix (label l1) (par E1 (prefix (label l2) E2)))
+                             (prefix (label l2) (par (prefix (label l1) E1) E2))``]
+                     (ASSUME ``TRANS E' u E2'``)) \\
+        IMP_RES_TAC TRANS_SUM \\ (* 2 sub-goals, sharing initial and end tacticals *)
+        IMP_RES_TAC TRANS_PREFIX \\
+        PURE_ONCE_ASM_REWRITE_TAC [] >|
+        [ MATCH_MP_TAC PAR1, MATCH_MP_TAC PAR2 ] \\
+        REWRITE_TAC [PREFIX] ] ]);
+
+(* Prove STRONG_PAR_PREF_SYNCR:
+   |- ∀l l'.
+     (l = COMPL l') ⇒
+     ∀E E'.
+       label l..E || label l'..E' ~
+       label l..(E || label l'..E') + label l'..(label l..E || E') +
+       τ..(E || E')
+ *)
+val STRONG_PAR_PREF_SYNCR = store_thm (
+   "STRONG_PAR_PREF_SYNCR",
+       ``!l l'. 
+         (l = COMPL l') ==>         
+         (!E E'.
+           STRONG_EQUIV 
+           (par (prefix (label l) E) (prefix (label l') E'))
+           (sum
+            (sum (prefix (label l) (par E (prefix (label l') E')))
+                 (prefix (label l') (par (prefix (label l) E) E')))
+            (prefix tau (par E E'))))``,    
+    REPEAT STRIP_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC
+       ``\x y. (x = y) \/
+              (?l1 l2 E1 E2. 
+               (l1 = COMPL l2) /\    
+               (x = par (prefix (label l1) E1) (prefix (label l2) E2)) /\
+               (y = sum
+                    (sum (prefix (label l1) (par E1 (prefix (label l2) E2)))
+                         (prefix (label l2) (par (prefix (label l1) E1) E2)))
+                    (prefix tau (par E1 E2))))``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC \\
+      DISJ2_TAC \\
+      take [`l`, `l'`, `E`, `E'`] \\
+      ASM_REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 4 sub-goals here *)
+      [ (* goal 2.1 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E: CCS = E'``]
+				 (ASSUME ``TRANS E u E1``)) \\
+        EXISTS_TAC ``E1: CCS`` \\
+        ASM_REWRITE_TAC [],
+        (* goal 2.2 (of 4) *)
+        EXISTS_TAC ``E2: CCS`` \\
+        ASM_REWRITE_TAC [],
+        (* goal 2.3 (of 4) *)
+        EXISTS_TAC ``E1': CCS`` \\
+        ASM_REWRITE_TAC [] \\
+        ASSUME_TAC (REWRITE_RULE
+			[ASSUME ``E = par (prefix (label l1) E1) (prefix (label l2) E2)``]
+			(ASSUME ``TRANS E u E1'``)) \\
+        IMP_RES_TAC TRANS_PAR >| (* 3 sub-goals here, sharing end tacticals *)
+        [ (* goal 2.3.1 (of 3) *)
+          MATCH_MP_TAC SUM1 >> MATCH_MP_TAC SUM1,
+          (* goal 2.3.2 (of 3) *)
+          MATCH_MP_TAC SUM1 >> MATCH_MP_TAC SUM2,
+          (* goal 2.3.3 (of 3) *)
+          MATCH_MP_TAC SUM2 ] \\
+        IMP_RES_TAC TRANS_PREFIX \\
+        ASM_REWRITE_TAC [PREFIX],
+        (* goal 2.4 (of 4) *)
+        EXISTS_TAC ``E2': CCS`` \\
+        ASM_REWRITE_TAC [] \\
+        ASSUME_TAC (REWRITE_RULE
+		     [ASSUME ``E' = sum (sum (prefix (label l1) (par E1 (prefix (label l2) E2)))
+					     (prefix (label l2) (par (prefix (label l1) E1) E2)))
+					(prefix tau (par E1 E2))``]
+                     (ASSUME ``TRANS E' u E2'``)) \\
+        IMP_RES_TAC TRANS_SUM >| (* 2 sub-goals here *)
+        [ (* goal 2.4.1 (of 2) *)
+          IMP_RES_TAC TRANS_SUM >| (* 4 sub-goals here *)
+          [ (* goal 2.4.1.1 (of 4) *)
+            IMP_RES_TAC TRANS_PREFIX >> ASM_REWRITE_TAC [] \\
+            MATCH_MP_TAC PAR1 >> REWRITE_TAC [PREFIX],
+            (* goal 2.4.1.2 (of 4) *)
+            IMP_RES_TAC TRANS_PREFIX \\
+            CHECK_ASSUME_TAC (REWRITE_RULE [ASSUME ``u = tau``, Action_distinct]
+                             (ASSUME ``u = label l1``)),
+            (* goal 2.4.1.3 (of 4) *)
+            IMP_RES_TAC TRANS_PREFIX >> ASM_REWRITE_TAC [] \\
+            MATCH_MP_TAC PAR2 >> REWRITE_TAC [PREFIX],
+            (* goal 2.4.1.4 (of 4) *)
+            IMP_RES_TAC TRANS_PREFIX \\
+            CHECK_ASSUME_TAC (REWRITE_RULE [ASSUME ``u = tau``, Action_distinct]
+                             (ASSUME ``u = label l2``)) ],
+          (* goal 2.4.2 (of 2) *)
+          IMP_RES_TAC TRANS_PREFIX >> ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC PAR3 \\
+          EXISTS_TAC ``COMPL (l2 :Label)`` \\
+          REWRITE_TAC [COMPL_COMPL_LAB, PREFIX] ] ] ]);
+
+(******************************************************************************)
+(*                                                                            *)
+(*      Basic laws of strong equivalence for the restriction operator         *)
+(*                                                                            *)
+(******************************************************************************)
+
+val STRONG_RESTR_NIL = store_thm (
+   "STRONG_RESTR_NIL", ``!L. STRONG_EQUIV (restr L nil) nil``,
+    GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC ``\x y. (?L'. (x = restr L' nil) /\ (y = nil))``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC >> EXISTS_TAC ``L: Label set`` >> REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] >> BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 2.1 (of 2) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E = restr L' nil``]
+				 (ASSUME ``TRANS E u E1``)) \\
+        IMP_RES_TAC RESTR_NIL_NO_TRANS,
+        (* goal 2.2 (of 2) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E' = nil``]
+				 (ASSUME ``TRANS E' u E2``)) \\
+        IMP_RES_TAC NIL_NO_TRANS ] ]);
+
+(* Prove STRONG_RESTR_SUM:
+   |- ∀E E' L. restr L (E + E') ~ restr L E + restr L E'
+ *)
+val STRONG_RESTR_SUM = store_thm (
+   "STRONG_RESTR_SUM",
+      ``!E E' L.
+         STRONG_EQUIV (restr L (sum E E')) (sum (restr L E) (restr L E'))``,
+    REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [PROPERTY_STAR]
+ >> REPEAT STRIP_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      EXISTS_TAC ``E1: CCS`` \\
+      REWRITE_TAC [STRONG_EQUIV_REFL] \\
+      IMP_RES_TAC TRANS_RESTR >| (* 2 sub-goals here *)
+      [ (* goal 1.1 (of 2) *)
+        IMP_RES_TAC TRANS_SUM >| (* 2 sub-goals here *)
+        [ (* goal 1.1.1 (of 2) *)
+          ASM_REWRITE_TAC [] >> MATCH_MP_TAC SUM1 \\
+          MATCH_MP_TAC RESTR \\
+          REWRITE_TAC [REWRITE_RULE [ASSUME ``u = tau``] 
+                       (ASSUME ``TRANS E u E''``)], 
+          (* goal 1.1.2 (of 2) *)
+          ASM_REWRITE_TAC [] >> MATCH_MP_TAC SUM2 \\
+          MATCH_MP_TAC RESTR \\
+          REWRITE_TAC [REWRITE_RULE [ASSUME ``u = tau``]
+                       (ASSUME ``TRANS E' u E''``)] ],
+        (* goal 1.2 (of 2) *)
+        IMP_RES_TAC TRANS_SUM >| (* 2 sub-goals here *)
+        [ (* goal 1.2.1 (of 2) *)
+          ASM_REWRITE_TAC [] >> MATCH_MP_TAC SUM1 \\
+          MATCH_MP_TAC RESTR \\
+          EXISTS_TAC ``l: Label`` \\
+          ASM_REWRITE_TAC [REWRITE_RULE [ASSUME ``u = label l``]
+                           (ASSUME ``TRANS E u E''``)],
+          (* goal 1.2.2 (of 2) *)
+          ASM_REWRITE_TAC [] >> MATCH_MP_TAC SUM2 \\
+          MATCH_MP_TAC RESTR \\
+          EXISTS_TAC ``l: Label`` \\
+          ASM_REWRITE_TAC [REWRITE_RULE [ASSUME ``u = label l``]
+                           (ASSUME ``TRANS E' u E''``)] ] ],
+      (* goal 2 (of 2) *)
+      EXISTS_TAC ``E2: CCS`` \\
+      REWRITE_TAC [STRONG_EQUIV_REFL] \\
+      IMP_RES_TAC TRANS_SUM >| (* 2 sub-goals here *)
+      [ (* goal 2.1 (of 2) *)
+        IMP_RES_TAC TRANS_RESTR >| (* 2 sub-goals here *)
+        [ (* goal 2.1.1 (of 2) *)
+          ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC RESTR >> REWRITE_TAC [] \\
+          MATCH_MP_TAC SUM1 \\
+          REWRITE_TAC [REWRITE_RULE [ASSUME ``u = tau``]
+                      (ASSUME ``TRANS E u E''``)],
+          (* goal 2.1.2 (of 2) *)
+          ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC RESTR \\
+          EXISTS_TAC ``l: Label`` >> ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC SUM1 \\
+          REWRITE_TAC [REWRITE_RULE [ASSUME ``u = label l``] 
+                      (ASSUME ``TRANS E u E''``)] ],
+        (* goal 2.2 (of 2) *)
+        IMP_RES_TAC TRANS_RESTR >| (* 2 sub-goals here *)
+        [ (* goal 2.2.1 (of 2) *)
+          ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC RESTR >> REWRITE_TAC [] \\
+          MATCH_MP_TAC SUM2 \\
+          REWRITE_TAC [REWRITE_RULE [ASSUME ``u = tau``]
+                      (ASSUME ``TRANS E' u E''``)],
+          (* goal 2.2.2 (of 2) *)
+          ASM_REWRITE_TAC[] \\
+          MATCH_MP_TAC RESTR \\
+          EXISTS_TAC ``l: Label`` >> ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC SUM2 \\
+          REWRITE_TAC [REWRITE_RULE [ASSUME ``u = label l``]
+                      (ASSUME ``TRANS E' u E''``)] ] ] ]);
+
+(* Prove STRONG_RESTR_PREFIX_TAU:
+   |- ∀E L. restr L (τ..E) ~ τ..restr L E
+ *)
+val STRONG_RESTR_PREFIX_TAU = store_thm (
+   "STRONG_RESTR_PREFIX_TAU",
+      ``!E L.
+         STRONG_EQUIV (restr L (prefix tau E)) (prefix tau (restr L E))``,
+    REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC
+       ``\x y. (x = y) \/ (?E' L'. (x = restr L' (prefix tau E')) /\
+                                   (y = prefix tau (restr L' E')))``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC >> DISJ2_TAC \\
+      EXISTS_TAC ``E: CCS`` \\
+      EXISTS_TAC ``L: Label set`` >> REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] >> BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 4 sub-goals here *)
+      [ (* goal 2.1 (of 4) *)
+        EXISTS_TAC ``E1: CCS`` \\
+        REWRITE_TAC [REWRITE_RULE [ASSUME ``E: CCS = E'``]
+                                  (ASSUME ``TRANS E u E1``)],
+        (* goal 2.2 (of 4) *)
+        EXISTS_TAC ``E2: CCS`` >> ASM_REWRITE_TAC [],
+        (* goal 2.3 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E = restr L' (prefix tau E'')``]
+                                 (ASSUME ``TRANS E u E1``)) \\
+        IMP_RES_TAC TRANS_RESTR >| (* 2 sub-goals *)
+        [ (* goal 2.3.1 (of 2) *)
+          IMP_RES_TAC TRANS_PREFIX \\
+          EXISTS_TAC ``E1: CCS`` >> ASM_REWRITE_TAC [PREFIX],
+          (* goal 2.3.2 (of 2) *)
+          IMP_RES_TAC TRANS_PREFIX \\
+          CHECK_ASSUME_TAC
+            (REWRITE_RULE [ASSUME ``u = tau``, Action_distinct]
+                          (ASSUME ``u = label l``)) ],
+        (* goal 2.4 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E' = prefix tau (restr L' E'')``]
+                                 (ASSUME ``TRANS E' u E2``)) \\
+        IMP_RES_TAC TRANS_PREFIX \\
+        EXISTS_TAC ``E2: CCS`` >> ASM_REWRITE_TAC [] \\
+        MATCH_MP_TAC RESTR >> REWRITE_TAC [PREFIX] ] ]);
+
+(* Prove STRONG_RESTR_PR_LAB_NIL:
+   |- ∀l L. l ∈ L ∨ COMPL l ∈ L ⇒ ∀E. restr L (label l..E) ~ nil:
+ *)
+val STRONG_RESTR_PR_LAB_NIL = store_thm (
+   "STRONG_RESTR_PR_LAB_NIL",
+      ``!l L.
+         (l IN L) \/ ((COMPL l) IN L) ==>
+         (!E. STRONG_EQUIV (restr L (prefix (label l) E)) nil)``,
+    REPEAT GEN_TAC
+ >> DISCH_TAC
+ >> GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC ``\x y. 
+                    (?l' L' E'. ((l' IN L') \/ ((COMPL l') IN L')) /\
+                                 (x = restr L' (prefix (label l') E')) /\
+                                 (y = nil))``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC \\
+      take [`l`, `L`, `E`] \\
+      ASM_REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 4 sub-goals here *)
+      [ (* goal 2.1 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E = restr L' (prefix (label l') E'')``]
+				 (ASSUME ``TRANS E u E1``)) \\
+        IMP_RES_TAC RESTR_LABEL_NO_TRANS,
+        (* goal 2.2 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E' = nil``]
+				 (ASSUME ``TRANS E' u E2``)) \\
+        IMP_RES_TAC NIL_NO_TRANS,
+        (* goal 2.3 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E = restr L' (prefix (label l') E'')``]
+				 (ASSUME ``TRANS E u E1``)) \\
+        IMP_RES_TAC RESTR_LABEL_NO_TRANS,
+        (* goal 2.4 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E' = nil``]
+				 (ASSUME ``TRANS E' u E2``)) \\
+        IMP_RES_TAC NIL_NO_TRANS ] ]);
+
+(* Prove STRONG_RESTR_PREFIX_LABEL:
+   |- ∀l L.
+     l ∉ L ∧ COMPL l ∉ L ⇒ ∀E. restr L (label l..E) ~ label l..restr L E
+ *)
+val STRONG_RESTR_PREFIX_LABEL = store_thm (
+   "STRONG_RESTR_PREFIX_LABEL",
+       ``!l L.
+         (~(l IN L) /\ ~((COMPL l) IN L)) ==>
+         (!E. STRONG_EQUIV (restr L (prefix (label l) E))
+                           (prefix (label l) (restr L E)))``,
+    REPEAT STRIP_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC 
+       ``\x y. (x = y) \/
+              (?l' L' E'. ~(l' IN L') /\ ~((COMPL l') IN L') /\ 
+                          (x = restr L' (prefix (label l') E')) /\
+                          (y = prefix (label l') (restr L' E')))``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC >> DISJ2_TAC \\
+      take [`l`, `L`, `E`] \\
+      ASM_REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 4 sub-goals here *)
+      [ (* goal 2.1 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E: CCS = E'``]
+				 (ASSUME ``TRANS E u E1``)) \\
+        EXISTS_TAC ``E1: CCS`` \\
+        ASM_REWRITE_TAC [],
+        (* goal 2.2 (of 4) *)
+        EXISTS_TAC ``E2: CCS`` \\
+        ASM_REWRITE_TAC [],
+        (* goal 2.3 (of 4) *)
+        EXISTS_TAC ``E1: CCS`` \\
+        REWRITE_TAC [] \\
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E = restr L' (prefix (label l') E'')``]
+				 (ASSUME ``TRANS E u E1``)) \\
+        IMP_RES_TAC TRANS_RESTR >| (* 2 sub-goals here *)
+        [ (* goal 2.3.1 (of 2) *)
+          IMP_RES_TAC TRANS_PREFIX \\
+          CHECK_ASSUME_TAC 
+            (REWRITE_RULE [ASSUME ``u = tau``, Action_distinct] 
+			  (ASSUME ``u = label l'``)),
+          (* goal 2.3.2 (of 2) *)
+          IMP_RES_TAC TRANS_PREFIX \\
+          ASM_REWRITE_TAC [PREFIX] ],
+        (* goal 2.4 (of 4) *)
+        EXISTS_TAC ``E2: CCS`` >> REWRITE_TAC [] \\
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E' = prefix (label l') (restr L' E'')``]
+				 (ASSUME ``TRANS E' u E2``)) \\
+        IMP_RES_TAC TRANS_PREFIX \\
+        ASM_REWRITE_TAC [] \\
+        MATCH_MP_TAC RESTR \\
+        EXISTS_TAC ``l': Label`` \\
+        ASM_REWRITE_TAC [PREFIX] ] ]);
+
+(******************************************************************************)
+(*                                                                            *)
+(*      Basic axioms of strong equivalence for the relabeling operator       *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Prove STRONG_RELAB_NIL:
+   |- ∀rf. nil[rf]  ~ nil
+ *)
+val STRONG_RELAB_NIL = store_thm (
+   "STRONG_RELAB_NIL", ``!rf. STRONG_EQUIV (relab nil rf) nil``,
+    GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC ``\x y. (?rf'. (x = relab nil rf') /\ (y = nil))``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC \\
+      EXISTS_TAC ``rf: Relabeling`` \\
+      REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC >> REPEAT STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 2.1 *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E = relab nil rf'``]
+                            (ASSUME ``TRANS E u E1``)) \\
+        IMP_RES_TAC RELAB_NIL_NO_TRANS,
+        (* goal 2.2 *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E' = nil``]
+                            (ASSUME ``TRANS E' u E2``)) \\
+        IMP_RES_TAC NIL_NO_TRANS ] ]);
+
+(* Prove STRONG_RELAB_SUM:
+   |- ∀E E' rf. (E + E')[rf] ~ E[rf] + E'[rf]:
+ *)
+val STRONG_RELAB_SUM = store_thm (
+   "STRONG_RELAB_SUM",
+       ``!E E' rf. 
+         STRONG_EQUIV (relab (sum E E') rf) (sum (relab E rf) (relab E' rf))``,  
+    REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [PROPERTY_STAR]
+ >> REPEAT STRIP_TAC (* 2 sub-goals *)
+ >| [ (* goal 1 (of 2) *)
+      EXISTS_TAC ``E1: CCS`` \\
+      REWRITE_TAC [STRONG_EQUIV_REFL] \\
+      IMP_RES_TAC TRANS_RELAB \\
+      IMP_RES_TAC TRANS_SUM \\ (* 2 sub-goals here, sharing initial tacticals *)
+      ASM_REWRITE_TAC [] >|
+      [ (* goal 1.1 (of 2) *) MATCH_MP_TAC SUM1,
+        (* goal 1.2 (of 2) *) MATCH_MP_TAC SUM2 ] \\
+      MATCH_MP_TAC RELAB >> ASM_REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      EXISTS_TAC ``E2: CCS`` >> REWRITE_TAC [STRONG_EQUIV_REFL] \\
+      IMP_RES_TAC TRANS_SUM \\(* 2 sub-goals here, sharing initial tacticals *)
+      IMP_RES_TAC TRANS_RELAB >> ASM_REWRITE_TAC [] \\
+      MATCH_MP_TAC RELAB >|
+      [ (* goal 2.1 (of 2) *) MATCH_MP_TAC SUM1,
+        (* goal 2.2 (of 2) *) MATCH_MP_TAC SUM2 ] \\
+      ASM_REWRITE_TAC [] ]);
+
+(* Prove STRONG_RELAB_PREFIX:
+   |- ∀u E labl. u..E[RELAB labl] ~ relabel (RELAB labl) u..(E[RELAB labl]):
+ *)
+val STRONG_RELAB_PREFIX = store_thm (
+   "STRONG_RELAB_PREFIX",
+       ``!u E labl.
+         STRONG_EQUIV (relab (prefix u E) (RELAB labl))
+                      (prefix (relabel (RELAB labl) u) (relab E (RELAB labl)))``,
+    REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC 
+       ``\x y. (x = y) \/ (?u' E'. (x = relab (prefix u' E') (RELAB labl)) /\  
+                                   (y = prefix (relabel (RELAB labl) u')
+                                               (relab E' (RELAB labl))))``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC >> DISJ2_TAC \\
+      EXISTS_TAC ``u: Action`` \\
+      EXISTS_TAC ``E: CCS`` >> REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] >> BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 4 sub-goals *)
+      [ (* goal 2.1 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E: CCS = E'``]
+				 (ASSUME ``TRANS E u E1``)) \\
+        EXISTS_TAC ``E1: CCS`` >> ASM_REWRITE_TAC [],
+        (* goal 2.2 (of 4) *)
+        EXISTS_TAC ``E2: CCS`` >> ASM_REWRITE_TAC [],
+        (* goal 2.3 (of 4) *)
+        EXISTS_TAC ``E1: CCS`` >> REWRITE_TAC [] \\
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E = relab (prefix u' E'') (RELAB labl)``]
+				 (ASSUME ``TRANS E u E1``)) \\
+        IMP_RES_TAC TRANS_RELAB \\
+        IMP_RES_TAC TRANS_PREFIX \\
+        ASM_REWRITE_TAC [PREFIX],
+        (* goal 2.4 (of 4) *)
+        EXISTS_TAC ``E2: CCS`` >> REWRITE_TAC [] \\
+        ASSUME_TAC (REWRITE_RULE
+			[ASSUME ``E' = prefix (relabel (RELAB labl) u')
+                                              (relab E'' (RELAB labl))``]
+                        (ASSUME ``TRANS E' u E2``)) \\
+        IMP_RES_TAC TRANS_PREFIX >> ASM_REWRITE_TAC [] \\
+        MATCH_MP_TAC RELAB >> REWRITE_TAC [PREFIX] ] ]);
+
+(******************************************************************************)
+(*                                                                            *)
+(*          Laws for the recursion operator and strong equivalence            *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* The unfolding law R1 for strong equivalence:
+   |- ∀X E. rec X E ~ CCS_Subst E (rec X E) X:
+ *)
+val STRONG_UNFOLDING = store_thm (
+   "STRONG_UNFOLDING",
+  ``!X E. STRONG_EQUIV (rec X E) (CCS_Subst E (rec X E) X)``,
+    REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC
+       ``\x y. (x = y) \/
+              (?Y E'. (x = rec Y E') /\ (y = CCS_Subst E' (rec Y E') Y))``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC >> DISJ2_TAC \\
+      EXISTS_TAC ``X: string`` \\
+      EXISTS_TAC ``E: CCS`` >> REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] >> BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 4 sub-goals here *)
+      [ (* goal 2.1 (of 4) *)
+        EXISTS_TAC ``E1: CCS`` \\
+        REWRITE_TAC [REWRITE_RULE [ASSUME ``E: CCS = E'``]
+                             (ASSUME ``TRANS E u E1``)],
+        (* goal 2.2 (of 4) *)
+        EXISTS_TAC ``E2: CCS`` >> ASM_REWRITE_TAC [],
+        (* goal 2.3 (of 4) *)
+        EXISTS_TAC ``E1: CCS`` \\
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E = rec Y E''``]
+                            (ASSUME ``TRANS E u E1``)) \\
+        IMP_RES_TAC TRANS_REC >> ASM_REWRITE_TAC [],
+        (* goal 2.4 (of 4) *)
+        EXISTS_TAC ``E2: CCS`` \\
+        ASM_REWRITE_TAC
+         [REWRITE_RULE [ASSUME ``E' = CCS_Subst E''(rec Y E'')Y``]  
+                 (ASSUME ``TRANS E' u E2``), TRANS_REC_EQ] ] ]);
+
+(* Prove the theorem STRONG_PREF_REC_EQUIV:
+   |- ∀u s v. u..rec s (v..u..var s) ~ rec s (u..v..var s):
+ *)
+val STRONG_PREF_REC_EQUIV = store_thm (
+   "STRONG_PREF_REC_EQUIV",
+      ``!u s v.
+         STRONG_EQUIV  
+         (prefix u (rec s (prefix v (prefix u (var s))))) 
+         (rec s (prefix u (prefix v (var s))))``,
+    REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC 
+       ``\x y. 
+        (?u' v' s'.  
+          (x = prefix u' (rec s' (prefix v' (prefix u' (var s'))))) /\ 
+          (y = rec s' (prefix u' (prefix v' (var s')))) \/ 
+          (x = rec s' (prefix v' (prefix u' (var s')))) /\ 
+          (y = prefix v' (rec s' (prefix u' (prefix v' (var s'))))))``
+ >> CONJ_TAC (* 2 sub-goals *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC \\
+      take [`u`, `v`, `s`] >> REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 4 sub-goals *)
+      [ (* goal 2.1 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE 
+               [ASSUME ``E = prefix u'(rec s' (prefix v' (prefix u' (var s'))))``]
+                                 (ASSUME ``TRANS E u E1``)) \\
+        IMP_RES_TAC TRANS_PREFIX \\
+        EXISTS_TAC ``prefix v' (rec s' (prefix u' (prefix v' (var s'))))`` \\
+        CONJ_TAC >| (* 2 sub-goals here *)
+        [ (* goal 2.1.1 (of 2) *)
+          ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC REC >> REWRITE_TAC [CCS_Subst_def, PREFIX],
+          (* goal 2.1.2 (of 2) *)
+          take [`u'`, `v'`, `s'`] >> ASM_REWRITE_TAC [] ],
+        (* goal 2.2 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE
+                     [ASSUME ``E' = rec s' (prefix u' (prefix v' (var s')))``,
+                      TRANS_REC_EQ, CCS_Subst_def]
+                            (ASSUME ``TRANS E' u E2``)) \\
+        IMP_RES_TAC TRANS_PREFIX \\
+        EXISTS_TAC ``rec s' (prefix v' (prefix u (var s')))`` \\
+        CONJ_TAC >| (* 2 sub-goals here, first one is easy *)
+        [ (* goal 2.2.1 (of 2) *)
+          ASM_REWRITE_TAC [PREFIX],
+          (* goal 2.2.2 (of 2) *)
+          take [`u`, `v'`, `s'`] \\
+          ASM_REWRITE_TAC
+            [REWRITE_RULE [ASSUME ``u': Action = u``]  
+               (ASSUME ``E2 = prefix v' (rec s' (prefix u' (prefix v' (var s'))))``)] ],
+        (* goal 2.3 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE
+                     [ASSUME ``E = rec s'(prefix v' (prefix u' (var s')))``,
+                      TRANS_REC_EQ, CCS_Subst_def]
+                            (ASSUME ``TRANS E u E1``)) \\
+        IMP_RES_TAC TRANS_PREFIX \\
+        EXISTS_TAC ``rec s' (prefix u' (prefix v' (var s')))`` \\
+        CONJ_TAC >| (* 2 sub-goals here, first one is easy *)
+        [ (* goal 2.3.1 (of 2) *)
+          ASM_REWRITE_TAC [PREFIX],
+          (* goal 2.3.2 (of 2) *)
+          take [`u'`, `v'`, `s'`] >> ASM_REWRITE_TAC [] ],
+        (* goal 2.4 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE
+             [ASSUME ``E' = prefix v' (rec s' (prefix u' (prefix v' (var s'))))``]
+                                 (ASSUME ``TRANS E' u E2``)) \\
+        IMP_RES_TAC TRANS_PREFIX \\
+        EXISTS_TAC ``prefix u' (rec s' (prefix v' (prefix u' (var s'))))`` \\
+        CONJ_TAC >| (* 2 sub-goals here *)
+        [ (* goal 2.4.1 (of 2) *)
+          ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC REC >> REWRITE_TAC [CCS_Subst_def, PREFIX],
+          (* goal 2.4.2 (of 2) *)
+          take [`u'`, `v'`, `s'`] >> ASM_REWRITE_TAC [] ] ] ]);
+
+(* Prove the theorem STRONG_REC_ACT2:
+   |- ∀s u. rec s (u..u..var s) ~ rec s (u..var s)
+ *)
+val STRONG_REC_ACT2 = store_thm (
+   "STRONG_REC_ACT2",
+      ``!s u.
+         STRONG_EQUIV
+         (rec s (prefix u (prefix u (var s))))
+         (rec s (prefix u (var s)))``,
+    REPEAT GEN_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC
+       ``\x y.
+        (?s' u'.
+          (x = rec s' (prefix u' (prefix u' (var s')))) /\
+          (y = rec s' (prefix u' (var s'))) \/
+          (x = prefix u' (rec s' (prefix u' (prefix u' (var s'))))) /\ 
+          (y = rec s' (prefix u' (var s'))))``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC \\
+      EXISTS_TAC ``s: string`` \\
+      EXISTS_TAC ``u: Action`` >> REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 4 sub-goals *)
+      [ (* goal 2.1 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE
+                     [ASSUME ``E = rec s' (prefix u' (prefix u' (var s')))``,
+                      TRANS_REC_EQ, CCS_Subst_def]
+                         (ASSUME ``TRANS E u E1``)) \\
+        IMP_RES_TAC TRANS_PREFIX >> EXISTS_TAC ``E': CCS`` \\
+        CONJ_TAC >| (* 2 sub-goals here *)
+        [ (* goal 2.1.1 (of 2) *)
+          ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC REC >> REWRITE_TAC [CCS_Subst_def, PREFIX],
+          (* goal 2.1.2 (of 2) *)
+          EXISTS_TAC ``s': string`` >> EXISTS_TAC ``u': Action`` \\
+          ASM_REWRITE_TAC [] ],
+        (* goal 2.2 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E' = rec s'(prefix u'(var s'))``,
+                                   TRANS_REC_EQ, CCS_Subst_def]
+                            (ASSUME ``TRANS E' u E2``)) \\
+        IMP_RES_TAC TRANS_PREFIX >> EXISTS_TAC ``prefix u' E`` \\
+        CONJ_TAC >| (* 2 sub-goals here *)
+        [ (* goal 2.2.1 (of 2) *)
+          ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC REC >> REWRITE_TAC [CCS_Subst_def, PREFIX],
+          (* goal 2.2.2 (of 2) *)
+          EXISTS_TAC ``s': string`` \\
+          EXISTS_TAC ``u': Action`` \\
+          ASM_REWRITE_TAC [] ],
+        (* goal 2.3 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE
+               [ASSUME ``E = prefix u' (rec s' (prefix u' (prefix u' (var s'))))``]
+                                 (ASSUME ``TRANS E u E1``)) \\
+        IMP_RES_TAC TRANS_PREFIX >> EXISTS_TAC ``E': CCS`` \\
+        CONJ_TAC >| (* 2 sub-goals here *)
+        [ (* goal 2.3.1 (of 2) *)
+          ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC REC >> REWRITE_TAC [CCS_Subst_def, PREFIX],
+          (* goal 2.3.2 (of 2) *)
+          EXISTS_TAC ``s': string`` \\
+          EXISTS_TAC ``u': Action`` \\
+          ASM_REWRITE_TAC [] ],
+        (* goal 2.4 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E' = rec s' (prefix u' (var s'))``,
+                                   TRANS_REC_EQ, CCS_Subst_def] 
+                            (ASSUME ``TRANS E' u E2``)) \\
+        IMP_RES_TAC TRANS_PREFIX \\
+        EXISTS_TAC ``rec s' (prefix u' (prefix u' (var s')))`` \\
+        CONJ_TAC >| (* 2 sub-goals here, first one is easy *)
+        [ (* goal 2.4.1 (of 2) *)
+          ASM_REWRITE_TAC [PREFIX],
+          (* goal 2.4.2 (of 2) *)
+          EXISTS_TAC ``s': string`` \\
+          EXISTS_TAC ``u': Action`` \\
+          ASM_REWRITE_TAC [] ] ] ]);
+
+(******************************************************************************)
+(*                                                                            *)
+(*      The strong laws for the parallel operator  in the general form        *)
+(*                                                                            *)
+(******************************************************************************)
+
+val PREF_ACT_def = Define `
+    PREF_ACT (prefix u E) = u `;
+
+val PREF_PROC_def = Define `
+    PREF_PROC (prefix u E) = E `;
+
+val Is_Prefix_def = Define `
+    Is_Prefix E = (?u E'. (E = prefix u E')) `;
+
+val PREF_IS_PREFIX = store_thm (
+   "PREF_IS_PREFIX", ``!u E. Is_Prefix (prefix u E)``,
+    REPEAT GEN_TAC
+ >> REWRITE_TAC [Is_Prefix_def]
+ >> EXISTS_TAC ``u: Action``
+ >> EXISTS_TAC ``E: CCS``
+ >> REWRITE_TAC []);
+
+(* --------------------------------------------------------------------------- *)
+(* Define the notation used for indexed summations:                            *)
+(* given a function f: num->CCS and an index n:num, the primitive recursive    *)
+(* function CCS_SIGMA is such that SIGMA f n denotes the summation             *)
+(* (f 0) + (f 1) + ... + (f n).                                                *)
+(* --------------------------------------------------------------------------- *)
+
+val CCS_SIGMA_def = Define `
+   (CCS_SIGMA (f :num -> CCS) 0 = f 0) /\
+   (CCS_SIGMA f (SUC n) = sum (CCS_SIGMA f n) (f (SUC n))) `;
+
+val _ = overload_on ("SIGMA", ``CCS_SIGMA``);
+
+(*
+ SIGMA_BASE =
+   |- ∀f. SIGMA f 0 = f 0
+ SIGMA_INDUCT =
+   |- ∀f n. SIGMA f (SUC n) = SIGMA f n + f (SUC n)
+ *)
+val [SIGMA_BASE, SIGMA_INDUCT] =
+    map (fn (s, thm) => save_thm (s, thm))
+        (combine (["SIGMA_BASE", "SIGMA_INDUCT"], CONJUNCTS CCS_SIGMA_def));
+
+(* --------------------------------------------------------------------------- *)
+(* Define the notation used for indexed compositions (par):                    *)
+(* given a function f: num->CCS and an index n:num, the primitive recursive    *)
+(* function CCS_COMP is such that SIGMA f n denotes the composition            *)
+(* (f 0) | (f 1) | ... | (f n).                                                *)
+(* --------------------------------------------------------------------------- *)
+
+val CCS_COMP_def = Define `
+   (CCS_COMP (f :num -> CCS) 0 = f 0) /\
+   (CCS_COMP f (SUC n) = par (CCS_COMP f n) (f (SUC n))) `;
+
+val _ = overload_on ("PI", ``CCS_COMP``);
+
+(*
+val COMP_BASE =
+   |- ∀f. PI f 0 = f 0
+val COMP_INDUCT =
+   |- ∀f n. PI f (SUC n) = PI f n || f (SUC n)
+ *)
+val [COMP_BASE, COMP_INDUCT] =
+    map (fn (s, thm) => save_thm (s, thm))
+        (combine (["COMP_BASE", "COMP_INDUCT"], CONJUNCTS CCS_COMP_def));
+
+(* --------------------------------------------------------------------------- *)
+(* Define the functions to compute the summation of the synchronizing summands *)
+(* of two summations of prefixed processes in parallel.                        *)
+(* SYNC computes the synchronizations between a summand u.P and the summation  *)
+(* f: num -> CCS representing the other process in parallel.             (303) *)
+(* --------------------------------------------------------------------------- *)
+
+val SYNC_def = Define `
+   (SYNC u P f 0 =
+	(if ((u = tau) \/ (PREF_ACT (f 0) = tau))
+	  then nil
+	  else (if (LABEL u = COMPL (LABEL (PREF_ACT (f 0))))
+		 then (prefix tau (par P (PREF_PROC (f 0))))
+		 else nil))) /\
+   (SYNC u P f (SUC n) =
+	(if ((u = tau) \/ (PREF_ACT (f (SUC n)) = tau))
+	  then (SYNC u P f n)
+	  else (if (LABEL u = COMPL (LABEL (PREF_ACT (f (SUC n)))))
+		  then (sum (prefix tau (par P (PREF_PROC (f (SUC n))))) (SYNC u P f n))
+		  else (SYNC u P f n))))`;
+
+val [SYNC_BASE, SYNC_INDUCT] =
+    map (fn (s,thm) => save_thm (s, thm))
+        (combine (["SYNC_BASE", "SYNC_INDUCT"], CONJ_LIST 2 SYNC_def));
+
+(* --------------------------------------------------------------------------- *)
+(* ALL_SYNC computes the summation of all possible synchronizations between    *)
+(* two process summations f, f': num -> CCS of length n, m respectively.       *)
+(* This is done using the function SYNC.                                 (228) *)
+(* --------------------------------------------------------------------------- *)
+
+val ALL_SYNC_def = Define `
+   (ALL_SYNC f 0 f' m = SYNC (PREF_ACT (f 0)) (PREF_PROC (f 0)) f' m) /\
+   (ALL_SYNC f (SUC n) f' m =
+         sum (ALL_SYNC f n f' m) 
+             (SYNC (PREF_ACT (f (SUC n))) (PREF_PROC (f (SUC n))) f' m)) `;
+
+val [ALL_SYNC_BASE, ALL_SYNC_INDUCT] =
+    map (fn (s,thm) => save_thm (s, thm))
+        (combine (["ALL_SYNC_BASE", "ALL_SYNC_INDUCT"], CONJUNCTS ALL_SYNC_def));
+
+(* LESS_SUC_LESS_EQ':
+ |- !m n. m < (SUC n) = m <= n
+ *)
+val LESS_SUC_LESS_EQ' = store_thm (
+   "LESS_SUC_LESS_EQ'", ``!m n. m < SUC n = m <= n``,
+    REWRITE_TAC [LESS_EQ, LESS_EQ_MONO]);
+
+(* |- ∀n m. m < SUC n ⇒ m ≤ n
+ *)
+val LESS_SUC_LESS_EQ = save_thm (
+   "LESS_SUC_LESS_EQ", EQ_IMP_LR LESS_SUC_LESS_EQ');
+
+(* LESS_EQ_ZERO_EQ:
+ |- !n. n <= 0 ==> (n = 0)
+ *)
+val LESS_EQ_ZERO_EQ = save_thm (
+   "LESS_EQ_ZERO_EQ", EQ_IMP_LR LESS_EQ_0);
+
+(* LESS_EQ_LESS_EQ_SUC:
+ |- !m n. m <= n ==> m <= (SUC n)
+ *)
+val LESS_EQ_LESS_EQ_SUC = store_thm (
+   "LESS_EQ_LESS_EQ_SUC",
+  ``!m n. m <= n ==> (m <= (SUC n))``,
+    REPEAT STRIP_TAC
+ >> IMP_RES_TAC LESS_EQ_IMP_LESS_SUC
+ >> IMP_RES_TAC LESS_IMP_LESS_OR_EQ);
+
+val SIGMA_TRANS_THM_EQ = store_thm (
+   "SIGMA_TRANS_THM_EQ",
+  ``!n f u E. TRANS (SIGMA f n) u E = (?k. k <= n /\ TRANS (f k) u E)``,
+    Induct (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      REPEAT GEN_TAC \\
+      REWRITE_TAC [LESS_EQ_0, SIGMA_BASE] \\
+      EQ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 1.1 (of 2) *)
+        DISCH_TAC \\
+        EXISTS_TAC ``0: num`` \\
+        ASM_REWRITE_TAC [],
+        (* goal 1.2 (of 2) *)
+        STRIP_TAC \\
+        REWRITE_TAC [REWRITE_RULE [ASSUME ``k = (0 :num)``]
+			(ASSUME ``TRANS ((f: num -> CCS) k) u E``)] ],
+      (* goal 2 (of 2) *)
+      REPEAT GEN_TAC \\
+      REWRITE_TAC [SIGMA_INDUCT, TRANS_SUM_EQ] \\
+      EQ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 2.1 (of 2) *)
+        STRIP_TAC >| (* 2 sub-goals here *)
+        [ (* goal 2.1.1 (of 2) *)
+          STRIP_ASSUME_TAC
+		(MATCH_MP (EQ_IMP_LR (ASSUME ``!f u E. TRANS (SIGMA f n) u E = 
+						(?k. k <= n /\ TRANS (f k) u E)``))
+			  (ASSUME ``TRANS (SIGMA f n) u E``)) \\
+          IMP_RES_TAC LESS_EQ_LESS_EQ_SUC \\
+          EXISTS_TAC ``k: num`` \\
+          ASM_REWRITE_TAC [],
+          (* goal 2.1.2 (of 2) *)
+          EXISTS_TAC ``SUC n`` \\
+          ASM_REWRITE_TAC [LESS_EQ_REFL] ],
+        (* goal 2.2 (of 2) *)
+        STRIP_TAC \\
+        IMP_RES_TAC LESS_OR_EQ >| (* 2 sub-goals here *)
+        [ (* goal 2.2.1 (of 2) *)
+          DISJ1_TAC \\
+          PURE_ONCE_ASM_REWRITE_TAC [] \\
+          EXISTS_TAC ``k: num`` \\
+          IMP_RES_TAC LESS_SUC_LESS_EQ \\
+          ASM_REWRITE_TAC [],
+          (* goal 2.2.2 (of 2) *)
+          DISJ2_TAC \\
+          REWRITE_TAC [REWRITE_RULE [ASSUME ``k = SUC n``]
+				    (ASSUME ``TRANS ((f: num -> CCS) k) u E``)] ] ] ]);
+
+(* SIGMA_TRANS_THM =
+ |- ∀u n f E. SIGMA f n --u-> E ⇒ ∃k. k ≤ n ∧ f k --u-> E
+ *)
+val SIGMA_TRANS_THM = save_thm (
+   "SIGMA_TRANS_THM", EQ_IMP_LR SIGMA_TRANS_THM_EQ);
+
+val SYNC_TRANS_THM_EQ = store_thm (
+   "SYNC_TRANS_THM_EQ",
+  ``!m u P f v Q. TRANS (SYNC u P f m) v Q =
+         (?j l. j <= m /\
+                (u = label l) /\ (PREF_ACT (f j) = label (COMPL l)) /\
+                (v = tau) /\ (Q = par P (PREF_PROC (f j))))``,
+    Induct_on `m` (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      REPEAT GEN_TAC \\
+      REWRITE_TAC [LESS_EQ_0, SYNC_BASE] \\ 
+      COND_CASES_TAC >| (* 2 sub-goals here *)
+      [ (* goal 1.1 (of 2) *)
+        REWRITE_TAC [NIL_NO_TRANS] \\
+        STRIP_TAC \\
+        DISJ_CASES_TAC
+	  (ASSUME ``(u = tau) \/ (PREF_ACT ((f: num -> CCS) 0) = tau)``) >| (* 2 sub-goals here *)
+        [ (* goal 1.1.1 (of 2) *)
+          ASSUME_TAC (REWRITE_RULE [ASSUME ``u = tau``]
+				   (ASSUME ``u = label l``)) \\
+          IMP_RES_TAC Action_distinct,
+          (* goal 1.1.2 (of 2) *)
+          CHECK_ASSUME_TAC
+		(REWRITE_RULE [ASSUME ``j = (0 :num)``,
+			       ASSUME ``PREF_ACT ((f: num -> CCS) 0) = tau``,
+			       Action_distinct]
+			(ASSUME ``PREF_ACT ((f: num -> CCS) j) = label (COMPL l)``)) ],
+        (* goal 1.2 (of 2) *)
+        STRIP_ASSUME_TAC
+         (REWRITE_RULE [DE_MORGAN_THM]
+          (ASSUME ``~((u = tau) \/ (PREF_ACT ((f: num -> CCS) 0) = tau))``)) \\
+        IMP_RES_TAC Action_not_tau_is_Label \\
+        ASM_REWRITE_TAC [LABEL_def] \\
+        COND_CASES_TAC >| (* 2 sub-goals here *)
+        [ (* goal 1.2.1 (of 2) *)
+          EQ_TAC >| (* 2 sub-goals here *)
+          [ (* goal 1.2.1.1 (of 2) *)
+            DISCH_TAC \\
+            IMP_RES_TAC TRANS_PREFIX \\
+            EXISTS_TAC ``0: num`` \\
+            EXISTS_TAC ``L': Label`` \\
+            ASM_REWRITE_TAC [COMPL_COMPL_LAB],
+            (* goal 1.2.1.2 (of 2) *)
+            STRIP_TAC \\
+            ASM_REWRITE_TAC [PREFIX] ],
+          (* goal 1.2.2 (of 2) *)
+          REWRITE_TAC [NIL_NO_TRANS] \\
+          STRIP_TAC \\ 
+          ASSUME_TAC (REWRITE_RULE [ASSUME ``j = (0 :num)``,
+				    ASSUME ``PREF_ACT ((f: num -> CCS) 0) = label L``]
+			(ASSUME ``PREF_ACT ((f: num -> CCS) j) = label (COMPL l)``)) \\
+          IMP_RES_TAC Action_11 \\
+          CHECK_ASSUME_TAC 
+		(REWRITE_RULE [ ASSUME ``L = COMPL (l :Label)``, COMPL_COMPL_LAB,
+				ASSUME ``L': Label = l`` ]
+			(ASSUME ``~(L' = COMPL (L: Label))``)) ] ],
+      (* goal 2 (of 2), inductive case *)
+      REPEAT GEN_TAC \\
+      PURE_ONCE_REWRITE_TAC [SYNC_INDUCT] \\
+      COND_CASES_TAC >| (* 2 sub-goals here *)
+      [ (* goal 2.1 (of 2) *)
+        EQ_TAC >| (* 2 sub-goals here *)
+        [ (* goal 2.1.1 (of 2) *)
+          DISCH_TAC \\
+          STRIP_ASSUME_TAC
+	      (MATCH_MP
+		(EQ_IMP_LR (ASSUME ``!u P f v Q.
+                                TRANS (SYNC u P f m) v Q =
+                                (?j l.
+                                  j <= m /\ (u = label l) /\
+                                  (PREF_ACT (f j) = label (COMPL l)) /\
+                                  (v = tau) /\ (Q = par P (PREF_PROC (f j))))``))
+		(ASSUME ``TRANS (SYNC u P f m) v Q``)) \\
+          IMP_RES_TAC LESS_EQ_LESS_EQ_SUC \\
+          EXISTS_TAC ``j: num`` \\
+          EXISTS_TAC ``l: Label`` \\
+          ASM_REWRITE_TAC [],
+          (* goal 2.1.2 (of 2) *)
+          STRIP_TAC \\
+          DISJ_CASES_TAC (ASSUME ``(u = tau) \/ (PREF_ACT (f (SUC m)) = tau)``) >|
+          [ (* goal 2.1.2.1 (of 2) *)
+            CHECK_ASSUME_TAC (REWRITE_RULE [ASSUME ``u = tau``, Action_distinct]
+                                    (ASSUME ``u = label l``)),
+            (* goal 2.1.2.2 (of 2) *)
+            ASM_REWRITE_TAC [] \\
+            IMP_RES_TAC LESS_OR_EQ >| (* 2 sub-goals here *)
+            [ (* goal 2.1.2.2.1 (of 2) *)
+              IMP_RES_TAC LESS_SUC_LESS_EQ \\
+              EXISTS_TAC ``j: num`` \\
+              EXISTS_TAC ``l: Label`` \\
+              ASM_REWRITE_TAC [],
+              (* goal 2.1.2.2.2 (of 2) *)
+              CHECK_ASSUME_TAC
+		(REWRITE_RULE [ASSUME ``j = SUC m``,
+			       ASSUME ``PREF_ACT ((f: num -> CCS) (SUC m)) = tau``,
+			       Action_distinct]
+			(ASSUME ``PREF_ACT ((f: num -> CCS) j) = label (COMPL l)``)) ] ] ],
+        (* goal 2.2 (of 2) *)
+        STRIP_ASSUME_TAC 
+         (REWRITE_RULE [DE_MORGAN_THM]
+           (ASSUME ``~((u = tau) \/ (PREF_ACT (f (SUC m)) = tau))``)) \\
+        IMP_RES_TAC Action_not_tau_is_Label \\
+        ASM_REWRITE_TAC [LABEL_def] \\
+        COND_CASES_TAC >| (* 2 sub-goals here *)
+        [ (* goal 2.2.1 (of 2) *)
+          EQ_TAC >| (* 2 sub-goals here *)
+          [ (* goal 2.2.1.1 (of 2) *)
+            DISCH_TAC \\
+            IMP_RES_TAC TRANS_SUM >| (* 2 sub-goals here *)
+            [ (* goal 2.2.1.1.1 (of 2) *)
+              IMP_RES_TAC TRANS_PREFIX \\
+              take [`SUC m`, `L'`] \\
+              ASM_REWRITE_TAC [LESS_EQ_REFL, COMPL_COMPL_LAB],
+              (* goal 2.2.1.1.2 (of 2) *)
+              STRIP_ASSUME_TAC
+               (MATCH_MP
+                 (EQ_IMP_LR (ASSUME ``!u P f v Q.
+                                  TRANS (SYNC u P f m) v Q =
+                                  (?j l.
+                                    j <= m /\ (u = label l) /\
+                                    (PREF_ACT (f j) = label (COMPL l)) /\
+                                    (v = tau) /\ (Q = par P (PREF_PROC (f j))))``))
+		 (ASSUME ``TRANS (SYNC (label L') P f m) v Q``)) \\
+              IMP_RES_TAC LESS_EQ_LESS_EQ_SUC \\
+              take [`j`, `l`] \\
+              ASM_REWRITE_TAC [] ],
+            (* goal 2.2.1.2 (of 2) *)
+            STRIP_TAC \\
+            IMP_RES_TAC LESS_OR_EQ >| (* 2 sub-goals here *)
+            [ (* goal 2.2.1.2.1 (of 2) *)
+              MATCH_MP_TAC SUM2 \\
+              PURE_ONCE_ASM_REWRITE_TAC [] \\
+              IMP_RES_TAC LESS_SUC_LESS_EQ \\
+              take [`j`, `l`] \\
+              ASM_REWRITE_TAC [],
+              (* goal 2.2.1.2.2 (of 2) *)
+              MATCH_MP_TAC SUM1 \\
+              ASM_REWRITE_TAC
+		[ REWRITE_RULE [ASSUME ``j = SUC m``]
+			(ASSUME ``Q = par P (PREF_PROC ((f: num -> CCS) j))``),
+		  PREFIX ] ] ],
+          (* goal 2.2.2 (of 2) *)
+          ASM_REWRITE_TAC [] \\
+          EQ_TAC >| (* 2 sub-goals here *)
+          [ (* goal 2.2.2.1 (of 2) *)
+            STRIP_TAC \\
+            IMP_RES_TAC LESS_EQ_LESS_EQ_SUC \\
+            take [`j`, `l`] \\
+            ASM_REWRITE_TAC [],
+            (* goal 2.2.2.2 (of 2) *)
+            STRIP_TAC \\
+            IMP_RES_TAC LESS_OR_EQ >| (* 2 sub-goals here *)
+            [ (* goal 2.2.2.2.1 (of 2) *)
+              IMP_RES_TAC LESS_SUC_LESS_EQ \\
+              take [`j`, `l`] \\
+              ASM_REWRITE_TAC [],
+              (* goal 2.2.2.2.2 (of 2) *)
+              ASSUME_TAC (REWRITE_RULE [ASSUME ``j = SUC m``,
+				        ASSUME ``PREF_ACT (f (SUC m)) = label L``]
+				(ASSUME ``PREF_ACT ((f: num -> CCS) j) = label (COMPL l)``)) \\
+              IMP_RES_TAC Action_11 \\
+              CHECK_ASSUME_TAC
+		(REWRITE_RULE [ASSUME ``L = COMPL (l :Label)``, COMPL_COMPL_LAB,
+			       ASSUME ``L': Label = l``]
+			      (ASSUME ``~(L' = COMPL (L: Label))``)) ] ] ] ] ] );
+
+(* SYNC_TRANS_THM =
+ |- ∀v u m f Q P.
+     SYNC u P f m --v-> Q ⇒
+     ∃j l.
+       j ≤ m ∧ (u = label l) ∧ (PREF_ACT (f j) = label (COMPL l)) ∧
+       (v = τ) ∧ (Q = P || PREF_PROC (f j))
+ *)
+val SYNC_TRANS_THM = save_thm (
+   "SYNC_TRANS_THM", EQ_IMP_LR SYNC_TRANS_THM_EQ);
+
+val ALL_SYNC_TRANS_THM_EQ = store_thm (
+   "ALL_SYNC_TRANS_THM_EQ",
+      ``!n m f f' u E.
+         TRANS (ALL_SYNC f n f' m) u E =
+         (?k k' l.
+           k <= n /\ k' <= m /\
+           (PREF_ACT (f k) = label l) /\ 
+           (PREF_ACT (f' k') = label (COMPL l)) /\
+           (u = tau) /\ (E = par (PREF_PROC (f k)) (PREF_PROC (f' k'))))``, 
+    Induct_on `n` (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      REPEAT GEN_TAC \\
+      REWRITE_TAC [LESS_EQ_0, ALL_SYNC_BASE, SYNC_TRANS_THM_EQ] \\
+      EQ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 1.1 (of 2) *)
+        STRIP_TAC \\
+        take [`0`, `j`, `l`] \\
+        ASM_REWRITE_TAC [],
+        (* goal 1.2 (of 2) *)
+        STRIP_TAC \\
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``k = (0 :num)``]
+				 (ASSUME ``PREF_ACT ((f: num -> CCS) k) = label l``)) \\
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``k = (0 :num)``]
+				 (ASSUME ``E = par (PREF_PROC ((f: num -> CCS) k))
+						   (PREF_PROC ((f': num -> CCS) k'))``)) \\
+        take [`k'`, `l`] \\
+        ASM_REWRITE_TAC [] ],
+      (* goal 2 (of 2), inductive case *)
+      REPEAT GEN_TAC \\
+      REWRITE_TAC [ALL_SYNC_INDUCT, TRANS_SUM_EQ] \\
+      EQ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 2.1 (of 2) *)
+        STRIP_TAC >| (* 2 sub-goals here *)
+        [ (* goal 2.1.1 (of 2) *)
+          STRIP_ASSUME_TAC
+           (MATCH_MP
+             (EQ_IMP_LR 
+               (ASSUME ``!m f f' u E.
+                      TRANS (ALL_SYNC f n f' m) u E =
+                      (?k k' l.
+                        k <= n /\ k' <= m /\
+                        (PREF_ACT (f k) = label l) /\
+                        (PREF_ACT (f' k') = label (COMPL l)) /\
+                        (u = tau) /\
+                        (E = par (PREF_PROC (f k)) (PREF_PROC (f' k'))))``))
+             (ASSUME ``TRANS (ALL_SYNC f n f' m) u E``)) \\  
+          IMP_RES_TAC LESS_EQ_LESS_EQ_SUC \\
+          take [`k`, `k'`, `l`] \\
+          ASM_REWRITE_TAC [],
+          (* goal 2.1.2 (of 2) *)
+          IMP_RES_TAC SYNC_TRANS_THM \\
+          take [`SUC n`, `j`, `l`] \\
+          ASM_REWRITE_TAC [LESS_EQ_REFL] ],
+        (* goal 2.2 (of 2) *)
+        STRIP_TAC \\
+        IMP_RES_TAC (SPECL [``k: num``, ``SUC n``] LESS_OR_EQ) >| (* 2 sub-goals here *)
+        [ (* goal 2.2.1 (of 2) *)
+          DISJ1_TAC \\
+          PURE_ONCE_ASM_REWRITE_TAC [] \\
+          IMP_RES_TAC LESS_SUC_LESS_EQ \\
+          take [`k`, `k'`, `l`] \\
+          ASM_REWRITE_TAC [],
+          (* goal 2.2.2 (of 2) *)
+          DISJ2_TAC \\
+          ASM_REWRITE_TAC [SYNC_TRANS_THM_EQ] \\
+          ASSUME_TAC (REWRITE_RULE [ASSUME ``k = SUC n``]
+				   (ASSUME ``PREF_ACT ((f: num -> CCS) k) = label l``)) \\
+          ASSUME_TAC (REWRITE_RULE [ASSUME ``k = SUC n``]
+				   (ASSUME ``E = par (PREF_PROC ((f: num -> CCS) k))
+						     (PREF_PROC ((f': num -> CCS) k'))``)) \\
+          take [`k'`, `l`] \\
+          ASM_REWRITE_TAC [] ] ] ]);
+
+(* ALL_SYNC_TRANS_THM =
+ |- ∀u n m f' f E.
+     ALL_SYNC f n f' m --u-> E ⇒
+     ∃k k' l.
+       k ≤ n ∧ k' ≤ m ∧ (PREF_ACT (f k) = label l) ∧
+       (PREF_ACT (f' k') = label (COMPL l)) ∧ (u = τ) ∧
+       (E = PREF_PROC (f k) || PREF_PROC (f' k')):
+ *)  
+val ALL_SYNC_TRANS_THM = save_thm (
+   "ALL_SYNC_TRANS_THM",
+    EQ_IMP_LR ALL_SYNC_TRANS_THM_EQ);
+
+(* The expansion law for strong equivalence:
+ |- ∀f n f' m.
+     (∀i. i ≤ n ⇒ Is_Prefix (f i)) ∧ (∀j. j ≤ m ⇒ Is_Prefix (f' j)) ⇒
+     SIGMA f n || SIGMA f' m
+     ∼
+     SIGMA (λi. PREF_ACT (f i)..(PREF_PROC (f i) || SIGMA f' m)) n +
+     SIGMA (λj. PREF_ACT (f' j)..(SIGMA f n || PREF_PROC (f' j))) m +
+     ALL_SYNC f n f' m:
+ *)
+val STRONG_PAR_LAW = store_thm (
+   "STRONG_PAR_LAW",
+      ``!f n f' m.
+         (!i. i <= n ==> Is_Prefix (f i)) /\ (!j. j <= m ==> Is_Prefix (f' j)) ==>
+         STRONG_EQUIV
+         (par (SIGMA f n) (SIGMA f' m))
+         (sum
+          (sum 
+           (SIGMA (\i. prefix (PREF_ACT (f i))
+                              (par (PREF_PROC (f i)) (SIGMA f' m))) n)
+           (SIGMA (\j. prefix (PREF_ACT (f' j))
+                              (par (SIGMA f n) (PREF_PROC (f' j)))) m))
+          (ALL_SYNC f n f' m))``,
+    REPEAT STRIP_TAC
+ >> PURE_ONCE_REWRITE_TAC [STRONG_EQUIV]
+ >> EXISTS_TAC
+      ``\x y. 
+        (x = y) \/ 
+        (?f1 n1 f2 m2. 
+         (!i. i <= n1 ==> Is_Prefix(f1 i)) /\ 
+         (!j. j <= m2 ==> Is_Prefix(f2 j)) /\ 
+         (x = par (SIGMA f1 n1) (SIGMA f2 m2)) /\  
+         (y = sum
+              (sum
+               (SIGMA (\i. prefix (PREF_ACT (f1 i))
+                                  (par (PREF_PROC (f1 i)) (SIGMA f2 m2))) n1)
+               (SIGMA (\j. prefix (PREF_ACT(f2 j))  
+                                  (par (SIGMA f1 n1) (PREF_PROC (f2 j)))) m2))
+              (ALL_SYNC f1 n1 f2 m2)))``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      BETA_TAC \\
+      DISJ2_TAC \\
+      take [`f`, `n`, `f'`, `m`] \\
+      ASM_REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      PURE_ONCE_REWRITE_TAC [STRONG_BISIM] \\
+      BETA_TAC \\
+      REPEAT STRIP_TAC >| (* 4 sub-goals here *)
+      [ (* goal 1 (of 4) *)
+        ASSUME_TAC (REWRITE_RULE [ASSUME ``E: CCS = E'``]
+				 (ASSUME ``TRANS E u E1``)) \\
+        EXISTS_TAC ``E1: CCS`` \\
+        ASM_REWRITE_TAC [],
+        (* goal 2 (of 4) *)
+        EXISTS_TAC ``E2: CCS`` \\
+        ASM_REWRITE_TAC [],
+        (* goal 3 (of 4) *)
+        EXISTS_TAC ``E1: CCS`` \\
+        ASM_REWRITE_TAC [] \\
+        ASSUME_TAC
+         (REWRITE_RULE [ASSUME ``E = par (SIGMA f1 n1) (SIGMA f2 m2)``]
+		       (ASSUME ``TRANS E u E1``)) \\
+        IMP_RES_TAC TRANS_PAR >| (* 3 sub-goals here *)
+        [ (* goal 3.1 (of 3) *)
+          MATCH_MP_TAC SUM1 \\
+          MATCH_MP_TAC SUM1 \\
+          PURE_ONCE_REWRITE_TAC [SIGMA_TRANS_THM_EQ] \\
+          BETA_TAC \\
+          IMP_RES_TAC SIGMA_TRANS_THM \\
+          EXISTS_TAC ``k: num`` \\ 
+          STRIP_ASSUME_TAC
+           (REWRITE_RULE [Is_Prefix_def]
+             (MATCH_MP (ASSUME ``!(i: num). i <= n1 ==> Is_Prefix (f1 i)``) 
+		       (ASSUME ``(k: num) <= n1``))) \\
+          ASSUME_TAC
+           (REWRITE_RULE [ASSUME ``(f1: num -> CCS) k = prefix u' E''``]
+			 (ASSUME ``TRANS ((f1: num -> CCS) k) u E1'``)) \\
+          IMP_RES_TAC TRANS_PREFIX \\ 
+          ASM_REWRITE_TAC [PREF_ACT_def, PREF_PROC_def, PREFIX],
+          (* goal 3.2 (of 3) *)
+          MATCH_MP_TAC SUM1 \\
+          MATCH_MP_TAC SUM2 \\
+          PURE_ONCE_REWRITE_TAC [SIGMA_TRANS_THM_EQ] \\
+          BETA_TAC \\
+          IMP_RES_TAC SIGMA_TRANS_THM \\
+          EXISTS_TAC ``k: num`` \\ 
+          STRIP_ASSUME_TAC
+           (REWRITE_RULE [Is_Prefix_def]
+             (MATCH_MP (ASSUME ``!(j :num). j <= m2 ==> Is_Prefix (f2 j)``)
+		       (ASSUME ``(k :num) <= m2``))) \\
+          ASSUME_TAC
+           (REWRITE_RULE [ASSUME ``(f2: num -> CCS) k = prefix u' E''``]
+			 (ASSUME ``TRANS ((f2: num -> CCS) k) u E1'``)) \\
+          IMP_RES_TAC TRANS_PREFIX \\
+          ASM_REWRITE_TAC [PREF_ACT_def, PREF_PROC_def, PREFIX],
+          (* goal 3.3 (of 3) *)
+          MATCH_MP_TAC SUM2 \\
+          ASM_REWRITE_TAC [ALL_SYNC_TRANS_THM_EQ] \\
+          IMP_RES_TAC SIGMA_TRANS_THM \\
+          STRIP_ASSUME_TAC
+           (REWRITE_RULE [Is_Prefix_def]
+             (MATCH_MP (ASSUME ``!(j :num). j <= m2 ==> Is_Prefix (f2 j)``)
+		       (ASSUME ``(k :num) <= m2``))) \\
+          STRIP_ASSUME_TAC
+           (REWRITE_RULE [Is_Prefix_def]
+             (MATCH_MP (ASSUME ``!(i :num). i <= n1 ==> Is_Prefix (f1 i)``)
+		       (ASSUME ``(k' :num) <= n1``))) \\
+          ASSUME_TAC
+           (REWRITE_RULE [ASSUME ``(f2: num -> CCS) k = prefix u' E''``]
+             (ASSUME ``TRANS ((f2: num -> CCS) k) (label (COMPL l)) E2``)) \\
+          ASSUME_TAC
+           (REWRITE_RULE [ASSUME ``(f1: num -> CCS) k' = prefix u'' E'''``]
+             (ASSUME ``TRANS ((f1: num -> CCS) k') (label l) E1'``)) \\
+          IMP_RES_TAC TRANS_PREFIX \\
+          take [`k'`, `k`, `l`] \\
+          ASM_REWRITE_TAC [PREF_ACT_def, PREF_PROC_def] ],
+        (* goal 4 (of 4) *)
+        EXISTS_TAC ``E2: CCS`` \\
+        ASM_REWRITE_TAC [] \\
+        ASSUME_TAC
+         (REWRITE_RULE
+          [ASSUME ``E' = sum (sum (SIGMA 
+                                   (\i:num. prefix (PREF_ACT (f1 i))
+                                              (par (PREF_PROC (f1 i)) (SIGMA f2 m2))) n1)
+                                  (SIGMA
+                                   (\j:num. prefix (PREF_ACT (f2 j))
+                                              (par (SIGMA f1 n1) (PREF_PROC (f2 j)))) m2))
+                             (ALL_SYNC f1 n1 f2 m2)``]
+          (ASSUME ``TRANS E' u E2``)) \\
+        IMP_RES_TAC TRANS_SUM >| (* 2 sub-goals here *)
+        [ (* goal 4.1 (of 2) *)
+          IMP_RES_TAC 
+            (SPECL [``SIGMA (\i:num. prefix (PREF_ACT (f1 i))
+                                       (par (PREF_PROC (f1 i)) (SIGMA f2 m2))) n1``, 
+                    ``SIGMA (\j:num. prefix (PREF_ACT (f2 j))
+                                       (par (SIGMA f1 n1) (PREF_PROC (f2 j)))) m2``, 
+                    ``u: Action``,
+                    ``E2: CCS``] TRANS_SUM) >| (* 2 subgoals *)
+          [ (* goal 4.1.1 (of 2) *)
+            IMP_RES_TAC SIGMA_TRANS_THM \\
+            ASSUME_TAC
+             (BETA_RULE
+               (ASSUME ``TRANS ((\i: num. prefix (PREF_ACT (f1 i))
+                                            (par (PREF_PROC (f1 i)) (SIGMA f2 m2))) k) u E2``)) \\
+            IMP_RES_TAC TRANS_PREFIX \\
+            STRIP_ASSUME_TAC
+             (REWRITE_RULE [Is_Prefix_def]
+                           (MATCH_MP (ASSUME ``!(i: num). i <= n1 ==> Is_Prefix (f1 i)``) 
+			             (ASSUME ``(k: num) <= n1``))) \\
+            ASM_REWRITE_TAC [] \\
+            MATCH_MP_TAC PAR1 \\
+            REWRITE_TAC [SIGMA_TRANS_THM_EQ] \\
+            EXISTS_TAC ``k: num`` \\
+            ASM_REWRITE_TAC [PREF_ACT_def, PREF_PROC_def, PREFIX],
+            (* goal 4.1.2 (of 2) *)
+            IMP_RES_TAC SIGMA_TRANS_THM \\
+            ASSUME_TAC
+             (BETA_RULE
+               (ASSUME ``TRANS ((\j: num. prefix (PREF_ACT (f2 j))
+                                            (par (SIGMA f1 n1) (PREF_PROC (f2 j)))) k) u E2``)) \\
+            IMP_RES_TAC TRANS_PREFIX \\
+            STRIP_ASSUME_TAC
+             (REWRITE_RULE [Is_Prefix_def]
+                           (MATCH_MP (ASSUME ``!(j :num). j <= m2 ==> Is_Prefix (f2 j)``)
+				     (ASSUME ``(k :num) <= m2``))) \\
+            ASM_REWRITE_TAC [] \\
+            MATCH_MP_TAC PAR2 \\
+            REWRITE_TAC [SIGMA_TRANS_THM_EQ] \\
+            EXISTS_TAC ``k: num`` \\
+            ASM_REWRITE_TAC [PREF_ACT_def, PREF_PROC_def, PREFIX] ],
+          (* goal 4.2 (of 2) *)
+          IMP_RES_TAC ALL_SYNC_TRANS_THM \\
+          ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC PAR3 \\
+          EXISTS_TAC ``l: Label`` \\
+          REWRITE_TAC [SIGMA_TRANS_THM_EQ] \\
+          CONJ_TAC >| (* 2 sub-goals here *)
+          [ (* goal 4.2.1 (of 2) *)
+            EXISTS_TAC ``k: num`` \\
+            STRIP_ASSUME_TAC
+             (REWRITE_RULE [Is_Prefix_def]
+		(MATCH_MP (ASSUME ``!(i: num). i <= n1 ==> Is_Prefix (f1 i)``)
+			  (ASSUME ``(k :num) <= n1``))) \\
+            ASSUME_TAC
+             (REWRITE_RULE [ASSUME ``(f1: num -> CCS) k = prefix u' E''``, PREF_ACT_def]
+			   (ASSUME ``PREF_ACT ((f1: num -> CCS) k) = label l``)) \\
+            ASM_REWRITE_TAC [PREF_PROC_def, PREFIX],
+            (* goal 4.2.2 (of 2) *)
+            EXISTS_TAC ``k': num`` \\
+            STRIP_ASSUME_TAC
+             (REWRITE_RULE [Is_Prefix_def]
+		(MATCH_MP (ASSUME ``!(j :num). j <= m2 ==> Is_Prefix (f2 j)``)
+			  (ASSUME ``(k' :num) <= m2``))) \\
+            ASSUME_TAC
+             (REWRITE_RULE [ASSUME ``(f2: num -> CCS) k' = prefix u' E''``, PREF_ACT_def]
+			   (ASSUME ``PREF_ACT ((f2: num -> CCS) k') = label (COMPL l)``)) \\
+            ASM_REWRITE_TAC [PREF_PROC_def, PREFIX] ] ] ] ]);
+
+val _ = export_theory ();
+val _ = DB.html_theory "StrongLaws";
+
+(* last updated: May 14, 2017 *)

--- a/examples/CCS/WeakEQScript.sml
+++ b/examples/CCS/WeakEQScript.sml
@@ -1,0 +1,145 @@
+(*
+ * Copyright 2016-2017  University of Bologna   (Author: Chun Tian)
+ *)
+
+open HolKernel Parse boolLib bossLib;
+
+open stringTheory pred_setTheory relationTheory listTheory;
+open CCSLib CCSTheory StrongEQTheory StrongEQLib;
+
+val _ = new_theory "WeakEQ";
+
+(******************************************************************************)
+(*                                                                            *)
+(*                             Weak transitions                               *)
+(*                                                                            *)
+(******************************************************************************)
+
+val epsilon_def = Define `epsilon = []`;
+val _ = Unicode.unicode_version { u = UTF8.chr 0x03B5, tmnm = "epsilon"};
+val _ = TeX_notation { hol = UTF8.chr 0x03B5,
+                       TeX = ("\\HOLepsilon", 1) };
+
+(* val _ = type_abbrev ("trace", ``:Label list``); *)
+
+val (TRACE_rules, TRACE_ind, TRACE_cases) = Hol_reln `
+    (!E.                               TRACE E epsilon E) /\
+    (!E E' l. TRANS E (label l) E' ==> TRACE E [l] E') /\
+    (!E1 E2 E3 l1 l2.
+              TRACE E1 l1 E2 /\
+              TRACE E2 l2 E3 ==> TRACE E1 (l1 ++ l2) E3)`;
+
+val (WEAK_TRACE_rules, WEAK_TRACE_ind, WEAK_TRACE_cases) = Hol_reln `
+    (!E.                               WEAK_TRACE E epsilon E) /\
+    (!E E'.   TRANS E tau E'       ==> WEAK_TRACE E epsilon E') /\
+    (!E E' l. TRANS E (label l) E' ==> WEAK_TRACE E [l] E') /\
+    (!E1 E2 E3 l1 l2.
+              WEAK_TRACE E1 l1 E2 /\
+              WEAK_TRACE E2 l2 E3 ==> WEAK_TRACE E1 (l1 ++ l2) E3)`;
+
+(* Weak trace relation with single action, not recursive *)
+val (EPS1_rules, EPS1_ind, EPS1_cases) = Hol_reln `
+    (!E E'. TRANS E tau E' ==> EPS1 E E')`;
+
+val EPS_def = Define `EPS = RTC EPS1`;
+
+val (WEAK_TRANS_rules, WEAK_TRANS_ind, WEAK_TRANS_cases) = Hol_reln `
+    (!E E' E1 E2 u. EPS E E1 /\ TRANS E1 u E2 /\ EPS E2 E' ==> WEAK_TRANS E u E')`;
+
+val _ =
+    add_rule { term_name = "WEAK_TRANS", fixity = Infix (NONASSOC, 450),
+	pp_elements = [ BreakSpace(1,0), TOK "==", HardSpace 0, TM, HardSpace 0, TOK "=>>",
+			BreakSpace(1,0) ],
+	paren_style = OnlyIfNecessary,
+	block_style = (AroundEachPhrase, (PP.CONSISTENT, 0)) };
+
+(******************************************************************************)
+(*                                                                            *)
+(*                 Weak bisimulation and weak bisimularity                    *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Define the weak bisimulation relation on CCS processes. *)
+val WEAK_BISIM = new_definition ("WEAK_BISIM",
+  ``WEAK_BISIM (Wbsm: CCS -> CCS -> bool) =
+    (!E E'.
+       Wbsm E E' ==>
+       (!l.
+         (!E1. TRANS E  (label l) E1 ==>
+               (?E2. WEAK_TRANS E' (label l) E2 /\ Wbsm E1 E2)) /\
+         (!E2. TRANS E' (label l) E2 ==>
+               (?E1. WEAK_TRANS E  (label l) E1 /\ Wbsm E1 E2))) /\
+       (!E1. TRANS E  tau E1 ==> (?E2. EPS E' E2 /\ Wbsm E1 E2)) /\
+       (!E2. TRANS E' tau E2 ==> (?E1. EPS E  E1 /\ Wbsm E1 E2)))``);
+
+(* An equivalent WEAK_EQUIV definition based on HOL's coinductive relation *)
+val (WEAK_EQUIV_rules, WEAK_EQUIV_coind, WEAK_EQUIV_cases) = Hol_coreln `
+    (!E E'.
+       (!l.
+         (!E1. TRANS E  (label l) E1 ==>
+               (?E2. WEAK_TRANS E' (label l) E2 /\ WEAK_EQUIV E1 E2)) /\
+         (!E2. TRANS E' (label l) E2 ==>
+               (?E1. WEAK_TRANS E  (label l) E1 /\ WEAK_EQUIV E1 E2))) /\
+       (!E1. TRANS E  tau E1 ==> (?E2. EPS E' E2 /\ WEAK_EQUIV E1 E2)) /\
+       (!E2. TRANS E' tau E2 ==> (?E1. EPS E  E1 /\ WEAK_EQUIV E1 E2))
+      ==> WEAK_EQUIV E E')`;
+
+(* "Weak bisimilarity is a weak bisimulation" *)
+val WEAK_EQUIV_IS_WEAK_BISIM = store_thm (
+   "WEAK_EQUIV_IS_WEAK_BISIM", ``WEAK_BISIM WEAK_EQUIV``,
+    PURE_ONCE_REWRITE_TAC [WEAK_BISIM]
+ >> REPEAT GEN_TAC
+ >> DISCH_TAC
+ >> PURE_ONCE_REWRITE_TAC [GSYM WEAK_EQUIV_cases]
+ >> ASM_REWRITE_TAC []);
+
+(* Alternative definition of WEAK_EQUIV, similar with STRONG_EQUIV (definition).
+   "Weak bisimilarity contains all weak bisimulations (thus maximal)"
+ *)
+val WEAK_EQUIV = store_thm ("WEAK_EQUIV",
+  ``!E E'. WEAK_EQUIV E E' = (?Wbsm. Wbsm E E' /\ WEAK_BISIM Wbsm)``,
+    REPEAT GEN_TAC
+ >> EQ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      DISCH_TAC \\
+      EXISTS_TAC ``WEAK_EQUIV`` \\
+      ASM_REWRITE_TAC [WEAK_EQUIV_IS_WEAK_BISIM],
+      (* goal 2 (of 2) *)
+      Q.SPEC_TAC (`E'`, `E'`) \\
+      Q.SPEC_TAC (`E`, `E`) \\
+      HO_MATCH_MP_TAC WEAK_EQUIV_coind \\ (* co-induction used here! *)
+      METIS_TAC [WEAK_BISIM] ]);
+
+val _ = set_mapped_fixity { fixity = Infix (NONASSOC, 450),
+			    tok = "~~~", term_name = "WEAK_EQUIV" };
+
+val _ = Unicode.unicode_version { u = UTF8.chr 0x2248, tmnm = "WEAK_EQUIV"};
+val _ = TeX_notation { hol = UTF8.chr 0x2248,
+                       TeX = ("\\HOLTokenWeakEquiv", 1) };
+
+(******************************************************************************)
+(*                                                                            *)
+(*                         Rooted weak bisimularity                           *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* Rooted weak bisimilarity (observation congruence) is based on WEAK_EQUIV *)
+val OBS_CONGR = new_definition ("OBS_CONGR",
+  ``OBS_CONGR E E' =
+       (!u.
+         (!E1. TRANS E u E1 ==>
+               (?E2. WEAK_TRANS E' u E2 /\ WEAK_EQUIV E1 E2)) /\
+         (!E2. TRANS E' u E2 ==>
+               (?E1. WEAK_TRANS E  u E1 /\ WEAK_EQUIV E1 E2)))``);
+
+val _ = set_mapped_fixity { fixity = Infix (NONASSOC, 450),
+			    tok = "~~c", term_name = "OBS_CONGR" };
+
+val _ = Unicode.unicode_version { u = UTF8.chr 0x2248 ^ UTF8.chr 0x02B3, tmnm = "OBS_CONGR"};
+val _ = TeX_notation { hol = UTF8.chr 0x2248 ^ UTF8.chr 0x02B3, (* double-tilde ^ r *)
+                       TeX = ("\\HOLTokenRootedWeakEquiv", 1) };
+
+val _ = export_theory ();
+val _ = DB.html_theory "WeakEQ";
+
+(* last updated: May 14, 2017 *)

--- a/examples/README
+++ b/examples/README
@@ -31,6 +31,12 @@ Currently here are the following:
        equivalent.  Results include Rice's theorem, and that if a set
        and its complement are r.e., then they are also recursive.
 
+  * CCS
+
+       This directory contains a formalization of the Process Algebra CCS.
+       (Milner's Calculus of Communicating Systems)
+       Author: Monica Nesi (ported from HOL88 by Chun Tian)
+
   * Crypto
 
        This directory holds a formalization of a number of different

--- a/tools/sequences/more-theories
+++ b/tools/sequences/more-theories
@@ -46,3 +46,4 @@ src/rational
 src/datatype/inftree
 !examples/hfs
 src/search
+!examples/CCS


### PR DESCRIPTION
Hi,

This is a formalization of CCS (Milner's Calculus of Communicating Systems) by Prof. Monica Nesi during 1992-1995, ported by Chun Tian (me) from old HOL88 proof scripts with some improvements.   Original proof scripts, project report (draft) and the original paper can be found here: https://github.com/binghe/informatica-public/tree/master/CCS

Among other features, I think this work is a classical example to demonstrate how Hol_coreln can be used to define "bisimulation equivalence" - the most well-studied co-induction relation.

The code is confirmed working with all HOL kernels (stdknl, expk, otknl), also in Kananaskis-11 final release.  (It doesn't build in Kanasnaskis-10 because Hol_coreln is not available)

This is only partial of the entire work. I'm receiving more old scripts from Monica Nesi, and in the future I may request to submit more code into this directory. The final aim is to have a model checking tools running on top of HOL4.

Thanks,

Chun Tian
University of Bologna