### PR TITLE
fix issue #416

### DIFF
--- a/src/1/Pmatch.sml
+++ b/src/1/Pmatch.sml
@@ -507,18 +507,21 @@ fun no_repeat_vars pat =
 (*---------------------------------------------------------------------------
      Routines to repair the bound variable names found in cases
  ---------------------------------------------------------------------------*)
+fun pat_match1 fvs pat given_pat =
+ let val (sub_tm, sub_ty) = Term.match_term pat given_pat
+     val _ = if null sub_ty then () else (raise ERR "pat_match1" "no type substitution expected");
 
-fun subst_inst (term_sub,type_sub) tm =
-    Term.subst term_sub (Term.inst type_sub tm);
-
-fun pat_match1 (pat,exp) given_pat =
- let val sub = Term.match_term pat given_pat
- in (subst_inst sub pat, subst_inst sub exp);
-    sub
+     fun is_valid_bound_var v = (is_var v andalso not (List.exists (fn tm => aconv tm v) fvs))
+     val _ = if List.all (fn m => is_valid_bound_var (#residue m)) sub_tm then () else
+           (raise ERR "pat_match1" "expected a bound variable renaming");
+ in sub_tm
  end
 
-fun pat_match2 pat_exps given_pat = tryfind (C pat_match1 given_pat) pat_exps
-                                    handle HOL_ERR _ => ([],[])
+fun pat_match2 fvs pat_exps given_pat = tryfind ((C (pat_match1 fvs) given_pat) o fst) pat_exps
+                                        handle HOL_ERR _ => ([]);
+
+fun subst_to_renaming (s : (term, term) subst) : (term * string) list =
+  map (fn m => (#redex m, fst (dest_var (#residue m)))) s;
 
 fun distinguish fvs pat_tm_mats =
     snd (List.foldr (fn ({redex,residue}, (vs,done)) =>
@@ -539,8 +542,8 @@ fun purge_wildcards term_sub = filter (fn {redex,residue} =>
         handle _ => false) term_sub
 
 fun pat_match3 fvs pat_exps given_pats =
-     (((distinguish fvs) o reduce_mats o purge_wildcards o flatten) ## flatten)
-           (unzip (map (pat_match2 pat_exps) given_pats))
+     ((subst_to_renaming o distinguish fvs o reduce_mats o purge_wildcards o flatten))
+           (map (pat_match2 fvs pat_exps) given_pats);
 
 
 (*---------------------------------------------------------------------------*)
@@ -704,20 +707,17 @@ fun strip_case tybase M =
   end
   else strip_case1 tybase M
 
-
-fun rename_case thy sub cs =
- if not (is_case thy cs) then subst_inst sub cs
- else
-   let val (cnst,arg,pat_exps) = dest_case thy cs
-       val pat_exps' = map (fn (pat,exp) =>
-                            (rename_case thy sub pat,
-                             rename_case thy sub exp))
-                       pat_exps
-       val arg' = rename_case thy sub arg
-       val cs' = mk_case thy (arg', pat_exps')
-   in cs'
-   end
-
+fun rename_top_bound_vars ren cs = (
+ case dest_term cs of
+    VAR _ => cs
+  | CONST _ => cs
+  | COMB (t1, t2) => mk_comb (rename_top_bound_vars ren t1, rename_top_bound_vars ren t2)
+  | LAMB (v, t) =>
+    let val cs' = rename_bvar (Lib.assoc v ren) cs handle HOL_ERR _ => cs
+        val (v', t') = dest_abs cs'
+        val t'' = rename_top_bound_vars ren t'
+    in mk_abs (v', t'') end
+);
 
 local fun paired1{lhs,rhs} = (lhs,rhs)
       and paired2{Rator,Rand} = (Rator,Rand)
@@ -733,9 +733,9 @@ fun mk_functional thy eqs =
      val f  = if is_var f0 then f0 else mk_var(dest_const f0)
      val _  = map no_repeat_vars pats
      val rows = zip (map (fn x => ([]:term list,[x])) pats) (map GIVEN (enumerate R))
-     val fvs = free_varsl (L@R)
-     val a = variant fvs (mk_var("a", type_of(Lib.trye hd pats)))
-     val FV = a::fvs
+     val avs = all_varsl (L@R)
+     val a = variant avs (mk_var("a", type_of(Lib.trye hd pats)))
+     val FV = a::avs
      val range_ty = type_of (Lib.trye hd R)
      val (patts, case_tm) = mk_case0 (match_info thy) (match_type thy)
                                      FV range_ty {path=[a], rows=rows}
@@ -767,20 +767,21 @@ fun mk_functional thy eqs =
              | _ => msg("The following input rows (counting from zero) are\
        \ inaccessible: "^stringize inaccessibles^".\nThey have been ignored.")
      (* The next lines repair bound variable names in the nested case term. *)
-     val (a',case_tm') =
+     val case_tm' =
          let val (_,pat_exps) = strip_case thy case_tm
-             val pat_exps = if null pat_exps then [(a,a)] else pat_exps
              val fvs = free_vars case_tm
-             val sub = pat_match3 fvs pat_exps pats (* better pats than givens patts3 *)
-         in (subst_inst sub a, rename_case thy sub case_tm)
-         end handle HOL_ERR _ => (a,case_tm)
+             val ren = pat_match3 fvs pat_exps pats (* better pats than givens patts3 *)
+         in (rename_top_bound_vars ren case_tm)
+         end handle HOL_ERR _ =>
+           (Feedback.HOL_WARNING "Pmatch" "mk_functional" "SHOULD NOT HAPPEN! RENAMING CASE_TM FAILED!";
+            case_tm)
      (* Ensure that the case test variable is fresh for the rest of the case *)
-     val avs = subtract (all_vars case_tm') [a']
-     val a'' = variant avs a'
-     val case_tm'' = if a'' = a' then case_tm'
-                                 else rename_case thy ([a' |-> a''],[]) case_tm'
+     val avs = subtract (all_vars case_tm') [a]
+     val a' = variant avs a
+     val case_tm'' = if a' = a then case_tm'
+                               else subst ([a |-> a']) case_tm'
  in
-   {functional = list_mk_abs ([f,a''], case_tm''),
+   {functional = list_mk_abs ([f,a'], case_tm''),
     pats = patts3}
  end
 end;

--- a/src/boss/theory_tests/github416Script.sml
+++ b/src/boss/theory_tests/github416Script.sml
@@ -1,0 +1,31 @@
+open HolKernel Parse boolLib bossLib;
+
+val _ = new_theory "github416";
+
+val _ = Datatype `exp = Const num num | Downcast num exp`;
+
+val test_def = Define `
+  test (e:exp) (map: exp -> num option) : bool =
+    case e of
+     | Const m n => (case map e of
+                      | SOME m' => m = m'
+                      | NONE => F)
+     | Downcast m e1 => (case map e, map e1 of
+                           | SOME m', SOME m1 => (m' = m) /\ test e1 map
+                           | _, _ => F)
+     | _ => F`;
+
+
+val test_THM = (store_thm ("test_THM", ``!m e m' m1 map.
+  (map (Downcast m e) = SOME m') /\
+  (map e = SOME m1) ==>
+
+  (test (Downcast m e) map <=> ((m' = m) /\ test e map))``,
+
+SIMP_TAC (srw_ss()) [Once test_def])) handle HOL_ERR _ => (
+  print "Test for github issue #416 failed - FAILURE\n";
+  OS.Process.exit OS.Process.failure);
+
+val _ = print "Test-case OK\n";
+
+val _ = export_theory();


### PR DESCRIPTION
I debugged issue #416 and hope this will fix it.

Issue #416 describes a bug in the case expression parsing. During case-parsing two bound variables could be identified with each other while they should really be separate ones. I tracked this problem down to `Pmatch.mk_functional`. After doing the real work and building `a` and `case_tm`, variable renamings should be applied to make the variable names similar to the ones used in the input. The bug is in this renaming code (see https://github.com/HOL-Theorem-Prover/HOL/blob/dea93fe0a3b84f048a4f7e82caf2dd5a9a014fa6/src/1/Pmatch.sml#L770-L781).

`pat_match3` computes the necessary variable renaming as a substitution and applies it via `rename_case` (see https://github.com/HOL-Theorem-Prover/HOL/blob/dea93fe0a3b84f048a4f7e82caf2dd5a9a014fa6/src/1/Pmatch.sml#L774-L775). The implementation of `rename_case` strips away all outer occurrences of case-expressions applies the substitution and builds the case-expressions again with substituted variable names (see https://github.com/HOL-Theorem-Prover/HOL/blob/dea93fe0a3b84f048a4f7e82caf2dd5a9a014fa6/src/1/Pmatch.sml#L708-L719). If a clause of the input case-expression has another case-expression at top-level, then this stripping is doing too much. The substitution is applied under a lambda abstraction which has not been taken in consideration while building the substitution. This is when variable capture might occur as demonstrated by issue #416.

I was thinking about how to best fix this bug. One option is to use markers to prevent the sustitution being applied too low. However, this would be not make the intention of variable renaming clear, be rather hackish and moreover cause dependency issues (or duplicate definitions) since marker and combinator theories are later in the build-chain. Instead I implemented a comparably large change to the code, which is however cleaner in my opinion.

I looked what is really supposed to happen. The substitution computed by `pat_match3` is really a renaming of bound variables. I made this explicit by changing the return type and adding checks that fail and produce an error message if this is not guaranteed. Moreover, by changing how the auxiliary variable names are generated by `vary`, I ensure that the bound variables renamed are only occurring once, i.e. not in the input. This allows me to implement `rename_case` completely differently as a renaming of bound variables via `rename_bvar`.

The works well for my tests. However, it is a potentially troublesome change. Moreover, I tested only with the standard kernel and after my last change, I only ran selftest level 1. So, it would be good, to check the results of the automatic tests carefully and also review my changes in case I implemented some nonsense.