### PR TITLE
fixed wrong num of args when calling copy-region-as-hol-definition-quietly

### DIFF
--- a/tools/hol-mode.src
+++ b/tools/hol-mode.src
@@ -566,7 +566,7 @@ variable before and after the region is sent."
 
 
 (defun copy-region-as-hol-definition-quietly (start end)
-   (interactive "r\n")
+   (interactive "r")
    (hol-toggle-quiet-quietdec)
    (copy-region-as-hol-definition start end 0)
    (hol-toggle-quiet-quietdec))


### PR DESCRIPTION
As Thomas has already found out, the "\n" in (interactive "r\np") is a separator of arguments, when "p" is removed, "\n" should be removed too, otherwise there will be a "wrong number of arguments" error in Emacs when using copy-region-as-hol-definition-quietly() by M-r C-r.