### PR TITLE
Further cleanup of util_probTheory with set theorems moved back to pred_setTheory

### DIFF
--- a/examples/miller/formalize/extra_pred_setScript.sml
+++ b/examples/miller/formalize/extra_pred_setScript.sml
@@ -1504,6 +1504,26 @@ val DISJOINT_ALT = store_thm
    RW_TAC std_ss [IN_DISJOINT]
    ++ PROVE_TAC []);
 
+(* NOTE: there's already a FINITE_BIJ_COUNT in pred_setTheory with different variable names,
+   but probScript here is very sensible to variable names in FINITE_BIJ_COUNT *)
+val FINITE_BIJ_COUNT = store_thm
+  ("FINITE_BIJ_COUNT",
+   ``!s. FINITE s = ?c n. BIJ c (count n) s``,
+   RW_TAC std_ss []
+   ++ REVERSE EQ_TAC >> PROVE_TAC [FINITE_COUNT, FINITE_BIJ]
+   ++ Q.SPEC_TAC (`s`, `s`)
+   ++ HO_MATCH_MP_TAC FINITE_INDUCT
+   ++ RW_TAC std_ss [BIJ_DEF, INJ_DEF, SURJ_DEF, NOT_IN_EMPTY]
+   >> (Q.EXISTS_TAC `c`
+       ++ Q.EXISTS_TAC `0`
+       ++ RW_TAC std_ss [COUNT_ZERO, NOT_IN_EMPTY])
+   ++ Q.EXISTS_TAC `\m. if m = n then e else c m`
+   ++ Q.EXISTS_TAC `SUC n`
+   ++ Know `!x. x IN count n ==> ~(x = n)`
+   >> RW_TAC arith_ss [IN_COUNT]
+   ++ RW_TAC std_ss [COUNT_SUC, IN_INSERT]
+   ++ PROVE_TAC []);
+
 val GCOMPL = store_thm
   ("GCOMPL",
    ``!p. {s | ~p s} = COMPL {s | p s}``,

--- a/examples/miller/formalize/measureScript.sml
+++ b/examples/miller/formalize/measureScript.sml
@@ -393,14 +393,14 @@ val SIGMA_ALGEBRA_ALT = store_thm
           f IN (UNIV -> a) ==> BIGUNION (IMAGE f UNIV) IN a)``,
    RW_TAC std_ss [sigma_algebra_def]
    ++ EQ_TAC
-   >> (RW_TAC std_ss [countable_def, IN_FUNSET, IN_UNIV]
+   >> (RW_TAC std_ss [COUNTABLE_ALT, IN_FUNSET, IN_UNIV]
        ++ Q.PAT_X_ASSUM `!c. P c ==> Q c` MATCH_MP_TAC
        ++ Reverse (RW_TAC std_ss [IN_IMAGE, SUBSET_DEF, IN_UNIV])
        >> PROVE_TAC []
        ++ Q.EXISTS_TAC `f`
        ++ RW_TAC std_ss []
        ++ PROVE_TAC [])
-   ++ RW_TAC std_ss [COUNTABLE_ALT]
+   ++ RW_TAC std_ss [COUNTABLE_ALT_BIJ]
    >> PROVE_TAC [ALGEBRA_FINITE_UNION]
    ++ Q.PAT_X_ASSUM `!f. P f` (MP_TAC o Q.SPEC `\n. enumerate c n`)
    ++ RW_TAC std_ss' [IN_UNIV, IN_FUNSET]
@@ -1404,7 +1404,7 @@ val SIGMA_ALGEBRA = store_thm
    ++ EQ_TAC >> PROVE_TAC []
    ++ RW_TAC std_ss []
    ++ Q.PAT_X_ASSUM `!c. P c` (MP_TAC o Q.SPEC `{s; t}`)
-   ++ RW_TAC std_ss [COUNTABLE_ALT, FINITE_INSERT, FINITE_EMPTY, SUBSET_DEF,
+   ++ RW_TAC std_ss [COUNTABLE_ALT_BIJ, FINITE_INSERT, FINITE_EMPTY, SUBSET_DEF,
                      BIGUNION_PAIR, IN_INSERT, NOT_IN_EMPTY]
    ++ PROVE_TAC []);
 
@@ -1443,7 +1443,7 @@ val MEASURABLE_SIGMA = store_thm
     ++ RW_TAC std_ss [sigma_algebra_def]
     ++ POP_ASSUM MATCH_MP_TAC
     ++ RW_TAC std_ss [SUBSET_DEF, IN_IMAGE]
-    ++ PROVE_TAC [COUNTABLE_IMAGE]]);
+    ++ PROVE_TAC [image_countable]]);
 
 val MEASURABLE_SUBSET = store_thm
   ("MEASURABLE_SUBSET",

--- a/examples/miller/formalize/probabilityScript.sml
+++ b/examples/miller/formalize/probabilityScript.sml
@@ -408,7 +408,7 @@ val EVENTS_COUNTABLE_INTER = store_thm
    ++ RW_TAC std_ss [COMPL_BIGINTER]
    ++ MATCH_MP_TAC EVENTS_COUNTABLE_UNION
    ++ Q.PAT_X_ASSUM `c SUBSET events p` MP_TAC
-   ++ RW_TAC std_ss [COUNTABLE_IMAGE, SUBSET_DEF, IN_IMAGE]
+   ++ RW_TAC std_ss [image_countable, SUBSET_DEF, IN_IMAGE]
    ++ PROVE_TAC [EVENTS_COMPL]);
 
 val ABS_PROB = store_thm
@@ -544,7 +544,7 @@ val PROB_COUNTABLY_SUBADDITIVE = store_thm
    >> (MATCH_MP_TAC PROB_INCREASING_UNION
        ++ RW_TAC std_ss [IN_FUNSET, IN_UNIV] <<
        [MATCH_MP_TAC EVENTS_COUNTABLE_UNION
-        ++ RW_TAC std_ss [SUBSET_DEF, IN_IMAGE, COUNTABLE_IMAGE,
+        ++ RW_TAC std_ss [SUBSET_DEF, IN_IMAGE, image_countable,
                           COUNTABLE_COUNT]
         ++ PROVE_TAC [],
         PSET_TAC []
@@ -577,7 +577,7 @@ val PROB_COUNTABLY_SUBADDITIVE = store_thm
    ++ MATCH_MP_TAC PROB_SUBADDITIVE
    ++ RW_TAC std_ss [] >> PROVE_TAC []
    ++ MATCH_MP_TAC EVENTS_COUNTABLE_UNION
-   ++ RW_TAC std_ss [SUBSET_DEF, IN_IMAGE, IN_COUNT, COUNTABLE_IMAGE,
+   ++ RW_TAC std_ss [SUBSET_DEF, IN_IMAGE, IN_COUNT, image_countable,
                      COUNTABLE_COUNT]
    ++ PROVE_TAC []);
 

--- a/examples/miller/prob/probScript.sml
+++ b/examples/miller/prob/probScript.sml
@@ -397,13 +397,13 @@ val EVENTS_BERN_COUNTABLE = store_thm
        ++ RW_TAC std_ss [IN_BIGUNION_IMAGE, IN_SING])
    ++ Rewr'
    ++ MATCH_MP_TAC EVENTS_COUNTABLE_UNION
-   ++ RW_TAC std_ss [PROB_SPACE_BERN, SUBSET_DEF, COUNTABLE_IMAGE, IN_IMAGE]
+   ++ RW_TAC std_ss [PROB_SPACE_BERN, SUBSET_DEF, image_countable, IN_IMAGE]
    ++ PROVE_TAC [EVENTS_BERN_SING]);
 
 val EVENTS_BERN_FINITE = store_thm
   ("EVENTS_BERN_FINITE",
    ``!c. FINITE c ==> c IN events bern``,
-   PROVE_TAC [EVENTS_BERN_COUNTABLE, FINITE_COUNTABLE]);
+   PROVE_TAC [EVENTS_BERN_COUNTABLE, finite_countable]);
 
 val PROB_BERN_SING = store_thm
   ("PROB_BERN_SING",
@@ -443,7 +443,7 @@ val PROB_BERN_FINITE = store_thm
 val PROB_BERN_COUNTABLE = store_thm
   ("PROB_BERN_COUNTABLE",
    ``!c. countable c ==> (prob bern c = 0)``,
-   RW_TAC std_ss [COUNTABLE_ALT, BIJ_DEF, SURJ_DEF, INJ_DEF, IN_UNIV]
+   RW_TAC std_ss [COUNTABLE_ALT_BIJ, BIJ_DEF, SURJ_DEF, INJ_DEF, IN_UNIV]
    >> PROVE_TAC [PROB_BERN_FINITE]
    ++ Suff
       `prob bern o (\x. {enumerate c x}) sums 0 /\
@@ -719,7 +719,7 @@ val EVENTS_BERN_PREFIX_COVER = store_thm
    ``!c. BIGUNION (IMAGE prefix_set c) IN events bern``,
    RW_TAC std_ss []
    ++ MATCH_MP_TAC EVENTS_COUNTABLE_UNION
-   ++ RW_TAC std_ss [COUNTABLE_IMAGE, COUNTABLE_BOOL_LIST, PROB_SPACE_BERN,
+   ++ RW_TAC std_ss [image_countable, COUNTABLE_BOOL_LIST, PROB_SPACE_BERN,
                      SUBSET_DEF, IN_IMAGE]
    ++ RW_TAC std_ss [EVENTS_BERN_PREFIX_SET]);
 
@@ -784,7 +784,7 @@ val INDEP_FN_PROB_PRESERVING = store_thm
        !s t.
          s IN IMAGE prefix_set c /\ t IN IMAGE prefix_set c /\ ~(s = t) ==>
          DISJOINT s t`
-   >> (CONJ_TAC >> RW_TAC std_ss [COUNTABLE_IMAGE, COUNTABLE_BOOL_LIST]
+   >> (CONJ_TAC >> RW_TAC std_ss [image_countable, COUNTABLE_BOOL_LIST]
        ++ RW_TAC std_ss [IN_IMAGE, o_THM]
        ++ MP_TAC
           (Q.SPECL [`c`, `prefix_set x`, `prefix_set x'`]
@@ -875,7 +875,7 @@ val INDEP_FN_STRONG = store_thm
        !s t.
          s IN IMAGE prefix_set c /\ t IN IMAGE prefix_set c /\ ~(s = t) ==>
          DISJOINT s t`
-   >> (CONJ_TAC >> RW_TAC std_ss [COUNTABLE_IMAGE, COUNTABLE_BOOL_LIST]
+   >> (CONJ_TAC >> RW_TAC std_ss [image_countable, COUNTABLE_BOOL_LIST]
        ++ RW_TAC std_ss [IN_IMAGE, o_THM]
        ++ MP_TAC
           (Q.SPECL [`c`, `prefix_set x''`, `prefix_set x'''`]
@@ -1003,7 +1003,7 @@ val INDEP_FN_UNIT = store_thm
    BasicProvers.NORM_TAC std_ss
    [indep_fn_def, GSPECIFICATION, FST_o_UNIT, SND_o_UNIT,
     IN_MEASURABLE, PREIMAGE_I, PREIMAGE_K, EVENTS_BERN_BASIC, I_THM]
-   >> RW_TAC std_ss [range_def, IMAGE_K, COUNTABLE_EMPTY, COUNTABLE_SING]
+   >> RW_TAC std_ss [range_def, IMAGE_K, countable_EMPTY, COUNTABLE_SING]
    ++ Q.EXISTS_TAC `{[]}`
    ++ RW_TAC std_ss [IN_SING, prefix_cover_def, IMAGE_INSERT, IMAGE_EMPTY,
                      prefix_set_def, BIGUNION_INSERT, BIGUNION_EMPTY,
@@ -1113,7 +1113,7 @@ val PREFIX_COVER_APPEND = store_thm
       (Q.ISPEC
        `IMAGE (\l. BIGUNION (IMAGE (prefix_set o APPEND l) (cf l))) c`
        COUNTABLE_DISJOINT_ENUM)
-   ++ RW_TAC std_ss [COUNTABLE_IMAGE, COUNTABLE_BOOL_LIST]
+   ++ RW_TAC std_ss [image_countable, COUNTABLE_BOOL_LIST]
    ++ POP_ASSUM MP_TAC
    ++ Know
    `!s t.
@@ -1157,7 +1157,7 @@ val PREFIX_COVER_APPEND = store_thm
        ++ STRIP_TAC >> RW_TAC std_ss [EVENTS_BERN_EMPTY]
        ++ RW_TAC std_ss []
        ++ MATCH_MP_TAC EVENTS_COUNTABLE_UNION
-       ++ RW_TAC std_ss [PROB_SPACE_BERN, SUBSET_DEF, COUNTABLE_IMAGE,
+       ++ RW_TAC std_ss [PROB_SPACE_BERN, SUBSET_DEF, image_countable,
                          COUNTABLE_BOOL_LIST, IN_IMAGE, o_THM]
        ++ RW_TAC std_ss [EVENTS_BERN_PREFIX_SET])
    ++ Know
@@ -1251,7 +1251,7 @@ val PREFIX_COVER_APPEND = store_thm
    >> RW_TAC std_ss [EVENTS_BERN_PREFIX_SET, PROB_BERN_STL_HALFSPACE]
    ++ MATCH_MP_TAC EVENTS_COUNTABLE_UNION
    ++ RW_TAC std_ss [PROB_SPACE_BERN, COUNTABLE_BOOL_LIST, SUBSET_DEF, IN_IMAGE,
-                     COUNTABLE_IMAGE, o_THM]
+                     image_countable, o_THM]
    ++ RW_TAC std_ss [EVENTS_BERN_PREFIX_SET]);
 
 val INDEP_FN_BIND = store_thm
@@ -1267,7 +1267,7 @@ val INDEP_FN_BIND = store_thm
        (INST_TYPE [alpha |-> ``:num -> bool``, beta |-> alpha, gamma |-> beta]
         RANGE_BIND)
     ++ MATCH_MP_TAC COUNTABLE_BIGUNION
-    ++ CONJ_TAC >> RW_TAC std_ss [COUNTABLE_IMAGE]
+    ++ CONJ_TAC >> RW_TAC std_ss [image_countable]
     ++ RW_TAC std_ss [IN_IMAGE, o_THM]
     ++ RW_TAC std_ss [],
     RW_TAC bool_ss [BIND_DEF, o_ASSOC]
@@ -1631,7 +1631,7 @@ val PROB_BERN_BIND_FINITE = store_thm
    >> (MATCH_MP_TAC PROB_ADDITIVE
        ++ RW_TAC std_ss [PROB_SPACE_BERN, o_THM] <<
        [MATCH_MP_TAC EVENTS_COUNTABLE_UNION
-        ++ RW_TAC std_ss [PROB_SPACE_BERN, COUNTABLE_IMAGE, COUNTABLE_COUNT,
+        ++ RW_TAC std_ss [PROB_SPACE_BERN, image_countable, COUNTABLE_COUNT,
                           SUBSET_DEF, IN_IMAGE, o_THM]
         ++ MATCH_MP_TAC EVENTS_INTER
         ++ Q.SPEC_TAC (`$= (c x')`, `q`)
@@ -1731,7 +1731,7 @@ val INDEP_FN_ENUM_RANGE = store_thm
        f IN indep_fn ==>
        (?c : num -> 'a. BIJ c UNIV (range (FST o f))) \/
        (?c n. BIJ c (count n) (range (FST o f)))``,
-   REVERSE (RW_TAC std_ss [indep_fn_def, GSPECIFICATION, COUNTABLE_ALT])
+   REVERSE (RW_TAC std_ss [indep_fn_def, GSPECIFICATION, COUNTABLE_ALT_BIJ])
    >> PROVE_TAC []
    ++ PROVE_TAC [FINITE_BIJ_COUNT]);
 
@@ -2234,7 +2234,7 @@ val PREFIX_COVER_STAR = store_thm
                          IN_DISJOINT, IN_BIGUNION_IMAGE]
        >> (MATCH_MP_TAC EVENTS_COUNTABLE_UNION
            ++ RW_TAC std_ss [PROB_SPACE_BERN, COUNTABLE_BOOL_LIST,
-                             COUNTABLE_IMAGE, SUBSET_DEF, IN_IMAGE]
+                             image_countable, SUBSET_DEF, IN_IMAGE]
            ++ RW_TAC std_ss [EVENTS_BERN_PREFIX_SET])
        ++ CCONTR_TAC
        ++ POP_ASSUM (MP_TAC o REWRITE_RULE [DE_MORGAN_THM])
@@ -2269,7 +2269,7 @@ val PREFIX_COVER_STAR = store_thm
    ++ RW_TAC std_ss [PROB_SPACE_BERN, IN_FUNSET, IN_UNIV, o_THM,
                      GSPECIFICATION, IN_BIGUNION_IMAGE] <<
    [MATCH_MP_TAC SIGMA_ALGEBRA_COUNTABLE_UNION
-    ++ RW_TAC std_ss [COUNTABLE_BOOL_LIST, COUNTABLE_IMAGE, SUBSET_DEF,
+    ++ RW_TAC std_ss [COUNTABLE_BOOL_LIST, image_countable, SUBSET_DEF,
                       IN_IMAGE, EVENTS_SIGMA_ALGEBRA, PROB_SPACE_BERN]
     ++ RW_TAC std_ss [EVENTS_BERN_PREFIX_SET],
     RW_TAC std_ss [DISJOINT_ALT, IN_BIGUNION_IMAGE]
@@ -2313,7 +2313,7 @@ val PROB_WHILE_TERMINATES_PREFIX_COVER_STAR = store_thm
    >> (RW_TAC std_ss [COUNTABLE_IMAGE_NUM, PROB_SPACE_BERN, SUBSET_DEF,
                       IN_IMAGE, IN_UNIV, GDEST]
        ++ MATCH_MP_TAC EVENTS_COUNTABLE_UNION
-       ++ RW_TAC std_ss [COUNTABLE_IMAGE, PROB_SPACE_BERN, SUBSET_DEF,
+       ++ RW_TAC std_ss [image_countable, PROB_SPACE_BERN, SUBSET_DEF,
                          COUNTABLE_BOOL_LIST, IN_IMAGE]
        ++ RW_TAC std_ss [EVENTS_BERN_PREFIX_SET])
    ++ RW_TAC std_ss [probably_def, probably_bern_def]
@@ -2407,8 +2407,8 @@ val PROB_WHILE_TERMINATES_PREFIX_COVER_STAR = store_thm
       ++ MATCH_MP_TAC EVENTS_DIFF
       ++ RW_TAC std_ss [PROB_SPACE_BERN]
       ++ MATCH_MP_TAC EVENTS_COUNTABLE_UNION
-      ++ RW_TAC std_ss [PROB_SPACE_BERN, FINITE_COUNTABLE, FINITE_COUNT,
-                        COUNTABLE_IMAGE, SUBSET_DEF, IN_IMAGE]
+      ++ RW_TAC std_ss [PROB_SPACE_BERN, finite_countable, FINITE_COUNT,
+                        image_countable, SUBSET_DEF, IN_IMAGE]
       ++ RW_TAC std_ss [])
    ++ STRIP_TAC
    ++ CONJ_TAC
@@ -2456,7 +2456,7 @@ val PROB_WHILE_TERMINATES_PREFIX_COVER_STAR = store_thm
    ++ DISCH_THEN (ONCE_REWRITE_TAC o wrap o SYM)
    ++ MP_TAC (Q.ISPEC `IMAGE prefix_set (ca a)` COUNTABLE_DISJOINT_ENUM)
    ++ Cond
-   >> (RW_TAC std_ss [COUNTABLE_IMAGE, COUNTABLE_BOOL_LIST]
+   >> (RW_TAC std_ss [image_countable, COUNTABLE_BOOL_LIST]
        ++ PROVE_TAC [PREFIX_COVER_DISJOINT])
    ++ RW_TAC std_ss [IN_FUNSET, IN_UNIV, IN_INSERT, IN_IMAGE]
    ++ RW_TAC std_ss []
@@ -2678,7 +2678,7 @@ val PROB_WHILE_WITNESS_COUNTABLE_RANGE = store_thm
    ++ Q.EXISTS_TAC
       `FST (ARB : 'a # (num -> bool)) INSERT
        BIGUNION (IMAGE (\n. range (FST o FUNPOW (UNCURRY b) n o UNIT a)) UNIV)`
-   ++ REVERSE (RW_TAC bool_ss [COUNTABLE_INSERT, SUBSET_DEF, IN_INSERT,
+   ++ REVERSE (RW_TAC bool_ss [countable_INSERT, SUBSET_DEF, IN_INSERT,
                                IN_BIGUNION_IMAGE, IN_UNIV])
    >> (MATCH_MP_TAC COUNTABLE_BIGUNION
        ++ RW_TAC bool_ss [IN_IMAGE, IN_UNIV, COUNTABLE_IMAGE_NUM]
@@ -2779,7 +2779,7 @@ val PROB_WHILE_WITNESS_MEASURABLE_FST = store_thm
        ++ RW_TAC std_ss [PROB_SPACE_BERN]
        ++ MATCH_MP_TAC EVENTS_COUNTABLE_UNION
        ++ RW_TAC std_ss [PROB_SPACE_BERN, COUNTABLE_COUNT, SUBSET_DEF,
-                         IN_IMAGE, IN_UNIV, COUNTABLE_IMAGE]
+                         IN_IMAGE, IN_UNIV, image_countable]
        ++ RW_TAC std_ss [])
    ++ Know
       `{x | FST (FUNPOW (UNCURRY b) m (a,x)) IN s} =
@@ -2878,7 +2878,7 @@ val PROB_WHILE_WITNESS_MEASURABLE_SND = store_thm
        ++ RW_TAC std_ss [PROB_SPACE_BERN]
        ++ MATCH_MP_TAC EVENTS_COUNTABLE_UNION
        ++ RW_TAC std_ss [PROB_SPACE_BERN, COUNTABLE_COUNT, SUBSET_DEF,
-                         IN_IMAGE, IN_UNIV, COUNTABLE_IMAGE]
+                         IN_IMAGE, IN_UNIV, image_countable]
        ++ RW_TAC std_ss [])
    ++ Know
       `{x | SND (FUNPOW (UNCURRY b) m (a,x)) IN s} =
@@ -3382,7 +3382,7 @@ val PROBABLY_RES_FORALL = store_thm
    ++ Rewr
    ++ Know `BIGUNION (IMAGE (\x. COMPL {s | m x s}) p) IN events bern`
    >> (MATCH_MP_TAC EVENTS_COUNTABLE_UNION
-        ++ RW_TAC std_ss [PROB_SPACE_BERN, COUNTABLE_IMAGE, SUBSET_DEF,
+        ++ RW_TAC std_ss [PROB_SPACE_BERN, image_countable, SUBSET_DEF,
                           IN_IMAGE]
         ++ MATCH_MP_TAC EVENTS_COMPL
         ++ RW_TAC std_ss [PROB_SPACE_BERN])
@@ -3392,7 +3392,7 @@ val PROBABLY_RES_FORALL = store_thm
    ++ Know `!a : real. (a = 0) ==> (1 - a = 1)` >> REAL_ARITH_TAC
    ++ DISCH_THEN MATCH_MP_TAC
    ++ MATCH_MP_TAC PROB_COUNTABLY_ZERO
-   ++ RW_TAC std_ss [PROB_SPACE_BERN, COUNTABLE_IMAGE, IN_IMAGE, SUBSET_DEF]
+   ++ RW_TAC std_ss [PROB_SPACE_BERN, image_countable, IN_IMAGE, SUBSET_DEF]
    >> RW_TAC std_ss [EVENTS_COMPL, PROB_SPACE_BERN]
    ++ RW_TAC std_ss [PROB_COMPL, PROB_SPACE_BERN]
    ++ REAL_ARITH_TAC);
@@ -3658,10 +3658,10 @@ val PROB_BERN_BIND_COUNTABLE = store_thm
        prob bern (p o FST o BIND f g)``,
    RW_TAC std_ss []
    ++ Know `countable (range (FST o f))`
-   >> (RW_TAC std_ss [countable_def]
+   >> (RW_TAC std_ss [COUNTABLE_ALT]
        ++ Q.EXISTS_TAC `c`
        ++ PROVE_TAC [])
-   ++ RW_TAC std_ss [COUNTABLE_ALT]
+   ++ RW_TAC std_ss [COUNTABLE_ALT_BIJ]
    >> ((MP_TAC o
         Q.ISPEC `range (FST o (f : (num -> bool) -> 'b # (num -> bool)))`)
        FINITE_BIJ_COUNT
@@ -3862,7 +3862,7 @@ val PROB_BERN_BIND_EQ = store_thm
    ++ Know `countable (range (FST o f1) UNION range (FST o f2))`
    >> (REPEAT (Q.PAT_X_ASSUM `X IN indep_fn` MP_TAC)
        ++ RW_TAC std_ss [indep_fn_def, COUNTABLE_UNION, GSPECIFICATION])
-   ++ RW_TAC std_ss [countable_def, IN_UNION, DISJ_IMP_THM, FORALL_AND_THM]
+   ++ RW_TAC std_ss [COUNTABLE_ALT, IN_UNION, DISJ_IMP_THM, FORALL_AND_THM]
    ++ MP_TAC (Q.SPECL [`p`, `f1`, `g1`, `f`] PROB_BERN_BIND_COUNTABLE)
    ++ Cond >> RW_TAC std_ss []
    ++ RW_TAC std_ss [SUMS_EQ]
@@ -4515,7 +4515,7 @@ val PROB_TERMINATES_HART_LEMMA = store_thm
    >> (RW_TAC std_ss [GBIGUNION_IMAGE]
        ++ MATCH_MP_TAC EVENTS_COUNTABLE_UNION
        ++ RW_TAC std_ss [PROB_SPACE_BERN, SUBSET_DEF, IN_IMAGE, COUNTABLE_NUM,
-                         IN_UNIV, COUNTABLE_IMAGE]
+                         IN_UNIV, image_countable]
        ++ Suff `{s | ~c (FST (prob_while_cut c b n a s))} =
                 {x | ~c x} o FST o prob_while_cut c b n a`
        >> RW_TAC std_ss [INDEP_FN_FST_EVENTS, INDEP_FN_PROB_WHILE_CUT]
@@ -4957,7 +4957,7 @@ val PROB_TERMINATES_MORGAN = store_thm
                           IN_BIGUNION_IMAGE, IN_o, o_THM, GSPECIFICATION] <<
        [MATCH_MP_TAC EVENTS_COUNTABLE_UNION
         ++ RW_TAC std_ss [PROB_SPACE_BERN, IN_IMAGE, COUNTABLE_NUM, IN_UNIV,
-                          COUNTABLE_IMAGE, SUBSET_DEF]
+                          image_countable, SUBSET_DEF]
         ++ RW_TAC std_ss [PROB_SPACE_BERN, INDEP_FN_FST_EVENTS,
                           INDEP_FN_PROB_WHILE_CUT],
         PROVE_TAC []])

--- a/examples/miller/prob/prob_bernoulliScript.sml
+++ b/examples/miller/prob/prob_bernoulliScript.sml
@@ -108,7 +108,7 @@ val PROB_TERMINATES_BERNOULLI = store_thm
                          PROB_SPACE_BERN, INDEP_FN_PROB_WHILE_CUT, o_THM] <<
        [MATCH_MP_TAC EVENTS_COUNTABLE_UNION
         ++ RW_TAC std_ss [PROB_SPACE_BERN, SUBSET_DEF, IN_UNIV, COUNTABLE_NUM,
-                          IN_IMAGE, COUNTABLE_IMAGE]
+                          IN_IMAGE, image_countable]
         ++ Know
            `{s |
              ISR (FST (prob_while_cut

--- a/examples/miller/prob/prob_walkScript.sml
+++ b/examples/miller/prob/prob_walkScript.sml
@@ -120,7 +120,7 @@ val EVENTS_BERN_RANDOM_LURCHES = store_thm
        events bern``,
    RW_TAC std_ss [GBIGUNION_IMAGE]
    ++ MATCH_MP_TAC EVENTS_COUNTABLE_UNION
-   ++ RW_TAC std_ss [PROB_SPACE_BERN, COUNTABLE_NUM, COUNTABLE_IMAGE,
+   ++ RW_TAC std_ss [PROB_SPACE_BERN, COUNTABLE_NUM, image_countable,
                      SUBSET_DEF, IN_IMAGE, IN_UNIV]
    ++ Suff
       `{s | FST (prob_while_cut ($< 0) random_lurch n a s) = 0} =

--- a/examples/miller/subtypes/subtypeScript.sml
+++ b/examples/miller/subtypes/subtypeScript.sml
@@ -47,12 +47,6 @@ val IN_EQ_UNIV_IMP = store_thm
 
 (* Subtype definitions *)
 
-val FUNSET_def = Define
-  `FUNSET (P:'a->bool) (Q:'b->bool) = \f. !x. x IN P ==> f x IN Q`;
-
-val DFUNSET_def = Define
-  `DFUNSET (P:'a->bool) (Q:'a->'b->bool) = \f. !x. x IN P ==> f x IN Q x`;
-
 val _ = add_infix("->", 250, HOLgrammars.RIGHT);
 
 val _ = overload_on
@@ -63,73 +57,18 @@ val _ = overload_on
 val pair_def = Define
   `pair (X : 'a -> bool) (Y : 'b -> bool) = \ (x, y). x IN X /\ y IN Y`;
 
-val IN_FUNSET = store_thm
-  ("IN_FUNSET",
-   ``!(f:'a->'b) P Q. f IN (P -> Q) = !x. x IN P ==> f x IN Q``,
-   RW_TAC std_ss [SPECIFICATION, FUNSET_def]);
-
-val IN_DFUNSET = store_thm
-  ("IN_DFUNSET",
-   ``!(f:'a->'b) (P:'a->bool) Q. f IN (P --> Q) = !x. x IN P ==> f x IN Q x``,
-   RW_TAC std_ss [SPECIFICATION, DFUNSET_def]);
-
 val IN_PAIR = store_thm
   ("IN_PAIR",
    ``!(x : 'a # 'b) X Y. x IN pair X Y = FST x IN X /\ SND x IN Y``,
    Cases
    ++ RW_TAC std_ss [pair_def, SPECIFICATION]);
 
-val FUNSET_THM = store_thm
-  ("FUNSET_THM",
-   ``!s t (f:'a->'b) x. f IN (s -> t) /\ x IN s ==> f x IN t``,
-    RW_TAC std_ss [IN_FUNSET] ++ PROVE_TAC []);
-
-(* Warning: do not add the following as a simplification *)
-val UNIV_FUNSET_UNIV = store_thm
-  ("UNIV_FUNSET_UNIV",
-   ``((UNIV : 'a -> bool) -> (UNIV : 'b -> bool)) = UNIV``,
-   SET_EQ_TAC
-   ++ RW_TAC std_ss [IN_FUNSET, IN_UNIV]);
-
 (* Simplifications *)
-
-val FUNSET_DFUNSET = store_thm
-  ("FUNSET_DFUNSET",
-   ``!(x : 'a -> bool) (y : 'b -> bool). (x -> y) = (x --> K y)``,
-   RW_TAC std_ss [SET_EQ, IN_FUNSET, IN_DFUNSET, K_DEF]);
 
 val PAIR_UNIV = store_thm
   ("PAIR_UNIV",
    ``pair UNIV UNIV = (UNIV : 'a # 'b -> bool)``,
    RW_TAC std_ss [SET_EQ, IN_PAIR, IN_UNIV]);
-
-val SUBSET_INTER = store_thm
-  ("SUBSET_INTER",
-   ``!(s : 'a -> bool) t u.
-   s SUBSET (t INTER u) = s SUBSET t /\ s SUBSET u``,
-   RW_TAC std_ss [SUBSET_DEF, IN_INTER]
-   ++ PROVE_TAC []);
-
-val K_SUBSET = store_thm
-  ("K_SUBSET",
-   ``!x y. K x SUBSET y = ~x \/ (UNIV SUBSET y)``,
-   RW_TAC std_ss [K_DEF, SUBSET_DEF, IN_UNIV]
-   ++ RW_TAC std_ss [SPECIFICATION]
-   ++ PROVE_TAC []);
-
-val SUBSET_K = store_thm
-  ("SUBSET_K",
-   ``!x y. x SUBSET K y = (x SUBSET EMPTY) \/ y``,
-   RW_TAC std_ss [K_DEF, SUBSET_DEF, NOT_IN_EMPTY]
-   ++ RW_TAC std_ss [SPECIFICATION]
-   ++ PROVE_TAC []);
-
-(* Judgements *)
-
-val SUBSET_THM = store_thm
-  ("SUBSET_THM",
-   ``!(P : 'a -> bool) Q. P SUBSET Q ==> (!x. x IN P ==> x IN Q)``,
-    RW_TAC std_ss [SUBSET_DEF]);
 
 (* Subtypes *)
 
@@ -280,16 +219,6 @@ val PAIRED_BETA_THM = store_thm
    STRIP_TAC
    ++ Cases
    ++ RW_TAC std_ss []);
-
-val EMPTY_FUNSET = store_thm
-  ("EMPTY_FUNSET",
-   ``!s. ({} -> s) = (UNIV : ('a -> 'b) -> bool)``,
-   RW_TAC std_ss [SET_EQ, IN_FUNSET, NOT_IN_EMPTY, IN_UNIV]);
-
-val FUNSET_EMPTY = store_thm
-  ("FUNSET_EMPTY",
-   ``!s (f : 'a -> 'b). f IN (s -> {}) = (s = {})``,
-   RW_TAC std_ss [IN_FUNSET, NOT_IN_EMPTY, SET_EQ]);
 
 (* non-interactive mode
 *)

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -5461,11 +5461,6 @@ val finite_countable = store_thm (* from util_prob *)
    >> Q.EXISTS_TAC `SUC n`
    >> RW_TAC std_ss [SUC_SUB1]);
 
-val COUNTABLE_EMPTY = store_thm (* from util_prob *)
-  ("COUNTABLE_EMPTY",
-   ``countable {}``,
-   PROVE_TAC [finite_countable, FINITE_EMPTY]);
-
 val COUNTABLE_COUNT = store_thm (* from util_prob *)
   ("COUNTABLE_COUNT",
    ``!n. countable (count n)``,
@@ -5577,6 +5572,12 @@ val inj_image_countable_IFF = store_thm(
   ``INJ f s (IMAGE f s) ==> (countable (IMAGE f s) <=> countable s)``,
   SRW_TAC[][EQ_IMP_THM, image_countable] THEN
   METIS_TAC[countable_def, INJ_COMPOSE]);
+
+val BIJ_NUM_COUNTABLE = store_thm (* from util_prob *)
+  ("BIJ_NUM_COUNTABLE",
+   ``!s. (?f :num -> 'a. BIJ f UNIV s) ==> countable s``,
+   RW_TAC std_ss [countable_alt, BIJ_DEF, SURJ_DEF, IN_UNIV]
+   >> PROVE_TAC []);
 
 val pow_no_surj = Q.store_thm ("pow_no_surj",
 `!s. ~?f. SURJ f s (POW s)`,

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -1582,6 +1582,12 @@ val IMAGE_I = store_thm("IMAGE_I[simp]",
   ``IMAGE I s = s``,
   full_simp_tac(srw_ss())[EXTENSION]);
 
+val IMAGE_II = store_thm (* from util_prob *)
+  ("IMAGE_II",
+   ``IMAGE I = I``,
+  RW_TAC std_ss [FUN_EQ_THM]
+  >> METIS_TAC [SPECIFICATION, IN_IMAGE, combinTheory.I_THM]);
+
 val o_THM = combinTheory.o_THM;
 
 val IMAGE_COMPOSE =
@@ -2975,6 +2981,32 @@ val BIJ_FINITE = store_thm(
     `!s. FINITE s ==> !f t. BIJ f s t ==> FINITE t` THEN1 METIS_TAC [] THEN
   Induct_on `FINITE s` THEN SRW_TAC[][BIJ_EMPTY, BIJ_INSERT] THEN
   METIS_TAC [FINITE_DELETE]);
+
+val BIJ_FINITE_SUBSET = store_thm (* from util_prob *)
+  ("BIJ_FINITE_SUBSET",
+   ``!(f : num -> 'a) s t.
+       BIJ f UNIV s /\ FINITE t /\ t SUBSET s ==>
+       ?N. !n. N <= n ==> ~(f n IN t)``,
+   RW_TAC std_ss []
+   >> POP_ASSUM MP_TAC
+   >> POP_ASSUM MP_TAC
+   >> Q.SPEC_TAC (`t`, `t`)
+   >> HO_MATCH_MP_TAC FINITE_INDUCT
+   >> RW_TAC std_ss [EMPTY_SUBSET, NOT_IN_EMPTY, INSERT_SUBSET, IN_INSERT]
+   >> Know `?!k. f k = e`
+   >- ( Q.PAT_X_ASSUM `BIJ a b c` MP_TAC \\
+        RW_TAC std_ss [BIJ_ALT] \\
+        ASSUME_TAC (INST_TYPE [``:'a`` |-> ``:num``] IN_UNIV) \\
+        PROVE_TAC [] )
+   >> CONV_TAC (DEPTH_CONV EXISTS_UNIQUE_CONV)
+   >> RW_TAC std_ss []
+   >> RES_TAC
+   >> Q.EXISTS_TAC `MAX N (SUC k)`
+   >> `!m n k. MAX m n <= k = m <= k /\ n <= k` by RW_TAC arith_ss [MAX_DEF]
+   >> RW_TAC std_ss []
+   >> STRIP_TAC
+   >> Know `n = k` >- PROVE_TAC []
+   >> DECIDE_TAC);
 
 val FINITE_BIJ = store_thm (* from util_prob *)
   ("FINITE_BIJ",
@@ -6084,7 +6116,7 @@ val PREIMAGE_DIFF = store_thm
 val PREIMAGE_I = store_thm
   ("PREIMAGE_I",
    ``PREIMAGE I = I``,
-  METIS_TAC [EXTENSION,IN_PREIMAGE, combinTheory.I_THM]);
+  METIS_TAC [EXTENSION, IN_PREIMAGE, combinTheory.I_THM]);
 
 val PREIMAGE_K = store_thm
   ("PREIMAGE_K",

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -3772,6 +3772,12 @@ val BIGUNION_SING = Q.store_thm
   SIMP_TAC bool_ss [EXTENSION, IN_BIGUNION, IN_INSERT, NOT_IN_EMPTY] THEN
   SIMP_TAC bool_ss [GSYM EXTENSION]);
 
+val BIGUNION_PAIR = store_thm (* from util_prob *)
+  ("BIGUNION_PAIR",
+   ``!s t. BIGUNION {s; t} = s UNION t``,
+   RW_TAC std_ss [EXTENSION, IN_BIGUNION, IN_UNION, IN_INSERT, NOT_IN_EMPTY]
+   >> PROVE_TAC []);
+
 val BIGUNION_UNION = Q.store_thm
 ("BIGUNION_UNION",
  `!s1 s2. BIGUNION (s1 UNION s2) = (BIGUNION s1) UNION (BIGUNION s2)`,
@@ -6013,6 +6019,104 @@ val in_max_set = Q.store_thm ("in_max_set",
  SRW_TAC [] []);
 
 (* end CakeML lemmas *)
+
+(*---------------------------------------------------------------------------*)
+(* PREIMAGE lemmas from util_probTheory                                      *)
+(*---------------------------------------------------------------------------*)
+
+val PREIMAGE_def = new_definition (
+   "PREIMAGE_def", ``PREIMAGE f s = {x | f x IN s}``);
+
+val PREIMAGE_ALT = store_thm
+  ("PREIMAGE_ALT",
+  ``!f s. PREIMAGE f s = s o f``,
+    Know `!x f s. x IN (s o f) = f x IN s`
+ >- RW_TAC std_ss [SPECIFICATION, combinTheory.o_THM]
+ >> RW_TAC std_ss [PREIMAGE_def, EXTENSION, GSPECIFICATION]);
+
+val IN_PREIMAGE = store_thm
+  ("IN_PREIMAGE",
+   ``!f s x. x IN PREIMAGE f s = f x IN s``,
+   RW_TAC std_ss [PREIMAGE_def, GSPECIFICATION]);
+
+val PREIMAGE_EMPTY = store_thm
+  ("PREIMAGE_EMPTY",
+   ``!f. PREIMAGE f {} = {}``,
+   RW_TAC std_ss [EXTENSION, IN_PREIMAGE, NOT_IN_EMPTY]);
+
+val PREIMAGE_UNIV = store_thm
+  ("PREIMAGE_UNIV",
+   ``!f. PREIMAGE f UNIV = UNIV``,
+   RW_TAC std_ss [EXTENSION, IN_PREIMAGE, IN_UNIV]);
+
+val PREIMAGE_COMPL = store_thm
+  ("PREIMAGE_COMPL",
+   ``!f s. PREIMAGE f (COMPL s) = COMPL (PREIMAGE f s)``,
+   RW_TAC std_ss [EXTENSION, IN_PREIMAGE, IN_COMPL]);
+
+val PREIMAGE_UNION = store_thm
+  ("PREIMAGE_UNION",
+   ``!f s t. PREIMAGE f (s UNION t) = PREIMAGE f s UNION PREIMAGE f t``,
+   RW_TAC std_ss [EXTENSION, IN_PREIMAGE, IN_UNION]);
+
+val PREIMAGE_INTER = store_thm
+  ("PREIMAGE_INTER",
+   ``!f s t. PREIMAGE f (s INTER t) = PREIMAGE f s INTER PREIMAGE f t``,
+   RW_TAC std_ss [EXTENSION, IN_PREIMAGE, IN_INTER]);
+
+val PREIMAGE_BIGUNION = store_thm
+  ("PREIMAGE_BIGUNION",
+   ``!f s. PREIMAGE f (BIGUNION s) = BIGUNION (IMAGE (PREIMAGE f) s)``,
+   RW_TAC std_ss [EXTENSION, IN_PREIMAGE, IN_BIGUNION_IMAGE]
+   >> RW_TAC std_ss [IN_BIGUNION]
+   >> PROVE_TAC []);
+
+val PREIMAGE_COMP = store_thm
+  ("PREIMAGE_COMP",
+   ``!f g s. PREIMAGE f (PREIMAGE g s) = PREIMAGE (g o f) s``,
+   RW_TAC std_ss [EXTENSION, IN_PREIMAGE, o_THM]);
+
+val PREIMAGE_DIFF = store_thm
+  ("PREIMAGE_DIFF",
+   ``!f s t. PREIMAGE f (s DIFF t) = PREIMAGE f s DIFF PREIMAGE f t``,
+   RW_TAC std_ss [Once EXTENSION, IN_PREIMAGE, IN_DIFF]);
+
+val PREIMAGE_I = store_thm
+  ("PREIMAGE_I",
+   ``PREIMAGE I = I``,
+  METIS_TAC [EXTENSION,IN_PREIMAGE, combinTheory.I_THM]);
+
+val PREIMAGE_K = store_thm
+  ("PREIMAGE_K",
+   ``!x s. PREIMAGE (K x) s = if x IN s then UNIV else {}``,
+   RW_TAC std_ss [EXTENSION, IN_PREIMAGE, combinTheory.K_THM, IN_UNIV, NOT_IN_EMPTY]);
+
+val PREIMAGE_DISJOINT = store_thm
+  ("PREIMAGE_DISJOINT",
+   ``!f s t. DISJOINT s t ==> DISJOINT (PREIMAGE f s) (PREIMAGE f t)``,
+   RW_TAC std_ss [DISJOINT_DEF, GSYM PREIMAGE_INTER, PREIMAGE_EMPTY]);
+
+val PREIMAGE_SUBSET = store_thm
+  ("PREIMAGE_SUBSET",
+   ``!f s t. s SUBSET t ==> PREIMAGE f s SUBSET PREIMAGE f t``,
+   RW_TAC std_ss [SUBSET_DEF, PREIMAGE_def, GSPECIFICATION]);
+
+val PREIMAGE_CROSS = store_thm
+  ("PREIMAGE_CROSS",
+   ``!f a b.
+       PREIMAGE f (a CROSS b) =
+       PREIMAGE (FST o f) a INTER PREIMAGE (SND o f) b``,
+   RW_TAC std_ss [EXTENSION, IN_PREIMAGE, IN_CROSS, IN_INTER, o_THM]);
+
+val PREIMAGE_COMPL_INTER = store_thm
+  ("PREIMAGE_COMPL_INTER", ``!f t sp. PREIMAGE f (COMPL t) INTER sp = sp DIFF (PREIMAGE f t)``,
+  RW_TAC std_ss [COMPL_DEF]
+  >> MP_TAC (REWRITE_RULE [PREIMAGE_UNIV] (Q.SPECL [`f`,`UNIV`,`t`] PREIMAGE_DIFF))
+  >> STRIP_TAC
+  >> `(PREIMAGE f (UNIV DIFF t)) INTER sp = (UNIV DIFF PREIMAGE f t) INTER sp` by METIS_TAC []
+  >> METIS_TAC [DIFF_INTER,INTER_UNIV]);
+
+(* end PREIMAGE lemmas *)
 
 val _ = export_rewrites
     [

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -5441,24 +5441,47 @@ val countable_alt = store_thm ("countable_alt",
         (* goal 2.2 (of 2) *)
         PROVE_TAC [subset_countable] ] ]);
 
-val finite_countable = Q.store_thm ("finite_countable",
-`!s. FINITE s ==> countable s`,
-HO_MATCH_MP_TAC FINITE_INDUCT THEN
-RWTAC [countable_def] THEN
-FSTAC [INJ_DEF, IN_UNIV] THEN
-Q.EXISTS_TAC `\x. if x IN s then f x else SUC (MAX_SET (IMAGE f s))` THEN
-RWTAC [] THEN
-`IMAGE f s <> {}` by (CCONTR_TAC THEN FSTAC [IMAGE_DEF])
-THENL [
-  `MAX_SET (IMAGE f s) IN IMAGE f s /\
-   (f x <= MAX_SET (IMAGE f s))`
-       by METIS_TAC [MAX_SET_DEF, IMAGE_FINITE, IN_IMAGE] THEN
-  METIS_TAC [DECIDE ``~(SUC x <= x)``],
-  `MAX_SET (IMAGE f s) IN IMAGE f s /\
-   (f y <= MAX_SET (IMAGE f s))`
-          by METIS_TAC [MAX_SET_DEF, IMAGE_FINITE, IN_IMAGE] THEN
-     METIS_TAC [DECIDE ``!x. ~(SUC x <= x)``]
-]);
+val COUNTABLE_SUBSET = store_thm (* from util_prob *)
+  ("COUNTABLE_SUBSET",
+   ``!s t. s SUBSET t /\ countable t ==> countable s``,
+   RW_TAC std_ss [countable_alt, SUBSET_DEF]
+   >> Q.EXISTS_TAC `f`
+   >> PROVE_TAC []);
+
+val finite_countable = store_thm (* from util_prob *)
+  ("finite_countable",
+   ``!s. FINITE s ==> countable s``,
+   REWRITE_TAC [countable_alt]
+   >> HO_MATCH_MP_TAC FINITE_INDUCT
+   >> RW_TAC std_ss [NOT_IN_EMPTY]
+   >> Q.EXISTS_TAC `\n. if n = 0 then e else f (n - 1)`
+   >> RW_TAC std_ss [IN_INSERT] >- PROVE_TAC []
+   >> Q.PAT_X_ASSUM `!x. P x` (MP_TAC o Q.SPEC `x`)
+   >> RW_TAC std_ss []
+   >> Q.EXISTS_TAC `SUC n`
+   >> RW_TAC std_ss [SUC_SUB1]);
+
+val COUNTABLE_EMPTY = store_thm (* from util_prob *)
+  ("COUNTABLE_EMPTY",
+   ``countable {}``,
+   PROVE_TAC [finite_countable, FINITE_EMPTY]);
+
+val COUNTABLE_COUNT = store_thm (* from util_prob *)
+  ("COUNTABLE_COUNT",
+   ``!n. countable (count n)``,
+   PROVE_TAC [FINITE_COUNT, finite_countable]);
+
+val COUNTABLE_NUM = store_thm (* from util_prob *)
+  ("COUNTABLE_NUM",
+   ``!s :num -> bool. countable s``,
+   RW_TAC std_ss [countable_alt]
+   >> Q.EXISTS_TAC `I`
+   >> RW_TAC std_ss [combinTheory.I_THM]);
+
+val COUNTABLE_IMAGE_NUM = store_thm (* from util_prob *)
+  ("COUNTABLE_IMAGE_NUM",
+   ``!f :num -> 'a. !s. countable (IMAGE f s)``,
+   PROVE_TAC [COUNTABLE_NUM, image_countable]);
 
 open numpairTheory
 

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -5419,6 +5419,28 @@ Q.EXISTS_TAC `f o f'` THEN
 RWTAC [] THEN
 METIS_TAC []);
 
+(* an alternative definition from util_probTheory *)
+val countable_alt = store_thm ("countable_alt",
+  ``countable s = ?f. !x : 'a. x IN s ==> ?n :num. f n = x``,
+    EQ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      REWRITE_TAC [countable_surj] \\
+      rpt STRIP_TAC >- RW_TAC std_ss [NOT_IN_EMPTY] \\
+      Q.EXISTS_TAC `f` \\
+      POP_ASSUM MP_TAC \\
+      REWRITE_TAC [SURJ_DEF] >> METIS_TAC [],
+      (* goal 2 (of 2) *)
+      rpt STRIP_TAC \\
+      ASSUME_TAC num_countable \\
+      `countable (IMAGE f (UNIV :num set))` by PROVE_TAC [image_countable] \\
+      ASSUME_TAC (INST_TYPE [``:'a`` |-> ``:num``] IN_UNIV) \\
+      Know `s SUBSET (IMAGE f (UNIV :num set))` >| (* 2 sub-goals here *)
+      [ (* goal 2.1 (of 2) *)
+        REWRITE_TAC [SUBSET_DEF, IN_IMAGE] \\
+        rpt STRIP_TAC >> PROVE_TAC [],
+        (* goal 2.2 (of 2) *)
+        PROVE_TAC [subset_countable] ] ]);
+
 val finite_countable = Q.store_thm ("finite_countable",
 `!s. FINITE s ==> countable s`,
 HO_MATCH_MP_TAC FINITE_INDUCT THEN

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -5421,7 +5421,7 @@ RWTAC [] THEN
 METIS_TAC []);
 
 (* an alternative definition from util_probTheory *)
-val countable_alt = store_thm ("countable_alt",
+val COUNTABLE_ALT = store_thm ("COUNTABLE_ALT",
   ``countable s = ?f. !x : 'a. x IN s ==> ?n :num. f n = x``,
     EQ_TAC (* 2 sub-goals here *)
  >| [ (* goal 1 (of 2) *)
@@ -5445,14 +5445,14 @@ val countable_alt = store_thm ("countable_alt",
 val COUNTABLE_SUBSET = store_thm (* from util_prob *)
   ("COUNTABLE_SUBSET",
    ``!s t. s SUBSET t /\ countable t ==> countable s``,
-   RW_TAC std_ss [countable_alt, SUBSET_DEF]
+   RW_TAC std_ss [COUNTABLE_ALT, SUBSET_DEF]
    >> Q.EXISTS_TAC `f`
    >> PROVE_TAC []);
 
 val finite_countable = store_thm (* from util_prob *)
   ("finite_countable",
    ``!s. FINITE s ==> countable s``,
-   REWRITE_TAC [countable_alt]
+   REWRITE_TAC [COUNTABLE_ALT]
    >> HO_MATCH_MP_TAC FINITE_INDUCT
    >> RW_TAC std_ss [NOT_IN_EMPTY]
    >> Q.EXISTS_TAC `\n. if n = 0 then e else f (n - 1)`
@@ -5470,7 +5470,7 @@ val COUNTABLE_COUNT = store_thm (* from util_prob *)
 val COUNTABLE_NUM = store_thm (* from util_prob *)
   ("COUNTABLE_NUM",
    ``!s :num -> bool. countable s``,
-   RW_TAC std_ss [countable_alt]
+   RW_TAC std_ss [COUNTABLE_ALT]
    >> Q.EXISTS_TAC `I`
    >> RW_TAC std_ss [combinTheory.I_THM]);
 
@@ -5712,7 +5712,7 @@ val INFINITE_EXPLICIT_ENUMERATE = store_thm (* from util_prob *)
 val BIJ_NUM_COUNTABLE = store_thm (* from util_prob *)
   ("BIJ_NUM_COUNTABLE",
    ``!s. (?f :num -> 'a. BIJ f UNIV s) ==> countable s``,
-   RW_TAC std_ss [countable_alt, BIJ_DEF, SURJ_DEF, IN_UNIV]
+   RW_TAC std_ss [COUNTABLE_ALT, BIJ_DEF, SURJ_DEF, IN_UNIV]
    >> PROVE_TAC []);
 
 (** enumerate functions as BIJ from univ(:num) to countable sets, from util_prob *)
@@ -5729,7 +5729,7 @@ val COUNTABLE_ALT_BIJ = store_thm (* from util_prob *)
    ``!s. countable s = FINITE s \/ BIJ (enumerate s) UNIV s``,
    rpt STRIP_TAC
    >> REVERSE EQ_TAC >- PROVE_TAC [finite_countable, BIJ_NUM_COUNTABLE]
-   >> RW_TAC std_ss [countable_alt]
+   >> RW_TAC std_ss [COUNTABLE_ALT]
    >> Cases_on `FINITE s` >- PROVE_TAC []
    >> RW_TAC std_ss [GSYM ENUMERATE]
    >> MATCH_MP_TAC BIJ_INJ_SURJ
@@ -5749,7 +5749,7 @@ val COUNTABLE_ENUM = store_thm (* from util_prob *)
    RW_TAC std_ss []
    >> REVERSE EQ_TAC
    >- (NTAC 2 (RW_TAC std_ss [countable_EMPTY])
-       >> RW_TAC std_ss [countable_alt]
+       >> RW_TAC std_ss [COUNTABLE_ALT]
        >> Q.EXISTS_TAC `f`
        >> RW_TAC std_ss [IN_IMAGE, IN_UNIV]
        >> PROVE_TAC [])

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -3179,24 +3179,6 @@ val COUNT_11 = store_thm(
              arithmeticTheory.LESS_EQUAL_ANTISYM]);
 val _ = export_rewrites ["COUNT_11"]
 
-val FINITE_BIJ_COUNT = store_thm (* from util_prob *)
-  ("FINITE_BIJ_COUNT",
-   ``!s. FINITE s = ?c n. BIJ c (count n) s``,
-   RW_TAC std_ss []
-   >> REVERSE EQ_TAC >- PROVE_TAC [FINITE_COUNT, FINITE_BIJ]
-   >> Q.SPEC_TAC (`s`, `s`)
-   >> HO_MATCH_MP_TAC FINITE_INDUCT
-   >> RW_TAC std_ss [BIJ_DEF, INJ_DEF, SURJ_DEF, NOT_IN_EMPTY]
-   >- (Q.EXISTS_TAC `c`
-       >> Q.EXISTS_TAC `0`
-       >> RW_TAC std_ss [COUNT_ZERO, NOT_IN_EMPTY])
-   >> Q.EXISTS_TAC `\m. if m = n then e else c m`
-   >> Q.EXISTS_TAC `SUC n`
-   >> Know `!x. x IN count n ==> ~(x = n)`
-   >- RW_TAC arith_ss [IN_COUNT]
-   >> RW_TAC std_ss [COUNT_SUC, IN_INSERT]
-   >> PROVE_TAC []);
-
 (* =====================================================================*)
 (* Infiniteness								*)
 (* =====================================================================*)

--- a/src/probability/extrealScript.sml
+++ b/src/probability/extrealScript.sml
@@ -3479,7 +3479,7 @@ val Q_not_infty = store_thm
 val Q_COUNTABLE = store_thm
   ("Q_COUNTABLE", ``countable Q_set``,
   RW_TAC std_ss [Q_set_def]
-  >> MATCH_MP_TAC COUNTABLE_UNION
+  >> MATCH_MP_TAC union_countable
   >> CONJ_TAC
   >- (RW_TAC std_ss [countable_alt]
       >> MP_TAC NUM_2D_BIJ_NZ_INV
@@ -3856,7 +3856,7 @@ val COUNTABLE_ENUM_Q = store_thm
    ``!c. countable c = (c = {}) \/ (?f:extreal->'a. c = IMAGE f Q_set)``,
   RW_TAC std_ss []
   >> REVERSE EQ_TAC
-  >- (NTAC 2 (RW_TAC std_ss [COUNTABLE_EMPTY])
+  >- (NTAC 2 (RW_TAC std_ss [countable_EMPTY])
       >> RW_TAC std_ss [image_countable, Q_COUNTABLE])
   >> REVERSE (RW_TAC std_ss [COUNTABLE_ALT])
   >- (DISJ2_TAC
@@ -3928,9 +3928,9 @@ val CROSS_COUNTABLE_LEMMA1 = store_thm
   >> Q.PAT_X_ASSUM `FINITE s` MP_TAC
   >> Q.SPEC_TAC (`s`, `s`)
   >> HO_MATCH_MP_TAC FINITE_INDUCT
-  >> RW_TAC std_ss [] >- METIS_TAC [CROSS_EMPTY,COUNTABLE_EMPTY]
+  >> RW_TAC std_ss [] >- METIS_TAC [CROSS_EMPTY, countable_EMPTY]
   >> RW_TAC std_ss [CROSS_EQNS]
-  >> MATCH_MP_TAC COUNTABLE_UNION
+  >> MATCH_MP_TAC union_countable
   >> RW_TAC std_ss []
   >> RW_TAC std_ss [image_countable]);
 

--- a/src/probability/extrealScript.sml
+++ b/src/probability/extrealScript.sml
@@ -3857,7 +3857,7 @@ val COUNTABLE_ENUM_Q = store_thm
   RW_TAC std_ss []
   >> REVERSE EQ_TAC
   >- (NTAC 2 (RW_TAC std_ss [COUNTABLE_EMPTY])
-      >> RW_TAC std_ss [COUNTABLE_IMAGE,Q_COUNTABLE])
+      >> RW_TAC std_ss [image_countable, Q_COUNTABLE])
   >> REVERSE (RW_TAC std_ss [COUNTABLE_ALT])
   >- (DISJ2_TAC
       >> `countable Q_set` by RW_TAC std_ss [Q_COUNTABLE]
@@ -3932,7 +3932,7 @@ val CROSS_COUNTABLE_LEMMA1 = store_thm
   >> RW_TAC std_ss [CROSS_EQNS]
   >> MATCH_MP_TAC COUNTABLE_UNION
   >> RW_TAC std_ss []
-  >> RW_TAC std_ss [COUNTABLE_IMAGE]);
+  >> RW_TAC std_ss [image_countable]);
 
 val CROSS_COUNTABLE_LEMMA2 = store_thm
   ("CROSS_COUNTABLE_LEMMA2", ``!s. countable s /\ countable t /\ FINITE t
@@ -3946,7 +3946,7 @@ val CROSS_COUNTABLE_LEMMA2 = store_thm
 	        >> RW_TAC std_ss [])
             >> RW_TAC std_ss [] >- RW_TAC std_ss []
             >> RW_TAC std_ss [])
-  >> METIS_TAC [COUNTABLE_IMAGE,CROSS_COUNTABLE_LEMMA1]);
+  >> METIS_TAC [image_countable, CROSS_COUNTABLE_LEMMA1]);
 
 val CROSS_COUNTABLE = store_thm
  ("CROSS_COUNTABLE", ``!s. countable s /\ countable t ==> countable (s CROSS t)``,
@@ -3974,7 +3974,7 @@ val CROSS_COUNTABLE = store_thm
      	    >> Cases_on `x'`
 	    >> RW_TAC std_ss []
 	    >> FULL_SIMP_TAC std_ss [BIJ_DEF,SURJ_DEF,INJ_DEF,IN_UNIV])
-  >> METIS_TAC [CROSS_COUNTABLE_UNIV,COUNTABLE_IMAGE]);
+  >> METIS_TAC [CROSS_COUNTABLE_UNIV, image_countable]);
 
 val open_interval_def = Define
     `open_interval a b = {x | a < x /\ x < b}`;
@@ -3998,6 +3998,6 @@ val COUNTABLE_RATIONAL_INTERVALS = store_thm
 	 >> Q.EXISTS_TAC `x'`
 	 >> Cases_on `x'`
 	 >> FULL_SIMP_TAC std_ss [PAIR_EQ,EXTENSION])
-  >> METIS_TAC [CROSS_COUNTABLE,Q_COUNTABLE,COUNTABLE_IMAGE]);
+  >> METIS_TAC [CROSS_COUNTABLE,Q_COUNTABLE, image_countable]);
 
 val _ = export_theory();

--- a/src/probability/extrealScript.sml
+++ b/src/probability/extrealScript.sml
@@ -3858,11 +3858,11 @@ val COUNTABLE_ENUM_Q = store_thm
   >> REVERSE EQ_TAC
   >- (NTAC 2 (RW_TAC std_ss [countable_EMPTY])
       >> RW_TAC std_ss [image_countable, Q_COUNTABLE])
-  >> REVERSE (RW_TAC std_ss [COUNTABLE_ALT])
+  >> REVERSE (RW_TAC std_ss [COUNTABLE_ALT_BIJ])
   >- (DISJ2_TAC
       >> `countable Q_set` by RW_TAC std_ss [Q_COUNTABLE]
       >> `~(FINITE Q_set)` by RW_TAC std_ss [Q_INFINITE]
-      >> (MP_TAC o Q.SPEC `Q_set`) (INST_TYPE [alpha |-> ``:extreal``] COUNTABLE_ALT)
+      >> (MP_TAC o Q.SPEC `Q_set`) (INST_TYPE [alpha |-> ``:extreal``] COUNTABLE_ALT_BIJ)
       >> RW_TAC std_ss []
       >> (MP_TAC o Q.SPECL [`enumerate Q_set`,`UNIV`,`Q_set`]) (INST_TYPE [alpha |-> ``:num``, ``:'b`` |-> ``:extreal``] BIJ_INV)
       >> (MP_TAC o Q.SPECL [`enumerate c`,`UNIV`,`c`]) (INST_TYPE [alpha |-> ``:num``, ``:'b`` |-> ``:'a``] BIJ_INV)
@@ -3953,8 +3953,8 @@ val CROSS_COUNTABLE = store_thm
   RW_TAC std_ss []
   >> Cases_on `FINITE s` >- METIS_TAC [CROSS_COUNTABLE_LEMMA1]
   >> Cases_on `FINITE t` >- METIS_TAC [CROSS_COUNTABLE_LEMMA2]
-  >> `BIJ (enumerate s) UNIV s` by METIS_TAC [COUNTABLE_ALT]
-  >> `BIJ (enumerate t) UNIV t` by METIS_TAC [COUNTABLE_ALT]
+  >> `BIJ (enumerate s) UNIV s` by METIS_TAC [COUNTABLE_ALT_BIJ]
+  >> `BIJ (enumerate t) UNIV t` by METIS_TAC [COUNTABLE_ALT_BIJ]
   >> Q.ABBREV_TAC `f = enumerate s`
   >> Q.ABBREV_TAC `g = enumerate t`
   >> `s CROSS t = IMAGE (\(x,y). (f x,g y)) (UNIV CROSS UNIV)`

--- a/src/probability/extrealScript.sml
+++ b/src/probability/extrealScript.sml
@@ -3481,7 +3481,7 @@ val Q_COUNTABLE = store_thm
   RW_TAC std_ss [Q_set_def]
   >> MATCH_MP_TAC COUNTABLE_UNION
   >> CONJ_TAC
-  >- (RW_TAC std_ss [countable_def]
+  >- (RW_TAC std_ss [countable_alt]
       >> MP_TAC NUM_2D_BIJ_NZ_INV
       >> RW_TAC std_ss []
       >> Q.EXISTS_TAC `(\(a,b). &a/(&b)) o f`
@@ -3494,7 +3494,7 @@ val Q_COUNTABLE = store_thm
       >> `?y. f y = (a,b)` by METIS_TAC [lt_imp_ne,extreal_of_num_def,extreal_lt_eq]
       >> Q.EXISTS_TAC `y`
       >> RW_TAC real_ss [])
-  >> RW_TAC std_ss [countable_def]
+  >> RW_TAC std_ss [countable_alt]
   >> MP_TAC NUM_2D_BIJ_NZ_INV
   >> RW_TAC std_ss []
   >> Q.EXISTS_TAC `(\(a,b). -(&a/(&b))) o f`
@@ -3915,7 +3915,7 @@ val COUNTABLE_ENUM_Q = store_thm
 
 val CROSS_COUNTABLE_UNIV = store_thm
  ("CROSS_COUNTABLE_UNIV", ``countable (UNIV:num->bool CROSS UNIV:num->bool)``,
-  RW_TAC std_ss [countable_def]
+  RW_TAC std_ss [countable_alt]
   >> `?(f :num -> num # num). BIJ f UNIV (UNIV CROSS UNIV)` by METIS_TAC [NUM_2D_BIJ_INV]
   >> Q.EXISTS_TAC `f`
   >> RW_TAC std_ss []

--- a/src/probability/extrealScript.sml
+++ b/src/probability/extrealScript.sml
@@ -3481,7 +3481,7 @@ val Q_COUNTABLE = store_thm
   RW_TAC std_ss [Q_set_def]
   >> MATCH_MP_TAC union_countable
   >> CONJ_TAC
-  >- (RW_TAC std_ss [countable_alt]
+  >- (RW_TAC std_ss [COUNTABLE_ALT]
       >> MP_TAC NUM_2D_BIJ_NZ_INV
       >> RW_TAC std_ss []
       >> Q.EXISTS_TAC `(\(a,b). &a/(&b)) o f`
@@ -3494,7 +3494,7 @@ val Q_COUNTABLE = store_thm
       >> `?y. f y = (a,b)` by METIS_TAC [lt_imp_ne,extreal_of_num_def,extreal_lt_eq]
       >> Q.EXISTS_TAC `y`
       >> RW_TAC real_ss [])
-  >> RW_TAC std_ss [countable_alt]
+  >> RW_TAC std_ss [COUNTABLE_ALT]
   >> MP_TAC NUM_2D_BIJ_NZ_INV
   >> RW_TAC std_ss []
   >> Q.EXISTS_TAC `(\(a,b). -(&a/(&b))) o f`
@@ -3915,7 +3915,7 @@ val COUNTABLE_ENUM_Q = store_thm
 
 val CROSS_COUNTABLE_UNIV = store_thm
  ("CROSS_COUNTABLE_UNIV", ``countable (UNIV:num->bool CROSS UNIV:num->bool)``,
-  RW_TAC std_ss [countable_alt]
+  RW_TAC std_ss [COUNTABLE_ALT]
   >> `?(f :num -> num # num). BIJ f UNIV (UNIV CROSS UNIV)` by METIS_TAC [NUM_2D_BIJ_INV]
   >> Q.EXISTS_TAC `f`
   >> RW_TAC std_ss []

--- a/src/probability/lebesgueScript.sml
+++ b/src/probability/lebesgueScript.sml
@@ -2444,7 +2444,7 @@ val pos_fn_integral_disjoint_sets_sum = store_thm
   >>  `~(e IN s)` by METIS_TAC [DELETE_NON_ELEMENT]
   >> `DISJOINT (a e) (BIGUNION (IMAGE a s))`
        by (RW_TAC std_ss [DISJOINT_BIGUNION,IN_IMAGE] >> METIS_TAC [])
-  >> `countable (IMAGE a s)` by METIS_TAC [COUNTABLE_IMAGE,FINITE_COUNTABLE]
+  >> `countable (IMAGE a s)` by METIS_TAC [image_countable, finite_countable]
   >> `(IMAGE a s) SUBSET measurable_sets m`
        by (RW_TAC std_ss [SUBSET_DEF,IMAGE_DEF,GSPECIFICATION]
 	   >> METIS_TAC [])
@@ -3862,7 +3862,7 @@ val finite_prod_measure_space_POW = store_thm
   >> FULL_SIMP_TAC std_ss [SIGMA_ALGEBRA, subsets_def]
   >> POP_ASSUM MATCH_MP_TAC
   >> CONJ_TAC
-  >- (MATCH_MP_TAC FINITE_COUNTABLE >> MATCH_MP_TAC IMAGE_FINITE
+  >- (MATCH_MP_TAC finite_countable >> MATCH_MP_TAC IMAGE_FINITE
       >> (MP_TAC o Q.ISPEC `(s1 :'a -> bool) CROSS (s2 :'b -> bool)`) SUBSET_FINITE
       >> RW_TAC std_ss [FINITE_CROSS]
       >> POP_ASSUM MATCH_MP_TAC
@@ -4032,7 +4032,7 @@ val finite_prod_measure_space_POW3 = store_thm
   >> FULL_SIMP_TAC std_ss [SIGMA_ALGEBRA, subsets_def]
   >> POP_ASSUM MATCH_MP_TAC
   >> CONJ_TAC
-  >- (MATCH_MP_TAC FINITE_COUNTABLE >> MATCH_MP_TAC IMAGE_FINITE
+  >- (MATCH_MP_TAC finite_countable >> MATCH_MP_TAC IMAGE_FINITE
       >> (MP_TAC o
           Q.ISPEC `(s1 :'a -> bool) CROSS ((s2 :'b -> bool) CROSS (s3:'c -> bool))`)
   		SUBSET_FINITE

--- a/src/probability/measureScript.sml
+++ b/src/probability/measureScript.sml
@@ -482,7 +482,7 @@ val SIGMA_ALGEBRA_ALT = store_thm
           f IN (UNIV -> (subsets a)) ==> BIGUNION (IMAGE f UNIV) IN (subsets a))``,
    RW_TAC std_ss [sigma_algebra_def]
    >> EQ_TAC
-   >- (RW_TAC std_ss [countable_def, IN_FUNSET, IN_UNIV]
+   >- (RW_TAC std_ss [countable_alt, IN_FUNSET, IN_UNIV]
        >> Q.PAT_X_ASSUM `!c. P c ==> Q c` MATCH_MP_TAC
        >> REVERSE (RW_TAC std_ss [IN_IMAGE, SUBSET_DEF, IN_UNIV])
        >- PROVE_TAC []

--- a/src/probability/measureScript.sml
+++ b/src/probability/measureScript.sml
@@ -482,7 +482,7 @@ val SIGMA_ALGEBRA_ALT = store_thm
           f IN (UNIV -> (subsets a)) ==> BIGUNION (IMAGE f UNIV) IN (subsets a))``,
    RW_TAC std_ss [sigma_algebra_def]
    >> EQ_TAC
-   >- (RW_TAC std_ss [countable_alt, IN_FUNSET, IN_UNIV]
+   >- (RW_TAC std_ss [COUNTABLE_ALT, IN_FUNSET, IN_UNIV]
        >> Q.PAT_X_ASSUM `!c. P c ==> Q c` MATCH_MP_TAC
        >> REVERSE (RW_TAC std_ss [IN_IMAGE, SUBSET_DEF, IN_UNIV])
        >- PROVE_TAC []

--- a/src/probability/measureScript.sml
+++ b/src/probability/measureScript.sml
@@ -489,7 +489,7 @@ val SIGMA_ALGEBRA_ALT = store_thm
        >> Q.EXISTS_TAC `f`
        >> RW_TAC std_ss []
        >> PROVE_TAC [])
-   >> RW_TAC std_ss [COUNTABLE_ALT]
+   >> RW_TAC std_ss [COUNTABLE_ALT_BIJ]
    >- PROVE_TAC [ALGEBRA_FINITE_UNION]
    >> Q.PAT_X_ASSUM `!f. P f` (MP_TAC o Q.SPEC `\n. enumerate c n`)
    >> RW_TAC std_ss' [IN_UNIV, IN_FUNSET]
@@ -1543,7 +1543,7 @@ val SIGMA_ALGEBRA = store_thm
    >> EQ_TAC >- PROVE_TAC []
    >> RW_TAC std_ss []
    >> Q.PAT_X_ASSUM `!c. P c` (MP_TAC o Q.SPEC `{s; t}`)
-   >> RW_TAC std_ss [COUNTABLE_ALT, FINITE_INSERT, FINITE_EMPTY, SUBSET_DEF,
+   >> RW_TAC std_ss [COUNTABLE_ALT_BIJ, FINITE_INSERT, FINITE_EMPTY, SUBSET_DEF,
                      BIGUNION_PAIR, IN_INSERT, NOT_IN_EMPTY]
    >> PROVE_TAC []);
 

--- a/src/probability/measureScript.sml
+++ b/src/probability/measureScript.sml
@@ -2300,7 +2300,7 @@ val MEASUBABLE_BIGUNION_LEMMA = store_thm
    >> REVERSE CONJ_TAC
    >- (Q.PAT_X_ASSUM `!c. countable c /\ c SUBSET subsets b ==> BIGUNION c IN subsets b`
            MATCH_MP_TAC
-       >> RW_TAC std_ss [COUNTABLE_IMAGE, SUBSET_DEF, IN_IMAGE]
+       >> RW_TAC std_ss [image_countable, SUBSET_DEF, IN_IMAGE]
        >> Suff `(\x''. x'' IN subsets b) (@x''. x'' IN subsets b /\ (PREIMAGE f x'' = x'))`
        >- RW_TAC std_ss []
        >> MATCH_MP_TAC SELECT_ELIM_THM
@@ -2409,7 +2409,7 @@ val MEASURABLE_SIGMA = store_thm
 	   >> RW_TAC std_ss []
            >> Q.PAT_X_ASSUM `!c. countable c /\ c SUBSET subsets a ==>
 	         BIGUNION c IN subsets a` MATCH_MP_TAC
-           >> RW_TAC std_ss [COUNTABLE_IMAGE, SUBSET_DEF, IN_IMAGE]
+           >> RW_TAC std_ss [image_countable, SUBSET_DEF, IN_IMAGE]
 	   >> PROVE_TAC [],
 	   PROVE_TAC []])
    >> RW_TAC std_ss [SUBSET_DEF, GSPECIFICATION]);
@@ -2766,7 +2766,7 @@ val MEASURABLE_POW_TO_POW_IMAGE = store_thm
 	     		(IMAGE f (m_space m), POW(IMAGE f (m_space m)))``,
    REPEAT STRIP_TAC
    >> (MP_TAC o Q.SPECL [`m`,`f`,`UNIV`]) MEASURABLE_RANGE_REDUCE
-   >> ASM_SIMP_TAC std_ss [UNIV_NEQ_EMPTY, INTER_UNIV, MEASURABLE_POW_TO_POW]);
+   >> ASM_SIMP_TAC std_ss [UNIV_NOT_EMPTY, INTER_UNIV, MEASURABLE_POW_TO_POW]);
 
 val MEASURE_SPACE_SUBSET = store_thm
   ("MEASURE_SPACE_SUBSET",
@@ -2977,7 +2977,7 @@ val SIGMA_ALGEBRA_FN_BIGINTER = store_thm
   >> `BIGUNION (IMAGE (\u. space a DIFF u) (IMAGE f UNIV)) IN subsets a`
         by (Q.PAT_X_ASSUM `!c. M ==> BIGUNION c IN subsets a` (MATCH_MP_TAC)
             >> RW_TAC std_ss []
-	    >- (MATCH_MP_TAC COUNTABLE_IMAGE
+	    >- (MATCH_MP_TAC image_countable
             	>> RW_TAC std_ss [COUNTABLE_ENUM]
             	>> Q.EXISTS_TAC `f`
             	>> RW_TAC std_ss [])
@@ -3113,7 +3113,7 @@ val BIGUNION_IMAGE_Q = store_thm
             ==> BIGUNION (IMAGE f Q_set) IN subsets a``,
    RW_TAC std_ss [SIGMA_ALGEBRA, IN_FUNSET, IN_UNIV, SUBSET_DEF]
    >> Q.PAT_X_ASSUM `!c. countable c /\ P c ==> Q c` MATCH_MP_TAC
-   >> RW_TAC std_ss [COUNTABLE_IMAGE, IN_IMAGE,Q_COUNTABLE]
+   >> RW_TAC std_ss [image_countable, IN_IMAGE, Q_COUNTABLE]
    >> METIS_TAC []);
 
 

--- a/src/probability/probabilityScript.sml
+++ b/src/probability/probabilityScript.sml
@@ -383,7 +383,7 @@ val EVENTS_COUNTABLE_INTER = store_thm
    >> RW_TAC std_ss [] >> POP_ASSUM (K ALL_TAC)
    >> MATCH_MP_TAC EVENTS_COUNTABLE_UNION
    >> Q.PAT_X_ASSUM `c SUBSET events p` MP_TAC
-   >> RW_TAC std_ss [COUNTABLE_IMAGE, SUBSET_DEF, IN_IMAGE]
+   >> RW_TAC std_ss [image_countable, SUBSET_DEF, IN_IMAGE]
    >> PROVE_TAC [EVENTS_COMPL]);
 
 val ABS_PROB = store_thm
@@ -506,7 +506,7 @@ val PROB_COUNTABLY_SUBADDITIVE = store_thm
    >- (MATCH_MP_TAC PROB_INCREASING_UNION
        >> RW_TAC std_ss [IN_FUNSET, IN_UNIV] >|
        [MATCH_MP_TAC EVENTS_COUNTABLE_UNION
-        >> RW_TAC std_ss [SUBSET_DEF, IN_IMAGE, COUNTABLE_IMAGE,
+        >> RW_TAC std_ss [SUBSET_DEF, IN_IMAGE, image_countable,
                           COUNTABLE_COUNT]
         >> PROVE_TAC [],
         RW_TAC std_ss [SUBSET_DEF, IN_BIGUNION, IN_IMAGE, IN_COUNT]
@@ -538,7 +538,7 @@ val PROB_COUNTABLY_SUBADDITIVE = store_thm
    >> MATCH_MP_TAC PROB_SUBADDITIVE
    >> RW_TAC std_ss [] >- PROVE_TAC []
    >> MATCH_MP_TAC EVENTS_COUNTABLE_UNION
-   >> RW_TAC std_ss [SUBSET_DEF, IN_IMAGE, IN_COUNT, COUNTABLE_IMAGE,
+   >> RW_TAC std_ss [SUBSET_DEF, IN_IMAGE, IN_COUNT, image_countable,
                      COUNTABLE_COUNT]
    >> PROVE_TAC []);
 
@@ -779,7 +779,7 @@ val PROB_DISCRETE_EVENTS = store_thm
   >> `FINITE {{x} | x IN s}`
       by (Suff `{{x} | x IN s} = IMAGE (\x. {x}) s` >- METIS_TAC [IMAGE_FINITE,SUBSET_FINITE]
           >> RW_TAC std_ss [EXTENSION,GSPECIFICATION,IN_IMAGE])
-  >> METIS_TAC [EVENTS_COUNTABLE_UNION,FINITE_COUNTABLE]);
+  >> METIS_TAC [EVENTS_COUNTABLE_UNION,finite_countable]);
 
 val PROB_DISCRETE_EVENTS_COUNTABLE = store_thm
 ("PROB_DISCRETE_EVENTS_COUNTABLE",``!p. prob_space p /\ countable (p_space p) /\
@@ -794,7 +794,7 @@ val PROB_DISCRETE_EVENTS_COUNTABLE = store_thm
       by (RW_TAC std_ss [SUBSET_DEF,GSPECIFICATION] >> METIS_TAC [SUBSET_DEF])
   >> `countable {{x} | x IN s}`
       by (Suff `{{x} | x IN s} = IMAGE (\x. {x}) s`
-  >- METIS_TAC [COUNTABLE_IMAGE,COUNTABLE_SUBSET]
+  >- METIS_TAC [image_countable, COUNTABLE_SUBSET]
           >> RW_TAC std_ss [EXTENSION,GSPECIFICATION,IN_IMAGE])
   >> METIS_TAC [EVENTS_COUNTABLE_UNION]);
 

--- a/src/probability/util_probScript.sml
+++ b/src/probability/util_probScript.sml
@@ -210,9 +210,6 @@ val lg_pow = store_thm
 (********************************************************************************************)
 (********************************************************************************************)
 
-val countable_def = Define
-  `countable s = ?f. !x : 'a. x IN s ==> ?n : num. f n = x`;
-
 val enumerate_def = Define `enumerate s = @f : num -> 'a. BIJ f UNIV s`;
 
 val NUM_2D_BIJ = store_thm
@@ -332,7 +329,7 @@ val BIGUNION_PAIR = store_thm
 val FINITE_COUNTABLE = store_thm
   ("FINITE_COUNTABLE",
    ``!s. FINITE s ==> countable s``,
-   REWRITE_TAC [countable_def]
+   REWRITE_TAC [countable_alt]
    >> HO_MATCH_MP_TAC FINITE_INDUCT
    >> RW_TAC std_ss [NOT_IN_EMPTY]
    >> Q.EXISTS_TAC `\n. if n = 0 then e else f (n - 1)`
@@ -345,7 +342,7 @@ val FINITE_COUNTABLE = store_thm
 val BIJ_NUM_COUNTABLE = store_thm
   ("BIJ_NUM_COUNTABLE",
    ``!s. (?f : num -> 'a. BIJ f UNIV s) ==> countable s``,
-   RW_TAC std_ss [countable_def, BIJ_DEF, SURJ_DEF, IN_UNIV]
+   RW_TAC std_ss [countable_alt, BIJ_DEF, SURJ_DEF, IN_UNIV]
    >> PROVE_TAC []);
 
 val COUNTABLE_EMPTY = store_thm
@@ -356,7 +353,7 @@ val COUNTABLE_EMPTY = store_thm
 val COUNTABLE_IMAGE = store_thm
   ("COUNTABLE_IMAGE",
    ``!s f. countable s ==> countable (IMAGE f s)``,
-   RW_TAC std_ss [countable_def, IN_IMAGE]
+   RW_TAC std_ss [countable_alt, IN_IMAGE]
    >> Q.EXISTS_TAC `f o f'`
    >> RW_TAC std_ss [o_THM]
    >> PROVE_TAC []);
@@ -365,7 +362,7 @@ val COUNTABLE_BIGUNION = store_thm
   ("COUNTABLE_BIGUNION",
    ``!c.
        countable c /\ (!s. s IN c ==> countable s) ==> countable (BIGUNION c)``,
-   RW_TAC std_ss [countable_def]
+   RW_TAC std_ss [countable_alt]
    >> POP_ASSUM
       (MP_TAC o CONV_RULE (DEPTH_CONV RIGHT_IMP_EXISTS_CONV THENC SKOLEM_CONV))
    >> MP_TAC NUM_2D_BIJ_INV
@@ -459,7 +456,7 @@ val COUNTABLE_ALT = store_thm
    ``!s. countable s = FINITE s \/ BIJ (enumerate s) UNIV s``,
    Strip
    >> REVERSE EQ_TAC >- PROVE_TAC [FINITE_COUNTABLE, BIJ_NUM_COUNTABLE]
-   >> RW_TAC std_ss [countable_def]
+   >> RW_TAC std_ss [countable_alt]
    >> Cases_on `FINITE s` >- PROVE_TAC []
    >> RW_TAC std_ss [GSYM ENUMERATE]
    >> MATCH_MP_TAC BIJ_INJ_SURJ
@@ -589,7 +586,7 @@ val UNIV_NEQ_EMPTY = store_thm
 val COUNTABLE_NUM = store_thm
   ("COUNTABLE_NUM",
    ``!s : num -> bool. countable s``,
-   RW_TAC std_ss [countable_def]
+   RW_TAC std_ss [countable_alt]
    >> Q.EXISTS_TAC `I`
    >> RW_TAC std_ss [I_THM]);
 
@@ -604,7 +601,7 @@ val COUNTABLE_ENUM = store_thm
    RW_TAC std_ss []
    >> REVERSE EQ_TAC
    >- (NTAC 2 (RW_TAC std_ss [COUNTABLE_EMPTY])
-       >> RW_TAC std_ss [countable_def]
+       >> RW_TAC std_ss [countable_alt]
        >> Q.EXISTS_TAC `f`
        >> RW_TAC std_ss [IN_IMAGE, IN_UNIV]
        >> PROVE_TAC [])
@@ -889,7 +886,7 @@ val COUNTABLE_COUNT = store_thm
 val COUNTABLE_SUBSET = store_thm
   ("COUNTABLE_SUBSET",
    ``!s t. s SUBSET t /\ countable t ==> countable s``,
-   RW_TAC std_ss [countable_def, SUBSET_DEF]
+   RW_TAC std_ss [countable_alt, SUBSET_DEF]
    >> Q.EXISTS_TAC `f`
    >> PROVE_TAC []);
 

--- a/src/probability/util_probScript.sml
+++ b/src/probability/util_probScript.sml
@@ -318,13 +318,6 @@ val NUM_2D_BIJ_NZ_ALT2_INV = store_thm
        (((UNIV : num -> bool) DIFF {0}) CROSS ((UNIV : num -> bool) DIFF {0}))``,
    PROVE_TAC [NUM_2D_BIJ_NZ_ALT2, BIJ_SYM]);
 
-val BIGUNION_PAIR = store_thm
-  ("BIGUNION_PAIR",
-   ``!s t. BIGUNION {s; t} = s UNION t``,
-   RW_TAC std_ss [EXTENSION, IN_BIGUNION, IN_UNION, IN_INSERT, NOT_IN_EMPTY]
-   >> PROVE_TAC []);
-
-val PREIMAGE_def = Define `PREIMAGE f s = {x | f x IN s}`;
 val prod_sets_def = Define `prod_sets a b = {s CROSS t | s IN a /\ t IN b}`;
 
 val K_PARTIAL = store_thm
@@ -337,83 +330,11 @@ val IN_o = store_thm
    ``!x f s. x IN (s o f) = f x IN s``,
    RW_TAC std_ss [SPECIFICATION, o_THM]);
 
-val PREIMAGE_ALT = store_thm
-  ("PREIMAGE_ALT",
-   ``!f s. PREIMAGE f s = s o f``,
-   RW_TAC std_ss [PREIMAGE_def, EXTENSION, GSPECIFICATION, IN_o]);
-
-val IN_PREIMAGE = store_thm
-  ("IN_PREIMAGE",
-   ``!f s x. x IN PREIMAGE f s = f x IN s``,
-   RW_TAC std_ss [PREIMAGE_def, GSPECIFICATION]);
-
-val PREIMAGE_EMPTY = store_thm
-  ("PREIMAGE_EMPTY",
-   ``!f. PREIMAGE f {} = {}``,
-   RW_TAC std_ss [EXTENSION, IN_PREIMAGE, NOT_IN_EMPTY]);
-
-val PREIMAGE_UNIV = store_thm
-  ("PREIMAGE_UNIV",
-   ``!f. PREIMAGE f UNIV = UNIV``,
-   RW_TAC std_ss [EXTENSION, IN_PREIMAGE, IN_UNIV]);
-
-val PREIMAGE_COMPL = store_thm
-  ("PREIMAGE_COMPL",
-   ``!f s. PREIMAGE f (COMPL s) = COMPL (PREIMAGE f s)``,
-   RW_TAC std_ss [EXTENSION, IN_PREIMAGE, IN_COMPL]);
-
-val PREIMAGE_UNION = store_thm
-  ("PREIMAGE_UNION",
-   ``!f s t. PREIMAGE f (s UNION t) = PREIMAGE f s UNION PREIMAGE f t``,
-   RW_TAC std_ss [EXTENSION, IN_PREIMAGE, IN_UNION]);
-
-val PREIMAGE_INTER = store_thm
-  ("PREIMAGE_INTER",
-   ``!f s t. PREIMAGE f (s INTER t) = PREIMAGE f s INTER PREIMAGE f t``,
-   RW_TAC std_ss [EXTENSION, IN_PREIMAGE, IN_INTER]);
-
-val PREIMAGE_BIGUNION = store_thm
-  ("PREIMAGE_BIGUNION",
-   ``!f s. PREIMAGE f (BIGUNION s) = BIGUNION (IMAGE (PREIMAGE f) s)``,
-   RW_TAC std_ss [EXTENSION, IN_PREIMAGE, IN_BIGUNION_IMAGE]
-   >> RW_TAC std_ss [IN_BIGUNION]
-   >> PROVE_TAC []);
-
-val PREIMAGE_COMP = store_thm
-  ("PREIMAGE_COMP",
-   ``!f g s. PREIMAGE f (PREIMAGE g s) = PREIMAGE (g o f) s``,
-   RW_TAC std_ss [EXTENSION, IN_PREIMAGE, o_THM]);
-
-val PREIMAGE_DIFF = store_thm
-  ("PREIMAGE_DIFF",
-   ``!f s t. PREIMAGE f (s DIFF t) = PREIMAGE f s DIFF PREIMAGE f t``,
-   RW_TAC std_ss [Once EXTENSION, IN_PREIMAGE, IN_DIFF]);
-
-val PREIMAGE_I = store_thm
-  ("PREIMAGE_I",
-   ``PREIMAGE I = I``,
-  METIS_TAC [EXTENSION,IN_PREIMAGE, I_THM]);
-
 val IMAGE_I = store_thm
   ("IMAGE_I",
    ``IMAGE I = I``,
   RW_TAC std_ss [FUN_EQ_THM]
   >> METIS_TAC [SPECIFICATION,IN_IMAGE,I_THM]);
-
-val PREIMAGE_K = store_thm
-  ("PREIMAGE_K",
-   ``!x s. PREIMAGE (K x) s = if x IN s then UNIV else {}``,
-   RW_TAC std_ss [EXTENSION, IN_PREIMAGE, K_THM, IN_UNIV, NOT_IN_EMPTY]);
-
-val PREIMAGE_DISJOINT = store_thm
-  ("PREIMAGE_DISJOINT",
-   ``!f s t. DISJOINT s t ==> DISJOINT (PREIMAGE f s) (PREIMAGE f t)``,
-   RW_TAC std_ss [DISJOINT_DEF, GSYM PREIMAGE_INTER, PREIMAGE_EMPTY]);
-
-val PREIMAGE_SUBSET = store_thm
-  ("PREIMAGE_SUBSET",
-   ``!f s t. s SUBSET t ==> PREIMAGE f s SUBSET PREIMAGE f t``,
-   RW_TAC std_ss [SUBSET_DEF, PREIMAGE_def, GSPECIFICATION]);
 
 val IN_PROD_SETS = store_thm
   ("IN_PROD_SETS",
@@ -423,13 +344,6 @@ val IN_PROD_SETS = store_thm
    >> RW_TAC std_ss []
    >> Q.EXISTS_TAC `(t, u)`
    >> RW_TAC std_ss []);
-
-val PREIMAGE_CROSS = store_thm
-  ("PREIMAGE_CROSS",
-   ``!f a b.
-       PREIMAGE f (a CROSS b) =
-       PREIMAGE (FST o f) a INTER PREIMAGE (SND o f) b``,
-   RW_TAC std_ss [EXTENSION, IN_PREIMAGE, IN_CROSS, IN_INTER, o_THM]);
 
 val RES_BIJ_ALT = store_thm
   ("RES_BIJ_ALT",
@@ -582,14 +496,6 @@ val finite_enumeration_of_sets_has_max_non_empty = store_thm
    >- (Q.PAT_X_ASSUM `!s. FINITE s ==> P` (MP_TAC o Q.SPEC `s DELETE {}`)
        >> RW_TAC std_ss [FINITE_DELETE, IN_INSERT, IN_DELETE])
    >> METIS_TAC [IN_INSERT]);
-
-val PREIMAGE_COMPL_INTER = store_thm
-  ("PREIMAGE_COMPL_INTER", ``!f t sp. PREIMAGE f (COMPL t) INTER sp = sp DIFF (PREIMAGE f t)``,
-  RW_TAC std_ss [COMPL_DEF]
-  >> MP_TAC (REWRITE_RULE [PREIMAGE_UNIV] (Q.SPECL [`f`,`UNIV`,`t`] PREIMAGE_DIFF))
-  >> STRIP_TAC
-  >> `(PREIMAGE f (UNIV DIFF t)) INTER sp = (UNIV DIFF PREIMAGE f t) INTER sp` by METIS_TAC []
-  >> METIS_TAC [DIFF_INTER,INTER_UNIV]);
 
 val PREIMAGE_REAL_COMPL1 = store_thm
   ("PREIMAGE_REAL_COMPL1", ``!c:real. COMPL {x | c < x} = {x | x <= c}``,

--- a/src/probability/util_probScript.sml
+++ b/src/probability/util_probScript.sml
@@ -431,8 +431,8 @@ val PREIMAGE_CROSS = store_thm
        PREIMAGE (FST o f) a INTER PREIMAGE (SND o f) b``,
    RW_TAC std_ss [EXTENSION, IN_PREIMAGE, IN_CROSS, IN_INTER, o_THM]);
 
-val BIJ_ALT = store_thm
-  ("BIJ_ALT",
+val RES_BIJ_ALT = store_thm
+  ("RES_BIJ_ALT",
    ``!f s t. BIJ f s t = f IN (s -> t) /\ (!y :: t. ?!x :: s. y = f x)``,
    RW_TAC std_ss [BIJ_DEF, INJ_DEF, SURJ_DEF, RES_EXISTS_UNIQUE_ALT]
    >> RESQ_TAC
@@ -466,7 +466,7 @@ val BIJ_FINITE_SUBSET = store_thm
    >> RW_TAC std_ss [EMPTY_SUBSET, NOT_IN_EMPTY, INSERT_SUBSET, IN_INSERT]
    >> Know `?!k. f k = e`
    >- (Q.PAT_X_ASSUM `BIJ a b c` MP_TAC
-       >> RW_TAC std_ss [BIJ_ALT, RES_EXISTS_UNIQUE_UNIV, RES_FORALL]
+       >> RW_TAC std_ss [RES_BIJ_ALT, RES_EXISTS_UNIQUE_UNIV, RES_FORALL]
        >> PROVE_TAC [])
    >> CONV_TAC (DEPTH_CONV EXISTS_UNIQUE_CONV)
    >> RW_TAC std_ss []
@@ -610,68 +610,6 @@ val PREIMAGE_REAL_COMPL4 = store_thm
   ("PREIMAGE_REAL_COMPL4", ``!c:real. COMPL {x | x < c} = {x | c <= x}``,
   RW_TAC real_ss [COMPL_DEF,UNIV_DEF,DIFF_DEF,EXTENSION]
   >> RW_TAC real_ss [GSPECIFICATION,GSYM real_lte,SPECIFICATION]);
-
-val DELETE_THEN_INSERT = store_thm
-  ("DELETE_THEN_INSERT",
-   ``!s. !x :: s. x INSERT (s DELETE x) = s``,
-   RESQ_TAC
-   >> RW_TAC std_ss [INSERT_DELETE]);
-
-val BIJ_INSERT = store_thm
-  ("BIJ_INSERT",
-   ``!f e s t.
-       ~(e IN s) /\ BIJ f (e INSERT s) t ==>
-       ?u. (f e INSERT u = t) /\ ~(f e IN u) /\ BIJ f s u``,
-   RW_TAC std_ss [BIJ_ALT]
-   >> Q.EXISTS_TAC `t DELETE f e`
-   >> FULL_SIMP_TAC std_ss [IN_FUNSET, DELETE_THEN_INSERT, ELT_IN_DELETE, IN_INSERT,
-              DISJ_IMP_THM]
-   >> RESQ_TAC
-   >> SIMP_TAC std_ss [IN_DELETE]
-   >> REPEAT STRIP_TAC
-   >> METIS_TAC [IN_INSERT]);
-
-val FINITE_BIJ = store_thm
-  ("FINITE_BIJ",
-   ``!f s t. FINITE s /\ BIJ f s t ==> FINITE t /\ (CARD s = CARD t)``,
-   Suff `!s. FINITE s ==> !f t. BIJ f s t ==> FINITE t /\ (CARD s = CARD t)`
-   >- PROVE_TAC []
-   >> HO_MATCH_MP_TAC FINITE_INDUCT
-   >> CONJ_TAC >-
-	(RW_TAC std_ss [BIJ_ALT, FINITE_EMPTY, CARD_EMPTY, IN_FUNSET, NOT_IN_EMPTY]
-	 >> RESQ_TAC
-	 >> FULL_SIMP_TAC std_ss [NOT_IN_EMPTY]
-	 >> `t = {}`
-		by RW_TAC std_ss [EXTENSION, NOT_IN_EMPTY]
-	 >> RW_TAC std_ss [FINITE_EMPTY, CARD_EMPTY])
-   >> NTAC 7 STRIP_TAC
-   >> MP_TAC (Q.SPECL [`f`, `e`, `s`, `t`] BIJ_INSERT)
-   >> ASM_REWRITE_TAC []
-   >> STRIP_TAC
-   >> Know `FINITE u` >- PROVE_TAC []
-   >> STRIP_TAC
-   >> CONJ_TAC >- PROVE_TAC [FINITE_INSERT]
-   >> Q.PAT_X_ASSUM `f e INSERT u = t` (fn th => RW_TAC std_ss [SYM th])
-   >> RW_TAC std_ss [CARD_INSERT]
-   >> PROVE_TAC []);
-
-val FINITE_BIJ_COUNT = store_thm
-  ("FINITE_BIJ_COUNT",
-   ``!s. FINITE s = ?c n. BIJ c (count n) s``,
-   RW_TAC std_ss []
-   >> REVERSE EQ_TAC >- PROVE_TAC [FINITE_COUNT, FINITE_BIJ]
-   >> Q.SPEC_TAC (`s`, `s`)
-   >> HO_MATCH_MP_TAC FINITE_INDUCT
-   >> RW_TAC std_ss [BIJ_DEF, INJ_DEF, SURJ_DEF, NOT_IN_EMPTY]
-   >- (Q.EXISTS_TAC `c`
-       >> Q.EXISTS_TAC `0`
-       >> RW_TAC std_ss [COUNT_ZERO, NOT_IN_EMPTY])
-   >> Q.EXISTS_TAC `\m. if m = n then e else c m`
-   >> Q.EXISTS_TAC `SUC n`
-   >> Know `!x. x IN count n ==> ~(x = n)`
-   >- RW_TAC arith_ss [IN_COUNT]
-   >> RW_TAC std_ss [COUNT_SUC, IN_INSERT]
-   >> PROVE_TAC []);
 
 val GBIGUNION_IMAGE = store_thm
   ("GBIGUNION_IMAGE",

--- a/src/probability/util_probScript.sml
+++ b/src/probability/util_probScript.sml
@@ -326,46 +326,6 @@ val BIGUNION_PAIR = store_thm
    RW_TAC std_ss [EXTENSION, IN_BIGUNION, IN_UNION, IN_INSERT, NOT_IN_EMPTY]
    >> PROVE_TAC []);
 
-val BIJ_NUM_COUNTABLE = store_thm
-  ("BIJ_NUM_COUNTABLE",
-   ``!s. (?f : num -> 'a. BIJ f UNIV s) ==> countable s``,
-   RW_TAC std_ss [countable_alt, BIJ_DEF, SURJ_DEF, IN_UNIV]
-   >> PROVE_TAC []);
-
-val COUNTABLE_BIGUNION = store_thm
-  ("COUNTABLE_BIGUNION",
-   ``!c.
-       countable c /\ (!s. s IN c ==> countable s) ==> countable (BIGUNION c)``,
-   RW_TAC std_ss [countable_alt]
-   >> POP_ASSUM
-      (MP_TAC o CONV_RULE (DEPTH_CONV RIGHT_IMP_EXISTS_CONV THENC SKOLEM_CONV))
-   >> MP_TAC NUM_2D_BIJ_INV
-   >> RW_TAC std_ss []
-   >> Q.EXISTS_TAC `(\ (a : num, b : num). f'' (f a) b) o f'`
-   >> RW_TAC std_ss [IN_BIGUNION]
-   >> Q.PAT_X_ASSUM `!x. P x ==> ?y. Q x y` (MP_TAC o Q.SPEC `s`)
-   >> RW_TAC std_ss []
-   >> Q.PAT_X_ASSUM `!x. P x` (MP_TAC o Q.SPEC `f (n : num)`)
-   >> RW_TAC std_ss []
-   >> POP_ASSUM (MP_TAC o Q.SPEC `x`)
-   >> RW_TAC std_ss []
-   >> Q.PAT_X_ASSUM `BIJ f' X Y` MP_TAC
-   >> RW_TAC std_ss [BIJ_DEF, SURJ_DEF, IN_UNIV, IN_CROSS]
-   >> POP_ASSUM (MP_TAC o Q.SPEC `(n, n')`)
-   >> RW_TAC std_ss []
-   >> Q.EXISTS_TAC `y`
-   >> RW_TAC std_ss [o_THM]);
-
-val COUNTABLE_UNION = store_thm
-  ("COUNTABLE_UNION",
-   ``!s t. countable s /\ countable t ==> countable (s UNION t)``,
-   RW_TAC std_ss [GSYM BIGUNION_PAIR]
-   >> MATCH_MP_TAC COUNTABLE_BIGUNION
-   >> (RW_TAC std_ss [IN_INSERT, NOT_IN_EMPTY]
-       >> RW_TAC std_ss [])
-   >> MATCH_MP_TAC finite_countable
-   >> RW_TAC std_ss [FINITE_INSERT, FINITE_EMPTY]);
-
 val ENUMERATE = store_thm
   ("ENUMERATE",
    ``!s. (?f : num -> 'a. BIJ f UNIV s) = BIJ (enumerate s) UNIV s``,
@@ -557,7 +517,7 @@ val COUNTABLE_ENUM = store_thm
    ``!c. countable c = (c = {}) \/ (?f : num -> 'a. c = IMAGE f UNIV)``,
    RW_TAC std_ss []
    >> REVERSE EQ_TAC
-   >- (NTAC 2 (RW_TAC std_ss [COUNTABLE_EMPTY])
+   >- (NTAC 2 (RW_TAC std_ss [countable_EMPTY])
        >> RW_TAC std_ss [countable_alt]
        >> Q.EXISTS_TAC `f`
        >> RW_TAC std_ss [IN_IMAGE, IN_UNIV]

--- a/src/probability/util_probScript.sml
+++ b/src/probability/util_probScript.sml
@@ -326,36 +326,10 @@ val BIGUNION_PAIR = store_thm
    RW_TAC std_ss [EXTENSION, IN_BIGUNION, IN_UNION, IN_INSERT, NOT_IN_EMPTY]
    >> PROVE_TAC []);
 
-val FINITE_COUNTABLE = store_thm
-  ("FINITE_COUNTABLE",
-   ``!s. FINITE s ==> countable s``,
-   REWRITE_TAC [countable_alt]
-   >> HO_MATCH_MP_TAC FINITE_INDUCT
-   >> RW_TAC std_ss [NOT_IN_EMPTY]
-   >> Q.EXISTS_TAC `\n. if n = 0 then e else f (n - 1)`
-   >> RW_TAC std_ss [IN_INSERT] >- PROVE_TAC []
-   >> Q.PAT_X_ASSUM `!x. P x` (MP_TAC o Q.SPEC `x`)
-   >> RW_TAC std_ss []
-   >> Q.EXISTS_TAC `SUC n`
-   >> RW_TAC std_ss [SUC_SUB1]);
-
 val BIJ_NUM_COUNTABLE = store_thm
   ("BIJ_NUM_COUNTABLE",
    ``!s. (?f : num -> 'a. BIJ f UNIV s) ==> countable s``,
    RW_TAC std_ss [countable_alt, BIJ_DEF, SURJ_DEF, IN_UNIV]
-   >> PROVE_TAC []);
-
-val COUNTABLE_EMPTY = store_thm
-  ("COUNTABLE_EMPTY",
-   ``countable {}``,
-   PROVE_TAC [FINITE_COUNTABLE, FINITE_EMPTY]);
-
-val COUNTABLE_IMAGE = store_thm
-  ("COUNTABLE_IMAGE",
-   ``!s f. countable s ==> countable (IMAGE f s)``,
-   RW_TAC std_ss [countable_alt, IN_IMAGE]
-   >> Q.EXISTS_TAC `f o f'`
-   >> RW_TAC std_ss [o_THM]
    >> PROVE_TAC []);
 
 val COUNTABLE_BIGUNION = store_thm
@@ -389,7 +363,7 @@ val COUNTABLE_UNION = store_thm
    >> MATCH_MP_TAC COUNTABLE_BIGUNION
    >> (RW_TAC std_ss [IN_INSERT, NOT_IN_EMPTY]
        >> RW_TAC std_ss [])
-   >> MATCH_MP_TAC FINITE_COUNTABLE
+   >> MATCH_MP_TAC finite_countable
    >> RW_TAC std_ss [FINITE_INSERT, FINITE_EMPTY]);
 
 val ENUMERATE = store_thm
@@ -455,7 +429,7 @@ val COUNTABLE_ALT = store_thm
   ("COUNTABLE_ALT",
    ``!s. countable s = FINITE s \/ BIJ (enumerate s) UNIV s``,
    Strip
-   >> REVERSE EQ_TAC >- PROVE_TAC [FINITE_COUNTABLE, BIJ_NUM_COUNTABLE]
+   >> REVERSE EQ_TAC >- PROVE_TAC [finite_countable, BIJ_NUM_COUNTABLE]
    >> RW_TAC std_ss [countable_alt]
    >> Cases_on `FINITE s` >- PROVE_TAC []
    >> RW_TAC std_ss [GSYM ENUMERATE]
@@ -577,23 +551,6 @@ val PREIMAGE_CROSS = store_thm
        PREIMAGE f (a CROSS b) =
        PREIMAGE (FST o f) a INTER PREIMAGE (SND o f) b``,
    RW_TAC std_ss [EXTENSION, IN_PREIMAGE, IN_CROSS, IN_INTER, o_THM]);
-
-val UNIV_NEQ_EMPTY = store_thm
-  ("UNIV_NEQ_EMPTY",
-   ``~(UNIV={})``,
-   RW_TAC std_ss [Once EXTENSION, NOT_IN_EMPTY, IN_UNIV]);
-
-val COUNTABLE_NUM = store_thm
-  ("COUNTABLE_NUM",
-   ``!s : num -> bool. countable s``,
-   RW_TAC std_ss [countable_alt]
-   >> Q.EXISTS_TAC `I`
-   >> RW_TAC std_ss [I_THM]);
-
-val COUNTABLE_IMAGE_NUM = store_thm
-  ("COUNTABLE_IMAGE_NUM",
-   ``!f : num -> 'a. !s. countable (IMAGE f s)``,
-   PROVE_TAC [COUNTABLE_NUM, COUNTABLE_IMAGE]);
 
 val COUNTABLE_ENUM = store_thm
   ("COUNTABLE_ENUM",
@@ -877,19 +834,6 @@ val GBIGUNION_IMAGE = store_thm
   ("GBIGUNION_IMAGE",
    ``!s p n. {s | ?n. p s n} = BIGUNION (IMAGE (\n. {s | p s n}) UNIV)``,
    RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_BIGUNION_IMAGE, IN_UNIV]);
-
-val COUNTABLE_COUNT = store_thm
-  ("COUNTABLE_COUNT",
-   ``!n. countable (count n)``,
-   PROVE_TAC [FINITE_COUNT, FINITE_COUNTABLE]);
-
-val COUNTABLE_SUBSET = store_thm
-  ("COUNTABLE_SUBSET",
-   ``!s t. s SUBSET t /\ countable t ==> countable s``,
-   RW_TAC std_ss [countable_alt, SUBSET_DEF]
-   >> Q.EXISTS_TAC `f`
-   >> PROVE_TAC []);
-
 
 (********************************************************************************************
 *********************************************************************************************)

--- a/src/probability/util_probScript.sml
+++ b/src/probability/util_probScript.sml
@@ -210,8 +210,6 @@ val lg_pow = store_thm
 (********************************************************************************************)
 (********************************************************************************************)
 
-val enumerate_def = Define `enumerate s = @f : num -> 'a. BIJ f UNIV s`;
-
 val NUM_2D_BIJ = store_thm
   ("NUM_2D_BIJ",
    ``?f.
@@ -326,84 +324,6 @@ val BIGUNION_PAIR = store_thm
    RW_TAC std_ss [EXTENSION, IN_BIGUNION, IN_UNION, IN_INSERT, NOT_IN_EMPTY]
    >> PROVE_TAC []);
 
-val ENUMERATE = store_thm
-  ("ENUMERATE",
-   ``!s. (?f : num -> 'a. BIJ f UNIV s) = BIJ (enumerate s) UNIV s``,
-   RW_TAC std_ss [boolTheory.EXISTS_DEF, enumerate_def]);
-
-val EXPLICIT_ENUMERATE_MONO = store_thm
-  ("EXPLICIT_ENUMERATE_MONO",
-   ``!n s. FUNPOW REST n s SUBSET s``,
-   Induct >- RW_TAC std_ss [FUNPOW, SUBSET_DEF]
-   >> RW_TAC std_ss [FUNPOW_SUC]
-   >> PROVE_TAC [SUBSET_TRANS, REST_SUBSET]);
-
-val EXPLICIT_ENUMERATE_NOT_EMPTY = store_thm
-  ("EXPLICIT_ENUMERATE_NOT_EMPTY",
-   ``!n s. INFINITE s ==> ~(FUNPOW REST n s = {})``,
-   REWRITE_TAC []
-   >> Induct >- (RW_TAC std_ss [FUNPOW] >> PROVE_TAC [FINITE_EMPTY])
-   >> RW_TAC std_ss [FUNPOW]
-   >> Q.PAT_X_ASSUM `!s. P s` (MP_TAC o Q.SPEC `REST s`)
-   >> PROVE_TAC [FINITE_REST_EQ]);
-
-val INFINITE_EXPLICIT_ENUMERATE = store_thm
-  ("INFINITE_EXPLICIT_ENUMERATE",
-   ``!s. INFINITE s ==> INJ (\n : num. CHOICE (FUNPOW REST n s)) UNIV s``,
-   RW_TAC std_ss [INJ_DEF, IN_UNIV]
-   >- (Suff `CHOICE (FUNPOW REST n s) IN FUNPOW REST n s`
-       >- PROVE_TAC [SUBSET_DEF, EXPLICIT_ENUMERATE_MONO]
-       >> RW_TAC std_ss [GSYM CHOICE_DEF, EXPLICIT_ENUMERATE_NOT_EMPTY])
-   >> rpt (POP_ASSUM MP_TAC)
-   >> Q.SPEC_TAC (`s`, `s`)
-   >> Q.SPEC_TAC (`n'`, `y`)
-   >> Q.SPEC_TAC (`n`, `x`)
-   >> (Induct >> Cases) >|
-   [PROVE_TAC [],
-    rpt STRIP_TAC
-    >> Suff `~(CHOICE (FUNPOW REST 0 s) IN FUNPOW REST (SUC n) s)`
-    >- (RW_TAC std_ss []
-        >> MATCH_MP_TAC CHOICE_DEF
-        >> PROVE_TAC [EXPLICIT_ENUMERATE_NOT_EMPTY])
-    >> POP_ASSUM K_TAC
-    >> RW_TAC std_ss [FUNPOW]
-    >> Suff `~(CHOICE s IN REST s)`
-    >- PROVE_TAC [SUBSET_DEF, EXPLICIT_ENUMERATE_MONO]
-    >> PROVE_TAC [CHOICE_NOT_IN_REST],
-    rpt STRIP_TAC
-    >> POP_ASSUM (ASSUME_TAC o ONCE_REWRITE_RULE [EQ_SYM_EQ])
-    >> Suff `~(CHOICE (FUNPOW REST 0 s) IN FUNPOW REST (SUC x) s)`
-    >- (RW_TAC std_ss []
-        >> MATCH_MP_TAC CHOICE_DEF
-        >> PROVE_TAC [EXPLICIT_ENUMERATE_NOT_EMPTY])
-    >> POP_ASSUM K_TAC
-    >> RW_TAC std_ss [FUNPOW]
-    >> Suff `~(CHOICE s IN REST s)`
-    >- PROVE_TAC [SUBSET_DEF, EXPLICIT_ENUMERATE_MONO]
-    >> PROVE_TAC [CHOICE_NOT_IN_REST],
-    RW_TAC std_ss [FUNPOW]
-    >> Q.PAT_X_ASSUM `!y. P y` (MP_TAC o Q.SPECL [`n`, `REST s`])
-    >> PROVE_TAC [FINITE_REST_EQ]]);
-
-val COUNTABLE_ALT = store_thm
-  ("COUNTABLE_ALT",
-   ``!s. countable s = FINITE s \/ BIJ (enumerate s) UNIV s``,
-   Strip
-   >> REVERSE EQ_TAC >- PROVE_TAC [finite_countable, BIJ_NUM_COUNTABLE]
-   >> RW_TAC std_ss [countable_alt]
-   >> Cases_on `FINITE s` >- PROVE_TAC []
-   >> RW_TAC std_ss [GSYM ENUMERATE]
-   >> MATCH_MP_TAC BIJ_INJ_SURJ
-   >> REVERSE CONJ_TAC
-   >- (Know `~(s = {})` >- PROVE_TAC [FINITE_EMPTY]
-       >> RW_TAC std_ss [GSYM MEMBER_NOT_EMPTY]
-       >> Q.EXISTS_TAC `\n. if f n IN s then f n else x`
-       >> RW_TAC std_ss [SURJ_DEF, IN_UNIV]
-       >> PROVE_TAC [])
-   >> MP_TAC (Q.SPEC `s` INFINITE_EXPLICIT_ENUMERATE)
-   >> RW_TAC std_ss []
-   >> PROVE_TAC []);
-
 val PREIMAGE_def = Define `PREIMAGE f s = {x | f x IN s}`;
 val prod_sets_def = Define `prod_sets a b = {s CROSS t | s IN a /\ t IN b}`;
 
@@ -416,7 +336,6 @@ val IN_o = store_thm
   ("IN_o",
    ``!x f s. x IN (s o f) = f x IN s``,
    RW_TAC std_ss [SPECIFICATION, o_THM]);
-
 
 val PREIMAGE_ALT = store_thm
   ("PREIMAGE_ALT",
@@ -511,42 +430,6 @@ val PREIMAGE_CROSS = store_thm
        PREIMAGE f (a CROSS b) =
        PREIMAGE (FST o f) a INTER PREIMAGE (SND o f) b``,
    RW_TAC std_ss [EXTENSION, IN_PREIMAGE, IN_CROSS, IN_INTER, o_THM]);
-
-val COUNTABLE_ENUM = store_thm
-  ("COUNTABLE_ENUM",
-   ``!c. countable c = (c = {}) \/ (?f : num -> 'a. c = IMAGE f UNIV)``,
-   RW_TAC std_ss []
-   >> REVERSE EQ_TAC
-   >- (NTAC 2 (RW_TAC std_ss [countable_EMPTY])
-       >> RW_TAC std_ss [countable_alt]
-       >> Q.EXISTS_TAC `f`
-       >> RW_TAC std_ss [IN_IMAGE, IN_UNIV]
-       >> PROVE_TAC [])
-   >> REVERSE (RW_TAC std_ss [COUNTABLE_ALT])
-   >- (DISJ2_TAC
-       >> Q.EXISTS_TAC `enumerate c`
-       >> POP_ASSUM MP_TAC
-       >> RW_TAC std_ss [IN_UNIV, IN_IMAGE, BIJ_DEF, SURJ_DEF, EXTENSION]
-       >> PROVE_TAC [])
-   >> POP_ASSUM MP_TAC
-   >> Q.SPEC_TAC (`c`, `c`)
-   >> HO_MATCH_MP_TAC FINITE_INDUCT
-   >> RW_TAC std_ss []
-   >- (DISJ2_TAC
-       >> Q.EXISTS_TAC `K e`
-       >> RW_TAC std_ss [EXTENSION, IN_SING, IN_IMAGE, IN_UNIV, K_THM])
-   >> DISJ2_TAC
-   >> Q.EXISTS_TAC `\n. num_CASE n e f`
-   >> RW_TAC std_ss [IN_INSERT, IN_IMAGE, EXTENSION, IN_UNIV]
-   >> EQ_TAC >|
-   [RW_TAC std_ss [] >|
-    [Q.EXISTS_TAC `0`
-     >> RW_TAC std_ss [num_case_def],
-     Q.EXISTS_TAC `SUC x'`
-     >> RW_TAC std_ss [num_case_def]],
-    RW_TAC std_ss [] >>
-    METIS_TAC [num_case_def, TypeBase.nchotomy_of ``:num``]]
-    );
 
 val BIJ_ALT = store_thm
   ("BIJ_ALT",

--- a/src/probability/util_probScript.sml
+++ b/src/probability/util_probScript.sml
@@ -330,12 +330,6 @@ val IN_o = store_thm
    ``!x f s. x IN (s o f) = f x IN s``,
    RW_TAC std_ss [SPECIFICATION, o_THM]);
 
-val IMAGE_I = store_thm
-  ("IMAGE_I",
-   ``IMAGE I = I``,
-  RW_TAC std_ss [FUN_EQ_THM]
-  >> METIS_TAC [SPECIFICATION,IN_IMAGE,I_THM]);
-
 val IN_PROD_SETS = store_thm
   ("IN_PROD_SETS",
    ``!s a b. s IN prod_sets a b = ?t u. (s = t CROSS u) /\ t IN a /\ u IN b``,
@@ -344,52 +338,6 @@ val IN_PROD_SETS = store_thm
    >> RW_TAC std_ss []
    >> Q.EXISTS_TAC `(t, u)`
    >> RW_TAC std_ss []);
-
-val RES_BIJ_ALT = store_thm
-  ("RES_BIJ_ALT",
-   ``!f s t. BIJ f s t = f IN (s -> t) /\ (!y :: t. ?!x :: s. y = f x)``,
-   RW_TAC std_ss [BIJ_DEF, INJ_DEF, SURJ_DEF, RES_EXISTS_UNIQUE_ALT]
-   >> RESQ_TAC
-   >> RW_TAC std_ss [IN_FUNSET, IN_DFUNSET, GSYM CONJ_ASSOC]
-   >> Know `!a b c. (a ==> (b = c)) ==> (a /\ b = a /\ c)` >- PROVE_TAC []
-   >> DISCH_THEN MATCH_MP_TAC
-   >> REPEAT (STRIP_TAC ORELSE EQ_TAC) >|
-   [PROVE_TAC [],
-    Q.PAT_X_ASSUM `!x. P x`
-    (fn th =>
-     MP_TAC (Q.SPEC `(f:'a->'b) x` th)
-     >> MP_TAC (Q.SPEC `(f:'a->'b) y` th))
-    >> Cond >- PROVE_TAC []
-    >> STRIP_TAC
-    >> Cond >- PROVE_TAC []
-    >> STRIP_TAC
-    >> PROVE_TAC [],
-    PROVE_TAC [],
-    PROVE_TAC []]);
-
-val BIJ_FINITE_SUBSET = store_thm
-  ("BIJ_FINITE_SUBSET",
-   ``!(f : num -> 'a) s t.
-       BIJ f UNIV s /\ FINITE t /\ t SUBSET s ==>
-       ?N. !n. N <= n ==> ~(f n IN t)``,
-   RW_TAC std_ss []
-   >> POP_ASSUM MP_TAC
-   >> POP_ASSUM MP_TAC
-   >> Q.SPEC_TAC (`t`, `t`)
-   >> HO_MATCH_MP_TAC FINITE_INDUCT
-   >> RW_TAC std_ss [EMPTY_SUBSET, NOT_IN_EMPTY, INSERT_SUBSET, IN_INSERT]
-   >> Know `?!k. f k = e`
-   >- (Q.PAT_X_ASSUM `BIJ a b c` MP_TAC
-       >> RW_TAC std_ss [RES_BIJ_ALT, RES_EXISTS_UNIQUE_UNIV, RES_FORALL]
-       >> PROVE_TAC [])
-   >> CONV_TAC (DEPTH_CONV EXISTS_UNIQUE_CONV)
-   >> RW_TAC std_ss []
-   >> RES_TAC
-   >> Q.EXISTS_TAC `MAX N (SUC k)`
-   >> RW_TAC std_ss [MAX_LE_X]
-   >> STRIP_TAC
-   >> Know `n = k` >- PROVE_TAC []
-   >> DECIDE_TAC);
 
 val NUM_2D_BIJ_SMALL_SQUARE = store_thm
   ("NUM_2D_BIJ_SMALL_SQUARE",


### PR DESCRIPTION
Hi,

This is a further work of PR #432:

1. In util_probTheory, there's a duplicated (simpler) definition for countable sets (countable_def), which is not the same but equivalent with the one in current pred_setTheory. I have proved the equivalence and then merged the two work together into pred_setTheory.  The alternative definition is now called COUNTABLE_ALT in pred_setTheory as a theorem, while the original alternative definition of countable sets (based on bijections), is now called COUNTABLE_ALT_BIJ in pred_setTheory. Some other beautiful theorems on countable sets were also moved:

COUNTABLE_SUBSET
COUNTABLE_ENUM

2. More theorems about bijections are moved to pred_setTheory:

BIJ_ALT
BIJ_INSERT_IMP
BIJ_FINITE_SUBSET
FINITE_BIJ
FINITE_BIJ_COUNT

3. the concept and theorems for PREIMAGE of sets, are moved from util_prob to pred_setTheory. There's no deep results, all basic definition and theorems.

Now there's no set theory theorems left in util_probTheory.  My changes didn't change the name of any existing theorem in pred_setTheory, thus I believe the potential compatibility issues (if there is) must be subtle. Now pred_setTheory looks rich: each new concept has enough supporting theorems.
