### PR TITLE
TeX notations for RUNION, RINTER and RSUBSET in relationTheory

### DIFF
--- a/src/TeX/holtexbasic.sty
+++ b/src/TeX/holtexbasic.sty
@@ -50,7 +50,9 @@
 \newcommand{\HOLTokenIn}{\ensuremath{\in}}
 \newcommand{\HOLTokenNotIn}{\ensuremath{\notin}}
 \newcommand{\HOLTokenUnion}{\ensuremath{\cup}}
+\newcommand{\HOLTokenRUnion}{\ensuremath{\cup_r}}
 \newcommand{\HOLTokenInter}{\ensuremath{\cap}}
+\newcommand{\HOLTokenRInter}{\ensuremath{\cap_r}}
 \newcommand{\HOLTokenLeftbrace}{\ensuremath{\left\{\right.}}
 \newcommand{\HOLTokenRightbrace}{\ensuremath{\left.\right\}}}
 \newcommand{\HOLTokenTurnstile}{\ensuremath{\:\:\vdash}}
@@ -102,6 +104,7 @@
 \newcommand{\HOLTokenLSmallTri}{\ensuremath{\triangleleft}}
 \newcommand{\HOLTokenRSmallTri}{\ensuremath{\triangleright}}
 \newcommand{\HOLTokenSubset}{\ensuremath{\subseteq}}
+\newcommand{\HOLTokenRSubset}{\ensuremath{\subseteq_r}}
 \newcommand{\HOLTokenPSubset}{\ensuremath{\subset}}
 \newcommand{\HOLTokenSubmap}{\ensuremath{\sqsubseteq}}
 \newcommand{\HOLTokenCompose}{\ensuremath{\circ}}

--- a/src/relation/relationScript.sml
+++ b/src/relation/relationScript.sml
@@ -1772,6 +1772,8 @@ val _ = set_fixity "RSUBSET" (Infix(NONASSOC, 450));
 val _ = OpenTheoryMap.OpenTheory_const_name {const={Thy="relation",Name="RSUBSET"},name=(["Relation"],"subrelation")}
 val _ = Unicode.unicode_version {u = UnicodeChars.subset ^ UnicodeChars.sub_r,
                                  tmnm = "RSUBSET"}
+val _ = TeX_notation { hol = UnicodeChars.subset ^ UnicodeChars.sub_r,
+                       TeX = ("\\HOLTokenRSubset{}", 1) }
 
 val irreflexive_RSUBSET = store_thm(
   "irreflexive_RSUBSET",
@@ -1800,6 +1802,8 @@ val RUNION_ASSOC = store_thm(
 
 val _ = Unicode.unicode_version {u = UnicodeChars.union ^ UnicodeChars.sub_r,
                                  tmnm = "RUNION"}
+val _ = TeX_notation { hol = UnicodeChars.union ^ UnicodeChars.sub_r,
+                       TeX = ("\\HOLTokenRUnion{}", 1) }
 
 (* ----------------------------------------------------------------------
     relational intersection
@@ -1812,6 +1816,8 @@ val _ = set_fixity "RINTER" (Infixl 600)
 val _ = OpenTheoryMap.OpenTheory_const_name {const={Thy="relation",Name="RINTER"},name=(["Relation"],"intersect")}
 val _ = Unicode.unicode_version {u = UnicodeChars.inter ^ UnicodeChars.sub_r,
                                  tmnm = "RINTER"}
+val _ = TeX_notation { hol = UnicodeChars.inter ^ UnicodeChars.sub_r,
+                       TeX = ("\\HOLTokenRInter{}", 1) }
 
 val RINTER_COMM = store_thm(
   "RINTER_COMM",


### PR DESCRIPTION
Currently there's no way to emit TeX code for terms using RUNION, RINTER and RSUBSET in relationTheory, because their TeX notations are not defined.  This PR has fixed the issue, now the TeX output is the same as their unicode versions. Then if user wants new notations, they can use \renewcommand to re-define the following 3 LaTeX variables:

\HOLTokenRUnion
\HOLTokenRInter
\HOLTokenRSubset
