### PR TITLE
Removed right-associative THEN and THEN1 in util_prob, extreal and lebesgue theories

### DIFF
--- a/src/probability/extrealScript.sml
+++ b/src/probability/extrealScript.sml
@@ -28,9 +28,6 @@ val _ = new_theory "extreal";
 (* Helpful proof tools                                                       *)
 (* ------------------------------------------------------------------------- *)
 
-infixr >> >|
-infix 1 >-
-
 val S_TAC = rpt (POP_ASSUM MP_TAC) >> rpt RESQ_STRIP_TAC;
 val Strip = S_TAC;
 
@@ -1126,28 +1123,29 @@ val add_ldistrib_pos = store_thm
   >> FULL_SIMP_TAC real_ss [GSYM real_lt,GSYM real_lte]
   >> METIS_TAC [REAL_LE_ANTISYM,REAL_LT_ADD,REAL_LT_IMP_LE,REAL_LT_IMP_NE,
                 REAL_LT_LE,REAL_ADD_LDISTRIB]);
+
 val add_ldistrib_neg = store_thm
   ("add_ldistrib_neg",
-   ``!x y z. y <= 0 /\ z <= 0 ==> (x * (y + z) = x * y + x * z)``,
-  Cases >> Cases >> Cases
-  >> RW_TAC real_ss [extreal_add_def,extreal_mul_def,extreal_le_def,
-                     extreal_of_num_def,real_lt,REAL_LT_ANTISYM,
-                     REAL_LE_ANTISYM,REAL_ADD_LID,REAL_ADD_RID,REAL_LT_LE]
-  >> FULL_SIMP_TAC real_ss [GSYM real_lt,GSYM real_lte,REAL_ADD_LDISTRIB]
-  >> Cases_on `0 < r` >- RW_TAC std_ss []
-  >> Cases_on `0 < r'` >- RW_TAC std_ss []
-  >> `r < 0 /\ r' < 0` by METIS_TAC [real_lte,REAL_LT_LE]
-  >> METIS_TAC [REAL_LT_ADD2,REAL_ADD_LID,REAL_LT_IMP_NE,REAL_LT_ANTISYM]);
+  ``!x y z. y <= 0 /\ z <= 0 ==> (x * (y + z) = x * y + x * z)``,
+    Cases >> Cases >> Cases (* 27 sub-goals here *)
+ >> RW_TAC real_ss [extreal_add_def, extreal_mul_def, extreal_le_def,
+                    extreal_of_num_def, real_lt, REAL_LT_ANTISYM,
+                    REAL_LE_ANTISYM, REAL_ADD_LID, REAL_ADD_RID, REAL_LT_LE] (* 17 goals left *)
+ >> FULL_SIMP_TAC real_ss [GSYM real_lt, GSYM real_lte, REAL_ADD_LDISTRIB] (* 4 goals left *)
+ >> ( Cases_on `0 < r` >- RW_TAC std_ss [] \\
+      Cases_on `0 < r'` >- RW_TAC std_ss [] \\
+      `r < 0 /\ r' < 0` by METIS_TAC [real_lte, REAL_LT_LE] \\
+      METIS_TAC [REAL_LT_ADD2, REAL_ADD_LID, REAL_LT_IMP_NE, REAL_LT_ANTISYM] ));
 
 val add_ldistrib_normal = store_thm
   ("add_ldistrib_normal",
    ``!x y z. (y <> PosInf /\ z <> PosInf) \/ (y <> NegInf /\ z <> NegInf)
          ==> (Normal x * (y + z) = Normal x * y + Normal x * z)``,
   RW_TAC std_ss [] >> Cases_on `y` >> Cases_on `z`
-  >> RW_TAC std_ss [extreal_add_def]
-  >> Cases_on `x=0`
-  >- METIS_TAC [extreal_of_num_def,mul_lzero,add_lzero]
-  >> RW_TAC std_ss [extreal_mul_def,extreal_add_def,REAL_ADD_LDISTRIB]);
+  >> RW_TAC std_ss [extreal_add_def] (* 8 sub-goals here, same tacticals *)
+  >> ( Cases_on `x=0`
+       >- METIS_TAC [extreal_of_num_def,mul_lzero,add_lzero]
+       >> RW_TAC std_ss [extreal_mul_def,extreal_add_def,REAL_ADD_LDISTRIB] ));
 
 val add_ldistrib_normal2 = store_thm
   ("add_ldistrib_normal2",
@@ -1162,9 +1160,9 @@ val add_rdistrib_normal = store_thm
           ((y + z) * Normal x = y * Normal x + z * Normal x)``,
   RW_TAC std_ss [] >> Cases_on `y` >> Cases_on `z`
   >> RW_TAC std_ss [extreal_add_def]
-  >> Cases_on `x=0`
-  >- METIS_TAC [extreal_of_num_def,mul_rzero,add_rzero]
-  >> RW_TAC std_ss [extreal_mul_def,extreal_add_def,REAL_ADD_RDISTRIB]);
+  >> ( Cases_on `x=0`
+       >- METIS_TAC [extreal_of_num_def,mul_rzero,add_rzero]
+       >> RW_TAC std_ss [extreal_mul_def,extreal_add_def,REAL_ADD_RDISTRIB] ));
 
 val add_rdistrib_normal2 = store_thm
   ("add_rdistrib_normal2",
@@ -3864,8 +3862,10 @@ val COUNTABLE_ENUM_Q = store_thm
       >> `~(FINITE Q_set)` by RW_TAC std_ss [Q_INFINITE]
       >> (MP_TAC o Q.SPEC `Q_set`) (INST_TYPE [alpha |-> ``:extreal``] COUNTABLE_ALT_BIJ)
       >> RW_TAC std_ss []
-      >> (MP_TAC o Q.SPECL [`enumerate Q_set`,`UNIV`,`Q_set`]) (INST_TYPE [alpha |-> ``:num``, ``:'b`` |-> ``:extreal``] BIJ_INV)
-      >> (MP_TAC o Q.SPECL [`enumerate c`,`UNIV`,`c`]) (INST_TYPE [alpha |-> ``:num``, ``:'b`` |-> ``:'a``] BIJ_INV)
+      >> (MP_TAC o Q.SPECL [`enumerate Q_set`,`UNIV`,`Q_set`])
+		(INST_TYPE [alpha |-> ``:num``, ``:'b`` |-> ``:extreal``] BIJ_INV)
+      >> (MP_TAC o Q.SPECL [`enumerate c`,`UNIV`,`c`])
+		(INST_TYPE [alpha |-> ``:num``, ``:'b`` |-> ``:'a``] BIJ_INV)
       >> RW_TAC std_ss []
       >> Q.EXISTS_TAC `(enumerate c) o g'`
       >> RW_TAC std_ss [IMAGE_DEF,EXTENSION,GSPECIFICATION]
@@ -3886,31 +3886,36 @@ val COUNTABLE_ENUM_Q = store_thm
       >> EQ_TAC
       >- (RW_TAC std_ss [] >> Q.EXISTS_TAC `0` >> METIS_TAC [NUM_IN_Q])
       >> RW_TAC std_ss [])
-  >>  DISJ2_TAC
-  >> ASSUME_TAC (Q.SPECL [`f:extreal->'a`,`Q_set`,`IMAGE f Q_set`] (INST_TYPE [alpha |-> ``:extreal``,``:'b`` |-> ``:'a``] INFINITE_INJ))
+  >> DISJ2_TAC
+  >> ASSUME_TAC (Q.SPECL [`f:extreal->'a`,`Q_set`,`IMAGE f Q_set`]
+			 (INST_TYPE [alpha |-> ``:extreal``,``:'b`` |-> ``:'a``] INFINITE_INJ))
   >> `~(INJ f Q_set (IMAGE f Q_set))` by METIS_TAC [MONO_NOT,Q_INFINITE]
   >> FULL_SIMP_TAC std_ss [INJ_DEF] >- METIS_TAC [IN_IMAGE]
   >> Q.EXISTS_TAC `(\u. if u=x then e else f u)`
-  >> `Q_set = (Q_set DIFF {x}) UNION {x}` by (RW_TAC std_ss [DIFF_DEF,UNION_DEF,EXTENSION,GSPECIFICATION,IN_SING] >> METIS_TAC [])
-  >> `(IMAGE (\u. if u = x then e else f u) Q_set) = (IMAGE (\u. if u = x then e else f u) (Q_set DIFF {x})) UNION (IMAGE (\u. if u = x then e else f u) {x})` by METIS_TAC [IMAGE_UNION]
-  >> `IMAGE (\u. if u = x then e else f u) {x} = {e}` by RW_TAC std_ss [IMAGE_DEF,EXTENSION,GSPECIFICATION,IN_SING]
+  >> `Q_set = (Q_set DIFF {x}) UNION {x}`
+	by (RW_TAC std_ss [DIFF_DEF,UNION_DEF,EXTENSION,GSPECIFICATION,IN_SING] >> METIS_TAC [])
+  >> `(IMAGE (\u. if u = x then e else f u) Q_set) =
+	(IMAGE (\u. if u = x then e else f u) (Q_set DIFF {x})) UNION
+	(IMAGE (\u. if u = x then e else f u) {x})`
+	by METIS_TAC [IMAGE_UNION]
+  >> `IMAGE (\u. if u = x then e else f u) {x} = {e}`
+	by RW_TAC std_ss [IMAGE_DEF,EXTENSION,GSPECIFICATION,IN_SING]
   >> `IMAGE (\u. if u = x then e else f u) (Q_set DIFF {x}) = IMAGE f Q_set`
-        by (RW_TAC std_ss [IMAGE_DEF,EXTENSION,GSPECIFICATION,DIFF_DEF,IN_UNION,
-                           IN_SING] >> METIS_TAC[])
-  >> `(IMAGE f Q_set) = (IMAGE f (Q_set DIFF {x})) UNION (IMAGE f {x})` by METIS_TAC [IMAGE_UNION]
+        by ( RW_TAC std_ss [IMAGE_DEF,EXTENSION,GSPECIFICATION,DIFF_DEF,IN_UNION,IN_SING] \\
+             METIS_TAC[] )
+  >> `IMAGE f Q_set = (IMAGE f (Q_set DIFF {x})) UNION (IMAGE f {x})` by METIS_TAC [IMAGE_UNION]
   >> `IMAGE f {x} = {f y}` by RW_TAC std_ss [IMAGE_DEF,EXTENSION,GSPECIFICATION,IN_SING]
   >> `IMAGE f Q_set = (IMAGE f (Q_set DIFF {x})) UNION {f y}` by METIS_TAC []
-  >> `{f y} SUBSET IMAGE f (Q_set DIFF {x})` by ( RW_TAC std_ss [SUBSET_DEF,IN_IMAGE,IN_SING] >> Q.EXISTS_TAC `y` >> RW_TAC std_ss [IN_DIFF,IN_SING])
+  >> `{f y} SUBSET IMAGE f (Q_set DIFF {x})`
+	by ( RW_TAC std_ss [SUBSET_DEF,IN_IMAGE,IN_SING] >> Q.EXISTS_TAC `y` \\
+	     RW_TAC std_ss [IN_DIFF,IN_SING] )
   >> `IMAGE f Q_set = IMAGE f (Q_set DIFF {x})` by METIS_TAC [SUBSET_UNION_ABSORPTION,UNION_COMM]
   >> `IMAGE (\u. if u = x then e else f u) (Q_set DIFF {x}) = IMAGE f (Q_set DIFF {x})`
-     by (RW_TAC std_ss [IMAGE_DEF,EXTENSION,GSPECIFICATION,DIFF_DEF,IN_SING]
-       	        >> EQ_TAC
-                >- (RW_TAC std_ss []
-         	    >> Q.EXISTS_TAC `u`
-       		    >> RW_TAC std_ss [])
-       		>> RW_TAC std_ss []
-       		>> Q.EXISTS_TAC `x''`
-       		>> RW_TAC std_ss [])
+     by (RW_TAC std_ss [IMAGE_DEF,EXTENSION,GSPECIFICATION,DIFF_DEF,IN_SING] \\
+	      ( EQ_TAC >- ( RW_TAC std_ss [] >> Q.EXISTS_TAC `u` >> RW_TAC std_ss [] )
+		>> RW_TAC std_ss []
+		>> Q.EXISTS_TAC `x''`
+		>> RW_TAC std_ss [] ))
   >> METIS_TAC [INSERT_SING_UNION,UNION_COMM]);
 
 val CROSS_COUNTABLE_UNIV = store_thm

--- a/src/probability/lebesgueScript.sml
+++ b/src/probability/lebesgueScript.sml
@@ -23,8 +23,6 @@ open HolKernel Parse boolLib bossLib arithmeticTheory realTheory prim_recTheory
 val _ = new_theory "lebesgue";
 
 val REVERSE = Tactical.REVERSE;
-infixr >> >|
-infix 1 >-
 
 val S_TAC = rpt (POP_ASSUM MP_TAC) >> rpt RESQ_STRIP_TAC;
 val Strip = S_TAC;
@@ -3837,7 +3835,8 @@ val measure_space_finite_prod_measure_POW2 = store_thm
       ONCE_REWRITE_TAC [EXTENSION] >> RW_TAC std_ss [IN_UNION, IN_PREIMAGE]]);
 
 val finite_prod_measure_space_POW = store_thm
- ("finite_prod_measure_space_POW", ``!s1 s2 u v. FINITE s1 /\ FINITE s2  ==>
+  ("finite_prod_measure_space_POW",
+  ``!s1 s2 u v. FINITE s1 /\ FINITE s2  ==>
           (prod_measure_space (s1, POW s1, u) (s2, POW s2, v) =
           (s1 CROSS s2, POW (s1 CROSS s2), prod_measure (s1, POW s1, u) (s2, POW s2, v)))``,
   RW_TAC std_ss [prod_measure_space_def, m_space_def, subsets_def, EXTENSION, subsets_def,
@@ -3845,16 +3844,16 @@ val finite_prod_measure_space_POW = store_thm
 	        IN_CROSS, GSPECIFICATION]
   >> RW_TAC std_ss [GSYM EXTENSION]
   >> EQ_TAC
-  >- (RW_TAC std_ss []
-      >> Q.PAT_X_ASSUM `!s. P ==> x IN s` (MP_TAC o Q.SPEC `POW (s1 CROSS s2)`)
-      >> RW_TAC std_ss [IN_POW, SUBSET_DEF, IN_CROSS, POW_SIGMA_ALGEBRA]
-      >> Suff `(!x''. (?x'. (x'',T) = (\(s,t). (s CROSS t,
-            	   (!x. x IN s ==> x IN s1) /\ !x. x IN t ==> x IN s2))
+  >- (RW_TAC std_ss [] \\ (* 2 sub-goals here, same tacticals *)
+      (Q.PAT_X_ASSUM `!s. P ==> x IN s` (MP_TAC o Q.SPEC `POW (s1 CROSS s2)`)
+       >> RW_TAC std_ss [IN_POW, SUBSET_DEF, IN_CROSS, POW_SIGMA_ALGEBRA]
+       >> Suff `(!x''. (?x'. (x'',T) = (\(s,t). (s CROSS t,
+                              (!x. x IN s ==> x IN s1) /\ !x. x IN t ==> x IN s2))
               		x') ==> !x. x IN x'' ==> FST x IN s1 /\ SND x IN s2)` >- METIS_TAC []
-      >> RW_TAC std_ss []
-      >> Cases_on `x'''`
-      >> FULL_SIMP_TAC std_ss []
-      >> METIS_TAC [IN_CROSS])
+        >> RW_TAC std_ss []
+        >> Cases_on `x'''`
+        >> FULL_SIMP_TAC std_ss []
+        >> METIS_TAC [IN_CROSS] ))
   >> RW_TAC std_ss []
   >> `x = BIGUNION (IMAGE (\a. {a}) x)`
     by (ONCE_REWRITE_TAC [EXTENSION] >> RW_TAC std_ss [IN_BIGUNION_IMAGE, IN_SING])
@@ -4001,7 +4000,8 @@ val measure_space_finite_prod_measure_POW3 = store_thm
   >> RW_TAC std_ss [EXTENSION,IN_PREIMAGE,IN_UNION]);
 
 val finite_prod_measure_space_POW3 = store_thm
- ("finite_prod_measure_space_POW3",``!s1 s2 s3 u v w.
+  ("finite_prod_measure_space_POW3",
+  ``!s1 s2 s3 u v w.
          FINITE s1 /\ FINITE s2 /\ FINITE s3 ==>
          (prod_measure_space3 (s1,POW s1,u) (s2,POW s2,v) (s3,POW s3,w) =
           (s1 CROSS (s2 CROSS s3),POW (s1 CROSS (s2 CROSS s3)),
@@ -4011,19 +4011,19 @@ val finite_prod_measure_space_POW3 = store_thm
 	        IN_CROSS, GSPECIFICATION]
   >> RW_TAC std_ss [GSYM EXTENSION]
   >> EQ_TAC
-  >- (RW_TAC std_ss []
-      >> Q.PAT_X_ASSUM `!s. P ==> x IN s` (MP_TAC o Q.SPEC `POW (s1 CROSS (s2 CROSS s3))`)
-      >> RW_TAC std_ss [IN_POW, SUBSET_DEF, IN_CROSS, POW_SIGMA_ALGEBRA]
-      >> Suff `(!x''. (?x'. (x'',T) =
+  >- (RW_TAC std_ss [] \\ (* 3 sub-goals here, same tacticals *)
+      (Q.PAT_X_ASSUM `!s. P ==> x IN s` (MP_TAC o Q.SPEC `POW (s1 CROSS (s2 CROSS s3))`)
+       >> RW_TAC std_ss [IN_POW, SUBSET_DEF, IN_CROSS, POW_SIGMA_ALGEBRA]
+       >> Suff `(!x''. (?x'. (x'',T) =
                (\(s,t,u'). (s CROSS (t CROSS u'),
                (!x. x IN s ==> x IN s1) /\ (!x. x IN t ==> x IN s2) /\
                 !x. x IN u' ==> x IN s3)) x') ==>
 	        !x. x IN x'' ==> FST x IN s1 /\ FST (SND x) IN s2 /\ SND (SND x) IN s3)`
-      >- METIS_TAC []
-      >> RW_TAC std_ss []
-      >> Cases_on `x'''` >> Cases_on `r`
-      >> FULL_SIMP_TAC std_ss []
-      >> METIS_TAC [IN_CROSS])
+       >- METIS_TAC []
+       >> RW_TAC std_ss []
+       >> Cases_on `x'''` >> Cases_on `r`
+       >> FULL_SIMP_TAC std_ss []
+       >> METIS_TAC [IN_CROSS] ))
   >> RW_TAC std_ss []
   >> `x = BIGUNION (IMAGE (\a. {a}) x)`
     by (ONCE_REWRITE_TAC [EXTENSION]

--- a/src/probability/probabilityScript.sml
+++ b/src/probability/probabilityScript.sml
@@ -53,6 +53,8 @@ val events_def = Define `events = measurable_sets`;
 
 val prob_def = Define `prob = measure`;
 
+val prob_preserving_def = Define `prob_preserving = measure_preserving`;
+
 val prob_space_def = Define
   `prob_space p = measure_space p /\ (measure p (p_space p) = 1)`;
 
@@ -60,6 +62,15 @@ val indep_def = Define
   `indep p a b =
    a IN events p /\ b IN events p /\
    (prob p (a INTER b) = prob p a * prob p b)`;
+
+val indep_families_def = Define `
+    indep_families p q r = !s t. s IN q /\ t IN r ==> indep p s t`;
+
+val indep_function_def = Define `
+    indep_function p =
+   {f |
+    indep_families p (IMAGE (PREIMAGE (FST o f)) UNIV)
+    (IMAGE (PREIMAGE (SND o f)) (events p))}`;
 
 val probably_def = Define `probably p e = (e IN events p) /\ (prob p e = 1)`;
 
@@ -230,6 +241,79 @@ val PROB_INDEP = store_thm
 val PSPACE = store_thm
 ("PSPACE", ``!a b c. p_space (a, b, c) = a``,
   RW_TAC std_ss [p_space_def, m_space_def]);
+
+val PROB_PRESERVING = store_thm (
+   "PROB_PRESERVING",
+  ``!p1 p2.
+       prob_preserving p1 p2 =
+       {f |
+        f IN measurable (p_space p1, events p1) (p_space p2, events p2) /\
+        measure_space p1 /\ measure_space p2 /\
+        !s. s IN events p2 ==> (prob p1 ((PREIMAGE f s) INTER (p_space p1)) = prob p2 s)}``,
+    REPEAT GEN_TAC
+ >> REWRITE_TAC [EXTENSION]
+ >> GEN_TAC
+ >> REWRITE_TAC [GSPECIFICATION]
+ >> BETA_TAC
+ >> REWRITE_TAC [PAIR_EQ]
+ >> RW_TAC std_ss [prob_preserving_def, events_def, prob_def, p_space_def]
+ >> RW_TAC std_ss [IN_MEASURE_PRESERVING]);
+
+val PROB_PRESERVING_SUBSET = store_thm (
+   "PROB_PRESERVING_SUBSET",
+  ``!p1 p2 a.
+       prob_space p1 /\ prob_space p2 /\
+       (events p2 = subsets (sigma (p_space p2) a)) ==>
+       prob_preserving p1 (p_space p2, a, prob p2) SUBSET
+       prob_preserving p1 p2``,
+    RW_TAC std_ss [prob_space_def, prob_preserving_def, prob_def, events_def, p_space_def]
+ >> MATCH_MP_TAC MEASURE_PRESERVING_SUBSET
+ >> ASM_REWRITE_TAC []);
+
+val PROB_PRESERVING_LIFT = store_thm (
+   "PROB_PRESERVING_LIFT",
+  ``!p1 p2 a f.
+       prob_space p1 /\ prob_space p2 /\
+       (events p2 = subsets (sigma (p_space p2) a)) /\
+       f IN prob_preserving p1 (p_space p2, a, prob p2) ==>
+       f IN prob_preserving p1 p2``,
+    RW_TAC std_ss [prob_space_def, prob_preserving_def, prob_def, events_def, p_space_def]
+ >> MATCH_MP_TAC MEASURE_PRESERVING_LIFT
+ >> Q.EXISTS_TAC `a`
+ >> ASM_REWRITE_TAC []);
+
+val PROB_PRESERVING_UP_LIFT = store_thm (
+   "PROB_PRESERVING_UP_LIFT",
+  ``!p1 p2 f.
+       prob_space p1 /\
+       f IN prob_preserving (p_space p1, a, prob p1) p2 /\
+       sigma_algebra (p_space p1, events p1) /\
+       a SUBSET events p1 ==>
+       f IN prob_preserving p1 p2``,
+    RW_TAC std_ss [prob_space_def, prob_preserving_def, prob_def, events_def, p_space_def]
+ >> MATCH_MP_TAC MEASURE_PRESERVING_UP_LIFT
+ >> ASM_REWRITE_TAC []);
+
+val PROB_PRESERVING_UP_SUBSET = store_thm (
+   "PROB_PRESERVING_UP_SUBSET",
+  ``!p1 p2.
+       prob_space p1 /\
+       a SUBSET events p1 /\
+       sigma_algebra (p_space p1, events p1) ==>
+       prob_preserving (p_space p1, a, prob p1) p2 SUBSET prob_preserving p1 p2``,
+    RW_TAC std_ss [prob_space_def, prob_preserving_def, prob_def, events_def, p_space_def]
+ >> MATCH_MP_TAC MEASURE_PRESERVING_UP_SUBSET
+ >> ASM_REWRITE_TAC []);
+
+val PROB_PRESERVING_UP_SIGMA = store_thm (
+   "PROB_PRESERVING_UP_SIGMA",
+  ``!p1 p2 a.
+       prob_space p1 /\
+       (events p1 = subsets (sigma (p_space p1) a)) ==>
+       prob_preserving (p_space p1, a, prob p1) p2 SUBSET prob_preserving p1 p2``,
+    RW_TAC std_ss [prob_space_def, prob_preserving_def, prob_def, events_def, p_space_def]
+ >> MATCH_MP_TAC MEASURE_PRESERVING_UP_SIGMA
+ >> ASM_REWRITE_TAC []);
 
 val EVENTS = store_thm
 ("EVENTS", ``!a b c. events (a, b, c) = b``,

--- a/src/probability/util_probScript.sml
+++ b/src/probability/util_probScript.sml
@@ -13,15 +13,11 @@ val _ = new_theory "util_prob";
 val S_TAC = rpt (POP_ASSUM MP_TAC) >> rpt RESQ_STRIP_TAC;
 val Strip = S_TAC;
 
-infixr >> >|
-infix 1 >-
-
 fun K_TAC _ = ALL_TAC;
 val KILL_TAC = POP_ASSUM_LIST K_TAC;
 val Know = Q_TAC KNOW_TAC;
 val Suff = Q_TAC SUFF_TAC;
 val POP_ORW = POP_ASSUM (fn thm => ONCE_REWRITE_TAC [thm]);
-
 
 val Cond =
   MATCH_MP_TAC (PROVE [] ``!a b c. a /\ (b ==> c) ==> ((a ==> b) ==> c)``)
@@ -819,12 +815,12 @@ val SUMINF_ADD = store_thm
        summable f /\ summable g ==>
        summable (\n. f n + g n) /\
        (suminf f + suminf g = suminf (\n. f n + g n))``,
-   RW_TAC std_ss []
-   >> Know `f sums suminf f /\ g sums suminf g` >- PROVE_TAC [SUMMABLE_SUM]
+    RW_TAC std_ss []
+ >> ( Know `f sums suminf f /\ g sums suminf g` >- PROVE_TAC [SUMMABLE_SUM]
    >> STRIP_TAC
    >> Know `(\n. f n + g n) sums (suminf f + suminf g)`
    >- RW_TAC std_ss [SER_ADD]
-   >> RW_TAC std_ss [SUMS_EQ]);
+   >> RW_TAC std_ss [SUMS_EQ] ));
 
 val SUMINF_2D = store_thm
   ("SUMINF_2D",


### PR DESCRIPTION
Some probability related scripts has the following historical setup (right-associative THEN and THEN1):

```
infixr >> >|
infix 1 >-
```

Now they're removed with minor changes in the proof of several theorems.

I also added a few new theorems in probabilityTheory, they're ported from version 2 of probability theory (examples/miller/formalize/probabilityScript.sml). they may be needed in the future (when robin-miller algorithm were ported to latest probabilityTheory)