### PR TITLE
Fixed config-override of DOT_PATH in Moscow ML (and Mac OS X)

### DIFF
--- a/src/enumfset/totoTacs.sml
+++ b/src/enumfset/totoTacs.sml
@@ -37,6 +37,8 @@ fun PURE_MATCH_MP f x = MP (PART_MATCH (rand o rator) f (concl x)) x;
 (* seem to need a tripartite equivalent of illegitimate REWR cpn_case_def
    (to avoid searching the whole term with REWRITE_CONV) *)
 
+val cpn_case_def = TypeBase.case_def_of ``:ordering``;
+
 val [LESS_REWR, EQUAL_REWR, GREATER_REWR] = CONJUNCTS cpn_case_def;
 
 (* LESS_REWR = |- !v0 v1 v2.

--- a/tools/configure-mosml.sml
+++ b/tools/configure-mosml.sml
@@ -186,7 +186,7 @@ val dynlib_available = (load "Dynlib"; true) handle _ => false;
 
 print "\n";
 
-val DOT_PATH = "/usr/bin/dot"
+val DOT_PATH = "";
 
 val _ = let
   val override = Path.concat(holdir, "config-override")
@@ -197,7 +197,7 @@ in
   else ()
 end;
 
-
+val DOT_PATH = if DOT_PATH = "" then "/usr/bin/dot" else DOT_PATH;
 
 fun verdict (prompt, value) =
     (print (StringCvt.padRight #" " 20 (prompt^":"));


### PR DESCRIPTION
Mac OS X doesn't ship with the "dot" command, so it's always in a non-standard location, and I always need to override the DOT_PATH variable when building HOL in Mac OS X. But I found the "config-override" of DOT_PATH doesn't work for Moscow ML , unless I change the configure scripts in a way similar with those for Poly/ML.
