### PR TITLE
Move FINITE_BIJ_COUNT_EQ to pred_setTheory to simplify FINITE_BIJ_COUNT

### DIFF
--- a/examples/diningcryptos/extra_pred_setScript.sml
+++ b/examples/diningcryptos/extra_pred_setScript.sml
@@ -386,35 +386,6 @@ val BIJ_INSERT = store_thm
    >> REPEAT STRIP_TAC
    >> METIS_TAC [IN_INSERT]);
 
-val FINITE_BIJ = store_thm
-  ("FINITE_BIJ",
-   ``!f s t. FINITE s /\ BIJ f s t ==> FINITE t /\ (CARD s = CARD t)``,
-   Suff `!s. FINITE s ==> !f t. BIJ f s t ==> FINITE t /\ (CARD s = CARD t)`
-   >- PROVE_TAC []
-   >> HO_MATCH_MP_TAC FINITE_INDUCT
-   >> CONJ_TAC >-
-	(RW_TAC std_ss [BIJ_ALT, FINITE_EMPTY, CARD_EMPTY, IN_FUNSET, NOT_IN_EMPTY]
-	 >> RESQ_TAC
-	 >> FULL_SIMP_TAC std_ss [NOT_IN_EMPTY]
-	 >> `t = {}`
-		by RW_TAC std_ss [EXTENSION, NOT_IN_EMPTY]
-	 >> RW_TAC std_ss [FINITE_EMPTY, CARD_EMPTY])
-   >> NTAC 7 STRIP_TAC
-   >> MP_TAC (Q.SPECL [`f`, `e`, `s`, `t`] BIJ_INSERT)
-   >> ASM_REWRITE_TAC []
-   >> STRIP_TAC
-   >> Know `FINITE u` >- PROVE_TAC []
-   >> STRIP_TAC
-   >> CONJ_TAC >- PROVE_TAC [FINITE_INSERT]
-   >> Q.PAT_X_ASSUM `f e INSERT u = t` (fn th => RW_TAC std_ss [SYM th])
-   >> RW_TAC std_ss [CARD_INSERT]
-   >> PROVE_TAC []);
-
-val FINITE_BIJ_CARD = store_thm
-  ("FINITE_BIJ_CARD",
-   ``!f s t. FINITE s /\ BIJ f s t ==> (CARD s = CARD t)``,
-   PROVE_TAC [FINITE_BIJ]);
-
 val FINITE_MAXIMAL = store_thm
   ("FINITE_MAXIMAL",
    ``!f s. FINITE s /\ ~(s = {}) ==> ?x :: s. !y :: s. (f y:num) <= f x``,
@@ -1452,35 +1423,6 @@ val BIGUNION_IMAGE_INSIDE = store_thm
        BIGUNION (IMAGE (BIGUNION o IMAGE f o g) s)``,
    SET_EQ_TAC
    >> RW_TAC std_ss [IN_BIGUNION_IMAGE, o_THM]
-   >> PROVE_TAC []);
-
-val DISJOINT_ALT = store_thm
-  ("DISJOINT_ALT",
-   ``!s t. DISJOINT s t = !x. x IN s ==> ~(x IN t)``,
-   RW_TAC std_ss [IN_DISJOINT]
-   >> PROVE_TAC []);
-
-val COUNTABLE_COUNT = store_thm
-  ("COUNTABLE_COUNT",
-   ``!n. countable (count n)``,
-   PROVE_TAC [FINITE_COUNT, FINITE_COUNTABLE]);
-
-val FINITE_BIJ_COUNT = store_thm
-  ("FINITE_BIJ_COUNT",
-   ``!s. FINITE s = ?c n. BIJ c (count n) s``,
-   RW_TAC std_ss []
-   >> REVERSE EQ_TAC >- PROVE_TAC [FINITE_COUNT, FINITE_BIJ]
-   >> Q.SPEC_TAC (`s`, `s`)
-   >> HO_MATCH_MP_TAC FINITE_INDUCT
-   >> RW_TAC std_ss [BIJ_DEF, INJ_DEF, SURJ_DEF, NOT_IN_EMPTY]
-   >- (Q.EXISTS_TAC `c`
-       >> Q.EXISTS_TAC `0`
-       >> RW_TAC std_ss [COUNT_ZERO, NOT_IN_EMPTY])
-   >> Q.EXISTS_TAC `\m. if m = n then e else c m`
-   >> Q.EXISTS_TAC `SUC n`
-   >> Know `!x. x IN count n ==> ~(x = n)`
-   >- RW_TAC arith_ss [IN_COUNT]
-   >> RW_TAC std_ss [COUNT_SUC, IN_INSERT]
    >> PROVE_TAC []);
 
 val GCOMPL = store_thm

--- a/examples/diningcryptos/lebesgueScript.sml
+++ b/examples/diningcryptos/lebesgueScript.sml
@@ -346,7 +346,7 @@ val pos_simple_fn_integral_present = store_thm
 		(!i. 0 <= z i) /\ (!i. 0 <= z' i))``,
    RW_TAC std_ss []
    >> `?p n. BIJ p (count n) (s CROSS s')`
-	by FULL_SIMP_TAC std_ss [GSYM FINITE_BIJ_COUNT, pos_simple_fn_def, FINITE_CROSS]
+	by FULL_SIMP_TAC std_ss [GSYM FINITE_BIJ_COUNT_EQ, pos_simple_fn_def, FINITE_CROSS]
    >> `?p'. BIJ p' (s CROSS s') (count n) /\
 	    (!x. x IN (count n) ==> ((p' o p) x = x)) /\
 	    (!x. x IN (s CROSS s') ==> ((p o p') x = x))`
@@ -2546,7 +2546,7 @@ val finite_space_integral_reduce = store_thm
 		(integral m f =
 		 finite_space_integral m f)``,
    REPEAT STRIP_TAC
-   >> `?c n. BIJ c (count n) (IMAGE f (m_space m))` by RW_TAC std_ss [GSYM FINITE_BIJ_COUNT, IMAGE_FINITE]
+   >> `?c n. BIJ c (count n) (IMAGE f (m_space m))` by RW_TAC std_ss [GSYM FINITE_BIJ_COUNT_EQ, IMAGE_FINITE]
    >> `pos_simple_fn m (pos_part f)
 	(count n) (\i. PREIMAGE f {c i} INTER m_space m) (\i. if 0 <= c i then c i else 0) /\
 	pos_simple_fn m (neg_part f)
@@ -2823,7 +2823,7 @@ val finite_space_POW_integral_reduce = store_thm
    >> `f IN borel_measurable (m_space m, measurable_sets m)`
 	by (Q.PAT_X_ASSUM `P = Q` (MP_TAC o GSYM)
 	    >> RW_TAC std_ss [borel_measurable_le_iff, IN_POW, SUBSET_DEF, GSPECIFICATION])
-   >> `?c n. BIJ c (count n) (m_space m)` by RW_TAC std_ss [GSYM FINITE_BIJ_COUNT]
+   >> `?c n. BIJ c (count n) (m_space m)` by RW_TAC std_ss [GSYM FINITE_BIJ_COUNT_EQ]
    >> `pos_simple_fn m (pos_part f)
 	(count n) (\i. {c i}) (\i. if 0 <= f(c i) then f(c i) else 0) /\
 	pos_simple_fn m (neg_part f)

--- a/examples/miller/formalize/extra_pred_setScript.sml
+++ b/examples/miller/formalize/extra_pred_setScript.sml
@@ -1025,25 +1025,7 @@ val COUNTABLE_BIGUNION = store_thm
   ("COUNTABLE_BIGUNION",
    ``!c.
        countable c /\ (!s. s IN c ==> countable s) ==> countable (BIGUNION c)``,
-   RW_TAC std_ss [COUNTABLE_ALT]
-   >> POP_ASSUM
-      (MP_TAC o CONV_RULE (DEPTH_CONV RIGHT_IMP_EXISTS_CONV THENC SKOLEM_CONV))
-   >> MP_TAC NUM_2D_BIJ_INV
-   >> RW_TAC std_ss []
-   >> Q.EXISTS_TAC `(\ (a : num, b : num). f'' (f a) b) o f'`
-   >> RW_TAC std_ss [IN_BIGUNION]
-   >> Q.PAT_X_ASSUM `!x. P x ==> ?y. Q x y` (MP_TAC o Q.SPEC `s`)
-   >> RW_TAC std_ss []
-   >> Q.PAT_X_ASSUM `!x. P x` (MP_TAC o Q.SPEC `f (n : num)`)
-   >> RW_TAC std_ss []
-   >> POP_ASSUM (MP_TAC o Q.SPEC `x`)
-   >> RW_TAC std_ss []
-   >> Q.PAT_X_ASSUM `BIJ f' X Y` MP_TAC
-   >> RW_TAC std_ss [BIJ_DEF, SURJ_DEF, IN_UNIV, IN_CROSS]
-   >> POP_ASSUM (MP_TAC o Q.SPEC `(n, n')`)
-   >> RW_TAC std_ss []
-   >> Q.EXISTS_TAC `y`
-   >> RW_TAC std_ss [o_THM]);
+   PROVE_TAC [bigunion_countable]);
 
 val COUNTABLE_BOOL_LIST = store_thm
   ("COUNTABLE_BOOL_LIST",
@@ -1262,26 +1244,6 @@ val BIGUNION_IMAGE_INSIDE = store_thm
        BIGUNION (IMAGE (BIGUNION o IMAGE f o g) s)``,
    SET_EQ_TAC
    >> RW_TAC std_ss [IN_BIGUNION_IMAGE, o_THM]
-   >> PROVE_TAC []);
-
-(* NOTE: there's already a FINITE_BIJ_COUNT in pred_setTheory with different variable names,
-   but probScript here is very sensible to variable names in FINITE_BIJ_COUNT *)
-val FINITE_BIJ_COUNT = store_thm
-  ("FINITE_BIJ_COUNT",
-   ``!s. FINITE s = ?c n. BIJ c (count n) s``,
-   RW_TAC std_ss []
-   >> REVERSE EQ_TAC >- PROVE_TAC [FINITE_COUNT, FINITE_BIJ]
-   >> Q.SPEC_TAC (`s`, `s`)
-   >> HO_MATCH_MP_TAC FINITE_INDUCT
-   >> RW_TAC std_ss [BIJ_DEF, INJ_DEF, SURJ_DEF, NOT_IN_EMPTY]
-   >- (Q.EXISTS_TAC `c`
-       >> Q.EXISTS_TAC `0`
-       >> RW_TAC std_ss [COUNT_ZERO, NOT_IN_EMPTY])
-   >> Q.EXISTS_TAC `\m. if m = n then e else c m`
-   >> Q.EXISTS_TAC `SUC n`
-   >> Know `!x. x IN count n ==> ~(x = n)`
-   >- RW_TAC arith_ss [IN_COUNT]
-   >> RW_TAC std_ss [COUNT_SUC, IN_INSERT]
    >> PROVE_TAC []);
 
 val GCOMPL = store_thm

--- a/examples/miller/prob/probScript.sml
+++ b/examples/miller/prob/probScript.sml
@@ -1897,7 +1897,7 @@ val INDEP_FN_ENUM_RANGE = store_thm
        (?c n. BIJ c (count n) (range (FST o f)))``,
    REVERSE (RW_TAC std_ss [indep_fn_def, GSPECIFICATION, COUNTABLE_ALT_BIJ])
    >- PROVE_TAC []
-   >> PROVE_TAC [FINITE_BIJ_COUNT]);
+   >> PROVE_TAC [FINITE_BIJ_COUNT_EQ]);
 
 (* |- ∀s. s ∈ events bern ⇒ (prob bern (COMPL s) = 1 − prob bern s) *)
 val PROB_COMPL_BERN = save_thm
@@ -3863,7 +3863,7 @@ val PROB_BERN_BIND_COUNTABLE = store_thm
    >> RW_TAC std_ss [COUNTABLE_ALT_BIJ]
    >- ((MP_TAC o
         Q.ISPEC `range (FST o (f : (num -> bool) -> 'b # (num -> bool)))`)
-       FINITE_BIJ_COUNT
+       FINITE_BIJ_COUNT_EQ
        >> RW_TAC std_ss []
        >> MP_TAC (Q.SPECL [`p`, `f`, `g`, `c'`, `n`] PROB_BERN_BIND_FINITE)
        >> RW_TAC std_ss []

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -3631,31 +3631,27 @@ val FINITE_INDUCT' =
 val NOT_IN_COUNT = Q.prove (`~ (m IN count m)`,
   REWRITE_TAC [IN_COUNT, LESS_REFL]) ;
 
+val FINITE_BIJ_COUNT_EQ = store_thm
+  ("FINITE_BIJ_COUNT_EQ",
+   ``!s. FINITE s = ?c n. BIJ c (count n) s``,
+   RW_TAC std_ss []
+   >> REVERSE EQ_TAC >- PROVE_TAC [FINITE_COUNT, FINITE_BIJ]
+   >> Q.SPEC_TAC (`s`, `s`)
+   >> HO_MATCH_MP_TAC FINITE_INDUCT
+   >> RW_TAC std_ss [BIJ_DEF, INJ_DEF, SURJ_DEF, NOT_IN_EMPTY]
+   >- (Q.EXISTS_TAC `c`
+       >> Q.EXISTS_TAC `0`
+       >> RW_TAC std_ss [COUNT_ZERO, NOT_IN_EMPTY])
+   >> Q.EXISTS_TAC `\m. if m = n then e else c m`
+   >> Q.EXISTS_TAC `SUC n`
+   >> Know `!x. x IN count n ==> ~(x = n)`
+   >- RW_TAC arith_ss [IN_COUNT]
+   >> RW_TAC std_ss [COUNT_SUC, IN_INSERT]
+   >> PROVE_TAC []);
+
 val FINITE_BIJ_COUNT = Q.store_thm ("FINITE_BIJ_COUNT",
   `!s. FINITE s ==> ?f b. BIJ f (count b) s`,
-  GEN_TAC THEN HO_MATCH_MP_TAC FINITE_INDUCT' THEN
-  REPEAT STRIP_TAC THEN1
-    (REWRITE_TAC [BIJ_EMPTY] THEN Q.EXISTS_TAC `0` THEN
-      REWRITE_TAC [COUNT_ZERO]) THEN
-  Q.EXISTS_TAC `\n. if n = b then e else f n` THEN
-  Q.EXISTS_TAC `SUC b` THEN
-  REWRITE_TAC [IN_INSERT, COUNT_SUC, BIJ_DEF, INJ_DEF, SURJ_DEF] THEN
-  BETA_TAC THEN
-  RULE_L_ASSUM_TAC (CONJUNCTS o REWRITE_RULE [BIJ_DEF, INJ_DEF, SURJ_DEF]) THEN
-  REPEAT CONJ_TAC THEN REPEAT GEN_TAC THEN
-  REPEAT COND_CASES_TAC THEN REPEAT BasicProvers.VAR_EQ_TAC THEN
-  REWRITE_TAC [NOT_IN_COUNT] THEN REPEAT STRIP_TAC THEN
-  REPEAT BasicProvers.VAR_EQ_TAC THEN
-  TRY (FIRST_X_ASSUM (fn tha => FIRST_X_ASSUM (fn thb =>
-    let val th = MATCH_MP thb tha in
-      REWRITE_TAC [th] THEN RULE_ASSUM_TAC (REWRITE_RULE [th]) end)) THEN
-      FIRST_ASSUM CONTR_TAC)
-  THENL [ RES_TAC,
-    Q.EXISTS_TAC `b` THEN REWRITE_TAC [],
-    RES_TAC THEN Q.EXISTS_TAC `y` THEN ASM_REWRITE_TAC [] THEN
-    COND_CASES_TAC THEN
-    (REFL_TAC ORELSE REPEAT BasicProvers.VAR_EQ_TAC) THEN
-    IMP_RES_TAC NOT_IN_COUNT]) ;
+   RW_TAC std_ss [FINITE_BIJ_COUNT_EQ]);
 
 fun drop_forall th = if is_forall (concl th) then [] else [th] ;
 

--- a/src/probability/lebesgueScript.sml
+++ b/src/probability/lebesgueScript.sml
@@ -126,7 +126,7 @@ val pos_simple_fn_integral_present = store_thm
 		(BIGUNION (IMAGE c k) = m_space m))``,
    RW_TAC std_ss []
    >> `?p n. BIJ p (count n) (s CROSS s')`
-	by FULL_SIMP_TAC std_ss [GSYM FINITE_BIJ_COUNT, pos_simple_fn_def, FINITE_CROSS]
+	by FULL_SIMP_TAC std_ss [GSYM FINITE_BIJ_COUNT_EQ, pos_simple_fn_def, FINITE_CROSS]
    >> `?p'. BIJ p' (s CROSS s') (count n) /\
 	    (!x. x IN (count n) ==> ((p' o p) x = x)) /\
 	    (!x. x IN (s CROSS s') ==> ((p o p') x = x))`
@@ -621,7 +621,7 @@ val pos_simple_fn_max = store_thm
 	?s'' a'' x''. pos_simple_fn m (\x. max (f x) (g x)) s'' a'' x''``,
   RW_TAC std_ss []
   >> `?p n. BIJ p (count n) (s CROSS s')`
-      by FULL_SIMP_TAC std_ss [GSYM FINITE_BIJ_COUNT, pos_simple_fn_def, FINITE_CROSS]
+      by FULL_SIMP_TAC std_ss [GSYM FINITE_BIJ_COUNT_EQ, pos_simple_fn_def, FINITE_CROSS]
   >> `?p'. BIJ p' (s CROSS s') (count n) /\ (!x. x IN (count n) ==> ((p' o p) x = x)) /\
       (!x. x IN (s CROSS s') ==> ((p o p') x = x))` by (MATCH_MP_TAC BIJ_INV >> RW_TAC std_ss [])
   >> Q.EXISTS_TAC `IMAGE p' (s CROSS s')`
@@ -3136,7 +3136,7 @@ val finite_space_integral_reduce = store_thm
               ==> (integral m f = finite_space_integral m f)``,
   REPEAT STRIP_TAC
   >> `?c1 n. BIJ c1 (count n) (IMAGE f (m_space m))`
-       by RW_TAC std_ss [GSYM FINITE_BIJ_COUNT, IMAGE_FINITE]
+       by RW_TAC std_ss [GSYM FINITE_BIJ_COUNT_EQ, IMAGE_FINITE]
   >> `?c. !i. (i IN count n ==> (c1 i = Normal (c i)))`
        by (Q.EXISTS_TAC `(\i. @r. c1 i = Normal r)`
 	   >> RW_TAC std_ss []
@@ -3286,7 +3286,7 @@ val finite_support_integral_reduce = store_thm
               ==> (integral m f = finite_space_integral m f)``,
   REPEAT STRIP_TAC
   >> `?c1 n. BIJ c1 (count n) (IMAGE f (m_space m))`
-       by RW_TAC std_ss [GSYM FINITE_BIJ_COUNT]
+       by RW_TAC std_ss [GSYM FINITE_BIJ_COUNT_EQ]
   >> `?c. !i. (i IN count n ==> (c1 i = Normal (c i)))`
        by (Q.EXISTS_TAC `(\i. @r. c1 i = Normal r)`
 	   >> RW_TAC std_ss []
@@ -3439,7 +3439,7 @@ val finite_space_POW_integral_reduce = store_thm
         by (RW_TAC std_ss [IN_MEASURABLE_BOREL,IN_FUNSET,IN_UNIV,space_def,subsets_def]
 	    >- FULL_SIMP_TAC std_ss [measure_space_def]
 	    >> METIS_TAC [INTER_SUBSET,IN_POW])
-  >> `?c n. BIJ c (count n) (m_space m)` by RW_TAC std_ss [GSYM FINITE_BIJ_COUNT]
+  >> `?c n. BIJ c (count n) (m_space m)` by RW_TAC std_ss [GSYM FINITE_BIJ_COUNT_EQ]
   >> `FINITE (count n)` by RW_TAC std_ss [FINITE_COUNT]
   >> `?x. !i. (i IN count n ==> (f (c i) = Normal (x i)))`
        by (Q.EXISTS_TAC `(\i. @r. f (c i) = Normal r)`


### PR DESCRIPTION
There's a theorem called `FINITE_BIJ_COUNT` in pred_setTheory since long time ago. It says for any countable set, there exists a bijection from {0, 1, 2, ..., b} to that set:
```
|- !s. FINITE s ==> ?f b. BIJ f (count b) s
```

But actually the stronger equation version also holds: (with more reasonable var names, found in miller and diningcryptos examples:
```
|- !s. FINITE s = ?c n. BIJ c (count n) s
```

I moved this equation theorem into `pred_setTheory` as `FINITE_BIJ_COUNT_EQ`, then the existing proof of `FINITE_BIJ_COUNT` becomes trivial. Total length of `pred_setTheory` decreased slightly, while one more useful theorem added.  The version in miller and diningcryptos examples can be deleted then, with other duplications identified and cleaned up too.

Some uses of `FINITE_BIJ_COUNT` in `lebesgueTheory` should actually be `FINITE_BIJ_COUNT_EQ`, because `GSYM` was called there, and it's only meaningful when calling with an equation theorem.