### PR TITLE
Added TeX notation for O (relation composition)

### DIFF
--- a/src/TeX/holtexbasic.sty
+++ b/src/TeX/holtexbasic.sty
@@ -108,6 +108,7 @@
 \newcommand{\HOLTokenPSubset}{\ensuremath{\subset}}
 \newcommand{\HOLTokenSubmap}{\ensuremath{\sqsubseteq}}
 \newcommand{\HOLTokenCompose}{\ensuremath{\circ}}
+\newcommand{\HOLTokenRCompose}{\ensuremath{\circ_r}}
 \newcommand{\HOLTokenInverse}{\ensuremath{{}^{-1}}}
 \newcommand{\HOLTokenHilbert}{\ensuremath{\varepsilon}}
 \newcommand{\HOLTokenBagLeft}{\ensuremath{\{\!|}}

--- a/src/relation/relationScript.sml
+++ b/src/relation/relationScript.sml
@@ -1754,7 +1754,8 @@ val O_DEF = new_definition(
 val _ = set_fixity "O" (Infixr 800)
 val _ = Unicode.unicode_version {u = UTF8.chr 0x2218 ^ UnicodeChars.sub_r,
                                  tmnm = "O"}
-
+val _ = TeX_notation { hol = UTF8.chr 0x2218 ^ UnicodeChars.sub_r,
+                       TeX = ("\\HOLTokenRCompose{}", 1) }
 
 val inv_O = store_thm(
   "inv_O",


### PR DESCRIPTION
This trivial PR extends previous PR #436, in which the TeX notations for RUNION, RINTER and RSUBSET in relationTheory were added. The TeX notation for big "O" (relation combination) is still missing, as a result, any theorem containing the big "O" cannot be output into TeX files and pass the compiling process.

I added new command `\HOLTokenRCompose`, and of course user can re-define it if they want.