### PR TITLE
Change behavior of MATCH_MP_TAC to fail only when being applied to a goal state

### DIFF
--- a/src/1/Tactic.sml
+++ b/src/1/Tactic.sml
@@ -781,26 +781,26 @@ in
             HOLset.intersection (FVL [concl thm] empty_tmset, hyp_frees thm)
         val hyptyvars = HOLset.listItems (hyp_tyvars thm)
         val (gvs, imp) = strip_forall (concl thm)
-        val (ant, conseq) =
-           with_exn dest_imp imp (ERR "MATCH_MP_TAC" "Not an implication")
-        val (cvs, con) = strip_forall conseq
-        val th1 = SPECL cvs (UNDISCH (SPECL gvs thm))
-        val (vs, evs) = partition (C Term.free_in con) gvs
-        val th2 = uncurry DISCH (itlist efn evs (ant, th1))
       in
-         fn (A, g) =>
-            let
-               val (vs, gl) = strip_forall g
-               val ins = match_terml hyptyvars lconsts con gl
-                         handle HOL_ERR _ => raise ERR "MATCH_MP_TAC" "No match"
-               val ith = INST_TY_TERM ins th2
-               val gth = GENL vs (UNDISCH ith)
-                         handle HOL_ERR _ => raise ERR "MATCH_MP_TAC"
-                                                       "Generalized var(s)."
-               val ant = fst (dest_imp (concl ith))
-            in
-               ([(A, ant)], fn thl => MP (DISCH ant gth) (hd thl))
-            end
+          fn (A,g) =>
+             let
+                 val (ant, conseq) =
+                     with_exn dest_imp imp (ERR "MATCH_MP_TAC" "Not an implication")
+                 val (cvs, con) = strip_forall conseq
+                 val th1 = SPECL cvs (UNDISCH (SPECL gvs thm))
+                 val (vs, evs) = partition (C Term.free_in con) gvs
+                 val th2 = uncurry DISCH (itlist efn evs (ant, th1))
+                 val (vs, gl) = strip_forall g
+                 val ins = match_terml hyptyvars lconsts con gl
+                           handle HOL_ERR _ => raise ERR "MATCH_MP_TAC" "No match"
+                 val ith = INST_TY_TERM ins th2
+                 val gth = GENL vs (UNDISCH ith)
+                           handle HOL_ERR _ => raise ERR "MATCH_MP_TAC"
+                                                     "Generalized var(s)."
+                 val ant = fst (dest_imp (concl ith))
+             in
+                 ([(A, ant)], fn thl => MP (DISCH ant gth) (hd thl))
+             end
       end
    val match_mp_tac = MATCH_MP_TAC
 end


### PR DESCRIPTION
Beforehand the following tactic would fail, even if ACCEPT_TAC succeeds:

    fun simple_apply thm = (ACCEPT_TAC thm) ORELSE (match_mp_tac thm);

Now the tactic only fails, if ACCEPT_TAC failed and match_mp_tac either is not given an implication or cannot match the theorem with the conclusion being matched on.

For more details, see https://sourceforge.net/p/hol/mailman/message/36008112/