### PR TITLE
Fix manual entry of “UNDISCH_TAC”.

### DIFF
--- a/help/Docfiles/Tactic.UNDISCH_TAC.doc
+++ b/help/Docfiles/Tactic.UNDISCH_TAC.doc
@@ -3,25 +3,37 @@
 \TYPE {UNDISCH_TAC : term -> tactic}
 
 \SYNOPSIS
-Undischarges an assumption.
+Undischarges an assumption and deletes all assumptions that are
+alpha-equivalent to it.
 
 \KEYWORDS
 tactic, discharge.
 
 \DESCRIBE
+Let {a1} to {an} be the assumptions that are alpha-equivalent to {v}, then
+{
+               A ?- t
+   ==============================  UNDISCH_TAC v
+    A - {a1, ..., an} ?- v ==> t
+}
+
+In pariticular, if {v} is among the assumptions of the goal and no other
+assumption is alpha-equivalent to it, then {UNDISCH_TAC} behaves as the
+opposite of {DISCH_TAC}:
 {
           A ?- t
    ====================  UNDISCH_TAC v
     A - {v} ?- v ==> t
 }
 
-
 \FAILURE
-{UNDISCH_TAC} will fail if {"v"} is not an assumption.
+{UNDISCH_TAC} fails if no assumption is alpha-equivalent to {v}.
 
 \COMMENTS
-{UNDISCH}arging {v} will remove all assumptions which are identical to {v},
-but those which are alpha-equivalent will remain.
+In the typical use {v} is among the assumptions. If only a single
+assumption alpha-equivalent to {v}, but it is different from {v} then the
+action of {UNDISCH_TAC} can be seen as undischarging followeed by
+alpha-conversion.
 
 \SEEALSO
 Thm.DISCH, Drule.DISCH_ALL, Tactic.DISCH_TAC, Thm_cont.DISCH_THEN, Drule.NEG_DISCH, Tactic.FILTER_DISCH_TAC, Thm_cont.FILTER_DISCH_THEN, Tactic.STRIP_TAC, Drule.UNDISCH, Drule.UNDISCH_ALL.

--- a/help/Docfiles/Tactic.UNDISCH_TAC.doc
+++ b/help/Docfiles/Tactic.UNDISCH_TAC.doc
@@ -32,7 +32,7 @@ opposite of {DISCH_TAC}:
 \COMMENTS
 In the typical use {v} is among the assumptions. If only a single
 assumption alpha-equivalent to {v}, but it is different from {v} then the
-action of {UNDISCH_TAC} can be seen as undischarging followeed by
+action of {UNDISCH_TAC} can be seen as undischarging followed by
 alpha-conversion.
 
 \SEEALSO

--- a/help/Docfiles/Tactic.UNDISCH_TAC.doc
+++ b/help/Docfiles/Tactic.UNDISCH_TAC.doc
@@ -17,7 +17,7 @@ Let {a1} to {an} be the assumptions that are alpha-equivalent to {v}, then
     A - {a1, ..., an} ?- v ==> t
 }
 
-In pariticular, if {v} is among the assumptions of the goal and no other
+In particular, if {v} is among the assumptions of the goal and no other
 assumption is alpha-equivalent to it, then {UNDISCH_TAC} behaves as the
 opposite of {DISCH_TAC}:
 {


### PR DESCRIPTION
Reference: GitHub issue #466
<https://github.com/HOL-Theorem-Prover/HOL/issues/466>.

This contribution (but not future contributions, unless explicitly stated)
is released to the public domain per the CC0 Public Domain Dedication
<https://creativecommons.org/publicdomain/zero/1.0/deed.en>.