### PR TITLE
Add simple snippets to emacs mode

### DIFF
--- a/tools/hol-mode.src
+++ b/tools/hol-mode.src
@@ -2308,4 +2308,9 @@ second is to show the new term.
    '("Start HOL - horizontal split" . hol-horizontal))
 
 (define-key global-map [menu-bar hol-menu hol-process hol-start]
-   '("Start HOL" . hol))
+  '("Start HOL" . hol))
+
+;; Support for snippet expansion, if yasnippet is installed.
+(when (require 'yasnippet nil 'noerror)
+  (let ((HOLsnippets (concat (getenv "HOLDIR") "/tools/yasnippets/")))
+    (setq yas-snippet-dirs (nconc yas-snippet-dirs (cons HOLsnippets '())))))

--- a/tools/hol-mode.src
+++ b/tools/hol-mode.src
@@ -2313,4 +2313,10 @@ second is to show the new term.
 ;; Support for snippet expansion, if yasnippet is installed.
 (when (require 'yasnippet nil 'noerror)
   (let ((HOLsnippets (concat (getenv "HOLDIR") "/tools/yasnippets/")))
-    (setq yas-snippet-dirs (nconc yas-snippet-dirs (cons HOLsnippets '())))))
+    (setq yas-snippet-dirs (nconc yas-snippet-dirs (cons HOLsnippets '())))
+    (yas-reload-all)))
+
+(when (locate-library "company-yasnippet")
+  (load-library "company")
+  (setq company-backends (cons 'company-yasnippet company-backends))
+  (define-key hol-map (kbd "TAB") 'company-yasnippet))

--- a/tools/yasnippets/sml-mode/Cases
+++ b/tools/yasnippets/sml-mode/Cases
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: Automatic case distinction for leading universal quantifier
+# key: Cases
+# expand-env: ((yas-indent-line 'fixed))
+# --
+Cases $0

--- a/tools/yasnippets/sml-mode/Cases_on
+++ b/tools/yasnippets/sml-mode/Cases_on
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: Automatic case distinction for given expression
+# key: Cases_on
+# expand-env: ((yas-indent-line 'fixed))
+# --
+Cases_on \`$1\` $0

--- a/tools/yasnippets/sml-mode/Define
+++ b/tools/yasnippets/sml-mode/Define
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: Definition of functions HOL4
+# key: Define
+# expand-env: ((yas-indent-line 'fixed))
+# --
+val $1_def = Define \`
+  $1 $0 \`;

--- a/tools/yasnippets/sml-mode/Hol_reln
+++ b/tools/yasnippets/sml-mode/Hol_reln
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: Inductive Relation in HOl4
+# key: Hol_reln
+# expand-env: ((yas-indent-line 'fixed))
+# --
+val ($1_rules, $1_ind, $1_cases = Hol_reln \`
+  $0\`;

--- a/tools/yasnippets/sml-mode/Induct
+++ b/tools/yasnippets/sml-mode/Induct
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: Perform induction on first variable behind universal quantifier
+# key: Induct
+# expand-env: ((yas-indent-line 'fixed))
+# --
+Induct

--- a/tools/yasnippets/sml-mode/Induct_on
+++ b/tools/yasnippets/sml-mode/Induct_on
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: Perform induction on given variable
+# key: Induct_on
+# expand-env: ((yas-indent-line 'fixed))
+# --
+Induct_on \`$1\` $0

--- a/tools/yasnippets/sml-mode/Lemma
+++ b/tools/yasnippets/sml-mode/Lemma
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: Lemma statement in HOl4
+# key: Lemma
+# expand-env: ((yas-indent-line 'fixed))
+# --
+val $1 = store_thm (
+  "$1",
+  \`\`$2\`\`,
+  $0
+);

--- a/tools/yasnippets/sml-mode/metis_tac
+++ b/tools/yasnippets/sml-mode/metis_tac
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: Apply first-order prover metis to current goal
+# key: metis_tac
+# expand-env: ((yas-indent-line 'fixed))
+# --
+metis_tac [$1] $0

--- a/tools/yasnippets/sml-mode/once_rewrite_tac
+++ b/tools/yasnippets/sml-mode/once_rewrite_tac
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: rewrite theorems only once
+# key: once_rewrite_tac
+# expand-env: ((yas-indent-line 'fixed))
+# --
+once_rewrite_tac [${1:theorem list}] $0

--- a/tools/yasnippets/sml-mode/qpat_x_assum
+++ b/tools/yasnippets/sml-mode/qpat_x_assum
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: Find first assumption matching pattern, give it to theorem tactic and remove it
+# key: qpat_x_assum
+# expand-env: ((yas-indent-line 'fixed))
+# --
+qpat_x_assum \`${1:term pattern}\` ${2:theorem tactic} $0

--- a/tools/yasnippets/sml-mode/qspecl_then
+++ b/tools/yasnippets/sml-mode/qspecl_then
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: Specialize given theorem based on term list, then give to theorem tactic
+# key: qspecl_then
+# expand-env: ((yas-indent-line 'fixed))
+# --
+qspecl_then [${1:term quotations}] ${2:theorem tactic} ${3:theorem}

--- a/tools/yasnippets/sml-mode/resolve
+++ b/tools/yasnippets/sml-mode/resolve
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: Automatic resolution of a theorem until no resolution possible
+# key: resolve
+# expand-env: ((yas-indent-line 'fixed))
+# --
+drule $1
+\\\\ rpt (disch_then drule)
+\\\\ $0

--- a/tools/yasnippets/sml-mode/rewrite_tac
+++ b/tools/yasnippets/sml-mode/rewrite_tac
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: rewrite theorems only once
+# key: rewrite_tac
+# expand-env: ((yas-indent-line 'fixed))
+# --
+rewrite_tac [${1:theorem list}] $0

--- a/tools/yasnippets/sml-mode/sg
+++ b/tools/yasnippets/sml-mode/sg
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: create a new subgoal prove with corresponding by clause
+# key: sg
+# expand-env: ((yas-indent-line 'fixed))
+# --
+\`${1:subgoal}\`
+  by (
+    $0)


### PR DESCRIPTION
I have been collecting some snippet for the emacs yasnippet plugin that I find helpful when writing down definitions, lemmas or proofs in HOL4 and I thought these may be helpful to some other HOL4 users. I also added a binding for "\M-h Tab" to expand snippets and give suggestions with company mode.

I tried to keep everything such that nothing breaks for any user, if yasnippet or company mode is not installed.  