### PR TITLE
Fixed building of Manual/Description.pdf due to removal of DISJ_ss

### DIFF
--- a/Manual/Description/libraries.stex
+++ b/Manual/Description/libraries.stex
@@ -2596,9 +2596,10 @@ For example, the following \simpset{} fragment will cause
 AC-normalisation of disjunctions
 \begin{hol}
 \begin{verbatim}
-   SSFRAG {ac = [(DISJ_ASSOC, DISJ_COMM)],
-           rewrs = [], filter = NONE, convs = [],
-           dprocs = [], congs = []}
+   SSFRAG {name = NONE,
+           convs = [], rewrs = [], congs = [],
+           filter = NONE, ac = [(DISJ_ASSOC, DISJ_COMM)],
+           dprocs = [] }
 \end{verbatim}
 \end{hol}
 The pair of provided theorems must state
@@ -2614,6 +2615,12 @@ above is bound to the \ML{} identifier \ml{DISJ\_ss}, its behaviour is
 demonstrated in the following example:
 \begin{session}
 \begin{alltt}
+>>__ load "simpLib";
+>>__ open simpLib;
+>>__ val DISJ_ss = SSFRAG {name = NONE,
+           convs = [], rewrs = [], congs = [],
+           filter = NONE, ac = [(DISJ_ASSOC, DISJ_COMM)],
+           dprocs = [] };
 >> SIMP_CONV (bool_ss ++ DISJ_ss) [] ``p /\ q \/ r \/ P z``;
 \end{alltt}
 \end{session}

--- a/Manual/Description/libraries.stex
+++ b/Manual/Description/libraries.stex
@@ -2594,14 +2594,16 @@ field.
 
 For example, the following \simpset{} fragment will cause
 AC-normalisation of disjunctions
-\begin{hol}
-\begin{verbatim}
-   SSFRAG {name = NONE,
+\begin{session}
+\begin{alltt}
+>>__ load "simpLib";
+>>__ open simpLib;
+##eval[DISJ_ss] SSFRAG { name = NONE,
            convs = [], rewrs = [], congs = [],
            filter = NONE, ac = [(DISJ_ASSOC, DISJ_COMM)],
            dprocs = [] }
-\end{verbatim}
-\end{hol}
+\end{alltt}
+\end{session}
 The pair of provided theorems must state
 \begin{eqnarray*}
 x \oplus y &=& y \oplus x\\
@@ -2615,12 +2617,6 @@ above is bound to the \ML{} identifier \ml{DISJ\_ss}, its behaviour is
 demonstrated in the following example:
 \begin{session}
 \begin{alltt}
->>__ load "simpLib";
->>__ open simpLib;
->>__ val DISJ_ss = SSFRAG {name = NONE,
-           convs = [], rewrs = [], congs = [],
-           filter = NONE, ac = [(DISJ_ASSOC, DISJ_COMM)],
-           dprocs = [] };
 >> SIMP_CONV (bool_ss ++ DISJ_ss) [] ``p /\ q \/ r \/ P z``;
 \end{alltt}
 \end{session}


### PR DESCRIPTION
I found HOL document "Description.pdf" can't build in latest GitHub.  It seems that `DISJ_ss` has been recently removed from HOL (?), as a result when manual tries to use it, error returned:

```
libraries.tex                                                       FAILED! <1>
 Exception raised on line 2618: Value or constructor (DISJ_ss) has not been declared
 Fail "Static Errors"
```

solution is to define it in the document and eval more ML code before using `DISJ_ss`.  The syntax of `SSFRAG` seems also changed, and previous definition in document must be modified according to be evaluated correctly in latest HOL.
