### PR TITLE
Added TeX_notation for "++" in listTheory

### DIFF
--- a/src/TeX/holtexbasic.sty
+++ b/src/TeX/holtexbasic.sty
@@ -46,6 +46,7 @@
 \newcommand{\HOLTokenBackslash}{\texttt{\char'134}}
 \newcommand{\HOLTokenTilde}{\texttt{\char'176}}
 \newcommand{\HOLTokenDoubleQuote}{\texttt{\char'42}}
+\newcommand{\HOLTokenDoublePlus}{\ensuremath{\mathbin{+\mkern-10mu+}}}
 \newcommand{\HOLTokenUnderscore}{\texttt{\_}}
 \newcommand{\HOLTokenIn}{\ensuremath{\in}}
 \newcommand{\HOLTokenNotIn}{\ensuremath{\notin}}

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -169,6 +169,8 @@ val _ = export_rewrites ["APPEND"]
 val _ = set_fixity "++" (Infixl 480);
 val _ = overload_on ("++", Term`APPEND`);
 val _ = Unicode.unicode_version {u = UnicodeChars.doubleplus, tmnm = "++"}
+val _ = TeX_notation { hol = UnicodeChars.doubleplus,
+		       TeX = ("\\HOLTokenDoublePlus", 1) }
 
 val FLAT = new_recursive_definition
       {name = "FLAT",


### PR DESCRIPTION
Hi,

The "++" (APPEND) operator has no TeX notation, as a result the theorem containing "++" outputs `UnicodeChars.doubleplus` directly into TeX files and it cannot be correct handled.  There's no other special symbols without TeX notations in `listTheory`.

This PR fixed the issue by adding `\HOLTokenDoublePlus` with a valid definition that I found on Internet [https://tex.stackexchange.com/questions/4194/how-to-typeset-haskell-operator-and-friends].

Chun Tian