### PR TITLE
hol-mode: Fix cleanup of leading connectives in "Apply tactic"

### DIFF
--- a/tools/hol-mode.src
+++ b/tools/hol-mode.src
@@ -467,9 +467,9 @@ With a prefix ARG, uses `expandf' rather than `e'."
   "Send selected region to HOL process as tactic."
   (interactive "r\nP")
   (let*
-      ((region-string0 (with-hol-locpragma start (buffer-substring start end)))
+      ((region-string0 (tactic-cleanup (buffer-substring start end)))
+       (region-string1 (with-hol-locpragma start region-string0))
        (ste "\"show_typecheck_errors\"")
-       (region-string1 (tactic-cleanup region-string0))
        (region-string (concat "let val old = Feedback.current_trace "
                               ste
                               " val _ = Feedback.set_trace "

--- a/tools/hol-mode.src
+++ b/tools/hol-mode.src
@@ -434,15 +434,21 @@ how long this took."
   "[[:space:]]*\\(THEN1\\|THENL\\|THEN\\|>>\\|>|\\|>-\\|\\\\\\\\\\)[[:space:]]*[[(]?"
   "Regular expression for strings used to put tactics together.")
 
-(defun tactic-cleanup (string)
-  "Remove trailing and leading instances of tactic connectives from a string.
+(defun tactic-cleanup-leading (string)
+  "Remove leading instances of tactic connectives from a string.
 A tactic connective is any one of \"THEN\", \"THENL\", \"THEN1\", \">>\", \">|\"
 or \">-\"."
   (let* ((case-fold-search nil)
-         (s0 (replace-regexp-in-string (concat "\\`" tactic-connective-regexp)
-                                      ""
-                                      string)))
-    (replace-regexp-in-string (concat tactic-connective-regexp "\\'") "" s0)))
+         (pattern (concat "\\`" tactic-connective-regexp)))
+    (replace-regexp-in-string pattern "" string)))
+
+(defun tactic-cleanup-trailing (string)
+  "Remove trailing instances of tactic connectives from a string.
+A tactic connective is any one of \"THEN\", \"THENL\", \"THEN1\", \">>\", \">|\"
+or \">-\"."
+  (let* ((case-fold-search nil)
+         (pattern (concat tactic-connective-regexp "\\'")))
+    (replace-regexp-in-string pattern "" string)))
 
 (defun hol-find-eval-next-tactic (arg)
   "Highlights the next tactic in the source and evaluates in the HOL buffer.
@@ -467,15 +473,18 @@ With a prefix ARG, uses `expandf' rather than `e'."
   "Send selected region to HOL process as tactic."
   (interactive "r\nP")
   (let*
-      ((region-string0 (tactic-cleanup (buffer-substring start end)))
-       (region-string1 (with-hol-locpragma start region-string0))
+      ((region-string0 (buffer-substring start end))
+       (region-string1 (tactic-cleanup-leading region-string0))
+       (region-string2 (tactic-cleanup-trailing region-string1))
+       (start-offset (- (length region-string0) (length region-string1)))
+       (region-string3 (with-hol-locpragma (+ start start-offset) region-string2))
        (ste "\"show_typecheck_errors\"")
        (region-string (concat "let val old = Feedback.current_trace "
                               ste
                               " val _ = Feedback.set_trace "
                               ste
                               " 0 in ("
-                              region-string1
+                              region-string3
                               ") before "
                               "Feedback.set_trace " ste " old end"))
        (e-string (concat "proofManagerLib." (if arg "expandf" "e")))


### PR DESCRIPTION
The bug was caused by a location pragma being prepended before
cleaning up the tactic string. Reversing the order of those operations seems to fix it.