### PR TITLE
Add Holmake support for the 'shell' function

### DIFF
--- a/tools/Holmake/internal_functions.sml
+++ b/tools/Holmake/internal_functions.sml
@@ -268,10 +268,21 @@ fun shell arg =
   let
     open Unix
 
-    val nl2spc = String.map (fn c => if c = #"\n" then #" " else c)
+    (* TODO This gets rid of all carriage returns; should only replace
+       those paired with a newline *)
+    fun fix_nls s =
+      let
+        val s = String.translate (fn c => if c = #"\r" then "" else String.str c) s
+        val s = if String.isSuffix "\n" s then
+                  String.substring (s, 0, String.size s - 1)
+                else s
+      in
+        String.map (fn c => if c = #"\n" then #" " else c) s
+      end
+
     val proc = execute ("/bin/sh", ["-c", arg])
     val ins = textInstreamOf proc
-    val str = nl2spc (TextIO.inputAll ins)
+    val str = fix_nls (TextIO.inputAll ins)
   in
     if OS.Process.isSuccess (reap proc) then str else ""
   end

--- a/tools/Holmake/internal_functions.sml
+++ b/tools/Holmake/internal_functions.sml
@@ -286,7 +286,7 @@ fun shell arg =
   in
     if OS.Process.isSuccess (reap proc) then str else ""
   end
-  handle OS.SysErr _ => "failure"
+  handle OS.SysErr _ => ""
 
 fun function_call (fnname, args, eval) = let
   open Substring

--- a/tools/Holmake/internal_functions.sml
+++ b/tools/Holmake/internal_functions.sml
@@ -264,6 +264,19 @@ fun which arg =
     | NONE => if isUnix then "" else smash (check ".")
   end
 
+fun shell arg =
+  let
+    open Unix
+
+    val nl2spc = String.map (fn c => if c = #"\n" then #" " else c)
+    val proc = execute ("/bin/sh", ["-c", arg])
+    val ins = textInstreamOf proc
+    val str = nl2spc (TextIO.inputAll ins)
+  in
+    if OS.Process.isSuccess (reap proc) then str else ""
+  end
+  handle OS.SysErr _ => "failure"
+
 fun function_call (fnname, args, eval) = let
   open Substring
 in
@@ -334,6 +347,13 @@ in
                   in
                     spacify (wildcard arg_evalled)
                   end
+  | "shell" => if length args <> 1 then
+                 raise Fail "Bad number of arguments to 'shell' function"
+               else let
+                 val arg_evalled = eval (hd args)
+               in
+                  shell arg_evalled
+               end
   | _ => raise Fail ("Unknown function name: "^fnname)
 end
 


### PR DESCRIPTION
Adds Holmake support for the 'shell' command (see [GNU make manual](https://www.gnu.org/software/make/manual/make.html#Shell-Function)). 

Writing
```
VAR=$(shell ls -lah)
```
executes `/bin/sh -c "ls -lah"` and assigns the output of the command to `VAR`.