### PR TITLE
HOL(y) Hammer OCaml 4.06.0 support

### DIFF
--- a/src/holyhammer/README
+++ b/src/holyhammer/README
@@ -9,11 +9,7 @@ Requires:
 
     opam install num
 
-* g++ >= 4.8 (recent version with C++11 support)  
-    Ubuntu 12.04:
-    sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-    sudo apt-get update
-    sudo apt-get install g++-4.8
+* g++ >= 4.8 (with C++11 support)
 
 Install holyhammer: (done during the build)
  

--- a/src/holyhammer/README
+++ b/src/holyhammer/README
@@ -2,8 +2,13 @@ HOLyHammer is a machine learning for theorem proving framework.
 
 Requires:
 
-* OCaml >= 3.12
-    sudo apt-get install ocaml 
+* OCaml >= 3.12, ocamlfind, and the OCaml package num
+
+    As of OCalm 4.06.0, the num package is no longer part of the compiler itself,
+    and must be installed separately. This can be done using e.g. OPAM:
+
+    opam install num
+
 * g++ >= 4.8 (recent version with C++11 support)  
     Ubuntu 12.04:
     sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y

--- a/src/holyhammer/README
+++ b/src/holyhammer/README
@@ -12,7 +12,7 @@ Requires:
 * g++ >= 4.8 (with C++11 support)
 
 Install holyhammer: (done during the build)
- 
+
   run Holmake in src/holyhammer
   run Holmake in src/holyhammer/hh/hh1
   run Holmake in src/holyhammer/hh
@@ -20,29 +20,29 @@ Install holyhammer: (done during the build)
   run Holmake in src/holyhammer/predict/mepo
 
 Provers: Eprover(1.8 1.9 2.0), Z3 (4.0)
-  
-  Binaries with the appropriate version should be copied or linked 
-  in the directory src/holyhammer/provers. 
+
+  Binaries with the appropriate version should be copied or linked
+  in the directory src/holyhammer/provers.
   Make sure you have the permission to execute them.
   Their names should respectively be eprover and z3.
 
-  Eprover 2.0 : http://wwwlehre.dhbw-stuttgart.de/~sschulz/E/E.html.
-  Z3 4.0 (not 4.4.0): http://isabelle.in.tum.de/components/ .
-  
+  Eprover 2.0: http://wwwlehre.dhbw-stuttgart.de/~sschulz/E/E.html
+  Z3 4.0 (not 4.4.0): http://isabelle.in.tum.de/components/
+
 Predictors:
 
-  The two best predictors are KNN and Mepo. The default predictor is KNN. 
+  The two best predictors are KNN and Mepo. The default predictor is KNN.
   - Mepo works best when your conjecture has rare symbols.
   - KNN learns from previous proofs.
-   
-Example: 
+
+Example:
 
   load "holyHammer";
   open holyHammer;
   hh [] ``1 + 1 = 2``;
-  METIS_PROVE lemmas ``1 + 1 = 2``; 
+  METIS_PROVE lemmas ``1 + 1 = 2``;
 
 Questions:
 
-  If you have any question, you can send an email to 
+  If you have any question, you can send an email to
   thibault.gauthier@uibk.ac.at.

--- a/src/holyhammer/hh/Holmakefile
+++ b/src/holyhammer/hh/Holmakefile
@@ -1,7 +1,5 @@
 .PHONY: all
 
-ifneq ($(which ocamlopt),)
-
 INCLUDES = hh1
 HH2_CMX=toolbox.cmx hh_parse.cmx hh_lexer.cmx read.cmx predict.cmx preprocess.cmx init.cmx \
 dependency.cmx thf1hh1.cmx features.cmx prepredict.cmx write.cmx
@@ -16,12 +14,17 @@ ALL_CMX=$(HL_CMX) $(HH2_CMX)
 
 EXTRA_CLEANS = $(HH2_CMX) $(patsubst %.cmx,%.cmi,$(HH2_CMX)) $(patsubst %.cmx,%.o,$(HH2_CMX)) hh_parse.ml hh_lexer.ml main.cmi main.cmx main.o hh
 
+OCAMLOPT=ocamlfind ocamlopt -package num -unsafe-string
 
+ifneq ($(which ocamlfind),)
+# Assume we have ocamlopt if we have ocamlfind
+
+ifeq ($(shell ocamlfind query num > /dev/null 2>&1; echo $$?),0)
 
 all: $(HH2_CMX) hh
 
 hh: main.ml $(ALL_CMX)
-	ocamlopt nums.cmxa str.cmxa unix.cmxa -o $@ -I hh1 $(ALL_CMX) $<
+	$(OCAMLOPT) nums.cmxa str.cmxa unix.cmxa -o $@ -I hh1 $(ALL_CMX) $<
 
 hh_parse.ml: hh_parse.mly
 	ocamlyacc $<
@@ -31,33 +34,40 @@ hh_lexer.ml: hh_lexer.mll hh_parse.ml
 	ocamllex $<
 
 toolbox.cmi toolbox.cmx: toolbox.ml
-	ocamlopt -c -I hh1 $<
+	$(OCAMLOPT) -c -I hh1 $<
 hh_parse.cmi hh_parse.cmx: hh_parse.ml
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 hh_lexer.cmi hh_lexer.cmx: hh_lexer.ml hh_parse.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 read.cmi read.cmx: read.ml hh_parse.cmi hh_lexer.cmi
-	ocamlopt -c -I hh1 $<
+	$(OCAMLOPT) -c -I hh1 $<
 predict.cmi predict.cmx: predict.ml toolbox.cmi
-	ocamlopt -c -I hh1 $<
+	$(OCAMLOPT) -c -I hh1 $<
 preprocess.cmi preprocess.cmx: preprocess.ml hh_parse.cmi
-	ocamlopt -c -I hh1 $<
+	$(OCAMLOPT) -c -I hh1 $<
 init.cmi init.cmx: init.ml hh_parse.cmi preprocess.cmi read.cmi
-	ocamlopt -c -I hh1 $<
+	$(OCAMLOPT) -c -I hh1 $<
 dependency.cmi dependency.cmx: dependency.ml read.cmi
-	ocamlopt -c -I hh1 $<
+	$(OCAMLOPT) -c -I hh1 $<
 thf1hh1.cmi thf1hh1.cmx: thf1hh1.ml hh_parse.cmi
-	ocamlopt -c -I hh1 $<
+	$(OCAMLOPT) -c -I hh1 $<
 features.cmi features.cmx: features.ml thf1hh1.cmi init.cmi
-	ocamlopt -c -I hh1 $<
+	$(OCAMLOPT) -c -I hh1 $<
 prepredict.cmx: prepredict.ml features.cmi predict.cmi
-	ocamlopt -c -I hh1 $<
+	$(OCAMLOPT) -c -I hh1 $<
 write.cmx: write.ml hh_parse.cmi thf1hh1.cmi dependency.cmi
-	ocamlopt -c -I hh1 $<
+	$(OCAMLOPT) -c -I hh1 $<
 
 else
 
 all:
-	@echo "No OCaml installation found -- giving up on hh"
+	@echo "No num OCaml package found -- giving up on hh"
+
+endif
+
+else
+
+all:
+	@echo "No ocamlfind found -- giving up on hh"
 
 endif

--- a/src/holyhammer/hh/hh1/Holmakefile
+++ b/src/holyhammer/hh/hh1/Holmakefile
@@ -4,57 +4,69 @@ FILES_CMX=lib.cmx fusion.cmx basics.cmx printer.cmx preterm.cmx hl_parser.cmx eq
 
 EXTRA_CLEANS = $(FILES_CMX) $(patsubst %.cmx,%.cmi,$(FILES_CMX)) $(patsubst %.cmx,%.o,$(FILES_CMX))
 
-ifneq($(which ocamlopt),)
+OCAMLOPT=ocamlfind ocamlopt -package num -unsafe-string
+
+ifneq ($(which ocamlfind),)
+# Assume we have ocamlopt if we have ocamlfind
+
+ifeq ($(shell ocamlfind query num > /dev/null 2>&1; echo $$?),0)
 
 all: $(FILES_CMX)
 
 lib.cmi lib.cmx: lib.ml
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 fusion.cmi fusion.cmx: fusion.ml lib.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 basics.cmi basics.cmx: basics.ml fusion.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 printer.cmi printer.cmx: printer.ml lib.cmi fusion.cmi basics.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 preterm.cmi preterm.cmx: preterm.ml fusion.cmi printer.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 hl_parser.cmi hl_parser.cmx: hl_parser.ml printer.cmi preterm.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 equal.cmx: equal.ml lib.cmi fusion.cmi preterm.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 bool.cmi bool.cmx: bool.ml printer.cmi preterm.cmi hl_parser.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 drule.cmi drule.cmx: drule.ml bool.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 tactics.cmi tactics.cmx: tactics.ml fusion.cmi basics.cmi printer.cmi \
                          hl_parser.cmi bool.cmi drule.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 simp.cmi simp.cmx: simp.ml fusion.cmi basics.cmi hl_parser.cmi drule.cmi \
                    tactics.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 theorems.cmi theorems.cmx: theorems.ml hl_parser.cmi bool.cmi simp.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 canon.cmi canon.cmx: canon.ml fusion.cmi basics.cmi hl_parser.cmi bool.cmi \
                      drule.cmi simp.cmi theorems.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 fol.cmx: fol.ml basics.cmi bool.cmi simp.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 follist.cmi follist.cmx: follist.ml basics.cmi simp.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 meson.cmx: meson.ml follist.cmi canon.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 hh_symbols.cmx: hh_symbols.ml fusion.cmi printer.cmi bool.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 features_dt.cmx: features_dt.ml basics.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 hh_tac.cmi hh_tac.cmx: hh_tac.ml hl_parser.cmi simp.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 hh_write.cmx: hh_write.ml basics.cmi bool.cmi tactics.cmi simp.cmi hh_tac.cmi
-	ocamlopt -c $<
+	$(OCAMLOPT) -c $<
 
 else
 
 all:
-	@echo "No OCaml detected -- giving up"
+	@echo "No num OCaml package found -- giving up on hh"
+
+endif
+
+else
+
+all:
+	@echo "No ocamlfind found -- giving up on hh"
 
 endif


### PR DESCRIPTION
Some simple Makefile fixes for hh to compile with OCaml 4.06.0.

Not sure how far back the -unsafe-string flag goes, so might break compatibility with very old OCaml versions. We also depend on ocamlfind being installed now, which was not the case previously.