### PR TITLE
Use the Unicode turnstile (user-customizable) when printing theorems

### DIFF
--- a/Manual/Tools/expected1
+++ b/Manual/Tools/expected1
@@ -18,14 +18,14 @@ val it =
 > open arithmeticTheory;\quad\textit{\small\dots{}output elided\dots{}}
 > ADD_CLAUSES;
 val it =
-   |- (0 + m = m) \(\land\) (m + 0 = m) \(\land\) (SUC m + n = SUC (m + n)) \(\land\)
-   (m + SUC n = SUC (m + n)):
+   \(\turn\) (0 + m = m) \(\land\) (m + 0 = m) \(\land\) (SUC m + n = SUC (m + n)) \(\land\)
+  (m + SUC n = SUC (m + n)):
    thm
 
 > load "bagTheory";
 val it = (): unit
 > bagTheory.BAG_IN_BAG_INSERT;
-val it = |- \(\forall\)b e1 e2. e1 <: BAG_INSERT e2 b \({\iff}\) (e1 = e2) \(\lor\) e1 <: b:
+val it = \(\turn\) \(\forall\)b e1 e2. e1 <: BAG_INSERT e2 b \({\iff}\) (e1 = e2) \(\lor\) e1 <: b:
    thm
 
 This case illustrates an interesting issue: the HOL system itself writes a message to standard out; we'd like to capture this so that it is properly sequenced with the other output.
@@ -103,9 +103,9 @@ val it =
 "foo",
 ``p /\bs{} q ==> p``,
 strip_tac);
-val foo = |- p \(\land\) q \(\Rightarrow\) p: thm
+val foo = \(\turn\) p \(\land\) q \(\Rightarrow\) p: thm
 > foo;
-val it = |- p \(\land\) q \(\Rightarrow\) p: thm
+val it = \(\turn\) p \(\land\) q \(\Rightarrow\) p: thm
 x /\bs{} y
 \(\alpha\) list
 :'a list

--- a/Manual/Tools/umap
+++ b/Manual/Tools/umap
@@ -25,6 +25,7 @@
 ⋙ \(>\!\!>\!\!>\)
 ₊ \({}\sb{+}\)
 ∅ \(\emptyset\)
+⊢ \(\turn\)
 “ \mbox{\textrm{``}}
 ” \mbox{\textrm{''}}
 ‘ \mbox{\textrm{`}}

--- a/src/parse/Parse.sml
+++ b/src/parse/Parse.sml
@@ -452,8 +452,9 @@ fun pp_thm ppstrm th =
                   add_break(1,0);
                   pp_terms sa asl; add_break(1,0)
                  );
-            add_string "|- ";
-            pp_term (concl th)
+            add_string (!Globals.thm_pp_prefix);
+            pp_term (concl th);
+            add_string (!Globals.thm_pp_suffix)
          end;
     end_block()
  end;

--- a/src/parse/type_pp.sml
+++ b/src/parse/type_pp.sml
@@ -16,13 +16,17 @@ val avoid_unicode = ref (Systeml.OS = "winNT")
 local
   open Globals
   fun ascii_delims () =
-    List.app (fn r => r := "``") [type_pp_prefix, type_pp_suffix,
-                                  term_pp_prefix, term_pp_suffix]
+    (List.app (fn r => r := "``") [type_pp_prefix, type_pp_suffix,
+                                   term_pp_prefix, term_pp_suffix];
+     thm_pp_prefix := "|- ";
+     thm_pp_suffix := "")
   fun unicode_delims () =
     (List.app (fn r => r := UnicodeChars.ldquo)
               [type_pp_prefix, term_pp_prefix];
      List.app (fn r => r := UnicodeChars.rdquo)
-              [type_pp_suffix, term_pp_suffix])
+              [type_pp_suffix, term_pp_suffix];
+     thm_pp_prefix := UnicodeChars.turnstile ^ " ";
+     thm_pp_suffix := "")
   fun avoidset i = if i = 0 then (unicode_delims(); avoid_unicode := false)
                    else (ascii_delims(); avoid_unicode := true)
   fun avoidget () = if !avoid_unicode then 1 else 0

--- a/src/prekernel/Globals.sig
+++ b/src/prekernel/Globals.sig
@@ -18,6 +18,8 @@ sig
   val type_pp_suffix          : string ref
   val term_pp_prefix          : string ref
   val term_pp_suffix          : string ref
+  val thm_pp_prefix           : string ref
+  val thm_pp_suffix           : string ref
   val goal_line               : string ref
   val old                     : string -> string
   val pp_flags                : {show_types         : bool ref,

--- a/src/prekernel/Globals.sml
+++ b/src/prekernel/Globals.sml
@@ -67,6 +67,7 @@ val output_HOL_ERR = ref outHOL_ERR_default
 
 val type_pp_prefix = ref "`" and type_pp_suffix = ref "`"
 val term_pp_prefix = ref "`" and term_pp_suffix = ref "`"
+val thm_pp_prefix = ref "|- " and thm_pp_suffix = ref ""
 
 (*---------------------------------------------------------------------------*
  * Tells the prettyprinters how wide the page is.                            *


### PR DESCRIPTION
When the trace “Unicode” is changed to 1 or 0 the theorem prefix is set to “⊢”
or the ASCII approximation “|-”, respectively. The prefix and suffix (empty by
default) can be customized via Globals.{thm_pp_prefix,thm_pp_suffix}.