### PR TITLE
Include Abbrev in dep_rewrite

### DIFF
--- a/src/1/dep_rewrite.sig
+++ b/src/1/dep_rewrite.sig
@@ -149,12 +149,7 @@
 
 signature dep_rewrite =
 sig
-type term = Term.term
-type fixity = Parse.fixity
-type thm = Thm.thm
-type tactic  = Abbrev.tactic
-type conv = Abbrev.conv
-type thm_tactic = Abbrev.thm_tactic
+include Abbrev
 
 
 (* ================================================================== *)

--- a/src/1/dep_rewrite.sml
+++ b/src/1/dep_rewrite.sml
@@ -143,13 +143,10 @@
 structure dep_rewrite :> dep_rewrite =
 struct
 
-open HolKernel Parse boolLib;
+open HolKernel Parse boolLib Abbrev;
 infix THEN THENL THENC ORELSE ORELSEC THEN_TCL ORELSE_TCL ## |->;
 infixr -->;
 
-type term = Term.term
-type fixity = Parse.fixity
-type thm = Thm.thm;
 
 
 
@@ -408,8 +405,6 @@ fun TAC_DEP tac = fn (asl,gl) =>
 
 
 (* DEP_TAC turns a dependent rewriting function into a tactic. *)
-
-type validation = Thm.thm list -> Thm.thm;
 
 fun DEP_TAC dep :tactic = fn g0 =>
     let val (asl1,gls,(pls:validation list),(gl2:goal list),(p2:validation))


### PR DESCRIPTION
Just a micro fix, before this fix this happened (not sure why exactly):

```
> rw [];
val it = fn: tactic

> open dep_rewrite;
[...]

> rw [];
val it = fn: bossLib.tactic
```