### PR TITLE
Words theory tex fixes

### DIFF
--- a/Manual/Description/description.tex
+++ b/Manual/Description/description.tex
@@ -7,7 +7,6 @@
 \usepackage{latexsym}
 %\usepackage{amsmath}
 \usepackage{amssymb}
-\usepackage{stix}
 %\usepackage{amsbsy}
 %\usepackage{amsthm}
 \usepackage{makeidx}

--- a/Manual/LaTeX/layout.sty
+++ b/Manual/LaTeX/layout.sty
@@ -36,8 +36,12 @@
 % FONT
 % ---------------------------------------------------------------------
 
+\usepackage{stix}
 \renewcommand{\rmdefault}{bch}
 \def\@pnumwidth{8mm}
+
+\usepackage{microtype}
+\DisableLigatures{encoding = T1, family = tt*}
 
 % ---------------------------------------------------------------------
 % MATH INDENTATION.  = \tabcolsep + three small verbatim spaces  (!)


### PR DESCRIPTION
This PR is an unsatisfactory workaround for a LaTeX problem occuring in the documentation for words theory.

The package stix enable T1 font encoding, which apparently enables ligatures inside ``holtxt``s. I think the proper fix to this is to use XeTeX instead of standard LaTeX because XeTeX is able to handle ligatures correctly (i.e., they are enabled outside ``holtxt``s but not inside). (But using XeTeX requires some porting work, mainly how fonts are selected/loaded I think.) One alternative workaround is to not use T1 font encoding (e.g., by saying notext to the stix package), another workaround is to use the microtype package and tell it to disable ligatures inside ``holtxt``s (but this has other consequences). (One should note that ``'``s are seemingly always pretty-printed inside ``holtxt``s regardless of standard-LaTeX-based workaround -- this is correctly handled by XeTeX also.) Because of all this complexity I did the simplest workaround possible...