### PR TITLE
Fix HOL mode emacs snippets not being loaded correctly, if the HOLDIR environment variable is not set

### DIFF
--- a/tools/hol-mode.src
+++ b/tools/hol-mode.src
@@ -2321,11 +2321,14 @@ second is to show the new term.
 
 ;; Support for snippet expansion, if yasnippet is installed.
 (when (require 'yasnippet nil 'noerror)
-  (let ((HOLsnippets (concat (getenv "HOLDIR") "/tools/yasnippets/")))
+  (let ((HOLsnippets
+         (concat
+          (string-remove-suffix "/bin/hol" hol-executable)
+          "/tools/yasnippets" "")))
     (setq yas-snippet-dirs (nconc yas-snippet-dirs (cons HOLsnippets '())))
-    (yas-reload-all)))
+    (yas-reload-all)
+    (define-key hol-map (kbd "TAB") 'yas-expand)))
 
 (when (locate-library "company-yasnippet")
   (load-library "company")
-  (setq company-backends (cons 'company-yasnippet company-backends))
-  (define-key hol-map (kbd "TAB") 'company-yasnippet))
+  (setq company-backends (cons 'company-yasnippet company-backends)))


### PR DESCRIPTION
I found out that I missed that on some platforms `HOLDIR` might not be set when starting emacs. 
Consequently snippets could not be used on these. This should fix this issue.