### PR TITLE
Emacs HOL mode fix, need subr-x for string-remove-suffix

### DIFF
--- a/tools/hol-mode.src
+++ b/tools/hol-mode.src
@@ -10,7 +10,7 @@
 
 (require 'thingatpt)
 (require 'cl)
-
+(require 'subr-x)
 
 (defgroup hol nil
   "Customising the Emacs interface to the HOL4 proof assistant."


### PR DESCRIPTION
PR #520 calls `string-remove-suffix` without requiring `subr-x`. My Emacs crashes saying that "I do not know what that function is" with the current code. I don't know anything about Emacs Lisp but this PR seems to fix it.