### PR TITLE
Added (require 'subr-x) for the use of `string-remove-suffix`

### DIFF
--- a/tools/hol-mode.src
+++ b/tools/hol-mode.src
@@ -11,6 +11,8 @@
 (require 'thingatpt)
 (require 'cl)
 
+;; Built-in library since Emacs 24.4, providing `string-remove-suffix`
+(require 'subr-x)
 
 (defgroup hol nil
   "Customising the Emacs interface to the HOL4 proof assistant."


### PR DESCRIPTION
Hi,

recently after updating to latest HOL, my Emacs cannot startup, due to the following error:

```
concat: Symbol’s function definition is void: string-remove-suffix
```

The function `string-remove-suffix` is used at the end of HOL's `hol-mode.el`. It's a new string manipulation function firstly introduced in Emacs 24.4 [1], provided by built-in library `subr-x`. But if this library is not required by any package currently loading in Emacs, an error like above will be thrown.

This PR simply added `(require 'subr-x)` into `hol-mode.el (.src)`.

[1] http://emacsredux.com/blog/2014/02/02/a-peek-at-emacs-24-dot-4-new-string-manipulation-functions/
