### PR TITLE
[CCS] fixed 3 broken lemmas due to changes of irule in d2d6d792.

### DIFF
--- a/examples/CCS/ExampleScript.sml
+++ b/examples/CCS/ExampleScript.sml
@@ -186,6 +186,21 @@ val List_eq_coList = store_thm (
    "List_eq_coList", ``!l. coList l = List l``,
     PROVE_TAC [List_imp_coList, coList_imp_List]);
 
+(******************************************************************************)
+(*                                                                            *)
+(*                        Example used in presentation                        *)
+(*                                                                            *)
+(******************************************************************************)
+
+local
+    val (temp_A, trans) = CCS_TRANS ``label (name "a")..nil || label (coname "a")..nil``;
+    val nodes = map (fn (l, s) => CCS_TRANS s) trans;
+in
+  val ex_A = save_thm ("ex_A", temp_A);
+  val [ex_A1, ex_A2, ex_A3] = map (fn (n, (thm, _)) => save_thm (n, thm))
+				(combine (["ex_A1", "ex_A2", "ex_A3"], nodes))
+end;
+
 val _ = export_theory ();
 val _ = html_theory "Example";
 

--- a/examples/CCS/UniqueSolutionsScript.sml
+++ b/examples/CCS/UniqueSolutionsScript.sml
@@ -1304,7 +1304,7 @@ val unfolding_lemma1 = store_thm (
     rpt STRIP_TAC
  >> REWRITE_TAC [o_DEF]
  >> BETA_TAC
- >> irule contracts_SUBST_GCONTEXT >- art []
+ >> irule contracts_SUBST_GCONTEXT >> art []
  >> Q.SPEC_TAC (`n`, `n`)
  >> Induct >- REWRITE_TAC [FUNPOW, contracts_REFL]
  >> REWRITE_TAC [FUNPOW_SUC]
@@ -1666,7 +1666,7 @@ val unfolding_lemma1' = store_thm (
     rpt STRIP_TAC
  >> REWRITE_TAC [o_DEF]
  >> BETA_TAC
- >> irule expands_SUBST_GCONTEXT >- art []
+ >> irule expands_SUBST_GCONTEXT >> art []
  >> Q.SPEC_TAC (`n`, `n`)
  >> Induct >- REWRITE_TAC [FUNPOW, expands_REFL]
  >> REWRITE_TAC [FUNPOW_SUC]
@@ -1897,7 +1897,7 @@ val OBS_unfolding_lemma1 = store_thm (
     rpt STRIP_TAC
  >> REWRITE_TAC [o_DEF]
  >> BETA_TAC
- >> irule OBS_contracts_SUBST_CONTEXT >- art []
+ >> irule OBS_contracts_SUBST_CONTEXT >> art []
  >> Q.SPEC_TAC (`n`, `n`)
  >> Induct >- REWRITE_TAC [FUNPOW, OBS_contracts_REFL]
  >> REWRITE_TAC [FUNPOW_SUC]


### PR DESCRIPTION
Hi,

I found 3 lemmas in CCS example were broken after changes of irule in d2d6d792. This PR fixed them with minor changes. (plus a small, irrelevant piece of additions in example code, aligned with my thesis presentation file)

Regards,

Chun
