### PR TITLE
Fixed building of HOL Reference under TeXlive 2018

### DIFF
--- a/Manual/Reference/reference.tex
+++ b/Manual/Reference/reference.tex
@@ -3,13 +3,21 @@
 % =====================================================================
 
 \documentclass[12pt,fleqn]{book}
+
+%  Font related packages
+\usepackage[utf8x]{inputenc}
+\usepackage[T1]{fontenc}        % This is necessary for the correct copy-paste of 8-bit characters
+\usepackage{lmodern}            % Latin Modern fonts (better than CM-Super)
+
 %\usepackage{amsmath}
-\usepackage{alltt}
 \usepackage{../LaTeX/layout}
 \usepackage{makeidx}
 \usepackage{alltt}
 \usepackage{fancyvrb}
 \usepackage{graphicx}
+
+% PDF metadata
+\usepackage[pdftitle={The HOL System REFERENCE}]{hyperref}
 
 % ---------------------------------------------------------------------
 % Read in defined macros and commands


### PR DESCRIPTION
Hi,

I got the following errors when trying to build HOL manual PDFs under newly released TeXlive 2018:

```
[471]

! Package inputenc Error: Unicode character ∀ (U+2200)
(inputenc)                not set up for use with LaTeX.

See the inputenc package documentation for explanation.
Type  H <return>  for immediate help.
 ...                                              
                                                  
l.21922    [|- 2 = SUC 1, |- ∀n. SUC n = 1 + n]:
```

The Unicode character (seems encoded in UCS, not even UTF-8) appears inside `verbatim` block, it's not working by TeX default configurations unless `inputenc` package is loaded with Unicode encoding enabled.

Beside this fix, I changed to use new Latin Modern font, and added support of copy&paste 8bit characters from PDF.  Also added the Manual title into PDF metadata.

--Chun
