### PR TITLE
Fixed src/temporal/examples.sml with HOL4_SMV_EXECUTABLE=NuSMV

### DIFF
--- a/src/temporal/src/Past_Temporal_LogicScript.sml
+++ b/src/temporal/src/Past_Temporal_LogicScript.sml
@@ -77,6 +77,14 @@ val PBEFORE = new_infixr_definition("PBEFORE",
                         a delta /\
                         !t. delta<=t /\ t<=t0 ==> ~b t”,200);
 
+(*---------------------------------------------------------------------------
+       Some aliases of Past Temporal Operators (borrowed from NuSMV)
+ ---------------------------------------------------------------------------*)
+
+val _ = overload_on ("PREV",	``PNEXT``);
+val _ = overload_on ("ONCE",	``PEVENTUAL``);
+val _ = overload_on ("SINCE",	``$PUNTIL``);
+val _ = set_fixity   "SINCE"	 (Infixr 200);
 
 (*---------------------------------------------------------------------------
        Initialization

--- a/src/temporal/src/temporalLib.sig
+++ b/src/temporal/src/temporalLib.sig
@@ -1,7 +1,5 @@
 signature temporalLib =
   sig
-    val smv_call    : string ref
-    val smv_path    : string ref
     val smv_tmp_dir : string ref
 
     type term = Term.term

--- a/src/temporal/src/temporalLib.sml
+++ b/src/temporal/src/temporalLib.sml
@@ -13,9 +13,6 @@ struct
  ---------------------------------------------------------------------------*)
 
 val smv_tmp_dir = ref "/tmp/";
-val smv_path    = ref (Path.concat(Globals.HOLDIR,"sigobj/"));
-val smv_call    = ref "smv.xable -r -v -f ";
-
 
 open HolKernel Parse boolLib Rsyntax;
 
@@ -1259,7 +1256,7 @@ fun genbuechi2smv_string b =
         "VAR\n"^(var_list2smv vars)^"\n"^
         "TRANS \n"^(term2smv_string(#Body(dest_forall transrel)))^"\n\n"^
         (acceptance (strip_conj accept))^"\n\n"^
-        "SPEC (EG 1) -> !"^(term2smv_string init_condition)^"\n\n"
+        "SPEC (EG TRUE) -> !"^(term2smv_string init_condition)^"\n\n"
     end;
 
 
@@ -1285,13 +1282,17 @@ fun interpret_smv_output stl =
             beginl (e::s) [] = false |
             beginl (e1::s1) (e2::s2) = (e1=e2) andalso (beginl s1 s2)
         fun begins s1 s2 = beginl (explode s1) (explode s2)
+        fun skip_lines [] = [] |
+            skip_lines (e::l) = if (e = "\n") then skip_lines l
+				else if (begins "*** " e) then skip_lines l
+				else if (begins "WARNING *** " e) then skip_lines l
+				else (e::l)
         val stll = ref stl
         val proved =
-            let val (l, ll) = Option.valOf (List.getItem (!stll))
-             in (stll := ll; beginl [#"\n",#"e",#"u",#"r",#"t"] (rev(explode l)))
+            let val (l, ll) = Option.valOf (List.getItem (skip_lines (!stll)))
+            in (stll := ll;
+		beginl [#"\n",#"e",#"u",#"r",#"t"] (rev (explode l))) (* ... is true *)
             end
-        fun skip_lines [] = []|
-            skip_lines (e::l) = if (e="\n") then skip_lines l else (e::l)
         fun read_state_lines() = (* reading lines until empty line is read *)
             let val (l, ll) = Option.valOf (List.getItem (!stll))
                 val _ = (stll := ll)
@@ -1322,9 +1323,6 @@ fun interpret_smv_output stl =
           Loop_Sequence = if !loop_sequence=[] then [] else rev(tl(!loop_sequence)),
           Resources = skip_lines(!stll)})
     end
-
-
-
 
 (* ************************************************************************************ *)
 (* Printing the countermodel on the terminal                                            *)
@@ -1387,13 +1385,16 @@ fun print_smv_info smv_info =
 
    ************************************************************************* *)
 
-
 fun SMV_RUN_FILE smv_file =
     let
-  val _ = Process.system
-      ((!smv_path)^(!smv_call)^" "
-      ^smv_file^" > "
-      ^(!smv_tmp_dir)^"smv_out")
+  val _ = case OS.Process.getEnv "HOL4_SMV_EXECUTABLE" of
+	    SOME file =>
+	      Process.system (file ^ " " ^ smv_file ^ " > " ^
+			      (!smv_tmp_dir) ^ "smv_out")
+	  | NONE =>
+	    raise Feedback.mk_HOL_ERR "SMV" smv_file
+		 ("SMV not configured: set the HOL4_SMV_EXECUTABLE environment" ^
+		  "variable to point to the SMV executable file.")
   val file_in = TextIO.openIn((!smv_tmp_dir)^"smv_out")
   val s = ref (TextIO.inputLine file_in)
   val sl = ref ([]:string list)
@@ -1421,9 +1422,6 @@ fun SMV_RUN smv_program =
   in
     SMV_RUN_FILE ((!smv_tmp_dir)^"smv_file.smv")
   end
-
-
-
 
 fun SMV_AUTOMATON_CONV automaton =
   let


### PR DESCRIPTION
Hi,

I believe the SML script `src/temporal/examples.sml` is a dead one for long time. Now I've fixed it, tested with NuSMV [1] - a reimplementation and extension of SMV, the first model checker based on BDDs. I don't think anyone is still using the original SMV program by McMillan, but my code changes didn't break the compatibility if the original SMV program were used.

Following the way of calling external programs like Z3, Yices, etc. by HolSmtLib, now I defined a new environment variable called `HOL4_SMV_EXECUTABLE` for user to setup an SMV-compatible program for the model checking of LTL (actually it's CTL in this case).

Now the LTL_CONV command works again:

```
> LTL_CONV ``(a SUNTIL b) 0
              = (EVENTUAL (\t. b t /\ PNEXT (PALWAYS a) t)) 0``;
val it = ⊢ ((a SUNTIL b) 0 ⇔ EVENTUAL (λt. b t ∧ PREV (PALWAYS a) t) 0) ⇔ T:
   thm
```

and it can produce a countermodel if the  proof fails:

```
> LTL_CONV ``(a UNTIL b) 0
                = (EVENTUAL (\t. b t /\ PNEXT (PALWAYS a) t)) 0``;
# SMV computes the following countermodel:
===============================================
Formula is not true! Consider the countermodel:
===============================================
===============================================
Trace Description: CTL Counterexample 
Trace Type: Counterexample 
  -- Loop starts here
  -> State: 1.1 <-
    a = TRUE
    b = FALSE
    ell0 = TRUE
    ell1 = TRUE
    ell2 = TRUE
    ell3 = FALSE
  -> State: 1.2 <-
===============================================
Exception-
   HOL_ERR
     {message = "", origin_function = "NO_CONV", origin_structure = "Conv"}
   raised
```

The only thing which still confuses me is the last theorem in this script:

```
val SEPARATE_EVENTUAL_ALWAYS_THM = store_thm (
   "SEPARATE_EVENTUAL_ALWAYS_THM", ``
                (EVENTUAL(ALWAYS (\t. a t \/ PNEXT b t))
                 =  EVENTUAL(ALWAYS (\t. NEXT a t \/ b t))
                ) /\
                (EVENTUAL(ALWAYS (\t. a t \/ PSNEXT b t))
                 =  EVENTUAL(ALWAYS (\t. NEXT a t \/ b t))
                ) /\
                (EVENTUAL(ALWAYS (\t. a t \/ (b PSUNTIL c) t)) 0
                =
                if ALWAYS (\t.~c t) 0
                  then EVENTUAL(ALWAYS a) 0
                  else if ALWAYS (EVENTUAL c) 0
                         then EVENTUAL(ALWAYS
                                (\t. b t \/ c t \/ ((NEXT c) BEFORE (\t. ~a t)) t)) 0
                         else if EVENTUAL(ALWAYS a) 0
                                then EVENTUAL(ALWAYS a) 0
                                else EVENTUAL(\t. c t /\ ALWAYS (NEXT b) t) 0

                )
                ``,
        REPEAT STRIP_TAC THEN CONV_TAC LTL_CONV);
```

Here the formula is well-formed, but HOL reports the following strange internal error:

```
Don't expect to find a | in this position after a <beginning of input>
at line 210, character 38 and in compiler-generated text.
Proof of 

(EVENTUAL (ALWAYS (λt. a t ∨ PREV b t)) =
 EVENTUAL (ALWAYS (λt. NEXT a t ∨ b t))) ∧
(EVENTUAL (ALWAYS (λt. a t ∨ PSNEXT b t)) =
 EVENTUAL (ALWAYS (λt. NEXT a t ∨ b t))) ∧
(EVENTUAL (ALWAYS (λt. a t ∨ (b PSUNTIL c) t)) 0 ⇔
 if ALWAYS (λt. ¬c t) 0 then EVENTUAL (ALWAYS a) 0
 else if ALWAYS (EVENTUAL c) 0 then
   EVENTUAL (ALWAYS (λt. b t ∨ c t ∨ (NEXT c BEFORE (λt. ¬a t)) t)) 0
 else if EVENTUAL (ALWAYS a) 0 then EVENTUAL (ALWAYS a) 0
 else EVENTUAL (λt. c t ∧ ALWAYS (NEXT b) t) 0)

failed.
Failed to prove theorem SEPARATE_EVENTUAL_ALWAYS_THM.

Exception raised at Absyn.Absyn:
in compiler-generated text:
Don't expect to find a | in this position after a <beginning of input>
at line 210, character 38 and in compiler-generated text.

Exception-
   HOL_ERR
     {message =
      "in compiler-generated text:\nDon't expect to find a | in this position after a <beginning of input>\nat line 210, character 38 and in compiler-generated text.\n",
      origin_function = "Absyn", origin_structure = "Absyn"} raised
```

The "|" in that position must be a logical "OR" from the SMV language. I guess it's not well handled by some LTL-specific code when trying to build a oracle theorem by calling MK_THM. But currently I didn't find the related code yet. Beside this issue, all other parts in this example scripts work well.

Besides, in `Past_Temporal_LogicScript.sml`, I have defined some overload names for past temporal operators, following their modern names found in major LTL literatures, e.g. instead of `PNEXT`, a better name is `PREV` (or `PREVIOUS` if you prefer). `PEVENTUAL` is `ONCE`, `PUNTIL` is `SINCE` now.  Feel free to cancel this part if you don't like it.

Regards,

Chun Tian

[1] https://es.fbk.eu/technologies/nusmv-symbolic-model-checker