### PR TITLE
Lambek calculus

### DIFF
--- a/doc/next-release.md
+++ b/doc/next-release.md
@@ -14,7 +14,7 @@ Contents
 -   [Bugs fixed](#bugs-fixed)
 -   [New theories](#new-theories)
 -   [New tools](#new-tools)
--   [Examples](#examples)
+-   [New Examples](#new-examples)
 -   [Incompatibilities](#incompatibilities)
 
 New features:

--- a/doc/next-release.md
+++ b/doc/next-release.md
@@ -66,7 +66,7 @@ New tools:
 New examples:
 ---------
 
-*   We have resurrected Monica Nesi’s CCS example (from the days of HOL88), ported and extended by Chun Tian (based on HOL4’s co-induction package `Hol_coreln`).
+*   We have resurrected Monica Nesi’s CCS example (from the days of HOL88, in `examples/CCS`), ported and extended by Chun Tian (based on HOL4’s co-induction package `Hol_coreln`).
     This includes all classical results of strong/weak bisimilarities and observation congruence, the theory of congruence for CCS, several versions of “bisimulation up to”,  “coarsest congruence contained in weak bisimilarity”, and “unique solution of equations” theorems, mainly from Robin Milner’s book, and Davide Sangiorgi’s “unique solutions of contractions” theorem published in 2017.
     There’s also a decision procedure written in SML for computing CCS transitions with the result automatically proved.
 
@@ -77,6 +77,8 @@ New examples:
 
 *   A theory of the basic syntax and semantics of Linear Temporal Logic formulas, along with a verified translation of such formulas into Generalised Büchi Automata *via* alternating automata (in `examples/logic/ltl`).
     This work is by Simon Jantsch.
+
+*   A theory of Lambek calculus (categorial grammars of natural or formal languages), in `examples/formal-languages/lambek`. Ported from [Coq contribs](https://github.com/coq-contribs/lambek) by Chun Tian. c.f. "The Logic of Categorial Grammars" by Richard Moot and Christian Retoré.
 
 Incompatibilities:
 ------------------

--- a/examples/formal-languages/lambek/.gitignore
+++ b/examples/formal-languages/lambek/.gitignore
@@ -1,0 +1,4 @@
+/.hollogs/
+/.HOLMK/
+/heap
+*Theory.*

--- a/examples/formal-languages/lambek/CutFreeScript.sml
+++ b/examples/formal-languages/lambek/CutFreeScript.sml
@@ -1,0 +1,1127 @@
+(*
+ * Formalized Lambek Calculus in Higher Order Logic (HOL4)
+ *
+ *  (based on https://github.com/coq-contribs/lambek)
+ *
+ * Copyright 2002-2003  Houda ANOUN and Pierre Casteran, LaBRI/INRIA.
+ * Copyright 2016-2017  University of Bologna, Italy (Author: Chun Tian)
+ *)
+
+(* This program is free software; you can redistribute it and/or      *)
+(* modify it under the terms of the GNU Lesser General Public License *)
+(* as published by the Free Software Foundation; either version 2.1   *)
+(* of the License, or (at your option) any later version.             *)
+(*                                                                    *)
+(* This program is distributed in the hope that it will be useful,    *)
+(* but WITHOUT ANY WARRANTY; without even the implied warranty of     *)
+(* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the      *)
+(* GNU General Public License for more details.                       *)
+(*                                                                    *)
+(* You should have received a copy of the GNU Lesser General Public   *)
+(* License along with this program; if not, write to the Free         *)
+(* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA *)
+(* 02110-1301 USA                                                     *)
+
+open HolKernel Parse boolLib bossLib;
+
+open relationTheory prim_recTheory arithmeticTheory listTheory;
+open LambekTheory;
+
+local
+    val PAT_X_ASSUM = PAT_ASSUM;
+    val qpat_x_assum = Q.PAT_ASSUM;
+    open Tactical
+in
+    (* Backward compatibility with Kananaskis 11 *)
+    val PAT_X_ASSUM = PAT_X_ASSUM;
+    val qpat_x_assum = qpat_x_assum;
+
+    (* Tacticals for better expressivity *)
+    fun fix  ts = MAP_EVERY Q.X_GEN_TAC ts;	(* from HOL Light *)
+    fun set  ts = MAP_EVERY Q.ABBREV_TAC ts;	(* from HOL mizar mode *)
+    fun take ts = MAP_EVERY Q.EXISTS_TAC ts;	(* from HOL mizar mode *)
+end;
+
+val _ = new_theory "CutFree";
+
+hide "S";
+
+(*** Module: CutSequent ***)
+
+(* this theorem was not in HOL kananaskis-11 final release, it's new in K-12 *)
+val MAX_EQ_0 = store_thm (
+   "MAX_EQ_0",
+  ``(MAX m n = 0) <=> (m = 0) /\ (n = 0)``,
+    SRW_TAC [] [MAX_DEF, EQ_IMP_THM]
+ >> FULL_SIMP_TAC (srw_ss()) [NOT_LESS_0, NOT_LESS]);
+
+val maxNatL = store_thm ("maxNatL",
+  ``(MAX n m = 0) ==> (n = 0)``, RW_TAC std_ss [MAX_EQ_0]);
+val maxNatR = store_thm ("maxNatR",
+  ``(MAX n m = 0) ==> (m = 0)``, RW_TAC std_ss [MAX_EQ_0]);
+
+val degreeFormula_def = Define `
+   (degreeFormula (At C) = 1) /\
+   (degreeFormula (Slash F1 F2) = SUC (MAX (degreeFormula F1) (degreeFormula F2))) /\
+   (degreeFormula (Backslash F1 F2) = SUC (MAX (degreeFormula F1) (degreeFormula F2))) /\
+   (degreeFormula (Dot F1 F2) = SUC (MAX (degreeFormula F1) (degreeFormula F2)))`;
+
+val degreeForm_0 = store_thm ("degreeForm_0", ``!F0. 1 <= (degreeFormula F0)``,
+    Induct >> rw [degreeFormula_def]);
+
+(* Deep Embeddings for Lambek's Sequent Calculus *)
+val _ = Datatype `Sequent = Sequent ('a gentzen_extension) ('a Term) ('a Form)`;
+
+val _ = Datatype `Rule = SeqAxiom
+		       | RightSlash | RightBackslash | RightDot
+		       | LeftSlash  | LeftBackslash  | LeftDot
+		       | CutRule    | SeqExt`;
+
+val all_rules_def = Define `
+    all_rules =
+	{ SeqAxiom; RightSlash; RightBackslash; RightDot;
+	  LeftSlash; LeftBackslash; LeftDot; SeqExt; CutRule }`;
+
+(* Note: (Dertree list) never has more than 2 elements in Lambek's Sequent Calculus *)
+val _ = Datatype `Dertree = Der ('a Sequent) Rule (Dertree list)
+			  | Unf ('a Sequent)`;
+
+val Dertree_induction = TypeBase.induction_of ``:'a Dertree``;
+val Dertree_nchotomy  = TypeBase.nchotomy_of ``:'a Dertree``;
+val Dertree_distinct  = TypeBase.distinct_of ``:'a Dertree``;
+val Dertree_distinct' = save_thm ("Dertree_distinct'", GSYM Dertree_distinct);
+val Dertree_11        = TypeBase.one_one_of ``:'a Dertree``;
+
+(* not used *)
+val Is_Unfinished_def = Define `
+   (Is_Unfinished (Der _ _ []) = F) /\
+   (Is_Unfinished (Der _ _ [D]) = Is_Unfinished D) /\
+   (Is_Unfinished (Der _ _ [D1; D2]) = (Is_Unfinished D1 /\ Is_Unfinished D2)) /\
+   (Is_Unfinished (Unf _) = T)`;
+
+(* not used *)
+val Is_Finished_def = Define `
+   (Is_Finished (Der _ _ []) = T) /\
+   (Is_Finished (Der _ _ [D]) = Is_Finished D) /\
+   (Is_Finished (Der _ _ [D1; D2]) = (Is_Finished D1 /\ Is_Finished D2)) /\
+   (Is_Finished (Unf _) = F)`;
+
+(* structure accessors *)
+val head_def = Define `
+   (head (Der seq _ _) = seq) /\
+   (head (Unf seq) = seq)`;
+
+val concl_def = Define `
+   (concl (Unf (Sequent E Delta A))     = A) /\
+   (concl (Der (Sequent E Delta A) _ _) = A)`;
+
+val prems_def = Define `
+   (prems (Unf (Sequent E Delta A))     = Delta) /\
+   (prems (Der (Sequent E Delta A) _ _) = Delta)`;
+
+val exten_def = Define `
+   (exten (Unf (Sequent E Delta A))     = E) /\
+   (exten (Der (Sequent E Delta A) _ _) = E)`;
+
+val degreeRule_def = Define `
+   (degreeRule (Der S SeqAxiom [])		= 0) /\
+   (degreeRule (Der S RightSlash [H])		= 0) /\
+   (degreeRule (Der S RightBackslash [H])	= 0) /\
+   (degreeRule (Der S RightDot [H1; H2])	= 0) /\
+   (degreeRule (Der S LeftSlash [H1; H2])	= 0) /\
+   (degreeRule (Der S LeftBackslash [H1; H2])	= 0) /\
+   (degreeRule (Der S LeftDot [H])		= 0) /\
+   (degreeRule (Der S SeqExt [H])		= 0) /\
+   (* The degree of a cut is the degree of the cut formula which disappears after
+      application of the rule. *)
+   (degreeRule (Der S CutRule [H1; H2])		= degreeFormula (concl H1))`;
+
+(* degreeProof, one way to check if CutRule gets used *)
+val degreeProof_def = Define `
+   (degreeProof (Der S SeqAxiom [])		= 0) /\
+   (degreeProof (Der S RightSlash [H])		= degreeProof H) /\
+   (degreeProof (Der S RightBackslash [H])	= degreeProof H) /\
+   (degreeProof (Der S RightDot [H1; H2])	= MAX (degreeProof H1) (degreeProof H2)) /\
+   (degreeProof (Der S LeftSlash [H1; H2])	= MAX (degreeProof H1) (degreeProof H2)) /\
+   (degreeProof (Der S LeftBackslash [H1; H2])	= MAX (degreeProof H1) (degreeProof H2)) /\
+   (degreeProof (Der S LeftDot [H])		= degreeProof H) /\
+   (degreeProof (Der S SeqExt [H])		= degreeProof H) /\
+   (* CutRule is special *)
+   (degreeProof (Der S CutRule [H1; H2])	=
+	MAX (degreeFormula (concl H1))
+	    (MAX (degreeProof H1) (degreeProof H2)))`;
+
+(* subFormula and their theorems *)
+val (subFormula_rules, subFormula_ind, subFormula_cases) = Hol_reln `
+    (!(A:'a Form).		subFormula A A) /\			(* equalForm *)
+    (!A B C. subFormula A B ==> subFormula A (Slash B C)) /\		(* slashL *)
+    (!A B C. subFormula A B ==> subFormula A (Slash C B)) /\		(* slashR *)
+    (!A B C. subFormula A B ==> subFormula A (Backslash B C)) /\	(* backslashL *)
+    (!A B C. subFormula A B ==> subFormula A (Backslash C B)) /\	(* backslashR *)
+    (!A B C. subFormula A B ==> subFormula A (Dot B C)) /\		(* dotL *)
+    (!A B C. subFormula A B ==> subFormula A (Dot C B))`;		(* dotR *)
+
+val [equalForm, slashL, slashR, backslashL, backslashR, dotL, dotR] =
+    map save_thm
+        (combine (["equalForm", "slashL", "slashR", "backslashL", "backslashR", "dotL", "dotR"],
+		  CONJUNCTS subFormula_rules));
+
+(* The simp set related to Form *)
+val Form_ss = DatatypeSimps.type_rewrites_ss [``:'a Form``];
+
+val subAt = store_thm ("subAt", ``!A a. subFormula A (At a) ==> (A = At a)``,
+    ONCE_REWRITE_TAC [subFormula_cases]
+ >> SIMP_TAC bool_ss [Form_distinct]); (* or: SIMP_TAC (bool_ss ++ Form_ss) [] *)
+
+val subSlash = store_thm ("subSlash",
+  ``!A B C. subFormula A (Slash B C) ==> (A = Slash B C) \/ subFormula A B \/ subFormula A C``,
+    REPEAT GEN_TAC
+ >> ONCE_REWRITE_TAC [Q.SPECL [`A`, `(Slash B C)`] subFormula_cases]
+ >> SIMP_TAC (bool_ss ++ Form_ss) [EQ_SYM_EQ]);
+
+val subBackslash = store_thm ("subBackslash",
+  ``!A B C. subFormula A (Backslash B C) ==> (A = Backslash B C) \/ subFormula A B \/ subFormula A C``,
+    REPEAT GEN_TAC
+ >> ONCE_REWRITE_TAC [Q.SPECL [`A`, `(Backslash B C)`] subFormula_cases]
+ >> SIMP_TAC (bool_ss ++ Form_ss) [EQ_SYM_EQ]);
+
+val subDot = store_thm ("subDot",
+  ``!A B C. subFormula A (Dot B C) ==> (A = Dot B C) \/ subFormula A B \/ subFormula A C``,
+    REPEAT GEN_TAC
+ >> ONCE_REWRITE_TAC [Q.SPECL [`A`, `(Dot B C)`] subFormula_cases]
+ >> SIMP_TAC (bool_ss ++ Form_ss) [EQ_SYM_EQ]);
+
+(* all previous theorems and rules were used in this proof ... *)
+val subFormulaTrans = store_thm (
+   "subFormulaTrans",
+  ``!A B C. subFormula A B ==> subFormula B C ==> subFormula A C``,
+    Induct_on `C`
+ >| [ (* case 1 *)
+      PROVE_TAC [subAt],
+      (* case 2, can be proved by PROVE_TAC [subSlash, slashL, slashR] *)
+      REPEAT STRIP_TAC \\
+      POP_ASSUM (STRIP_ASSUME_TAC o MATCH_MP subSlash) >|
+      [ PROVE_TAC [],
+        PROVE_TAC [slashL],
+        PROVE_TAC [slashR] ],
+      (* case 3 *)
+      PROVE_TAC [subBackslash, backslashL, backslashR],
+      (* case 4 *)
+      PROVE_TAC [subDot, dotL, dotR] ]);
+
+val subFormulaTrans' = store_thm (
+   "subFormulaTrans'", ``transitive subFormula``,
+    PROVE_TAC [subFormulaTrans, transitive_def]);
+
+(* subFormTerm *)
+val (subFormTerm_rules, subFormTerm_ind, subFormTerm_cases) = Hol_reln `
+    (!A B.     subFormula  A B  ==> subFormTerm A (OneForm B)) /\	(* eqFT *)
+    (!A T1 T2. subFormTerm A T1 ==> subFormTerm A (Comma T1 T2)) /\	(* comL *)
+    (!A T1 T2. subFormTerm A T1 ==> subFormTerm A (Comma T2 T1))`;	(* comR *)
+
+val [eqFT, comL, comR] =
+    map save_thm (combine (["eqFT", "comL", "comR"], CONJUNCTS subFormTerm_rules));
+
+val Term_11 = TypeBase.one_one_of ``:'a Term``;
+val Term_distinct = TypeBase.distinct_of ``:'a Term``;
+
+val oneFormSub = store_thm (
+   "oneFormSub", ``!A B. subFormTerm A (OneForm B) ==> subFormula A B``,
+    ONCE_REWRITE_TAC [subFormTerm_cases]
+ >> REPEAT STRIP_TAC
+ >| [ PROVE_TAC [Term_11],
+      PROVE_TAC [Term_distinct],
+      PROVE_TAC [Term_distinct] ]);
+
+val oneFormSubEQ = store_thm (
+   "oneFormSubEQ[simp]", ``!A B. subFormTerm A (OneForm B) = subFormula A B``,
+    REPEAT GEN_TAC
+ >> EQ_TAC (* 2 sub-goals here *)
+ >| [ REWRITE_TAC [oneFormSub],
+      REWRITE_TAC [eqFT] ]);
+
+val comSub = store_thm ("comSub",
+  ``!f T1 T2. subFormTerm f (Comma T1 T2) ==> subFormTerm f T1 \/ subFormTerm f T2``,
+    REPEAT GEN_TAC
+ >> GEN_REWRITE_TAC LAND_CONV empty_rewrites [Once subFormTerm_cases]
+ >> REPEAT STRIP_TAC
+ >| [ PROVE_TAC [Term_distinct],
+      PROVE_TAC [Term_11],
+      PROVE_TAC [Term_11] ]);
+
+val subReplace1 = store_thm ("subReplace1",
+  ``!f T1 T2 T3 T4. replace T1 T2 T3 T4 ==> subFormTerm f T3 ==> subFormTerm f T1``,
+    GEN_TAC
+ >> HO_MATCH_MP_TAC replace_ind
+ >> REPEAT STRIP_TAC
+ >- PROVE_TAC [comL]
+ >> PROVE_TAC [comR]);
+
+val subReplace2 = store_thm ("subReplace2",
+  ``!f T1 T2 T3 T4. replace T1 T2 T3 T4 ==> subFormTerm f T4 ==> subFormTerm f T2``,
+    GEN_TAC
+ >> HO_MATCH_MP_TAC replace_ind
+ >> REPEAT STRIP_TAC
+ >- PROVE_TAC [comL]
+ >> PROVE_TAC [comR]);
+
+val subReplace3 = store_thm ("subReplace3",
+  ``!X T1 T2 T3 T4. replace T1 T2 T3 T4 ==> subFormTerm X T1
+		==> subFormTerm X T2 \/ subFormTerm X T3``,
+    GEN_TAC
+ >> HO_MATCH_MP_TAC replace_ind
+ >> REPEAT STRIP_TAC
+ >- ASM_REWRITE_TAC []
+ >| [ (* case 2 *)
+      `subFormTerm X T1 \/ subFormTerm X Delta` by PROVE_TAC [comSub] >|
+      [ `subFormTerm X T2 \/ subFormTerm X T3` by PROVE_TAC [] \\
+	PROVE_TAC [comL],
+	PROVE_TAC [comR] ],
+      (* case 3 *)
+      `subFormTerm X Delta \/ subFormTerm X T1` by PROVE_TAC [comSub] >|
+      [ PROVE_TAC [comL], 
+	`subFormTerm X T2 \/ subFormTerm X T3` by PROVE_TAC [] \\
+	PROVE_TAC [comR] ] ]);
+
+val CutFreeProof_def = Define `
+    CutFreeProof p = (degreeProof p = 0)`;
+
+val notCutFree = store_thm ("notCutFree",
+  ``!E T1 T2 D A C p p1 p2.
+     replace T1 T2 (OneForm A) D /\
+     (p1 = Sequent E D A) /\ (p2 = Sequent E T1 C) ==>
+     ~CutFreeProof (Der _ CutRule [Der p1 _ _; Der p2 _ _])``,
+    REPEAT GEN_TAC
+ >> STRIP_TAC
+ >> REWRITE_TAC [CutFreeProof_def]
+ >> RW_TAC std_ss [degreeProof_def, concl_def]
+ >> STRIP_TAC
+ >> `1 <= degreeFormula A` by REWRITE_TAC [degreeForm_0]
+ >> `degreeFormula A = 0` by PROVE_TAC [MAX_EQ_0]
+ >> RW_TAC arith_ss []);
+
+val (subProofOne_rules, subProofOne_ind, subProofOne_cases) = Hol_reln `
+    (!p0 p E Gamma A B R D.
+		(p0 = Sequent E Gamma (Slash A B)) /\
+		(p = Der (Sequent E (Comma Gamma (OneForm B)) A) R D)
+	    ==> subProofOne p  (Der p0 RightSlash [p]))			/\ (* 1. rs *)
+
+    (!p0 p E Gamma A B R D.
+		(p0 = Sequent E Gamma (Backslash B A)) /\
+		(p = Der (Sequent E (Comma (OneForm B) Gamma) A) R D)
+	    ==> subProofOne p  (Der p0 RightBackslash [p]))		/\ (* 2. rbs *)
+
+    (!p0 p1 p2 E Gamma Delta A B R D.
+		(p0 = Sequent E (Comma Gamma Delta) (Dot A B)) /\
+		(p1 = Der (Sequent E Gamma A) R D) /\
+		(p2 = Der (Sequent E Delta B) R D)
+	    ==> subProofOne p1 (Der p0 RightDot  [p1; p2]))		/\ (* 3. rd1 *)
+
+    (!p0 p1 p2 E Gamma Delta A B R D.
+		(p0 = Sequent E (Comma Gamma Delta) (Dot A B)) /\
+		(p1 = Der (Sequent E Gamma A) R D) /\
+		(p2 = Der (Sequent E Delta B) R D)
+	    ==> subProofOne p2 (Der p0 RightDot  [p1; p2]))		/\ (* 4. rd2 *)
+
+    (!p0 p1 p2 E Gamma Gamma' Delta A B C R D.
+		(p0 = Sequent E Gamma' C) /\
+		(p1 = Der (Sequent E Delta B) R D) /\
+		(p2 = Der (Sequent E Gamma C) R D) /\
+		(replace Gamma Gamma' (OneForm A) (Comma (OneForm (Slash A B)) Delta))
+	    ==> subProofOne p1 (Der p0 LeftSlash [p1; p2]))		/\ (* 5. ls1 *)
+
+    (!p0 p1 p2 E Gamma Gamma' Delta A B C R D.
+		(p0 = Sequent E Gamma' C) /\
+		(p1 = Der (Sequent E Delta B) R D) /\
+		(p2 = Der (Sequent E Gamma C) R D) /\
+		replace Gamma Gamma' (OneForm A) (Comma (OneForm (Slash A B)) Delta)
+	    ==> subProofOne p2 (Der p0 LeftSlash [p1; p2]))		/\ (* 6. ls2 *)
+
+    (!p0 p1 p2 E Gamma Gamma' Delta A B C R D.
+		(p0 = Sequent E Gamma' C) /\
+		(p1 = Der (Sequent E Delta B) R D) /\
+		(p2 = Der (Sequent E Gamma C) R D) /\
+		replace Gamma Gamma' (OneForm A) (Comma Delta (OneForm (Backslash B A)))
+	    ==> subProofOne p1 (Der p0 LeftBackslash [p1; p2]))		/\ (* 7. lbs1 *)
+
+    (!p0 p1 p2 E Gamma Gamma' Delta A B C R D.
+		(p0 = Sequent E Gamma' C) /\
+		(p1 = Der (Sequent E Delta B) R D) /\
+		(p2 = Der (Sequent E Gamma C) R D) /\
+		replace Gamma Gamma' (OneForm A) (Comma Delta (OneForm (Backslash B A)))
+	    ==> subProofOne p2 (Der p0 LeftBackslash [p1; p2]))		/\ (* 8. lbs2 *)
+
+    (!p0 p E Gamma Gamma' A B C R D.
+		(p0 = Sequent E Gamma' C) /\
+		(p = Der (Sequent E Gamma C) R D) /\
+		replace Gamma Gamma' (Comma (OneForm A) (OneForm B)) (OneForm (Dot A B))
+	    ==>	subProofOne p  (Der p0 LeftDot [p]))			/\ (* 9. ld *)
+
+    (!p0 p1 p2 E Gamma Gamma' Delta A C R D.
+		(p0 = Sequent E Gamma' C) /\
+		(p1 = Der (Sequent E Delta A) R D) /\
+		(p2 = Der (Sequent E Gamma C) R D) /\
+		replace Gamma Gamma' (OneForm A) Delta
+	    ==> subProofOne p1 (Der p0 CutRule [p1; p2]))		/\ (* 10. cr1 *)
+
+    (!p0 p1 p2 E Gamma Gamma' Delta A C R D.
+		(p0 = Sequent E Gamma' C) /\
+		(p1 = Der (Sequent E Delta A) R D) /\
+		(p2 = Der (Sequent E Gamma C) R D) /\
+		replace Gamma Gamma' (OneForm A) Delta
+	    ==> subProofOne p2 (Der p0 CutRule [p1; p2]))		/\ (* 11. cr2 *)
+
+    (!p0 p E Gamma Gamma' T1 T2 C R D.
+		(p0 = Sequent E Gamma' C) /\
+		(p = Der (Sequent E Gamma C) R D) /\
+		(E :'a gentzen_extension) T1 T2 /\
+		replace Gamma Gamma' T1 T2
+	    ==> subProofOne p  (Der p0 SeqExt [p])) `;			   (* se *)
+
+val [rs, rbs, rd1, rd2, ls1, ls2, lbs1, lbs2, ld, cr1, cr2, se] =
+    map save_thm
+        (combine (["rs", "rbs", "rd1", "rd2", "ls1", "ls2", "lbs1", "lbs2",
+		   "ld", "cr1", "cr2", "se"],
+		  CONJUNCTS subProofOne_rules));
+
+(* (subProof :'a Dertree -> 'a Dertree -> bool) *)
+val subProof_def = Define `subProof = RTC subProofOne`;
+
+val sameProof = store_thm (
+   "sameProof", ``!p. subProof p p``,
+    REWRITE_TAC [subProof_def, RTC_REFL]);
+
+val subProof1 = store_thm (
+   "subProof1", ``!p1 p2 p3. subProofOne p1 p2 /\ subProof p2 p3 ==> subProof p1 p3``,
+    REWRITE_TAC [subProof_def, RTC_RULES]);
+
+val subProof_rules = save_thm (
+   "subProof_rules", LIST_CONJ [sameProof, subProof1]);
+
+(*
+ |- ∀P.
+     (∀x. P x x) ∧
+     (∀x y z. subProofOne x y ∧ P y z ⇒ P x z) ⇒
+     ∀x y. subProof x y ⇒ P x y
+ *)
+val subProof_ind = save_thm (
+   "subProof_ind",
+    REWRITE_RULE [GSYM subProof_def] (Q.ISPEC `subProofOne` RTC_INDUCT));
+
+(*
+ |- ∀P.
+     (∀x. P x x) ∧
+     (∀x y z. subProofOne x y ∧ subProof y z ∧ P y z ⇒ P x z) ⇒
+     ∀x y. subProof x y ⇒ P x y:
+ *)
+val subProof_strongind = save_thm (
+   "subProof_strongind",
+    REWRITE_RULE [GSYM subProof_def] (Q.ISPEC `subProofOne` RTC_STRONG_INDUCT));
+
+(* 
+ |- ∀x y. subProof x y ⇔ (x = y) ∨ ∃u. subProofOne x u ∧ subProof u y
+ *)
+val subProof_cases = save_thm (
+   "subProof_cases",
+    REWRITE_RULE [GSYM subProof_def] (Q.ISPEC `subProofOne` RTC_CASES1));
+
+(*
+ |- ∀x y. subProof x y ⇔ (x = y) ∨ ∃u. subProof x u ∧ subProofOne u y
+ *)
+val subProof_cases' = save_thm (
+   "subProof_cases'",
+    REWRITE_RULE [GSYM subProof_def] (Q.ISPEC `subProofOne` RTC_CASES2));
+
+(* original code:
+val (subProof'_rules, subProof'_ind, subProof'_cases) = Hol_reln `
+    (!(p :'a Dertree). subProof' p p) /\
+    (!p1 p2 p3. subProof' p2 p1 /\ subProofOne p3 p2 ==> subProof' p3 p1)`;
+ *)
+
+val CutFreeSubProofOne = store_thm ("CutFreeSubProofOne",
+  ``!q p. subProofOne q p ==> CutFreeProof p ==> CutFreeProof q``,
+    Induct_on `subProofOne`
+ >> REWRITE_TAC [CutFreeProof_def, degreeProof_def]
+ >> PROVE_TAC [MAX_EQ_0]);
+
+val CutFreeSubProof = store_thm ("CutFreeSubProof",
+  ``!q p. subProof q p ==> CutFreeProof p ==> CutFreeProof q``,
+    REWRITE_TAC [subProof_def]
+ >> HO_MATCH_MP_TAC RTC_INDUCT
+ >> PROVE_TAC [CutFreeSubProofOne]);
+
+val extensionSub_def = Define `
+    extensionSub E = !Form T1 T2. E T1 T2 ==> subFormTerm Form T1 ==> subFormTerm Form T2`;
+
+val subProofOne_extension = store_thm (
+   "subProofOne_extension",
+  ``!q p. subProofOne q p ==>
+          extensionSub (exten p) ==> extensionSub (exten q)``,
+    REPEAT GEN_TAC
+ >> ONCE_REWRITE_TAC [subProofOne_cases]
+ >> REPEAT STRIP_TAC (* 12 subgoals, all sharing the same tacticals *)
+ >> `extensionSub E` by METIS_TAC [exten_def]
+ >> ASM_REWRITE_TAC [exten_def]);
+
+val subProof_extension = store_thm (
+   "subProof_extension",
+  ``!q p. subProof q p ==>
+          extensionSub (exten p) ==> extensionSub (exten q)``,
+    HO_MATCH_MP_TAC subProof_strongind
+ >> REPEAT STRIP_TAC
+ >> RES_TAC
+ >> IMP_RES_TAC subProofOne_extension);
+
+(* one-step derivation (of proofs): Dertree -> Dertree -> bool *)
+val (derivOne_rules, derivOne_ind, derivOne_cases) = Hol_reln `
+    (!E A.
+     derivOne (Unf (Sequent E (OneForm A) A))
+	(Der (Sequent E (OneForm A) A) SeqAxiom [])) /\
+    (!E Gamma A B.
+     derivOne (Unf (Sequent E Gamma (Slash A B)))
+	(Der (Sequent E Gamma (Slash A B)) RightSlash
+	     [ Unf (Sequent E (Comma Gamma (OneForm B)) A) ])) /\
+    (!E Gamma A B.
+     derivOne (Unf (Sequent E Gamma (Backslash B A)))
+	(Der (Sequent E Gamma (Backslash B A)) RightBackslash
+	     [ Unf (Sequent E (Comma (OneForm B) Gamma) A) ])) /\
+    (!E Gamma Delta A B.
+     derivOne (Unf (Sequent E (Comma Gamma Delta) (Dot A B)))
+	(Der (Sequent E (Comma Gamma Delta) (Dot A B)) RightDot
+	     [ Unf (Sequent E Gamma A); Unf (Sequent E Delta B) ])) /\
+    (!E Gamma Gamma' Delta A B C.
+     replace Gamma Gamma' (OneForm A) (Comma (OneForm (Slash A B)) Delta) ==>
+     derivOne (Unf (Sequent E Gamma' C))
+	(Der (Sequent E Gamma' C) LeftSlash
+	     [ Unf (Sequent E Gamma C); Unf (Sequent E Delta B) ])) /\
+    (!E Gamma Gamma' Delta A B C.
+     replace Gamma Gamma' (OneForm A) (Comma Delta (OneForm (Backslash B A))) ==>
+     derivOne (Unf (Sequent E Gamma' C))
+	(Der (Sequent E Gamma' C) LeftBackslash
+	     [ Unf (Sequent E Gamma C); Unf (Sequent E Delta B) ])) /\
+    (!E Gamma Gamma' A B C.
+     replace Gamma Gamma' (Comma (OneForm A) (OneForm B)) (OneForm (Dot A B)) ==>
+     derivOne (Unf (Sequent E Gamma' C))
+	(Der (Sequent E Gamma' C) LeftDot
+	     [ Unf (Sequent E Gamma C) ])) /\
+    (!E Delta Gamma Gamma' A C.
+     replace Gamma Gamma' (OneForm A) Delta ==>
+     derivOne (Unf (Sequent E Gamma' C))
+	(Der (Sequent E Gamma' C) CutRule
+	     [ Unf (Sequent E Gamma C); Unf (Sequent E Delta A) ])) /\
+    (!E Gamma Gamma' Delta Delta' C.
+     replace Gamma Gamma' Delta Delta' /\ E Delta Delta' ==>
+     derivOne (Unf (Sequent E Gamma' C))
+	(Der (Sequent E Gamma' C) SeqExt
+	     [ Unf (Sequent E Gamma C) ]))`;
+
+val [derivSeqAxiom, derivRightSlash, derivRightBackslash, derivRightDot,
+     derivLeftSlash, derivLeftBackslash, derivLeftDot, derivCutRule, derivSeqExt] =
+    map save_thm
+        (combine (["derivSeqAxiom", "derivRightSlash", "derivRightBackslash",
+		   "derivRightDot", "derivLeftSlash", "derivLeftBackslash",
+		   "derivLeftDot", "derivCutRule", "derivSeqExt"],
+		  CONJUNCTS derivOne_rules));
+
+(* structure rules *)
+val (deriv_rules, deriv_ind, deriv_cases) = Hol_reln `
+    (!D1 D2.          derivOne D1 D2  ==> deriv D1 D2)					/\
+    (!S R D1 D1'.        deriv D1 D1' ==> deriv (Der S R [D1])    (Der S R [D1']))	/\
+    (!S R D1 D1' D.      deriv D1 D1' ==> deriv (Der S R [D1; D]) (Der S R [D1'; D]))	/\
+    (!S R D2 D2' D.      deriv D2 D2' ==> deriv (Der S R [D; D2]) (Der S R [D; D2']))	/\
+    (!S R D1 D1' D2 D2'. deriv D1 D1' /\ deriv D2 D2'
+		     ==> deriv (Der S R [D1; D2]) (Der S R [D1'; D2']))`;
+
+val [derivDerivOne, derivOne, derivLeft, derivRight, derivBoth] =
+    map save_thm
+        (combine (["derivDerivOne", "derivOne", "derivLeft", "derivRight", "derivBoth"],
+		  CONJUNCTS deriv_rules));
+
+(* closure rules, in this way we can finish a proof *)
+val Deriv_def = Define `Deriv = RTC deriv`;
+
+(* |- ∀x. Deriv x x *)
+val Deriv_refl  = save_thm (
+   "Deriv_refl",
+    REWRITE_RULE [SYM Deriv_def]
+	(((Q.ISPEC `deriv`) o (Q.GEN `R`) o (Q.GEN `x`)) RTC_REFL));
+
+(* |- ∀x y z. Deriv x y ∧ Deriv y z ⇒ Deriv x z *)
+val Deriv_trans = save_thm (
+   "Deriv_trans",
+    REWRITE_RULE [SYM Deriv_def]
+	(Q.ISPEC `deriv` (REWRITE_RULE [transitive_def] RTC_TRANSITIVE)));
+
+fun derivToDeriv thm =
+    REWRITE_RULE [SYM Deriv_def] (MATCH_MP RTC_SINGLE thm);
+
+fun derivOneToDeriv thm =
+    REWRITE_RULE [GSYM Deriv_def]
+      (MATCH_MP (Q.ISPEC `deriv` RTC_SINGLE)
+	(MATCH_MP derivDerivOne (SPEC_ALL thm)));
+
+(* derivation rules expressed in relation `Deriv`, for convinence *)
+
+(* |- ∀E A.
+     Deriv (Unf (E:- OneForm A |- A))
+       (Der (E:- OneForm A |- A) SeqAxiom [])
+ *)
+val DerivSeqAxiom = save_thm (
+   "DerivSeqAxiom",
+  ((Q.GEN `E`) o (Q.GEN `A`) o derivOneToDeriv) derivSeqAxiom);
+
+val DerivRightSlash = save_thm (
+   "DerivRightSlash",
+  ((Q.GEN `E`) o (Q.GEN `Gamma`) o (Q.GEN `A`) o (Q.GEN `B`) o
+    derivOneToDeriv) derivRightSlash);
+
+val DerivRightBackslash = save_thm (
+   "DerivRightBackslash",
+  ((Q.GEN `E`) o (Q.GEN `Gamma`) o (Q.GEN `A`) o (Q.GEN `B`) o
+    derivOneToDeriv) derivRightBackslash);
+
+val DerivRightDot = save_thm (
+   "DerivRightDot",
+  ((Q.GEN `E`) o (Q.GEN `Gamma`) o (Q.GEN `Delta`) o (Q.GEN `A`) o (Q.GEN `B`) o
+    derivOneToDeriv) derivRightDot);
+
+val DerivLeftSlash = store_thm (
+   "DerivLeftSlash",
+  ``!E Gamma Gamma' Delta A B C.
+     replace Gamma Gamma' (OneForm A) (Comma (OneForm (Slash A B)) Delta) ==>
+     Deriv (Unf (Sequent E Gamma' C))
+	(Der (Sequent E Gamma' C) LeftSlash
+	     [ Unf (Sequent E Gamma C); Unf (Sequent E Delta B) ])``,
+    REPEAT STRIP_TAC
+ >> REWRITE_TAC [Deriv_def]
+ >> MATCH_MP_TAC (Q.ISPEC `deriv` RTC_SINGLE)
+ >> MATCH_MP_TAC derivDerivOne
+ >> POP_ASSUM MP_TAC
+ >> REWRITE_TAC [derivLeftSlash]);
+
+val DerivLeftBackslash = store_thm (
+   "DerivLeftBackslash",
+  ``!E Gamma Gamma' Delta A B C.
+     replace Gamma Gamma' (OneForm A) (Comma Delta (OneForm (Backslash B A))) ==>
+     Deriv (Unf (Sequent E Gamma' C))
+	(Der (Sequent E Gamma' C) LeftBackslash
+	     [ Unf (Sequent E Gamma C); Unf (Sequent E Delta B) ])``,
+    REPEAT STRIP_TAC
+ >> REWRITE_TAC [Deriv_def]
+ >> MATCH_MP_TAC (Q.ISPEC `deriv` RTC_SINGLE)
+ >> MATCH_MP_TAC derivDerivOne
+ >> POP_ASSUM MP_TAC
+ >> REWRITE_TAC [derivLeftBackslash]);
+
+val DerivLeftDot = store_thm (
+   "DerivLeftDot",
+  ``!E Gamma Gamma' A B C.
+     replace Gamma Gamma' (Comma (OneForm A) (OneForm B)) (OneForm (Dot A B)) ==>
+     Deriv (Unf (Sequent E Gamma' C))
+	(Der (Sequent E Gamma' C) LeftDot
+	     [ Unf (Sequent E Gamma C) ])``,
+    REPEAT STRIP_TAC
+ >> REWRITE_TAC [Deriv_def]
+ >> MATCH_MP_TAC (Q.ISPEC `deriv` RTC_SINGLE)
+ >> MATCH_MP_TAC derivDerivOne
+ >> POP_ASSUM MP_TAC
+ >> REWRITE_TAC [derivLeftDot]);
+
+val DerivCutRule = store_thm (
+   "DerivCutRule",
+  ``!E Delta Gamma Gamma' A C.
+     replace Gamma Gamma' (OneForm A) Delta ==>
+     Deriv (Unf (Sequent E Gamma' C))
+	(Der (Sequent E Gamma' C) CutRule
+	     [ Unf (Sequent E Gamma C); Unf (Sequent E Delta A) ])``,
+    REPEAT STRIP_TAC
+ >> REWRITE_TAC [Deriv_def]
+ >> MATCH_MP_TAC (Q.ISPEC `deriv` RTC_SINGLE)
+ >> MATCH_MP_TAC derivDerivOne
+ >> POP_ASSUM MP_TAC
+ >> REWRITE_TAC [derivCutRule]);
+
+val DerivSeqExt = store_thm (
+   "DerivSeqExt",
+  ``!E Gamma Gamma' Delta Delta' C.
+     replace Gamma Gamma' Delta Delta' /\ E Delta Delta' ==>
+     Deriv (Unf (Sequent E Gamma' C))
+	(Der (Sequent E Gamma' C) SeqExt
+	     [ Unf (Sequent E Gamma C) ])``,
+    REPEAT STRIP_TAC
+ >> REWRITE_TAC [Deriv_def]
+ >> MATCH_MP_TAC (Q.ISPEC `deriv` RTC_SINGLE)
+ >> MATCH_MP_TAC derivDerivOne
+ >> PROVE_TAC [derivSeqExt]);
+
+val DerivOne = store_thm ("DerivOne",
+  ``!S R D1 D1'. Deriv D1 D1' ==> Deriv (Der S R [D1]) (Der S R [D1'])``,
+    NTAC 2 GEN_TAC
+ >> REWRITE_TAC [Deriv_def]
+ >> HO_MATCH_MP_TAC RTC_INDUCT
+ >> REPEAT STRIP_TAC (* 2 sub-goals here, first one is easy *)
+ >- REWRITE_TAC [RTC_REFL]
+ >> PAT_X_ASSUM ``deriv D1 D1'`` (ASSUME_TAC o (MATCH_MP derivOne))
+ >> POP_ASSUM (ASSUME_TAC o (MATCH_MP (Q.ISPEC `deriv` RTC_SINGLE))
+			  o (SPECL [``S :'a Sequent``, ``R :Rule``]))
+ >> IMP_RES_TAC (Q.ISPEC `deriv` (REWRITE_RULE [transitive_def] RTC_TRANSITIVE)));
+
+val DerivLeft = store_thm ("DerivLeft",
+  ``!S R D D1 D1'. Deriv D1 D1' ==> Deriv (Der S R [D1; D]) (Der S R [D1'; D])``,
+    NTAC 3 GEN_TAC
+ >> REWRITE_TAC [Deriv_def]
+ >> HO_MATCH_MP_TAC RTC_INDUCT
+ >> REPEAT STRIP_TAC (* 2 sub-goals here, first one is easy *)
+ >- REWRITE_TAC [RTC_REFL]
+ >> PAT_X_ASSUM ``deriv D1 D1'`` (ASSUME_TAC o (MATCH_MP derivLeft))
+ >> POP_ASSUM (ASSUME_TAC o (MATCH_MP (Q.ISPEC `deriv` RTC_SINGLE)) o (Q.SPECL [`S`, `R`, `D`]))
+ >> IMP_RES_TAC (Q.ISPEC `deriv` (REWRITE_RULE [transitive_def] RTC_TRANSITIVE)));
+
+val DerivRight = store_thm ("DerivRight",
+  ``!S R D D2 D2'. Deriv D2 D2' ==> Deriv (Der S R [D; D2]) (Der S R [D; D2'])``,
+    NTAC 3 GEN_TAC
+ >> REWRITE_TAC [Deriv_def]
+ >> HO_MATCH_MP_TAC RTC_INDUCT
+ >> REPEAT STRIP_TAC (* 2 sub-goals here, first one is easy *)
+ >- REWRITE_TAC [RTC_REFL]
+ >> PAT_X_ASSUM ``deriv D1 D1'`` (ASSUME_TAC o (MATCH_MP derivRight))
+ >> POP_ASSUM (ASSUME_TAC o (MATCH_MP (Q.ISPEC `deriv` RTC_SINGLE)) o (Q.SPECL [`S`, `R`, `D`]))
+ >> IMP_RES_TAC (Q.ISPEC `deriv` (REWRITE_RULE [transitive_def] RTC_TRANSITIVE)));
+
+val DerivBoth = store_thm ("DerivBoth",
+  ``!S R D2 D2' D1 D1'. Deriv D1 D1' ==> Deriv D2 D2'
+		    ==> Deriv (Der S R [D1; D2]) (Der S R [D1'; D2'])``,
+    NTAC 4 GEN_TAC
+ >> REWRITE_TAC [Deriv_def]
+ >> HO_MATCH_MP_TAC RTC_INDUCT
+ >> REPEAT STRIP_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      POP_ASSUM MP_TAC \\
+      Q.SPEC_TAC (`D2'`, `D2'`) \\
+      Q.SPEC_TAC (`D2`, `D2`) \\
+      HO_MATCH_MP_TAC RTC_INDUCT \\
+      REPEAT STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 1.1 (of 2) *)
+        REWRITE_TAC [RTC_REFL],
+        (* goal 1.2 (of 2) *)
+        PAT_X_ASSUM ``deriv D2 D2'`` (ASSUME_TAC o (MATCH_MP derivRight)) \\
+        POP_ASSUM (ASSUME_TAC o (MATCH_MP (Q.ISPEC `deriv` RTC_SINGLE))
+			      o (Q.SPECL [`S`, `R`, `D1`])) \\
+        IMP_RES_TAC (Q.ISPEC `deriv` (REWRITE_RULE [transitive_def] RTC_TRANSITIVE)) ],
+      (* goal 2 (of 2) *)
+      RES_TAC \\
+      PAT_X_ASSUM ``deriv D1 D1'`` (ASSUME_TAC o (MATCH_MP derivLeft)) \\
+      POP_ASSUM (ASSUME_TAC o (MATCH_MP (Q.ISPEC `deriv` RTC_SINGLE))
+			    o (Q.SPECL [`S`, `R`, `D2`])) \\
+      IMP_RES_TAC (Q.ISPEC `deriv` (REWRITE_RULE [transitive_def] RTC_TRANSITIVE)) ]);
+
+(* All Deriv rules *)
+val Deriv_rules = save_thm ("Deriv_rules",
+    LIST_CONJ [ DerivSeqAxiom, DerivRightSlash, DerivRightBackslash, DerivRightDot,
+		DerivLeftSlash, DerivLeftBackslash, DerivLeftDot,
+		DerivCutRule, DerivSeqExt,
+		DerivOne, DerivLeft, DerivRight, DerivBoth,
+		Deriv_refl, Deriv_trans ]);
+
+(* Inductively define a "finished" proof *)
+val (Proof_rules, Proof_ind, Proof_cases) = Hol_reln `
+    (!S R.       Proof (Der S R [])) /\
+    (!S R D.     Proof D ==> Proof (Der S R [D])) /\
+    (!S R D1 D2. Proof D1 /\ Proof D2 ==> Proof (Der S R [D1; D2]))`;
+
+val [ProofZero, ProofOne, ProofTwo] =
+    map save_thm
+	(combine (["ProofZero", "ProofOne", "ProofTwo"], CONJUNCTS Proof_rules));
+
+(* Derivations starting from "Unf" are not finished! *)
+val notProofUnf = store_thm (
+   "notProofUnf",
+  ``!S. ~Proof (Unf S)``,
+    GEN_TAC
+ >> ONCE_REWRITE_TAC [Proof_cases]
+ >> rw []);
+
+(* Now we make a connection between our derivation proofs and gentzenSequent relation *)
+
+(* the easy direction (completeness) *)
+val gentzenToDeriv = store_thm (
+   "gentzenToDeriv",
+  ``!E Gamma A. gentzenSequent E Gamma A
+	    ==> (?D. Deriv (Unf (Sequent E Gamma A)) D /\ Proof D)``,
+    Induct_on `gentzenSequent`
+ >> REPEAT STRIP_TAC (* 9 sub-goals here *)
+ >| [ (* goal 1 (of 9) *)
+      EXISTS_TAC ``(Der (Sequent E (OneForm A) A) SeqAxiom [])`` \\
+      REWRITE_TAC [DerivSeqAxiom, Proof_rules],
+      (* goal 2 (of 9) *)
+      EXISTS_TAC ``(Der (Sequent E Gamma (Slash A B)) RightSlash [D])`` \\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 2.1 (of 2) *)
+        ASSUME_TAC (SPEC_ALL DerivRightSlash) \\
+        PAT_X_ASSUM ``Deriv (Unf (Sequent E (Comma Gamma (OneForm B)) A)) D``
+	  (ASSUME_TAC o (MATCH_MP DerivOne)) \\
+        POP_ASSUM (ASSUME_TAC o (Q.SPECL [`Sequent E Gamma (Slash A B)`, `RightSlash`])) \\
+        IMP_RES_TAC Deriv_trans,
+        (* goal 2.2 (of 2) *)
+        POP_ASSUM MP_TAC \\
+        REWRITE_TAC [ProofOne] ],
+      (* goal 3 (of 9) *)
+      EXISTS_TAC ``(Der (Sequent E Gamma (Backslash B A)) RightBackslash [D])`` \\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 3.1 (of 2) *)
+        ASSUME_TAC (SPEC_ALL DerivRightBackslash) \\
+        PAT_X_ASSUM ``Deriv (Unf (Sequent E (Comma (OneForm B) Gamma) A)) D``
+	  (ASSUME_TAC o (MATCH_MP DerivOne)) \\
+        POP_ASSUM (ASSUME_TAC o (Q.SPECL [`Sequent E Gamma (Backslash B A)`, `RightBackslash`])) \\
+        IMP_RES_TAC Deriv_trans,
+        (* goal 3.2 (of 2) *)
+        POP_ASSUM MP_TAC \\
+        REWRITE_TAC [ProofOne] ],
+      (* goal 4 (of 9) *)
+      EXISTS_TAC ``(Der (Sequent E (Comma Gamma Gamma') (Dot A A')) RightDot [D; D'])`` \\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 4.1 (of 2) *)
+        `Deriv (Der (Sequent E (Comma Gamma Gamma') (Dot A A')) RightDot
+		  [ (Unf (Sequent E Gamma A)); (Unf (Sequent E Gamma' A')) ])
+	       (Der (Sequent E (Comma Gamma Gamma') (Dot A A')) RightDot [D; D'])`
+	    by PROVE_TAC [DerivBoth] \\
+        ASSUME_TAC (Q.SPECL [`E`, `Gamma`, `Gamma'`, `A`, `A'`] DerivRightDot) \\
+        IMP_RES_TAC Deriv_trans,
+        (* goal 4.2 (of 2) *)
+        MATCH_MP_TAC ProofTwo >> ASM_REWRITE_TAC [] ],
+      (* goal 5 (of 9) *)
+      EXISTS_TAC ``(Der (Sequent E Gamma' A'') LeftSlash [D'; D])`` \\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 5.1 (of 2) *)
+        `Deriv (Der (Sequent E Gamma' A'') LeftSlash
+		 [ (Unf (Sequent E Gamma A'')); (Unf (Sequent E Gamma'' A')) ])
+	       (Der (Sequent E Gamma' A'') LeftSlash [D'; D])`
+	    by PROVE_TAC [DerivBoth] \\
+        ASSUME_TAC (Q.SPECL [`E`, `Gamma`, `Gamma'`, `Gamma''`, `A`, `A'`, `A''`]
+			    DerivLeftSlash) \\
+        RES_TAC >> IMP_RES_TAC Deriv_trans,
+        (* goal 5.2 (of 2) *)
+        MATCH_MP_TAC ProofTwo >> ASM_REWRITE_TAC [] ],
+      (* goal 6 (of 9) *)
+      EXISTS_TAC ``(Der (Sequent E Gamma' A'') LeftBackslash [D'; D])`` \\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 6.1 (of 2) *)
+        `Deriv (Der (Sequent E Gamma' A'') LeftBackslash
+		 [ (Unf (Sequent E Gamma A'')); (Unf (Sequent E Gamma'' A')) ])
+	       (Der (Sequent E Gamma' A'') LeftBackslash [D'; D])`
+	    by PROVE_TAC [DerivBoth] \\
+        ASSUME_TAC (Q.SPECL [`E`, `Gamma`, `Gamma'`, `Gamma''`, `A`, `A'`, `A''`]
+			    DerivLeftBackslash) \\
+        RES_TAC >> IMP_RES_TAC Deriv_trans,
+        (* goal 6.2 (of 2) *)
+        MATCH_MP_TAC ProofTwo >> ASM_REWRITE_TAC [] ],
+      (* goal 7 (of 9) *)
+      EXISTS_TAC ``(Der (Sequent E Gamma' A') LeftDot [D])`` \\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 7.1 (of 2) *)
+        IMP_RES_TAC DerivLeftDot \\
+        POP_ASSUM (ASSUME_TAC o (Q.SPECL [`E`, `A'`])) \\
+        PAT_X_ASSUM ``Deriv (Unf (Sequent E Gamma A')) D``
+	  (ASSUME_TAC o (MATCH_MP DerivOne)) \\
+        POP_ASSUM (ASSUME_TAC o (Q.SPECL [`Sequent E Gamma' A'`, `LeftDot`])) \\
+        IMP_RES_TAC Deriv_trans,
+        (* goal 7.2 (of 2) *)
+        POP_ASSUM MP_TAC \\
+        REWRITE_TAC [ProofOne] ],
+      (* goal 8 (of 9) *)
+      EXISTS_TAC ``(Der (Sequent E Gamma'' A') CutRule [D'; D])`` \\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 8.1 (of 2) *)
+        IMP_RES_TAC DerivCutRule \\
+        POP_ASSUM (ASSUME_TAC o (Q.SPECL [`E`, `A'`])) \\
+        `Deriv (Der (Sequent E Gamma'' A') CutRule
+		 [ (Unf (Sequent E Gamma' A')); (Unf (Sequent E Gamma A)) ])
+	       (Der (Sequent E Gamma'' A') CutRule [D'; D])`
+	    by PROVE_TAC [DerivBoth] \\
+        IMP_RES_TAC Deriv_trans,
+        (* goal 8.2 (of 2) *)
+        MATCH_MP_TAC ProofTwo >> ASM_REWRITE_TAC [] ],
+      (* goal 9 (of 9) *)
+      EXISTS_TAC ``(Der (Sequent E Gamma' A) SeqExt [D])`` \\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 9.1 (of 2) *)
+        IMP_RES_TAC DerivOne \\
+        POP_ASSUM (ASSUME_TAC o (Q.SPECL [`(Sequent E Gamma' A)`, `SeqExt`])) \\
+        `Deriv (Unf (Sequent E Gamma' A))
+	       (Der (Sequent E Gamma' A) SeqExt [Unf (Sequent E Gamma A)])`
+	    by PROVE_TAC [DerivSeqExt] \\
+        IMP_RES_TAC Deriv_trans,
+        (* goal 9.2 (of 2) *)
+        POP_ASSUM MP_TAC \\
+        REWRITE_TAC [ProofOne] ] ]);
+
+(******************************************************************************)
+(*                                                                            *)
+(*               Sub-formula properties in cut-free proofs                    *)
+(*                                                                            *)
+(******************************************************************************)
+
+val subFormulaPropertyOne = store_thm (
+   "subFormulaPropertyOne",
+  ``!q p. subProofOne q p ==>
+	  extensionSub (exten p) ==>
+	  CutFreeProof p ==>
+      !x. (subFormTerm x (prems q) \/ subFormula x (concl q)) ==>
+	  (subFormTerm x (prems p) \/ subFormula x (concl p))``,
+    REPEAT GEN_TAC
+ >> NTAC 3 DISCH_TAC
+ >> GEN_TAC
+ >> DISCH_TAC
+ >> PAT_X_ASSUM ``subProofOne q p`` MP_TAC
+ >> ONCE_REWRITE_TAC [subProofOne_cases]
+ >> STRIP_TAC (* 12 sub-goals here *)
+ >| [ (* goal 1 (of 12) *)
+      PAT_X_ASSUM ``subFormTerm x (prems q) \/ subFormula x (concl q)`` MP_TAC \\
+      ASM_REWRITE_TAC [prems_def, concl_def] \\
+      STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 1.1 (of 2) *)
+        POP_ASSUM (MP_TAC o (MATCH_MP comSub)) >> rw [] >| (* 2 sub-goals here *)
+        [ (* goal 1.1.1 (of 2) *)
+          DISJ1_TAC >> ASM_REWRITE_TAC [],
+          (* goal 1.1.2 (of 2) *)
+          (* Removed due to oneFormSubEQ[simp]:
+             POP_ASSUM (ASSUME_TAC o (MATCH_MP oneFormSub)) \\ *)
+          POP_ASSUM (ASSUME_TAC o (Q.SPEC `A`) o (MATCH_MP slashR)) \\
+          ASM_REWRITE_TAC [] ],
+        (* goal 1.2 (of 2) *)
+        DISJ2_TAC \\
+        POP_ASSUM (ASSUME_TAC o (Q.SPEC `B`) o (MATCH_MP slashL)) \\
+        ASM_REWRITE_TAC [] ],
+      (* goal 2 (of 12) *)
+      PAT_X_ASSUM ``subFormTerm x (prems q) \/ subFormula x (concl q)`` MP_TAC \\
+      ASM_REWRITE_TAC [prems_def, concl_def] \\
+      STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 2.1 (of 2) *)
+        POP_ASSUM (MP_TAC o (MATCH_MP comSub)) >> rw [] >| (* 2 sub-goals here *)
+        [ (* goal 2.1.1 (of 2) *)
+          (* Removed due to oneFormSubEQ[simp]:
+             POP_ASSUM (ASSUME_TAC o (MATCH_MP oneFormSub)) \\ *)
+          POP_ASSUM (ASSUME_TAC o (Q.SPEC `A`) o (MATCH_MP backslashL)) \\
+          ASM_REWRITE_TAC [],
+          (* goal 2.1.2 (of 2) *)
+          DISJ1_TAC >> ASM_REWRITE_TAC [] ],
+        (* goal 2.2 (of 2) *)
+        DISJ2_TAC \\
+        POP_ASSUM (ASSUME_TAC o (Q.SPEC `B`) o (MATCH_MP backslashR)) \\
+        ASM_REWRITE_TAC [] ],
+      (* goal 3 (of 12) *)
+      PAT_X_ASSUM ``subFormTerm x (prems q) \/ subFormula x (concl q)`` MP_TAC \\
+      ASM_REWRITE_TAC [prems_def, concl_def] \\
+      STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 3.1 (of 2) *)
+        DISJ1_TAC \\
+        POP_ASSUM (ASSUME_TAC o (Q.SPEC `Delta`) o (MATCH_MP comL)) \\
+        ASM_REWRITE_TAC [],
+        (* goal 3.2 (of 2) *)
+        DISJ2_TAC \\
+        POP_ASSUM (ASSUME_TAC o (Q.SPEC `B`) o (MATCH_MP dotL)) \\
+        ASM_REWRITE_TAC [] ],
+      (* goal 4 (of 12) *)
+      PAT_X_ASSUM ``subFormTerm x (prems q) \/ subFormula x (concl q)`` MP_TAC \\
+      ASM_REWRITE_TAC [prems_def, concl_def] \\
+      STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 4.1 (of 2) *)
+        DISJ1_TAC \\
+        POP_ASSUM (ASSUME_TAC o (Q.SPEC `Gamma`) o (MATCH_MP comR)) \\
+        ASM_REWRITE_TAC [],
+        (* goal 4.2 (of 2) *)
+        DISJ2_TAC \\
+        POP_ASSUM (ASSUME_TAC o (Q.SPEC `A`) o (MATCH_MP dotR)) \\
+        ASM_REWRITE_TAC [] ],
+      (* goal 5 (of 12) *)
+      PAT_X_ASSUM ``subFormTerm x (prems q) \/ subFormula x (concl q)`` MP_TAC \\
+      ASM_REWRITE_TAC [prems_def, concl_def] \\
+      STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 5.1 (of 2) *)
+        DISJ1_TAC \\
+        IMP_RES_TAC subReplace2 \\
+        POP_ASSUM (MP_TAC o (Q.SPEC `x`)) \\
+        POP_ASSUM (ASSUME_TAC o (SPEC ``(OneForm (Slash A B))``) o (MATCH_MP comR)) \\
+        DISCH_TAC >> RES_TAC,
+        (* goal 5.2 (of 2) *)
+        DISJ1_TAC \\
+        IMP_RES_TAC subReplace2 \\
+        POP_ASSUM (MP_TAC o (Q.SPEC `x`)) \\
+        POP_ASSUM (ASSUME_TAC o (Q.SPEC `A`) o (MATCH_MP slashR)) \\
+        POP_ASSUM (ASSUME_TAC o (MATCH_MP eqFT)) \\
+        POP_ASSUM (ASSUME_TAC o (Q.SPEC `Delta`) o (MATCH_MP comL)) \\
+        DISCH_TAC >> RES_TAC ],
+      (* goal 6 (of 12) *)
+      PAT_X_ASSUM ``subFormTerm x (prems q) \/ subFormula x (concl q)`` MP_TAC \\
+      ASM_REWRITE_TAC [prems_def, concl_def] \\
+      STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 6.1 (of 2) *)
+        IMP_RES_TAC subReplace3 >| (* 2 sub-goals here *)
+        [ (* goal 6.1.1 (of 2) *)
+          ASM_REWRITE_TAC [],
+          (* goal 6.1.2 (of 2) *)
+          IMP_RES_TAC subReplace2 \\
+          POP_ASSUM (MP_TAC o (Q.SPEC `x`)) \\
+          POP_ASSUM (ASSUME_TAC o (MATCH_MP oneFormSub)) \\
+          POP_ASSUM (ASSUME_TAC o (Q.SPEC `B`) o (MATCH_MP slashL)) \\
+          POP_ASSUM (ASSUME_TAC o (MATCH_MP eqFT)) \\
+          POP_ASSUM (ASSUME_TAC o (Q.SPEC `Delta`) o (MATCH_MP comL)) \\
+          DISCH_TAC >> RES_TAC >> ASM_REWRITE_TAC [] ],
+        (* goal 6.2 (of 2) *)
+        DISJ2_TAC >> ASM_REWRITE_TAC [] ],
+      (* goal 7 (of 12) *)
+      PAT_X_ASSUM ``subFormTerm x (prems q) \/ subFormula x (concl q)`` MP_TAC \\
+      ASM_REWRITE_TAC [prems_def, concl_def] \\
+      STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 7.1 (of 2) *)
+        DISJ1_TAC \\
+        IMP_RES_TAC subReplace2 \\
+        POP_ASSUM (MP_TAC o (Q.SPEC `x`)) \\
+        POP_ASSUM (ASSUME_TAC o (SPEC ``(OneForm (Backslash B A))``) o (MATCH_MP comL)) \\
+        DISCH_TAC >> RES_TAC,
+        (* goal 7.2 (of 2) *)
+        DISJ1_TAC \\
+        IMP_RES_TAC subReplace2 \\
+        POP_ASSUM (MP_TAC o (Q.SPEC `x`)) \\
+        POP_ASSUM (ASSUME_TAC o (Q.SPEC `A`) o (MATCH_MP backslashL)) \\
+        POP_ASSUM (ASSUME_TAC o (MATCH_MP eqFT)) \\
+        POP_ASSUM (ASSUME_TAC o (Q.SPEC `Delta`) o (MATCH_MP comR)) \\
+        DISCH_TAC >> RES_TAC ],
+      (* goal 8 (of 12) *)
+      PAT_X_ASSUM ``subFormTerm x (prems q) \/ subFormula x (concl q)`` MP_TAC \\
+      ASM_REWRITE_TAC [prems_def, concl_def] \\
+      STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 8.1 (of 2) *)
+        IMP_RES_TAC subReplace3 >| (* 2 sub-goals here *)
+        [ (* goal 8.1.1 (of 2) *)
+          ASM_REWRITE_TAC [],
+          (* goal 8.1.2 (of 2) *)
+          IMP_RES_TAC subReplace2 \\
+          POP_ASSUM (MP_TAC o (Q.SPEC `x`)) \\
+          POP_ASSUM (ASSUME_TAC o (MATCH_MP oneFormSub)) \\
+          POP_ASSUM (ASSUME_TAC o (Q.SPEC `B`) o (MATCH_MP backslashR)) \\
+          POP_ASSUM (ASSUME_TAC o (MATCH_MP eqFT)) \\
+          POP_ASSUM (ASSUME_TAC o (Q.SPEC `Delta`) o (MATCH_MP comR)) \\
+          DISCH_TAC >> RES_TAC >> ASM_REWRITE_TAC [] ],
+        (* goal 8.2 (of 2) *)
+        DISJ2_TAC >> ASM_REWRITE_TAC [] ],
+      (* goal 9 (of 12) *)
+      PAT_X_ASSUM ``subFormTerm x (prems q) \/ subFormula x (concl q)`` MP_TAC \\
+      ASM_REWRITE_TAC [prems_def, concl_def] \\
+      STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 9.1 (of 2) *)
+        IMP_RES_TAC subReplace3 >| (* 2 sub-goals here *)
+        [ (* goal 9.1.1 (of 2) *)
+          ASM_REWRITE_TAC [],
+          (* goal 9.1.2 (of 2) *)
+          IMP_RES_TAC subReplace2 \\
+          POP_ASSUM (MP_TAC o (Q.SPEC `x`)) \\
+          POP_ASSUM (MP_TAC o (MATCH_MP comSub)) \\
+          STRIP_TAC >| (* 2 sub-goals here *)
+          [ (* goal 9.1.2.1 (of 2) *)
+            POP_ASSUM (ASSUME_TAC o (MATCH_MP oneFormSub)) \\
+            POP_ASSUM (ASSUME_TAC o (Q.SPEC `B`) o (MATCH_MP dotL)) \\
+            POP_ASSUM (ASSUME_TAC o (MATCH_MP eqFT)) \\
+            DISCH_TAC >> RES_TAC >> ASM_REWRITE_TAC [],
+            (* goal 9.1.2.2 (of 2) *)
+            POP_ASSUM (ASSUME_TAC o (MATCH_MP oneFormSub)) \\
+            POP_ASSUM (ASSUME_TAC o (Q.SPEC `A`) o (MATCH_MP dotR)) \\
+            POP_ASSUM (ASSUME_TAC o (MATCH_MP eqFT)) \\
+            DISCH_TAC >> RES_TAC \\
+            ASM_REWRITE_TAC [] ] ],
+        (* goal 9.2 (of 2) *)
+        DISJ2_TAC >> ASM_REWRITE_TAC [] ],
+      (* goal 10 (of 12) *)
+      PAT_X_ASSUM ``subFormTerm x (prems q) \/ subFormula x (concl q)`` MP_TAC \\
+      ASM_REWRITE_TAC [prems_def, concl_def] \\
+      STRIP_TAC \\ (* 2 sub-goals here, sharing the same tactical *)
+      METIS_TAC [notCutFree],
+      (* goal 11 (of 12) *)
+      PAT_X_ASSUM ``subFormTerm x (prems q) \/ subFormula x (concl q)`` MP_TAC \\
+      ASM_REWRITE_TAC [prems_def, concl_def] \\
+      STRIP_TAC \\ (* 2 sub-goals here, sharing the same tactical *)
+      METIS_TAC [notCutFree],
+      (* goal 12 (of 12) *)
+      PAT_X_ASSUM ``subFormTerm x (prems q) \/ subFormula x (concl q)`` MP_TAC \\
+      ASM_REWRITE_TAC [prems_def, concl_def] \\
+      STRIP_TAC >| (* 2 sub-goals here, sharing the same tactical *)
+      [ (* goal 12.1 (of 2) *)
+        IMP_RES_TAC subReplace3 >- ASM_REWRITE_TAC [] \\
+        DISJ1_TAC >> IMP_RES_TAC subReplace2 \\
+        POP_ASSUM (ASSUME_TAC o (Q.SPEC `x`)) \\
+        `extensionSub E` by METIS_TAC [exten_def] \\
+        IMP_RES_TAC extensionSub_def >> RES_TAC,
+        (* goal 12.2 (of 2) *)
+        DISJ2_TAC >> ASM_REWRITE_TAC [] ] ]);
+
+(* original statements in the Coq version *)
+val subFormulaPropertyOne' = store_thm (
+   "subFormulaPropertyOne'",
+  ``!Gamma1 Gamma2 B C x E p q.
+     (p = Der (Sequent E Gamma1 B) _ _) ==>
+     (q = Der (Sequent E Gamma2 C) _ _) ==>
+     extensionSub E ==>
+     subProofOne q p ==>
+     CutFreeProof p ==>
+     (subFormTerm x Gamma2 \/ subFormula x C) ==>
+     (subFormTerm x Gamma1 \/ subFormula x B)``,
+    REPEAT GEN_TAC
+ >> NTAC 5 STRIP_TAC
+ >> `Gamma1 = prems p` by PROVE_TAC [prems_def]
+ >> `Gamma2 = prems q` by PROVE_TAC [prems_def]
+ >> `B = concl p` by PROVE_TAC [concl_def]
+ >> `C = concl q` by PROVE_TAC [concl_def]
+ >> `E = exten p` by PROVE_TAC [exten_def]
+ >> `extensionSub (exten p)` by PROVE_TAC []
+ >> ONCE_ASM_REWRITE_TAC []
+ >> METIS_TAC [subFormulaPropertyOne]);
+
+val subFormulaProperty = store_thm (
+   "subFormulaProperty",
+  ``!q p. subProof q p ==>
+	  extensionSub (exten p) ==>
+	  CutFreeProof p ==>
+      !x. (subFormTerm x (prems q) \/ subFormula x (concl q)) ==>
+	  (subFormTerm x (prems p) \/ subFormula x (concl p))``,
+    HO_MATCH_MP_TAC subProof_strongind
+ >> STRIP_TAC >- rw []
+ >> fix [`p3`, `p2`, `p1`]
+ >> set [`T1 = prems p1`, `T2 = prems p2`, `T3 = prems p3`,
+	 `A1 = concl p1`, `A2 = concl p2`, `A3 = concl p3`,
+	 `E  = exten p1`]
+ >> PURE_ONCE_REWRITE_TAC []
+ >> NTAC 4 STRIP_TAC >> DISCH_TAC
+ >> `subFormTerm x T2 \/ subFormula x A2 ==>
+     subFormTerm x T1 \/ subFormula x A1` by METIS_TAC []
+ >> `CutFreeProof p2` by METIS_TAC [CutFreeSubProof]
+ >> `extensionSub (exten p2)` by METIS_TAC [subProof_extension]
+ >> `subFormTerm x T2 \/ subFormula x A2`
+	by METIS_TAC [subFormulaPropertyOne]
+ >> METIS_TAC []);
+
+(* original statements in the Coq version *)
+val subFormulaProperty' = store_thm (
+   "subFormulaProperty'",
+  ``!Gamma1 Gamma2 B C x E p q.
+     (p = Der (Sequent E Gamma1 B) _ _) ==>
+     (q = Der (Sequent E Gamma2 C) _ _) ==>
+     extensionSub E ==>
+     subProof q p ==>
+     CutFreeProof p ==>
+     (subFormTerm x Gamma2 \/ subFormula x C) ==>
+     (subFormTerm x Gamma1 \/ subFormula x B)``,
+    REPEAT GEN_TAC
+ >> NTAC 5 STRIP_TAC
+ >> `Gamma1 = prems p` by PROVE_TAC [prems_def]
+ >> `Gamma2 = prems q` by PROVE_TAC [prems_def]
+ >> `B = concl p` by PROVE_TAC [concl_def]
+ >> `C = concl q` by PROVE_TAC [concl_def]
+ >> `E = exten p` by PROVE_TAC [exten_def]
+ >> `extensionSub (exten p)` by PROVE_TAC []
+ >> ONCE_ASM_REWRITE_TAC []
+ >> METIS_TAC [subFormulaProperty]);
+
+val _ = export_theory ();
+val _ = html_theory "CutFree";
+
+(* last updated: April 25, 2017 *)

--- a/examples/formal-languages/lambek/ExampleScript.sml
+++ b/examples/formal-languages/lambek/ExampleScript.sml
@@ -1,0 +1,523 @@
+(*
+ * Formalized Lambek Calculus in Higher Order Logic (HOL4)
+ *
+ *  (based on https://github.com/coq-contribs/lambek)
+ *
+ * Copyright 2016-2017  University of Bologna, Italy (Author: Chun Tian)
+ *)
+
+(* This program is free software; you can redistribute it and/or      *)
+(* modify it under the terms of the GNU Lesser General Public License *)
+(* as published by the Free Software Foundation; either version 2.1   *)
+(* of the License, or (at your option) any later version.             *)
+(*                                                                    *)
+(* This program is distributed in the hope that it will be useful,    *)
+(* but WITHOUT ANY WARRANTY; without even the implied warranty of     *)
+(* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the      *)
+(* GNU General Public License for more details.                       *)
+(*                                                                    *)
+(* You should have received a copy of the GNU Lesser General Public   *)
+(* License along with this program; if not, write to the Free         *)
+(* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA *)
+(* 02110-1301 USA                                                     *)
+
+open HolKernel Parse boolLib bossLib;
+
+open pred_setTheory relationTheory pairTheory listTheory prim_recTheory arithmeticTheory
+open stringTheory integerTheory LambekTheory CutFreeTheory;
+
+local
+    val PAT_X_ASSUM = PAT_ASSUM;
+    val qpat_x_assum = Q.PAT_ASSUM;
+    open Tactical
+in
+    (* Backward compatibility with Kananaskis 11 *)
+    val PAT_X_ASSUM = PAT_X_ASSUM;
+    val qpat_x_assum = qpat_x_assum;
+
+    (* Tacticals for better expressivity *)
+    fun fix  ts = MAP_EVERY Q.X_GEN_TAC ts;	(* from HOL Light *)
+    fun set  ts = MAP_EVERY Q.ABBREV_TAC ts;	(* from HOL mizar mode *)
+    fun take ts = MAP_EVERY Q.EXISTS_TAC ts;	(* from HOL mizar mode *)
+end;
+
+val _ = new_theory "Example";
+
+(* check if a given sentence has category s *)
+val sentence_def = Define `
+    sentence words = arrow NL words (At "S")`;
+
+(******************************************************************************)
+(*                                                                            *)
+(*              Example 1: check simple sentences in (arrow NL)               *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* in most simple cases, we have one-one mapping between words and their syntactic categories *)
+val John = ``At "np"``;
+val works = ``Backslash (At "np") (At "S")``;
+
+val John_works = ``(Dot ^John ^works)``;
+
+(* "John works" is a sentence, manual proof *)
+val John_works_thm = store_thm (
+   "John_works_thm", ``sentence ^John_works``,
+    REWRITE_TAC [sentence_def]
+ >> MATCH_MP_TAC gamma'
+ >> REWRITE_TAC [one]);
+
+(* same proof, done automatically *)
+val John_works_thm2 = store_thm (
+   "John_works_thm2", ``sentence ^John_works``,
+    REWRITE_TAC [sentence_def]
+ >> PROVE_TAC [arrow_rules]);
+
+local
+    val before_tac = REWRITE_TAC [sentence_def]
+    and after_tac  = PROVE_TAC [arrow_rules]
+in
+    fun check_arrow tm =
+	prove (tm, before_tac >> after_tac)
+end;
+
+val John_works_thm3 = save_thm (
+   "John_works_thm3", check_arrow ``sentence ^John_works``);
+
+(******************************************************************************)
+(*                                                                            *)
+(*           Example 2: check complex sentences in Natural Deduction          *)
+(*                                                                            *)
+(******************************************************************************)
+
+val Ex1 = store_thm ("Ex1", (* sn/n . n |- sn *)
+  ``natDed NL_Sequent (OneForm (Dot (Slash (At "sn") (At "n")) (At "n"))) (At "sn")``,
+    MATCH_MP_TAC DotElim
+ >> ONCE_REWRITE_TAC [replace_cases]
+ >> RW_TAC std_ss [Term_11, Term_distinct]
+ >> EXISTS_TAC ``Slash (At "sn") (At "n")``
+ >> EXISTS_TAC ``At "n"``
+ >> RW_TAC std_ss [NatAxiom]
+ >> MATCH_MP_TAC SlashElim
+ >> EXISTS_TAC ``At "n"``
+ >> RW_TAC std_ss [NatAxiom]);
+
+val Ex2 = store_thm ("Ex2", (* sn . (((sn \ n) / S) . S)) |- n *)
+  ``natDed NL_Sequent
+	(OneForm (Dot (At "sn") (Dot (Slash (Backslash (At "sn") (At "n")) (At "S")) (At "S"))))
+	(At "n")``,
+    MATCH_MP_TAC DotElim
+ >> ONCE_REWRITE_TAC [replace_cases]
+ >> RW_TAC std_ss [Term_11, Term_distinct]
+ >> EXISTS_TAC ``At "sn"``
+ >> EXISTS_TAC ``Dot (Slash (Backslash (At "sn") (At "n")) (At "S")) (At "S")``
+ >> RW_TAC std_ss [NatAxiom]
+ >> MATCH_MP_TAC BackslashElim
+ >> EXISTS_TAC ``At "sn"``
+ >> RW_TAC std_ss [NatAxiom]
+ >> MATCH_MP_TAC DotElim
+ >> ONCE_REWRITE_TAC [replace_cases]
+ >> RW_TAC std_ss [Term_11, Term_distinct]
+ >> EXISTS_TAC ``Slash (Backslash (At "sn") (At "n")) (At "S")``
+ >> EXISTS_TAC ``At "S"``
+ >> RW_TAC std_ss [NatAxiom]
+ >> MATCH_MP_TAC SlashElim
+ >> EXISTS_TAC ``At "S"``
+ >> RW_TAC std_ss [NatAxiom]);
+
+(******************************************************************************)
+(*                                                                            *)
+(*           Example 3: check complex sentences in Natural Deduction          *)
+(*                                                                            *)
+(******************************************************************************)
+
+val Kevin = ``At "np"``;
+val talks = ``Slash (Backslash (At "np") (At "S")) (At "pp")``; (* (np \ s) / pp *)
+
+val to = ``Slash (At "pp") (At "np")``;
+
+val himself = (* ((np \ s) / np) \ (np \ s) *)
+  ``Backslash (Slash (Backslash (At "np") (At "S")) (At "np"))
+	      (Backslash (At "np") (At "S"))``;
+
+(* (Kevin, ((talks, to), himself)) *)
+val Kevin_talks_to_himself = ``Dot ^Kevin (Dot (Dot ^talks ^to) ^himself)``;
+
+(* this time automatic proof search by arrow doesn't work:
+
+> check_arrow ``sentence ^Kevin_talks_to_himself``;
+Meson search level: ................Exception- Interrupt raised
+ *)
+
+(*
+val Kevin_talks_to_himself_thm = store_thm (
+   "Kevin_talks_to_himself_thm", ``arrow NL ^Kevin_talks_to_himself (At "S")``,
+ >> );
+*)
+
+(******************************************************************************)
+(*                                                                            *)
+(*     Example 4: "cosa guarda passare" in bot natDed and gentzenSequent      *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* a basic category type, but how to use it? *)
+(* val _ = Datatype `Lexicon = <| word : string ; category : 'a Form |>`; *)
+
+val cosa = ``(At "S") / ((At "S") / (At "np"))``;
+val guarda = ``(At "S") / (At "inf")``;
+val passare = ``(At "inf") / (At "np")``;
+val il = ``(At "np") / (At "n")``;
+val treno = ``At "n"``;
+
+(*
+S/(S/np) * (S/inf * inf/np) --> S
+S/(S/np) --> S / (S/inf * inf/np)
+1. S/inf * inf/np --> S/np
+S/(S/np) * S/np --> S
+S/(S/np) --> S/(S/np)
+val cosa_guarda_passare_arrow = store_thm (
+   "cosa_guarda_passare_arrow",
+  ``arrow L (Dot ^cosa (Dot ^guarda ^passare)) (At "S")``,
+);
+ *)
+
+(* Natural Deduction for Lambek Calculus:
+
+                                   inf/np |- inf/np   np |- np
+                                  ----------------------------- /e
+                  S/inf |- S/inf    inf/np, np |- inf
+                  ----------------------------------- /e
+                       S/inf, (inf/np, np) |- S
+                      -------------------------- L_Sequent
+                       (S/inf, inf/np), np |- S
+                      -------------------------- /i
+ S/(S/np) |- S/(S/np)	 S/inf, inf/np |- S/np
+------------------------------------------------ /e
+    S/(S/np), (S/inf, inf/np) |- S
+------------------------------------ Lex
+("cosa", ("guarda", "passare")) |- S
+
+ *)
+val cosa_guarda_passare_natDed = store_thm (
+   "cosa_guarda_passare_natDed",
+  ``natDed L_Sequent (Comma (OneForm ^cosa) (Comma (OneForm ^guarda) (OneForm ^passare)))
+		     (At "S")``,
+    MATCH_MP_TAC SlashElim
+ >> EXISTS_TAC ``(At "S") / (At "np")`` (* guess 1 *)
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 *)
+      REWRITE_TAC [NatAxiom],
+      (* goal 2 *)
+      MATCH_MP_TAC SlashIntro \\
+      MATCH_MP_TAC NatExtSimpl \\
+      EXISTS_TAC ``(Comma (OneForm (At "S" / At "inf"))
+			  (Comma (OneForm (At "inf" / At "np")) (OneForm (At "np"))))`` \\
+      CONJ_TAC >- REWRITE_TAC [L_Sequent_rules] \\
+      MATCH_MP_TAC SlashElim \\
+      EXISTS_TAC ``At "inf"`` \\ (* guess 2 *)
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 2.1 *)
+        REWRITE_TAC [NatAxiom],
+        (* goal 2.2 *)
+        MATCH_MP_TAC SlashElim \\
+        EXISTS_TAC ``At "np"`` \\ (* guess 3 *)
+        REWRITE_TAC [NatAxiom] ] ]);
+
+(* Lambek's Sequent Calculus:
+
+       S |- S   inf |- inf
+      --------------------- /L
+       S/inf, inf |- S       np |- np
+      -------------------------------- /L
+          S/inf, (inf/np, np) |- S
+         -------------------------- L_Sequent
+          (S/inf, inf/np), np |- S
+         ----------------------------- /R
+ S |- S		S/inf, inf/np |- S/np
+-------------------------------------- /L
+    S/(S/np), (S/inf, inf/np) |- S
+------------------------------------ Lex
+("cosa", ("guarda", "passare")) |- S
+
+ *)
+val cosa_guarda_passare_gentzenSequent = store_thm (
+   "cosa_guarda_passare_gentzenSequent",
+  ``gentzenSequent L_Sequent (Comma (OneForm ^cosa) (Comma (OneForm ^guarda) (OneForm ^passare)))
+			     (At "S")``,
+    MATCH_MP_TAC LeftSlashSimpl
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 *)
+      MATCH_MP_TAC RightSlash \\
+      MATCH_MP_TAC SeqExtSimpl \\
+      EXISTS_TAC ``(Comma (OneForm (At "S" / At "inf"))
+			  (Comma (OneForm (At "inf" / At "np")) (OneForm (At "np"))))`` \\
+      CONJ_TAC >- REWRITE_TAC [L_Sequent_rules] \\
+      MATCH_MP_TAC LeftSlashSimpl \\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 1.1 *)
+        MATCH_MP_TAC LeftSlashSimpl \\
+        REWRITE_TAC [SeqAxiom],
+        (* goal 1.2 *)
+        REWRITE_TAC [SeqAxiom] ],
+      (* goal 2 *)
+      REWRITE_TAC [SeqAxiom] ]);
+
+val r0 =
+  ``(Unf (Sequent L_Sequent (Comma (OneForm (At "S" / (At "S" / At "np")))
+				   (Comma (OneForm (At "S" / At "inf")) (OneForm (At "inf" / At "np"))))
+			    (At "S")))``;
+
+val r1 =
+  ``(Der (Sequent L_Sequent (Comma (OneForm (At "S" / (At "S" / At "np")))
+				   (Comma (OneForm (At "S" / At "inf")) (OneForm (At "inf" / At "np"))))
+			    (At "S"))
+	 LeftSlash
+      [ (Unf (Sequent L_Sequent (OneForm (At "S")) (At "S"))) ;
+	(Unf (Sequent L_Sequent (Comma (OneForm (At "S" / At "inf")) (OneForm (At "inf" / At "np")))
+				(At "S" / At "np"))) ])``;
+
+val r0_to_r1 = store_thm (
+   "r0_to_r1", ``derivOne ^r0 ^r1``,
+    MATCH_MP_TAC derivLeftSlash
+ >> EXISTS_TAC ``At "S"``
+ >> REWRITE_TAC [replaceRoot]);
+
+val r0_to_r1' = store_thm (
+   "r0_to_r1'", ``deriv ^r0 ^r1``,
+    MATCH_MP_TAC derivDerivOne
+ >> REWRITE_TAC [r0_to_r1]);
+
+val r0_to_r1'' = store_thm (
+   "r0_to_r1''", ``Deriv ^r0 ^r1``,
+    REWRITE_TAC [Deriv_def]
+ >> MATCH_MP_TAC RTC_SINGLE
+ >> REWRITE_TAC [r0_to_r1']);
+
+val r2 =
+  ``(Der (Sequent L_Sequent (Comma (OneForm (At "S" / (At "S" / At "np")))
+				   (Comma (OneForm (At "S" / At "inf")) (OneForm (At "inf" / At "np"))))
+			    (At "S"))
+	 LeftSlash
+      [ (Der (Sequent L_Sequent (OneForm (At "S")) (At "S"))
+	     SeqAxiom []) ;
+	(Unf (Sequent L_Sequent (Comma (OneForm (At "S" / At "inf")) (OneForm (At "inf" / At "np")))
+				(At "S" / At "np"))) ])``;
+
+val r1_to_r2 = store_thm (
+   "r1_to_r2", ``deriv ^r1 ^r2``,
+    MATCH_MP_TAC derivLeft
+ >> MATCH_MP_TAC derivDerivOne
+ >> REWRITE_TAC [derivSeqAxiom]);
+
+val r3 =
+  ``(Der (Sequent L_Sequent (Comma (OneForm (At "S" / (At "S" / At "np")))
+				   (Comma (OneForm (At "S" / At "inf")) (OneForm (At "inf" / At "np"))))
+			    (At "S"))
+	 LeftSlash
+      [ (Der (Sequent L_Sequent (OneForm (At "S")) (At "S"))
+	     SeqAxiom []) ;
+	(Der (Sequent L_Sequent (Comma (OneForm (At "S" / At "inf")) (OneForm (At "inf" / At "np")))
+				(At "S" / At "np"))
+	     RightSlash
+	  [ (Unf (Sequent L_Sequent (Comma (Comma (OneForm (At "S" / At "inf"))
+						  (OneForm (At "inf" / At "np")))
+					   (OneForm (At "np")))
+				    (At "S"))) ]) ])``;
+
+val r2_to_r3 = store_thm (
+   "r2_to_r3", ``deriv ^r2 ^r3``,
+    MATCH_MP_TAC derivRight
+ >> MATCH_MP_TAC derivDerivOne
+ >> REWRITE_TAC [derivRightSlash]);
+
+val r4 =
+  ``(Der (Sequent L_Sequent (Comma (OneForm (At "S" / (At "S" / At "np")))
+				   (Comma (OneForm (At "S" / At "inf")) (OneForm (At "inf" / At "np"))))
+			    (At "S"))
+	 LeftSlash
+      [ (Der (Sequent L_Sequent (OneForm (At "S")) (At "S"))
+	     SeqAxiom []) ;
+	(Der (Sequent L_Sequent (Comma (OneForm (At "S" / At "inf")) (OneForm (At "inf" / At "np")))
+				(At "S" / At "np"))
+	     RightSlash
+	  [ (Der (Sequent L_Sequent (Comma (Comma (OneForm (At "S" / At "inf"))
+						  (OneForm (At "inf" / At "np")))
+					   (OneForm (At "np")))
+				    (At "S"))
+			  SeqExt
+		    [ (Unf (Sequent L_Sequent (Comma (OneForm (At "S" / At "inf"))
+						     (Comma (OneForm (At "inf" / At "np"))
+							    (OneForm (At "np"))))
+					      (At "S"))) ]) ]) ])``;
+
+val r3_to_r4 = store_thm (
+   "r3_to_r4", ``deriv ^r3 ^r4``,
+    MATCH_MP_TAC derivRight
+ >> MATCH_MP_TAC derivOne
+ >> MATCH_MP_TAC derivDerivOne
+ >> MATCH_MP_TAC derivSeqExt
+ >> EXISTS_TAC ``(Comma (OneForm (At "S" / At "inf"))
+			(Comma (OneForm (At "inf" / At "np")) (OneForm (At "np"))))``
+ >> EXISTS_TAC ``(Comma (Comma (OneForm (At "S" / At "inf"))
+			       (OneForm (At "inf" / At "np")))
+			(OneForm (At "np")))``
+ >> REWRITE_TAC [replaceRoot, L_Sequent_rules]);
+
+val r5 =
+  ``(Der (Sequent L_Sequent (Comma (OneForm (At "S" / (At "S" / At "np")))
+				   (Comma (OneForm (At "S" / At "inf")) (OneForm (At "inf" / At "np"))))
+			    (At "S"))
+	 LeftSlash
+      [ (Der (Sequent L_Sequent (OneForm (At "S")) (At "S"))
+	     SeqAxiom []) ;
+	(Der (Sequent L_Sequent (Comma (OneForm (At "S" / At "inf")) (OneForm (At "inf" / At "np")))
+				(At "S" / At "np"))
+	     RightSlash
+	  [ (Der (Sequent L_Sequent (Comma (Comma (OneForm (At "S" / At "inf"))
+						  (OneForm (At "inf" / At "np")))
+					   (OneForm (At "np")))
+				    (At "S"))
+			  SeqExt
+		    [ (Der (Sequent L_Sequent (Comma (OneForm (At "S" / At "inf"))
+						     (Comma (OneForm (At "inf" / At "np"))
+							    (OneForm (At "np"))))
+					      (At "S"))
+			   LeftSlash
+			[ (Unf (Sequent L_Sequent (Comma (OneForm (At "S" / At "inf"))
+							 (OneForm (At "inf")))
+						  (At "S"))) ;
+			  (Unf (Sequent L_Sequent (OneForm (At "np")) (At "np"))) ]) ]) ]) ])``;
+
+val r4_to_r5 = store_thm (
+   "r4_to_r5", ``deriv ^r4 ^r5``,
+    MATCH_MP_TAC derivRight
+ >> MATCH_MP_TAC derivOne
+ >> MATCH_MP_TAC derivOne
+ >> MATCH_MP_TAC derivDerivOne
+ >> MATCH_MP_TAC derivLeftSlash
+ >> EXISTS_TAC ``At "inf"``
+ >> MATCH_MP_TAC replaceRight
+ >> REWRITE_TAC [replaceRoot]);
+
+val r6 =
+  ``(Der (Sequent L_Sequent (Comma (OneForm (At "S" / (At "S" / At "np")))
+				   (Comma (OneForm (At "S" / At "inf")) (OneForm (At "inf" / At "np"))))
+			    (At "S"))
+	 LeftSlash
+      [ (Der (Sequent L_Sequent (OneForm (At "S")) (At "S"))
+	     SeqAxiom []) ;
+	(Der (Sequent L_Sequent (Comma (OneForm (At "S" / At "inf")) (OneForm (At "inf" / At "np")))
+				(At "S" / At "np"))
+	     RightSlash
+	  [ (Der (Sequent L_Sequent (Comma (Comma (OneForm (At "S" / At "inf"))
+						  (OneForm (At "inf" / At "np")))
+					   (OneForm (At "np")))
+				    (At "S"))
+			  SeqExt
+		    [ (Der (Sequent L_Sequent (Comma (OneForm (At "S" / At "inf"))
+						     (Comma (OneForm (At "inf" / At "np"))
+							    (OneForm (At "np"))))
+					      (At "S"))
+			   LeftSlash
+			[ (Der (Sequent L_Sequent (Comma (OneForm (At "S" / At "inf"))
+							 (OneForm (At "inf")))
+						  (At "S"))
+					LeftSlash
+			    [ (Unf (Sequent L_Sequent (OneForm (At "S")) (At "S"))) ;
+			      (Unf (Sequent L_Sequent (OneForm (At "inf")) (At "inf"))) ]) ;
+			  (Unf (Sequent L_Sequent (OneForm (At "np")) (At "np"))) ]) ]) ]) ])``;
+
+val r5_to_r6 = store_thm (
+   "r5_to_r6", ``deriv ^r5 ^r6``,
+    MATCH_MP_TAC derivRight
+ >> MATCH_MP_TAC derivOne
+ >> MATCH_MP_TAC derivOne
+ >> MATCH_MP_TAC derivLeft
+ >> MATCH_MP_TAC derivDerivOne
+ >> MATCH_MP_TAC derivLeftSlash
+ >> EXISTS_TAC ``At "S"``
+ >> REWRITE_TAC [replaceRoot]);
+
+val r_final =
+  ``(Der (Sequent L_Sequent (Comma (OneForm (At "S" / (At "S" / At "np")))
+				   (Comma (OneForm (At "S" / At "inf")) (OneForm (At "inf" / At "np"))))
+			    (At "S"))
+	 LeftSlash
+      [ (Der (Sequent L_Sequent (OneForm (At "S")) (At "S"))
+	     SeqAxiom []) ;
+	(Der (Sequent L_Sequent (Comma (OneForm (At "S" / At "inf")) (OneForm (At "inf" / At "np")))
+				(At "S" / At "np"))
+	     RightSlash
+	  [ (Der (Sequent L_Sequent (Comma (Comma (OneForm (At "S" / At "inf"))
+						  (OneForm (At "inf" / At "np")))
+					   (OneForm (At "np")))
+				    (At "S"))
+			  SeqExt
+		    [ (Der (Sequent L_Sequent (Comma (OneForm (At "S" / At "inf"))
+						     (Comma (OneForm (At "inf" / At "np"))
+							    (OneForm (At "np"))))
+					      (At "S"))
+			   LeftSlash
+			[ (Der (Sequent L_Sequent (Comma (OneForm (At "S" / At "inf"))
+							 (OneForm (At "inf")))
+						  (At "S"))
+					LeftSlash
+			    [ (Der (Sequent L_Sequent (OneForm (At "S")) (At "S")) SeqAxiom []) ;
+			      (Der (Sequent L_Sequent (OneForm (At "inf")) (At "inf")) SeqAxiom []) ]) ;
+			  (Der (Sequent L_Sequent (OneForm (At "np")) (At "np")) SeqAxiom []) ]) ]) ]) ])``;
+
+val r_finished = store_thm (
+   "r_finished", ``Proof ^r_final``,
+    PROVE_TAC [Proof_rules]);
+
+val r_degree_zero = store_thm (
+   "r_degree_zero", ``degreeProof ^r_final = 0``,
+    REWRITE_TAC [degreeProof_def]
+ >> rw [MAX_EQ_0]);
+
+val r6_to_final = store_thm (
+   "r6_to_final", ``deriv ^r6 ^r_final``,
+    MATCH_MP_TAC derivRight
+ >> MATCH_MP_TAC derivOne
+ >> MATCH_MP_TAC derivOne
+ >> MATCH_MP_TAC derivBoth
+ >> CONJ_TAC
+ >| [ MATCH_MP_TAC derivBoth \\
+      CONJ_TAC \\ (* 2 sub-goals, same tacticals *)
+      MATCH_MP_TAC derivDerivOne >> REWRITE_TAC [derivSeqAxiom],
+      MATCH_MP_TAC derivDerivOne >> REWRITE_TAC [derivSeqAxiom] ]);
+
+fun derivToDeriv thm =
+    REWRITE_RULE [SYM Deriv_def] (MATCH_MP RTC_SINGLE thm);
+
+val r0_to_final = store_thm (
+   "r0_to_final", ``Deriv ^r0 ^r_final``,
+    ASSUME_TAC r0_to_r1''
+ >> ASSUME_TAC (derivToDeriv r1_to_r2)
+ >> ASSUME_TAC (derivToDeriv r2_to_r3)
+ >> ASSUME_TAC (derivToDeriv r3_to_r4)
+ >> ASSUME_TAC (derivToDeriv r4_to_r5)
+ >> ASSUME_TAC (derivToDeriv r5_to_r6)
+ >> ASSUME_TAC (derivToDeriv r6_to_final)
+ >> REPEAT (IMP_RES_TAC Deriv_trans));
+
+val _ = export_theory ();
+val _ = html_theory "Example";
+
+(* Emit theory books in TeX *)
+(*
+if (OS.FileSys.isDir "../papers" handle e => false) then
+    let in
+	OS.FileSys.remove "../papers/references.tex" handle e => {};
+	OS.FileSys.remove "../papers/HOLLambek.tex" handle e => {};
+	OS.FileSys.remove "../papers/HOLCutFree.tex" handle e => {};
+	OS.FileSys.remove "../papers/HOLExample.tex" handle e => {};
+
+	EmitTeX.print_theories_as_tex_doc
+	    ["Lambek", "CutFree", "Example"] "../papers/references"
+    end
+else
+    {};
+ *)
+
+(* last updated: April 9, 2017 *)

--- a/examples/formal-languages/lambek/Holmakefile
+++ b/examples/formal-languages/lambek/Holmakefile
@@ -1,0 +1,33 @@
+# INCLUDES = ../context-free
+OPTIONS = QUIT_ON_FAILURE
+# CLINE_OPTIONS = -j1
+
+THYFILES = $(patsubst %Script.sml,%Theory.uo,$(wildcard *.sml))
+TARGETS = $(patsubst %.sml,%.uo,$(THYFILES))
+EXTRA_CLEANS = heap munge.exe selftest.exe \
+	$(patsubst %Theory.uo,%Theory.html,$(TARGETS)) \
+	$(patsubst %Theory.uo,%Theory.lst,$(TARGETS))
+
+ifdef POLY
+HOLHEAP = heap
+OBJNAMES = UnicodeChars pred_setTheory arithmeticTheory pairTheory relationTheory
+DEPS = $(patsubst %,$(dprot $(SIGOBJ)/%.uo),$(OBJNAMES))
+
+all: $(HOLHEAP)
+
+$(HOLHEAP): $(DEPS) $(dprot $(HOLDIR)/bin/hol.state0)
+	$(protect $(HOLDIR)/bin/buildheap) -o $@ $(OBJNAMES)
+endif
+
+all: $(TARGETS) munge.exe
+
+MUNGE_DEPS = LambekTheory CutFreeTheory ExampleTheory
+
+munge.exe: $(patsubst %,%.uo,$(MUNGE_DEPS))
+	$(HOLDIR)/bin/mkmunge.exe $(MUNGE_DEPS)
+
+ifeq ($(KERNELID),otknl)
+all: $(patsubst %Script.sml,%.ot.art,$(wildcard *Script.sml))
+endif
+
+.PHONY: all

--- a/examples/formal-languages/lambek/LambekScript.sml
+++ b/examples/formal-languages/lambek/LambekScript.sml
@@ -1,0 +1,2272 @@
+(*
+ * Formalized Lambek Calculus in Higher Order Logic (HOL4)
+ *
+ *  (based on https://github.com/coq-contribs/lambek)
+ *
+ * Copyright 2002-2003  Houda ANOUN and Pierre Casteran, LaBRI/INRIA.
+ * Copyright 2016-2017  University of Bologna, Italy (Author: Chun Tian)
+ *)
+
+(* This program is free software; you can redistribute it and/or      *)
+(* modify it under the terms of the GNU Lesser General Public License *)
+(* as published by the Free Software Foundation; either version 2.1   *)
+(* of the License, or (at your option) any later version.             *)
+(*                                                                    *)
+(* This program is distributed in the hope that it will be useful,    *)
+(* but WITHOUT ANY WARRANTY; without even the implied warranty of     *)
+(* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the      *)
+(* GNU General Public License for more details.                       *)
+(*                                                                    *)
+(* You should have received a copy of the GNU Lesser General Public   *)
+(* License along with this program; if not, write to the Free         *)
+(* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA *)
+(* 02110-1301 USA                                                     *)
+
+open HolKernel Parse boolLib bossLib;
+
+open pred_setTheory pairTheory listTheory arithmeticTheory integerTheory;
+open relationTheory;
+
+local
+    val PAT_X_ASSUM = PAT_ASSUM;
+    val qpat_x_assum = Q.PAT_ASSUM;
+    open Tactical
+in
+    (* Backward compatibility with Kananaskis 11 *)
+    val PAT_X_ASSUM = PAT_X_ASSUM;
+    val qpat_x_assum = qpat_x_assum;
+
+    (* Tacticals for better expressivity *)
+    fun fix  ts = MAP_EVERY Q.X_GEN_TAC ts;	(* from HOL Light *)
+    fun set  ts = MAP_EVERY Q.ABBREV_TAC ts;	(* from HOL mizar mode *)
+    fun take ts = MAP_EVERY Q.EXISTS_TAC ts;	(* from HOL mizar mode *)
+end;
+
+val _ = new_theory "Lambek";
+
+(******************************************************************************)
+(*                                                                            *)
+(*                              Module: Form                                  *)
+(*                                                                            *)
+(******************************************************************************)
+
+val _ = Datatype `Form = At 'a | Slash Form Form | Backslash Form Form | Dot Form Form`;
+
+val _ = overload_on ("*", ``Dot``); (* \HOLTokenProd *)
+val _ = overload_on ("/", ``Slash``);
+val _ = overload_on ("\\\\", ``Backslash``);
+val _ = set_fixity "\\\\" (Infixr 1500);
+val _ = TeX_notation { hol = "\\\\", TeX = ("\\HOLTokenBackslash", 1) };
+
+val Form_induction = TypeBase.induction_of ``:'a Form``;
+val Form_nchotomy  = TypeBase.nchotomy_of ``:'a Form``;
+val Form_distinct  = TypeBase.distinct_of ``:'a Form``;
+val Form_distinct' = save_thm ("Form_distinct'", GSYM Form_distinct);
+val Form_11        = TypeBase.one_one_of ``:'a Form``;
+
+val _ = type_abbrev ("arrow_extension", ``:'a Form -> 'a Form -> bool``);
+
+(* Rules of Lambek's "Syntactic Calculus" (non-associative + extension) *)
+val (arrow_rules, arrow_ind, arrow_cases) = Hol_reln `
+    (!X A. arrow X A A) /\						(* one *)
+    (!X A B C. arrow X (Dot A B) C ==> arrow X A (Slash C B)) /\	(* beta *)
+    (!X A B C. arrow X A (Slash C B) ==> arrow X (Dot A B) C) /\	(* beta' *)
+    (!X A B C. arrow X (Dot A B) C ==> arrow X B (Backslash A C)) /\	(* gamma *)
+    (!X A B C. arrow X B (Backslash A C) ==> arrow X (Dot A B) C) /\	(* gamma' *)
+    (!X A B C. arrow X A B /\ arrow X B C ==> arrow X A C) /\		(* comp *)
+    (!(X :'a arrow_extension) A B. X A B ==> arrow X A B) `;		(* arrow_plus *)
+
+val [one, beta, beta', gamma, gamma', comp, arrow_plus] =
+    map save_thm
+        (combine (["one", "beta", "beta'", "gamma", "gamma'", "comp", "arrow_plus"],
+		  CONJUNCTS arrow_rules));
+
+val beta_EQ = store_thm ("beta_EQ",
+  ``!X A B C. arrow X A (Slash C B) = arrow X (Dot A B) C``,
+    REPEAT STRIP_TAC
+ >> EQ_TAC
+ >| [ REWRITE_TAC [beta'],
+      REWRITE_TAC [beta] ]);
+
+val gamma_EQ = store_thm ("gamma_EQ",
+  ``!X A B C. arrow X B (Backslash A C) = arrow X (Dot A B) C``,
+    REPEAT STRIP_TAC
+ >> EQ_TAC
+ >| [ REWRITE_TAC [gamma'],
+      REWRITE_TAC [gamma] ]);
+
+val arrow_transitive = store_thm (
+   "arrow_transitive", ``!X. transitive (arrow X)``,
+   REWRITE_TAC [transitive_def, comp]);
+
+val arrow_reflexive = store_thm (
+   "arrow_reflexive", ``!X. reflexive (arrow X)``,
+   REWRITE_TAC [reflexive_def, one]);
+
+(** The arrow relationship and its extensions (like associativity, commutativity  etc.) **)
+
+val _ = overload_on("add_extension", ``relation$RUNION``);
+(* X extends (to) X', or X is extended to X' *)
+val _ = overload_on("extends", ``relation$RSUBSET``);
+
+val no_extend = store_thm ("no_extend", ``!X. extends X X``,
+    RW_TAC bool_ss [RSUBSET]);
+
+val add_extend_l = store_thm ("add_extend_l", ``!X X'. extends X (add_extension X X')``,
+    RW_TAC bool_ss [RSUBSET, RUNION]);
+
+val add_extend_r = store_thm ("add_extend_r", ``!X X'. extends X' (add_extension X X')``,
+    RW_TAC bool_ss [RSUBSET, RUNION]);
+
+val extends_trans = store_thm ("extends_trans",
+  ``!X Y Z. extends X Y /\ extends Y Z ==> extends X Z``,
+    RW_TAC bool_ss [RSUBSET]);
+
+val extends_transitive = store_thm (
+   "extends_transitive", ``transitive extends``,
+    REWRITE_TAC [transitive_def, extends_trans]);
+
+(** most popular extensions **)
+
+val NL_def = Define `(NL :'a arrow_extension) = EMPTY_REL`;
+
+(* L is defined by two rules, and it's reflexitive *)
+val (L_rules, L_ind, L_cases) = Hol_reln `
+    (!A B C. L (Dot A (Dot B C)) (Dot (Dot A B) C)) /\
+    (!A B C. L (Dot (Dot A B) C) (Dot A (Dot B C)))`;
+
+val [L_rule_rl, L_rule_lr] =
+    map save_thm (combine (["L_rule_rl", "L_rule_lr"], CONJUNCTS L_rules));
+
+(* NLP is defined by only one rule, it's reflexitive too. *)
+val (NLP_rules, NLP_ind, NLP_cases) = Hol_reln `
+    (!A B. NLP (Dot A B) (Dot B A))`;
+
+val LP_def = Define `LP = add_extension NLP L`;
+
+val NLextendsAll = store_thm (
+   "NLextendsAll", ``!X. extends NL X``,
+    RW_TAC bool_ss [NL_def, EMPTY_REL_DEF, RSUBSET]);
+
+val NLPextendsLP = store_thm ("NLPextendsLP", ``extends NLP LP``,
+    REWRITE_TAC [LP_def, add_extend_l]);
+
+val LextendsLP = store_thm ("LextendsLP", ``extends L LP``,
+    REWRITE_TAC [LP_def, add_extend_r]);
+
+(* Some derived rules for arrow.
+   Note: all theorems here can be simply proved by PROVE_TAC [arrow_rules]. *)
+
+val Dot_mono_right = store_thm ("Dot_mono_right",
+  ``!X A B B'. arrow X B' B ==> arrow X (Dot A B') (Dot A B)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC gamma'
+ >> MATCH_MP_TAC comp
+ >> Q.EXISTS_TAC `B`
+ >> CONJ_TAC
+ >- ASM_REWRITE_TAC []
+ >> MATCH_MP_TAC gamma
+ >> RW_TAC bool_ss [one]);
+
+val Dot_mono_left = store_thm ("Dot_mono_left",
+  ``!X A B A'. arrow X A' A ==> arrow X (Dot A' B) (Dot A B)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC beta'
+ >> MATCH_MP_TAC comp
+ >> Q.EXISTS_TAC `A`
+ >> CONJ_TAC
+ >- ASM_REWRITE_TAC []
+ >> MATCH_MP_TAC beta
+ >> RW_TAC bool_ss [one]);
+
+val Dot_mono = store_thm ("Dot_mono",
+  ``!X A B C D. arrow X A C /\ arrow X B D ==> arrow X (Dot A B) (Dot C D)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC comp
+ >> EXISTS_TAC ``(Dot C B)``
+ >> CONJ_TAC
+ >| [ MATCH_MP_TAC Dot_mono_left >> RW_TAC bool_ss [],
+      MATCH_MP_TAC Dot_mono_right >> RW_TAC bool_ss [] ]);
+
+val Slash_mono_left = store_thm ("Slash_mono_left",
+  ``!X C B C'. arrow X C' C ==> arrow X (Slash C' B) (Slash C B)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC beta
+ >> MATCH_MP_TAC comp
+ >> Q.EXISTS_TAC `C'`
+ >> CONJ_TAC
+ >| [ MATCH_MP_TAC beta' >> RW_TAC bool_ss [one],
+      RW_TAC bool_ss [] ]);
+
+val Slash_antimono_right = store_thm ("Slash_antimono_right",
+  ``!X C B B'. arrow X B' B ==> arrow X (Slash C B) (Slash C B')``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC beta
+ >> MATCH_MP_TAC gamma'
+ >> MATCH_MP_TAC comp
+ >> Q.EXISTS_TAC `B`
+ >> CONJ_TAC
+ >- ASM_REWRITE_TAC []
+ >> MATCH_MP_TAC gamma
+ >> MATCH_MP_TAC beta'
+ >> RW_TAC bool_ss [one]);
+
+val Backslash_antimono_left = store_thm ("Backslash_antimono_left",
+  ``!X A C A'. arrow X A A' ==> arrow X (Backslash A' C) (Backslash A C)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC gamma
+ >> MATCH_MP_TAC beta'
+ >> MATCH_MP_TAC comp
+ >> Q.EXISTS_TAC `A'`
+ >> CONJ_TAC
+ >- ASM_REWRITE_TAC []
+ >> MATCH_MP_TAC beta
+ >> MATCH_MP_TAC gamma'
+ >> RW_TAC bool_ss [one]);
+
+val Backslash_mono_right = store_thm ("Backslash_mono_right",
+  ``!X A C C'. arrow X C' C ==> arrow X (Backslash A C') (Backslash A C)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC gamma
+ >> MATCH_MP_TAC comp
+ >> Q.EXISTS_TAC `C'`
+ >> CONJ_TAC
+ >| [ MATCH_MP_TAC beta' \\
+      MATCH_MP_TAC beta \\
+      MATCH_MP_TAC gamma' \\
+      RW_TAC bool_ss [one],
+      ASM_REWRITE_TAC [] ]);
+
+val mono_X = store_thm ("mono_X",
+  ``!X' X A B. arrow X A B ==> extends X X' ==> arrow X' A B``,
+    GEN_TAC
+ >> Induct_on `arrow`
+ >> REPEAT STRIP_TAC (* 7 sub-goals here *)
+ >- REWRITE_TAC [one]
+ >- RW_TAC bool_ss [beta]
+ >- RW_TAC bool_ss [beta']
+ >- RW_TAC bool_ss [gamma]
+ >- RW_TAC bool_ss [gamma']
+ >- PROVE_TAC [comp]
+ >> PROVE_TAC [arrow_plus, RSUBSET]);
+
+val pi = store_thm ("pi",
+  ``!X. extends NLP X ==> !A B. arrow X (Dot A B) (Dot B A)``,
+    REPEAT STRIP_TAC
+ >> `NLP (Dot A B) (Dot B A)` by REWRITE_TAC [NLP_rules]
+ >> `arrow NLP (Dot A B) (Dot B A)` by RW_TAC bool_ss [arrow_plus]
+ >> PROVE_TAC [mono_X]);
+
+val pi_NLP = store_thm ("pi_NLP", ``!A B. arrow NLP (Dot A B) (Dot B A)``,
+    MATCH_MP_TAC pi
+ >> REWRITE_TAC [no_extend]);
+
+val pi_LP = store_thm ("pi_LP", ``!A B. arrow LP (Dot A B) (Dot B A)``,
+    MATCH_MP_TAC pi
+ >> REWRITE_TAC [NLPextendsLP]);
+
+val alfa = store_thm ("alfa",
+  ``!X. extends L X ==> !A B C. arrow X (Dot A (Dot B C)) (Dot (Dot A B) C)``,
+    REPEAT STRIP_TAC
+ >> `L (Dot A (Dot B C)) (Dot (Dot A B) C)`
+	by REWRITE_TAC [L_rule_rl]
+ >> `arrow L (Dot A (Dot B C)) (Dot (Dot A B) C)`
+	by RW_TAC bool_ss [arrow_plus]
+ >> PROVE_TAC [mono_X]);
+
+val alfa_L = store_thm ("alfa_L",
+  ``!A B C. arrow L (Dot A (Dot B C)) (Dot (Dot A B) C)``,
+    MATCH_MP_TAC alfa
+ >> REWRITE_TAC [no_extend]);
+
+val alfa_LP = store_thm ("alfa_LP",
+  ``!A B C. arrow LP (Dot A (Dot B C)) (Dot (Dot A B) C)``,
+    MATCH_MP_TAC alfa
+ >> REWRITE_TAC [LextendsLP]);
+
+val alfa' = store_thm ("alfa'",
+  ``!X. extends L X ==> !A B C. arrow X (Dot (Dot A B) C) (Dot A (Dot B C))``,
+    REPEAT STRIP_TAC
+ >> `L (Dot (Dot A B) C) (Dot A (Dot B C))` by REWRITE_TAC [L_rule_lr]
+ >> `arrow L (Dot (Dot A B) C) (Dot A (Dot B C))` by RW_TAC bool_ss [arrow_plus]
+ >> PROVE_TAC [mono_X]);
+
+val alfa'_L = store_thm ("alfa'_L",
+  ``!A B C. arrow L (Dot (Dot A B) C) (Dot A (Dot B C))``,
+    MATCH_MP_TAC alfa'
+ >> REWRITE_TAC [no_extend]);
+
+val alfa'_LP = store_thm ("alfa'_LP",
+  ``!A B C. arrow LP (Dot (Dot A B) C) (Dot A (Dot B C))``,
+    MATCH_MP_TAC alfa'
+ >> REWRITE_TAC [LextendsLP]);
+
+(******************************************************************************)
+(*                                                                            *)
+(*                            L rules                                         *)
+(*                                                                            *)
+(******************************************************************************)
+
+val L_a = store_thm ("L_a", ``!x. arrow L x x``, REWRITE_TAC [one]);
+val L_b = store_thm ("L_b",  ``!x y z. arrow L (Dot (Dot x y) z) (Dot x (Dot y z))``,
+    REWRITE_TAC [alfa'_L]);
+val L_b' = store_thm ("L_b'", ``!x y z. arrow L (Dot x (Dot y z)) (Dot (Dot x y) z)``,
+    REWRITE_TAC [alfa_L, alfa'_L]);
+val L_c  = store_thm ("L_c",  ``!x y z. arrow L (Dot x y) z ==> arrow L x (Slash z y)``,
+    REWRITE_TAC [beta]);
+val L_c' = store_thm ("L_c'", ``!x y z. arrow L (Dot x y) z ==> arrow L y (Backslash x z)``,
+    REWRITE_TAC [gamma]);
+val L_d  = store_thm ("L_d",  ``!x y z. arrow L x (Slash z y) ==> arrow L (Dot x y) z``,
+    REWRITE_TAC [beta']);
+val L_d' = store_thm ("L_d'", ``!x y z. arrow L y (Backslash x z) ==> arrow L (Dot x y) z``,
+    REWRITE_TAC [gamma']);
+val L_e  = store_thm ("L_e",  ``!x y z. arrow L x y /\ arrow L y z ==> arrow L x z``,
+    REWRITE_TAC [comp]);
+
+val L_arrow_rules = save_thm (
+   "L_arrow_rules", LIST_CONJ [L_a, L_b, L_b', L_c, L_c', L_d, L_d', L_e]);
+
+local
+  val t = PROVE_TAC [L_arrow_rules]
+in
+  val L_f  = store_thm ("L_f",  ``!x y. arrow L x (Slash (Dot x y) y)``, t)
+  and L_g  = store_thm ("L_g",  ``!y z. arrow L (Dot (Slash z y) y) z``, t)
+  and L_h  = store_thm ("L_h",  ``!y z. arrow L y (Backslash (Slash z y) z)``, t)
+  and L_i  = store_thm ("L_i",  ``!x y z. arrow L (Dot (Slash z y) (Slash y x)) (Slash z x)``, t)
+  and L_j  = store_thm ("L_j",  ``!x y z. arrow L (Slash z y) (Slash (Slash z x) (Slash y x))``, t)
+
+  and L_k  = store_thm ("L_k",  ``!x y z. arrow L (Slash (Backslash x y) z)
+						  (Backslash x (Slash y z))``, t)
+
+  and L_k' = store_thm ("L_k'", ``!x y z. arrow L (Backslash x (Slash y z))
+						  (Slash (Backslash x y) z)``, t)
+
+  and L_l  = store_thm ("L_l",  ``!x y z. arrow L (Slash (Slash x y) z) (Slash x (Dot z y))``, t)
+  and L_l' = store_thm ("L_l'", ``!x y z. arrow L (Slash x (Dot z y)) (Slash (Slash x y) z)``, t)
+  and L_m  = store_thm ("L_m",  ``!x x' y y'. arrow L x x' /\ arrow L y y'
+					  ==> arrow L (Dot x y) (Dot x' y')``, t)
+  and L_n  = store_thm ("L_n",  ``!x x' y y'. arrow L x x' /\ arrow L y y'
+					  ==> arrow L (Slash x y') (Slash x' y)``, t);
+
+  val L_arrow_rules_ex = save_thm (
+     "L_arrow_rules_ex", LIST_CONJ [L_f, L_g, L_h, L_i, L_j, L_k, L_k', L_l, L_l', L_m, L_n])
+end;
+
+local
+  val t = PROVE_TAC [L_a, L_c, L_c', L_d, L_d', L_e] (* L_b and L_b' are not used *)
+in
+  val L_dot_mono_r = store_thm ("L_dot_mono_r",
+    ``!A B B'. arrow L B B' ==> arrow L (Dot A B) (Dot A B')``, t)
+  and L_dot_mono_l = store_thm ("L_dot_mono_l",
+    ``!A B A'. arrow L A A' ==> arrow L (Dot A B) (Dot A' B)``, t)
+  and L_slash_mono_l = store_thm ("L_slash_mono_l",
+    ``!C B C'. arrow L C C' ==> arrow L (Slash C B) (Slash C' B)``, t)
+  and L_slash_antimono_r = store_thm ("L_slash_antimono_r",
+    ``!C B B'. arrow L B B' ==> arrow L (Slash C B') (Slash C B)``, t)
+  and L_backslash_antimono_l = store_thm ("L_backslash_antimono_l",
+    ``!A C A'. arrow L A A' ==> arrow L (Backslash A' C) (Backslash A C)``, t)
+  and L_backslash_mono_r = store_thm ("L_backslash_mono_r",
+    ``!A C'. arrow L C C' ==> arrow L (Backslash A C) (Backslash A C')``, t);
+
+  val L_arrow_rules_mono = save_thm (
+     "L_arrow_rules_mono",
+      LIST_CONJ [L_dot_mono_r, L_dot_mono_l,
+		 L_slash_mono_l, L_slash_antimono_r,
+		 L_backslash_antimono_l, L_backslash_mono_r])
+end;
+
+(******************************************************************************)
+(*                                                                            *)
+(*                              Module: Terms                                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+val _ = Datatype `Term = OneForm ('a Form) | Comma Term Term`;
+
+val Term_induction = TypeBase.induction_of ``:'a Term``;
+val Term_nchotomy  = TypeBase.nchotomy_of ``:'a Term``;
+val Term_distinct  = TypeBase.distinct_of ``:'a Term``;
+val Term_distinct' = save_thm ("Term_distinct'", GSYM Term_distinct);
+val Term_11        = TypeBase.one_one_of ``:'a Term``;
+
+val _ = type_abbrev ("gentzen_extension", ``:'a Term -> 'a Term -> bool``);
+
+(* Definition of the recursive function that translates Terms to Forms *)
+val deltaTranslation_def = Define `
+   (deltaTranslation (OneForm f) = f) /\
+   (deltaTranslation (Comma t1 t2) = Dot (deltaTranslation t1) (deltaTranslation t2))`;
+
+val deltaTranslationOneForm = store_thm (
+   "deltaTranslationOneForm[simp]",
+  ``deltaTranslation (OneForm f) = f``, RW_TAC std_ss [deltaTranslation_def]);
+
+val deltaTranslationComma = store_thm (
+   "deltaTranslationComma[simp]",
+  ``deltaTranslation (Comma t1 t2) = Dot (deltaTranslation t1) (deltaTranslation t2)``,
+    RW_TAC std_ss [deltaTranslation_def]);
+
+(* Non-associative extension, an empty relation actually *)
+val NL_Sequent_def = Define `
+   (NL_Sequent :'a gentzen_extension) = EMPTY_REL`;
+
+(* NLP Sequent extension *)
+val (NLP_Sequent_rules, NLP_Sequent_ind, NLP_Sequent_cases) = Hol_reln `
+    (!A B. NLP_Sequent (Comma A B) (Comma B A))`;
+
+val NLP_Intro = save_thm ("NLP_Intro", NLP_Sequent_rules);
+
+(* L Sequent extension, the Full Lambek Sequent Calculus extension *)
+val (L_Sequent_rules, L_Sequent_ind, L_Sequent_cases) = Hol_reln `
+    (!A B C. L_Sequent (Comma A (Comma B C)) (Comma (Comma A B) C)) /\
+    (!A B C. L_Sequent (Comma (Comma A B) C) (Comma A (Comma B C)))`;
+
+val [L_Intro_lr, L_Intro_rl] =
+    map save_thm (combine (["L_Intro_lr", "L_Intro_rl"], CONJUNCTS L_Sequent_rules));
+
+val LP_Sequent_def = Define `
+    LP_Sequent = add_extension NLP_Sequent L_Sequent`;
+
+val NLP_Sequent_LP_Sequent = store_thm (
+   "NLP_Sequent_LP_Sequent", ``extends NLP_Sequent LP_Sequent``,
+    REWRITE_TAC [LP_Sequent_def, add_extend_l]);
+
+val L_Sequent_LP_Sequent = store_thm (
+   "L_Sequent_LP_Sequent", ``extends L_Sequent LP_Sequent``,
+    REWRITE_TAC [LP_Sequent_def, add_extend_r]);
+
+val LPextendsL = store_thm ("LPextendsL",
+  ``!E. extends LP_Sequent E ==> extends L_Sequent E``,
+    RW_TAC bool_ss [LP_Sequent_def, RSUBSET, RUNION]);
+
+val LPextendsNLP = store_thm ("LPextendsNLP",
+  ``!E. extends LP_Sequent E ==> extends NLP_Sequent E``,
+    RW_TAC bool_ss [LP_Sequent_def, RSUBSET, RUNION]);
+
+(******************************************************************************)
+(*                                                                            *)
+(*                            Module: ReplaceProp                             *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* The `replace` operator has the type ('a ReplaceProp) *)
+val _ = type_abbrev ("ReplaceProp", ``:'a Term -> 'a Term -> 'a Term -> 'a Term -> bool``);
+
+(* Inductive definition of `replace` such that when ``replace Gamma Gamma' Delta Delta'``
+   then Gamma' results from replacing a distinguished occurrence of the subterm Delta in
+   the term Gamma by Delta' *)
+
+val (replace_rules, replace_ind, replace_cases) = Hol_reln `
+    (!F1 F2. replace F1 F2 F1 F2) /\					(* replaceRoot *)
+    (!Gamma1 Gamma2 Delta F1 F2.
+     replace Gamma1 Gamma2 F1 F2 ==>
+     replace (Comma Gamma1 Delta) (Comma Gamma2 Delta) F1 F2) /\	(* replaceLeft *)
+    (!Gamma1 Gamma2 Delta F1 F2.
+     replace Gamma1 Gamma2 F1 F2 ==>
+     replace (Comma Delta Gamma1) (Comma Delta Gamma2) F1 F2)`;		(* replaceRight *)
+
+local
+    val list = CONJUNCTS replace_rules
+in
+    val replaceRoot  = save_thm ("replaceRoot[simp]",  List.nth (list, 0))
+    and replaceLeft  = save_thm ("replaceLeft",  List.nth (list, 1))
+    and replaceRight = save_thm ("replaceRight", List.nth (list, 2))
+end;
+
+(* Definition of `replaceCommaDot` such that when ``replaceCommaDot Gamma Gamma'``
+   then Gamma' is the result of replacing a number of commas in Gamma by the connector dot.
+
+   Example: ``!A B. replaceCommaDot (A , (A , B)) (A , (A . B)))`` where in this case only
+   one occurrence of comma is replaced by a dot. *)
+
+val (replaceCommaDot1_rules, replaceCommaDot1_ind, replaceCommaDot1_cases) = Hol_reln `
+    (!T1 T2 A B. replace T1 T2 (Comma (OneForm A) (OneForm B)) (OneForm (Dot A B))
+	     ==> replaceCommaDot1 T1 T2)`;
+
+val replaceCommaDot_def = Define `replaceCommaDot = RTC replaceCommaDot1`;
+
+val replaceCommaDot_rule = store_thm ("replaceCommaDot_rule",
+  ``!T1 T2 A B. replace T1 T2 (Comma (OneForm A) (OneForm B)) (OneForm (Dot A B))
+	    ==> replaceCommaDot T1 T2``,
+    PROVE_TAC [replaceCommaDot_def, replaceCommaDot1_rules, RTC_SINGLE]);
+
+val replaceTransitive = store_thm ("replaceTransitive", ``transitive replaceCommaDot``,
+    REWRITE_TAC [replaceCommaDot_def, RTC_TRANSITIVE]);
+
+(* a more practical version *)
+val replaceTransitive' = store_thm ("replaceTransitive'",
+  ``!T1 T2 T3. replaceCommaDot T1 T2 /\ replaceCommaDot T2 T3 ==> replaceCommaDot T1 T3``,
+    PROVE_TAC [replaceTransitive, transitive_def]);
+
+val noReplace = store_thm ("noReplace[simp]", ``!T. replaceCommaDot T T``,
+    PROVE_TAC [replaceCommaDot_def, RTC_REFLEXIVE, reflexive_def]);
+
+local
+  val t = PROVE_TAC [replaceCommaDot1_rules, replaceCommaDot_def, replaceTransitive,
+		     transitive_def, RTC_SINGLE]
+in
+  val replaceOneComma = store_thm ("replaceOneComma",
+    ``!T1 T2 T3 A B. replaceCommaDot T1 T2 /\
+		     replace T2 T3 (Comma (OneForm A) (OneForm B)) (OneForm (Dot A B))
+		 ==> replaceCommaDot T1 T3``, t)
+
+  and replaceOneComma' = store_thm ("replaceOneComma'",
+    ``!T1 T2 T3 A B. replace T1 T2 (Comma (OneForm A) (OneForm B)) (OneForm (Dot A B)) /\
+		     replaceCommaDot T2 T3
+		 ==> replaceCommaDot T1 T3``, t);
+
+  val replaceCommaDot_rules = save_thm (
+     "replaceCommaDot_rules", LIST_CONJ [noReplace, replaceCommaDot_rule,
+					 replaceOneComma, replaceOneComma'])
+end;
+
+(* An induction theorem for RTC replaceCommaDot1, similar to those generated by Hol_reln *)
+val replaceCommaDot_ind = store_thm ("replaceCommaDot_ind",
+  ``!(P:'a gentzen_extension).
+	(!x. P x x) /\
+	(!x y z A B. replace x y (Comma (OneForm A) (OneForm B)) (OneForm (Dot A B)) /\ P y z ==> P x z)
+    ==> (!x y. replaceCommaDot x y ==> P x y)``,
+ (* The idea is to use RTC_INDUCT thm to prove induct theorems for RTCs *)
+    REWRITE_TAC [replaceCommaDot_def]
+ >> GEN_TAC   (* remove outer !P *)
+ >> STRIP_TAC (* prepare for higher order matching *)
+ >> HO_MATCH_MP_TAC (ISPEC ``replaceCommaDot1:'a gentzen_extension`` RTC_INDUCT)
+ >> PROVE_TAC [replaceCommaDot1_cases]);
+
+local
+  val t = GEN_TAC \\ (* prepare for higher order matching and induction *)
+	  HO_MATCH_MP_TAC replaceCommaDot_ind \\
+	  PROVE_TAC [replace_rules, replaceCommaDot_rules]
+in
+  val replaceMonoRight = store_thm ("replaceMonoRight",
+    ``!T3 T1 T2. replaceCommaDot T1 T2
+	     ==> replaceCommaDot (Comma T1 T3) (Comma T2 T3)``, t)
+  and replaceMonoLeft = store_thm ("replaceMonoLeft",
+    ``!T3 T1 T2. replaceCommaDot T1 T2
+	     ==> replaceCommaDot (Comma T3 T1) (Comma T3 T2)``, t)
+end;
+
+val replaceMono = store_thm ("replaceMono",
+  ``!T1 T2 T3 T4. replaceCommaDot T1 T2 /\ replaceCommaDot T3 T4
+	      ==> replaceCommaDot (Comma T1 T3) (Comma T2 T4)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC replaceTransitive'
+ >> EXISTS_TAC ``Comma T2 T3``
+ >> PROVE_TAC [replaceMonoLeft, replaceMonoRight]);
+
+val replaceTranslation = store_thm ("replaceTranslation",
+  ``!T. replaceCommaDot T (OneForm (deltaTranslation T))``,
+    Induct
+ >- PROVE_TAC [deltaTranslation_def, noReplace] (* base case *)
+ >> REWRITE_TAC [deltaTranslation_def]        (* induct case *)
+ >> MATCH_MP_TAC replaceTransitive'
+ >> EXISTS_TAC ``Comma (OneForm (deltaTranslation T')) (OneForm (deltaTranslation T''))``
+ >> PROVE_TAC [replaceOneComma, noReplace, replaceRoot, replaceMono]);
+
+val replace_inv1 = store_thm ("replace_inv1",
+  ``!Gamma' Delta X C.
+     replace (OneForm C) Gamma' (OneForm X) Delta ==> (Gamma' = Delta) /\ (X = C)``,
+    REPEAT GEN_TAC
+ >> ONCE_REWRITE_TAC [replace_cases] \\
+ REPEAT STRIP_TAC
+ >- ASM_REWRITE_TAC []
+ >- PROVE_TAC [Term_11]
+ >> PROVE_TAC [Term_distinct]);
+
+val replace_inv2 = store_thm ("replace_inv2",
+  ``!Gamma1 Gamma2 Gamma' Delta X.
+     replace (Comma Gamma1 Gamma2) Gamma' (OneForm X) Delta ==>
+     (?G. (Gamma' = Comma G Gamma2) /\ replace Gamma1 G (OneForm X) Delta) \/
+     (?G. (Gamma' = Comma Gamma1 G) /\ replace Gamma2 G (OneForm X) Delta)``,
+    REPEAT STRIP_TAC
+ >> POP_ASSUM (MP_TAC o (ONCE_REWRITE_RULE [replace_cases]))
+ >> REPEAT STRIP_TAC
+ >- PROVE_TAC [Term_distinct]
+ >| [ `(Gamma1 = Gamma1') /\ (Gamma2 = Delta')` by PROVE_TAC [Term_11] \\
+      ASM_REWRITE_TAC [] \\
+      MATCH_MP_TAC OR_INTRO_THM1 \\
+      Q.EXISTS_TAC `Gamma2'` \\
+      ASM_REWRITE_TAC [] ,
+      `(Gamma1 = Delta') /\ (Gamma2 = Gamma1')` by PROVE_TAC [Term_11] \\
+      ASM_REWRITE_TAC [] \\
+      MATCH_MP_TAC OR_INTRO_THM2 \\
+      Q.EXISTS_TAC `Gamma2'` \\
+      ASM_REWRITE_TAC [] ]);
+
+val doubleReplace = store_thm ("doubleReplace",
+  ``!Gamma Gamma' T1 T2.
+     replace Gamma Gamma' T1 T2 ==>
+     !Gamma2 A T3. replace Gamma' Gamma2 (OneForm A) T3 ==>
+	      (?G. replace Gamma G (OneForm A) T3 /\ replace G Gamma2 T1 T2) \/
+	      (?G. replace T2 G (OneForm A) T3 /\ replace Gamma Gamma2 T1 G)``,
+    Induct_on `replace`
+ >> REPEAT STRIP_TAC (* 3 sub-goals here *)
+ >| [ (* goal 1 (of 3) *)
+      DISJ2_TAC \\
+      Q.EXISTS_TAC `Gamma2` \\
+      ASM_REWRITE_TAC [replaceRoot],
+      (* goal 2 (of 3) *)
+      POP_ASSUM (MP_TAC o (MATCH_MP replace_inv2)) \\
+      REPEAT STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 2.1 (of 2) *)
+        ASM_REWRITE_TAC [] >> RES_TAC >| (* 2 sub-goals here *)
+        [ (* goal 2.1.1 (of 2) *)
+          DISJ1_TAC \\
+          EXISTS_TAC ``(Comma G' Delta)`` \\
+          CONJ_TAC >| (* 2 sub-goals here *)
+          [ (* goal 2.1.1.1 (of 2) *)
+            MATCH_MP_TAC replaceLeft >> ASM_REWRITE_TAC [],
+            (* goal 2.1.1.2 (of 2) *)
+            MATCH_MP_TAC replaceLeft >> ASM_REWRITE_TAC [] ],
+          (* goal 2.1.2 (of 2) *)
+          DISJ2_TAC \\
+          Q.EXISTS_TAC `G'` \\
+          CONJ_TAC >- ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC replaceLeft >> ASM_REWRITE_TAC [] ],
+        (* goal 2.2 (of 2) *)
+        ASM_REWRITE_TAC [] \\
+        DISJ1_TAC \\
+        EXISTS_TAC ``(Comma Gamma G)`` \\
+        CONJ_TAC >| (* 2 sub-goals here *)
+        [ (* goal 2.2.1 (of 2) *)
+          MATCH_MP_TAC replaceRight >> ASM_REWRITE_TAC [],
+          (* goal 2.2.2 (of 2) *)
+          MATCH_MP_TAC replaceLeft >> ASM_REWRITE_TAC [] ] ],
+      (* goal 3 (of 3) *)
+      POP_ASSUM (MP_TAC o (MATCH_MP replace_inv2)) \\
+      REPEAT STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 3.1 (of 2) *)
+        ASM_REWRITE_TAC [] \\
+        DISJ1_TAC \\
+        EXISTS_TAC ``(Comma G Gamma)`` \\
+        CONJ_TAC >| (* 2 sub-goals here *)
+        [ (* goal 3.1.1 (of 2) *)
+          MATCH_MP_TAC replaceLeft >> ASM_REWRITE_TAC [],
+          (* goal 3.1.2 (of 2) *)
+          MATCH_MP_TAC replaceRight >> ASM_REWRITE_TAC [] ],
+        (* goal 3.2 (of 2) *)
+        ASM_REWRITE_TAC [] >> RES_TAC >| (* 2 sub-goals here *)
+        [ (* goal 3.2.1 (of 2) *)
+          DISJ1_TAC \\
+          EXISTS_TAC ``(Comma Delta G')`` \\
+          CONJ_TAC >| (* 2 sub-goals here *)
+          [ (* goal 3.2.1.1 (of 2) *)
+            MATCH_MP_TAC replaceRight >> ASM_REWRITE_TAC [],
+            (* goal 3.2.1.2 (of 2) *)
+            MATCH_MP_TAC replaceRight >> ASM_REWRITE_TAC [] ],
+          (* goal 3.2.2 (of 2) *)
+          DISJ2_TAC \\
+          Q.EXISTS_TAC `G'` \\
+          CONJ_TAC >- ASM_REWRITE_TAC [] \\
+          MATCH_MP_TAC replaceRight >> ASM_REWRITE_TAC [] ] ] ]);
+
+val replaceSameP = store_thm ("replaceSameP",
+  ``!T1 T2 T3 T4. replace T1 T2 T3 T4 ==>
+		  !G. ?G'. replace T1 G' T3 G /\ replace G' T2 G T4``,
+    Induct_on `replace`
+ >> REPEAT STRIP_TAC
+ >| [ Q.EXISTS_TAC `G` >> REWRITE_TAC [replaceRoot],
+      POP_ASSUM (ASSUME_TAC o (Q.SPEC `G`))
+   >> POP_ASSUM CHOOSE_TAC
+   >> EXISTS_TAC ``(Comma G' Delta)``
+   >> RW_TAC bool_ss [replaceLeft],
+      POP_ASSUM (ASSUME_TAC o (Q.SPEC `G`))
+   >> POP_ASSUM CHOOSE_TAC
+   >> EXISTS_TAC ``(Comma Delta G')``
+   >> RW_TAC bool_ss [replaceRight] ]);
+
+val replaceTrans = store_thm ("replaceTrans",
+  ``!T5 T6 T1 T2 T3 T4.
+     replace T1 T2 T3 T4 ==> replace T3 T4 T5 T6 ==> replace T1 T2 T5 T6``,
+    NTAC 2 GEN_TAC
+ >> Induct_on `replace`
+ >> REPEAT STRIP_TAC
+ >| [ PROVE_TAC [replaceLeft],
+      PROVE_TAC [replaceRight] ]);
+
+(* easier for MATCH_MP_TAC *)
+val replaceTrans' = store_thm ("replaceTrans'",
+  ``!T5 T6 T1 T2 T3 T4.
+     replace T1 T2 T3 T4 /\ replace T3 T4 T5 T6 ==> replace T1 T2 T5 T6``,
+    PROVE_TAC [replaceTrans]);
+
+(******************************************************************************)
+(*                                                                            *)
+(*                         Module: NaturalDeduction                           *)
+(*                                                                            *)
+(******************************************************************************)
+
+val (natDed_rules, natDed_ind, natDed_cases) = Hol_reln `
+    (!(E:'a gentzen_extension) A.				(* NatAxiom *)
+      natDed E (OneForm A) A) /\
+    (!E Gamma A B.						(* SlashIntro *)
+      natDed E (Comma Gamma (OneForm B)) A ==>
+      natDed E Gamma (Slash A B)) /\
+    (!E Gamma A B.						(* BackslashIntro *)
+      natDed E (Comma (OneForm B) Gamma) A ==>
+      natDed E Gamma (Backslash B A)) /\
+    (!E Gamma Delta A B.					(* DotIntro *)
+      natDed E Gamma A /\ natDed E Delta B ==>
+      natDed E (Comma Gamma Delta) (Dot A B)) /\
+    (!E Gamma Delta A B.					(* SlashElim *)
+      natDed E Gamma (Slash A B) /\ natDed E Delta B ==>
+      natDed E (Comma Gamma Delta) A) /\
+    (!E Gamma Delta A B.				 	(* BackslashElim *)
+      natDed E Gamma B /\ natDed E Delta (Backslash B A) ==>
+      natDed E (Comma Gamma Delta) A) /\
+    (!E Gamma Gamma' Delta A B C.				(* DotElim *)
+      replace Gamma Gamma' (Comma (OneForm A) (OneForm B)) Delta /\
+      natDed E Delta (Dot A B) /\ natDed E Gamma C ==>
+      natDed E Gamma' C) /\
+    (!(E:'a gentzen_extension) C Gamma Gamma' Delta Delta'.	(* NatExt *)
+      replace Gamma Gamma' Delta Delta' /\ E Delta Delta' /\
+      natDed E Gamma C ==> natDed E Gamma' C)`;
+
+val [NatAxiom, SlashIntro, BackslashIntro, DotIntro, SlashElim, BackslashElim, DotElim, NatExt] =
+    map save_thm
+        (combine (["NatAxiom[simp]", "SlashIntro", "BackslashIntro", "DotIntro", "SlashElim",
+		   "BackslashElim", "DotElim", "NatExt"], CONJUNCTS natDed_rules));
+
+val NatAxiomGeneralized = store_thm ("NatAxiomGeneralized[simp]",
+  ``!E Gamma. natDed E Gamma (deltaTranslation Gamma)``,
+    Induct_on `Gamma:'a Term`
+ >- PROVE_TAC [deltaTranslation_def, NatAxiom]
+ >> REWRITE_TAC [deltaTranslation_def]
+ >> PROVE_TAC [DotIntro]);
+
+val DotElimGeneralized = store_thm ("DotElimGeneralized",
+  ``!E C Gamma Gamma'. replaceCommaDot Gamma Gamma'
+		   ==> natDed E Gamma C ==> natDed E Gamma' C``,
+    NTAC 2 GEN_TAC
+ >> HO_MATCH_MP_TAC replaceCommaDot_ind
+ >> REPEAT STRIP_TAC
+ >> `natDed E (OneForm (Dot A B)) (Dot A B)` by PROVE_TAC [NatAxiomGeneralized, deltaTranslation_def]
+ >> `natDed E Gamma' C` by PROVE_TAC [DotElim]
+ >> RW_TAC bool_ss []);
+
+val NatTermToForm = store_thm ("NatTermToForm",
+  ``!E Gamma C. natDed E Gamma C ==> natDed E (OneForm (deltaTranslation Gamma)) C``,
+    REPEAT STRIP_TAC
+ >> PROVE_TAC [DotElimGeneralized, replaceTranslation]);
+
+val NatExtSimpl = store_thm (
+   "NatExtSimpl", ``!E Gamma Gamma' C. E Gamma Gamma' /\ natDed E Gamma C ==> natDed E Gamma' C``,
+    REPEAT STRIP_TAC
+ >> `replace Gamma Gamma' Gamma Gamma'` by REWRITE_TAC [replaceRoot]
+ >> IMP_RES_TAC NatExt);
+
+(******************************************************************************)
+(*                                                                            *)
+(*                        Module: Sequent Calculus                            *)
+(*                                                                            *)
+(******************************************************************************)
+
+(* gentzen presentation using sequents. *)
+val (gentzenSequent_rules, gentzenSequent_ind, gentzenSequent_cases) = Hol_reln `
+    (!(E:'a gentzen_extension) A.				(* SeqAxiom = NatAxiom *)
+      gentzenSequent E (OneForm A) A) /\
+    (!E Gamma A B.						(* RightSlash = SlashIntro *)
+      gentzenSequent E (Comma Gamma (OneForm B)) A ==>
+      gentzenSequent E Gamma (Slash A B)) /\
+    (!E Gamma A B.						(* RightBackslash = BackslashIntro *)
+      gentzenSequent E (Comma (OneForm B) Gamma) A ==>
+      gentzenSequent E Gamma (Backslash B A)) /\
+    (!E Gamma Delta A B.					(* RightDot = DotIntro *)
+      gentzenSequent E Gamma A /\ gentzenSequent E Delta B ==>
+      gentzenSequent E (Comma Gamma Delta) (Dot A B)) /\
+
+    (* Delta |- B /\ Gamma[A] |- C ==> Gamma[A / B, Delta] |- C  *)
+    (!E Gamma Gamma' Delta A B C.				(* LeftSlash *)
+      replace Gamma Gamma' (OneForm A) (Comma (OneForm (Slash A B)) Delta) /\
+      gentzenSequent E Delta B /\ gentzenSequent E Gamma C ==>
+      gentzenSequent E Gamma' C) /\
+
+    (* Delta |- B /\ Gamma[A] |- C ==> Gamma[Delta, B \ A] |- C *)
+    (!E Gamma Gamma' Delta A B C.				(* LeftBackslash *)
+      replace Gamma Gamma' (OneForm A) (Comma Delta (OneForm (Backslash B A))) /\
+      gentzenSequent E Delta B /\ gentzenSequent E Gamma C ==>
+      gentzenSequent E Gamma' C) /\
+
+    (* Gamma[A, B] |- C ==> Gamma[A * B] |- C *)
+    (!E Gamma Gamma' A B C.					(* LeftDot *)
+      replace Gamma Gamma' (Comma (OneForm A) (OneForm B)) (OneForm (Dot A B)) /\
+      gentzenSequent E Gamma C ==>
+      gentzenSequent E Gamma' C) /\
+
+    (* Delta |- A /\ Gamma[A] |- C ==> Gamma[Delta] |- C *)
+    (!E Delta Gamma Gamma' A C.					(* CutRule *)
+      replace Gamma Gamma' (OneForm A) Delta /\
+      gentzenSequent E Delta A /\ gentzenSequent E Gamma C ==>
+      gentzenSequent E Gamma' C) /\
+
+    (* E Delta Delta' /\ Gamma[Delta] |- C ==> Gamma[Delta'] |- C *)
+    (!(E:'a gentzen_extension) Gamma Gamma' Delta Delta' C.	(* SeqExt = NatExt *)
+      replace Gamma Gamma' Delta Delta' /\ E Delta Delta' /\
+      gentzenSequent E Gamma C ==> gentzenSequent E Gamma' C)`;
+
+val [SeqAxiom, RightSlash, RightBackslash, RightDot, LeftSlash, LeftBackslash, LeftDot,
+     CutRule, SeqExt] =
+    map save_thm
+        (combine (["SeqAxiom[simp]", "RightSlash", "RightBackslash", "RightDot",
+		   "LeftSlash", "LeftBackslash", "LeftDot", "CutRule", "SeqExt"],
+		  CONJUNCTS gentzenSequent_rules));
+
+(* old name: axiomeGeneralisation *)
+val SeqAxiomGeneralized = store_thm ("SeqAxiomGeneralized[simp]",
+  ``!E Gamma. gentzenSequent E Gamma (deltaTranslation Gamma)``,
+    Induct_on `Gamma:'a Term`
+ >| [ PROVE_TAC [deltaTranslation_def, SeqAxiom], (* base case *)
+      REWRITE_TAC [deltaTranslation_def] \\     (* induct case *)
+      PROVE_TAC [RightDot] ]);
+
+(* Some derived properties concerning gentzenSequent *)
+
+val LeftDotSimpl = store_thm ("LeftDotSimpl",
+  ``!E A B C. gentzenSequent E (Comma (OneForm A) (OneForm B)) C ==>
+	      gentzenSequent E (OneForm (Dot A B)) C``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC LeftDot
+ >> EXISTS_TAC ``(Comma (OneForm A) (OneForm B))``
+ >> Q.EXISTS_TAC `A`
+ >> Q.EXISTS_TAC `B`
+ >> PROVE_TAC [replaceRoot]);
+
+val LeftDotGeneralized = store_thm ("LeftDotGeneralized",
+  ``!E C T1 T2. replaceCommaDot T1 T2 ==> gentzenSequent E T1 C ==> gentzenSequent E T2 C``,
+    NTAC 2 GEN_TAC
+ >> HO_MATCH_MP_TAC replaceCommaDot_ind
+ >> REPEAT STRIP_TAC
+ >> PROVE_TAC [LeftDot]);
+
+val SeqTermToForm = store_thm ("SeqTermToForm",
+  ``!E Gamma C. gentzenSequent E Gamma C
+	    ==> gentzenSequent E (OneForm (deltaTranslation Gamma)) C``,
+    REPEAT GEN_TAC
+ >> MATCH_MP_TAC LeftDotGeneralized
+ >> RW_TAC bool_ss [replaceTranslation]);
+
+val LeftSlashSimpl = store_thm ("LeftSlashSimpl",
+  ``!E Gamma A B C. gentzenSequent E Gamma B /\ gentzenSequent E (OneForm A) C
+	        ==> gentzenSequent E (Comma (OneForm (Slash A B)) Gamma) C``,
+    PROVE_TAC [replace_rules, replaceCommaDot_rules, LeftSlash]);
+
+val LeftBackslashSimpl = store_thm ("LeftBackslashSimpl",
+  ``!E Gamma A B C. gentzenSequent E Gamma B /\ gentzenSequent E (OneForm A) C
+	        ==> gentzenSequent E (Comma Gamma (OneForm (Backslash B A))) C``,
+    PROVE_TAC [replace_rules, replaceCommaDot_rules, LeftBackslash]);
+
+val CutRuleSimpl = store_thm ("CutRuleSimpl",
+  ``!E Gamma A C. gentzenSequent E Gamma A /\ gentzenSequent E (OneForm A) C
+	      ==> gentzenSequent E Gamma C``,
+    PROVE_TAC [replace_rules, replaceCommaDot_rules, CutRule]);
+
+val DotRightSlash' = store_thm ("DotRightSlash'",
+  ``!E A B C. gentzenSequent E (OneForm A) (Slash C B)
+	  ==> gentzenSequent E (OneForm (Dot A B)) C``,
+    PROVE_TAC [replace_rules, replaceCommaDot_rules, gentzenSequent_rules]);
+
+val DotRightBackslash' = store_thm ("DotRightBackslash'",
+  ``!E A B C. gentzenSequent E (OneForm B) (Backslash A C)
+	  ==> gentzenSequent E (OneForm (Dot A B)) C``,
+    PROVE_TAC [replace_rules, replaceCommaDot_rules, gentzenSequent_rules]);
+
+val SeqExtSimpl = store_thm (
+   "SeqExtSimpl", ``!E Gamma Gamma' C. E Gamma Gamma' /\ gentzenSequent E Gamma C
+				   ==> gentzenSequent E Gamma' C``,
+    REPEAT STRIP_TAC
+ >> `replace Gamma Gamma' Gamma Gamma'` by REWRITE_TAC [replaceRoot]
+ >> IMP_RES_TAC SeqExt);
+
+(* some definitions concerning extensions *)
+
+val LextensionSimpl = store_thm ("LextensionSimpl",
+  ``!E T1 T2 T3 C. extends L_Sequent E /\
+		   gentzenSequent E (Comma T1 (Comma T2 T3)) C
+	       ==> gentzenSequent E (Comma (Comma T1 T2) T3) C``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC SeqExt
+ >> EXISTS_TAC ``(Comma T1 (Comma T2 T3))``	(* Gamma *)
+ >> EXISTS_TAC ``(Comma T1 (Comma T2 T3))``	(* Delta *)
+ >> EXISTS_TAC ``(Comma (Comma T1 T2) T3)``	(* Delta' *)
+ >> REPEAT STRIP_TAC (* 3 sub-goals here *)
+ >- REWRITE_TAC [replaceRoot]
+ >- PROVE_TAC [RSUBSET, L_Intro_lr]
+ >> ASM_REWRITE_TAC []);
+
+val LextensionSimpl' = store_thm ("LextensionSimpl'", (* dual theorem of above *)
+  ``!E T1 T2 T3 C. extends L_Sequent E /\
+		   gentzenSequent E (Comma (Comma T1 T2) T3) C
+	       ==> gentzenSequent E (Comma T1 (Comma T2 T3)) C``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC SeqExt
+ >> EXISTS_TAC ``(Comma (Comma T1 T2) T3)``	(* Gamma *)
+ >> EXISTS_TAC ``(Comma (Comma T1 T2) T3)``	(* Delta *)
+ >> EXISTS_TAC ``(Comma T1 (Comma T2 T3))``	(* Delta' *)
+ >> REPEAT STRIP_TAC (* 3 sub-goals here *)
+ >- REWRITE_TAC [replaceRoot]
+ >- PROVE_TAC [RSUBSET, L_Intro_rl]
+ >> ASM_REWRITE_TAC []);
+
+val LextensionSimplDot = store_thm ("LextensionSimplDot",
+  ``!E A B C D. extends L_Sequent E /\
+		gentzenSequent E (OneForm (Dot A (Dot B C))) D
+	    ==> gentzenSequent E (OneForm (Dot (Dot A B) C)) D``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC LeftDotSimpl
+ >> MATCH_MP_TAC LeftDot
+ >> EXISTS_TAC ``(Comma (Comma (OneForm A) (OneForm B)) (OneForm C))``
+ >> Q.EXISTS_TAC `A`
+ >> Q.EXISTS_TAC `B`
+ >> STRIP_TAC
+ >- RW_TAC bool_ss [replaceLeft, replaceRoot]
+ >> MATCH_MP_TAC LextensionSimpl
+ >> STRIP_TAC
+ >- ASM_REWRITE_TAC []
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(deltaTranslation (Comma (OneForm A) (Comma (OneForm B) (OneForm C))))``
+ >> RW_TAC bool_ss [SeqAxiomGeneralized, deltaTranslation_def]);
+
+val LextensionSimplDot' = store_thm ("LextensionSimplDot'", (* dual theorem of above *)
+  ``!E A B C D. extends L_Sequent E /\
+		gentzenSequent E (OneForm (Dot (Dot A B) C)) D
+	    ==> gentzenSequent E (OneForm (Dot A (Dot B C))) D``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC LeftDotSimpl
+ >> MATCH_MP_TAC LeftDot
+ >> EXISTS_TAC ``(Comma (OneForm A) (Comma (OneForm B) (OneForm C)))``
+ >> Q.EXISTS_TAC `B`
+ >> Q.EXISTS_TAC `C`
+ >> STRIP_TAC
+ >- RW_TAC bool_ss [replaceRight, replaceRoot]
+ >> MATCH_MP_TAC LextensionSimpl'
+ >> STRIP_TAC
+ >- ASM_REWRITE_TAC []
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(deltaTranslation (Comma (Comma (OneForm A) (OneForm B)) (OneForm C)))``
+ >> RW_TAC bool_ss [SeqAxiomGeneralized, deltaTranslation_def]);
+
+val NLPextensionSimpl = store_thm ("NLPextensionSimpl",
+  ``!E T1 T2 C. extends NLP_Sequent E /\
+		gentzenSequent E (Comma T1 T2) C
+	    ==> gentzenSequent E (Comma T2 T1) C``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC SeqExt
+ >> EXISTS_TAC ``(Comma T1 T2)``
+ >> EXISTS_TAC ``(Comma T1 T2)``
+ >> EXISTS_TAC ``(Comma T2 T1)``
+ >> REPEAT STRIP_TAC (* 3 sub-goals here *)
+ >- REWRITE_TAC [replaceRoot]
+ >- PROVE_TAC [RSUBSET, NLP_Intro]
+ >> ASM_REWRITE_TAC []);
+
+val NLPextensionSimplDot = store_thm ("NLPextensionSimplDot",
+  ``!E A B C. extends NLP_Sequent E /\
+	      gentzenSequent E (OneForm (Dot A B)) C
+	  ==> gentzenSequent E (OneForm (Dot B A)) C``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC LeftDotSimpl
+ >> MATCH_MP_TAC NLPextensionSimpl
+ >> STRIP_TAC
+ >- ASM_REWRITE_TAC []
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(deltaTranslation (Comma (OneForm A) (OneForm B)))``
+ >> RW_TAC bool_ss [SeqAxiomGeneralized, deltaTranslation_def]);
+
+(* original name: gentzenExtends, see also mono_X *)
+val mono_E = store_thm ("mono_E",
+  ``!E' E Gamma A. gentzenSequent E Gamma A
+	       ==> extends E E'
+	       ==> gentzenSequent E' Gamma A``,
+    GEN_TAC
+ >> HO_MATCH_MP_TAC gentzenSequent_ind
+ >> REPEAT STRIP_TAC (* 9 goals here *)
+ >- REWRITE_TAC [SeqAxiom]
+ >- RW_TAC bool_ss [RightSlash]
+ >- RW_TAC bool_ss [RightBackslash]
+ >- RW_TAC bool_ss [RightDot]
+ >- PROVE_TAC [LeftSlash]
+ >- PROVE_TAC [LeftBackslash]
+ >- PROVE_TAC [LeftDot]
+ >- PROVE_TAC [CutRule]
+ >> `E' Delta Delta'` by PROVE_TAC [RSUBSET]
+ >> `gentzenSequent E' Gamma A` by RW_TAC bool_ss []
+ >> PROVE_TAC [SeqExt]);
+
+(* Some theorems and derived properties
+   These definitions can be applied for all gentzen extensions,
+   we can see how CutRuleSimpl gets used in most of time. *)
+
+val application = store_thm ("application",
+  ``!E A B. gentzenSequent E (OneForm (Dot (Slash A B) B)) A``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC LeftDotSimpl
+ >> MATCH_MP_TAC LeftSlashSimpl
+ >> REWRITE_TAC [SeqAxiom]);
+
+val application' = store_thm ("application'",
+  ``!E A B. gentzenSequent E (OneForm (Dot B (Backslash B A))) A``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC LeftDotSimpl
+ >> MATCH_MP_TAC LeftBackslashSimpl
+ >> REWRITE_TAC [SeqAxiom]);
+
+val RightSlashDot = store_thm ("RightSlashDot",
+  ``!E A B C. gentzenSequent E (OneForm (Dot A C)) B
+	  ==> gentzenSequent E (OneForm A) (Slash B C)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC RightSlash
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(deltaTranslation (Comma (OneForm A) (OneForm C)))``
+ >> RW_TAC bool_ss [SeqAxiomGeneralized, deltaTranslation_def]);
+
+val RightBackslashDot = store_thm ("RightBackslashDot",
+  ``!E A B C. gentzenSequent E (OneForm (Dot B A)) C
+	  ==> gentzenSequent E (OneForm A) (Backslash B C)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC RightBackslash
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(deltaTranslation (Comma (OneForm B) (OneForm A)))``
+ >> RW_TAC bool_ss [SeqAxiomGeneralized, deltaTranslation_def]);
+
+val coApplication = store_thm ("coApplication",
+  ``!E A B. gentzenSequent E (OneForm A) (Slash (Dot A B) B)``,
+    PROVE_TAC [RightSlash, RightDot, SeqAxiom]);
+
+val coApplication' = store_thm ("coApplication'",
+  ``!E A B. gentzenSequent E (OneForm A) (Backslash B (Dot B A))``,
+    PROVE_TAC [RightBackslash, RightDot, SeqAxiom]);
+
+val monotonicity = store_thm ("monotonicity",
+  ``!E A B C D. gentzenSequent E (OneForm A) B /\
+		gentzenSequent E (OneForm C) D
+	    ==> gentzenSequent E (OneForm (Dot A C)) (Dot B D)``,
+    PROVE_TAC [LeftDotSimpl, RightDot]);
+
+val isotonicity = store_thm ("isotonicity",
+  ``!E A B C. gentzenSequent E (OneForm A) B
+	  ==> gentzenSequent E (OneForm (Slash A C)) (Slash B C)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC RightSlash
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> Q.EXISTS_TAC `A`
+ >> PROVE_TAC [LeftSlashSimpl, SeqAxiom]);
+
+val isotonicity' = store_thm ("isotonicity'",
+  ``!E A B C. gentzenSequent E (OneForm A) B
+	  ==> gentzenSequent E (OneForm (Backslash C A)) (Backslash C B)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC RightBackslash
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> Q.EXISTS_TAC `A`
+ >> PROVE_TAC [LeftBackslashSimpl, SeqAxiom]);
+
+val antitonicity = store_thm ("antitonicity",
+  ``!E A B C. gentzenSequent E (OneForm A) B
+	  ==> gentzenSequent E (OneForm (Slash C B)) (Slash C A)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC RightSlash
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(Dot (Slash C B) B)``
+ >> STRIP_TAC
+ >- PROVE_TAC [RightDot, SeqAxiom]
+ >> REWRITE_TAC [application]);
+
+val antitonicity' = store_thm ("antitonicity'",
+  ``!E A B C. gentzenSequent E (OneForm A) B
+	  ==> gentzenSequent E (OneForm (Backslash B C)) (Backslash A C)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC RightBackslash
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(Dot B (Backslash B C))``
+ >> STRIP_TAC
+ >- PROVE_TAC [RightDot, SeqAxiom]
+ >> REWRITE_TAC [application']);
+
+val lifting = store_thm ("lifting",
+  ``!E A B C. gentzenSequent E (OneForm A) (Slash B (Backslash A B))``,
+    REPEAT GEN_TAC
+ >> MATCH_MP_TAC RightSlash
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(Dot A (Backslash A B))``
+ >> STRIP_TAC
+ >- PROVE_TAC [RightDot, SeqAxiom]
+ >> REWRITE_TAC [application']);
+
+val lifting' = store_thm ("lifting'",
+  ``!E A B C. gentzenSequent E (OneForm A) (Backslash (Slash B A) B)``,
+    REPEAT GEN_TAC
+ >> MATCH_MP_TAC RightBackslash
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(Dot (Slash B A) A)``
+ >> STRIP_TAC
+ >- PROVE_TAC [RightDot, SeqAxiom]
+ >> REWRITE_TAC [application]);
+
+(* These definitions can be applied iff associativity is supported by our logical system *)
+
+val mainGeach = store_thm ("mainGeach",
+  ``!E A B C. extends L_Sequent E
+	  ==> gentzenSequent E (OneForm (Slash A B))
+			       (Slash (Slash A C) (Slash B C))``,
+    REPEAT STRIP_TAC
+ >> NTAC 2 (MATCH_MP_TAC RightSlash)
+ >> MATCH_MP_TAC LextensionSimpl
+ >> CONJ_TAC
+ >- POP_ASSUM ACCEPT_TAC
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(Dot (Slash A B) B)``
+ >> CONJ_TAC
+ >| [ MATCH_MP_TAC RightDot \\
+      CONJ_TAC >|
+      [ REWRITE_TAC [SeqAxiom],
+	MATCH_MP_TAC LeftSlashSimpl \\
+	STRIP_TAC \\
+	REWRITE_TAC [SeqAxiom] ],
+      REWRITE_TAC [application] ]);
+
+val mainGeach' = store_thm ("mainGeach'",
+  ``!E A B C. extends L_Sequent E
+	  ==> gentzenSequent E (OneForm (Backslash B A))
+			       (Backslash (Backslash C B) (Backslash C A))``,
+    REPEAT STRIP_TAC
+ >> NTAC 2 (MATCH_MP_TAC RightBackslash)
+ >> MATCH_MP_TAC LextensionSimpl'
+ >> CONJ_TAC
+ >- POP_ASSUM ACCEPT_TAC
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(Dot B (Backslash B A))``
+ >> CONJ_TAC
+ >| [ MATCH_MP_TAC RightDot \\
+      CONJ_TAC >|
+      [ MATCH_MP_TAC LeftBackslashSimpl \\
+	STRIP_TAC \\
+	REWRITE_TAC [SeqAxiom],
+	REWRITE_TAC [SeqAxiom] ] ,
+      REWRITE_TAC [application'] ]);
+
+val secondaryGeach = store_thm ("secondaryGeach",
+  ``!E A B C. extends L_Sequent E
+	  ==> gentzenSequent E (OneForm (Slash B C))
+			       (Backslash (Slash A B) (Slash A C))``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC RightBackslash
+ >> MATCH_MP_TAC RightSlash
+ >> MATCH_MP_TAC LextensionSimpl
+ >> CONJ_TAC >- (POP_ASSUM ACCEPT_TAC)
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(Dot (Slash A B) B)``
+ >> CONJ_TAC
+ >| [ MATCH_MP_TAC RightDot \\
+      CONJ_TAC >|
+      [ REWRITE_TAC [SeqAxiom],
+	MATCH_MP_TAC LeftSlashSimpl \\
+	STRIP_TAC \\
+	REWRITE_TAC [SeqAxiom] ],
+      REWRITE_TAC [application] ]);
+
+val secondaryGeach' = store_thm ("secondaryGeach'",
+``!E A B C. extends L_Sequent E
+	==> gentzenSequent E (OneForm (Backslash C B))
+			     (Slash (Backslash C A) (Backslash B A))``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC RightSlash
+ >> MATCH_MP_TAC RightBackslash
+ >> MATCH_MP_TAC LextensionSimpl'
+ >> CONJ_TAC
+ >- POP_ASSUM ACCEPT_TAC
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(Dot B (Backslash B A))``
+ >> CONJ_TAC
+ >| [ MATCH_MP_TAC RightDot \\
+      STRIP_TAC >|
+      [ MATCH_MP_TAC LeftBackslashSimpl \\
+	STRIP_TAC \\
+	REWRITE_TAC [SeqAxiom],
+	REWRITE_TAC [SeqAxiom] ] ,
+      REWRITE_TAC [application'] ]);
+
+val composition = store_thm ("composition",
+  ``!E A B C. extends L_Sequent E
+	  ==> gentzenSequent E (OneForm (Dot (Slash A B) (Slash B C)))
+			       (Slash A C)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(Dot (Slash (Slash A C) (Slash B C)) (Slash B C))``
+ >> CONJ_TAC
+ >| [ MATCH_MP_TAC monotonicity \\
+      CONJ_TAC >|
+      [ RW_TAC bool_ss [mainGeach], REWRITE_TAC [SeqAxiom] ],
+      REWRITE_TAC [application] ]);
+
+val composition' = store_thm ("composition'",
+  ``!E A B C. extends L_Sequent E
+	  ==> gentzenSequent E (OneForm (Dot (Backslash C B) (Backslash B A)))
+			       (Backslash C A)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(Dot (Slash (Backslash C A) (Backslash B A)) (Backslash B A))``
+ >> CONJ_TAC
+ >| [ MATCH_MP_TAC monotonicity \\
+      CONJ_TAC >|
+      [ RW_TAC bool_ss [secondaryGeach'], REWRITE_TAC [SeqAxiom] ],
+      REWRITE_TAC [application] ]);
+
+val restructuring = store_thm ("restructuring",
+  ``!E A B C. extends L_Sequent E
+	  ==> gentzenSequent E (OneForm (Slash (Backslash A B) C))
+			       (Backslash A (Slash B C))``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC RightBackslash
+ >> MATCH_MP_TAC RightSlash
+ >> MATCH_MP_TAC LextensionSimpl
+ >> CONJ_TAC
+ >- POP_ASSUM ACCEPT_TAC
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(Dot A (Backslash A B))``
+ >> CONJ_TAC
+ >| [ MATCH_MP_TAC RightDot \\
+      CONJ_TAC >| [ REWRITE_TAC [SeqAxiom],
+		    MATCH_MP_TAC LeftSlashSimpl \\
+		    REWRITE_TAC [SeqAxiom] ],
+      REWRITE_TAC [application'] ]);
+
+val restructuring' = store_thm ("restructuring'",
+  ``!E A B C. extends L_Sequent E
+	  ==> gentzenSequent E (OneForm (Backslash A (Slash B C)))
+			       (Slash (Backslash A B) C)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC RightSlash
+ >> MATCH_MP_TAC RightBackslash
+ >> MATCH_MP_TAC LextensionSimpl'
+ >> CONJ_TAC
+ >- POP_ASSUM ACCEPT_TAC
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(Dot (Slash B C) C)``
+ >> CONJ_TAC
+ >| [ MATCH_MP_TAC RightDot \\
+      CONJ_TAC >| [ MATCH_MP_TAC LeftBackslashSimpl \\
+		    REWRITE_TAC [SeqAxiom],
+		    REWRITE_TAC [SeqAxiom] ],
+      REWRITE_TAC [application] ]);
+
+val currying = store_thm ("currying",
+  ``!E A B C. extends L_Sequent E
+	  ==> gentzenSequent E (OneForm (Slash A (Dot B C)))
+			       (Slash (Slash A C) B)``,
+    REPEAT STRIP_TAC
+ >> NTAC 2 (MATCH_MP_TAC RightSlashDot)
+ >> MATCH_MP_TAC LextensionSimplDot
+ >> CONJ_TAC
+ >- POP_ASSUM ACCEPT_TAC
+ >> REWRITE_TAC [application]);
+
+val currying' = store_thm ("currying'",
+  ``!E A B C. extends L_Sequent E
+	  ==> gentzenSequent E (OneForm (Slash (Slash A C) B))
+			       (Slash A (Dot B C))``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC RightSlashDot
+ >> MATCH_MP_TAC LextensionSimplDot'
+ >> CONJ_TAC
+ >- POP_ASSUM ACCEPT_TAC
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(Dot (Slash A C) C)``
+ >> CONJ_TAC
+ >| [ MATCH_MP_TAC monotonicity
+   >> CONJ_TAC
+   >> REWRITE_TAC [application, SeqAxiom],
+      REWRITE_TAC [application] ]);
+
+val decurrying = store_thm ("decurrying",
+  ``!E A B C. extends L_Sequent E
+	  ==> gentzenSequent E (OneForm (Backslash (Dot A B) C))
+			       (Backslash B (Backslash A C))``,
+    REPEAT STRIP_TAC
+ >> NTAC 2 (MATCH_MP_TAC RightBackslashDot)
+ >> MATCH_MP_TAC LextensionSimplDot'
+ >> CONJ_TAC
+ >- POP_ASSUM ACCEPT_TAC
+ >> REWRITE_TAC [application']);
+
+val decurrying' = store_thm ("decurrying'",
+  ``!E A B C. extends L_Sequent E
+	  ==> gentzenSequent E (OneForm (Backslash B (Backslash A C)))
+			       (Backslash (Dot A B) C)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC RightBackslashDot
+ >> MATCH_MP_TAC LextensionSimplDot
+ >> CONJ_TAC
+ >- POP_ASSUM ACCEPT_TAC
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(Dot A (Backslash A C))``
+ >> CONJ_TAC
+ >| [ MATCH_MP_TAC monotonicity \\
+      REWRITE_TAC [application', SeqAxiom],
+      REWRITE_TAC [application'] ]);
+
+(* Theorem for systems that support commutativity: if its extension extends NLP_Sequent *)
+
+val permutation = store_thm ("permutation",
+  ``!E A B C. extends NLP_Sequent E
+	  ==> gentzenSequent E (OneForm A) (Backslash B C)
+	  ==> gentzenSequent E (OneForm B) (Backslash A C)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC RightBackslashDot
+ >> MATCH_MP_TAC NLPextensionSimplDot
+ >> CONJ_TAC
+ >- ASM_REWRITE_TAC []
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(Dot B (Backslash B C))``
+ >> CONJ_TAC
+ >| [ MATCH_MP_TAC monotonicity >> ASM_REWRITE_TAC [SeqAxiom],
+      REWRITE_TAC [application'] ]);
+
+val exchange = store_thm ("exchange",
+  ``!E A B. extends NLP_Sequent E
+	==> gentzenSequent E (OneForm (Slash A B)) (Backslash B A)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC RightBackslashDot
+ >> MATCH_MP_TAC NLPextensionSimplDot
+ >> RW_TAC bool_ss [application]);
+
+val exchange' = store_thm ("exchange'",
+  ``!E A B. extends NLP_Sequent E
+	==> gentzenSequent E (OneForm (Backslash B A)) (Slash A B)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC RightSlashDot
+ >> MATCH_MP_TAC NLPextensionSimplDot
+ >> RW_TAC bool_ss [application']);
+
+val preposing = store_thm ("preposing",
+  ``!E A B. extends NLP_Sequent E
+	==> gentzenSequent E (OneForm A) (Slash B (Slash B A))``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC RightSlashDot
+ >> MATCH_MP_TAC NLPextensionSimplDot
+ >> RW_TAC bool_ss [application]);
+
+val postposing = store_thm ("postposing",
+  ``!E A B. extends NLP_Sequent E
+	==> gentzenSequent E (OneForm A) (Backslash (Backslash A B) B)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC RightBackslashDot
+ >> MATCH_MP_TAC NLPextensionSimplDot
+ >> RW_TAC bool_ss [application']);
+
+(* For systems that support both commutativity and associativity *)
+
+val mixedComposition = store_thm ("mixedComposition",
+  ``!E A B C. extends LP_Sequent E
+	  ==> gentzenSequent E (OneForm (Dot (Slash A B) (Backslash C B))) (Backslash C A)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC NLPextensionSimplDot
+ >> CONJ_TAC
+ >- RW_TAC bool_ss [LPextendsNLP]
+ >> MATCH_MP_TAC RightBackslashDot
+ >> MATCH_MP_TAC LextensionSimplDot'
+ >> CONJ_TAC
+ >- RW_TAC bool_ss [LPextendsL]
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(Dot B (Slash A B))``
+ >> CONJ_TAC
+ >| [ MATCH_MP_TAC monotonicity \\
+      RW_TAC bool_ss [application', SeqAxiom],
+      MATCH_MP_TAC NLPextensionSimplDot \\
+      RW_TAC bool_ss [application, LPextendsNLP] ]);
+
+val mixedComposition' = store_thm ("mixedComposition'",
+  ``!E A B C. extends LP_Sequent E
+	 ==>  gentzenSequent E (OneForm (Dot (Slash B C) (Backslash B A))) (Slash A C)``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC NLPextensionSimplDot
+ >> CONJ_TAC
+ >- RW_TAC bool_ss [LPextendsNLP]
+ >> MATCH_MP_TAC RightSlashDot
+ >> MATCH_MP_TAC LextensionSimplDot
+ >> CONJ_TAC
+ >- RW_TAC bool_ss [LPextendsL]
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(Dot (Backslash B A) B)``
+ >> CONJ_TAC
+ >| [ MATCH_MP_TAC monotonicity \\
+      RW_TAC bool_ss [application, SeqAxiom],
+      MATCH_MP_TAC NLPextensionSimplDot \\
+      RW_TAC bool_ss [application', LPextendsNLP] ]);
+
+(******************************************************************************)
+(*                                                                            *)
+(*                          Module: ArrowGentzen                              *)
+(*                                                                            *)
+(******************************************************************************)
+
+val replace_arrow = store_thm ("replace_arrow",
+  ``!X Gamma Gamma' T1 T2.
+     replace Gamma Gamma' T1 T2 ==>
+     arrow X (deltaTranslation T2) (deltaTranslation T1) ==>
+     arrow X (deltaTranslation Gamma') (deltaTranslation Gamma)``,
+    GEN_TAC
+ >> HO_MATCH_MP_TAC replace_ind
+ >> REPEAT STRIP_TAC (* 2 sub-goals here *)
+ >| [ REWRITE_TAC [deltaTranslation_def] \\
+      RES_TAC \\
+      POP_ASSUM (ASSUME_TAC o (MATCH_MP Dot_mono_left)) \\
+      ASM_REWRITE_TAC [],
+      REWRITE_TAC [deltaTranslation_def] \\
+      RES_TAC \\
+      POP_ASSUM (ASSUME_TAC o (MATCH_MP Dot_mono_right)) \\
+      ASM_REWRITE_TAC [] ]);
+
+val replace_arrow' = store_thm ("replace_arrow'",
+  ``!C X Gamma Gamma' T1 T2.
+     replace Gamma Gamma' T1 T2 ==>
+     arrow X (deltaTranslation T2) (deltaTranslation T1) ==>
+     arrow X (deltaTranslation Gamma) C ==>
+     arrow X (deltaTranslation Gamma') C``,
+    REPEAT STRIP_TAC
+ >> IMP_RES_TAC replace_arrow
+ >> IMP_RES_TAC comp);
+
+(* from axiomatic presentation to sequent calculus *)
+val arrowToGentzenExt_def = Define `
+    arrowToGentzenExt (X :'a arrow_extension) (E :'a gentzen_extension) =
+	!A B. X A B ==> gentzenSequent E (OneForm A) B`;
+
+val NLToNL_Sequent = store_thm (
+   "NLToNL_Sequent", ``arrowToGentzenExt NL NL_Sequent``,
+    REWRITE_TAC [arrowToGentzenExt_def]
+ >> RW_TAC std_ss [NL_def, EMPTY_REL_DEF]);
+
+val NLPToNLP_Sequent = store_thm (
+   "NLPToNLP_Sequent", ``arrowToGentzenExt NLP NLP_Sequent``,
+    REWRITE_TAC [arrowToGentzenExt_def]
+ >> REWRITE_TAC [NLP_cases]
+ >> REPEAT STRIP_TAC
+ >> ASM_REWRITE_TAC []
+ >> ASSUME_TAC (ISPEC ``NLP_Sequent`` no_extend)
+ >> MATCH_MP_TAC NLPextensionSimplDot
+ >> ASM_REWRITE_TAC []
+ >> REWRITE_TAC [SeqAxiom]);
+
+val LToL_Sequent = store_thm (
+   "LToL_Sequent", ``arrowToGentzenExt L L_Sequent``,
+    REWRITE_TAC [arrowToGentzenExt_def]
+ >> REWRITE_TAC [L_cases]
+ >> ASSUME_TAC (ISPEC ``L_Sequent`` no_extend)
+ >> REPEAT STRIP_TAC (* 2 sub-goals here *)
+ >> ASM_REWRITE_TAC []
+ >| [ MATCH_MP_TAC LextensionSimplDot' >> ASM_REWRITE_TAC [] \\
+      REWRITE_TAC [SeqAxiom],
+      MATCH_MP_TAC LextensionSimplDot >> ASM_REWRITE_TAC [] \\
+      REWRITE_TAC [SeqAxiom] ]);
+
+val LPToLP_Sequent = store_thm (
+   "LPToLP_Sequent", ``arrowToGentzenExt LP LP_Sequent``,
+    REWRITE_TAC [arrowToGentzenExt_def, LP_def, RUNION]
+ >> REPEAT STRIP_TAC (* two sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      MP_TAC NLP_Sequent_LP_Sequent \\
+      POP_ASSUM (MP_TAC o (MATCH_MP (REWRITE_RULE [arrowToGentzenExt_def] NLPToNLP_Sequent))) \\
+      REWRITE_TAC [mono_E],
+      (* goal 2 (of 2) *)
+      MP_TAC L_Sequent_LP_Sequent \\
+      POP_ASSUM (MP_TAC o (MATCH_MP (REWRITE_RULE [arrowToGentzenExt_def] LToL_Sequent))) \\
+      REWRITE_TAC [mono_E] ]);
+
+val arrowToGentzen = store_thm (
+   "arrowToGentzen",
+  ``!E X A B. arrow X A B ==> arrowToGentzenExt X E ==> gentzenSequent E (OneForm A) B``,
+    GEN_TAC
+ >> HO_MATCH_MP_TAC arrow_ind
+ >> REPEAT STRIP_TAC (* 7 goals here, first is easy *)
+ >- REWRITE_TAC [SeqAxiom] (* rest 6 goals *)
+ >| [ (* goal 1 (of 6) *)
+      MATCH_MP_TAC RightSlashDot >> RES_TAC,
+      (* goal 2 (of 6) *)
+      MATCH_MP_TAC DotRightSlash' >> RES_TAC,
+      (* goal 3 (of 6) *)
+      MATCH_MP_TAC RightBackslashDot >> RES_TAC,
+      (* goal 4 (of 6) *)
+      MATCH_MP_TAC DotRightBackslash' >> RES_TAC,
+      (* goal 5 (of 6) *)
+      MATCH_MP_TAC CutRuleSimpl \\
+      Q.EXISTS_TAC `A'` \\
+      RES_TAC \\
+      ASM_REWRITE_TAC [],
+      (* goal 6 (of 6) *)
+      POP_ASSUM (ASSUME_TAC o (REWRITE_RULE [arrowToGentzenExt_def])) \\
+      RES_TAC ]);
+
+(* particular cases for NLP, L; LP and NL systems *)
+val arrowToGentzenNL = store_thm (
+   "arrowToGentzenNL",
+  ``!A B. arrow NL A B ==> gentzenSequent NL_Sequent (OneForm A) B``,
+    REPEAT STRIP_TAC
+ >> irule arrowToGentzen
+ >> Q.EXISTS_TAC `NL`
+ >> ASM_REWRITE_TAC [NLToNL_Sequent]);
+
+val arrowToGentzenNLP = store_thm (
+   "arrowToGentzenNLP",
+  ``!A B. arrow NLP A B ==> gentzenSequent NLP_Sequent (OneForm A) B``,
+    REPEAT STRIP_TAC
+ >> irule arrowToGentzen
+ >> Q.EXISTS_TAC `NLP`
+ >> ASM_REWRITE_TAC [NLPToNLP_Sequent]);
+
+val arrowToGentzenL = store_thm (
+   "arrowToGentzenL",
+  ``!A B. arrow L A B ==> gentzenSequent L_Sequent (OneForm A) B``,
+    REPEAT STRIP_TAC
+ >> irule arrowToGentzen
+ >> Q.EXISTS_TAC `L`
+ >> ASM_REWRITE_TAC [LToL_Sequent]);
+
+val arrowToGentzenLP = store_thm (
+   "arrowToGentzenLP",
+  ``!A B. arrow LP A B ==> gentzenSequent LP_Sequent (OneForm A) B``,
+    REPEAT STRIP_TAC
+ >> irule arrowToGentzen
+ >> Q.EXISTS_TAC `LP`
+ >> ASM_REWRITE_TAC [LPToLP_Sequent]);
+
+(* from sequent calculus to axiomatic presentation.
+   Notice the strange thing here: the order of T1 and T2 are changed from E to X. *)
+val gentzenToArrowExt_def = Define
+   `gentzenToArrowExt (E :'a gentzen_extension) (X :'a arrow_extension) =
+	(!T1 T2. E T1 T2 ==> X (deltaTranslation T2) (deltaTranslation T1))`;
+
+(* Build arrow_extensions directly from gentzen_extensions *)
+val ToArrowExt_def = Define `
+    ToArrowExt (E :'a gentzen_extension) =
+	CURRY { (deltaTranslation y, deltaTranslation x) | (x,y) IN (UNCURRY E) }`;
+
+val ToArrowExt_thm = store_thm (
+   "ToArrowExt_thm",
+  ``!E T1 T2. E T1 T2 ==> (ToArrowExt E) (deltaTranslation T2) (deltaTranslation T1)``,
+    REPEAT STRIP_TAC
+ >> REWRITE_TAC [ToArrowExt_def, CURRY_DEF]
+ >> ONCE_REWRITE_TAC [GSYM SPECIFICATION]
+ >> ONCE_REWRITE_TAC [GSPECIFICATION]
+ >> Q.EXISTS_TAC `(T2, T1)`
+ >> `(T1, T2) IN (UNCURRY E)`
+	by PROVE_TAC [UNCURRY_DEF, SPECIFICATION]
+ >> FULL_SIMP_TAC std_ss []);
+
+val gentzenToArrowExt_thm = store_thm (
+   "gentzenToArrowExt_thm", ``!E. gentzenToArrowExt E (ToArrowExt E)``,
+    REWRITE_TAC [gentzenToArrowExt_def, ToArrowExt_thm]);
+
+val NL_SequentToNL = store_thm (
+   "NL_SequentToNL", ``gentzenToArrowExt NL_Sequent NL``,
+    REWRITE_TAC [gentzenToArrowExt_def]
+ >> RW_TAC std_ss [NL_Sequent_def, EMPTY_REL_DEF]);
+
+val NLP_SequentToNLP = store_thm (
+   "NLP_SequentToNLP", ``gentzenToArrowExt NLP_Sequent NLP``,
+    REWRITE_TAC [gentzenToArrowExt_def]
+ >> REWRITE_TAC [NLP_Sequent_cases]
+ >> REPEAT STRIP_TAC
+ >> ASM_REWRITE_TAC [deltaTranslation_def]
+ >> REWRITE_TAC [NLP_rules]);
+
+val L_SequentToL = store_thm (
+   "L_SequentToL", ``gentzenToArrowExt L_Sequent L``,
+    REWRITE_TAC [gentzenToArrowExt_def]
+ >> REWRITE_TAC [L_Sequent_cases]
+ >> REPEAT STRIP_TAC
+ >> ASM_REWRITE_TAC [deltaTranslation_def]
+ >| [ REWRITE_TAC [L_rule_lr],
+      REWRITE_TAC [L_rule_rl] ]);
+
+val LP_SequentToLP = store_thm (
+   "LP_SequentToLP", ``gentzenToArrowExt LP_Sequent LP``,
+    REWRITE_TAC [gentzenToArrowExt_def, LP_Sequent_def, RUNION]
+ >> REPEAT STRIP_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      POP_ASSUM (MP_TAC o (MATCH_MP (REWRITE_RULE [gentzenToArrowExt_def] NLP_SequentToNLP))) \\
+      MP_TAC NLPextendsLP \\
+      RW_TAC std_ss [RSUBSET],
+      (* goal 2 (of 2) *)
+      POP_ASSUM (MP_TAC o (MATCH_MP (REWRITE_RULE [gentzenToArrowExt_def] L_SequentToL))) \\
+      MP_TAC LextendsLP \\
+      RW_TAC std_ss [RSUBSET] ]);
+
+val gentzenToArrow' = store_thm (
+   "gentzenToArrow'",
+  ``!X E Gamma A. gentzenSequent E Gamma A ==> gentzenToArrowExt E X ==>
+		  arrow X (deltaTranslation Gamma) A``,
+    GEN_TAC
+ >> HO_MATCH_MP_TAC gentzenSequent_ind
+ >> REPEAT STRIP_TAC (* 9 sub-goals here *)
+ >| [ (* goal 1 *)
+      REWRITE_TAC [deltaTranslation_def, one],
+      (* goal 2 *)
+      RES_TAC >> POP_ASSUM MP_TAC \\
+      REWRITE_TAC [deltaTranslation_def, beta],
+      (* goal 3 *)
+      RES_TAC >> POP_ASSUM MP_TAC \\
+      REWRITE_TAC [deltaTranslation_def, gamma],
+      (* goal 4 *)
+      RES_TAC >> POP_ASSUM MP_TAC >> POP_ASSUM MP_TAC \\
+      RW_TAC std_ss [deltaTranslation_def, Dot_mono],
+      (* goal 5 *)
+      RES_TAC \\
+      SUFF_TAC ``arrow X (deltaTranslation (Comma (OneForm (Slash A A')) Gamma''))
+			 (deltaTranslation (OneForm A))`` >| (* 2 sub-goals here *)
+      [ (* goal 5.1 (of 2) *)
+	DISCH_TAC \\
+	`arrow X (deltaTranslation Gamma') (deltaTranslation Gamma)`
+		by PROVE_TAC [replace_arrow] \\
+	IMP_RES_TAC comp,
+	(* goal 5.2 (of 2) *)
+	REWRITE_TAC [deltaTranslation_def] \\
+	MATCH_MP_TAC beta' \\
+	MATCH_MP_TAC Slash_antimono_right \\
+	POP_ASSUM ACCEPT_TAC ],
+      (* goal 6 *)
+      RES_TAC \\
+      SUFF_TAC ``arrow X (deltaTranslation (Comma Gamma'' (OneForm (Backslash A' A))))
+			 (deltaTranslation (OneForm A))`` >| (* 2 sub-goals here *)
+      [ (* goal 6.1 (of 2) *)
+	DISCH_TAC \\
+	`arrow X (deltaTranslation Gamma') A''` by PROVE_TAC [replace_arrow'],
+	(* goal 6.2 (of 2) *)
+	REWRITE_TAC [deltaTranslation_def] \\
+	MATCH_MP_TAC gamma' \\
+	MATCH_MP_TAC Backslash_antimono_left \\
+	POP_ASSUM ACCEPT_TAC ],
+      (* goal 7 *)
+      RES_TAC \\
+      SUFF_TAC ``arrow X (deltaTranslation (OneForm (Dot A B)))
+			 (deltaTranslation (Comma (OneForm A) (OneForm B)))`` >|
+      (* 2 sub-goals here *)
+      [ (* goal 7.1 *)
+	DISCH_TAC \\
+	`arrow X (deltaTranslation Gamma') A'` by PROVE_TAC [replace_arrow'],
+	(* goal 7.2 *)
+	REWRITE_TAC [deltaTranslation_def, one] ],
+     (* goal 8 *)
+     RES_TAC \\
+     `arrow X (deltaTranslation Gamma) (deltaTranslation (OneForm A))`
+	by ASM_REWRITE_TAC [deltaTranslation_def] \\
+     `arrow X (deltaTranslation Gamma'') A'` by PROVE_TAC [replace_arrow'],
+     (* goal 9 *)
+     FULL_SIMP_TAC std_ss [gentzenToArrowExt_def] \\
+     RES_TAC \\
+     `arrow X (deltaTranslation Delta') (deltaTranslation Delta)`
+	by PROVE_TAC [arrow_plus] \\
+     `arrow X (deltaTranslation Gamma') A` by PROVE_TAC [replace_arrow'] ]);
+
+val gentzenToArrow = store_thm (
+   "gentzenToArrow",
+  ``!E X Gamma A. gentzenToArrowExt E X /\ gentzenSequent E Gamma A
+	      ==> arrow X (deltaTranslation Gamma) A``,
+    REPEAT STRIP_TAC
+ >> PAT_X_ASSUM ``gentzenToArrowExt E X`` MP_TAC
+ >> POP_ASSUM MP_TAC
+ >> REWRITE_TAC [gentzenToArrow']);
+
+val gentzenToArrow_E = store_thm (
+   "gentzenToArrow_E",
+  ``!E Gamma A. gentzenSequent E Gamma A ==> arrow (ToArrowExt E) (deltaTranslation Gamma) A``,
+    REPEAT STRIP_TAC
+ >> ASSUME_TAC (Q.SPEC `E` gentzenToArrowExt_thm)
+ >> NTAC 2 (POP_ASSUM MP_TAC)
+ >> REWRITE_TAC [gentzenToArrow']);
+
+val NLGentzenToArrow = store_thm (
+   "NLGentzenToArrow",
+  ``!Gamma A. gentzenSequent NL_Sequent Gamma A ==> arrow NL (deltaTranslation Gamma) A``,
+    REPEAT STRIP_TAC
+ >> MP_TAC NL_SequentToNL
+ >> POP_ASSUM MP_TAC
+ >> REWRITE_TAC [gentzenToArrow']);
+
+val NLPGentzenToArrow = store_thm (
+   "NLPGentzenToArrow",
+  ``!Gamma A. gentzenSequent NLP_Sequent Gamma A ==> arrow NLP (deltaTranslation Gamma) A``,
+    REPEAT STRIP_TAC
+ >> MP_TAC NLP_SequentToNLP
+ >> POP_ASSUM MP_TAC
+ >> REWRITE_TAC [gentzenToArrow']);
+
+val LGentzenToArrow = store_thm (
+   "LGentzenToArrow",
+  ``!Gamma A. gentzenSequent L_Sequent Gamma A ==> arrow L (deltaTranslation Gamma) A``,
+    REPEAT STRIP_TAC
+ >> MP_TAC L_SequentToL
+ >> POP_ASSUM MP_TAC
+ >> REWRITE_TAC [gentzenToArrow']);
+
+val LPGentzenToArrow = store_thm (
+   "LPGentzenToArrow",
+  ``!Gamma A. gentzenSequent LP_Sequent Gamma A ==> arrow LP (deltaTranslation Gamma) A``,
+    REPEAT STRIP_TAC
+ >> MP_TAC LP_SequentToLP
+ >> POP_ASSUM MP_TAC
+ >> REWRITE_TAC [gentzenToArrow']);
+
+(******************************************************************************)
+(*                                                                            *)
+(*          Module: Gentzen's Sequent Calculus and Natural Deduction          *)
+(*                                                                            *)
+(******************************************************************************)
+
+val replaceGentzen = store_thm ("replaceGentzen",
+  ``!E Gamma Gamma' Delta Delta'.
+     replace Gamma Gamma' Delta Delta' ==>
+     gentzenSequent E Delta' (deltaTranslation Delta) ==>
+     gentzenSequent E Gamma' (deltaTranslation Gamma)``,
+    X_GEN_TAC ``E :'a gentzen_extension``
+ >> Induct_on `replace`
+ >> REPEAT STRIP_TAC
+ >> `gentzenSequent E Delta (deltaTranslation Delta)` by PROVE_TAC [SeqAxiomGeneralized]
+ >> `gentzenSequent E Gamma' (deltaTranslation Gamma)` by PROVE_TAC []
+ >> PROVE_TAC [RightDot, deltaTranslation_def]);
+
+val replaceGentzen' = store_thm (
+   "replaceGentzen'",
+  ``!Gamma Gamma' Delta Delta' C E.
+     replace Gamma Gamma' Delta Delta' /\
+     gentzenSequent E Delta' (deltaTranslation Delta) /\
+     gentzenSequent E Gamma C ==>
+     gentzenSequent E Gamma' C``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC CutRuleSimpl
+ >> EXISTS_TAC ``(deltaTranslation Gamma)``
+ >> CONJ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      IMP_RES_TAC replaceGentzen,
+      (* goal 2 (of 2) *)
+      MATCH_MP_TAC SeqTermToForm \\
+      ASM_REWRITE_TAC [] ]);
+
+val replaceNatDed = store_thm ("replaceNatDed",
+  ``!E Gamma Gamma' Delta Delta'.
+    replace Gamma Gamma' Delta Delta' ==>
+    natDed E Delta' (deltaTranslation Delta) ==>
+    natDed E Gamma' (deltaTranslation Gamma)``,
+    GEN_TAC
+ >> HO_MATCH_MP_TAC replace_ind
+ >> CONJ_TAC
+ >- RW_TAC bool_ss []
+ >> REWRITE_TAC [deltaTranslation_def]
+ >> CONJ_TAC
+ >> REPEAT STRIP_TAC
+ >> MATCH_MP_TAC DotIntro
+ >> RW_TAC bool_ss [NatAxiomGeneralized]);
+
+(* E T1[A] T2[A] ==> ?T1[Delta]. X T1[Delta] T2[Delta] *)
+val condCutExt_def = Define `
+    condCutExt (E :'a gentzen_extension) =
+	!Gamma T1 T2 A Delta.
+	 E T1 T2 ==> replace T2 Gamma (OneForm A) Delta
+	         ==> ?Gamma'. E Gamma' Gamma /\ replace T1 Gamma' (OneForm A) Delta`;
+
+val conditionOKNL = store_thm ("conditionOKNL", ``condCutExt NL_Sequent``,
+    REWRITE_TAC [condCutExt_def]
+ >> REPEAT GEN_TAC
+ >> GEN_REWRITE_TAC (RATOR_CONV o ONCE_DEPTH_CONV) empty_rewrites [NL_Sequent_def]
+ >> RW_TAC std_ss [EMPTY_REL_DEF]);
+
+val conditionOKNLP = store_thm ("conditionOKNLP", ``condCutExt NLP_Sequent``,
+    REWRITE_TAC [condCutExt_def]
+ >> REPEAT GEN_TAC
+ >> GEN_REWRITE_TAC (RATOR_CONV o ONCE_DEPTH_CONV) empty_rewrites [NLP_Sequent_cases]
+ >> REPEAT STRIP_TAC
+ >> `replace (Comma B A') Gamma (OneForm A) Delta` by PROVE_TAC []
+ >> ASM_REWRITE_TAC []
+ >> POP_ASSUM (MP_TAC o (MATCH_MP replace_inv2))
+ >> REPEAT STRIP_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      ASM_REWRITE_TAC [] \\
+      EXISTS_TAC ``(Comma A' G)`` \\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ REWRITE_TAC [NLP_Sequent_rules],
+        MATCH_MP_TAC replaceRight >> ASM_REWRITE_TAC [] ],
+      ASM_REWRITE_TAC [] \\
+      EXISTS_TAC ``(Comma G B)`` \\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ REWRITE_TAC [NLP_Sequent_rules],
+        MATCH_MP_TAC replaceLeft >> ASM_REWRITE_TAC [] ] ]);
+
+val conditionOKL = store_thm ("conditionOKL", ``condCutExt L_Sequent``,
+    REWRITE_TAC [condCutExt_def]
+ >> REPEAT GEN_TAC
+ >> GEN_REWRITE_TAC (RATOR_CONV o ONCE_DEPTH_CONV) empty_rewrites [L_Sequent_cases]
+ >> REPEAT STRIP_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 *)
+      ASM_REWRITE_TAC []						\\
+      `replace (Comma (Comma A' B) C) Gamma (OneForm A) Delta`
+	by PROVE_TAC []							\\
+      POP_ASSUM (MP_TAC o (MATCH_MP replace_inv2))			\\
+      REPEAT STRIP_TAC >| (* 2 sub sub-goals here *)
+      [ (* goal 1.1 (of 2) *)
+	POP_ASSUM (MP_TAC o (MATCH_MP replace_inv2))			\\
+	REPEAT STRIP_TAC >| (* 2 sub-goals here *)
+	[ (* goal 1.1.1 (of 2) *)
+	  ASM_REWRITE_TAC []						\\
+	  EXISTS_TAC ``(Comma G' (Comma B C))``				\\
+	  CONJ_TAC >- REWRITE_TAC [L_Sequent_rules]			\\
+	  MATCH_MP_TAC replaceLeft					\\
+	  ASM_REWRITE_TAC [],
+	  (* goal 1.1.2 (of 2) *)
+	  ASM_REWRITE_TAC []						\\
+	  EXISTS_TAC ``(Comma A' (Comma G' C))``			\\
+	  CONJ_TAC >- REWRITE_TAC [L_Sequent_rules]			\\
+	  MATCH_MP_TAC replaceRight					\\
+	  MATCH_MP_TAC replaceLeft					\\
+	  ASM_REWRITE_TAC [] ],
+	(* goal 1.2 (of 2) *)
+	ASM_REWRITE_TAC []						\\
+	EXISTS_TAC ``(Comma A' (Comma B G))``				\\
+	CONJ_TAC >- REWRITE_TAC [L_Sequent_rules]			\\
+	NTAC 2 (MATCH_MP_TAC replaceRight)				\\
+        ASM_REWRITE_TAC [] ],
+      (* goal 2 (of 2) *)
+      ASM_REWRITE_TAC []						\\
+      `replace (Comma A' (Comma B C)) Gamma (OneForm A) Delta`
+	by PROVE_TAC []							\\
+      POP_ASSUM (MP_TAC o (MATCH_MP replace_inv2))			\\
+      REPEAT STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 2.1 (of 2) *)
+	ASM_REWRITE_TAC []						\\
+	EXISTS_TAC ``(Comma (Comma G B) C)``				\\
+	CONJ_TAC >- REWRITE_TAC [L_Sequent_rules]			\\
+	NTAC 2 (MATCH_MP_TAC replaceLeft)				\\
+	ASM_REWRITE_TAC [],
+	(* goal 2.2 (of 2) *)
+	POP_ASSUM (MP_TAC o (MATCH_MP replace_inv2))			\\
+	REPEAT STRIP_TAC >| (* 2 sub-goals here *)
+	[ (* goal 2.2.1 (of 2) *)
+	  ASM_REWRITE_TAC []						\\
+	  EXISTS_TAC ``(Comma (Comma A' G') C)``			\\
+	  CONJ_TAC >- REWRITE_TAC [L_Sequent_rules]			\\
+	  MATCH_MP_TAC replaceLeft					\\
+	  MATCH_MP_TAC replaceRight					\\
+	  ASM_REWRITE_TAC [],
+	  (* goal 2.2.2 (of 2) *)
+	  ASM_REWRITE_TAC []						\\
+	  EXISTS_TAC ``(Comma (Comma A' B) G')``			\\
+	  CONJ_TAC >- REWRITE_TAC [L_Sequent_rules]			\\
+	  MATCH_MP_TAC replaceRight					\\
+	  ASM_REWRITE_TAC [] ] ] ]);
+
+val condAddExt = store_thm (
+   "condAddExt",
+  ``!E E'. condCutExt E /\ condCutExt E' ==> condCutExt (add_extension E E')``,
+    REPEAT GEN_TAC
+ >> REWRITE_TAC [condCutExt_def, RUNION]
+ >> REPEAT STRIP_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      RES_TAC \\
+      Q.EXISTS_TAC `Gamma'` \\
+      ASM_REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      RES_TAC \\
+      Q.EXISTS_TAC `Gamma'` \\
+      ASM_REWRITE_TAC [] ]);
+
+val CutNatDed = store_thm (
+   "CutNatDed",
+  ``!Delta A E Gamma C. natDed E Gamma C ==> condCutExt E ==> natDed E Delta A ==>
+	!Gamma'. replace Gamma Gamma' (OneForm A) Delta ==> natDed E Gamma' C``,
+    NTAC 2 GEN_TAC
+ >> Induct_on `natDed`
+ >> REPEAT CONJ_TAC (* 8 sub-goals here *)
+ >| [ (* goal 1 (of 8) *)
+      fix [`E`, `C`] >> rpt STRIP_TAC					\\
+      POP_ASSUM (MP_TAC o (MATCH_MP replace_inv1))			\\
+      RW_TAC std_ss []							\\
+      ASM_REWRITE_TAC [],
+      (* goal 2 (of 8) *)
+      fix [`E`, `Gamma`, `C`, `B`] >> rpt STRIP_TAC			\\
+      MATCH_MP_TAC SlashIntro						\\
+      IMP_RES_TAC replaceLeft						\\
+      POP_ASSUM (ASSUME_TAC o (SPEC ``(OneForm B)``))			\\
+      RES_TAC,
+      (* goal 3 (of 8) *)
+      fix [`E`, `Gamma`, `C`, `B`] >> rpt STRIP_TAC			\\
+      MATCH_MP_TAC BackslashIntro					\\
+      IMP_RES_TAC replaceRight						\\
+      POP_ASSUM (ASSUME_TAC o (SPEC ``(OneForm B)``))			\\
+      RES_TAC,
+      (* goal 4 (of 8) *)
+      fix [`E`, `Gamma`, `Gamma'`, `C`, `C'`] >> rpt STRIP_TAC		\\
+      POP_ASSUM (MP_TAC o (MATCH_MP replace_inv2))			\\
+      REPEAT STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 4.1 (of 2) *)
+        ASM_REWRITE_TAC []						\\
+        MATCH_MP_TAC DotIntro						\\
+        CONJ_TAC >- RES_TAC						\\
+        ASM_REWRITE_TAC [],
+        (* goal 4.2 (of 2) *)
+        ASM_REWRITE_TAC []						\\
+        MATCH_MP_TAC DotIntro						\\
+        CONJ_TAC >- ASM_REWRITE_TAC []					\\
+        RES_TAC ],
+      (* goal 5 (of 8) *)
+      fix [`E`, `Gamma`, `Gamma'`, `C`, `C'`] >> rpt STRIP_TAC		\\
+      POP_ASSUM (MP_TAC o (MATCH_MP replace_inv2))			\\
+      REPEAT STRIP_TAC (* 2 sub-goals here, same tacticals *)		\\
+      ASM_REWRITE_TAC []						\\
+      MATCH_MP_TAC SlashElim						\\
+      Q.EXISTS_TAC `C'`							\\
+      ASM_REWRITE_TAC [] >> RES_TAC,
+      (* goal 6 (of 8) *)
+      fix [`E`, `Gamma`, `Gamma'`, `C`, `C'`] >> rpt STRIP_TAC		\\
+      POP_ASSUM (MP_TAC o (MATCH_MP replace_inv2))			\\
+      REPEAT STRIP_TAC (* 2 sub-goals here, same tacticals *)		\\
+      ASM_REWRITE_TAC []						\\
+      MATCH_MP_TAC BackslashElim					\\
+      Q.EXISTS_TAC `C'`							\\
+      ASM_REWRITE_TAC [] >> RES_TAC,
+      (* goal 7 (of 8) *)
+      fix [`E`, `Gamma`, `Gamma'`, `Gamma''`, `A'`, `B`, `C'`]		\\
+      REPEAT STRIP_TAC							\\
+      PAT_X_ASSUM ``replace Gamma Gamma' (Comma (OneForm A') (OneForm B)) Gamma''``
+	(ASSUME_TAC o (MATCH_MP doubleReplace))				\\
+      POP_ASSUM (ASSUME_TAC o (Q.SPECL [`Gamma'''`, `A`, `Delta`]))	\\
+      RES_TAC (* 2 sub-goals here, same tactical *)			\\
+      IMP_RES_TAC DotElim,
+      (* goal 8 (of 8) *)
+      fix [`E`, `C`, `Gamma`, `Gamma'`, `Delta'`, `Delta''`]		\\
+      REPEAT STRIP_TAC							\\
+      PAT_X_ASSUM ``condCutExt E ==> P``
+	(ASSUME_TAC o
+	  (fn thm => (MATCH_MP thm (ASSUME ``condCutExt E``))))		\\
+      PAT_X_ASSUM ``natDed E Delta A ==> P``
+	(ASSUME_TAC o
+	  (fn thm => (MATCH_MP thm (ASSUME ``natDed E Delta A``))))	\\
+      PAT_X_ASSUM ``condCutExt E``
+	(ASSUME_TAC o (REWRITE_RULE [condCutExt_def]))			\\
+      PAT_X_ASSUM ``replace Gamma Gamma' Delta' Delta''``
+	(ASSUME_TAC o (MATCH_MP doubleReplace))				\\
+      POP_ASSUM (ASSUME_TAC o (Q.SPECL [`Gamma''`, `A`, `Delta`]))	\\
+      POP_ASSUM (MP_TAC o
+	(fn thm => (MATCH_MP
+		     thm (ASSUME ``replace Gamma' Gamma'' (OneForm A) Delta``)))) \\
+      REPEAT STRIP_TAC >| (* 2 sub-goals here *)
+      [ (* goal 8.1 (of 2) *)
+	MATCH_MP_TAC NatExt						\\
+	Q.EXISTS_TAC `G`						\\
+	Q.EXISTS_TAC `Delta'`						\\
+	Q.EXISTS_TAC `Delta''`						\\
+	CONJ_TAC >- ASM_REWRITE_TAC []					\\
+	CONJ_TAC >- ASM_REWRITE_TAC []					\\
+	PAT_X_ASSUM ``!Gamma'. replace Gamma Gamma' (OneForm A) Delta ==> P``
+	  (ASSUME_TAC o (Q.SPEC `G`))					\\
+	RES_TAC,
+        (* goal 8.2 (of 2) *)
+        PAT_X_ASSUM ``!Gamma T1 T2 A Delta. E T1 T2 ==> P``
+	  (ASSUME_TAC o
+	    (Q.SPECL [`G`, `Delta'`, `Delta''`, `A`, `Delta`]))		\\
+        POP_ASSUM (ASSUME_TAC o
+	  (fn thm => (MP thm (ASSUME ``(E :'a gentzen_extension) Delta' Delta''``)))) \\
+        POP_ASSUM (ASSUME_TAC o
+	  (fn thm => (MP thm (ASSUME ``replace Delta'' G (OneForm A) Delta``)))) \\
+        POP_ASSUM MP_TAC >> STRIP_TAC					\\
+        PAT_X_ASSUM ``replace Gamma Gamma'' Delta' G``
+	  (ASSUME_TAC o (MATCH_MP replaceSameP))			\\
+        POP_ASSUM (ASSUME_TAC o (Q.SPEC `Gamma'''`))			\\
+        POP_ASSUM (Q.X_CHOOSE_TAC `G'`)					\\
+        POP_ASSUM MP_TAC >> STRIP_TAC					\\
+        MATCH_MP_TAC NatExt						\\
+        Q.EXISTS_TAC `G'`						\\
+        Q.EXISTS_TAC `Gamma'''`						\\
+        Q.EXISTS_TAC `G`						\\
+        CONJ_TAC >- ASM_REWRITE_TAC []					\\
+        CONJ_TAC >- ASM_REWRITE_TAC []					\\
+        PAT_X_ASSUM ``!Gamma'. P`` MATCH_MP_TAC				\\
+        MATCH_MP_TAC replaceTrans'					\\
+        Q.EXISTS_TAC `Delta'`						\\
+        Q.EXISTS_TAC `Gamma'''`						\\
+        CONJ_TAC >- ASM_REWRITE_TAC []					\\
+        ASM_REWRITE_TAC [] ] ] );
+
+val natDedComposition = store_thm (
+   "natDedComposition",
+  ``!E Gamma F1 F2. condCutExt E /\ natDed E Gamma F1 /\ natDed E (OneForm F1) F2
+		==> natDed E Gamma F2``,
+    REPEAT STRIP_TAC
+ >> irule CutNatDed
+ >> ASM_REWRITE_TAC []
+ >> take [`F1`, `Gamma`, `OneForm F1`]
+ >> RW_TAC std_ss [replaceRoot]);
+
+(* The easy direction, doesn't depend on new theorems in this section *)
+val natDedToGentzen = store_thm (
+   "natDedToGentzen",
+  ``!E Gamma C. natDed E Gamma C ==> gentzenSequent E Gamma C``,
+    HO_MATCH_MP_TAC natDed_ind (* or: Induct_on `natDed` *)
+ >> REPEAT STRIP_TAC (* 8 sub-goals here *)
+ >| [ (* goal 1 (of 8) *)
+      REWRITE_TAC [SeqAxiom],
+      (* goal 2 (of 8) *)
+      MATCH_MP_TAC RightSlash						\\
+      ASM_REWRITE_TAC [],
+      (* goal 3 (of 8) *)
+      MATCH_MP_TAC RightBackslash					\\
+      ASM_REWRITE_TAC [],
+      (* goal 4 (of 8) *)
+      MATCH_MP_TAC RightDot						\\
+      ASM_REWRITE_TAC [],
+      (* goal 5 (of 8) *)
+      MATCH_MP_TAC CutRule						\\
+      Q.EXISTS_TAC `Gamma` (* for Delta' *)				\\
+      EXISTS_TAC ``(Comma (OneForm (Slash A B)) Delta)``		\\
+      EXISTS_TAC ``(Slash A B)``					\\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 5.1 (of 2) *)
+        MATCH_MP_TAC replaceLeft					\\
+        REWRITE_TAC [replaceRoot],
+        (* goal 5.2 (of 2) *)
+        CONJ_TAC >- ASM_REWRITE_TAC []					\\
+        MATCH_MP_TAC LeftSlashSimpl					\\
+        CONJ_TAC >- ASM_REWRITE_TAC []					\\
+        REWRITE_TAC [SeqAxiom] ],
+      (* goal 6 (of 8) *)
+      MATCH_MP_TAC CutRule						\\
+      Q.EXISTS_TAC `Delta`						\\
+      EXISTS_TAC ``(Comma Gamma (OneForm (Backslash B A)))``		\\
+      EXISTS_TAC ``(Backslash B A)``					\\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 6.1 (of 2) *)
+        MATCH_MP_TAC replaceRight					\\
+        REWRITE_TAC [replaceRoot],
+        (* goal 6.2 (of 2) *)
+        CONJ_TAC >- ASM_REWRITE_TAC []					\\
+        MATCH_MP_TAC LeftBackslashSimpl					\\
+        CONJ_TAC >- ASM_REWRITE_TAC []					\\
+        REWRITE_TAC [SeqAxiom] ],
+      (* goal 7 (of 8) *)
+      MATCH_MP_TAC replaceGentzen'					\\
+      Q.EXISTS_TAC `Gamma`						\\
+      EXISTS_TAC ``(Comma (OneForm A) (OneForm B))``			\\
+      Q.EXISTS_TAC `Delta`						\\
+      CONJ_TAC >- ASM_REWRITE_TAC []					\\
+      REWRITE_TAC [deltaTranslation_def]				\\
+      CONJ_TAC >- ASM_REWRITE_TAC []					\\
+      ASM_REWRITE_TAC [],
+      (* goal 8 (of 8) *)
+      MP_TAC (SPEC_ALL SeqExt) >> REPEAT STRIP_TAC			\\
+      RES_TAC ]);
+
+(* The hard direction, heavily depends on theorems proved recently *)
+val gentzenToNatDed = store_thm (
+   "gentzenToNatDed",
+  ``!E Gamma C. gentzenSequent E Gamma C ==> condCutExt E ==> natDed E Gamma C``,
+    HO_MATCH_MP_TAC gentzenSequent_ind (* or: Induct_on `gentzenSequent` *)
+ >> REPEAT CONJ_TAC (* 9 sub-goals here *)
+ >| [ (* goal 1 (of 9) *)
+      fix [`E`, `C`] >> rpt STRIP_TAC					\\
+      REWRITE_TAC [NatAxiom],
+      (* goal 2 (of 9) *)
+      fix [`E`, `Gamma`, `C`, `B`] >> rpt STRIP_TAC			\\
+      RES_TAC								\\
+      MATCH_MP_TAC SlashIntro >> ASM_REWRITE_TAC [],
+      (* goal 3 (of 9) *)
+      fix [`E`, `Gamma`, `C`, `B`] >> rpt STRIP_TAC			\\
+      RES_TAC								\\
+      MATCH_MP_TAC BackslashIntro >> ASM_REWRITE_TAC [],
+      (* goal 4 (of 9) *)
+      fix [`E`, `Gamma`, `Gamma'`, `C`, `C'`] >> rpt STRIP_TAC		\\
+      RES_TAC								\\
+      MATCH_MP_TAC DotIntro >> ASM_REWRITE_TAC [],
+      (* goal 5 (of 9) *)
+      fix [`E`, `Gamma`, `Gamma'`, `Gamma''`, `A`, `C`, `C'`]		\\
+      REPEAT STRIP_TAC							\\
+      MATCH_MP_TAC natDedComposition					\\
+      EXISTS_TAC ``(deltaTranslation Gamma)``				\\
+      CONJ_TAC >- ASM_REWRITE_TAC []					\\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 5.1 (of 2) *)
+        irule replaceNatDed						\\
+        EXISTS_TAC ``(OneForm A)``					\\
+        EXISTS_TAC ``(Comma (OneForm (Slash A C)) Gamma'')``		\\
+        CONJ_TAC >| (* 2 sub-goals here *)
+        [ (* goal 5.1.1 (of 2) *)
+          REWRITE_TAC [deltaTranslation_def]				\\
+          MATCH_MP_TAC SlashElim					\\
+          Q.EXISTS_TAC `C`						\\
+          CONJ_TAC >- REWRITE_TAC [NatAxiom] >> RES_TAC,
+          (* goal 5.1.2 (of 2) *)
+          ASM_REWRITE_TAC [] ],
+        (* goal 5.2 (of 2) *)
+        MATCH_MP_TAC NatTermToForm >> RES_TAC ],
+      (* goal 6 (of 9) *)
+      fix [`E`, `Gamma`, `Gamma'`, `Gamma''`, `A`, `C`, `C'`]		\\
+      REPEAT STRIP_TAC							\\
+      MATCH_MP_TAC natDedComposition					\\
+      EXISTS_TAC ``(deltaTranslation Gamma)``				\\
+      CONJ_TAC >- ASM_REWRITE_TAC []					\\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 6.1 (of 2) *)
+        irule replaceNatDed						\\
+        EXISTS_TAC ``(OneForm A)``					\\
+        EXISTS_TAC ``(Comma Gamma'' (OneForm (Backslash C A)))``	\\
+        CONJ_TAC >| (* 2 sub-goals here *)
+        [ (* goal 6.1.1 (of 2) *)
+          REWRITE_TAC [deltaTranslation_def]				\\
+          MATCH_MP_TAC BackslashElim					\\
+          Q.EXISTS_TAC `C`						\\
+          CONJ_TAC >- RES_TAC						\\
+          REWRITE_TAC [NatAxiom],
+          (* goal 6.1.2 (of 2) *)
+          ASM_REWRITE_TAC [] ],
+        (* goal 6.2 (of 2) *)
+        MATCH_MP_TAC NatTermToForm >> RES_TAC ],
+      (* goal 7 (of 9) *)
+      fix [`E`, `Gamma`, `Gamma'`, `A`, `B`, `C`] >> rpt STRIP_TAC	\\
+      MATCH_MP_TAC natDedComposition					\\
+      EXISTS_TAC ``(deltaTranslation Gamma)``				\\
+      CONJ_TAC >- ASM_REWRITE_TAC []					\\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 7.1 (of 2) *)
+        irule replaceNatDed						\\
+        EXISTS_TAC ``(Comma (OneForm A) (OneForm B))``			\\
+        EXISTS_TAC ``(OneForm (Dot A B))``				\\
+        CONJ_TAC >| (* 2 sub-goals here *)
+        [ (* goal 7.1.1 (of 2) *)
+          REWRITE_TAC [deltaTranslation_def]				\\
+          REWRITE_TAC [NatAxiom],
+          (* goal 7.1.2 (of 2) *)
+          ASM_REWRITE_TAC [] ],
+        (* goal 7.2 (of 2) *)
+        MATCH_MP_TAC NatTermToForm >> RES_TAC ],
+      (* goal 8 (of 9) *)
+      fix [`E`, `Gamma`, `Gamma'`, `Gamma''`, `C`, `C'`]		\\
+      REPEAT STRIP_TAC							\\	
+      MATCH_MP_TAC natDedComposition					\\
+      EXISTS_TAC ``(deltaTranslation Gamma')``				\\
+      CONJ_TAC >- ASM_REWRITE_TAC []					\\
+      CONJ_TAC >| (* 2 sub-goals here *)
+      [ (* goal 8.1 (of 2) *)
+        irule replaceNatDed						\\
+        EXISTS_TAC ``(OneForm C)``					\\
+        Q.EXISTS_TAC `Gamma`						\\
+        CONJ_TAC >| (* 2 sub-goals here *)
+        [ (* goal 8.1.1 (of 2) *)
+          REWRITE_TAC [deltaTranslation_def] >> RES_TAC,
+          (* goal 8.1.2 (of 2) *)
+          ASM_REWRITE_TAC [] ],
+        (* goal 8.2 (of 2) *)
+        MATCH_MP_TAC NatTermToForm >> RES_TAC ],
+      (* goal 9 (of 9) *)
+      fix [`E`, `Gamma`, `Gamma'`, `Delta`, `Delta'`, `C`]		\\
+      REPEAT STRIP_TAC							\\
+      MATCH_MP_TAC NatExt						\\
+      Q.EXISTS_TAC `Gamma`						\\
+      Q.EXISTS_TAC `Delta`						\\
+      Q.EXISTS_TAC `Delta'`						\\
+      CONJ_TAC >- ASM_REWRITE_TAC []					\\
+      CONJ_TAC >- ASM_REWRITE_TAC []					\\
+      RES_TAC ]);
+
+val gentzenEqNatDed = store_thm (
+   "gentzenEqNatDed",
+  ``!E Gamma C. condCutExt E ==> (gentzenSequent E Gamma C = natDed E Gamma C)``,
+    REPEAT STRIP_TAC
+ >> EQ_TAC (* 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      DISCH_TAC \\
+      irule gentzenToNatDed \\ (* 2 sub-goals sharing the same tactical *)
+      ASM_REWRITE_TAC [],
+      (* goal 2 (of 2) *)
+      REWRITE_TAC [natDedToGentzen] ]);
+
+val NLgentzenEqNatDed = store_thm (
+   "NLgentzenEqNatDed",
+  ``!Gamma C. gentzenSequent NL_Sequent Gamma C = natDed NL_Sequent Gamma C``,
+    REPEAT STRIP_TAC
+ >> MP_TAC conditionOKNL
+ >> REWRITE_TAC [gentzenEqNatDed]);
+
+val LgentzenEqNatDed = store_thm (
+   "LgentzenEqNatDed",
+  ``!Gamma C. gentzenSequent L_Sequent Gamma C = natDed L_Sequent Gamma C``,
+    REPEAT STRIP_TAC
+ >> MP_TAC conditionOKL
+ >> REWRITE_TAC [gentzenEqNatDed]);
+
+val NLPgentzenEqNatDed = store_thm (
+   "NLPgentzenEqNatDed",
+ ``!Gamma C. gentzenSequent NLP_Sequent Gamma C = natDed NLP_Sequent Gamma C``,
+    REPEAT STRIP_TAC
+ >> MP_TAC conditionOKNLP
+ >> REWRITE_TAC [gentzenEqNatDed]);
+
+(******************************************************************************)
+(*                                                                            *)
+(*                    Module: Arrow and Natural Deduction                     *)
+(*                                                                            *)
+(******************************************************************************)
+
+val natDedToArrow = store_thm (
+   "natDedToArrow",
+  ``!E X Gamma A. gentzenToArrowExt E X ==>
+                  natDed E Gamma A ==> arrow X (deltaTranslation Gamma) A``,
+    REPEAT STRIP_TAC
+ >> MATCH_MP_TAC gentzenToArrow
+ >> Q.EXISTS_TAC `E`
+ >> CONJ_TAC
+ >- ASM_REWRITE_TAC []
+ >> MATCH_MP_TAC natDedToGentzen
+ >> ASM_REWRITE_TAC []);
+
+val natDedToArrow_E = store_thm (
+   "natDedToArrow_E",
+  ``!E Gamma A. natDed E Gamma A ==> arrow (ToArrowExt E) (deltaTranslation Gamma) A``,
+    REPEAT GEN_TAC
+ >> MP_TAC (Q.SPEC `E` gentzenToArrowExt_thm)
+ >> REWRITE_TAC [natDedToArrow]);
+
+val arrowToNatDed = store_thm (
+   "arrowToNatDed",
+  ``!E X A B. condCutExt E /\ arrowToGentzenExt X E /\ arrow X A B
+	  ==> natDed E (OneForm A) B``,
+    REPEAT STRIP_TAC
+ >> irule gentzenToNatDed
+ >> ASM_REWRITE_TAC []
+ >> irule arrowToGentzen
+ >> Q.EXISTS_TAC `X`
+ >> ASM_REWRITE_TAC []);
+
+(******************************************************************************)
+(*                                                                            *)
+(*                          Grammar support in HOL                            *)
+(*                                                                            *)
+(******************************************************************************)
+
+fun enable_grammar () = let
+in
+    add_rule { term_name = "arrow", fixity = Infix (NONASSOC, 450),
+	pp_elements = [ HardSpace 0, TOK ":-", BreakSpace(1,0), TM, BreakSpace(1,0), TOK "-->",
+			BreakSpace(1,0) ],
+	paren_style = OnlyIfNecessary,
+	block_style = (AroundEachPhrase, (PP.CONSISTENT, 0)) };
+
+    add_rule { term_name = "natDed", fixity = Infix (NONASSOC, 450),
+	pp_elements = [ HardSpace 0, TOK ":-", BreakSpace(1,0), TM, BreakSpace(1,0), TOK "|-n",
+			BreakSpace(1,0) ],
+	paren_style = OnlyIfNecessary,
+	block_style = (AroundEachPhrase, (PP.CONSISTENT, 0)) };
+
+    add_rule { term_name = "gentzenSequent", fixity = Infix (NONASSOC, 450),
+	pp_elements = [ HardSpace 0, TOK ":-", BreakSpace(1,0), TM, BreakSpace(1,0), TOK "|-g",
+			BreakSpace(1,0) ],
+	paren_style = OnlyIfNecessary,
+	block_style = (AroundEachPhrase, (PP.CONSISTENT, 0)) };
+
+    add_rule { term_name = "Sequent", fixity = Infix (NONASSOC, 450),
+	pp_elements = [ HardSpace 0, TOK ":-", BreakSpace(1,0), TM, BreakSpace(1,0), TOK "|-",
+			BreakSpace(1,0) ],
+	paren_style = OnlyIfNecessary,
+	block_style = (AroundEachPhrase, (PP.CONSISTENT, 0)) }
+end;
+
+(* val _ = enable_grammar (); *)
+
+val _ = export_theory ();
+val _ = html_theory "Lambek";
+
+(* last updated: April 10, 2017 *)

--- a/examples/formal-languages/lambek/LambekScript.sml
+++ b/examples/formal-languages/lambek/LambekScript.sml
@@ -2240,31 +2240,31 @@ val arrowToNatDed = store_thm (
 fun enable_grammar () = let
 in
     add_rule { term_name = "arrow", fixity = Infix (NONASSOC, 450),
-	pp_elements = [ HardSpace 0, TOK ":-", BreakSpace(1,0), TM, BreakSpace(1,0), TOK "-->",
+	pp_elements = [ BreakSpace(1,0), TOK ":-", BreakSpace(1,0), TM, BreakSpace(1,0), TOK "-->",
 			BreakSpace(1,0) ],
 	paren_style = OnlyIfNecessary,
 	block_style = (AroundEachPhrase, (PP.CONSISTENT, 0)) };
 
     add_rule { term_name = "natDed", fixity = Infix (NONASSOC, 450),
-	pp_elements = [ HardSpace 0, TOK ":-", BreakSpace(1,0), TM, BreakSpace(1,0), TOK "|-n",
+	pp_elements = [ BreakSpace(1,0), TOK ":-", BreakSpace(1,0), TM, BreakSpace(1,0), TOK "|-n",
 			BreakSpace(1,0) ],
 	paren_style = OnlyIfNecessary,
 	block_style = (AroundEachPhrase, (PP.CONSISTENT, 0)) };
 
     add_rule { term_name = "gentzenSequent", fixity = Infix (NONASSOC, 450),
-	pp_elements = [ HardSpace 0, TOK ":-", BreakSpace(1,0), TM, BreakSpace(1,0), TOK "|-g",
+	pp_elements = [ BreakSpace(1,0), TOK ":-", BreakSpace(1,0), TM, BreakSpace(1,0), TOK "|-g",
 			BreakSpace(1,0) ],
 	paren_style = OnlyIfNecessary,
 	block_style = (AroundEachPhrase, (PP.CONSISTENT, 0)) };
 
     add_rule { term_name = "Sequent", fixity = Infix (NONASSOC, 450),
-	pp_elements = [ HardSpace 0, TOK ":-", BreakSpace(1,0), TM, BreakSpace(1,0), TOK "|-",
+	pp_elements = [ BreakSpace(1,0), TOK ":-", BreakSpace(1,0), TM, BreakSpace(1,0), TOK "|-",
 			BreakSpace(1,0) ],
 	paren_style = OnlyIfNecessary,
 	block_style = (AroundEachPhrase, (PP.CONSISTENT, 0)) }
 end;
 
-(* val _ = enable_grammar (); *)
+val _ = enable_grammar ();
 
 val _ = export_theory ();
 val _ = html_theory "Lambek";

--- a/examples/formal-languages/lambek/README.md
+++ b/examples/formal-languages/lambek/README.md
@@ -1,0 +1,25 @@
+---
+author: Chun Tian
+---
+
+# A Formalized Lambek Calculus in Higher Order Logic \(HOL4\)
+
+based on an implementation of Lambek Calculus [1] in *Coq proof assistant*
+by **Houda ANOUN** and **Pierre CASTERAN** in 2003 [2].
+
+The following is a brief listing of what's available in the distribution:
+
+-   LambekScript.sml: Basic definitions and theorems of Lambek Calculus
+
+-   CutFreeScript.sml: Properties of “cut-free” sequent proofs
+
+-   ExampleScript.sml: Some examples
+
+Project paper is on arXiv: [https://arxiv.org/abs/1705.07318](https://arxiv.org/abs/1705.07318)
+
+**Related information**  
+
+[1] Richard Moot and Christian Retoré. The Logic of Categorial
+Grammars: A Deductive Account of Natural Language Syntax and
+Semantics. Springer, 2012.
+[2] https://github.com/coq-contribs/lambek

--- a/examples/formal-languages/lambek/README.md
+++ b/examples/formal-languages/lambek/README.md
@@ -22,4 +22,5 @@ Project paper is on arXiv: [https://arxiv.org/abs/1705.07318](https://arxiv.org/
 [1] Richard Moot and Christian Retoré. The Logic of Categorial
 Grammars: A Deductive Account of Natural Language Syntax and
 Semantics. Springer, 2012.
+
 [2] https://github.com/coq-contribs/lambek

--- a/tools/sequences/more-theories
+++ b/tools/sequences/more-theories
@@ -48,3 +48,4 @@ src/datatype/inftree
 !examples/hfs
 src/search
 !examples/CCS
+!examples/formal-languages/lambek


### PR DESCRIPTION
Hi,

this was my first HOL project done in 2016-2017 on the formalization of Lambek Calculus (a version of Categorial Grammar for formal/natural languages). Basically I ported the same work from Coq's `contribs` library.   For students who is learning the same thing in NLP courses, now HOL4 can be used for proving the grammatical correctness of simple sentences  (as shown in the `ExampleTheory`).

The whole formalization (I mean the original one) is quite a beautiful work: it's a deep embedding, but it has a flexible relation definition (based on `Hol_reln`) with ability to accept extensions. Thus various version of Lambek Calculus (associative, non-associative, commutative or non-commutative) can be supported together, with possibility of other extensions. I believe, with some extra efforts we can turn HOL4 into a language parser based on Lambek grammars.

In `CutFreeTheory` I've created a deep embedding for "derivation tree (proof)", which is first-class object in Coq but not in HOL. This idea was learnt from prof. Jeremy Dawson (c.f. "Difficulties when migrating proof scripts from Coq" in HOL mailing list, on Jan 12, 2017).   I ported and proved many necessary lemmas towards the "Cut elimination theorem" for Lambek Calculus (L and NL), but I didn't finish the final proof (so is the original work in Coq!)  I hope I could find some time to finally finish it (and draft a paper).

I have to fix some `irule` issues to be able to build it in latest HOL4, maybe that's another good reason to put it inside HOL code base, because it may not run in old HOL versions any more.

Regards, 

Chun Tian