### PR TITLE
Fixed use of the old syntax for conditional expressions in temporalLib

### DIFF
--- a/src/temporal/src/temporalLib.sml
+++ b/src/temporal/src/temporalLib.sml
@@ -207,7 +207,7 @@ fun temporal2hol truesig  = “\t:num.T”
            val t1 = temporal2hol f1
            val t2 = temporal2hol f2
            val t3 = temporal2hol f3
-         in “\t:num. ^t1 t => ^t2 t | ^t3 t ”
+         in “\t:num. if ^t1 t then ^t2 t else ^t3 t”
         end
   | temporal2hol (next f) =
         mk_comb{Rator=NEXT,Rand=(temporal2hol f)}


### PR DESCRIPTION
Hi,

based on the hints from Michael on the possible use of the old syntax for conditional expressions in temporalLib, now I found and fixed it.  With this fix, the last theorem in `src/temporal/examples.sml` now works:

```
> val SEPARATE_EVENTUAL_ALWAYS_THM =
   ⊢ (EVENTUAL (ALWAYS (λt. a t ∨ PREV b t)) =
      EVENTUAL (ALWAYS (λt. NEXT a t ∨ b t))) ∧
     (EVENTUAL (ALWAYS (λt. a t ∨ PSNEXT b t)) =
      EVENTUAL (ALWAYS (λt. NEXT a t ∨ b t))) ∧
     (EVENTUAL (ALWAYS (λt. a t ∨ (b PSUNTIL c) t)) 0 ⇔
      if ALWAYS (λt. ¬c t) 0 then EVENTUAL (ALWAYS a) 0
      else if ALWAYS (EVENTUAL c) 0 then
        EVENTUAL (ALWAYS (λt. b t ∨ c t ∨ (NEXT c BEFORE (λt. ¬a t)) t)) 0
      else if EVENTUAL (ALWAYS a) 0 then EVENTUAL (ALWAYS a) 0
      else EVENTUAL (λt. c t ∧ ALWAYS (NEXT b) t) 0): thm
```

So this "bug" has been there since HOL has turned to use "if ... then ... else" for conditional expressions.

Regards,

Chun Tian
