### PR TITLE
Minor description manual formatting fixes

### DIFF
--- a/Manual/Description/conv.stex
+++ b/Manual/Description/conv.stex
@@ -121,7 +121,7 @@ occasion to construct rewriting tools of their own design, by similar
 methods.  The next section introduces the conversion-building tools in
 general.
 
-\section{Indicating unchangedness}
+\section{Indicating Unchangedness}
 
 All conversions may raise the special exception \ml{Conv.UNCHANGED} on
 an input term \ml{t}, as a ``short-hand'' instead of returning the
@@ -136,7 +136,7 @@ to provide a theorem directly).  \ml{QCONV}'s implementation is
 \end{alltt}
 
 
-\section{Conversion combining operators}
+\section{Conversion Combining Operators}
 \label{avra1}
 
 A term $u$ is said to {\it reduce\/}\index{reduction, by conversions}\index{conversions!reduction by} to a term $v$ by a conversion $c$ if
@@ -459,7 +459,7 @@ that used the second  search strategy could be defined as shown below
 strategy used by the \HOL\ rewriting tools described in Section~\ref{avra3}.
 \index{conversions!operators on|)}
 
-\section{Writing compound conversions}
+\section{Writing Compound Conversions}
 \label{avra2}
 
 \index{conversions!functions for building|(}
@@ -730,7 +730,7 @@ used in the system has been optimised to use failure to avoid
 rebuilding unchanged subterms.
 
 
-\section{Built in conversions}\label{built-in-conv}
+\section{Built-in Conversions}\label{built-in-conv}
 
 
 Many conversions are predefined in \HOL; only those likely to be of
@@ -1033,7 +1033,7 @@ The complete set is:
 \end{verbatim}\end{hol}
 
 
-\section{Rewriting tools}
+\section{Rewriting Tools}
 \label{avra3}
 
 The rewriting tool\index{rewriting!as based on conversions|(}

--- a/Manual/Description/definitions.stex
+++ b/Manual/Description/definitions.stex
@@ -1125,7 +1125,7 @@ $
 \end{center}
 \end{table}
 
-\paragraph{Pattern Expansion}
+\paragraph{Pattern expansion}
 In general, \ml{Define} attempts to derive exactly the specified
 conjunction of equations. However, the rich syntax of patterns allows
 some ambiguity. For example, the input
@@ -1385,7 +1385,7 @@ analogous to \ml{prove}. Thus, \ml{Defn.tgoal} is used to take the
 result of \ml{Hol\_defn} and set up a goal for proving termination
 of the definition.
 
-\paragraph{Example.} An invocation of {\small\verb+Define+} on
+\paragraph{Example} An invocation of {\small\verb+Define+} on
 the following equations for Quicksort will currently fail, since the
 termination proof is currently beyond the capabilities of the naive termination
 prover. Instead, we make an application of {\small\verb+Hol_defn+}:
@@ -1576,7 +1576,7 @@ invoke \ml{WF\_REL\_TAC}:
 %
 The built-in reasoning then suffices to prove the remaining goal.
 
-\paragraph{Weighting Functions}
+\paragraph{Weighting functions}
 
 Sometimes one needs a measure function that is itself recursive.  For
 example, consider a type of binary trees and a function that
@@ -1628,7 +1628,7 @@ must be admitted that finding the correct weighting for a termination
 proof is more an art than a science. Typically, one makes a guess and
 then tries the termination proof to see if it works.
 
-\paragraph{Lexicographic Combinations}
+\paragraph{Lexicographic combinations}
 
 Occasionally, there's a combination of factors that complicate the
 termination argument. For example, the following specification
@@ -1811,7 +1811,7 @@ The `add' and `drop' functions only affect the current state of the congruence d
 
 
 
-\paragraph{Higher Order Recursion and Congruence Rules}
+\paragraph{Higher-order recursion and congruence rules}
 
 A `higher-order` recursion is one in which a higher-order function is
 used to apply the recursive function to arguments. In order for the
@@ -2048,10 +2048,10 @@ possible ways of obtaining it by the rules.
 If the ``stem'' of the first constant defined in a set of clauses is such that resulting \ML{} bindings in an exported theory file will result in illegal \ML{}, then the \ml{xHol\_reln} function should be used.
 The \ml{xHol\_reln} function is analogous to the \ml{xDefine} function for defining recursive functions (see Section~\ref{TFL}).
 
-\paragraph{Strong Induction Principles}
+\paragraph{Strong induction principles}
 So called ``strong'' versions of induction principles (in which instances of the relation being defined appear as extra hypotheses), are automatically proved when a definition is made with \ml{Hol\_reln}. The strong induction principle for a relation is used when the \ml{Induct\_on} tactic is used.
 
-\paragraph{Adding Monotone Operators}
+\paragraph{Adding monotone operators}
 \index{inductive relations!monotone operators for}
 New constants may occur recursively throughout rules' hypotheses, as
 long as it can be shown that the rules remain monotone with respect to
@@ -2167,7 +2167,7 @@ as in the definition of \holtxt{EVEN} and \holtxt{ODD}.  The relations
 may or may not be mutually recursive.  The clauses for each relation
 need not be contiguous.
 
-\subsection{Proofs with Inductive Relations}
+\subsection{Proofs with inductive relations}
 \index{inductive relations!performing proofs}
 
 The ``rules'' theorem of an inductive relation provides a straightforward way of proving arguments belong to a relation.

--- a/Manual/Description/drules.stex
+++ b/Manual/Description/drules.stex
@@ -582,7 +582,7 @@ $$\Gamma\turn t_1=t_2\over
 
 
 
-\subsection{\T-Introduction}
+\subsection{\T-introduction}
 \label{sec:T}
 
 \index{T@\holtxt{T}!rules of inference for|(}

--- a/Manual/Description/drules.stex
+++ b/Manual/Description/drules.stex
@@ -585,12 +585,12 @@ $$\Gamma\turn t_1=t_2\over
 \subsection{\T-introduction}
 \label{sec:T}
 
+\begin{holboxed}
 \index{T@\holtxt{T}!rules of inference for|(}
-\begin{hol}
 \begin{verbatim}
-   TRUTH
+   TRUTH : thm
 \end{verbatim}
-\end{hol}
+\end{holboxed}
 
 \vspace{12pt plus2pt minus1pt}
 

--- a/Manual/Description/libraries.stex
+++ b/Manual/Description/libraries.stex
@@ -1848,7 +1848,7 @@ rewrites.  The latter ``advantage'' is based on the assumption that
 of unused rewrites is never a concern: the presence of rewrites that
 do the wrong thing can be a major irritation.
 
-\subsubsection{Abbreviated ``Power'' Tactics}
+\subsubsection{Abbreviated ``Power'' tactics}
 \HOL{}'s \ml{bossLib} module (part of the standard interactive environment) comes with a number of powerful simplification tactics with short lower-case names.
 These do not require or allow for the specification of a particular \simpset{} because they use \ml{srw_ss()} combined with the arithmetic decision procedure for the natural numbers, as well as a \simpset{} fragment that eliminates \holtxt{let}-terms.
 All of the tactics take a list of rewrite theorems as their one argument.
@@ -3489,7 +3489,7 @@ There are also bit-blasting tactics: \ml{BBLAST\_TAC} and \ml{FULL\_BBLAST\_TAC}
 \section{The \texttt{Quantifier Heuristics} library}\label{sec:QuantHeuristicsLib}
 \input{QuantHeuristics.tex}
 
-\section{Tree-structured Finite Sets and Finite Maps}\label{sec:enumfset}
+\section{Tree-Structured Finite Sets and Finite Maps}\label{sec:enumfset}
 \input{enumfset.tex}
 
 

--- a/Manual/Description/misc.tex
+++ b/Manual/Description/misc.tex
@@ -99,7 +99,7 @@ Finally, the \ml{trace} function allows for a trace to be temporarily set while 
 
 
 
-\section{Maintaining \HOL{} Formalizations with \holmake}
+\section{\texorpdfstring{Maintaining \HOL{} Formalizations with \holmake}{Maintaining HOL Formalizations with \holmake}}
 \label{Holmake}
 \index{Holmake@\holmake|(}
 
@@ -160,9 +160,9 @@ a theory, the user should
   the theory file is available for use.
 \end{enumerate}
 
-\subsection{Source Conventions for Script and SML Files}
+\subsection{Source conventions for script and SML files}
 
-\paragraph{Script and Theory Files}
+\paragraph{Script and theory files}
 The file that generates the \HOL{} theory \textit{my}\texttt{Theory} must be called \textit{my}\texttt{Script.sml}.
 After the theory has been successfully generated, it can be \texttt{open}-ed at the head of other developments:
 \begin{alltt}
@@ -237,7 +237,7 @@ Finally, take care not to have the string ``\texttt{Theory}'' appear at the end 
 This will also remove other files with names containing ``\texttt{Theory.sml}'' or ``\texttt{Theory.sig}''.
 For example, if, in your development directory, you had a file of \ML{} code named \texttt{MyTheory.sml} and you were also managing a \HOL{} development there with \holmake, then \texttt{MyTheory.sml} would get deleted if \texttt{Holmake~clean} were invoked.
 
-\paragraph{Other SML Code}
+\paragraph{Other SML code}
 When developing \HOL{} libraries, one should again attempt to follow Moscow~ML's conventions.
 Most importantly, file names should match \texttt{signature} and \texttt{structure} names.
 If this can be done, the automatic dependency analysis done by \holmake{} will work ``out of the box''.
@@ -514,7 +514,7 @@ In particular, this means that hash-characters do \emph{not} start
 comments on command-lines, and such ``comments'' will be passed to the
 shell, which may or may not treat them as comments when it sees them.
 
-\paragraph{Special Targets}
+\paragraph{Special targets}
 Some target names for rules are handled specially by \holmake{}:
 \begin{itemize}
 \item Dependencies associated with the target name \texttt{.PHONY} are taken to be list of other targets in the make-file that are not actually the name of files to be built.
@@ -696,7 +696,7 @@ treated as a reference to an environment variable.  If there is no
 such variable in the environment, then the variable is silently given
 the empty string as its value.
 
-\paragraph{Conditional Parts of Makefiles}
+\paragraph{Conditional parts of makefiles}
 \index{Holmake@\holmake!conditional inclusion of sections}
 As in GNU~\textsf{make}, parts of a \texttt{Holmakefile} can be included or excluded dynamically, depending on tests that can be performed on strings including variables.
 %
@@ -764,7 +764,7 @@ Note that environment variables with non-empty values are also considered to be 
 \index{Holmake@\holmake|)}
 
 
-\section{Generating and Using Heaps in Poly/ML \HOL{}}
+\section{\texorpdfstring{Generating and Using Heaps in Poly/ML \HOL{}}{Generating and Using Heaps in Poly/ML HOL}}
 \label{sec:polyml-heaps}
 
 \index{heaps (in Poly/ML)|(}
@@ -780,7 +780,7 @@ Users can use the same basic technology to ``dump'' heaps of their own.
 Such heaps can be preloaded with source code implementing special-purpose reasoning facilities, and with various necessary background theories.
 This can make developing big mechanisations considerably more pleasant.
 
-\subsection{Generating \HOL{} Heaps}
+\subsection{\texorpdfstring{Generating \HOL{} heaps}{Generating HOL heaps}}
 
 The easiest way to generate a \HOL{} heap is to use the \texttt{buildheap} executable that is built as part of the standard build process for (Poly/ML)~\HOL.
 This program takes a list of object files to include in a heap, an optional heap to build upon (use the \texttt{-b} command-line switch; the default is to use the heap behind the core \texttt{hol} executable), and an optional name for the new heap (the default is the traditional Unix \texttt{a.out}).
@@ -814,7 +814,7 @@ Finally, note how the use of the \texttt{dprot} and \texttt{protect} functions w
 \label{fig:realheap-makefile}
 \end{figure}
 
-\subsection{Using \HOL{} Heaps}
+\subsection{\texorpdfstring{Using \HOL{} heaps}{Using HOL heaps}}
 As just described, if a \texttt{Holmakefile} specifies a \texttt{HOLHEAP}, then files in that directory will be built on top of that heap rather than the default.
 This is also true if the specified heap is in another directory (\ie, the \texttt{HOLHEAP} line might specify a file such as \texttt{otherdir/myheap}).
 In this case, the \texttt{Holmakefile} won't (shouldn't) include instructions on how to build that heap, but the advantages of that heap are still available.
@@ -938,7 +938,7 @@ Total: 165.
 \index{timing of HOL evaluations@timing of \HOL{} evaluations|)}
 
 
-\section{Embedding \HOL{} in \LaTeX{}}
+\section{\texorpdfstring{Embedding \HOL{} in \LaTeX{}}{Embedding HOL in \LaTeX{}}}
 
 \index{LaTeX@\LaTeX!embedding HOL@embedding in \HOL{}|(}
 %
@@ -971,7 +971,7 @@ and then runs \LaTeX{} on \texttt{article.tex}.
 %
 One would probably automate this process with a makefile of course.
 
-\subsection{Munging Commands}
+\subsection{Munging commands}
 \label{sec:munging-commands}
 % need to get backslashes conveniently obscures the real names,
 % preventing the munger from seeing them, which will be useful when we
@@ -979,7 +979,7 @@ One would probably automate this process with a makefile of course.
 \newcommand{\holtm}{\texttt{\bs{}HOLtm}}
 \newcommand{\holty}{\texttt{\bs{}HOLty}}
 \newcommand{\holthm}{\texttt{\bs{}HOLthm}}
-\paragraph{Before Starting} In order to use the munger, one must ``include'' (use the \texttt{\bs{}usepackage} command) the \texttt{holtexbasic.sty} style-file, which is found in the HOL source directory \texttt{src/TeX}.
+\paragraph{Before starting} In order to use the munger, one must ``include'' (use the \texttt{\bs{}usepackage} command) the \texttt{holtexbasic.sty} style-file, which is found in the HOL source directory \texttt{src/TeX}.
 
 \bigskip
 There are then three commands for inserting text corresponding to \HOL{} entities into \LaTeX{} documents: \holtm, \holty{} and \holthm.
@@ -1050,7 +1050,7 @@ By default, the output is \emph{not} wrapped in an \texttt{\bs{}mbox}, making it
 The \texttt{verbatim} environment does the former, but not the latter.)
 \end{description}
 
-\paragraph{Munging Command Options}
+\paragraph{Munging command options}
 \index{munging (producing LaTeX from HOL)@munging (producing \LaTeX{} from \HOL{})!command options}
 There are a great many options for controlling the behaviour of each of these commands.
 %
@@ -1321,7 +1321,7 @@ If printing depends on particular variable name choices, the ``last minute'' man
 The width of the \LaTeX{} string is taken to be the width of the original token $t$.
 \end{description}
 
-\subsection{Math-Mode Munging}
+\subsection{Math-mode munging}
 \label{sec:math-mode-munging}
 \index{munging (producing LaTeX from HOL)@munging (producing \LaTeX{} from \HOL{})!math mode}
 \index{math mode (in the LaTeX munger)@math mode (in the \LaTeX{} munger)}
@@ -1361,7 +1361,7 @@ Occasionally, one will want to arrange blocks of \HOL{} material within a larger
 The \texttt{HOLarray} environment is a simple alias for a single-column left-aligned array that one can use in these situations.
 
 
-\subsection{Creating a Munger}
+\subsection{Creating a munger}
 \label{sec:munger-creation}
 
 \newcommand{\mkmunge}{\texttt{mkmunge.exe}}
@@ -1389,7 +1389,7 @@ Doing so allows for the incorporation of many theories at once, and will be more
 The use of a base heap argument to \mkmunge{} doesn't affect the efficiency of the resulting munging tool.
 
 
-\subsection{Running a Munger}
+\subsection{Running a munger}
 \label{sec:running-munger}
 
 \index{munging (producing LaTeX from HOL)@munging (producing \LaTeX{} from \HOL{})!running a munger}
@@ -1559,7 +1559,7 @@ you to run Holindex using AUCTeX.
 \end{description}
 
 
-\paragraph{Defining and Formatting Terms, Types and Theorems}
+\paragraph{Defining and formatting terms, types and theorems}
 
   Most of the Holindex commands require an identifier of a theorem,
   term or type as arguments. Theorem identifiers of the form
@@ -1684,14 +1684,14 @@ included.
 \end{description}
 
 
-\paragraph{Additional Documentation}
+\paragraph{Additional documentation}
 For more information about Holindex, please refer to
 the demonstration file \texttt{src/TeX/holindex-demo.tex}. This file contains
 documentation for rarely used commands as well as explanations of how to
 customise Holindex.
 
 
-\subsection{Making \HOL{} Theories \LaTeX{}-ready}
+\subsection{\texorpdfstring{Making \HOL{} theories \LaTeX{}-ready}{Making HOL theories \LaTeX{}-ready}}
 \label{sec:holtheories-tex-ready}
 
 Though one might specify all one's desired token-replacements in an \texttt{overrides} file, there is also support for specifying token replacements in the theory where tokens are first ``defined''.

--- a/Manual/Description/system.stex
+++ b/Manual/Description/system.stex
@@ -1881,7 +1881,7 @@ the current theory.
 
 \noindent Evaluating
  \ml{new\_definition("$name$", \holquote{$c\ v_1\ \cdots\ v_n\ =\ t$})},
-declares the sequent
+declares the sequent\\
 \ml{(\lb\rb{},$c = \lambda v_1\ \cdots\ v_n.\  t$)} to be a constant definition
 \index{definitions, adding to HOL logic@definitions, adding to \HOL{} logic}
 of the current theory. The name associated with the definition in

--- a/Manual/Description/system.stex
+++ b/Manual/Description/system.stex
@@ -1,4 +1,4 @@
-\chapter{The \HOL{} Logic in ML}\label{HOLsyschapter}
+\chapter{\texorpdfstring{The \HOL{} Logic in ML}{The HOL Logic in ML}}\label{HOLsyschapter}
 
 In this chapter, the concrete representation of the \HOL{} logic is
 described.  This involves describing the \ML\ functions that comprise
@@ -1071,7 +1071,7 @@ in \LOGIC, \ml{SELECT\_AX}.
 \end{session}
 \index{theorem notation, in HOL logic@theorem notation, in \HOL{} logic|)}
 
-\section{Primitive Rules of Inference of the \HOL{} Logic}
+\section{\texorpdfstring{Primitive Rules of Inference of the \HOL{} Logic}{Primitive Rules of Inference of the HOL Logic}}
 \label{rules}
 
 \index{inference rules, of HOL logic@inference rules, of \HOL{} logic!primitive|(}

--- a/Manual/Description/tactics.stex
+++ b/Manual/Description/tactics.stex
@@ -60,7 +60,7 @@ translating subgoals solutions to solutions of goals.
 %from the ones
 %in Edinburgh \LCF\ \cite{Edinburgh-LCF}).
 
-\section{Tactics, goals and validations}
+\section{Tactics, Goals and Validations}
 \label{tactics}
 
 \index{goal directed proof search!concepts of|(}
@@ -378,7 +378,7 @@ There can be a lot of book-keeping required to support such an activity.
 For this reason, most interactive theorem-proving uses the subgoal or goalstack package described in Section~\ref{sec:goalstack}.
 
 
-\section{Some tactics built into HOL}
+\section{\texorpdfstring{Some Tactics Built into \HOL{}}{Some Tactics Built into HOL}}
 
 This section contains a selection of the more commonly
 \index{tactics!list of some|(}
@@ -916,7 +916,7 @@ $T$ until it fails. It is defined in \ML{} by:
 \index{tacticals!list of some|)}
 \index{tactics!tacticals for|)}
 
-\section{Tactics for manipulating assumptions}
+\section{Tactics for Manipulating Assumptions}
 \label{asm-manip}
 
 \index{tactics!for manipulating assumptions|(}

--- a/Manual/Description/theories.stex
+++ b/Manual/Description/theories.stex
@@ -2945,7 +2945,7 @@ total relation.
 
 
 
-\subsubsection{Indexed Lists}
+\subsubsection{Indexed lists}
 \label{sec:indexed-lists}
 
 \index{EL, the HOL constant@\holtxt{EL}, the \HOL{} constant|pin}
@@ -2986,7 +2986,7 @@ The basic characterisation of the link between \holtxt{EL} and \holtxt{LUPDATE} 
 \end{alltt}
 \end{hol}
 
-\paragraph{The \ml{indexedLists} Theory} The \ml{indexedLists} theory defines a number of extra constants that are ``aware'' of lists as indexed values.
+\paragraph{The \ml{indexedLists} theory} The \ml{indexedLists} theory defines a number of extra constants that are ``aware'' of lists as indexed values.
 Some of these constants are:
 \begin{hol}
 \begin{verbatim}
@@ -4052,7 +4052,7 @@ where all the elements not in the set have been dropped
 \end{verbatim}
 \end{hol}
 
-\paragraph {Sets and Multisets}
+\paragraph {Sets and multisets}
 
 Moving between bags and sets is accomplished by the following two
 definitions.
@@ -4803,7 +4803,7 @@ Subsequently, the translation from $\mathit{vs}\;\holtxt{\lt-} M_1\holtxt{;}\;M_
 If there is no variable-arrow on the first binding, then $M_1\holtxt{;}\;M_2$ translates to something equivalent to $\holtxt{monad\_bind}\;M_1\;(\holtxt{K}\;M_2)$, where \holtxt{K} is the K-combinator from \ml{combinTheory} (see Section~\ref{sec:combinTheory}).
 Finally, the \holtxt{return} keyword is an overloading for the monad instance's unit function (which will have type $\alpha \to \alpha\,\holtxt{M}$).
 
-\subsection{Declaring Monads}
+\subsection{Declaring monads}
 
 Monad instances have to be declared if the system is to support their parsing and pretty-printing.
 The function responsible is \index{declare_monad@\ml{declare\_monad}}\ml{declare\_monad} in the \ml{monadsyntax} module.
@@ -4877,7 +4877,7 @@ A typical use of \holtxt{assert} might be in a function such as
 \end{alltt}
 where the \holtxt{assert} ensures that the subsequent call to \holtxt{HD} makes sense.
 
-\subsection{Enabling Monad Syntax}
+\subsection{Enabling monad syntax}
 
 There are two steps to being able to use monadic syntax.
 Both steps \emph{persist}, meaning that their effects are preserved for the benefit of descendant theories.
@@ -4948,7 +4948,7 @@ Everything that has been enabled can in turn be disabled, with calls drawn from:
      temp_disable_monadsyntax : unit -> unit
 \end{alltt}
 
-\subsection{Some Built-in Monad Theories}
+\subsection{Some built-in monad theories}
 
 See Figure~\ref{fig:bind-defns} for the bind definitions for a number of different monads that are present in the core HOL set of theories.
 \begin{figure}[hbtp]


### PR DESCRIPTION
I tired to make the section header capitalization more consistent in the description manual. `Section`s are in title case, and everything else (`subsection`s, `paragraph`s, ...) are in sentence case. I think/hope I normalized capitalization to the style that was previously dominating for each level.