### PR TITLE
Remove copyright notes wrongly touched by Mario Castelán Castro

### DIFF
--- a/src/1/Conv.sml
+++ b/src/1/Conv.sml
@@ -13,17 +13,6 @@
 (* TRANSLATOR    : Konrad Slind, University of Calgary                   *)
 (* DATE          : September 11, 1991                                    *)
 (* Many micro-optimizations added, February 24, 1992, KLS                *)
-
-(* This file as a whole is assumed to be under the license in the file
-"COPYRIGHT" in the HOL4 distribution (note added by Mario Castelán         UOK
-Castro).
-
-For the avoidance of legal uncertainty, I (Mario Castelán Castro) hereby   UOK
-place my modifications to this file in the public domain per the Creative
-Commons CC0 1.0 public domain dedication <https://creativecommons.org/publ
-icdomain/zero/1.0/legalcode>. This should not be interpreted as a personal
-endorsement of permissive (non-Copyleft) licenses. *)
-
 (* ===================================================================== *)
 
 structure Conv :> Conv =

--- a/src/res_quan/src/res_quanLib.sig
+++ b/src/res_quan/src/res_quanLib.sig
@@ -5,19 +5,9 @@ DESCRIPTION   : Signature for restricted quantification inference rules
 AUTHOR        : P Curzon
 DATE          : May 1993
 UPDATED       : Joe Hurd, October 2001
-UPDATED       : Mario Castelán Castro, 2017                                UOK
+UPDATED       : Mario Castelan Castro, 2017
 
-This file as a whole is assumed to be under the license in the file
-"COPYRIGHT" in the HOL4 distribution (note added by Mario Castelán         UOK
-Castro).
-
-For the avoidance of legal uncertainty, I (Mario Castelán Castro) hereby   UOK
-place my modifications to this file in the public domain per the Creative
-Commons CC0 public domain dedication <https://creativecommons.org/publicdo
-main/zero/1.0/legalcode>. This should not be interpreted as a personal
-endorsement of permissive (non-Copyleft) licenses.
-
-============================================================================*)
+===========================================================================*)
 
 signature res_quanLib =
 sig

--- a/src/res_quan/src/res_quanLib.sml
+++ b/src/res_quan/src/res_quanLib.sml
@@ -3,17 +3,7 @@
 FILE: res_rules.ml       DATE: 1 Aug 92      BY: Wai Wong
 TRANSLATED               DATE: 28 May 93     BY: Paul Curzon
 UPDATED                  DATE: 30 Oct 01     BY: Joe Hurd
-UPDATED                  DATE: 20 Oct 17     BY: Mario Castelán Castro     UOK
-
-This file as a whole is assumed to be under the license in the file
-"COPYRIGHT" in the HOL4 distribution (note added by Mario Castelán         UOK
-Castro).
-
-For the avoidance of legal uncertainty, I (Mario Castelán Castro) hereby   UOK
-place my modifications to this file in the public domain per the Creative
-Commons CC0 public domain dedication <https://creativecommons.org/publicdo
-main/zero/1.0/legalcode>. This should not be interpreted as a personal
-endorsement of permissive (non-Copyleft) licenses.
+UPDATED                  DATE: 20 Oct 17     BY: Mario Castelan Castro
 
 ============================================================================*)
 

--- a/src/res_quan/src/res_quanScript.sml
+++ b/src/res_quan/src/res_quanScript.sml
@@ -5,17 +5,7 @@ DATE: 1 Aug 92
 CHANGED BY: Joe Hurd, June 2001 (to use predicate sets)
 CHANGED BY: Joe Hurd, June 2001 (to remove the ARB from RES_ABSTRACT)
 CHANGED BY: Joe Hurd, October 2001 (moved definitions to boolTheory)
-CHANGED BY: Mario Castelán Castro, 2017                                    UOK
-
-This file as a whole is assumed to be under the license in the file
-"COPYRIGHT" in the HOL4 distribution (note added by Mario Castelán         UOK
-Castro).
-
-For the avoidance of legal uncertainty, I (Mario Castelán Castro) hereby   UOK
-place my modifications to this file in the public domain per the Creative
-Commons CC0 public domain dedication <https://creativecommons.org/publicdo
-main/zero/1.0/legalcode>. This should not be interpreted as a personal
-endorsement of permissive (non-Copyleft) licenses.
+CHANGED BY: Mario Castelan Castro, 2017
 
 ============================================================================*)
 


### PR DESCRIPTION
In case #559 concluded with the decision of removing copyright notes wrongly touched by Mario Castelán Castro, the current PR quickly gets the job done.

