### PR TITLE
Add sort_vars to HolKernelDoc

### DIFF
--- a/src/postkernel/HolKernelDoc.sig
+++ b/src/postkernel/HolKernelDoc.sig
@@ -57,6 +57,7 @@ sig
   val strip_gen_right : ('a -> 'a * 'b) -> 'a -> 'a * 'b list
   val strip_gen_left_opt : ('a -> ('b * 'a) option) -> 'a -> 'b list * 'a
   val strip_gen_left : ('a -> 'b * 'a) -> 'a -> 'b list * 'a
+  val sort_vars: string list -> term list -> term list
   val subst_occs:
      int list list -> {redex: term, residue: term} list -> term -> term
   val syntax_fns:


### PR DESCRIPTION
The function sort_vars was missing from HolKernelDoc, so the documentation available in help/Docfiles/HolKernel.sort_vars.doc was not visible when browsing the HTML documentation for HolKernel.

(Maybe HolKernel should have a signature file so it's easier to compare HolKernelDoc with the actual HolKernel?)