### PR TITLE
Hide vim scratch buffer from the list of buffers

### DIFF
--- a/tools/vim/hol.src
+++ b/tools/vim/hol.src
@@ -11,9 +11,10 @@ endif
 let s:holtogglequiet = "val _ = HOL_Interactive.toggle_quietdec();"
 
 new
-set buftype=nofile
-set bufhidden=hide
-set noswapfile
+setlocal buftype=nofile
+setlocal bufhidden=hide
+setlocal nobuflisted
+setlocal noswapfile
 let s:holnr = bufnr("")
 hide
 


### PR DESCRIPTION
Until for `*.sml` files scratch buffers are cluttering the list of buffers. This hides the buffers from the list of buffers, maintaining the functionality.