### PR TITLE
eliminating ref-matches

### DIFF
--- a/src/1/Rewrite.sml
+++ b/src/1/Rewrite.sml
@@ -86,8 +86,7 @@ with
 fun add_rewrites (RW{thms,net}) thl =
  let val rewrites = itlist (append o local_mk_rewrites) thl []
      fun appconv (c,UNBOUNDED) tm     = c tm
-       | appconv (c,BOUNDED(ref 0)) _ = failwith "exceeded bound"
-       | appconv (c,BOUNDED r) tm     = c tm before Portable.dec r
+       | appconv (c,BOUNDED r) tm     = if !r = 0 then failwith "exceeded bound" else c tm before Portable.dec r
  in
    RW{thms = thms@thl,
        net = itlist Net.insert

--- a/src/compute/src/clauses.sml
+++ b/src/compute/src/clauses.sml
@@ -188,13 +188,15 @@ fun assoc_clause (RWS rws) cst =
 ;
 
 fun add_in_db_upd rws (name,arity,hcst) act =
-  let val (rl as ref(db,sk)) = assoc_clause rws name
+  let val rl = assoc_clause rws name
+    val (db, sk) = !rl
   in rl := (add_in_db (arity,hcst,act,db), sk)
   end
 ;
 
 fun set_skip (rws as RWS htbl) p sk =
-  let val (rl as ref(db,_)) = assoc_clause rws p
+  let val rl = assoc_clause rws p
+    val (db,_) = !rl
   in rl := (db,sk)
   end;
 
@@ -301,9 +303,9 @@ fun scrub_thms lthm rws =
 (* Support for analysis of compsets                                          *)
 (*---------------------------------------------------------------------------*)
 
-fun rws_of (RWS (ref rbmap)) =
- let val thinglist = Redblackmap.listItems rbmap
-     fun db_of_entry (ss, ref (db,opt)) = db
+fun rws_of (RWS rrbmap) =
+ let val rbmap = !rrbmap val thinglist = Redblackmap.listItems rbmap
+     fun db_of_entry (ss, r) = let val (db,opt) = !r in db end
      val dblist = List.map db_of_entry thinglist
      fun get_actions db =
       case db
@@ -331,9 +333,10 @@ datatype transform
 (* to make all the dependencies explicit.                                    *)
 (*---------------------------------------------------------------------------*)
 
-fun deplist (RWS (ref rbmap)) =
- let val thinglist = Redblackmap.listItems rbmap
-     fun db_of_entry (ss, ref (db,opt)) = (ss,db)
+fun deplist (RWS rrbmap) =
+ let val rbmap = !rrbmap
+     val thinglist = Redblackmap.listItems rbmap
+     fun db_of_entry (ss, r) = let val (db,opt) = !r in (ss,db) end
      val dblist = List.map db_of_entry thinglist
      fun get_actions db =
       case db

--- a/src/compute/src/equations.sml
+++ b/src/compute/src/equations.sml
@@ -87,7 +87,7 @@ fun comb_ct {Head,Args,Rws=NeedArg tail, Skip} arg =
 
 fun mk_clos(env,t) =
   case t of
-    Cst (hc,ref(db,b)) => CST{Head=hc, Args=[], Rws= db, Skip = b}
+    Cst (hc,r) => let val (db,b) = !r in CST{Head=hc, Args=[], Rws= db, Skip = b} end
   | Bv i => List.nth(env,i)
   | Fv => NEUTR
   | _ => CLOS{Env=env, Term=t}

--- a/src/parse/parse_term.sml
+++ b/src/parse/parse_term.sml
@@ -86,14 +86,16 @@ val complained_already = ref false;
 
 structure Polyhash =
 struct
-   fun peek (ref dict) k = Binarymap.peek(dict,k)
-   fun peekInsert (r as ref dict) (k,v) =
-       case Binarymap.peek(dict,k) of
-         NONE => (r := Binarymap.insert(dict,k,v); NONE)
-       | x => x
-   fun insert (r as ref dict) (k,v) =
-       r := Binarymap.insert(dict,k,v)
-   fun listItems (ref dict) = Binarymap.listItems dict
+   fun peek (dict) k = Binarymap.peek(!dict,k)
+   fun peekInsert r (k,v) =
+       let val dict = !r in
+         case Binarymap.peek(dict,k) of
+           NONE => (r := Binarymap.insert(dict,k,v); NONE)
+         | x => x
+       end
+   fun insert r (k,v) =
+       r := Binarymap.insert(!r,k,v)
+   fun listItems dict = Binarymap.listItems (!dict)
    fun mkDict cmp = let
      val newref = ref (Binarymap.mkDict cmp)
    in

--- a/src/parse/qbuf.sml
+++ b/src/parse/qbuf.sml
@@ -79,7 +79,7 @@ struct
 
   fun new_buffer q = ref (new_buffer0 NONE 0 q)
 
-  fun current (ref (_, x, _, _)) = x
+  fun current r = case !r of (_, x, _, _) => x
 
   fun buffer_from_lbuf lexfn nf_q q =
       let val (t,locn) = lexfn ()
@@ -87,7 +87,7 @@ struct
           buffer_from_tok lexfn (t,locn) nf_q q
       end
 
-  fun advance (r as ref (lbopt, (curr,cloc), nf_q, q)) =
+  fun advance r = case !r of (lbopt, (curr,cloc), nf_q, q) =>
       case curr of
           BT_AQ _ => r := new_buffer0 (SOME cloc) nf_q q
         | BT_EOI => ()
@@ -103,9 +103,9 @@ struct
     recurse []
   end
 
-  fun replace_current t (r as ref (lb, _, nf_q, q)) = r := (lb, t, nf_q, q)
+  fun replace_current t r = case !r of (lb, _, nf_q, q) => r := (lb, t, nf_q, q)
 
-  fun toString (r as ref (lbopt, (c,_), nf_q, q)) = let
+  fun toString r = case !r of (lbopt, (c,_), nf_q, q) => let
     fun lb_toStringList acc lexfn = let
       val (t,locn) = lexfn ()
     in

--- a/src/parse/term_pp.sml
+++ b/src/parse/term_pp.sml
@@ -71,16 +71,16 @@ fun apply_absargs f abs =
 
 val casesplit_munger = ref (NONE: (term -> term * (term * term)list) option)
 fun init_casesplit_munger f =
-    case casesplit_munger of
-      ref NONE => casesplit_munger := SOME f
+    case !casesplit_munger of
+      NONE => casesplit_munger := SOME f
     | _ => raise PP_ERR "init_casesplit_munger"
                         "casesplit munger already initialised"
 
 exception CaseConversionFailed
 fun convert_case tm =
-    case casesplit_munger of
-      ref NONE => raise CaseConversionFailed
-    | ref (SOME f) => let
+    case !casesplit_munger of
+      NONE => raise CaseConversionFailed
+    | (SOME f) => let
         val (split_on, splits) = f tm
             handle HOL_ERR _ => raise CaseConversionFailed
         val _ = not (null splits) orelse raise CaseConversionFailed

--- a/src/portableML/OldPP.sml
+++ b/src/portableML/OldPP.sml
@@ -36,7 +36,7 @@ abstype 'a queue = QUEUE of {elems: 'a array, (* the contents *)
                              size: int}  (* fixed size of element array *)
 with
 
-  fun is_empty (QUEUE{front=ref ~1, back=ref ~1,...}) = true
+  fun is_empty (QUEUE{front=f, back=b,...}) = (!f = ~1 andalso !b = ~1)
     | is_empty _ = false
 
   fun mk_queue n init_val =
@@ -225,50 +225,48 @@ end
    be printable? Because of what goes on in add_string. See there for details.
 *)
 
-fun print_BB (_,{Pblocks = ref [], Ublocks = ref []}) =
-             raise Fail "PP-error: print_BB"
-  | print_BB (PPS{the_indent_stack,linewidth,space_left=ref sp_left,...},
-             {Pblocks as ref({How_to_indent=CONSISTENT,Block_size,
-                              Block_offset}::rst),
-              Ublocks=ref[]}) =
-       (push ((if (!Block_size > sp_left)
+fun print_BB (PPS {the_indent_stack,linewidth,space_left,...}, {Pblocks, Ublocks}) =
+  let val sp_left = !space_left in
+  case (!Pblocks, !Ublocks) of
+    ([], []) =>
+      raise Fail "PP-error: print_BB"
+  | ({How_to_indent=CONSISTENT,Block_size, Block_offset}::rst, []) =>
+      (push ((if (!Block_size > sp_left)
                then ONE_PER_LINE (linewidth - (sp_left - Block_offset))
                else FITS),
               the_indent_stack);
         Pblocks := rst)
-  | print_BB(PPS{the_indent_stack,linewidth,space_left=ref sp_left,...},
-             {Pblocks as ref({Block_size,Block_offset,...}::rst),Ublocks=ref[]}) =
-       (push ((if (!Block_size > sp_left)
-               then PACK_ONTO_LINE (linewidth - (sp_left - Block_offset))
-               else FITS),
-              the_indent_stack);
-        Pblocks := rst)
-  | print_BB (PPS{the_indent_stack, linewidth, space_left=ref sp_left,...},
-              {Ublocks,...}) =
-      let fun pr_end_Ublock [{How_to_indent=CONSISTENT,Block_size,Block_offset}] l =
-                (push ((if (!Block_size > sp_left)
-                        then ONE_PER_LINE (linewidth - (sp_left - Block_offset))
-                        else FITS),
-                       the_indent_stack);
-                 List.rev l)
-            | pr_end_Ublock [{Block_size,Block_offset,...}] l =
-                (push ((if (!Block_size > sp_left)
-                        then PACK_ONTO_LINE (linewidth - (sp_left - Block_offset))
-                        else FITS),
-                       the_indent_stack);
-                 List.rev l)
-            | pr_end_Ublock (a::rst) l = pr_end_Ublock rst (a::l)
-            | pr_end_Ublock _ _ =
-                raise Fail "PP-error: print_BB: internal error"
-       in Ublocks := pr_end_Ublock(!Ublocks) []
-      end
-
+  | ({Block_size,Block_offset,...}::rst, []) =>
+      (push ((if (!Block_size > sp_left)
+                     then PACK_ONTO_LINE (linewidth - (sp_left - Block_offset))
+                     else FITS),
+                    the_indent_stack);
+              Pblocks := rst)
+  | (_, Ubl) =>
+        let fun pr_end_Ublock [{How_to_indent=CONSISTENT,Block_size,Block_offset}] l =
+                    (push ((if (!Block_size > sp_left)
+                            then ONE_PER_LINE (linewidth - (sp_left - Block_offset))
+                            else FITS),
+                           the_indent_stack);
+                     List.rev l)
+                | pr_end_Ublock [{Block_size,Block_offset,...}] l =
+                    (push ((if (!Block_size > sp_left)
+                            then PACK_ONTO_LINE (linewidth - (sp_left - Block_offset))
+                            else FITS),
+                           the_indent_stack);
+                     List.rev l)
+                | pr_end_Ublock (a::rst) l = pr_end_Ublock rst (a::l)
+                | pr_end_Ublock _ _ =
+                    raise Fail "PP-error: print_BB: internal error"
+       in Ublocks := pr_end_Ublock Ubl []
+       end
+end
 
 (* Uend should always be 0 when print_E is called. *)
-fun print_E (_,{Pend = ref 0, Uend = ref 0}) =
-      raise Fail "PP-error: print_E"
-  | print_E (istack,{Pend, ...}) =
-      let fun pop_n_times 0 = ()
+fun print_E (istack,{Pend, Uend, ...}) =
+  if !Pend = 0 andalso !Uend = 0
+  then raise Fail "PP-error: print_E"
+  else let fun pop_n_times 0 = ()
             | pop_n_times n = (pop istack; pop_n_times(n-1))
        in pop_n_times(!Pend); Pend := 0
       end
@@ -340,9 +338,8 @@ fun E_inc_right_index(PPS{the_token_buffer,right_index, ++,...})=
 fun pointers_coincide(PPS{left_index,right_index,the_token_buffer,...}) =
     (!left_index = !right_index) andalso
     (case (the_token_buffer sub (!left_index))
-       of (BB {Pblocks = ref [], Ublocks = ref []}) => true
-        | (BB _) => false
-        | (E {Pend = ref 0, Uend = ref 0}) => true
+       of (BB {Pblocks = Pb, Ublocks = Ub}) => (case (!Pb, !Ub) of ([], []) => true | _ => false)
+        | (E {Pend = Pe, Uend = Ue}) => !Pe = 0 andalso !Ue = 0
         | (E _) => false
         | _ => true)
 
@@ -360,16 +357,17 @@ fun advance_left (ppstrm as PPS{consumer,left_index,left_sum,
           | last_size (_::rst) = last_size rst
           | last_size _ = raise Fail "PP-error: last_size: internal error"
         fun token_size (S{Length, ...}) = Length
-          | token_size (BB b) =
-             (case b
-                of {Pblocks = ref [], Ublocks = ref []} =>
-                     raise Fail "PP-error: BB_size"
-                 | {Pblocks as ref(_::_),Ublocks=ref[]} => POS
-                 | {Ublocks, ...} => last_size (!Ublocks))
-          | token_size (E{Pend = ref 0, Uend = ref 0}) =
-              raise Fail "PP-error: token_size.E"
-          | token_size (E{Pend = ref 0, ...}) = NEG
-          | token_size (E _) = POS
+                    | token_size (BB {Pblocks, Ublocks}) =
+             (case (!Pblocks, !Ublocks) of
+               ([], []) => raise Fail "PP-error: BB_size"
+             | (_::_, []) => POS
+             | (_, ub) => last_size ub)
+          | token_size (E{Pend, Uend}) =
+            (case (!Pend, !Uend) of
+              (0, 0) =>
+                raise Fail "PP-error: token_size.E"
+            | (0, _) => NEG
+            | _ => POS)
           | token_size (BR {Distance_to_next_break, ...}) = !Distance_to_next_break
         fun loop (instr) =
             if (token_size instr < 0)  (* synchronization point; cannot advance *)
@@ -391,16 +389,18 @@ fun advance_left (ppstrm as PPS{consumer,left_index,left_sum,
        mangled output.)
     *)
                        (case (the_token_buffer sub (!left_index))
-                          of (BB {Pblocks = ref [], Ublocks = ref []}) =>
+                          of (BB {Pblocks, Ublocks}) =>
+                            (case (!Pblocks, !Ublocks) of ([], []) =>
                                (update(the_token_buffer,!left_index,
                                        initial_token_value);
                                 ++left_index)
-                           | (BB _) => ()
-                           | (E {Pend = ref 0, Uend = ref 0}) =>
+                             | _ => ())
+                           | (E {Pend, Uend}) =>
+                              if !Pend = 0 andalso !Uend = 0 then
                                (update(the_token_buffer,!left_index,
                                        initial_token_value);
                                 ++left_index)
-                           | (E _) => ()
+                              else ()
                            | _ => ++left_index;
                         loop (the_token_buffer sub (!left_index))))
      in loop instr
@@ -451,8 +451,9 @@ local
               if (delim_stack_is_empty the_delim_stack)
               then ()
               else case(the_token_buffer sub (top_delim_stack the_delim_stack))
-                     of (BB{Ublocks as ref ((b as {Block_size, ...})::rst),
-                            Pblocks}) =>
+                     of (BB{Ublocks, Pblocks}) =>
+                      (case !Pblocks of
+                        ((b as {Block_size, ...})::rst) =>
                            if (k>0)
                            then (Block_size := !right_sum + !Block_size;
                                  Pblocks := b :: (!Pblocks);
@@ -462,6 +463,7 @@ local
                                  else ();
                                  check(k-1))
                            else ()
+                        | _ => raise Fail "PP-error: check_delim_stack.catch empty !Pblocks")
                       | (E{Pend,Uend}) =>
                            (Pend := (!Pend) + (!Uend);
                             Uend := 0;
@@ -524,10 +526,13 @@ fun add_stringsz0 (pps : ppstream0) (s,slen) =
           | fnl (_::rst) = fnl rst
           | fnl _ = raise Fail "PP-error: fnl: internal error"
 
-        fun set(dstack,BB{Ublocks as ref[{Block_size,...}:block_info],...}) =
+        fun set(dstack,BB{Ublocks, ...}) =
+            (case !Ublocks of
+              [{Block_size,...}:block_info] =>
               (pop_bottom_delim_stack dstack;
-               Block_size := INFINITY)
-          | set (_,BB {Ublocks = ref(_::rst), ...}) = fnl rst
+                Block_size := INFINITY)
+            | (_::rst) => fnl rst
+            | _ => raise (Fail "PP-error: add_string.set"))
           | set (dstack, E{Pend,Uend}) =
               (Pend := (!Pend) + (!Uend);
                Uend := 0;

--- a/src/portableML/poly/Random.sml
+++ b/src/portableML/poly/Random.sml
@@ -35,10 +35,16 @@ fun newgen () =
       newgenseed (Real.fromLargeInt sec + Real.fromLargeInt usec)
    end
 
-fun random {seedref as ref seed} = (seedref := nextrand seed; seed / m)
+fun random {seedref} =
+  let
+    val seed = !seedref
+  in
+    (seedref := nextrand seed; seed / m)
+  end
 
-fun randomlist (n, {seedref as ref seed0}) =
+fun randomlist (n, {seedref}) =
    let
+      val seed0 = !seedref
       fun h 0 seed res = (seedref := seed; res)
         | h i seed res = h (i - 1) (nextrand seed) (seed / m :: res)
    in
@@ -48,21 +54,25 @@ fun randomlist (n, {seedref as ref seed0}) =
 fun range (min, max) =
    if min > max
       then raise Fail "Random.range: empty range"
-   else fn {seedref as ref seed} =>
+   else fn {seedref} =>
+         let
+            val seed = !seedref
+         in
            (seedref := nextrand seed
             ; min + floor (real (max - min) * seed / m))
+         end
 
 fun rangelist (min, max) =
    if min > max
       then raise Fail "Random.rangelist: empty range"
-   else fn (n, {seedref as ref seed0}) =>
+   else fn (n, {seedref}) =>
            let
               fun h 0 seed res = (seedref := seed; res)
                 | h i seed res =
                     h (i - 1) (nextrand seed)
                       (min + floor (real (max - min) * seed / m) :: res)
            in
-              h n seed0 []
+              h n (!seedref) []
            end
 
 end

--- a/src/portableML/seq.sml
+++ b/src/portableML/seq.sml
@@ -11,13 +11,14 @@ datatype 'a seq =
 
 fun delay f = LDELAYREF (ref (LDELAYED f))
 fun force s =
-  case s of
-    LDELAYREF (r as ref (LDELAYED f)) => let
-      val new = f ()
-    in
-      r := new; new
-    end
-  | LDELAYREF (ref x) => x
+  case s of LDELAYREF r =>
+    (case !r of LDELAYED f =>
+      let
+        val new = f ()
+      in
+        r := new; new
+      end
+    | x => x)
   | x => x
 
 fun cons x xs = LCONS(x, xs)

--- a/src/prekernel/Nonce.sml
+++ b/src/prekernel/Nonce.sml
@@ -3,6 +3,6 @@ struct
 
   type 'a t = 'a ref
   fun mk v = ref v
-  fun dest (ref v) = v
+  fun dest r = !r
 
 end

--- a/src/simp/src/Cache.sml
+++ b/src/simp/src/Cache.sml
@@ -71,8 +71,8 @@ end
 
 fun clear_cache cache = (cache := new_table())
 
-fun cache_values (ref (cache : table)) = let
-  val items = Redblackmap.listItems (!cache)
+fun cache_values (cache : table ref) = let
+  val items = Redblackmap.listItems (!(!cache))
   fun tolist (set, thmopt) = (HOLset.listItems set, thmopt)
   fun ToList (k, stlist) = (k, map tolist stlist)
 in

--- a/src/simp/src/Traverse.sml
+++ b/src/simp/src/Traverse.sml
@@ -220,14 +220,14 @@ fun TRAVERSE_IN_CONTEXT limit rewriters dprocs travrules stack ctxt tm = let
   val add_context' = add_context rewriters dprocs
   val change_relation' = change_relation travrules
   val lim_r = ref limit
-  fun check (ref NONE) = ()
-    | check (ref (SOME n)) = if n <= 0 then
+  fun check r = case !r of NONE => ()
+    | SOME n => if n <= 0 then
                                (trace(2,TEXT "Limit exhausted");
                                 raise ERR "TRAVERSE_IN_CONTEXT"
                                           "Limit exhausted")
                              else ()
-  fun dec (ref NONE) = ()
-    | dec (r as ref (SOME n)) = r := SOME (n - 1)
+  fun dec r = case !r of NONE => ()
+    | SOME n => r := SOME (n - 1)
 
   fun trav stack context  = let
     val TSTATE {contexts1,contexts2, freevars,

--- a/tools/mlyacc/mlyacclib/MLY_stream.sml
+++ b/tools/mlyacc/mlyacclib/MLY_stream.sml
@@ -31,9 +31,10 @@ struct
 
    type 'a stream = 'a str ref
 
-   fun get(ref(EVAL t)) = t
-     | get(s as ref(UNEVAL f)) =
-	    let val t = (f(), ref(UNEVAL f)) in s := EVAL t; t end
+   fun get s = (case !s of
+       EVAL t => t
+     | UNEVAL f =>
+	    let val t = (f(), ref(UNEVAL f)) in s := EVAL t; t end)
 
    fun streamify f = ref(UNEVAL f)
    fun cons(a,s) = ref(EVAL(a,s))


### PR DESCRIPTION
In a couple of places, the HOL4 code uses ref matching (i.e., ref is used as a pseudo constructor that dereferences the cell). Would you mind converting those to explicit dereference operations?

This change would make it easier to abstract over the concrete implementation of reference cells.