### PR TITLE
Make sure all HTML pages are interpreted as utf-8 encoded

### DIFF
--- a/help/src-sml/DOT
+++ b/help/src-sml/DOT
@@ -139,8 +139,9 @@ in
       val ostrm = openOut mapfile
       fun out s = output(ostrm, s^"\n")
     in
-      out "<!doctype html>";
+      out "<!DOCTYPE html>";
       out "<HTML>";
+      out "<META CHARSET=\"utf-8\">";
       out "<HEAD><TITLE>HOL Theory Hierarchy</TITLE></HEAD>";
       out "<BODY bgcolor=linen>";
       out "<H1>HOL Theory Hierarchy (clickable)</H1>";

--- a/help/src-sml/Doc2Html.sml
+++ b/help/src-sml/Doc2Html.sml
@@ -140,12 +140,10 @@ fun html (name,sectionl) ostrm =
        | markout_section (TYPE _) = raise Fail "markout_section: TYPE"
 
      fun front_matter name (TYPE ss) =
-           (out "<!DOCTYPE HTML PUBLIC \"-//W32//DTD HTML 4.01//EN\"\
-                 \ \"http://www.w3.org/TR/html4/strict.dtd\">\n";
+           (out "<!DOCTYPE html>\n";
             out "<HTML>\n";
             out "<HEAD>\n";
-            out "<meta http-equiv=\"content-type\" content=\"text/html ; \
-                \charset=US-ASCII\">\n";
+            out "<META CHARSET=\"utf-8\">\n";
             out "<TITLE>"; out name; out "</TITLE>\n";
             out "<LINK REL = \"STYLESHEET\" HREF = \"../";
             out cssURL;

--- a/help/src-sml/Htmlsigs.sml
+++ b/help/src-sml/Htmlsigs.sml
@@ -282,10 +282,9 @@ fun processSig db version bgcolor HOLpath SRCFILES sigfile htmlfile =
 	print sigfile; print "\n"
        ; *)
         traverse pass1;
-        out "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\">\n";
+        out "<!DOCTYPE html>\n";
         out "<html><head>\n";
-        out "<meta http-equiv=\"content-type\" content=\"text/html ; \
-            \charset=UTF-8\">\n";
+        out "<meta charset=\"utf-8\">\n";
         out "<title>Structure ";
         out strName; out "</title>\n";
         out "<style type=\"text/css\">\n";
@@ -429,7 +428,7 @@ fun printHTMLBase version bgcolor HOLpath pred header (sigfile, outfile) =
                 end))
         val seps = Listsort.sort Char.compare (separators db [])
     in
-	out "<html><head><title>"; out header; out "</title></head>\n";
+	out "<!DOCTYPE html><html><head><meta charset=\"utf-8\"><title>"; out header; out "</title></head>\n";
 	out "<body bgcolor=\""; out bgcolor; out "\">\n";
 	out "<h1>"; out header; out "</h1>\n";
 	mkalphaindex seps;


### PR DESCRIPTION
Yet another minor fix:

E.g. computeLib.CBV_CONV didn't display properly before this commit

Also use the "html5 doctype" in affected files