### PR TITLE
`topologyTheory` (new), `metricTheory` and `rich_topologyTheory` in release notes

### DIFF
--- a/doc/next-release.md
+++ b/doc/next-release.md
@@ -26,14 +26,14 @@ Bugs fixed:
 New theories:
 -------------
 
-*   Now HOL4 has a rather complete Elementary Topology in Euclidean
+*   HOL4 now has a rather complete theory of Elementary Topology in Euclidean
     Space (`rich_topologyTheory`), ported by Muhammad Qasim and Osman
     Hasan from HOL light (up to 2015). The part of General Topology
-    (independent of `realTheory`) is now at `topologyTheory` (HOL4's
-    old `topologyTheory` is renamed to `metricTheory`).
+    (independent of `realTheory`) is now available at
+    `topologyTheory`; the old `topologyTheory` is renamed to `metricTheory`.
 
     There is a minor backwards-incompatibility: old proof scripts using
-    the metric-related stuff in previous `topologyTheory` should now
+    the metric-related results in previous `topologyTheory` should now
     open `metricTheory` instead. (Thanks to Chun Tian for this work.)
 
 New tools:

--- a/doc/next-release.md
+++ b/doc/next-release.md
@@ -26,6 +26,16 @@ Bugs fixed:
 New theories:
 -------------
 
+*   Now HOL4 has a rather complete Elementary Topology in Euclidean
+    Space (`rich_topologyTheory`), ported by Muhammad Qasim and Osman
+    Hasan from HOL light (up to 2015). The part of General Topology
+    (independent of `realTheory`) is now at `topologyTheory` (HOL4's
+    old `topologyTheory` is renamed to `metricTheory`).
+
+    There is a minor backwards-incompatibility: old proof scripts using
+    the metric-related stuff in previous `topologyTheory` should now
+    open `metricTheory` instead. (Thanks to Chun Tian for this work.)
+
 New tools:
 ----------
 


### PR DESCRIPTION
Hi,

as requested by Michael Norrish, I have put a paragraph into next release notes on what I have ﻿done for HOL4's new Topology Theory scripts. Feel free to revise the texts.

---
Chun Tian
