### PR TITLE
Fixed PSL examples 

### DIFF
--- a/examples/PSL/1.01/executable-semantics/ExecuteSemanticsScript.sml
+++ b/examples/PSL/1.01/executable-semantics/ExecuteSemanticsScript.sml
@@ -34,7 +34,7 @@ quietdec := true;
 *)
 
 open bossLib metisLib listTheory rich_listTheory pred_setLib intLib
-     arithmeticTheory;
+     arithmeticTheory whileTheory;
 open regexpTheory matcherTheory;
 open FinitePathTheory PathTheory SyntaxTheory SyntacticSugarTheory
      UnclockedSemanticsTheory ClockedSemanticsTheory PropertiesTheory;
@@ -70,12 +70,8 @@ val arith_suc_ss = simpLib.++ (arith_ss, numSimps.SUC_FILTER_ss);
 (* Symbolic tacticals.                                                       *)
 (*---------------------------------------------------------------------------*)
 
-infixr 0 ++ << || THENC ORELSEC ORELSER ##;
-infix 1 >>;
+infixr 0 || THENC ORELSEC ORELSER;
 
-val op ++ = op THEN;
-val op << = op THENL;
-val op >> = op THEN1;
 val op || = op ORELSE;
 val Know = Q_TAC KNOW_TAC;
 val Suff = Q_TAC SUFF_TAC;
@@ -295,16 +291,16 @@ val UF_SEM_F_SUFFIX_IMP_REC =
 val CONCAT_is_CONCAT = prove
   (``FinitePath$CONCAT = regexp$CONCAT``,
    RW_TAC std_ss [FUN_EQ_THM]
-   ++ Induct_on `x`
-   ++ RW_TAC std_ss [FinitePathTheory.CONCAT_def, regexpTheory.CONCAT_def]);
+   >> Induct_on `x`
+   >> RW_TAC std_ss [FinitePathTheory.CONCAT_def, regexpTheory.CONCAT_def]);
 
 val RESTN_is_BUTFIRSTN = prove
   (``!n l. n <= LENGTH l ==> (RESTN l n = BUTFIRSTN n l)``,
    Induct_on `l`
-   >> RW_TAC arith_ss [LENGTH, BUTFIRSTN, FinitePathTheory.RESTN_def]
-   ++ GEN_TAC
-   ++ Cases >> RW_TAC arith_ss [LENGTH, BUTFIRSTN, FinitePathTheory.RESTN_def]
-   ++ RW_TAC arith_ss
+   >- RW_TAC arith_ss [LENGTH, BUTFIRSTN, FinitePathTheory.RESTN_def]
+   >> GEN_TAC
+   >> Cases >- RW_TAC arith_ss [LENGTH, BUTFIRSTN, FinitePathTheory.RESTN_def]
+   >> RW_TAC arith_ss
       [LENGTH, BUTFIRSTN, FinitePathTheory.RESTN_def,
        FinitePathTheory.REST_def, TL]);
 
@@ -313,25 +309,25 @@ val SEL_FINITE_is_BUTFIRSTN_FIRSTN = prove
        j <= k /\ k < LENGTH l ==>
        (SEL (FINITE l) (j,k) = BUTFIRSTN j (FIRSTN (SUC k) l))``,
    SIMP_TAC std_ss [SEL_def]
-   ++ Induct_on `l` >> RW_TAC arith_ss [LENGTH, FIRSTN]
-   ++ GEN_TAC
-   ++ GEN_TAC
-   ++ Cases
-   >> (ONCE_REWRITE_TAC [SEL_REC_AUX]
-       ++ RW_TAC arith_ss [LENGTH, FIRSTN, HEAD_def, HD]
-       ++ ONCE_REWRITE_TAC [SEL_REC_AUX]
-       ++ RW_TAC arith_ss [BUTFIRSTN])
-   ++ FULL_SIMP_TAC arith_ss [LENGTH]
-   ++ ONCE_REWRITE_TAC [SEL_REC_AUX]
-   ++ RW_TAC arith_ss
+   >> Induct_on `l` >- RW_TAC arith_ss [LENGTH, FIRSTN]
+   >> GEN_TAC
+   >> GEN_TAC
+   >> Cases
+   >- (ONCE_REWRITE_TAC [SEL_REC_AUX]
+       >> RW_TAC arith_ss [LENGTH, FIRSTN, HEAD_def, HD]
+       >> ONCE_REWRITE_TAC [SEL_REC_AUX]
+       >> RW_TAC arith_ss [BUTFIRSTN])
+   >> FULL_SIMP_TAC arith_ss [LENGTH]
+   >> ONCE_REWRITE_TAC [SEL_REC_AUX]
+   >> RW_TAC arith_ss
       [LENGTH, FIRSTN, arithmeticTheory.ADD1, HEAD_def, HD, REST_def, TL,
        BUTFIRSTN]
-   << [Q.PAT_ASSUM `!j. P j` (MP_TAC o Q.SPECL [`0`, `n`])
-       ++ RW_TAC arith_ss [BUTFIRSTN, arithmeticTheory.ADD1],
-       Q.PAT_ASSUM `!j. P j` (MP_TAC o Q.SPECL [`j - 1`, `n`])
-       ++ RW_TAC arith_ss [BUTFIRSTN, arithmeticTheory.ADD1]
-       ++ Cases_on `j`
-       ++ RW_TAC arith_ss [BUTFIRSTN]]);
+   >| [Q.PAT_X_ASSUM `!j. P j` (MP_TAC o Q.SPECL [`0`, `n`])
+       >> RW_TAC arith_ss [BUTFIRSTN, arithmeticTheory.ADD1],
+       Q.PAT_X_ASSUM `!j. P j` (MP_TAC o Q.SPECL [`j - 1`, `n`])
+       >> RW_TAC arith_ss [BUTFIRSTN, arithmeticTheory.ADD1]
+       >> Cases_on `j`
+       >> RW_TAC arith_ss [BUTFIRSTN]]);
 
 val sere2regexp_def = Define
   `(sere2regexp (S_BOOL b) = Atom (\l. B_SEM l b)) /\
@@ -344,10 +340,10 @@ val sere2regexp_def = Define
 val sere2regexp = prove
   (``!r l. S_CLOCK_FREE r ==> (US_SEM l r = sem (sere2regexp r) l)``,
    INDUCT_THEN sere_induct ASSUME_TAC
-   ++ RW_TAC std_ss
+   >> RW_TAC std_ss
       [US_SEM_def, sem_def, sere2regexp_def, ELEM_EL, EL, S_CLOCK_FREE_def]
-   ++ CONV_TAC (DEPTH_CONV ETA_CONV)
-   ++ RW_TAC std_ss [CONCAT_is_CONCAT]);
+   >> CONV_TAC (DEPTH_CONV ETA_CONV)
+   >> RW_TAC std_ss [CONCAT_is_CONCAT]);
 
 val EVAL_US_SEM = store_thm
   ("EVAL_US_SEM",
@@ -366,9 +362,9 @@ val EVAL_UF_SEM_F_SUFFIX_IMP = store_thm
        if S_CLOCK_FREE r then acheck (sere2regexp r) (\x. UF_SEM (FINITE x) f) w
        else UF_SEM (FINITE w) (F_SUFFIX_IMP (r,f))``,
    RW_TAC list_resq_ss [acheck, UF_SEM_def, sere2regexp, RESTN_FINITE]
-   ++ RW_TAC arith_ss
+   >> RW_TAC arith_ss
       [RESTN_is_BUTFIRSTN, SEL_FINITE_is_BUTFIRSTN_FIRSTN, BUTFIRSTN]
-   ++ METIS_TAC []);
+   >> METIS_TAC []);
 
 val FINITE_UF_SEM_F_STRONG_IMP_F_SUFFIX_IMP = store_thm
   ("FINITE_UF_SEM_F_STRONG_IMP_F_SUFFIX_IMP",
@@ -377,25 +373,25 @@ val FINITE_UF_SEM_F_STRONG_IMP_F_SUFFIX_IMP = store_thm
        UF_SEM (FINITE w)
        (F_SUFFIX_IMP (r1, F_NOT (F_SUFFIX_IMP (r2, F_BOOL B_FALSE))))``,
    RW_TAC list_resq_ss [UF_SEM_def, B_SEM, AND_IMP_INTRO]
-   ++ HO_MATCH_MP_TAC
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``(!j. P j ==> (Q j = R j)) ==> ((!j. P j ==> Q j) = !j. P j ==> R j)``)
-   ++ RW_TAC std_ss []
-   ++ HO_MATCH_MP_TAC
+   >> RW_TAC std_ss []
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``!R. (!k. P k ==> (?k'. k = k' + j)) /\ (!k. P (k + j) = Q k) ==>
              ((?j. P j) = ?j. Q j)``)
-   ++ CONJ_TAC
-   >> (RW_TAC std_ss []
-       ++ Q.EXISTS_TAC `k - j`
-       ++ RW_TAC arith_ss [])
-   ++ RW_TAC arith_ss []
-   ++ Know `(j,j+j') = (j+0,j+j')` >> RW_TAC arith_ss []
-   ++ DISCH_THEN (fn th => REWRITE_TAC [th, GSYM SEL_RESTN])
-   ++ MATCH_MP_TAC (PROVE [] ``(a ==> (b = c)) ==> (b /\ a = c /\ a)``)
-   ++ STRIP_TAC
-   ++ RW_TAC arith_ss [xnum_to_def, RESTN_FINITE, LENGTH_def]
-   ++ RW_TAC arith_ss [FinitePathTheory.LENGTH_RESTN]);
+   >> CONJ_TAC
+   >- (RW_TAC std_ss []
+       >> Q.EXISTS_TAC `k - j`
+       >> RW_TAC arith_ss [])
+   >> RW_TAC arith_ss []
+   >> Know `(j,j+j') = (j+0,j+j')` >- RW_TAC arith_ss []
+   >> DISCH_THEN (fn th => REWRITE_TAC [th, GSYM SEL_RESTN])
+   >> MATCH_MP_TAC (PROVE [] ``(a ==> (b = c)) ==> (b /\ a = c /\ a)``)
+   >> STRIP_TAC
+   >> RW_TAC arith_ss [xnum_to_def, RESTN_FINITE, LENGTH_def]
+   >> RW_TAC arith_ss [FinitePathTheory.LENGTH_RESTN]);
 
 val INFINITE_UF_SEM_F_STRONG_IMP_F_SUFFIX_IMP = store_thm
   ("INFINITE_UF_SEM_F_STRONG_IMP_F_SUFFIX_IMP",
@@ -404,7 +400,7 @@ val INFINITE_UF_SEM_F_STRONG_IMP_F_SUFFIX_IMP = store_thm
        UF_SEM (INFINITE p)
        (F_SUFFIX_IMP (r1, F_NOT (F_SUFFIX_IMP (r2, F_BOOL B_FALSE))))``,
    RW_TAC list_resq_ss [UF_SEM_def, B_SEM, AND_IMP_INTRO]
-    THEN HO_MATCH_MP_TAC (* MJCG tried using ++, <<, but it wouldn't parse *)
+    THEN HO_MATCH_MP_TAC (* MJCG tried using >>, >|, but it wouldn't parse *)
           (METIS_PROVE []
            ``(!j. P j ==> (Q j = R j)) ==> ((!j. P j ==> Q j) = !j. P j ==> R j)``)
     THEN RW_TAC arith_ss [LENGTH_RESTN_INFINITE,xnum_to_def,SEL_RESTN]
@@ -432,12 +428,12 @@ val BUTFIRSTN_FIRSTN = prove
        k + n <= LENGTH l ==>
        (BUTFIRSTN n (FIRSTN (k + n) l) = FIRSTN k (BUTFIRSTN n l))``,
    Induct
-   ++ GEN_TAC
-   ++ Cases
-   ++ RW_TAC arith_ss [BUTFIRSTN, FIRSTN, HD, TL, LENGTH, arithmeticTheory.ADD]
-   ++ Q.PAT_ASSUM `!x. P x` (MP_TAC o GSYM o Q.SPECL [`k`, `t`])
-   ++ RW_TAC arith_ss []
-   ++ RW_TAC arith_ss [BUTFIRSTN, FIRSTN, arithmeticTheory.ADD_CLAUSES]);
+   >> GEN_TAC
+   >> Cases
+   >> RW_TAC arith_ss [BUTFIRSTN, FIRSTN, HD, TL, LENGTH, arithmeticTheory.ADD]
+   >> Q.PAT_X_ASSUM `!x. P x` (MP_TAC o GSYM o Q.SPECL [`k`, `t`])
+   >> RW_TAC arith_ss []
+   >> RW_TAC arith_ss [BUTFIRSTN, FIRSTN, arithmeticTheory.ADD_CLAUSES]);
 
 val UF_SEM_F_WEAK_IMP_FINITE = prove
   (``!w r1 r2.
@@ -449,19 +445,19 @@ val UF_SEM_F_WEAK_IMP_FINITE = prove
          \/
          ?w'. US_SEM (SEL (FINITE w) (j, LENGTH w - 1) <> w') r2``,
    RW_TAC list_resq_ss [UF_SEM_def]
-   ++ ONCE_REWRITE_TAC [PROVE [] ``a \/ b = ~a ==> b``]
-   ++ REWRITE_TAC [AND_IMP_INTRO]
-   ++ HO_MATCH_MP_TAC
+   >> ONCE_REWRITE_TAC [PROVE [] ``a \/ b = ~a ==> b``]
+   >> REWRITE_TAC [AND_IMP_INTRO]
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``(!j. A j ==> (B j = C j)) ==> ((!j. A j ==> B j) = !j. A j ==> C j)``)
-   ++ RW_TAC std_ss []
-   ++ EQ_TAC
-   >> (DISCH_THEN (MP_TAC o Q.SPEC `LENGTH (w : ('a -> bool) list) - 1`)
-       ++ RW_TAC arith_ss [])
-   ++ RW_TAC std_ss []
-   ++ Cases_on `k = LENGTH w - 1` >> METIS_TAC []
-   ++ Q.EXISTS_TAC `SEL (FINITE w) (k + 1, LENGTH w - 1) <> w'`
-   ++ RW_TAC arith_ss [APPEND_ASSOC, GSYM SEL_SPLIT]);
+   >> RW_TAC std_ss []
+   >> EQ_TAC
+   >- (DISCH_THEN (MP_TAC o Q.SPEC `LENGTH (w : ('a -> bool) list) - 1`)
+       >> RW_TAC arith_ss [])
+   >> RW_TAC std_ss []
+   >> Cases_on `k = LENGTH w - 1` >- METIS_TAC []
+   >> Q.EXISTS_TAC `SEL (FINITE w) (k + 1, LENGTH w - 1) <> w'`
+   >> RW_TAC arith_ss [APPEND_ASSOC, GSYM SEL_SPLIT]);
 
 val EVAL_UF_SEM_F_WEAK_IMP = store_thm
   ("EVAL_UF_SEM_F_WEAK_IMP",
@@ -475,37 +471,37 @@ val EVAL_UF_SEM_F_WEAK_IMP = store_thm
        else UF_SEM (FINITE w) (F_WEAK_IMP (r1,r2))``,
    RW_TAC list_resq_ss
      [UF_SEM_F_WEAK_IMP_FINITE, acheck, amatch, sere2regexp]
-   ++ ONCE_REWRITE_TAC [UF_SEM_def]
-   ++ ONCE_REWRITE_TAC [EVAL_UF_SEM_F_SUFFIX_IMP]
-   ++ RW_TAC arith_ss
+   >> ONCE_REWRITE_TAC [UF_SEM_def]
+   >> ONCE_REWRITE_TAC [EVAL_UF_SEM_F_SUFFIX_IMP]
+   >> RW_TAC arith_ss
         [acheck, RESTN_is_BUTFIRSTN, SEL_FINITE_is_BUTFIRSTN_FIRSTN, sem_def,
          BUTFIRSTN]
-   ++ RW_TAC std_ss [AND_IMP_INTRO]
-   ++ HO_MATCH_MP_TAC
+   >> RW_TAC std_ss [AND_IMP_INTRO]
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``(!j. A j ==> (B j = C j)) ==> ((!j. A j ==> B j) = !j. A j ==> C j)``)
-   ++ RW_TAC std_ss []
-   ++ MATCH_MP_TAC (PROVE [] ``(a = b) /\ (c = d) ==> (a \/ c = b \/ d)``)
-   ++ REVERSE CONJ_TAC
-   >> (Know `SUC (LENGTH w - 1) = LENGTH w` >> DECIDE_TAC
-       ++ RW_TAC std_ss [FIRSTN_LENGTH_ID])
-   ++ RW_TAC arith_ss [UF_SEM_def, B_SEM]
-   ++ HO_MATCH_MP_TAC
+   >> RW_TAC std_ss []
+   >> MATCH_MP_TAC (PROVE [] ``(a = b) /\ (c = d) ==> (a \/ c = b \/ d)``)
+   >> REVERSE CONJ_TAC
+   >- (Know `SUC (LENGTH w - 1) = LENGTH w` >- DECIDE_TAC
+       >> RW_TAC std_ss [FIRSTN_LENGTH_ID])
+   >> RW_TAC arith_ss [UF_SEM_def, B_SEM]
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``!f.
            (!j. A j ==> ?x. f x = j) /\ (!j. A (f j) = B j) ==>
            ((?j. A j) = ?j. B j)``)
-   ++ Q.EXISTS_TAC `\k. k + n`
-   ++ RW_TAC arith_ss [] >> (Q.EXISTS_TAC `k - n` ++ RW_TAC arith_ss [])
-   ++ RW_TAC arith_ss [LENGTH_BUTFIRSTN]
-   ++ Cases_on `n + n' < LENGTH w`
-   ++ RW_TAC arith_ss [SEL_FINITE_is_BUTFIRSTN_FIRSTN]
-   ++ AP_TERM_TAC
-   ++ Know `SUC (n + n') <= LENGTH w` >> DECIDE_TAC
-   ++ POP_ASSUM_LIST (K ALL_TAC)
-   ++ Know `SUC (n + n') = SUC n' + n` >> DECIDE_TAC
-   ++ DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
-   ++ METIS_TAC [BUTFIRSTN_FIRSTN]);
+   >> Q.EXISTS_TAC `\k. k + n`
+   >> RW_TAC arith_ss [] >- (Q.EXISTS_TAC `k - n` >> RW_TAC arith_ss [])
+   >> RW_TAC arith_ss [LENGTH_BUTFIRSTN]
+   >> Cases_on `n + n' < LENGTH w`
+   >> RW_TAC arith_ss [SEL_FINITE_is_BUTFIRSTN_FIRSTN]
+   >> AP_TERM_TAC
+   >> Know `SUC (n + n') <= LENGTH w` >- DECIDE_TAC
+   >> POP_ASSUM_LIST (K ALL_TAC)
+   >> Know `SUC (n + n') = SUC n' + n` >- DECIDE_TAC
+   >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
+   >> METIS_TAC [BUTFIRSTN_FIRSTN]);
 
 (******************************************************************************
 * always{r} = {T[*]} |-> {r}
@@ -526,18 +522,18 @@ val F_SERE_NEVER_amatch = store_thm
        (UF_SEM w (F_SERE_NEVER r) =
         !n. ~amatch (sere2regexp (S_CAT (S_REPEAT S_TRUE,r))) (SEL w (0,n)))``,
    RW_TAC std_ss [F_SERE_NEVER_def]
-   ++ Know `LENGTH w = INFINITY`
-   >> PROVE_TAC [PathTheory.IS_INFINITE_EXISTS, PathTheory.LENGTH_def]
-   ++ RW_TAC list_resq_ss [UF_SEM_def, xnum_to_def]
-   ++ Know `!l. US_SEM l S_FALSE = F`
-   >> RW_TAC std_ss [US_SEM_def, S_FALSE_def, B_SEM]
-   ++ DISCH_THEN (fn th => RW_TAC std_ss [th])
-   ++ ONCE_REWRITE_TAC [EVAL_US_SEM]
-   ++ RW_TAC std_ss [S_CLOCK_FREE_def, S_TRUE_def]
-   ++ Suff `!j : num. (!k : num. ~(j <= k)) = F`
-   >> DISCH_THEN (fn th => REWRITE_TAC [th])
-   ++ RW_TAC std_ss []
-   ++ PROVE_TAC [arithmeticTheory.LESS_EQ_REFL]);
+   >> Know `LENGTH w = INFINITY`
+   >- PROVE_TAC [PathTheory.IS_INFINITE_EXISTS, PathTheory.LENGTH_def]
+   >> RW_TAC list_resq_ss [UF_SEM_def, xnum_to_def]
+   >> Know `!l. US_SEM l S_FALSE = F`
+   >- RW_TAC std_ss [US_SEM_def, S_FALSE_def, B_SEM]
+   >> DISCH_THEN (fn th => RW_TAC std_ss [th])
+   >> ONCE_REWRITE_TAC [EVAL_US_SEM]
+   >> RW_TAC std_ss [S_CLOCK_FREE_def, S_TRUE_def]
+   >> Suff `!j : num. (!k : num. ~(j <= k)) = F`
+   >- DISCH_THEN (fn th => REWRITE_TAC [th])
+   >> RW_TAC std_ss []
+   >> PROVE_TAC [arithmeticTheory.LESS_EQ_REFL]);
 
 (******************************************************************************
 * Generating FSA checkers for the simple subset of PSL.
@@ -549,37 +545,37 @@ val ELEM_SEL = store_thm
   ("ELEM_SEL",
    ``!w i. ELEM (SEL w (0,i)) 0 = ELEM w 0``,
    Cases
-   ++ RW_TAC arith_ss
+   >> RW_TAC arith_ss
       [FinitePathTheory.ELEM_def, FinitePathTheory.RESTN_def,
        FinitePathTheory.HEAD_def, ELEM_def, RESTN_def, SEL_def]
-   ++ REWRITE_TAC [GSYM arithmeticTheory.ADD1, SEL_REC_def, HEAD_def, HD]);
+   >> REWRITE_TAC [GSYM arithmeticTheory.ADD1, SEL_REC_def, HEAD_def, HD]);
 
 val US_SEM_REPEAT_TRUE = store_thm
   ("US_SEM_REPEAT_TRUE",
    ``!w. US_SEM w (S_REPEAT S_TRUE)``,
    RW_TAC std_ss [US_SEM_def, B_SEM, S_TRUE_def]
-   ++ Q.EXISTS_TAC `MAP (\x. [x]) w`
-   ++ (RW_TAC std_ss [listTheory.EVERY_MAP, listTheory.LENGTH]
-       ++ RW_TAC std_ss [listTheory.EVERY_MEM])
-   ++ Induct_on `w`
-   ++ RW_TAC std_ss [CONCAT_def, MAP, APPEND]
-   ++ PROVE_TAC []);
+   >> Q.EXISTS_TAC `MAP (\x. [x]) w`
+   >> (RW_TAC std_ss [listTheory.EVERY_MAP, listTheory.LENGTH]
+       >> RW_TAC std_ss [listTheory.EVERY_MEM])
+   >> Induct_on `w`
+   >> RW_TAC std_ss [CONCAT_def, MAP, APPEND]
+   >> PROVE_TAC []);
 
 val US_SEM_APPEND = store_thm
   ("US_SEM_APPEND",
    ``!r r' w w'.
        US_SEM w r /\ US_SEM w' r' ==> US_SEM (APPEND w w') (S_CAT (r,r'))``,
    RW_TAC std_ss []
-   ++ ONCE_REWRITE_TAC [US_SEM_def]
-   ++ Q.EXISTS_TAC `w`
-   ++ Q.EXISTS_TAC `w'`
-   ++ RW_TAC std_ss []);
+   >> ONCE_REWRITE_TAC [US_SEM_def]
+   >> Q.EXISTS_TAC `w`
+   >> Q.EXISTS_TAC `w'`
+   >> RW_TAC std_ss []);
 
 val CONCAT_EMPTY = store_thm
   ("CONCAT_EMPTY",
    ``!l. (FinitePath$CONCAT l = []) = EVERY (\x. x = []) l``,
    Induct
-   ++ RW_TAC std_ss [CONCAT_def, listTheory.EVERY_DEF,
+   >> RW_TAC std_ss [CONCAT_def, listTheory.EVERY_DEF,
                      listTheory.APPEND_eq_NIL]);
 
 val EMPTY_CONCAT = store_thm
@@ -593,8 +589,8 @@ val S_FLEX_AND_EMPTY = store_thm
    RW_TAC std_ss [US_SEM_def, S_FLEX_AND_def, S_TRUE_def, B_SEM,
                   listTheory.APPEND_eq_NIL, EMPTY_CONCAT,
                   GSYM listTheory.EVERY_CONJ]
-   ++ RW_TAC (simpLib.++ (arith_ss, boolSimps.CONJ_ss)) [LENGTH]
-   ++ RW_TAC std_ss [ALL_EL_F]);
+   >> RW_TAC (simpLib.++ (arith_ss, boolSimps.CONJ_ss)) [LENGTH]
+   >> RW_TAC std_ss [ALL_EL_F]);
 
 val SEL_NIL = store_thm
   ("SEL_NIL",
@@ -606,47 +602,47 @@ val SEL_INIT_APPEND = store_thm
    ``!p w.
        (?l n. SEL p (0,n) = APPEND w l) ==>
        (w = []) \/ (SEL p (0, LENGTH w - 1) = w)``,
-   Induct_on `w` >> RW_TAC std_ss []
-   ++ RW_TAC std_ss []
-   ++ POP_ASSUM MP_TAC
-   ++ Cases_on `n`
-   >> RW_TAC arith_suc_ss [APPEND, LENGTH, arithmeticTheory.PRE_SUB1,
+   Induct_on `w` >- RW_TAC std_ss []
+   >> RW_TAC std_ss []
+   >> POP_ASSUM MP_TAC
+   >> Cases_on `n`
+   >- RW_TAC arith_suc_ss [APPEND, LENGTH, arithmeticTheory.PRE_SUB1,
                            listTheory.APPEND_eq_NIL, SEL_def, SEL_REC_def]
-   ++ Know `!l. ~(l = []) ==> (l = HD l :: TL l)`
-   >> (Cases ++ RW_TAC std_ss [HD, TL])
-   ++ DISCH_THEN (MP_TAC o Q.SPEC `SEL p (0,SUC n')`)
-   ++ SIMP_TAC std_ss [SEL_NIL]
-   ++ DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
-   ++ RW_TAC std_ss [TL_SEL0, HD_SEL0, APPEND]
-   ++ Know `!l. ~(l = []) ==> (l = HD l :: TL l)`
-   >> (Cases ++ RW_TAC std_ss [HD, TL])
-   ++ DISCH_THEN (MP_TAC o Q.SPEC `SEL p (0, LENGTH (HEAD p :: w) - 1)`)
-   ++ SIMP_TAC std_ss [SEL_NIL]
-   ++ DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
-   ++ RW_TAC arith_ss [TL_SEL0, HD_SEL0, LENGTH]
-   ++ REPEAT (POP_ASSUM MP_TAC)
-   ++ Cases_on `LENGTH w`
-   >> (POP_ASSUM MP_TAC
-       ++ RW_TAC arith_suc_ss [LENGTH_NIL, SEL_def, SEL_REC_def, TL])
-   ++ RW_TAC arith_ss [TL_SEL0]
-   ++ Know `~(w = [])`
-   >> (STRIP_TAC
-       ++ Q.PAT_ASSUM `LENGTH w = SUC n` MP_TAC
-       ++ RW_TAC std_ss [LENGTH])
-   ++ REWRITE_TAC [IMP_DISJ_THM]
-   ++ FIRST_ASSUM MATCH_MP_TAC
-   ++ PROVE_TAC []);
+   >> Know `!l. ~(l = []) ==> (l = HD l :: TL l)`
+   >- (Cases >> RW_TAC std_ss [HD, TL])
+   >> DISCH_THEN (MP_TAC o Q.SPEC `SEL p (0,SUC n')`)
+   >> SIMP_TAC std_ss [SEL_NIL]
+   >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
+   >> RW_TAC std_ss [TL_SEL0, HD_SEL0, APPEND]
+   >> Know `!l. ~(l = []) ==> (l = HD l :: TL l)`
+   >- (Cases >> RW_TAC std_ss [HD, TL])
+   >> DISCH_THEN (MP_TAC o Q.SPEC `SEL p (0, LENGTH (HEAD p :: w) - 1)`)
+   >> SIMP_TAC std_ss [SEL_NIL]
+   >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
+   >> RW_TAC arith_ss [TL_SEL0, HD_SEL0, LENGTH]
+   >> REPEAT (POP_ASSUM MP_TAC)
+   >> Cases_on `LENGTH w`
+   >- (POP_ASSUM MP_TAC
+       >> RW_TAC arith_suc_ss [LENGTH_NIL, SEL_def, SEL_REC_def, TL])
+   >> RW_TAC arith_ss [TL_SEL0]
+   >> Know `~(w = [])`
+   >- (STRIP_TAC
+       >> Q.PAT_X_ASSUM `LENGTH w = SUC n` MP_TAC
+       >> RW_TAC std_ss [LENGTH])
+   >> REWRITE_TAC [IMP_DISJ_THM]
+   >> FIRST_ASSUM MATCH_MP_TAC
+   >> PROVE_TAC []);
 
 val CAT_APPEND = store_thm
   ("CAT_APPEND",
    ``!a b c. CAT (a, CAT (b,c)) = CAT (a <> b, c)``,
-   Induct ++ RW_TAC std_ss [APPEND, CAT_def]);
+   Induct >> RW_TAC std_ss [APPEND, CAT_def]);
 
 val REST_CAT = store_thm
   ("REST_CAT",
    ``!l p. ~(l = []) ==> (REST (CAT (l,p)) = CAT (TL l, p))``,
-   Induct >> RW_TAC std_ss []
-   ++ RW_TAC std_ss [CAT_def, REST_CONS, TL]);
+   Induct >- RW_TAC std_ss []
+   >> RW_TAC std_ss [CAT_def, REST_CONS, TL]);
 
 val S_EMPTY_def = Define `S_EMPTY = S_REPEAT S_FALSE`;
 
@@ -668,7 +664,7 @@ val S_OR_CAT = store_thm
        US_SEM p (S_CAT (S_OR (a,b), c)) =
        US_SEM p (S_OR (S_CAT (a,c), S_CAT (b,c)))``,
    RW_TAC std_ss [US_SEM_def]
-   ++ PROVE_TAC []);
+   >> PROVE_TAC []);
 
 val S_REPEAT_UNWIND = store_thm
   ("S_REPEAT_UNWIND",
@@ -676,19 +672,19 @@ val S_REPEAT_UNWIND = store_thm
        US_SEM p (S_OR (S_EMPTY, S_CAT (a, S_REPEAT a))) =
        US_SEM p (S_REPEAT a)``,
    RW_TAC std_ss [US_SEM_def, S_EMPTY]
-   ++ EQ_TAC
-   << [STRIP_TAC
-       >> (Q.EXISTS_TAC `[]`
-           ++ RW_TAC std_ss [CONCAT_def, listTheory.EVERY_DEF])
-       ++ Q.EXISTS_TAC `w1 :: wlist`
-       ++ RW_TAC std_ss [CONCAT_def, listTheory.EVERY_DEF],
+   >> EQ_TAC
+   >| [STRIP_TAC
+       >- (Q.EXISTS_TAC `[]`
+           >> RW_TAC std_ss [CONCAT_def, listTheory.EVERY_DEF])
+       >> Q.EXISTS_TAC `w1 :: wlist`
+       >> RW_TAC std_ss [CONCAT_def, listTheory.EVERY_DEF],
        RW_TAC std_ss []
-       ++ Cases_on `wlist` >> RW_TAC std_ss [CONCAT_def]
-       ++ DISJ2_TAC
-       ++ Q.EXISTS_TAC `h`
-       ++ Q.EXISTS_TAC `FinitePath$CONCAT t`
-       ++ FULL_SIMP_TAC std_ss [CONCAT_def, listTheory.EVERY_DEF]
-       ++ PROVE_TAC []]);
+       >> Cases_on `wlist` >- RW_TAC std_ss [CONCAT_def]
+       >> DISJ2_TAC
+       >> Q.EXISTS_TAC `h`
+       >> Q.EXISTS_TAC `FinitePath$CONCAT t`
+       >> FULL_SIMP_TAC std_ss [CONCAT_def, listTheory.EVERY_DEF]
+       >> PROVE_TAC []]);
 
 val S_REPEAT_CAT_UNWIND = store_thm
   ("S_REPEAT_CAT_UNWIND",
@@ -696,12 +692,12 @@ val S_REPEAT_CAT_UNWIND = store_thm
        US_SEM p (S_OR (b, S_CAT (a, S_CAT (S_REPEAT a, b)))) =
        US_SEM p (S_CAT (S_REPEAT a, b))``,
    RW_TAC std_ss []
-   ++ CONV_TAC (LAND_CONV (ONCE_REWRITE_CONV [US_SEM_def]))
-   ++ CONV_TAC (LAND_CONV (LAND_CONV (ONCE_REWRITE_CONV [GSYM S_EMPTY_CAT])))
-   ++ RW_TAC std_ss [GSYM S_CAT_ASSOC]
-   ++ RW_TAC std_ss [GSYM US_SEM_def, GSYM S_OR_CAT]
-   ++ ONCE_REWRITE_TAC [US_SEM_def]
-   ++ RW_TAC std_ss [GSYM S_REPEAT_UNWIND]);
+   >> CONV_TAC (LAND_CONV (ONCE_REWRITE_CONV [US_SEM_def]))
+   >> CONV_TAC (LAND_CONV (LAND_CONV (ONCE_REWRITE_CONV [GSYM S_EMPTY_CAT])))
+   >> RW_TAC std_ss [GSYM S_CAT_ASSOC]
+   >> RW_TAC std_ss [GSYM US_SEM_def, GSYM S_OR_CAT]
+   >> ONCE_REWRITE_TAC [US_SEM_def]
+   >> RW_TAC std_ss [GSYM S_REPEAT_UNWIND]);
 
 val SEL_REC0 = store_thm
   ("SEL_REC0",
@@ -716,88 +712,88 @@ val S_FLEX_AND_SEL_REC = store_thm
          US_SEM (SEL_REC n 0 p)
          (S_AND (S_CAT (f, S_REPEAT S_TRUE), S_CAT (g, S_REPEAT S_TRUE)))``,
    RW_TAC std_ss [S_FLEX_AND_def, GSYM S_TRUE_def]
-   ++ EQ_TAC
-   >> (CONV_TAC (LAND_CONV (ONCE_REWRITE_CONV [US_SEM_def]))
-       ++ RW_TAC std_ss []
-       << [Q.EXISTS_TAC `n`
-           ++ POP_ASSUM MP_TAC
-           ++ ONCE_REWRITE_TAC [US_SEM_def]
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [US_SEM_def]
-           ++ RW_TAC std_ss [US_SEM_REPEAT_TRUE]
-           ++ PROVE_TAC [APPEND_NIL],
+   >> EQ_TAC
+   >- (CONV_TAC (LAND_CONV (ONCE_REWRITE_CONV [US_SEM_def]))
+       >> RW_TAC std_ss []
+       >| [Q.EXISTS_TAC `n`
+           >> POP_ASSUM MP_TAC
+           >> ONCE_REWRITE_TAC [US_SEM_def]
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [US_SEM_def]
+           >> RW_TAC std_ss [US_SEM_REPEAT_TRUE]
+           >> PROVE_TAC [APPEND_NIL],
            Q.EXISTS_TAC `n`
-           ++ POP_ASSUM MP_TAC
-           ++ ONCE_REWRITE_TAC [US_SEM_def]
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [US_SEM_def]
-           ++ RW_TAC std_ss [US_SEM_REPEAT_TRUE]
-           ++ PROVE_TAC [APPEND_NIL]])
-    ++ CONV_TAC (LAND_CONV (ONCE_REWRITE_CONV [US_SEM_def]))
-    ++ CONV_TAC (LAND_CONV (ONCE_REWRITE_CONV [US_SEM_def]))
-    ++ RW_TAC std_ss [US_SEM_REPEAT_TRUE]
-    ++ Know `LENGTH w1 <= LENGTH w1' \/ LENGTH w1' <= LENGTH w1`
-    >> DECIDE_TAC
-    ++ REWRITE_TAC [LESS_EQ_EXISTS]
-    ++ DISCH_THEN (STRIP_ASSUME_TAC o GSYM)
-    << [Q.EXISTS_TAC `LENGTH w1'`
-        ++ ONCE_REWRITE_TAC [US_SEM_def]
-        ++ DISJ2_TAC
-        ++ Know `n = LENGTH w1' + LENGTH w2'`
-        >> METIS_TAC [LENGTH_APPEND, LENGTH_SEL_REC]
-        ++ RW_TAC std_ss []
-        ++ ONCE_REWRITE_TAC [US_SEM_def]
-        ++ REVERSE CONJ_TAC
-        >> (Q.PAT_ASSUM `SEL_REC A B C = w1' <> w2'` MP_TAC
-            ++ ONCE_REWRITE_TAC [ADD_COMM]
-            ++ ONCE_REWRITE_TAC [SEL_REC_SPLIT]
-            ++ RW_TAC arith_ss [APPEND_LENGTH_EQ, LENGTH_SEL_REC])
-        ++ Know `LENGTH w1' + LENGTH w2' = LENGTH w1 + LENGTH w2`
-        >> METIS_TAC [listTheory.LENGTH_APPEND, LENGTH_SEL_REC]
-        ++ STRIP_TAC
-        ++ Know `p' + LENGTH w2' = LENGTH w2`
-        >> DECIDE_TAC
-        ++ POP_ASSUM (K ALL_TAC)
-        ++ STRIP_TAC
-        ++ Q.PAT_ASSUM `SEL_REC A B C = D` (K ALL_TAC)
-        ++ Q.PAT_ASSUM `SEL_REC A B C = D` MP_TAC
-        ++ Q.PAT_ASSUM `A = LENGTH w1'`(fn th => REWRITE_TAC [GSYM th])
-        ++ ASM_REWRITE_TAC [GSYM ADD_ASSOC]
-        ++ ONCE_REWRITE_TAC [ADD_COMM]
-        ++ ONCE_REWRITE_TAC [SEL_REC_SPLIT]
-        ++ ONCE_REWRITE_TAC [US_SEM_def]
-        ++ RW_TAC arith_ss
+           >> POP_ASSUM MP_TAC
+           >> ONCE_REWRITE_TAC [US_SEM_def]
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [US_SEM_def]
+           >> RW_TAC std_ss [US_SEM_REPEAT_TRUE]
+           >> PROVE_TAC [APPEND_NIL]])
+    >> CONV_TAC (LAND_CONV (ONCE_REWRITE_CONV [US_SEM_def]))
+    >> CONV_TAC (LAND_CONV (ONCE_REWRITE_CONV [US_SEM_def]))
+    >> RW_TAC std_ss [US_SEM_REPEAT_TRUE]
+    >> Know `LENGTH w1 <= LENGTH w1' \/ LENGTH w1' <= LENGTH w1`
+    >- DECIDE_TAC
+    >> REWRITE_TAC [LESS_EQ_EXISTS]
+    >> DISCH_THEN (STRIP_ASSUME_TAC o GSYM)
+    >| [Q.EXISTS_TAC `LENGTH w1'`
+        >> ONCE_REWRITE_TAC [US_SEM_def]
+        >> DISJ2_TAC
+        >> Know `n = LENGTH w1' + LENGTH w2'`
+        >- METIS_TAC [LENGTH_APPEND, LENGTH_SEL_REC]
+        >> RW_TAC std_ss []
+        >> ONCE_REWRITE_TAC [US_SEM_def]
+        >> REVERSE CONJ_TAC
+        >- (Q.PAT_X_ASSUM `SEL_REC A B C = w1' <> w2'` MP_TAC
+            >> ONCE_REWRITE_TAC [ADD_COMM]
+            >> ONCE_REWRITE_TAC [SEL_REC_SPLIT]
+            >> RW_TAC arith_ss [APPEND_LENGTH_EQ, LENGTH_SEL_REC])
+        >> Know `LENGTH w1' + LENGTH w2' = LENGTH w1 + LENGTH w2`
+        >- METIS_TAC [listTheory.LENGTH_APPEND, LENGTH_SEL_REC]
+        >> STRIP_TAC
+        >> Know `p' + LENGTH w2' = LENGTH w2`
+        >- DECIDE_TAC
+        >> POP_ASSUM (K ALL_TAC)
+        >> STRIP_TAC
+        >> Q.PAT_X_ASSUM `SEL_REC A B C = D` (K ALL_TAC)
+        >> Q.PAT_X_ASSUM `SEL_REC A B C = D` MP_TAC
+        >> Q.PAT_X_ASSUM `A = LENGTH w1'`(fn th => REWRITE_TAC [GSYM th])
+        >> ASM_REWRITE_TAC [GSYM ADD_ASSOC]
+        >> ONCE_REWRITE_TAC [ADD_COMM]
+        >> ONCE_REWRITE_TAC [SEL_REC_SPLIT]
+        >> ONCE_REWRITE_TAC [US_SEM_def]
+        >> RW_TAC arith_ss
            [US_SEM_REPEAT_TRUE, APPEND_LENGTH_EQ, LENGTH_SEL_REC]
-        ++ PROVE_TAC [],
+        >> PROVE_TAC [],
         Q.EXISTS_TAC `LENGTH w1`
-        ++ ONCE_REWRITE_TAC [US_SEM_def]
-        ++ DISJ1_TAC
-        ++ Know `n = LENGTH w1 + LENGTH w2`
-        >> METIS_TAC [LENGTH_APPEND, LENGTH_SEL_REC]
-        ++ RW_TAC std_ss []
-        ++ ONCE_REWRITE_TAC [US_SEM_def]
-        ++ CONJ_TAC
-        >> (Q.PAT_ASSUM `SEL_REC A B C = w1 <> w2` MP_TAC
-            ++ ONCE_REWRITE_TAC [ADD_COMM]
-            ++ ONCE_REWRITE_TAC [SEL_REC_SPLIT]
-            ++ RW_TAC arith_ss [APPEND_LENGTH_EQ, LENGTH_SEL_REC])
-        ++ Know `LENGTH w1' + LENGTH w2' = LENGTH w1 + LENGTH w2`
-        >> METIS_TAC [listTheory.LENGTH_APPEND, LENGTH_SEL_REC]
-        ++ STRIP_TAC
-        ++ Know `p' + LENGTH w2 = LENGTH w2'`
-        >> DECIDE_TAC
-        ++ POP_ASSUM (K ALL_TAC)
-        ++ STRIP_TAC
-        ++ Q.PAT_ASSUM `SEL_REC A B C = D` MP_TAC
-        ++ Q.PAT_ASSUM `SEL_REC A B C = D` (K ALL_TAC)
-        ++ Q.PAT_ASSUM `A = LENGTH w1`(fn th => REWRITE_TAC [GSYM th])
-        ++ ASM_REWRITE_TAC [GSYM ADD_ASSOC]
-        ++ ONCE_REWRITE_TAC [ADD_COMM]
-        ++ ONCE_REWRITE_TAC [SEL_REC_SPLIT]
-        ++ ONCE_REWRITE_TAC [US_SEM_def]
-        ++ RW_TAC arith_ss
+        >> ONCE_REWRITE_TAC [US_SEM_def]
+        >> DISJ1_TAC
+        >> Know `n = LENGTH w1 + LENGTH w2`
+        >- METIS_TAC [LENGTH_APPEND, LENGTH_SEL_REC]
+        >> RW_TAC std_ss []
+        >> ONCE_REWRITE_TAC [US_SEM_def]
+        >> CONJ_TAC
+        >- (Q.PAT_X_ASSUM `SEL_REC A B C = w1 <> w2` MP_TAC
+            >> ONCE_REWRITE_TAC [ADD_COMM]
+            >> ONCE_REWRITE_TAC [SEL_REC_SPLIT]
+            >> RW_TAC arith_ss [APPEND_LENGTH_EQ, LENGTH_SEL_REC])
+        >> Know `LENGTH w1' + LENGTH w2' = LENGTH w1 + LENGTH w2`
+        >- METIS_TAC [listTheory.LENGTH_APPEND, LENGTH_SEL_REC]
+        >> STRIP_TAC
+        >> Know `p' + LENGTH w2 = LENGTH w2'`
+        >- DECIDE_TAC
+        >> POP_ASSUM (K ALL_TAC)
+        >> STRIP_TAC
+        >> Q.PAT_X_ASSUM `SEL_REC A B C = D` MP_TAC
+        >> Q.PAT_X_ASSUM `SEL_REC A B C = D` (K ALL_TAC)
+        >> Q.PAT_X_ASSUM `A = LENGTH w1`(fn th => REWRITE_TAC [GSYM th])
+        >> ASM_REWRITE_TAC [GSYM ADD_ASSOC]
+        >> ONCE_REWRITE_TAC [ADD_COMM]
+        >> ONCE_REWRITE_TAC [SEL_REC_SPLIT]
+        >> ONCE_REWRITE_TAC [US_SEM_def]
+        >> RW_TAC arith_ss
            [US_SEM_REPEAT_TRUE, APPEND_LENGTH_EQ, LENGTH_SEL_REC]
-        ++ PROVE_TAC []]);
+        >> PROVE_TAC []]);
 
 val S_FLEX_AND_SEL = store_thm
   ("S_FLEX_AND_SEL",
@@ -808,24 +804,24 @@ val S_FLEX_AND_SEL = store_thm
          US_SEM (SEL p (0,n))
          (S_AND (S_CAT (f, S_REPEAT S_TRUE), S_CAT (g, S_REPEAT S_TRUE)))``,
    RW_TAC std_ss []
-   ++ MP_TAC (Q.SPECL [`p`, `f`, `g`] S_FLEX_AND_SEL_REC)
-   ++ Know `!P Q.
+   >> MP_TAC (Q.SPECL [`p`, `f`, `g`] S_FLEX_AND_SEL_REC)
+   >> Know `!P Q.
               ((?n. P n) = ?n. Q n) =
               (P 0 \/ (?n. P (SUC n)) = Q 0 \/ ?n. Q (SUC n))`
-   >> METIS_TAC [num_CASES]
-   ++ DISCH_THEN (fn th => SIMP_TAC std_ss [th])
-   ++ MATCH_MP_TAC
+   >- METIS_TAC [num_CASES]
+   >> DISCH_THEN (fn th => SIMP_TAC std_ss [th])
+   >> MATCH_MP_TAC
       (PROVE []
        ``(A = B) /\ (C = D) /\ (E = G) ==> ((A \/ C = E) ==> (B \/ D = G))``)
-   ++ CONJ_TAC >> SIMP_TAC arith_ss [SEL_REC_def]
-   ++ CONJ_TAC >> RW_TAC arith_ss [SEL_def, ADD1]
-   ++ SIMP_TAC arith_ss [SEL_def, ADD1]
-   ++ MATCH_MP_TAC (PROVE [] ``(B ==> A) ==> (B \/ A = A)``)
-   ++ ONCE_REWRITE_TAC [US_SEM_def]
-   ++ ONCE_REWRITE_TAC [US_SEM_def]
-   ++ RW_TAC std_ss [SEL_REC_def, US_SEM_REPEAT_TRUE, APPEND_eq_NIL]
-   ++ Q.EXISTS_TAC `0`
-   ++ PROVE_TAC [APPEND]);
+   >> CONJ_TAC >- SIMP_TAC arith_ss [SEL_REC_def]
+   >> CONJ_TAC >- RW_TAC arith_ss [SEL_def, ADD1]
+   >> SIMP_TAC arith_ss [SEL_def, ADD1]
+   >> MATCH_MP_TAC (PROVE [] ``(B ==> A) ==> (B \/ A = A)``)
+   >> ONCE_REWRITE_TAC [US_SEM_def]
+   >> ONCE_REWRITE_TAC [US_SEM_def]
+   >> RW_TAC std_ss [SEL_REC_def, US_SEM_REPEAT_TRUE, APPEND_eq_NIL]
+   >> Q.EXISTS_TAC `0`
+   >> PROVE_TAC [APPEND]);
 
 val S_FLEX_AND = store_thm
   ("S_FLEX_AND",
@@ -833,41 +829,41 @@ val S_FLEX_AND = store_thm
        (?n. US_SEM (SEL_REC n 0 p) (S_FLEX_AND (f,g))) =
        (?n. US_SEM (SEL_REC n 0 p) f) /\ (?n. US_SEM (SEL_REC n 0 p) g)``,
    RW_TAC std_ss [S_FLEX_AND_SEL_REC]
-   ++ ONCE_REWRITE_TAC [US_SEM_def]
-   ++ ONCE_REWRITE_TAC [US_SEM_def]
-   ++ RW_TAC std_ss [US_SEM_REPEAT_TRUE]
-   ++ EQ_TAC
-   << [RW_TAC std_ss []
-       << [Know `n = LENGTH w2 + LENGTH w1`
-           >> PROVE_TAC [LENGTH_APPEND, LENGTH_SEL_REC, ADD_COMM]
-           ++ RW_TAC std_ss []
-           ++ Q.PAT_ASSUM `X = Y` (K ALL_TAC)
-           ++ Q.PAT_ASSUM `X = Y` MP_TAC
-           ++ RW_TAC arith_ss [SEL_REC_SPLIT, APPEND_LENGTH_EQ, LENGTH_SEL_REC]
-           ++ PROVE_TAC [],
+   >> ONCE_REWRITE_TAC [US_SEM_def]
+   >> ONCE_REWRITE_TAC [US_SEM_def]
+   >> RW_TAC std_ss [US_SEM_REPEAT_TRUE]
+   >> EQ_TAC
+   >| [RW_TAC std_ss []
+       >| [Know `n = LENGTH w2 + LENGTH w1`
+           >- PROVE_TAC [LENGTH_APPEND, LENGTH_SEL_REC, ADD_COMM]
+           >> RW_TAC std_ss []
+           >> Q.PAT_X_ASSUM `X = Y` (K ALL_TAC)
+           >> Q.PAT_X_ASSUM `X = Y` MP_TAC
+           >> RW_TAC arith_ss [SEL_REC_SPLIT, APPEND_LENGTH_EQ, LENGTH_SEL_REC]
+           >> PROVE_TAC [],
            Know `n = LENGTH w2' + LENGTH w1'`
-           >> PROVE_TAC [LENGTH_APPEND, LENGTH_SEL_REC, ADD_COMM]
-           ++ RW_TAC std_ss []
-           ++ Q.PAT_ASSUM `X = Y` MP_TAC
-           ++ Q.PAT_ASSUM `X = Y` (K ALL_TAC)
-           ++ RW_TAC arith_ss [SEL_REC_SPLIT, APPEND_LENGTH_EQ, LENGTH_SEL_REC]
-           ++ PROVE_TAC []],
+           >- PROVE_TAC [LENGTH_APPEND, LENGTH_SEL_REC, ADD_COMM]
+           >> RW_TAC std_ss []
+           >> Q.PAT_X_ASSUM `X = Y` MP_TAC
+           >> Q.PAT_X_ASSUM `X = Y` (K ALL_TAC)
+           >> RW_TAC arith_ss [SEL_REC_SPLIT, APPEND_LENGTH_EQ, LENGTH_SEL_REC]
+           >> PROVE_TAC []],
        RW_TAC std_ss []
-       ++ Know `n <= n' \/ n' <= n` >> DECIDE_TAC
-       ++ REWRITE_TAC [LESS_EQ_EXISTS]
-       ++ DISCH_THEN (STRIP_ASSUME_TAC o GSYM)
-       << [Q.EXISTS_TAC `n'`
-           ++ REVERSE CONJ_TAC >> PROVE_TAC [APPEND_NIL]
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC arith_ss [SEL_REC_SPLIT]
-           ++ PROVE_TAC [APPEND_LENGTH_EQ, LENGTH_SEL_REC],
+       >> Know `n <= n' \/ n' <= n` >- DECIDE_TAC
+       >> REWRITE_TAC [LESS_EQ_EXISTS]
+       >> DISCH_THEN (STRIP_ASSUME_TAC o GSYM)
+       >| [Q.EXISTS_TAC `n'`
+           >> REVERSE CONJ_TAC >- PROVE_TAC [APPEND_NIL]
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC arith_ss [SEL_REC_SPLIT]
+           >> PROVE_TAC [APPEND_LENGTH_EQ, LENGTH_SEL_REC],
            Q.EXISTS_TAC `n`
-           ++ CONJ_TAC >> PROVE_TAC [APPEND_NIL]
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC arith_ss [SEL_REC_SPLIT]
-           ++ PROVE_TAC [APPEND_LENGTH_EQ, LENGTH_SEL_REC]]]);
+           >> CONJ_TAC >- PROVE_TAC [APPEND_NIL]
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC arith_ss [SEL_REC_SPLIT]
+           >> PROVE_TAC [APPEND_LENGTH_EQ, LENGTH_SEL_REC]]]);
 
 val S_CAT_SEL_REC = store_thm
   ("S_CAT_SEL_REC",
@@ -876,22 +872,22 @@ val S_CAT_SEL_REC = store_thm
        (?m. US_SEM (SEL_REC m 0 p) s /\
             ?n. US_SEM (SEL_REC n 0 (RESTN p m)) t)``,
    RW_TAC std_ss [US_SEM_def]
-   ++ EQ_TAC
-   << [RW_TAC std_ss []
-       ++ Know `n = LENGTH w2 + LENGTH w1`
-       >> PROVE_TAC [LENGTH_SEL_REC, LENGTH_APPEND, ADD_COMM]
-       ++ RW_TAC std_ss []
-       ++ FULL_SIMP_TAC arith_ss
+   >> EQ_TAC
+   >| [RW_TAC std_ss []
+       >> Know `n = LENGTH w2 + LENGTH w1`
+       >- PROVE_TAC [LENGTH_SEL_REC, LENGTH_APPEND, ADD_COMM]
+       >> RW_TAC std_ss []
+       >> FULL_SIMP_TAC arith_ss
           [SEL_REC_SPLIT, APPEND_LENGTH_EQ, LENGTH_SEL_REC]
-       ++ Q.EXISTS_TAC `LENGTH w1`
-       ++ RW_TAC std_ss []
-       ++ Q.EXISTS_TAC `LENGTH w2`
-       ++ RW_TAC arith_ss [SEL_REC_RESTN],
+       >> Q.EXISTS_TAC `LENGTH w1`
+       >> RW_TAC std_ss []
+       >> Q.EXISTS_TAC `LENGTH w2`
+       >> RW_TAC arith_ss [SEL_REC_RESTN],
        RW_TAC std_ss []
-       ++ Q.EXISTS_TAC `n + m`
-       ++ Q.EXISTS_TAC `SEL_REC m 0 p`
-       ++ Q.EXISTS_TAC `SEL_REC n 0 (RESTN p m)`
-       ++ RW_TAC arith_ss [SEL_REC_SPLIT, SEL_REC_RESTN]]);
+       >> Q.EXISTS_TAC `n + m`
+       >> Q.EXISTS_TAC `SEL_REC m 0 p`
+       >> Q.EXISTS_TAC `SEL_REC n 0 (RESTN p m)`
+       >> RW_TAC arith_ss [SEL_REC_SPLIT, SEL_REC_RESTN]]);
 
 val S_FUSION_SEL_REC = store_thm
   ("S_FUSION_SEL_REC",
@@ -900,40 +896,40 @@ val S_FUSION_SEL_REC = store_thm
        (?m. US_SEM (SEL_REC (m + 1) 0 p) s /\
             ?n. US_SEM (SEL_REC (n + 1) 0 (RESTN p m)) t)``,
    RW_TAC std_ss [US_SEM_def]
-   ++ EQ_TAC
-   << [RW_TAC std_ss []
-       ++ Know `n = LENGTH w2 + LENGTH [l] + LENGTH w1`
-       >> METIS_TAC [LENGTH_SEL_REC, LENGTH_APPEND, ADD_COMM, ADD_ASSOC]
-       ++ RW_TAC std_ss []
-       ++ Q.PAT_ASSUM `X = Y`
+   >> EQ_TAC
+   >| [RW_TAC std_ss []
+       >> Know `n = LENGTH w2 + LENGTH [l] + LENGTH w1`
+       >- METIS_TAC [LENGTH_SEL_REC, LENGTH_APPEND, ADD_COMM, ADD_ASSOC]
+       >> RW_TAC std_ss []
+       >> Q.PAT_X_ASSUM `X = Y`
           (MP_TAC o SIMP_RULE arith_ss
            [SEL_REC_SPLIT, APPEND_LENGTH_EQ, LENGTH_SEL_REC, APPEND_ASSOC,
             LENGTH_APPEND])
-       ++ RW_TAC std_ss [LENGTH]
-       ++ Q.EXISTS_TAC `LENGTH w1`
-       ++ CONJ_TAC
-       >> (ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC arith_ss [SEL_REC_SPLIT])
-       ++ Q.EXISTS_TAC `LENGTH w2`
-       ++ RW_TAC arith_ss [SEL_REC_RESTN]
-       ++ RW_TAC arith_ss [SEL_REC_SPLIT],
+       >> RW_TAC std_ss [LENGTH]
+       >> Q.EXISTS_TAC `LENGTH w1`
+       >> CONJ_TAC
+       >- (ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC arith_ss [SEL_REC_SPLIT])
+       >> Q.EXISTS_TAC `LENGTH w2`
+       >> RW_TAC arith_ss [SEL_REC_RESTN]
+       >> RW_TAC arith_ss [SEL_REC_SPLIT],
        RW_TAC std_ss []
-       ++ Q.EXISTS_TAC `n + 1 + m`
-       ++ Q.EXISTS_TAC `SEL_REC m 0 p`
-       ++ Q.EXISTS_TAC `SEL_REC n 0 (RESTN p (m + 1))`
-       ++ Q.EXISTS_TAC `ELEM p m`
-       ++ ASM_SIMP_TAC arith_ss [APPEND_11, SEL_REC_SPLIT, GSYM APPEND_ASSOC]
-       ++ Know `[ELEM p m] = SEL_REC 1 0 (RESTN p m)`
-       >> RW_TAC bool_ss [ELEM_def, SEL_REC_def, ONE]
-       ++ DISCH_THEN (fn th => REWRITE_TAC [th])
-       ++ CONJ_TAC >> RW_TAC arith_ss [SEL_REC_RESTN]
-       ++ CONJ_TAC
-       >> (Q.PAT_ASSUM `US_SEM X s` MP_TAC
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC arith_ss [SEL_REC_RESTN, SEL_REC_SPLIT])
-       ++ POP_ASSUM MP_TAC
-       ++ SIMP_TAC arith_ss [SEL_REC_SPLIT]
-       ++ RW_TAC arith_ss [SEL_REC_RESTN]]);
+       >> Q.EXISTS_TAC `n + 1 + m`
+       >> Q.EXISTS_TAC `SEL_REC m 0 p`
+       >> Q.EXISTS_TAC `SEL_REC n 0 (RESTN p (m + 1))`
+       >> Q.EXISTS_TAC `ELEM p m`
+       >> ASM_SIMP_TAC arith_ss [APPEND_11, SEL_REC_SPLIT, GSYM APPEND_ASSOC]
+       >> Know `[ELEM p m] = SEL_REC 1 0 (RESTN p m)`
+       >- RW_TAC bool_ss [ELEM_def, SEL_REC_def, ONE]
+       >> DISCH_THEN (fn th => REWRITE_TAC [th])
+       >> CONJ_TAC >- RW_TAC arith_ss [SEL_REC_RESTN]
+       >> CONJ_TAC
+       >- (Q.PAT_X_ASSUM `US_SEM X s` MP_TAC
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC arith_ss [SEL_REC_RESTN, SEL_REC_SPLIT])
+       >> POP_ASSUM MP_TAC
+       >> SIMP_TAC arith_ss [SEL_REC_SPLIT]
+       >> RW_TAC arith_ss [SEL_REC_RESTN]]);
 
 val S_CAT_SEL_REC0 = store_thm
   ("S_CAT_SEL_REC0",
@@ -944,60 +940,60 @@ val S_CAT_SEL_REC0 = store_thm
          US_SEM (SEL_REC m 0 p) s /\
          US_SEM (SEL_REC (n - m) 0 (RESTN p m)) t)``,
    RW_TAC std_ss [US_SEM_def]
-   ++ EQ_TAC
-   << [RW_TAC std_ss []
-       ++ Know `n = LENGTH w2 + LENGTH w1`
-       >> PROVE_TAC [LENGTH_SEL_REC, LENGTH_APPEND, ADD_COMM]
-       ++ RW_TAC std_ss []
-       ++ FULL_SIMP_TAC arith_ss
+   >> EQ_TAC
+   >| [RW_TAC std_ss []
+       >> Know `n = LENGTH w2 + LENGTH w1`
+       >- PROVE_TAC [LENGTH_SEL_REC, LENGTH_APPEND, ADD_COMM]
+       >> RW_TAC std_ss []
+       >> FULL_SIMP_TAC arith_ss
             [SEL_REC_SPLIT, APPEND_LENGTH_EQ, LENGTH_SEL_REC]
-       ++ Q.EXISTS_TAC `LENGTH w1`
-       ++ RW_TAC arith_ss []
-       ++ RW_TAC arith_ss [SEL_REC_RESTN],
+       >> Q.EXISTS_TAC `LENGTH w1`
+       >> RW_TAC arith_ss []
+       >> RW_TAC arith_ss [SEL_REC_RESTN],
        RW_TAC std_ss []
-       ++ Q.EXISTS_TAC `SEL_REC m 0 p`
-       ++ Q.EXISTS_TAC `SEL_REC (n - m) 0 (RESTN p m)`
-       ++ RW_TAC arith_ss [SEL_REC_RESTN]
-       ++ MP_TAC (Q.SPECL [`p`, `n - m`, `m`, `0`]
+       >> Q.EXISTS_TAC `SEL_REC m 0 p`
+       >> Q.EXISTS_TAC `SEL_REC (n - m) 0 (RESTN p m)`
+       >> RW_TAC arith_ss [SEL_REC_RESTN]
+       >> MP_TAC (Q.SPECL [`p`, `n - m`, `m`, `0`]
                   (GEN_ALL (INST_TYPE [alpha |-> ``:'a -> bool``]
                             (GSYM SEL_REC_SPLIT))))
-       ++ RW_TAC arith_ss []]);
+       >> RW_TAC arith_ss []]);
 
 val RESTN_CAT = store_thm
   ("RESTN_CAT",
    ``!l p n. (LENGTH l = n) ==> (RESTN (CAT (l,p)) n = p)``,
    Induct
-   ++ RW_TAC std_ss [CAT_def, LENGTH]
-   ++ RW_TAC std_ss [RESTN_def, REST_CONS]);
+   >> RW_TAC std_ss [CAT_def, LENGTH]
+   >> RW_TAC std_ss [RESTN_def, REST_CONS]);
 
 val CONS_HEAD_REST = store_thm
   ("CONS_HEAD_REST",
    ``!p. LENGTH p > 0 ==> (CONS (HEAD p, REST p) = p)``,
    Cases
-   ++ RW_TAC arith_ss [LENGTH_def, GT, REST_def, CONS_def, HEAD_def, FUN_EQ_THM]
-   ++ PROVE_TAC [CONS, LENGTH_NOT_NULL, GREATER_DEF]);
+   >> RW_TAC arith_ss [LENGTH_def, GT, REST_def, CONS_def, HEAD_def, FUN_EQ_THM]
+   >> PROVE_TAC [CONS, LENGTH_NOT_NULL, GREATER_DEF]);
 
 val CAT_SEL_REC_RESTN = store_thm
   ("CAT_SEL_REC_RESTN",
    ``!n p. IS_INFINITE p ==> (CAT (SEL_REC n 0 p, RESTN p n) = p)``,
    Induct
-   ++ RW_TAC std_ss [CAT_def, SEL_REC_def, RESTN_def, IS_INFINITE_REST]
-   ++ PROVE_TAC [CONS_HEAD_REST, GT, LENGTH_def, IS_INFINITE_EXISTS]);
+   >> RW_TAC std_ss [CAT_def, SEL_REC_def, RESTN_def, IS_INFINITE_REST]
+   >> PROVE_TAC [CONS_HEAD_REST, GT, LENGTH_def, IS_INFINITE_EXISTS]);
 
 val SEL_REC_CAT_0 = store_thm
   ("SEL_REC_CAT_0",
    ``!n l p. (LENGTH l = n) ==> (SEL_REC n 0 (CAT (l,p)) = l)``,
    Induct_on `l`
-   ++ RW_TAC std_ss [LENGTH]
-   ++ RW_TAC std_ss [SEL_REC_def, CAT_def, HEAD_CONS, REST_CONS]);
+   >> RW_TAC std_ss [LENGTH]
+   >> RW_TAC std_ss [SEL_REC_def, CAT_def, HEAD_CONS, REST_CONS]);
 
 val SEL_REC_CAT = store_thm
   ("SEL_REC_CAT",
    ``!n m l p. (LENGTH l = n) ==> (SEL_REC m n (CAT (l,p)) = SEL_REC m 0 p)``,
    Induct_on `l`
-   ++ RW_TAC std_ss [LENGTH]
-   ++ Cases_on `m`
-   ++ RW_TAC std_ss [SEL_REC_def, CAT_def, HEAD_CONS, REST_CONS]);
+   >> RW_TAC std_ss [LENGTH]
+   >> Cases_on `m`
+   >> RW_TAC std_ss [SEL_REC_def, CAT_def, HEAD_CONS, REST_CONS]);
 
 val UF_SEM_F_W_ALT = store_thm
   ("UF_SEM_F_W_ALT",
@@ -1006,46 +1002,46 @@ val UF_SEM_F_W_ALT = store_thm
        !j :: 0 to LENGTH w.
          ~UF_SEM (RESTN w j) f ==> ?k :: 0 to SUC j. UF_SEM (RESTN w k) g``,
    RW_TAC std_ss []
-   ++ (Cases_on `w`
-       ++ RW_TAC arith_resq_ss
+   >> (Cases_on `w` (* 2 subgoals *)
+       >> RW_TAC arith_resq_ss
             [UF_SEM_F_W, UF_SEM_def, UF_SEM_F_G, xnum_to_def]
-       ++ Know `!m n. (m:num) < SUC n = m <= n` >> DECIDE_TAC
-       ++ DISCH_THEN (fn th => REWRITE_TAC [th]))
-   << [REVERSE EQ_TAC
-       >> (RW_TAC std_ss []
-           ++ MATCH_MP_TAC (PROVE [] ``(~b ==> a) ==> a \/ b``)
-           ++ SIMP_TAC std_ss []
-           ++ DISCH_THEN (MP_TAC o HO_MATCH_MP LEAST_EXISTS_IMP)
-           ++ Q.SPEC_TAC
+       >> `!m n. (m:num) < SUC n = m <= n` by DECIDE_TAC
+       >> ASM_REWRITE_TAC [])
+   >| [REVERSE EQ_TAC
+       >- (RW_TAC std_ss []
+           >> MATCH_MP_TAC (PROVE [] ``(~b ==> a) ==> a \/ b``)
+           >> SIMP_TAC std_ss []
+           >> DISCH_THEN (MP_TAC o HO_MATCH_MP LEAST_EXISTS_IMP)
+           >> Q.SPEC_TAC
               (`LEAST i. i < LENGTH l /\ ~UF_SEM (RESTN (FINITE l) i) f`,`i`)
-           ++ RW_TAC arith_ss [GSYM AND_IMP_INTRO]
-           ++ Q.PAT_ASSUM `!j. P j ==> Q j ==> R j` (MP_TAC o Q.SPEC `i`)
-           ++ RW_TAC arith_ss []
-           ++ Q.EXISTS_TAC `k`
-           ++ RW_TAC arith_ss [])
-       ++ RW_TAC std_ss []
-       >> (Q.EXISTS_TAC `k`
-           ++ RW_TAC arith_ss []
-           ++ Know `!m n. (m:num) <= (n:num) \/ n < m` >> DECIDE_TAC
-           ++ METIS_TAC [])
-       ++ METIS_TAC [],
+           >> RW_TAC arith_ss [GSYM AND_IMP_INTRO]
+           >> Q.PAT_X_ASSUM `!j. P j ==> Q j ==> R j` (MP_TAC o Q.SPEC `i`)
+           >> RW_TAC arith_ss []
+           >> Q.EXISTS_TAC `k`
+           >> RW_TAC arith_ss [])
+       >> RW_TAC std_ss []
+       >- (Q.EXISTS_TAC `k`
+           >> RW_TAC arith_ss []
+           >> Know `!m n. (m:num) <= (n:num) \/ n < m` >- DECIDE_TAC
+           >> METIS_TAC [])
+       >> METIS_TAC [],
        REVERSE EQ_TAC
-       >> (RW_TAC std_ss []
-           ++ MATCH_MP_TAC (PROVE [] ``(~b ==> a) ==> a \/ b``)
-           ++ SIMP_TAC std_ss []
-           ++ DISCH_THEN (MP_TAC o HO_MATCH_MP LEAST_EXISTS_IMP)
-           ++ Q.SPEC_TAC (`LEAST i. ~UF_SEM (RESTN (INFINITE f') i) f`,`i`)
-           ++ RW_TAC arith_ss []
-           ++ Q.PAT_ASSUM `!j. P j ==> ?k. Q j k` (MP_TAC o Q.SPEC `i`)
-           ++ RW_TAC arith_ss []
-           ++ Q.EXISTS_TAC `k`
-           ++ RW_TAC arith_ss [])
-       ++ RW_TAC std_ss []
-       >> (Q.EXISTS_TAC `k`
-           ++ RW_TAC arith_ss []
-           ++ Know `!m n. (m:num) <= (n:num) \/ n < m` >> DECIDE_TAC
-           ++ METIS_TAC [])
-       ++ METIS_TAC []]);
+       >- (RW_TAC std_ss []
+           >> MATCH_MP_TAC (PROVE [] ``(~b ==> a) ==> a \/ b``)
+           >> SIMP_TAC std_ss []
+           >> DISCH_THEN (MP_TAC o HO_MATCH_MP LEAST_EXISTS_IMP)
+           >> Q.SPEC_TAC (`LEAST i. ~UF_SEM (RESTN (INFINITE f') i) f`,`i`)
+           >> RW_TAC arith_ss []
+           >> Q.PAT_X_ASSUM `!j. P j ==> ?k. Q j k` (MP_TAC o Q.SPEC `i`)
+           >> RW_TAC arith_ss []
+           >> Q.EXISTS_TAC `k`
+           >> RW_TAC arith_ss [])
+       >> RW_TAC std_ss []
+       >- (Q.EXISTS_TAC `k`
+           >> RW_TAC arith_ss []
+           >> Know `!m n. (m:num) <= (n:num) \/ n < m` >- DECIDE_TAC
+           >> METIS_TAC [])
+       >> METIS_TAC []]);
 
 val UF_SEM_WEAK_UNTIL = store_thm
   ("UF_SEM_WEAK_UNTIL",
@@ -1064,8 +1060,8 @@ val CAT_SEL_REC_RESTN = store_thm
   ("CAT_SEL_REC_RESTN",
    ``!n p. IS_INFINITE p ==> (CAT (SEL_REC n 0 p, RESTN p n) = p)``,
    Induct
-   ++ RW_TAC std_ss [SEL_REC_def, RESTN_def, CAT_def, IS_INFINITE_REST]
-   ++ PROVE_TAC [CONS_HEAD_REST, LENGTH_IS_INFINITE, GT]);
+   >> RW_TAC std_ss [SEL_REC_def, RESTN_def, CAT_def, IS_INFINITE_REST]
+   >> PROVE_TAC [CONS_HEAD_REST, LENGTH_IS_INFINITE, GT]);
 
 (* Safety violations *)
 
@@ -1079,8 +1075,8 @@ val safety_violation_alt = store_thm
        safety_violation p f =
        ?n. !w. ~UF_SEM (CAT (SEL_REC n 0 p, INFINITE w)) f``,
    REPEAT STRIP_TAC
-   ++ REWRITE_TAC [safety_violation_def]
-   ++ PROVE_TAC [IS_INFINITE_EXISTS, path_nchotomy, IS_INFINITE_def]);
+   >> REWRITE_TAC [safety_violation_def]
+   >> PROVE_TAC [IS_INFINITE_EXISTS, path_nchotomy, IS_INFINITE_def]);
 
 val safety_violation = store_thm
   ("safety_violation",
@@ -1088,13 +1084,13 @@ val safety_violation = store_thm
        safety_violation p f =
        ?n. !q. IS_INFINITE q ==> ~UF_SEM (CAT (SEL p (0,n), q)) f``,
    REPEAT STRIP_TAC
-   ++ SIMP_TAC arith_ss [safety_violation_def, SEL_def]
-   ++ REVERSE EQ_TAC >> PROVE_TAC []
-   ++ STRIP_TAC
-   ++ POP_ASSUM MP_TAC
-   ++ REVERSE (Cases_on `n`) >> PROVE_TAC [ADD1]
-   ++ SIMP_TAC std_ss [SEL_REC_def, CAT_def]
-   ++ PROVE_TAC [IS_INFINITE_CAT]);
+   >> SIMP_TAC arith_ss [safety_violation_def, SEL_def]
+   >> REVERSE EQ_TAC >- PROVE_TAC []
+   >> STRIP_TAC
+   >> POP_ASSUM MP_TAC
+   >> REVERSE (Cases_on `n`) >- PROVE_TAC [ADD1]
+   >> SIMP_TAC std_ss [SEL_REC_def, CAT_def]
+   >> PROVE_TAC [IS_INFINITE_CAT]);
 
 val safety_violation_aux = store_thm
   ("safety_violation_aux",
@@ -1102,18 +1098,18 @@ val safety_violation_aux = store_thm
        safety_violation p f =
        ?n. !w. ~UF_SEM (CAT (SEL p (0,n), INFINITE w)) f``,
    REPEAT STRIP_TAC
-   ++ REWRITE_TAC [safety_violation]
-   ++ PROVE_TAC [IS_INFINITE_EXISTS, path_nchotomy, IS_INFINITE_def]);
+   >> REWRITE_TAC [safety_violation]
+   >> PROVE_TAC [IS_INFINITE_EXISTS, path_nchotomy, IS_INFINITE_def]);
 
 val safety_violation_refl = store_thm
   ("safety_violation_refl",
    ``!p f. IS_INFINITE p /\ safety_violation p f ==> ~UF_SEM p f``,
    RW_TAC std_ss [safety_violation_alt]
-   ++ MP_TAC (Q.SPECL [`n`, `p`]
+   >> MP_TAC (Q.SPECL [`n`, `p`]
               (INST_TYPE [alpha |-> ``:'a->bool``] CAT_SEL_REC_RESTN))
-   ++ ASM_REWRITE_TAC []
-   ++ DISCH_THEN (fn th => ONCE_REWRITE_TAC [GSYM th])
-   ++ PROVE_TAC [IS_INFINITE_EXISTS, IS_INFINITE_RESTN]);
+   >> ASM_REWRITE_TAC []
+   >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [GSYM th])
+   >> PROVE_TAC [IS_INFINITE_EXISTS, IS_INFINITE_RESTN]);
 
 val safety_violation_NOT_NOT = store_thm
   ("safety_violation_NOT_NOT",
@@ -1176,10 +1172,10 @@ val boolean_simple = store_thm
   ("boolean_simple",
    ``!f. boolean f ==> simple f /\ simple (F_NOT f)``,
    (INDUCT_THEN fl_induct ASSUME_TAC
-    ++ RW_TAC std_ss [boolean_def, simple_def])
-   ++ (Cases_on `f` ++ RW_TAC std_ss [simple_def])
-   ++ (Cases_on `f''` ++ RW_TAC std_ss [simple_def])
-   ++ FULL_SIMP_TAC std_ss [boolean_def]);
+    >> RW_TAC std_ss [boolean_def, simple_def])
+   >> (Cases_on `f` >> RW_TAC std_ss [simple_def])
+   >> (Cases_on `f''` >> RW_TAC std_ss [simple_def])
+   >> FULL_SIMP_TAC std_ss [boolean_def]);
 
 val UF_SEM_boolean = store_thm
   ("UF_SEM_boolean",
@@ -1187,7 +1183,7 @@ val UF_SEM_boolean = store_thm
        boolean f /\ LENGTH p > 0 ==>
        (UF_SEM (FINITE [ELEM p 0]) f = UF_SEM p f)``,
    INDUCT_THEN fl_induct ASSUME_TAC
-   ++ RW_TAC std_ss
+   >> RW_TAC std_ss
       [boolean_def, UF_SEM_def, LENGTH, ELEM_def,
        RESTN_def, GT, LENGTH_SEL, LENGTH_def, HEAD_def, HD]);
 
@@ -1197,18 +1193,18 @@ val boolean_safety_violation = store_thm
        boolean f /\ IS_INFINITE p ==>
        (safety_violation p f = ~UF_SEM (FINITE [ELEM p 0]) f)``,
    GEN_TAC
-   ++ Know `!P : num -> (num -> 'a -> bool) -> ('a -> bool) path.
+   >> Know `!P : num -> (num -> 'a -> bool) -> ('a -> bool) path.
               (!n w. LENGTH (P n w) > 0) ==>
               !f. boolean f ==>
                 !n w. ~UF_SEM (P n w) f = ~UF_SEM (FINITE [ELEM (P n w) 0]) f`
-   >> (RW_TAC std_ss [] ++ PROVE_TAC [UF_SEM_boolean])
-   ++ DISCH_THEN (MP_TAC o Q.SPEC `\n w. CAT (SEL p (0,n), INFINITE w)`)
-   ++ MATCH_MP_TAC (PROVE [] ``a /\ (b ==> c) ==> (a ==> b) ==> c``)
-   ++ CONJ_TAC >> RW_TAC std_ss [LENGTH_def, LENGTH_CAT, GT]
-   ++ BETA_TAC
-   ++ STRIP_TAC
-   ++ INDUCT_THEN fl_induct (K ALL_TAC)
-   ++ RW_TAC std_ss [boolean_def, safety_violation_aux, ELEM_CAT_SEL]);
+   >- (RW_TAC std_ss [] >> PROVE_TAC [UF_SEM_boolean])
+   >> DISCH_THEN (MP_TAC o Q.SPEC `\n w. CAT (SEL p (0,n), INFINITE w)`)
+   >> MATCH_MP_TAC (PROVE [] ``a /\ (b ==> c) ==> (a ==> b) ==> c``)
+   >> CONJ_TAC >- RW_TAC std_ss [LENGTH_def, LENGTH_CAT, GT]
+   >> BETA_TAC
+   >> STRIP_TAC
+   >> INDUCT_THEN fl_induct (K ALL_TAC)
+   >> RW_TAC std_ss [boolean_def, safety_violation_aux, ELEM_CAT_SEL]);
 
 (* The basic constraint on simple formulas *)
 
@@ -1216,345 +1212,345 @@ val simple_safety = store_thm
   ("simple_safety",
    ``!f p. simple f /\ IS_INFINITE p ==> (safety_violation p f = ~UF_SEM p f)``,
    RW_TAC std_ss []
-   ++ EQ_TAC >> METIS_TAC [safety_violation_refl]
-   ++ REPEAT (POP_ASSUM MP_TAC)
-   ++ SIMP_TAC std_ss [AND_IMP_INTRO, GSYM CONJ_ASSOC]
-   ++ Q.SPEC_TAC (`p`,`p`)
-   ++ Q.SPEC_TAC (`f`,`f`)
-   ++ recInduct simple_ind
-   ++ (REPEAT CONJ_TAC
-       ++ TRY (ASM_SIMP_TAC std_ss [simple_def, boolean_def] ++ NO_TAC)
-       ++ SIMP_TAC std_ss [boolean_def]
-       ++ RW_TAC std_ss []
-       ++ Q.PAT_ASSUM `simple X` MP_TAC
-       ++ ONCE_REWRITE_TAC [simple_def]
-       ++ RW_TAC std_ss [boolean_def])
-   << [(* F_BOOL *)
-       Q.PAT_ASSUM `~UF_SEM X Y` MP_TAC
-       ++ RW_TAC std_ss [simple_def, safety_violation_alt, UF_SEM_def]
-       >> METIS_TAC [LENGTH_def, IS_INFINITE_EXISTS, GT]
-       ++ Q.EXISTS_TAC `1`
-       ++ RW_TAC bool_ss
+   >> EQ_TAC >- METIS_TAC [safety_violation_refl]
+   >> REPEAT (POP_ASSUM MP_TAC)
+   >> SIMP_TAC std_ss [AND_IMP_INTRO, GSYM CONJ_ASSOC]
+   >> Q.SPEC_TAC (`p`,`p`)
+   >> Q.SPEC_TAC (`f`,`f`)
+   >> recInduct simple_ind
+   >> (REPEAT CONJ_TAC
+       >> TRY (ASM_SIMP_TAC std_ss [simple_def, boolean_def] >> NO_TAC)
+       >> SIMP_TAC std_ss [boolean_def]
+       >> RW_TAC std_ss []
+       >> Q.PAT_X_ASSUM `simple X` MP_TAC
+       >> ONCE_REWRITE_TAC [simple_def]
+       >> RW_TAC std_ss [boolean_def])
+   >| [(* F_BOOL *)
+       Q.PAT_X_ASSUM `~UF_SEM X Y` MP_TAC
+       >> RW_TAC std_ss [simple_def, safety_violation_alt, UF_SEM_def]
+       >- METIS_TAC [LENGTH_def, IS_INFINITE_EXISTS, GT]
+       >> Q.EXISTS_TAC `1`
+       >> RW_TAC bool_ss
             [ONE, SEL_REC_def, CAT_def, ELEM_def, RESTN_def, HEAD_CONS]
-       ++ PROVE_TAC [ELEM_def, RESTN_def],
+       >> PROVE_TAC [ELEM_def, RESTN_def],
 
        (* F_NOT (F_NOT f) *)
        FULL_SIMP_TAC std_ss [safety_violation_NOT_NOT, UF_SEM_def],
 
        (* F_NOT (F_AND (F_NOT (F_UNTIL (f,g)), _)) *)
-       Q.PAT_ASSUM `~UF_SEM X Y` MP_TAC
-       ++ ASM_SIMP_TAC arith_resq_ss
+       Q.PAT_X_ASSUM `~UF_SEM X Y` MP_TAC
+       >> ASM_SIMP_TAC arith_resq_ss
            [safety_violation_alt, UF_SEM_WEAK_UNTIL, UF_SEM_F_W_ALT,
             xnum_to_def, LENGTH_CAT, LENGTH_IS_INFINITE]
-       ++ Know `!m n. (m:num) < SUC n = m <= n` >> DECIDE_TAC
-       ++ DISCH_THEN (fn th => REWRITE_TAC [th])
-       ++ SIMP_TAC arith_ss [GSYM IMP_DISJ_THM]
-       ++ RW_TAC std_ss []
-       ++ Q.PAT_ASSUM `!p. X p /\ Y p ==> Z p` (MP_TAC o Q.SPEC `RESTN p j`)
-       ++ RW_TAC arith_ss
+       >> Know `!m n. (m:num) < SUC n = m <= n` >- DECIDE_TAC
+       >> DISCH_THEN (fn th => REWRITE_TAC [th])
+       >> SIMP_TAC arith_ss [GSYM IMP_DISJ_THM]
+       >> RW_TAC std_ss []
+       >> Q.PAT_X_ASSUM `!p. X p /\ Y p ==> Z p` (MP_TAC o Q.SPEC `RESTN p j`)
+       >> RW_TAC arith_ss
             [IS_INFINITE_RESTN, safety_violation_alt, SEL_REC_RESTN]
-       ++ Q.EXISTS_TAC `SUC n + j`
-       ++ RW_TAC std_ss []
-       ++ Q.EXISTS_TAC `j`
-       ++ CONJ_TAC
-       >> (RW_TAC arith_ss
+       >> Q.EXISTS_TAC `SUC n + j`
+       >> RW_TAC std_ss []
+       >> Q.EXISTS_TAC `j`
+       >> CONJ_TAC
+       >- (RW_TAC arith_ss
              [SEL_REC_SPLIT, GSYM CAT_APPEND, RESTN_CAT, LENGTH_SEL_REC]
-           ++ RW_TAC bool_ss [ADD1]
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
-           ++ METIS_TAC [IS_INFINITE_EXISTS, IS_INFINITE_def, IS_INFINITE_CAT])
-       ++ RW_TAC std_ss []
-       ++ MP_TAC
+           >> RW_TAC bool_ss [ADD1]
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
+           >> METIS_TAC [IS_INFINITE_EXISTS, IS_INFINITE_def, IS_INFINITE_CAT])
+       >> RW_TAC std_ss []
+       >> MP_TAC
           (Q.SPECL [`g`,`RESTN (CAT (SEL_REC (SUC n + j) 0 p,INFINITE w)) k`]
            (GSYM UF_SEM_boolean))
-       ++ MATCH_MP_TAC (PROVE [] ``a /\ (b ==> c) ==> ((a ==> b) ==> c)``)
-       ++ CONJ_TAC
-       >> (RW_TAC std_ss []
-           ++ PROVE_TAC [LENGTH_IS_INFINITE, IS_INFINITE_def,
+       >> MATCH_MP_TAC (PROVE [] ``a /\ (b ==> c) ==> ((a ==> b) ==> c)``)
+       >> CONJ_TAC
+       >- (RW_TAC std_ss []
+           >> PROVE_TAC [LENGTH_IS_INFINITE, IS_INFINITE_def,
                          IS_INFINITE_RESTN, IS_INFINITE_CAT, GT])
-       ++ DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
-       ++ Q.PAT_ASSUM `!w. P w` (K ALL_TAC)
-       ++ Q.PAT_ASSUM `!w. P w` (MP_TAC o Q.SPEC `k`)
-       ++ ASM_SIMP_TAC std_ss []
-       ++ MP_TAC (Q.SPECL [`g`,`RESTN p k`] (GSYM UF_SEM_boolean))
-       ++ MATCH_MP_TAC (PROVE [] ``a /\ (b ==> c) ==> ((a ==> b) ==> c)``)
-       ++ CONJ_TAC
-       >> (RW_TAC std_ss []
-           ++ PROVE_TAC [LENGTH_IS_INFINITE, IS_INFINITE_def,
+       >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
+       >> Q.PAT_X_ASSUM `!w. P w` (K ALL_TAC)
+       >> Q.PAT_X_ASSUM `!w. P w` (MP_TAC o Q.SPEC `k`)
+       >> ASM_SIMP_TAC std_ss []
+       >> MP_TAC (Q.SPECL [`g`,`RESTN p k`] (GSYM UF_SEM_boolean))
+       >> MATCH_MP_TAC (PROVE [] ``a /\ (b ==> c) ==> ((a ==> b) ==> c)``)
+       >> CONJ_TAC
+       >- (RW_TAC std_ss []
+           >> PROVE_TAC [LENGTH_IS_INFINITE, IS_INFINITE_def,
                          IS_INFINITE_RESTN, IS_INFINITE_CAT, GT])
-       ++ DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
-       ++ MATCH_MP_TAC (PROVE [] ``(a = b) ==> (a ==> b)``)
-       ++ NTAC 6 (AP_TERM_TAC || AP_THM_TAC)
-       ++ RW_TAC arith_ss [ELEM_RESTN]
-       ++ RW_TAC arith_ss [ELEM_def]
-       ++ Know `k <= j + SUC n` >> DECIDE_TAC
-       ++ RW_TAC bool_ss [LESS_EQ_EXISTS]
-       ++ RW_TAC std_ss []
-       ++ ONCE_REWRITE_TAC [ADD_COMM]
-       ++ RW_TAC std_ss
+       >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
+       >> MATCH_MP_TAC (PROVE [] ``(a = b) ==> (a ==> b)``)
+       >> NTAC 6 (AP_TERM_TAC || AP_THM_TAC)
+       >> RW_TAC arith_ss [ELEM_RESTN]
+       >> RW_TAC arith_ss [ELEM_def]
+       >> Know `k <= j + SUC n` >- DECIDE_TAC
+       >> RW_TAC bool_ss [LESS_EQ_EXISTS]
+       >> RW_TAC std_ss []
+       >> ONCE_REWRITE_TAC [ADD_COMM]
+       >> RW_TAC std_ss
             [SEL_REC_SPLIT, GSYM CAT_APPEND, RESTN_CAT, LENGTH_SEL_REC]
-       ++ RW_TAC arith_ss []
-       ++ Cases_on `p'` >> FULL_SIMP_TAC arith_ss []
-       ++ RW_TAC std_ss [SEL_REC_SUC, CAT_def, HEAD_CONS, ELEM_def],
+       >> RW_TAC arith_ss []
+       >> Cases_on `p'` >- FULL_SIMP_TAC arith_ss []
+       >> RW_TAC std_ss [SEL_REC_SUC, CAT_def, HEAD_CONS, ELEM_def],
 
        (* F_NOT (F_AND (f,g)) *)
        RW_TAC std_ss [safety_violation_def]
-       ++ Q.PAT_ASSUM `~UF_SEM X Y` MP_TAC
-       ++ ONCE_REWRITE_TAC [UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
-       ++ ONCE_REWRITE_TAC [GSYM UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
-       ++ STRIP_TAC
-       ++ HO_MATCH_MP_TAC
+       >> Q.PAT_X_ASSUM `~UF_SEM X Y` MP_TAC
+       >> ONCE_REWRITE_TAC [UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
+       >> ONCE_REWRITE_TAC [GSYM UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
+       >> STRIP_TAC
+       >> HO_MATCH_MP_TAC
           (METIS_PROVE []
            ``!P Q R.
                (?n. (!q. P n q ==> Q n q) /\ (!q. P n q ==> R n q)) ==>
                ?n. (!q. P n q ==> Q n q /\ R n q)``)
-       ++ REPEAT (Q.PAT_ASSUM `!p. P p` (MP_TAC o Q.SPEC `p`))
-       ++ RW_TAC std_ss [safety_violation_def]
-       ++ Know `n <= n' \/ n' <= n` >> DECIDE_TAC
-       ++ RW_TAC std_ss [LESS_EQ_EXISTS]
-       << [Q.EXISTS_TAC `n + p'`
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
-           ++ METIS_TAC [IS_INFINITE_CAT],
+       >> REPEAT (Q.PAT_X_ASSUM `!p. P p` (MP_TAC o Q.SPEC `p`))
+       >> RW_TAC std_ss [safety_violation_def]
+       >> Know `n <= n' \/ n' <= n` >- DECIDE_TAC
+       >> RW_TAC std_ss [LESS_EQ_EXISTS]
+       >| [Q.EXISTS_TAC `n + p'`
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
+           >> METIS_TAC [IS_INFINITE_CAT],
            Q.EXISTS_TAC `n' + p'`
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
-           ++ METIS_TAC [IS_INFINITE_CAT]],
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
+           >> METIS_TAC [IS_INFINITE_CAT]],
        RW_TAC std_ss [safety_violation_def]
-       ++ Q.PAT_ASSUM `~UF_SEM X Y` MP_TAC
-       ++ ONCE_REWRITE_TAC [UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
-       ++ ONCE_REWRITE_TAC [GSYM UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
-       ++ STRIP_TAC
-       ++ HO_MATCH_MP_TAC
+       >> Q.PAT_X_ASSUM `~UF_SEM X Y` MP_TAC
+       >> ONCE_REWRITE_TAC [UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
+       >> ONCE_REWRITE_TAC [GSYM UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
+       >> STRIP_TAC
+       >> HO_MATCH_MP_TAC
           (METIS_PROVE []
            ``!P Q R.
                (?n. (!q. P n q ==> Q n q) /\ (!q. P n q ==> R n q)) ==>
                ?n. (!q. P n q ==> Q n q /\ R n q)``)
-       ++ REPEAT (Q.PAT_ASSUM `!p. P p` (MP_TAC o Q.SPEC `p`))
-       ++ RW_TAC std_ss [safety_violation_def]
-       ++ Know `n <= n' \/ n' <= n` >> DECIDE_TAC
-       ++ RW_TAC std_ss [LESS_EQ_EXISTS]
-       << [Q.EXISTS_TAC `n + p'`
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
-           ++ METIS_TAC [IS_INFINITE_CAT],
+       >> REPEAT (Q.PAT_X_ASSUM `!p. P p` (MP_TAC o Q.SPEC `p`))
+       >> RW_TAC std_ss [safety_violation_def]
+       >> Know `n <= n' \/ n' <= n` >- DECIDE_TAC
+       >> RW_TAC std_ss [LESS_EQ_EXISTS]
+       >| [Q.EXISTS_TAC `n + p'`
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
+           >> METIS_TAC [IS_INFINITE_CAT],
            Q.EXISTS_TAC `n' + p'`
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
-           ++ METIS_TAC [IS_INFINITE_CAT]],
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
+           >> METIS_TAC [IS_INFINITE_CAT]],
        RW_TAC std_ss [safety_violation_def]
-       ++ Q.PAT_ASSUM `~UF_SEM X Y` MP_TAC
-       ++ ONCE_REWRITE_TAC [UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
-       ++ ONCE_REWRITE_TAC [GSYM UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
-       ++ STRIP_TAC
-       ++ HO_MATCH_MP_TAC
+       >> Q.PAT_X_ASSUM `~UF_SEM X Y` MP_TAC
+       >> ONCE_REWRITE_TAC [UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
+       >> ONCE_REWRITE_TAC [GSYM UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
+       >> STRIP_TAC
+       >> HO_MATCH_MP_TAC
           (METIS_PROVE []
            ``!P Q R.
                (?n. (!q. P n q ==> Q n q) /\ (!q. P n q ==> R n q)) ==>
                ?n. (!q. P n q ==> Q n q /\ R n q)``)
-       ++ REPEAT (Q.PAT_ASSUM `!p. P p` (MP_TAC o Q.SPEC `p`))
-       ++ RW_TAC std_ss [safety_violation_def]
-       ++ Know `n <= n' \/ n' <= n` >> DECIDE_TAC
-       ++ RW_TAC std_ss [LESS_EQ_EXISTS]
-       << [Q.EXISTS_TAC `n + p'`
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
-           ++ METIS_TAC [IS_INFINITE_CAT],
+       >> REPEAT (Q.PAT_X_ASSUM `!p. P p` (MP_TAC o Q.SPEC `p`))
+       >> RW_TAC std_ss [safety_violation_def]
+       >> Know `n <= n' \/ n' <= n` >- DECIDE_TAC
+       >> RW_TAC std_ss [LESS_EQ_EXISTS]
+       >| [Q.EXISTS_TAC `n + p'`
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
+           >> METIS_TAC [IS_INFINITE_CAT],
            Q.EXISTS_TAC `n' + p'`
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
-           ++ METIS_TAC [IS_INFINITE_CAT]],
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
+           >> METIS_TAC [IS_INFINITE_CAT]],
        RW_TAC std_ss [safety_violation_def]
-       ++ Q.PAT_ASSUM `~UF_SEM X Y` MP_TAC
-       ++ ONCE_REWRITE_TAC [UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
-       ++ ONCE_REWRITE_TAC [GSYM UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
-       ++ STRIP_TAC
-       ++ HO_MATCH_MP_TAC
+       >> Q.PAT_X_ASSUM `~UF_SEM X Y` MP_TAC
+       >> ONCE_REWRITE_TAC [UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
+       >> ONCE_REWRITE_TAC [GSYM UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
+       >> STRIP_TAC
+       >> HO_MATCH_MP_TAC
           (METIS_PROVE []
            ``!P Q R.
                (?n. (!q. P n q ==> Q n q) /\ (!q. P n q ==> R n q)) ==>
                ?n. (!q. P n q ==> Q n q /\ R n q)``)
-       ++ REPEAT (Q.PAT_ASSUM `!p. P p` (MP_TAC o Q.SPEC `p`))
-       ++ RW_TAC std_ss [safety_violation_def]
-       ++ Know `n <= n' \/ n' <= n` >> DECIDE_TAC
-       ++ RW_TAC std_ss [LESS_EQ_EXISTS]
-       << [Q.EXISTS_TAC `n + p'`
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
-           ++ METIS_TAC [IS_INFINITE_CAT],
+       >> REPEAT (Q.PAT_X_ASSUM `!p. P p` (MP_TAC o Q.SPEC `p`))
+       >> RW_TAC std_ss [safety_violation_def]
+       >> Know `n <= n' \/ n' <= n` >- DECIDE_TAC
+       >> RW_TAC std_ss [LESS_EQ_EXISTS]
+       >| [Q.EXISTS_TAC `n + p'`
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
+           >> METIS_TAC [IS_INFINITE_CAT],
            Q.EXISTS_TAC `n' + p'`
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
-           ++ METIS_TAC [IS_INFINITE_CAT]],
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
+           >> METIS_TAC [IS_INFINITE_CAT]],
        RW_TAC std_ss [safety_violation_def]
-       ++ Q.PAT_ASSUM `~UF_SEM X Y` MP_TAC
-       ++ ONCE_REWRITE_TAC [UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
-       ++ ONCE_REWRITE_TAC [GSYM UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
-       ++ STRIP_TAC
-       ++ HO_MATCH_MP_TAC
+       >> Q.PAT_X_ASSUM `~UF_SEM X Y` MP_TAC
+       >> ONCE_REWRITE_TAC [UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
+       >> ONCE_REWRITE_TAC [GSYM UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
+       >> STRIP_TAC
+       >> HO_MATCH_MP_TAC
           (METIS_PROVE []
            ``!P Q R.
                (?n. (!q. P n q ==> Q n q) /\ (!q. P n q ==> R n q)) ==>
                ?n. (!q. P n q ==> Q n q /\ R n q)``)
-       ++ REPEAT (Q.PAT_ASSUM `!p. P p` (MP_TAC o Q.SPEC `p`))
-       ++ RW_TAC std_ss [safety_violation_def]
-       ++ Know `n <= n' \/ n' <= n` >> DECIDE_TAC
-       ++ RW_TAC std_ss [LESS_EQ_EXISTS]
-       << [Q.EXISTS_TAC `n + p'`
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
-           ++ METIS_TAC [IS_INFINITE_CAT],
+       >> REPEAT (Q.PAT_X_ASSUM `!p. P p` (MP_TAC o Q.SPEC `p`))
+       >> RW_TAC std_ss [safety_violation_def]
+       >> Know `n <= n' \/ n' <= n` >- DECIDE_TAC
+       >> RW_TAC std_ss [LESS_EQ_EXISTS]
+       >| [Q.EXISTS_TAC `n + p'`
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
+           >> METIS_TAC [IS_INFINITE_CAT],
            Q.EXISTS_TAC `n' + p'`
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
-           ++ METIS_TAC [IS_INFINITE_CAT]],
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
+           >> METIS_TAC [IS_INFINITE_CAT]],
        RW_TAC std_ss [safety_violation_def]
-       ++ Q.PAT_ASSUM `~UF_SEM X Y` MP_TAC
-       ++ ONCE_REWRITE_TAC [UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
-       ++ ONCE_REWRITE_TAC [GSYM UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
-       ++ STRIP_TAC
-       ++ HO_MATCH_MP_TAC
+       >> Q.PAT_X_ASSUM `~UF_SEM X Y` MP_TAC
+       >> ONCE_REWRITE_TAC [UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
+       >> ONCE_REWRITE_TAC [GSYM UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
+       >> STRIP_TAC
+       >> HO_MATCH_MP_TAC
           (METIS_PROVE []
            ``!P Q R.
                (?n. (!q. P n q ==> Q n q) /\ (!q. P n q ==> R n q)) ==>
                ?n. (!q. P n q ==> Q n q /\ R n q)``)
-       ++ REPEAT (Q.PAT_ASSUM `!p. P p` (MP_TAC o Q.SPEC `p`))
-       ++ RW_TAC std_ss [safety_violation_def]
-       ++ Know `n <= n' \/ n' <= n` >> DECIDE_TAC
-       ++ RW_TAC std_ss [LESS_EQ_EXISTS]
-       << [Q.EXISTS_TAC `n + p'`
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
-           ++ METIS_TAC [IS_INFINITE_CAT],
+       >> REPEAT (Q.PAT_X_ASSUM `!p. P p` (MP_TAC o Q.SPEC `p`))
+       >> RW_TAC std_ss [safety_violation_def]
+       >> Know `n <= n' \/ n' <= n` >- DECIDE_TAC
+       >> RW_TAC std_ss [LESS_EQ_EXISTS]
+       >| [Q.EXISTS_TAC `n + p'`
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
+           >> METIS_TAC [IS_INFINITE_CAT],
            Q.EXISTS_TAC `n' + p'`
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
-           ++ METIS_TAC [IS_INFINITE_CAT]],
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
+           >> METIS_TAC [IS_INFINITE_CAT]],
        RW_TAC std_ss [safety_violation_def]
-       ++ Q.PAT_ASSUM `~UF_SEM X Y` MP_TAC
-       ++ ONCE_REWRITE_TAC [UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
-       ++ ONCE_REWRITE_TAC [GSYM UF_SEM_def]
-       ++ PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
-       ++ STRIP_TAC
-       ++ HO_MATCH_MP_TAC
+       >> Q.PAT_X_ASSUM `~UF_SEM X Y` MP_TAC
+       >> ONCE_REWRITE_TAC [UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
+       >> ONCE_REWRITE_TAC [GSYM UF_SEM_def]
+       >> PURE_ONCE_REWRITE_TAC [DE_MORGAN_THM]
+       >> STRIP_TAC
+       >> HO_MATCH_MP_TAC
           (METIS_PROVE []
            ``!P Q R.
                (?n. (!q. P n q ==> Q n q) /\ (!q. P n q ==> R n q)) ==>
                ?n. (!q. P n q ==> Q n q /\ R n q)``)
-       ++ REPEAT (Q.PAT_ASSUM `!p. P p` (MP_TAC o Q.SPEC `p`))
-       ++ RW_TAC std_ss [safety_violation_def]
-       ++ Know `n <= n' \/ n' <= n` >> DECIDE_TAC
-       ++ RW_TAC std_ss [LESS_EQ_EXISTS]
-       << [Q.EXISTS_TAC `n + p'`
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
-           ++ METIS_TAC [IS_INFINITE_CAT],
+       >> REPEAT (Q.PAT_X_ASSUM `!p. P p` (MP_TAC o Q.SPEC `p`))
+       >> RW_TAC std_ss [safety_violation_def]
+       >> Know `n <= n' \/ n' <= n` >- DECIDE_TAC
+       >> RW_TAC std_ss [LESS_EQ_EXISTS]
+       >| [Q.EXISTS_TAC `n + p'`
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
+           >> METIS_TAC [IS_INFINITE_CAT],
            Q.EXISTS_TAC `n' + p'`
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
-           ++ METIS_TAC [IS_INFINITE_CAT]],
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC std_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
+           >> METIS_TAC [IS_INFINITE_CAT]],
 
        (* F_NOT (F_BOOL b) *)
        RW_TAC std_ss [safety_violation_alt]
-       ++ Q.EXISTS_TAC `1`
-       ++ POP_ASSUM MP_TAC
-       ++ RW_TAC bool_ss [ONE, SEL_REC_def, CAT_def, UF_SEM_def]
-       >> RW_TAC std_ss [LENGTH_def, CONS_def, GT]
-       ++ POP_ASSUM MP_TAC
-       ++ RW_TAC std_ss [ELEM_def, RESTN_def, HEAD_CONS],
+       >> Q.EXISTS_TAC `1`
+       >> POP_ASSUM MP_TAC
+       >> RW_TAC bool_ss [ONE, SEL_REC_def, CAT_def, UF_SEM_def]
+       >- RW_TAC std_ss [LENGTH_def, CONS_def, GT]
+       >> POP_ASSUM MP_TAC
+       >> RW_TAC std_ss [ELEM_def, RESTN_def, HEAD_CONS],
 
        (* F_AND (f,g) *)
        RW_TAC std_ss [safety_violation_alt]
-       ++ Q.PAT_ASSUM `~UF_SEM X Y` MP_TAC
-       ++ RW_TAC std_ss [UF_SEM_def]
-       << [Q.PAT_ASSUM `!p. P p` (K ALL_TAC)
-           ++ Q.PAT_ASSUM `!p. P p` (MP_TAC o Q.SPEC `p`)
-           ++ RW_TAC std_ss [safety_violation_alt]
-           ++ METIS_TAC [],
-           Q.PAT_ASSUM `!p. P p` (MP_TAC o Q.SPEC `p`)
-           ++ RW_TAC std_ss [safety_violation_alt]
-           ++ METIS_TAC []],
+       >> Q.PAT_X_ASSUM `~UF_SEM X Y` MP_TAC
+       >> RW_TAC std_ss [UF_SEM_def]
+       >| [Q.PAT_X_ASSUM `!p. P p` (K ALL_TAC)
+           >> Q.PAT_X_ASSUM `!p. P p` (MP_TAC o Q.SPEC `p`)
+           >> RW_TAC std_ss [safety_violation_alt]
+           >> METIS_TAC [],
+           Q.PAT_X_ASSUM `!p. P p` (MP_TAC o Q.SPEC `p`)
+           >> RW_TAC std_ss [safety_violation_alt]
+           >> METIS_TAC []],
 
        (* F_NEXT f *)
        RW_TAC std_ss [safety_violation_alt]
-       ++ Q.PAT_ASSUM `~UF_SEM X Y` MP_TAC
-       ++ RW_TAC std_ss [UF_SEM_def]
-       >> PROVE_TAC [LENGTH_IS_INFINITE, GT]
-       ++ Q.PAT_ASSUM `!p. P p` (MP_TAC o Q.SPEC `RESTN p 1`)
-       ++ RW_TAC std_ss [safety_violation_alt, IS_INFINITE_RESTN]
-       ++ Q.EXISTS_TAC `SUC n`
-       ++ RW_TAC std_ss []
-       ++ DISJ2_TAC
-       ++ RW_TAC bool_ss [ONE, SEL_REC_def, CAT_def, RESTN_def, REST_CONS]
-       ++ METIS_TAC [RESTN_def, ONE],
+       >> Q.PAT_X_ASSUM `~UF_SEM X Y` MP_TAC
+       >> RW_TAC std_ss [UF_SEM_def]
+       >- PROVE_TAC [LENGTH_IS_INFINITE, GT]
+       >> Q.PAT_X_ASSUM `!p. P p` (MP_TAC o Q.SPEC `RESTN p 1`)
+       >> RW_TAC std_ss [safety_violation_alt, IS_INFINITE_RESTN]
+       >> Q.EXISTS_TAC `SUC n`
+       >> RW_TAC std_ss []
+       >> DISJ2_TAC
+       >> RW_TAC bool_ss [ONE, SEL_REC_def, CAT_def, RESTN_def, REST_CONS]
+       >> METIS_TAC [RESTN_def, ONE],
 
        (* F_SUFFIX_IMP (r,f) *)
        RW_TAC std_ss [safety_violation_alt]
-       ++ Q.PAT_ASSUM `~UF_SEM X Y` MP_TAC
-       ++ RW_TAC arith_resq_ss
+       >> Q.PAT_X_ASSUM `~UF_SEM X Y` MP_TAC
+       >> RW_TAC arith_resq_ss
             [UF_SEM_def, xnum_to_def, LENGTH_CAT, LENGTH_IS_INFINITE, SEL_def]
-       ++ Q.PAT_ASSUM `!p. P p` (MP_TAC o Q.SPEC `RESTN p j`)
-       ++ RW_TAC std_ss [safety_violation_alt, IS_INFINITE_RESTN]
-       ++ Q.EXISTS_TAC `SUC n + j`
-       ++ RW_TAC std_ss []
-       ++ Q.EXISTS_TAC `j`
-       ++ REVERSE CONJ_TAC
-       >> (Q.PAT_ASSUM `!w. P w` MP_TAC
-           ++ RW_TAC arith_ss
+       >> Q.PAT_X_ASSUM `!p. P p` (MP_TAC o Q.SPEC `RESTN p j`)
+       >> RW_TAC std_ss [safety_violation_alt, IS_INFINITE_RESTN]
+       >> Q.EXISTS_TAC `SUC n + j`
+       >> RW_TAC std_ss []
+       >> Q.EXISTS_TAC `j`
+       >> REVERSE CONJ_TAC
+       >- (Q.PAT_X_ASSUM `!w. P w` MP_TAC
+           >> RW_TAC arith_ss
                 [SEL_REC_SPLIT, RESTN_CAT, LENGTH_SEL_REC, GSYM CAT_APPEND,
                  SEL_REC_RESTN]
-           ++ RW_TAC std_ss [ADD1]
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC arith_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
-           ++ METIS_TAC [IS_INFINITE_def, IS_INFINITE_CAT, IS_INFINITE_EXISTS])
-       ++ Q.PAT_ASSUM `US_SEM X Y` MP_TAC
-       ++ MATCH_MP_TAC (PROVE [] ``(a = b) ==> (a ==> b)``)
-       ++ AP_THM_TAC
-       ++ AP_TERM_TAC
-       ++ Know `SUC n + j = n + (j + 1)` >> DECIDE_TAC
-       ++ DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
-       ++ CONV_TAC (RAND_CONV (RAND_CONV (ONCE_REWRITE_CONV [SEL_REC_SPLIT])))
-       ++ RW_TAC arith_ss [GSYM CAT_APPEND]
-       ++ Q.SPEC_TAC (`CAT (SEL_REC n (j + 1) p,INFINITE w)`,`q`)
-       ++ Q.SPEC_TAC (`p`,`p`)
-       ++ Q.SPEC_TAC (`j + 1`,`j`)
-       ++ Induct
-       ++ RW_TAC std_ss [SEL_REC_def, CAT_def, HEAD_CONS, REST_CONS]
-       ++ PROVE_TAC []]);
+           >> RW_TAC std_ss [ADD1]
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC arith_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
+           >> METIS_TAC [IS_INFINITE_def, IS_INFINITE_CAT, IS_INFINITE_EXISTS])
+       >> Q.PAT_X_ASSUM `US_SEM X Y` MP_TAC
+       >> MATCH_MP_TAC (PROVE [] ``(a = b) ==> (a ==> b)``)
+       >> AP_THM_TAC
+       >> AP_TERM_TAC
+       >> Know `SUC n + j = n + (j + 1)` >- DECIDE_TAC
+       >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
+       >> CONV_TAC (RAND_CONV (RAND_CONV (ONCE_REWRITE_CONV [SEL_REC_SPLIT])))
+       >> RW_TAC arith_ss [GSYM CAT_APPEND]
+       >> Q.SPEC_TAC (`CAT (SEL_REC n (j + 1) p,INFINITE w)`,`q`)
+       >> Q.SPEC_TAC (`p`,`p`)
+       >> Q.SPEC_TAC (`j + 1`,`j`)
+       >> Induct
+       >> RW_TAC std_ss [SEL_REC_def, CAT_def, HEAD_CONS, REST_CONS]
+       >> PROVE_TAC []]);
 
 (* The regexp checker *)
 
@@ -1584,16 +1580,16 @@ val boolean_checker_CLOCK_FREE = store_thm
   ("boolean_checker_CLOCK_FREE",
    ``!f. boolean f ==> S_CLOCK_FREE (boolean_checker f)``,
    Induct
-   ++ RW_TAC std_ss [simple_def, S_CLOCK_FREE_def, boolean_checker_def]);
+   >> RW_TAC std_ss [simple_def, S_CLOCK_FREE_def, boolean_checker_def]);
 
 val boolean_checker_initially_ok = store_thm
   ("boolean_checker_initially_ok",
    ``!f. boolean f ==> ~US_SEM [] (boolean_checker f)``,
    recInduct simple_ind
-   ++ REPEAT CONJ_TAC
-   ++ RW_TAC arith_ss [boolean_def, boolean_checker_def, bool_checker_def]
-   ++ ONCE_REWRITE_TAC [US_SEM_def]
-   ++ RW_TAC arith_ss [listTheory.LENGTH]);
+   >> REPEAT CONJ_TAC
+   >> RW_TAC arith_ss [boolean_def, boolean_checker_def, bool_checker_def]
+   >> ONCE_REWRITE_TAC [US_SEM_def]
+   >> RW_TAC arith_ss [listTheory.LENGTH]);
 
 val boolean_checker = store_thm
   ("boolean_checker",
@@ -1605,9 +1601,9 @@ val boolean_checker = store_thm
      [amatch, GSYM sere2regexp, boolean_checker_CLOCK_FREE,
       boolean_safety_violation, boolean_checker_def, bool_checker_def,
       US_SEM_def, B_SEM, UF_SEM_def, LENGTH_SEL, ELEM_SEL]
-   ++ INDUCT_THEN fl_induct ASSUME_TAC
-   ++ REPEAT (POP_ASSUM MP_TAC)
-   ++ SIMP_TAC arith_ss
+   >> INDUCT_THEN fl_induct ASSUME_TAC
+   >> REPEAT (POP_ASSUM MP_TAC)
+   >> SIMP_TAC arith_ss
       [boolean_def, bool_checker_def, UF_SEM_def, LENGTH_def, HD,
        ELEM_def, GT, B_SEM_def, RESTN_def, HEAD_def, listTheory.LENGTH]);
 
@@ -1620,11 +1616,11 @@ val boolean_checker_SEL_REC = store_thm
    RW_TAC arith_ss
      [boolean_checker, SEL_def, amatch, GSYM sere2regexp,
       boolean_checker_CLOCK_FREE]
-   ++ EQ_TAC >> PROVE_TAC []
-   ++ STRIP_TAC
-   ++ POP_ASSUM MP_TAC
-   ++ REVERSE (Cases_on `n`) >> PROVE_TAC [ADD1]
-   ++ RW_TAC std_ss [SEL_REC_def, boolean_checker_initially_ok]);
+   >> EQ_TAC >- PROVE_TAC []
+   >> STRIP_TAC
+   >> POP_ASSUM MP_TAC
+   >> REVERSE (Cases_on `n`) >- PROVE_TAC [ADD1]
+   >> RW_TAC std_ss [SEL_REC_def, boolean_checker_initially_ok]);
 
 val boolean_checker_US_SEM = store_thm
   ("boolean_checker_US_SEM",
@@ -1642,9 +1638,9 @@ val US_SEM_boolean_checker = store_thm
        US_SEM w (boolean_checker f) =
        (?x. (w = [x]) /\ US_SEM [x] (boolean_checker f))``,
    RW_TAC std_ss [US_SEM_def, boolean_checker_def]
-   ++ Cases_on `w` >> RW_TAC std_ss [LENGTH]
-   ++ REVERSE (Cases_on `t`) >> RW_TAC bool_ss [LENGTH, ONE]
-   ++ RW_TAC std_ss []);
+   >> Cases_on `w` >- RW_TAC std_ss [LENGTH]
+   >> REVERSE (Cases_on `t`) >- RW_TAC bool_ss [LENGTH, ONE]
+   >> RW_TAC std_ss []);
 
 val US_SEM_boolean_checker_SEL_REC = store_thm
   ("US_SEM_boolean_checker_SEL_REC",
@@ -1652,19 +1648,19 @@ val US_SEM_boolean_checker_SEL_REC = store_thm
        US_SEM (SEL_REC n m p) (boolean_checker f) =
        (n = 1) /\ US_SEM (SEL_REC 1 m p) (boolean_checker f)``,
    RW_TAC std_ss []
-   ++ CONV_TAC (LAND_CONV (ONCE_REWRITE_CONV [US_SEM_boolean_checker]))
-   ++ Cases_on `n` >> RW_TAC std_ss [SEL_REC_def]
-   ++ EQ_TAC
-   << [STRIP_TAC
-       ++ MATCH_MP_TAC (PROVE [] ``(a ==> b) /\ a ==> a /\ b``)
-       ++ CONJ_TAC >> PROVE_TAC []
-       ++ METIS_TAC [LENGTH_SEL_REC, ONE, LENGTH],
+   >> CONV_TAC (LAND_CONV (ONCE_REWRITE_CONV [US_SEM_boolean_checker]))
+   >> Cases_on `n` >- RW_TAC std_ss [SEL_REC_def]
+   >> EQ_TAC
+   >| [STRIP_TAC
+       >> MATCH_MP_TAC (PROVE [] ``(a ==> b) /\ a ==> a /\ b``)
+       >> CONJ_TAC >- PROVE_TAC []
+       >> METIS_TAC [LENGTH_SEL_REC, ONE, LENGTH],
        RW_TAC bool_ss [ONE]
-       ++ Cases_on `SEL_REC (SUC 0) m p`
-       >> PROVE_TAC [LENGTH_SEL_REC, LENGTH, numTheory.NOT_SUC]
-       ++ Suff `t = []` >> PROVE_TAC []
-       ++ Cases_on `t` >> RW_TAC std_ss []
-       ++ PROVE_TAC [LENGTH_SEL_REC, LENGTH, numTheory.NOT_SUC,
+       >> Cases_on `SEL_REC (SUC 0) m p`
+       >- PROVE_TAC [LENGTH_SEL_REC, LENGTH, numTheory.NOT_SUC]
+       >> Suff `t = []` >- PROVE_TAC []
+       >> Cases_on `t` >- RW_TAC std_ss []
+       >> PROVE_TAC [LENGTH_SEL_REC, LENGTH, numTheory.NOT_SUC,
                      prim_recTheory.INV_SUC_EQ]]);
 
 val US_SEM_boolean_checker_CONJ = store_thm
@@ -1673,14 +1669,14 @@ val US_SEM_boolean_checker_CONJ = store_thm
        (?w. US_SEM w (boolean_checker f) /\ p w f) =
        (?x. US_SEM [x] (boolean_checker f) /\ p [x] f)``,
    RW_TAC std_ss [US_SEM_def, boolean_checker_def]
-   ++ MATCH_MP_TAC EQ_SYM
-   ++ MP_TAC
+   >> MATCH_MP_TAC EQ_SYM
+   >> MP_TAC
       (PROVE [list_CASES]
        ``!p q. (q = p [] \/ ?t (h : 'a -> bool). p (h::t)) ==> (q = ?l. p l)``)
-   ++ DISCH_THEN (fn th => HO_MATCH_MP_TAC th ++ ASSUME_TAC th)
-   ++ SIMP_TAC std_ss [LENGTH]
-   ++ POP_ASSUM HO_MATCH_MP_TAC
-   ++ RW_TAC arith_ss [LENGTH]);
+   >> DISCH_THEN (fn th => HO_MATCH_MP_TAC th >> ASSUME_TAC th)
+   >> SIMP_TAC std_ss [LENGTH]
+   >> POP_ASSUM HO_MATCH_MP_TAC
+   >> RW_TAC arith_ss [LENGTH]);
 
 val boolean_checker_US_SEM1 = store_thm
   ("boolean_checker_US_SEM1",
@@ -1688,32 +1684,32 @@ val boolean_checker_US_SEM1 = store_thm
        boolean f /\ IS_INFINITE p ==>
        (US_SEM (SEL_REC 1 0 p) (boolean_checker f) = ~UF_SEM p f)``,
    RW_TAC std_ss []
-   ++ MP_TAC (Q.SPECL [`f`, `p`] (GSYM boolean_checker_US_SEM))
-   ++ CONV_TAC (LAND_CONV (ONCE_REWRITE_CONV [US_SEM_boolean_checker_SEL_REC]))
-   ++ RW_TAC std_ss []
-   ++ RW_TAC std_ss [simple_safety, boolean_simple]);
+   >> MP_TAC (Q.SPECL [`f`, `p`] (GSYM boolean_checker_US_SEM))
+   >> CONV_TAC (LAND_CONV (ONCE_REWRITE_CONV [US_SEM_boolean_checker_SEL_REC]))
+   >> RW_TAC std_ss []
+   >> RW_TAC std_ss [simple_safety, boolean_simple]);
 
 val checker_initially_ok = store_thm
   ("checker_initially_ok",
    ``!f. simple f ==> ~US_SEM [] (checker f)``,
    recInduct simple_ind
-   ++ REPEAT CONJ_TAC
-   ++ RW_TAC arith_ss [simple_def, checker_def, boolean_checker_def,
+   >> REPEAT CONJ_TAC
+   >> RW_TAC arith_ss [simple_def, checker_def, boolean_checker_def,
                        bool_checker_def]
-   ++ ONCE_REWRITE_TAC [US_SEM_def]
-   ++ ONCE_REWRITE_TAC [US_SEM_def]
-   ++ RW_TAC arith_ss [listTheory.LENGTH, US_SEM_REPEAT_TRUE,
+   >> ONCE_REWRITE_TAC [US_SEM_def]
+   >> ONCE_REWRITE_TAC [US_SEM_def]
+   >> RW_TAC arith_ss [listTheory.LENGTH, US_SEM_REPEAT_TRUE,
                        listTheory.APPEND_eq_NIL, S_FLEX_AND_EMPTY]
-   ++ RW_TAC std_ss [US_SEM_def, S_TRUE_def, LENGTH]);
+   >> RW_TAC std_ss [US_SEM_def, S_TRUE_def, LENGTH]);
 
 val checker_CLOCK_FREE = store_thm
   ("checker_CLOCK_FREE",
    ``!f. simple f ==> S_CLOCK_FREE (checker f)``,
    recInduct simple_ind
-   ++ REPEAT CONJ_TAC
-   ++ RW_TAC std_ss [simple_def, S_CLOCK_FREE_def, checker_def, S_TRUE_def,
+   >> REPEAT CONJ_TAC
+   >> RW_TAC std_ss [simple_def, S_CLOCK_FREE_def, checker_def, S_TRUE_def,
                      boolean_checker_CLOCK_FREE, S_FLEX_AND_def, S_FALSE_def]
-   ++ PROVE_TAC [boolean_def, boolean_checker_CLOCK_FREE]);
+   >> PROVE_TAC [boolean_def, boolean_checker_CLOCK_FREE]);
 
 val checker_NOT_AND = store_thm
   ("checker_NOT_AND",
@@ -1733,21 +1729,21 @@ val checker_NOT_AND = store_thm
             US_SEM (SEL_REC n 0 p)
               (S_FLEX_AND (checker (F_NOT f),checker (F_NOT g))))``,
    RW_TAC std_ss [safety_violation_alt, UF_SEM_def, S_FLEX_AND]
-   ++ REPEAT (Q.PAT_ASSUM `!x. P x` (fn th => RW_TAC std_ss [GSYM th]))
-   ++ EQ_TAC >> PROVE_TAC []
-   ++ RW_TAC std_ss []
-   ++ Know `n <= n' \/ n' <= n` >> DECIDE_TAC
-   ++ RW_TAC std_ss [LESS_EQ_EXISTS]
-   << [Q.EXISTS_TAC `n + p'`
-       ++ RW_TAC std_ss []
-       ++ ONCE_REWRITE_TAC [ADD_COMM]
-       ++ RW_TAC arith_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
-       ++ PROVE_TAC [IS_INFINITE_CAT, IS_INFINITE_EXISTS],
+   >> REPEAT (Q.PAT_X_ASSUM `!x. P x` (fn th => RW_TAC std_ss [GSYM th]))
+   >> EQ_TAC >- PROVE_TAC []
+   >> RW_TAC std_ss []
+   >> Know `n <= n' \/ n' <= n` >- DECIDE_TAC
+   >> RW_TAC std_ss [LESS_EQ_EXISTS]
+   >| [Q.EXISTS_TAC `n + p'`
+       >> RW_TAC std_ss []
+       >> ONCE_REWRITE_TAC [ADD_COMM]
+       >> RW_TAC arith_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
+       >> PROVE_TAC [IS_INFINITE_CAT, IS_INFINITE_EXISTS],
        Q.EXISTS_TAC `n' + p'`
-       ++ RW_TAC std_ss []
-       ++ ONCE_REWRITE_TAC [ADD_COMM]
-       ++ RW_TAC arith_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
-       ++ PROVE_TAC [IS_INFINITE_CAT, IS_INFINITE_EXISTS]]);
+       >> RW_TAC std_ss []
+       >> ONCE_REWRITE_TAC [ADD_COMM]
+       >> RW_TAC arith_ss [SEL_REC_SPLIT, GSYM CAT_APPEND]
+       >> PROVE_TAC [IS_INFINITE_CAT, IS_INFINITE_EXISTS]]);
 
 val checker_AND = store_thm
   ("checker_AND",
@@ -1765,7 +1761,7 @@ val checker_AND = store_thm
          (safety_violation p (F_AND (f,g)) =
           ?n. US_SEM (SEL_REC n 0 p) (S_OR (checker f,checker g)))``,
    RW_TAC std_ss [simple_safety, simple_def, UF_SEM_def, US_SEM_def]
-   ++ METIS_TAC []);
+   >> METIS_TAC []);
 
 val checker_NEXT = store_thm
   ("checker_NEXT",
@@ -1779,37 +1775,37 @@ val checker_NEXT = store_thm
         (safety_violation p (F_NEXT f) =
          ?n. US_SEM (SEL_REC n 0 p) (S_CAT (S_TRUE,checker f)))``,
    RW_TAC std_ss []
-   ++ RW_TAC arith_suc_ss
+   >> RW_TAC arith_suc_ss
         [safety_violation_alt, UF_SEM_def, US_SEM_def, LENGTH_CAT,
          S_TRUE_def, GT, B_SEM, RESTN_def, REST_CAT, SEL_NIL]
-   ++ Know `!P Q. (P 0 \/ (?n. P (SUC n)) = Q) ==> ((?n. P n) = Q)`
-   >> PROVE_TAC [arithmeticTheory.num_CASES]
-   ++ DISCH_THEN HO_MATCH_MP_TAC
-   ++ RW_TAC std_ss [SEL_REC_def, CAT_def, REST_CONS]
-   ++ MATCH_MP_TAC (PROVE [] ``(a ==> b) /\ (b = c) ==> (a \/ b = c)``)
-   ++ CONJ_TAC
-   >> (RW_TAC std_ss []
-       ++ Q.EXISTS_TAC `0`
-       ++ RW_TAC std_ss [SEL_REC_def, CAT_def]
-       ++ Know `!q. IS_INFINITE q ==> ~UF_SEM (REST q) f`
-       >> PROVE_TAC [IS_INFINITE_def, path_nchotomy]
-       ++ DISCH_THEN (MP_TAC o Q.SPEC `CONS (x, INFINITE w)`)
-       ++ RW_TAC std_ss [REST_CONS, IS_INFINITE_CONS, IS_INFINITE_def])
-   ++ RW_TAC std_ss [GSYM safety_violation_alt, IS_INFINITE_REST]
-   ++ Know `!P Q. (P = (?n. Q n []) \/ (?n h. Q n [h]) \/
+   >> Know `!P Q. (P 0 \/ (?n. P (SUC n)) = Q) ==> ((?n. P n) = Q)`
+   >- PROVE_TAC [arithmeticTheory.num_CASES]
+   >> DISCH_THEN HO_MATCH_MP_TAC
+   >> RW_TAC std_ss [SEL_REC_def, CAT_def, REST_CONS]
+   >> MATCH_MP_TAC (PROVE [] ``(a ==> b) /\ (b = c) ==> (a \/ b = c)``)
+   >> CONJ_TAC
+   >- (RW_TAC std_ss []
+       >> Q.EXISTS_TAC `0`
+       >> RW_TAC std_ss [SEL_REC_def, CAT_def]
+       >> Know `!q. IS_INFINITE q ==> ~UF_SEM (REST q) f`
+       >- PROVE_TAC [IS_INFINITE_def, path_nchotomy]
+       >> DISCH_THEN (MP_TAC o Q.SPEC `CONS (x, INFINITE w)`)
+       >> RW_TAC std_ss [REST_CONS, IS_INFINITE_CONS, IS_INFINITE_def])
+   >> RW_TAC std_ss [GSYM safety_violation_alt, IS_INFINITE_REST]
+   >> Know `!P Q. (P = (?n. Q n []) \/ (?n h. Q n [h]) \/
                    (?h1 h2 t n. Q n (h1 :: h2 :: t))) ==>
                   (P = ?n w1. Q (n : num) (w1 : ('a -> bool) list))`
-   >> metisLib.METIS_TAC [list_CASES]
-   ++ DISCH_THEN HO_MATCH_MP_TAC
-   ++ RW_TAC arith_suc_ss [LENGTH, APPEND]
-   ++ Know `!P Q. (?h w2. P h (w2 : ('a -> bool) list) /\ Q w2) =
+   >- metisLib.METIS_TAC [list_CASES]
+   >> DISCH_THEN HO_MATCH_MP_TAC
+   >> RW_TAC arith_suc_ss [LENGTH, APPEND]
+   >> Know `!P Q. (?h w2. P h (w2 : ('a -> bool) list) /\ Q w2) =
                   ?w2. (?h : 'a -> bool. P h w2) /\ Q w2`
-   >> PROVE_TAC []
-   ++ DISCH_THEN (fn th => SIMP_TAC std_ss [th])
-   ++ Know `!P Q. (Q = P 0 \/ ?n. P (SUC n)) ==> (Q = ?n. P n)`
-   >> PROVE_TAC [arithmeticTheory.num_CASES]
-   ++ DISCH_THEN HO_MATCH_MP_TAC
-   ++ RW_TAC arith_suc_ss [SEL_REC_def, TL, checker_initially_ok]);
+   >- PROVE_TAC []
+   >> DISCH_THEN (fn th => SIMP_TAC std_ss [th])
+   >> Know `!P Q. (Q = P 0 \/ ?n. P (SUC n)) ==> (Q = ?n. P n)`
+   >- PROVE_TAC [arithmeticTheory.num_CASES]
+   >> DISCH_THEN HO_MATCH_MP_TAC
+   >> RW_TAC arith_suc_ss [SEL_REC_def, TL, checker_initially_ok]);
 
 val checker_UNTIL = store_thm
   ("checker_UNTIL",
@@ -1828,154 +1824,154 @@ val checker_UNTIL = store_thm
                  (S_REPEAT (boolean_checker g),
                   S_FLEX_AND (checker f,boolean_checker g))))``,
    RW_TAC std_ss []
-   ++ Know
+   >> Know
       `safety_violation p
        (F_NOT (F_AND (F_NOT (F_UNTIL (f,g)),F_UNTIL (F_BOOL B_TRUE,F_NOT f)))) =
        safety_violation p (F_W (f,g))`
-   >> (RW_TAC std_ss
+   >- (RW_TAC std_ss
        [safety_violation_def, UF_SEM_def, F_W_def, F_OR_def, F_G_def, F_F_def])
-   ++ DISCH_THEN (fn th => SIMP_TAC std_ss [th])
-   ++ RW_TAC arith_resq_ss
+   >> DISCH_THEN (fn th => SIMP_TAC std_ss [th])
+   >> RW_TAC arith_resq_ss
         [safety_violation_alt, UF_SEM_F_W_ALT, LENGTH_CAT, S_TRUE_def]
-   ++ Know `!m n. (m:num) < SUC n = m <= n` >> DECIDE_TAC
-   ++ DISCH_THEN (fn th => REWRITE_TAC [th])
-   ++ SIMP_TAC arith_ss [GSYM IMP_DISJ_THM]
-   ++ REVERSE EQ_TAC
-   >> (RW_TAC std_ss [S_CAT_SEL_REC, S_FLEX_AND]
-       ++ Q.EXISTS_TAC `m + n`
-       ++ POP_ASSUM MP_TAC
-       ++ ONCE_REWRITE_TAC [US_SEM_boolean_checker_SEL_REC]
-       ++ RW_TAC std_ss [RESTN_RESTN]
-       ++ Q.EXISTS_TAC `m`
-       ++ CONJ_TAC
-       >> (ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC arith_ss
+   >> Know `!m n. (m:num) < SUC n = m <= n` >- DECIDE_TAC
+   >> DISCH_THEN (fn th => REWRITE_TAC [th])
+   >> SIMP_TAC arith_ss [GSYM IMP_DISJ_THM]
+   >> REVERSE EQ_TAC
+   >- (RW_TAC std_ss [S_CAT_SEL_REC, S_FLEX_AND]
+       >> Q.EXISTS_TAC `m + n`
+       >> POP_ASSUM MP_TAC
+       >> ONCE_REWRITE_TAC [US_SEM_boolean_checker_SEL_REC]
+       >> RW_TAC std_ss [RESTN_RESTN]
+       >> Q.EXISTS_TAC `m`
+       >> CONJ_TAC
+       >- (ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC arith_ss
                 [SEL_REC_SPLIT, LENGTH_SEL_REC, RESTN_CAT, GSYM CAT_APPEND]
-           ++ Know `m = 0 + m` >> DECIDE_TAC
-           ++ DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
-           ++ RW_TAC std_ss [GSYM SEL_REC_RESTN]
-           ++ MATCH_MP_TAC safety_violation_refl
-           ++ RW_TAC std_ss
+           >> Know `m = 0 + m` >- DECIDE_TAC
+           >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
+           >> RW_TAC std_ss [GSYM SEL_REC_RESTN]
+           >> MATCH_MP_TAC safety_violation_refl
+           >> RW_TAC std_ss
                 [IS_INFINITE_CAT, IS_INFINITE_def, IS_INFINITE_RESTN]
-           ++ Q.EXISTS_TAC `n`
-           ++ RW_TAC std_ss [SEL_REC_CAT_0, LENGTH_SEL_REC])
-       ++ RW_TAC std_ss []
-       ++ STRIP_TAC
-       ++ Q.PAT_ASSUM `k <= m` MP_TAC
-       ++ Suff `~(k = m) /\ m <= k` >> DECIDE_TAC
-       ++ CONJ_TAC
-       >> (STRIP_TAC
-           ++ RW_TAC arith_ss []
-           ++ POP_ASSUM MP_TAC
-           ++ RW_TAC std_ss []
-           ++ MATCH_MP_TAC safety_violation_refl
-           ++ RW_TAC std_ss
+           >> Q.EXISTS_TAC `n`
+           >> RW_TAC std_ss [SEL_REC_CAT_0, LENGTH_SEL_REC])
+       >> RW_TAC std_ss []
+       >> STRIP_TAC
+       >> Q.PAT_X_ASSUM `k <= m` MP_TAC
+       >> Suff `~(k = m) /\ m <= k` >- DECIDE_TAC
+       >> CONJ_TAC
+       >- (STRIP_TAC
+           >> RW_TAC arith_ss []
+           >> POP_ASSUM MP_TAC
+           >> RW_TAC std_ss []
+           >> MATCH_MP_TAC safety_violation_refl
+           >> RW_TAC std_ss
                 [IS_INFINITE_RESTN, IS_INFINITE_CAT, IS_INFINITE_def,
                  boolean_checker_US_SEM]
-           ++ Q.EXISTS_TAC `1`
-           ++ POP_ASSUM MP_TAC
-           ++ MATCH_MP_TAC (PROVE [] ``(a = b) ==> (a ==> b)``)
-           ++ AP_THM_TAC
-           ++ AP_TERM_TAC
-           ++ RW_TAC arith_ss [SEL_REC_RESTN]
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC arith_ss
+           >> Q.EXISTS_TAC `1`
+           >> POP_ASSUM MP_TAC
+           >> MATCH_MP_TAC (PROVE [] ``(a = b) ==> (a ==> b)``)
+           >> AP_THM_TAC
+           >> AP_TERM_TAC
+           >> RW_TAC arith_ss [SEL_REC_RESTN]
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC arith_ss
                 [SEL_REC_SPLIT, GSYM CAT_APPEND, SEL_REC_CAT, LENGTH_SEL_REC]
-           ++ Know `~(n = 0)` >> PROVE_TAC [checker_initially_ok, SEL_REC_def]
-           ++ STRIP_TAC
-           ++ Know `1 <= n` >> DECIDE_TAC
-           ++ RW_TAC std_ss [LESS_EQ_EXISTS]
-           ++ RW_TAC std_ss []
-           ++ ONCE_REWRITE_TAC [ADD_COMM]
-           ++ RW_TAC std_ss
+           >> Know `~(n = 0)` >- PROVE_TAC [checker_initially_ok, SEL_REC_def]
+           >> STRIP_TAC
+           >> Know `1 <= n` >- DECIDE_TAC
+           >> RW_TAC std_ss [LESS_EQ_EXISTS]
+           >> RW_TAC std_ss []
+           >> ONCE_REWRITE_TAC [ADD_COMM]
+           >> RW_TAC std_ss
                 [SEL_REC_SPLIT, GSYM CAT_APPEND, SEL_REC_CAT_0, LENGTH_SEL_REC])
-       ++ Q.PAT_ASSUM `UF_SEM X Y` MP_TAC
-       ++ Q.PAT_ASSUM `US_SEM X (S_REPEAT Y)` MP_TAC
-       ++ Q.PAT_ASSUM `IS_INFINITE p` MP_TAC
-       ++ Q.SPEC_TAC (`p`,`p`)
-       ++ Q.SPEC_TAC (`k`,`k`)
-       ++ Q.SPEC_TAC (`m`,`m`)
-       ++ Q.PAT_ASSUM `boolean g` MP_TAC
-       ++ POP_ASSUM_LIST (K ALL_TAC)
-       ++ STRIP_TAC
-       ++ SIMP_TAC std_ss [AND_IMP_INTRO]
-       ++ Induct
-       ++ RW_TAC arith_ss []
-       ++ Q.PAT_ASSUM `US_SEM X Y` MP_TAC
-       ++ ONCE_REWRITE_TAC [GSYM S_REPEAT_UNWIND]
-       ++ ONCE_REWRITE_TAC [US_SEM_def]
-       ++ SIMP_TAC std_ss [S_EMPTY, S_CAT_SEL_REC0]
-       ++ STRIP_TAC >> PROVE_TAC [LENGTH_SEL_REC, LENGTH, numTheory.NOT_SUC]
-       ++ REPEAT (Q.PAT_ASSUM `US_SEM X Y` MP_TAC)
-       ++ ONCE_REWRITE_TAC [US_SEM_boolean_checker_SEL_REC]
-       ++ RW_TAC arith_ss []
-       ++ Cases_on `k`
-       >> (RW_TAC arith_ss []
-           ++ Q.PAT_ASSUM `!k. P k` (K ALL_TAC)
-           ++ Q.PAT_ASSUM `UF_SEM X Y` MP_TAC
-           ++ RW_TAC std_ss [RESTN_def]
-           ++ MATCH_MP_TAC safety_violation_refl
-           ++ RW_TAC std_ss
+       >> Q.PAT_X_ASSUM `UF_SEM X Y` MP_TAC
+       >> Q.PAT_X_ASSUM `US_SEM X (S_REPEAT Y)` MP_TAC
+       >> Q.PAT_X_ASSUM `IS_INFINITE p` MP_TAC
+       >> Q.SPEC_TAC (`p`,`p`)
+       >> Q.SPEC_TAC (`k`,`k`)
+       >> Q.SPEC_TAC (`m`,`m`)
+       >> Q.PAT_X_ASSUM `boolean g` MP_TAC
+       >> POP_ASSUM_LIST (K ALL_TAC)
+       >> STRIP_TAC
+       >> SIMP_TAC std_ss [AND_IMP_INTRO]
+       >> Induct
+       >> RW_TAC arith_ss []
+       >> Q.PAT_X_ASSUM `US_SEM X Y` MP_TAC
+       >> ONCE_REWRITE_TAC [GSYM S_REPEAT_UNWIND]
+       >> ONCE_REWRITE_TAC [US_SEM_def]
+       >> SIMP_TAC std_ss [S_EMPTY, S_CAT_SEL_REC0]
+       >> STRIP_TAC >- PROVE_TAC [LENGTH_SEL_REC, LENGTH, numTheory.NOT_SUC]
+       >> REPEAT (Q.PAT_X_ASSUM `US_SEM X Y` MP_TAC)
+       >> ONCE_REWRITE_TAC [US_SEM_boolean_checker_SEL_REC]
+       >> RW_TAC arith_ss []
+       >> Cases_on `k`
+       >- (RW_TAC arith_ss []
+           >> Q.PAT_X_ASSUM `!k. P k` (K ALL_TAC)
+           >> Q.PAT_X_ASSUM `UF_SEM X Y` MP_TAC
+           >> RW_TAC std_ss [RESTN_def]
+           >> MATCH_MP_TAC safety_violation_refl
+           >> RW_TAC std_ss
                 [IS_INFINITE_RESTN, IS_INFINITE_CAT, IS_INFINITE_def,
                  boolean_checker_US_SEM]
-           ++ Q.EXISTS_TAC `1`
-           ++ Know `n + SUC m = (n + m) + 1` >> DECIDE_TAC
-           ++ DISCH_THEN (fn th => REWRITE_TAC [th])
-           ++ ONCE_REWRITE_TAC [SEL_REC_SPLIT]
-           ++ RW_TAC std_ss [GSYM CAT_APPEND, SEL_REC_CAT_0, LENGTH_SEL_REC])
-       ++ RW_TAC arith_ss []
-       ++ FIRST_ASSUM MATCH_MP_TAC
-       ++ Q.EXISTS_TAC `REST p`
-       ++ POP_ASSUM MP_TAC
-       ++ RW_TAC bool_ss [IS_INFINITE_REST, ONE, RESTN_def]
-       ++ Q.PAT_ASSUM `UF_SEM X Y` MP_TAC
-       ++ MATCH_MP_TAC (PROVE [] ``(a = b) ==> (a ==> b)``)
-       ++ AP_THM_TAC
-       ++ AP_TERM_TAC
-       ++ RW_TAC std_ss [RESTN_def, ADD_CLAUSES, SEL_REC_def, REST_CAT, TL]
-       ++ PROVE_TAC [ADD_COMM])
-   ++ STRIP_TAC
-   ++ RW_TAC std_ss [S_CAT_SEL_REC, S_FLEX_AND]
-   ++ ONCE_REWRITE_TAC [US_SEM_boolean_checker_SEL_REC]
-   ++ RW_TAC std_ss []
-   ++ Know `?w. INFINITE w = RESTN p n`
-   >> METIS_TAC [IS_INFINITE_EXISTS, IS_INFINITE_RESTN]
-   ++ STRIP_TAC
-   ++ Q.PAT_ASSUM `!w. P w` (MP_TAC o Q.SPEC `w`)
-   ++ RW_TAC std_ss [CAT_SEL_REC_RESTN]
-   ++ Q.PAT_ASSUM `INFINITE w = x` (K ALL_TAC)
-   ++ Q.PAT_ASSUM `!p : ('a -> bool) path. P p` (MP_TAC o Q.SPEC `RESTN p j`)
-   ++ RW_TAC std_ss [IS_INFINITE_RESTN, simple_safety]
-   ++ Q.EXISTS_TAC `j`
-   ++ REVERSE CONJ_TAC
-   >> (CONJ_TAC >> METIS_TAC []
-       ++ RW_TAC std_ss [boolean_checker_US_SEM1, IS_INFINITE_RESTN]
-       ++ PROVE_TAC [LESS_EQ_REFL])
-   ++ Know `j = j + 0` >> DECIDE_TAC
-   ++ DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
-   ++ Know `p = RESTN p (j - (j + 0))` >> RW_TAC arith_ss [RESTN_def]
-   ++ DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
-   ++ Know `j + 0 <= j` >> DECIDE_TAC
-   ++ Q.SPEC_TAC (`j + 0`, `k`)
-   ++ Induct
-   >> (RW_TAC std_ss [SEL_REC_def, US_SEM_def]
-       ++ METIS_TAC [CONCAT_def, EVERY_DEF])
-   ++ ONCE_REWRITE_TAC [GSYM S_REPEAT_UNWIND]
-   ++ ONCE_REWRITE_TAC [US_SEM_def]
-   ++ ONCE_REWRITE_TAC [US_SEM_def]
-   ++ RW_TAC std_ss []
-   ++ DISJ2_TAC
-   ++ RW_TAC std_ss [ADD1, SEL_REC_SPLIT]
-   ++ Q.PAT_ASSUM `X ==> Y` MP_TAC
-   ++ (MP_TAC o Q.SPEC `k` o GENL [``m:num``,``n:num``,``r:num``] o
+           >> Q.EXISTS_TAC `1`
+           >> Know `n + SUC m = (n + m) + 1` >- DECIDE_TAC
+           >> DISCH_THEN (fn th => REWRITE_TAC [th])
+           >> ONCE_REWRITE_TAC [SEL_REC_SPLIT]
+           >> RW_TAC std_ss [GSYM CAT_APPEND, SEL_REC_CAT_0, LENGTH_SEL_REC])
+       >> RW_TAC arith_ss []
+       >> FIRST_ASSUM MATCH_MP_TAC
+       >> Q.EXISTS_TAC `REST p`
+       >> POP_ASSUM MP_TAC
+       >> RW_TAC bool_ss [IS_INFINITE_REST, ONE, RESTN_def]
+       >> Q.PAT_X_ASSUM `UF_SEM X Y` MP_TAC
+       >> MATCH_MP_TAC (PROVE [] ``(a = b) ==> (a ==> b)``)
+       >> AP_THM_TAC
+       >> AP_TERM_TAC
+       >> RW_TAC std_ss [RESTN_def, ADD_CLAUSES, SEL_REC_def, REST_CAT, TL]
+       >> PROVE_TAC [ADD_COMM])
+   >> STRIP_TAC
+   >> RW_TAC std_ss [S_CAT_SEL_REC, S_FLEX_AND]
+   >> ONCE_REWRITE_TAC [US_SEM_boolean_checker_SEL_REC]
+   >> RW_TAC std_ss []
+   >> Know `?w. INFINITE w = RESTN p n`
+   >- METIS_TAC [IS_INFINITE_EXISTS, IS_INFINITE_RESTN]
+   >> STRIP_TAC
+   >> Q.PAT_X_ASSUM `!w. P w` (MP_TAC o Q.SPEC `w`)
+   >> RW_TAC std_ss [CAT_SEL_REC_RESTN]
+   >> Q.PAT_X_ASSUM `INFINITE w = x` (K ALL_TAC)
+   >> Q.PAT_X_ASSUM `!p : ('a -> bool) path. P p` (MP_TAC o Q.SPEC `RESTN p j`)
+   >> RW_TAC std_ss [IS_INFINITE_RESTN, simple_safety]
+   >> Q.EXISTS_TAC `j`
+   >> REVERSE CONJ_TAC
+   >- (CONJ_TAC >- METIS_TAC []
+       >> RW_TAC std_ss [boolean_checker_US_SEM1, IS_INFINITE_RESTN]
+       >> PROVE_TAC [LESS_EQ_REFL])
+   >> Know `j = j + 0` >- DECIDE_TAC
+   >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
+   >> Know `p = RESTN p (j - (j + 0))` >- RW_TAC arith_ss [RESTN_def]
+   >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
+   >> Know `j + 0 <= j` >- DECIDE_TAC
+   >> Q.SPEC_TAC (`j + 0`, `k`)
+   >> Induct
+   >- (RW_TAC std_ss [SEL_REC_def, US_SEM_def]
+       >> METIS_TAC [CONCAT_def, EVERY_DEF])
+   >> ONCE_REWRITE_TAC [GSYM S_REPEAT_UNWIND]
+   >> ONCE_REWRITE_TAC [US_SEM_def]
+   >> ONCE_REWRITE_TAC [US_SEM_def]
+   >> RW_TAC std_ss []
+   >> DISJ2_TAC
+   >> RW_TAC std_ss [ADD1, SEL_REC_SPLIT]
+   >> Q.PAT_X_ASSUM `X ==> Y` MP_TAC
+   >> (MP_TAC o Q.SPEC `k` o GENL [``m:num``,``n:num``,``r:num``] o
        INST_TYPE [alpha |-> ``:'a -> bool``]) SEL_REC_RESTN
-   ++ RW_TAC arith_ss []
-   ++ Q.EXISTS_TAC `SEL_REC 1 0 (RESTN p (j - (k + 1)))`
-   ++ Q.EXISTS_TAC `SEL_REC k (j - k) p`
-   ++ RW_TAC std_ss []
-   ++ RW_TAC std_ss [boolean_checker_US_SEM1, IS_INFINITE_RESTN]
-   ++ FIRST_ASSUM MATCH_MP_TAC
-   ++ DECIDE_TAC);
+   >> RW_TAC arith_ss []
+   >> Q.EXISTS_TAC `SEL_REC 1 0 (RESTN p (j - (k + 1)))`
+   >> Q.EXISTS_TAC `SEL_REC k (j - k) p`
+   >> RW_TAC std_ss []
+   >> RW_TAC std_ss [boolean_checker_US_SEM1, IS_INFINITE_RESTN]
+   >> FIRST_ASSUM MATCH_MP_TAC
+   >> DECIDE_TAC);
 
 val checker_SEL_REC = store_thm
   ("checker_SEL_REC",
@@ -1984,57 +1980,57 @@ val checker_SEL_REC = store_thm
        (safety_violation p f =
         ?n. amatch (sere2regexp (checker f)) (SEL_REC n 0 p))``,
    SIMP_TAC std_ss [amatch, GSYM sere2regexp, checker_CLOCK_FREE]
-   ++ recInduct simple_ind
-   ++ (REPEAT CONJ_TAC
-       ++ TRY (ASM_SIMP_TAC std_ss [simple_def, boolean_def] ++ NO_TAC)
-       ++ SIMP_TAC std_ss [boolean_def])
-   << [(* F_BOOL *)
+   >> recInduct simple_ind
+   >> (REPEAT CONJ_TAC
+       >> TRY (ASM_SIMP_TAC std_ss [simple_def, boolean_def] >> NO_TAC)
+       >> SIMP_TAC std_ss [boolean_def])
+   >| [(* F_BOOL *)
        RW_TAC std_ss [boolean_checker_US_SEM, boolean_def, checker_def],
 
        (* F_NOT (F_NOT f) *)
        RW_TAC std_ss [safety_violation_def, UF_SEM_def, simple_def, checker_def]
-       ++ RW_TAC std_ss [GSYM safety_violation_def],
+       >> RW_TAC std_ss [GSYM safety_violation_def],
 
        (* F_NOT (F_AND (F_NOT (F_UNTIL (f,g)), _)) *)
        ONCE_REWRITE_TAC [simple_def, checker_def]
-       ++ METIS_TAC [checker_UNTIL],
+       >> METIS_TAC [checker_UNTIL],
 
        (* F_NOT (F_AND (f,g)) *)
        RW_TAC std_ss []
-       ++ Q.PAT_ASSUM `simple X` MP_TAC
-       ++ ONCE_REWRITE_TAC [simple_def, checker_def]
-       ++ RW_TAC std_ss [boolean_def]
-       ++ METIS_TAC [checker_NOT_AND],
+       >> Q.PAT_X_ASSUM `simple X` MP_TAC
+       >> ONCE_REWRITE_TAC [simple_def, checker_def]
+       >> RW_TAC std_ss [boolean_def]
+       >> METIS_TAC [checker_NOT_AND],
        RW_TAC std_ss []
-       ++ Q.PAT_ASSUM `simple X` MP_TAC
-       ++ ONCE_REWRITE_TAC [simple_def, checker_def]
-       ++ RW_TAC std_ss [boolean_def]
-       ++ METIS_TAC [checker_NOT_AND],
+       >> Q.PAT_X_ASSUM `simple X` MP_TAC
+       >> ONCE_REWRITE_TAC [simple_def, checker_def]
+       >> RW_TAC std_ss [boolean_def]
+       >> METIS_TAC [checker_NOT_AND],
        RW_TAC std_ss []
-       ++ Q.PAT_ASSUM `simple X` MP_TAC
-       ++ ONCE_REWRITE_TAC [simple_def, checker_def]
-       ++ RW_TAC std_ss [boolean_def]
-       ++ METIS_TAC [checker_NOT_AND],
+       >> Q.PAT_X_ASSUM `simple X` MP_TAC
+       >> ONCE_REWRITE_TAC [simple_def, checker_def]
+       >> RW_TAC std_ss [boolean_def]
+       >> METIS_TAC [checker_NOT_AND],
        RW_TAC std_ss []
-       ++ Q.PAT_ASSUM `simple X` MP_TAC
-       ++ ONCE_REWRITE_TAC [simple_def, checker_def]
-       ++ RW_TAC std_ss [boolean_def]
-       ++ METIS_TAC [checker_NOT_AND],
+       >> Q.PAT_X_ASSUM `simple X` MP_TAC
+       >> ONCE_REWRITE_TAC [simple_def, checker_def]
+       >> RW_TAC std_ss [boolean_def]
+       >> METIS_TAC [checker_NOT_AND],
        RW_TAC std_ss []
-       ++ Q.PAT_ASSUM `simple X` MP_TAC
-       ++ ONCE_REWRITE_TAC [simple_def, checker_def]
-       ++ RW_TAC std_ss [boolean_def]
-       ++ METIS_TAC [checker_NOT_AND],
+       >> Q.PAT_X_ASSUM `simple X` MP_TAC
+       >> ONCE_REWRITE_TAC [simple_def, checker_def]
+       >> RW_TAC std_ss [boolean_def]
+       >> METIS_TAC [checker_NOT_AND],
        RW_TAC std_ss []
-       ++ Q.PAT_ASSUM `simple X` MP_TAC
-       ++ ONCE_REWRITE_TAC [simple_def, checker_def]
-       ++ RW_TAC std_ss [boolean_def]
-       ++ METIS_TAC [checker_NOT_AND],
+       >> Q.PAT_X_ASSUM `simple X` MP_TAC
+       >> ONCE_REWRITE_TAC [simple_def, checker_def]
+       >> RW_TAC std_ss [boolean_def]
+       >> METIS_TAC [checker_NOT_AND],
        RW_TAC std_ss []
-       ++ Q.PAT_ASSUM `simple X` MP_TAC
-       ++ ONCE_REWRITE_TAC [simple_def, checker_def]
-       ++ RW_TAC std_ss [boolean_def]
-       ++ METIS_TAC [checker_NOT_AND],
+       >> Q.PAT_X_ASSUM `simple X` MP_TAC
+       >> ONCE_REWRITE_TAC [simple_def, checker_def]
+       >> RW_TAC std_ss [boolean_def]
+       >> METIS_TAC [checker_NOT_AND],
 
        (* F_NOT (F_BOOL b) *)
        RW_TAC std_ss
@@ -2042,20 +2038,20 @@ val checker_SEL_REC = store_thm
 
        (* F_AND (f,g) *)
        ONCE_REWRITE_TAC [simple_def, checker_def]
-       ++ METIS_TAC [checker_AND],
+       >> METIS_TAC [checker_AND],
 
        (* F_NEXT f *)
        ONCE_REWRITE_TAC [simple_def, checker_def]
-       ++ METIS_TAC [checker_NEXT],
+       >> METIS_TAC [checker_NEXT],
 
        (* F_SUFFIX_IMP (r,f) *)
        RW_TAC arith_resq_ss
          [simple_def, checker_def, simple_safety, UF_SEM_def,
           LENGTH_IS_INFINITE, SEL_def, IS_INFINITE_RESTN, S_FUSION_SEL_REC]
-       ++ REVERSE EQ_TAC >> METIS_TAC []
-       ++ RW_TAC std_ss []
-       ++ REVERSE (Cases_on `n`) >> METIS_TAC [ADD1]
-       ++ METIS_TAC [SEL_REC_def, checker_initially_ok]]);
+       >> REVERSE EQ_TAC >- METIS_TAC []
+       >> RW_TAC std_ss []
+       >> REVERSE (Cases_on `n`) >- METIS_TAC [ADD1]
+       >> METIS_TAC [SEL_REC_def, checker_initially_ok]]);
 
 val checker = store_thm
   ("checker",
@@ -2064,10 +2060,10 @@ val checker = store_thm
        (safety_violation p f =
         ?n. amatch (sere2regexp (checker f)) (SEL p (0,n)))``,
    RW_TAC arith_ss [checker_SEL_REC, SEL_def]
-   ++ REVERSE EQ_TAC >> METIS_TAC []
-   ++ RW_TAC std_ss [amatch, GSYM sere2regexp, checker_CLOCK_FREE]
-   ++ REVERSE (Cases_on `n`) >> METIS_TAC [ADD1]
-   ++ METIS_TAC [SEL_REC_def, checker_initially_ok]);
+   >> REVERSE EQ_TAC >- METIS_TAC []
+   >> RW_TAC std_ss [amatch, GSYM sere2regexp, checker_CLOCK_FREE]
+   >> REVERSE (Cases_on `n`) >- METIS_TAC [ADD1]
+   >> METIS_TAC [SEL_REC_def, checker_initially_ok]);
 
 (******************************************************************************
 * Beginning of some stuff that turned out to be useless for execution.

--- a/examples/PSL/1.01/executable-semantics/Holmakefile
+++ b/examples/PSL/1.01/executable-semantics/Holmakefile
@@ -1,0 +1,2 @@
+PRE_INCLUDES=../../path ../../regexp
+INCLUDES=../official-semantics

--- a/examples/PSL/1.01/official-semantics/Holmakefile
+++ b/examples/PSL/1.01/official-semantics/Holmakefile
@@ -1,0 +1,1 @@
+PRE_INCLUDES=${HOLDIR}/examples/PSL/path

--- a/examples/PSL/1.1/executable-semantics/Holmakefile
+++ b/examples/PSL/1.1/executable-semantics/Holmakefile
@@ -1,0 +1,2 @@
+PRE_INCLUDES=../../path ../../regexp
+INCLUDES=../official-semantics

--- a/examples/PSL/1.1/official-semantics/LemmasScript.sml
+++ b/examples/PSL/1.1/official-semantics/LemmasScript.sml
@@ -222,6 +222,7 @@ val S_CLOCK_FREE_def =
 (******************************************************************************
 * Structural induction rule for SEREs
 ******************************************************************************)
+
 val sere_induct = save_thm
   ("sere_induct",
    Q.GEN
@@ -234,7 +235,7 @@ val sere_induct = save_thm
         PROVE[]``(!x y. P x ==> Q(x,y)) = !x. P x ==> !y. Q(x,y)``,
         PROVE[]``(!x y. P y ==> Q(x,y)) = !y. P y ==> !x. Q(x,y)``]
        (Q.SPECL
-         [`P`,`\(r1,r2). P r1 /\ P r2`,`\(r,b). P r`]
+         [`P`,`\ (r,b). P r`, `\ (r1,r2). P r1 /\ P r2`]
          (TypeBase.induction_of ``:'a sere``)))));
 
 val LAST_APPEND_CONS =
@@ -816,7 +817,7 @@ val Lemma7 =
              THEN Q.EXISTS_TAC `l`
              THEN RW_TAC arith_ss [SEL_APPEND3,APPEND_LEFT_CANCEL,GSYM APPEND_ASSOC]
              THEN ASSUM_LIST
-                   (fn thl => ASSUME_TAC(Q.SPEC `k - (LENGTH v1 + 1)` (el 2 thl)))
+                   (fn thl => ASSUME_TAC(Q.SPEC `k - (LENGTH (v1 :'a letter list) + 1)` (el 2 thl)))
              THEN FULL_SIMP_TAC std_ss [LENGTH,LENGTH_APPEND]
              THEN `LENGTH [l] = 1` by RW_TAC list_ss []
              THEN IMP_RES_TAC

--- a/examples/PSL/1.1/official-semantics/ProjectionScript.sml
+++ b/examples/PSL/1.1/official-semantics/ProjectionScript.sml
@@ -1018,19 +1018,15 @@ val LENGTH_FILTER_FIRSTN =
       (LENGTH(FILTER P (FIRSTN (LENGTH (TAKE_FIRSTN P n l)) l)) = n)``,
    RW_TAC list_ss [FIRSTN_TAKE_FIRSTN,GSYM FIRSTN_FILTER_TAKE_FIRSTN,LENGTH_FIRSTN]);
 
-val SPLIT_APPEND =
- store_thm
+val SPLIT_APPEND = store_thm
   ("SPLIT_APPEND",
-   ``!u1 u2 v1 v2:'a list.
+  ``!u1 u2 v1 v2:'a list.
       (u1 <> u2 = v1 <> v2) /\ (LENGTH u1 = LENGTH v1) ==> (u2 = v2)``,
-   Induct
-    THEN RW_TAC list_ss []
-    THENL
-     [`v1 = []` by PROVE_TAC[LENGTH_NIL]
-       THEN RW_TAC list_ss [],
-      Cases_on `v1`
-       THEN RW_TAC list_ss []
-       THEN FULL_SIMP_TAC list_ss []]);
+    Induct
+ >> RW_TAC list_ss []
+ >> Cases_on `v1`
+ >> RW_TAC list_ss []
+ >> FULL_SIMP_TAC list_ss []);
 
 val S_PROJ_S_BOOL =
  store_thm
@@ -1918,7 +1914,7 @@ val HD_RESTN_TL =
    ``!n l. HD (RESTN (TL l) n) = EL n (TL l)``,
    Induct
     THEN RW_TAC list_ss
-          [FinitePathTheory.RESTN_def,FinitePathTheory.REST_def]);
+          [FinitePathTheory.RESTN_def,FinitePathTheory.REST_def,EL]);
 
 val ELEM_FINITE =
  store_thm
@@ -1928,7 +1924,7 @@ val ELEM_FINITE =
     THEN RW_TAC list_ss
           [ELEM_def,HEAD_def,RESTN_def,
            FinitePathTheory.RESTN_def,FinitePathTheory.REST_def,
-           REST_def,RESTN_FINITE,HD_RESTN_TL]);
+           REST_def,RESTN_FINITE,HD_RESTN_TL,EL]);
 
 val ELEM_INFINITE =
  store_thm

--- a/examples/PSL/path/FinitePathScript.sml
+++ b/examples/PSL/path/FinitePathScript.sml
@@ -677,22 +677,22 @@ val ADD_SUC_lem =
 in
 
 val FINITE_SEL_REC_SEL_REC = store_thm("FINITE_SEL_REC_SEL_REC",
-    (--`!n1 m1 n2 m2 (l:'a list).
+    (``!n1 m1 n2 m2 (l:'a list).
      (((n1 + m1) <= (LENGTH l)) /\ ((n2 + m2) <= n1)) ==>
-     (SEL_REC n2 m2 (SEL_REC n1 m1 l) = SEL_REC n2 (m1 + m2) l)`--),
+     (SEL_REC n2 m2 (SEL_REC n1 m1 l) = SEL_REC n2 (m1 + m2) l)``),
     REPEAT numLib.INDUCT_TAC THEN INDUCT_THEN list_INDUCT ASSUME_TAC
     THEN REWRITE_TAC[LENGTH,FINITE_SEL_REC,NOT_LESS_0,NOT_SUC_LESS_EQ_0,ADD,ADD_0]
     THENL[
         GEN_TAC THEN REWRITE_TAC[LESS_EQ_MONO,CONS_11]
-        THEN STRIP_TAC THEN SUBST_OCCS_TAC[([3],SYM(SPEC(--`0`--)ADD_0))]
+        THEN STRIP_TAC THEN SUBST_OCCS_TAC[([3],SYM(SPEC(``0``)ADD_0))]
         THEN FIRST_ASSUM MATCH_MP_TAC THEN ASM_REWRITE_TAC[ADD_0],
 
         REWRITE_TAC[LESS_EQ_MONO,ADD_SUC_lem] THEN STRIP_TAC
-        THEN SUBST_OCCS_TAC[([2],SYM(SPEC(--`m2:num`--)(CONJUNCT1 ADD)))]
+        THEN SUBST_OCCS_TAC[([2],SYM(SPEC(``m2:num``)(CONJUNCT1 ADD)))]
         THEN FIRST_ASSUM MATCH_MP_TAC THEN ASM_REWRITE_TAC[ADD_0],
 
         REWRITE_TAC[LESS_EQ_MONO,ADD_SUC_lem] THEN STRIP_TAC
-        THEN SUBST_OCCS_TAC[([2],SYM(SPEC(--`m1:num`--)ADD_0))]
+        THEN SUBST_OCCS_TAC[([2],SYM(SPEC(``m1:num``)ADD_0))]
         THEN FIRST_ASSUM MATCH_MP_TAC
         THEN ASM_REWRITE_TAC[LESS_EQ_MONO,ADD_0],
 
@@ -703,16 +703,16 @@ val FINITE_SEL_REC_SEL_REC = store_thm("FINITE_SEL_REC_SEL_REC",
             ASM_REWRITE_TAC[ADD,LESS_EQ_MONO]]]);
 
 val FINITE_SEL_REC_SUC_CONS = store_thm("FINITE_SEL_REC_SUC_CONS",
-    (--`!m n l (x:'a). (SEL_REC m (SUC n) (CONS x l) = SEL_REC m n l)`--),
+    (``!m n l (x:'a). (SEL_REC m (SUC n) (CONS x l) = SEL_REC m n l)``),
     numLib.INDUCT_TAC THEN REWRITE_TAC[FINITE_SEL_REC]);
 
 val FINITE_SEL_REC_APPEND = store_thm("FINITE_SEL_REC_APPEND",
-    (--`!m (l1:'a list) n l2. (m < LENGTH l1) /\ ((LENGTH l1) <= (n + m)) /\
+    (``!m (l1:'a list) n l2. (m < LENGTH l1) /\ ((LENGTH l1) <= (n + m)) /\
       ((n + m) <= ((LENGTH l1) + (LENGTH l2))) ==>
       (SEL_REC n m (APPEND l1 l2) =
-        APPEND (SEL_REC ((LENGTH l1) - m) m l1) (SEL_REC ((n + m)-(LENGTH l1)) 0 l2))`--),
+        APPEND (SEL_REC ((LENGTH l1) - m) m l1) (SEL_REC ((n + m)-(LENGTH l1)) 0 l2))``),
     numLib.INDUCT_TAC THEN INDUCT_THEN list_INDUCT ASSUME_TAC
-    THEN REPEAT (FILTER_GEN_TAC (--`n:num`--))
+    THEN REPEAT (FILTER_GEN_TAC (``n:num``))
     THEN numLib.INDUCT_TAC THEN INDUCT_THEN list_INDUCT ASSUME_TAC
     THEN REPEAT GEN_TAC
     THEN REWRITE_TAC[LENGTH,FINITE_SEL_REC,NOT_LESS_0,NOT_SUC_LESS_EQ_0,ADD,ADD_0,SUB_0]
@@ -723,7 +723,7 @@ val FINITE_SEL_REC_APPEND = store_thm("FINITE_SEL_REC_APPEND",
         DISCH_THEN (CONJUNCTS_THEN ASSUME_TAC)
         THEN POP_ASSUM (SUBST1_TAC o (MATCH_MP LESS_EQUAL_ANTISYM))
         THEN REWRITE_TAC[FINITE_SEL_REC,APPEND_NIL,SUB_EQUAL_0],
-        STRIP_TAC THEN DISJ_CASES_TAC (SPEC (--`LENGTH (l1:'a list)`--)LESS_0_CASES)
+        STRIP_TAC THEN DISJ_CASES_TAC (SPEC (``LENGTH (l1:'a list)``)LESS_0_CASES)
         THENL[
             POP_ASSUM (ASSUME_TAC o SYM) THEN IMP_RES_TAC LENGTH_NIL
             THEN ASM_REWRITE_TAC[APPEND,FINITE_SEL_REC,SUB_0],

--- a/examples/PSL/regexp/matcherScript.sml
+++ b/examples/PSL/regexp/matcherScript.sml
@@ -13,8 +13,9 @@ app load
 open HolKernel Parse boolLib;
 open bossLib metisLib
 open pairTheory combinTheory listTheory rich_listTheory
-     stringTheory pred_setTheory arithmeticTheory;
+     stringTheory arithmeticTheory;
 open regexpTheory;
+open pred_setTheory;
 
 val () = new_theory "matcher";
 
@@ -22,17 +23,11 @@ val () = new_theory "matcher";
 (* Symbolic tacticals.                                                       *)
 (*---------------------------------------------------------------------------*)
 
-infixr 0 ++ << || THENC ORELSEC ORELSER ##;
-infix 1 >>;
+infixr 0 THENC ORELSEC ORELSER;
 
-val op ++ = op THEN;
-val op << = op THENL;
-val op >> = op THEN1;
-val op || = op ORELSE;
 val Know = Q_TAC KNOW_TAC;
 val Suff = Q_TAC SUFF_TAC;
 val REVERSE = Tactical.REVERSE;
-val lemma = prove;
 
 fun FULL_CONV_TAC c =
   CONV_TAC c THEN POP_ASSUM_LIST (EVERY o map (ASSUME_TAC o CONV_RULE c) o rev);
@@ -81,14 +76,14 @@ val WF_MLEX = store_thm
   ("WF_MLEX",
    ``!f r. WF r ==> WF (MLEX f r)``,
    RW_TAC std_ss []
-   ++ Suff `MLEX f r = inv_image ((<) LEX r) (\x. (f x, x))`
-   >> METIS_TAC [prim_recTheory.WF_LESS, WF_LEX, relationTheory.WF_inv_image]
-   ++ RW_TAC std_ss [FUN_EQ_THM,MLEX_def,relationTheory.inv_image_def,LEX_DEF]);
+   >> Suff `MLEX f r = inv_image ((<) LEX r) (\x. (f x, x))`
+   >- METIS_TAC [prim_recTheory.WF_LESS, WF_LEX, relationTheory.WF_inv_image]
+   >> RW_TAC std_ss [FUN_EQ_THM,MLEX_def,relationTheory.inv_image_def,LEX_DEF]);
 
 val NO_MEM = store_thm
   ("NO_MEM",
    ``!l. (!x. ~MEM x l) = (l = [])``,
-   Cases ++ RW_TAC std_ss [MEM] ++ METIS_TAC []);
+   Cases >> RW_TAC std_ss [MEM] >> METIS_TAC []);
 
 val set_of_list_def = Define
   `(set_of_list [] = {}) /\
@@ -97,7 +92,7 @@ val set_of_list_def = Define
 val set_of_list = store_thm
   ("set_of_list",
    ``!l x. x IN set_of_list l = MEM x l``,
-   Induct ++ RW_TAC std_ss [set_of_list_def, MEM, NOT_IN_EMPTY, IN_INSERT]);
+   Induct >> RW_TAC std_ss [set_of_list_def, MEM, NOT_IN_EMPTY, IN_INSERT]);
 
 val interval_def = Define
   `(interval x 0 = []) /\
@@ -107,14 +102,14 @@ val MEM_interval = store_thm
   ("MEM_interval",
    ``!x k n. MEM x (interval k n) = k <= x /\ x < k + n``,
    Induct_on `n`
-   ++ RW_TAC arith_ss [MEM, interval_def]);
+   >> RW_TAC arith_ss [MEM, interval_def]);
 
 val MEM_FILTER = store_thm
   ("MEM_FILTER",
    ``!p l x. MEM x (FILTER p l) = MEM x l /\ p x``,
    Induct_on `l`
-   ++ RW_TAC std_ss [FILTER, MEM]
-   ++ METIS_TAC []);
+   >> RW_TAC std_ss [FILTER, MEM]
+   >> METIS_TAC []);
 
 val EVERY_MONO = store_thm
   ("EVERY_MONO",
@@ -130,12 +125,12 @@ val LENGTH_partition = store_thm
   ("LENGTH_partition",
    ``!p l x y. (partition p l = (x,y)) ==> (LENGTH l = LENGTH x + LENGTH y)``,
    Induct_on `l`
-   ++ RW_TAC list_ss [partition_def]
-   ++ Introduce `partition p l = (a,b)`
-   ++ REPEAT (POP_ASSUM MP_TAC)
-   ++ RW_TAC arith_ss [LENGTH]
-   ++ RES_TAC
-   ++ RW_TAC arith_ss [LENGTH]);
+   >> RW_TAC list_ss [partition_def]
+   >> Introduce `partition p l = (a,b)`
+   >> REPEAT (POP_ASSUM MP_TAC)
+   >> RW_TAC arith_ss [LENGTH]
+   >> RES_TAC
+   >> RW_TAC arith_ss [LENGTH]);
 
 val MEM_partition = store_thm
   ("MEM_partition",
@@ -144,13 +139,13 @@ val MEM_partition = store_thm
        (MEM k x = p k /\ MEM k l) /\
        (MEM k y = ~p k /\ MEM k l)``,
    Induct_on `l`
-   ++ RW_TAC list_ss [partition_def]
-   ++ Introduce `partition p l = (a,b)`
-   ++ REPEAT (POP_ASSUM MP_TAC)
-   ++ RW_TAC arith_ss [MEM]
-   ++ RES_TAC
-   ++ RW_TAC arith_ss [MEM]
-   ++ METIS_TAC []);
+   >> RW_TAC list_ss [partition_def]
+   >> Introduce `partition p l = (a,b)`
+   >> REPEAT (POP_ASSUM MP_TAC)
+   >> RW_TAC arith_ss [MEM]
+   >> RES_TAC
+   >> RW_TAC arith_ss [MEM]
+   >> METIS_TAC []);
 
 val BUTFIRSTN_EL = store_thm
   ("BUTFIRSTN_EL",
@@ -158,22 +153,22 @@ val BUTFIRSTN_EL = store_thm
        n < LENGTH l ==>
        (EL n l :: BUTFIRSTN (SUC n) l = BUTFIRSTN n l)``,
    Induct
-   ++ Cases
-   ++ RW_TAC arith_ss [EL, BUTFIRSTN, LENGTH, HD, TL]);
+   >> Cases
+   >> RW_TAC arith_ss [EL, BUTFIRSTN, LENGTH, HD, TL]);
 
 val BUTFIRSTN_HD = store_thm
   ("BUTFIRSTN_HD",
    ``!n l. n < LENGTH l ==> (HD (BUTFIRSTN n l) = EL n l)``,
    Induct
-   ++ Cases
-   ++ RW_TAC arith_ss [EL, BUTFIRSTN, LENGTH, HD, TL]);
+   >> Cases
+   >> RW_TAC arith_ss [EL, BUTFIRSTN, LENGTH, HD, TL]);
 
 val BUTFIRSTN_TL = store_thm
   ("BUTFIRSTN_TL",
    ``!n l. n < LENGTH l ==> (TL (BUTFIRSTN n l) = BUTFIRSTN (SUC n) l)``,
    Induct
-   ++ Cases
-   ++ RW_TAC arith_ss [EL, BUTFIRSTN, LENGTH, HD, TL]);
+   >> Cases
+   >> RW_TAC arith_ss [EL, BUTFIRSTN, LENGTH, HD, TL]);
 
 (*---------------------------------------------------------------------------*)
 (* Theorems for reducing character equations.                                *)
@@ -210,44 +205,44 @@ val accepting_path_tail = store_thm
          n <= LENGTH ks /\ (j :: js = BUTFIRSTN n (k :: ks)) /\
          ~p j /\ EVERY p js /\ accepting_path t a j js``,
    completeInduct_on `LENGTH ks`
-   ++ RW_TAC std_ss []
-   ++ Cases_on `EVERY p ks`
-   >> (Q.EXISTS_TAC `k`
-       ++ Q.EXISTS_TAC `ks`
-       ++ Q.EXISTS_TAC `0`
-       ++ RW_TAC arith_ss [EVERY_MEM, BUTFIRSTN])
-   ++ POP_ASSUM (MP_TAC o REWRITE_RULE [EVERY_MEM, MEM_EL])
-   ++ RW_TAC std_ss []
-   ++ Suff
+   >> RW_TAC std_ss []
+   >> Cases_on `EVERY p ks`
+   >- (Q.EXISTS_TAC `k`
+       >> Q.EXISTS_TAC `ks`
+       >> Q.EXISTS_TAC `0`
+       >> RW_TAC arith_ss [EVERY_MEM, BUTFIRSTN])
+   >> POP_ASSUM (MP_TAC o REWRITE_RULE [EVERY_MEM, MEM_EL])
+   >> RW_TAC std_ss []
+   >> Suff
       `?j js n'.
          n' <= LENGTH (BUTFIRSTN (SUC n) ks) /\
          (j::js = BUTFIRSTN n' (EL n ks :: BUTFIRSTN (SUC n) ks)) /\ ~p j /\
          ALL_EL p js /\ accepting_path t a j js`
-   >> (Q.PAT_ASSUM `!m. P m` (K ALL_TAC)
-       ++ RW_TAC arith_ss [BUTFIRSTN_EL, LENGTH_BUTFIRSTN]
-       ++ Know `n' + n < LENGTH ks` >> DECIDE_TAC
-       ++ STRIP_TAC
-       ++ Q.EXISTS_TAC `EL (n + n') ks`
-       ++ Q.EXISTS_TAC `BUTFIRSTN (SUC n + n') ks`
-       ++ Q.EXISTS_TAC `SUC n + n'`
-       ++ FULL_SIMP_TAC arith_ss
+   >- (Q.PAT_X_ASSUM `!m. P m` (K ALL_TAC)
+       >> RW_TAC arith_ss [BUTFIRSTN_EL, LENGTH_BUTFIRSTN]
+       >> Know `n' + n < LENGTH ks` >- DECIDE_TAC
+       >> STRIP_TAC
+       >> Q.EXISTS_TAC `EL (n + n') ks`
+       >> Q.EXISTS_TAC `BUTFIRSTN (SUC n + n') ks`
+       >> Q.EXISTS_TAC `SUC n + n'`
+       >> FULL_SIMP_TAC arith_ss
           [BUTFIRSTN, ALL_EL_BUTFIRSTN, BUTFIRSTN_EL, BUTFIRSTN_BUTFIRSTN, ADD]
-       ++ Suff `(j = EL (n + n') ks) /\ (js = BUTFIRSTN (SUC (n + n')) ks)`
-       >> METIS_TAC []
-       ++ METIS_TAC [HD, TL, BUTFIRSTN_HD, BUTFIRSTN_TL])
-   ++ Q.PAT_ASSUM `!x. P x` MP_TAC
-   ++ SIMP_TAC std_ss [GSYM RIGHT_FORALL_IMP_THM, AND_IMP_INTRO]
-   ++ DISCH_THEN MATCH_MP_TAC
-   ++ RW_TAC arith_ss [LENGTH_BUTFIRSTN]
-   ++ POP_ASSUM (K ALL_TAC)
-   ++ POP_ASSUM MP_TAC
-   ++ POP_ASSUM MP_TAC
-   ++ Q.SPEC_TAC (`k`, `k`)
-   ++ Q.SPEC_TAC (`ks`, `ks`)
-   ++ Induct_on `n`
-   ++ Cases
-   ++ RW_TAC arith_ss [BUTFIRSTN, LENGTH, EL, HD, accepting_path_def, TL]
-   ++ METIS_TAC []);
+       >> Suff `(j = EL (n + n') ks) /\ (js = BUTFIRSTN (SUC (n + n')) ks)`
+       >- METIS_TAC []
+       >> METIS_TAC [HD, TL, BUTFIRSTN_HD, BUTFIRSTN_TL])
+   >> Q.PAT_X_ASSUM `!x. P x` MP_TAC
+   >> SIMP_TAC std_ss [GSYM RIGHT_FORALL_IMP_THM, AND_IMP_INTRO]
+   >> DISCH_THEN MATCH_MP_TAC
+   >> RW_TAC arith_ss [LENGTH_BUTFIRSTN]
+   >> POP_ASSUM (K ALL_TAC)
+   >> POP_ASSUM MP_TAC
+   >> POP_ASSUM MP_TAC
+   >> Q.SPEC_TAC (`k`, `k`)
+   >> Q.SPEC_TAC (`ks`, `ks`)
+   >> Induct_on `n`
+   >> Cases
+   >> RW_TAC arith_ss [BUTFIRSTN, LENGTH, EL, HD, accepting_path_def, TL]
+   >> METIS_TAC []);
 
 val (dijkstra_def, dijkstra_ind) = Defn.tprove
  (Defn.Hol_defn "dijkstra"
@@ -256,10 +251,10 @@ val (dijkstra_def, dijkstra_ind) = Defn.tprove
     let (x,y) = partition (t s) w
     in EXISTS a x \/ dijkstra t a (x <> l) y)`,
   WF_REL_TAC `measure (\ (_,_,l,w). LENGTH l + LENGTH w)`
-  ++ RW_TAC list_ss []
-  ++ POP_ASSUM (ASSUME_TAC o SYM)
-  ++ MP_TAC (Q.SPECL [`(t : 'a->'a->bool) s`, `w`, `x`, `y`] LENGTH_partition)
-  ++ RW_TAC arith_ss []);
+  >> RW_TAC list_ss []
+  >> POP_ASSUM (ASSUME_TAC o SYM)
+  >> MP_TAC (Q.SPECL [`(t : 'a->'a->bool) s`, `w`, `x`, `y`] LENGTH_partition)
+  >> RW_TAC arith_ss []);
 
 val _ = save_thm ("dijkstra_def", dijkstra_def);
 
@@ -271,125 +266,125 @@ val dijkstra = store_thm
          MEM k u /\ EVERY (\x. MEM x (u <> v)) l /\
          accepting_path t a k l``,
    SIMP_TAC std_ss [EXISTS_MEM]
-   ++ recInduct dijkstra_ind
-   ++ RW_TAC list_ss [dijkstra_def]
-   ++ Introduce `partition (t s) w = (x,y)`
-   ++ Q.PAT_ASSUM `!x y. P x y` (MP_TAC o Q.SPECL [`x`, `y`])
-   ++ RW_TAC std_ss []
-   ++ RW_TAC std_ss [RIGHT_AND_OVER_OR, EXISTS_OR_THM, GSYM DISJ_ASSOC]
-   ++ RW_TAC std_ss [DISJ_ASSOC]
-   ++ Know
+   >> recInduct dijkstra_ind
+   >> RW_TAC list_ss [dijkstra_def]
+(* >> Introduce `partition (t s) w = (x,y)` *)
+   >> Q.PAT_X_ASSUM `!x y. P x y` (MP_TAC o Q.SPECL [`x`, `y`])
+   >> RW_TAC std_ss []
+   >> RW_TAC std_ss [RIGHT_AND_OVER_OR, EXISTS_OR_THM, GSYM DISJ_ASSOC]
+   >> RW_TAC std_ss [DISJ_ASSOC]
+   >> Know
       `(a s \/ (?k. IS_EL k l /\ a k)) \/ SOME_EL a x =
        a s \/ ?k. (IS_EL k x \/ IS_EL k l) /\ a k`
-   >> METIS_TAC [EXISTS_MEM]
-   ++ DISCH_THEN (fn th => REWRITE_TAC [th])
-   ++ RW_TAC std_ss [GSYM DISJ_ASSOC]
-   ++ Q.PAT_ASSUM `X = Y` (K ALL_TAC)
-   ++ Cases_on
+   >- METIS_TAC [EXISTS_MEM]
+   >> DISCH_THEN (fn th => REWRITE_TAC [th])
+   >> RW_TAC std_ss [GSYM DISJ_ASSOC]
+   >> Q.PAT_X_ASSUM `X = Y` (K ALL_TAC)
+   >> Cases_on
       `?q.
          ALL_EL (\k. (k = s) \/ IS_EL k l \/ IS_EL k w) q /\
          accepting_path t a s q`
-   >> (ASM_SIMP_TAC std_ss []
-       ++ Know
+   >- (ASM_SIMP_TAC std_ss []
+       >> Know
           `?q. ALL_EL (\x. IS_EL x l \/ IS_EL x w) q /\ accepting_path t a s q`
-       >> (POP_ASSUM STRIP_ASSUME_TAC
-           ++ MP_TAC (Q.SPECL [`\k. ~(k = s)`, `t`, `a`, `s`, `l'`]
+       >- (POP_ASSUM STRIP_ASSUME_TAC
+           >> MP_TAC (Q.SPECL [`\k. ~(k = s)`, `t`, `a`, `s`, `q`]
                       accepting_path_tail)
-           ++ RW_TAC std_ss []
-           ++ Q.EXISTS_TAC `js`
-           ++ RW_TAC std_ss []
-           ++ Suff `ALL_EL (\k. ~(k = s)) js /\
+           >> RW_TAC std_ss []
+           >> Q.EXISTS_TAC `js`
+           >> RW_TAC std_ss []
+           >> Suff `ALL_EL (\k. ~(k = s)) js /\
                     ALL_EL (\k. (k = s) \/ IS_EL k l \/ IS_EL k w) js`
-           >> (SIMP_TAC std_ss [GSYM EVERY_CONJ]
-               ++ Q.SPEC_TAC (`js`, `js`)
-               ++ MATCH_MP_TAC EVERY_MONOTONIC
-               ++ RW_TAC std_ss [FUN_EQ_THM]
-               ++ METIS_TAC [])
-           ++ RW_TAC std_ss []
-           ++ Q.PAT_ASSUM `X = BUTFIRSTN N L` MP_TAC
-           ++ Cases_on `n`
-           ++ RW_TAC std_ss [BUTFIRSTN]
-           ++ Know `js = TL (BUTFIRSTN n' l')` >> METIS_TAC [TL]
-           ++ RW_TAC arith_ss [BUTFIRSTN_TL]
-           ++ METIS_TAC [ALL_EL_BUTFIRSTN])
-       ++ POP_ASSUM (K ALL_TAC)
-       ++ RW_TAC std_ss []
-       ++ POP_ASSUM MP_TAC
-       ++ Cases_on `q`
-       ++ RW_TAC std_ss [accepting_path_def]
-       ++ DISJ2_TAC
-       ++ Q.EXISTS_TAC `h`
-       ++ Q.EXISTS_TAC `t'`
-       ++ RW_TAC std_ss []
-       >> (FULL_SIMP_TAC std_ss [EVERY_DEF] ++ METIS_TAC [MEM_partition])
-       ++ MATCH_MP_TAC EVERY_MONO
-       ++ Q.EXISTS_TAC `\k. MEM k l \/ MEM k w`
-       ++ (RW_TAC std_ss [] ++ FULL_SIMP_TAC std_ss [EVERY_DEF])
-       ++ METIS_TAC [MEM_partition])
-   ++ ASM_SIMP_TAC std_ss []
-   ++ POP_ASSUM MP_TAC
-   ++ SIMP_TAC std_ss []
-   ++ DISCH_THEN (MP_TAC o ONCE_REWRITE_RULE [PROVE [] ``a \/ b = ~a ==> b``])
-   ++ SIMP_TAC std_ss []
-   ++ STRIP_TAC
-   ++ Cases_on `a s`
-   >> (Q.PAT_ASSUM `!x. P x` (MP_TAC o Q.SPEC `[]`)
-       ++ RW_TAC std_ss [EVERY_DEF, accepting_path_def])
-   ++ RW_TAC std_ss []
-   ++ RW_TAC std_ss [RIGHT_AND_OVER_OR, EXISTS_OR_THM]
-   ++ MATCH_MP_TAC (PROVE [] ``~a /\ (b = c) ==> (a \/ b = c)``)
-   ++ CONJ_TAC
-   >> (SIMP_TAC std_ss []
-       ++ ONCE_REWRITE_TAC [PROVE [] ``a \/ b = ~a ==> b``]
-       ++ ONCE_REWRITE_TAC [PROVE [] ``a \/ b = ~a ==> b``]
-       ++ RW_TAC std_ss []
-       ++ STRIP_TAC
-       ++ Q.PAT_ASSUM `!x. P x` (MP_TAC o Q.SPEC `k :: l'`)
-       ++ RW_TAC std_ss [EVERY_DEF, accepting_path_def]
-       << [METIS_TAC [MEM_partition],
+           >- (SIMP_TAC std_ss [GSYM EVERY_CONJ]
+               >> Q.SPEC_TAC (`js`, `js`)
+               >> MATCH_MP_TAC EVERY_MONOTONIC
+               >> RW_TAC std_ss [FUN_EQ_THM]
+               >> METIS_TAC [])
+           >> RW_TAC std_ss []
+           >> Q.PAT_X_ASSUM `X = BUTFIRSTN N L` MP_TAC
+           >> Cases_on `n`
+           >> RW_TAC std_ss [BUTFIRSTN]
+           >> Know `js = TL (BUTFIRSTN n' q)` >- METIS_TAC [TL]
+           >> RW_TAC arith_ss [BUTFIRSTN_TL]
+           >> METIS_TAC [ALL_EL_BUTFIRSTN])
+       >> POP_ASSUM (K ALL_TAC)
+       >> RW_TAC std_ss []
+       >> POP_ASSUM MP_TAC
+       >> Cases_on `q`
+       >> RW_TAC std_ss [accepting_path_def]
+       >> DISJ2_TAC
+       >> Q.EXISTS_TAC `h`
+       >> Q.EXISTS_TAC `t'`
+       >> RW_TAC std_ss []
+       >- (FULL_SIMP_TAC std_ss [EVERY_DEF] >> METIS_TAC [MEM_partition])
+       >> MATCH_MP_TAC EVERY_MONO
+       >> Q.EXISTS_TAC `\k. MEM k l \/ MEM k w`
+       >> (RW_TAC std_ss [] >> FULL_SIMP_TAC std_ss [EVERY_DEF])
+       >> METIS_TAC [MEM_partition])
+   >> ASM_SIMP_TAC std_ss []
+   >> POP_ASSUM MP_TAC
+   >> SIMP_TAC std_ss []
+   >> DISCH_THEN (MP_TAC o ONCE_REWRITE_RULE [PROVE [] ``a \/ b = ~a ==> b``])
+   >> SIMP_TAC std_ss []
+   >> STRIP_TAC
+   >> Cases_on `a s`
+   >- (Q.PAT_X_ASSUM `!x. P x` (MP_TAC o Q.SPEC `[]`)
+       >> RW_TAC std_ss [EVERY_DEF, accepting_path_def])
+   >> RW_TAC std_ss []
+   >> RW_TAC std_ss [RIGHT_AND_OVER_OR, EXISTS_OR_THM]
+   >> MATCH_MP_TAC (PROVE [] ``~a /\ (b = c) ==> (a \/ b = c)``)
+   >> CONJ_TAC
+   >- (SIMP_TAC std_ss []
+       >> ONCE_REWRITE_TAC [PROVE [] ``a \/ b = ~a ==> b``]
+       >> ONCE_REWRITE_TAC [PROVE [] ``a \/ b = ~a ==> b``]
+       >> RW_TAC std_ss []
+       >> STRIP_TAC
+       >> Q.PAT_X_ASSUM `!x. P x` (MP_TAC o Q.SPEC `k :: l'`)
+       >> RW_TAC std_ss [EVERY_DEF, accepting_path_def]
+       >| [METIS_TAC [MEM_partition],
            MATCH_MP_TAC EVERY_MONO
-           ++ Q.EXISTS_TAC `\k. IS_EL k x \/ IS_EL k l \/ IS_EL k y`
-           ++ RW_TAC std_ss []
-           ++ METIS_TAC [MEM_partition],
+           >> Q.EXISTS_TAC `\k. IS_EL k x \/ IS_EL k l \/ IS_EL k y`
+           >> RW_TAC std_ss []
+           >> METIS_TAC [MEM_partition],
            METIS_TAC [MEM_partition]])
-   ++ HO_MATCH_MP_TAC
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``(!x y. A x y /\ C x y ==> (B x y = D x y)) ==>
          ((?x y. A x y /\ B x y /\ C x y) = (?x y. A x y /\ D x y /\ C x y))``)
-   ++ RW_TAC std_ss []
-   ++ EQ_TAC
-   >> (Q.SPEC_TAC (`l'`, `l'`)
-       ++ MATCH_MP_TAC EVERY_MONOTONIC
-       ++ METIS_TAC [MEM_partition])
-   ++ STRIP_TAC
-   ++ Suff `EVERY (\k. ~(k = s)) l'`
-   >> (POP_ASSUM MP_TAC
-       ++ SIMP_TAC std_ss [AND_IMP_INTRO, GSYM EVERY_CONJ]
-       ++ Q.SPEC_TAC (`l'`, `l'`)
-       ++ MATCH_MP_TAC EVERY_MONOTONIC
-       ++ METIS_TAC [MEM_partition])
-   ++ RW_TAC std_ss [EVERY_MEM, MEM_EL]
-   ++ CCONTR_TAC
-   ++ FULL_SIMP_TAC std_ss []
-   ++ Q.PAT_ASSUM `!x. P x` (MP_TAC o Q.SPEC `BUTFIRSTN (SUC n) l'`)
-   ++ RW_TAC std_ss []
-   >> (Q.PAT_ASSUM `EVERY P L` MP_TAC
-       ++ Q.SPEC_TAC (`EL n l'`, `s`)
-       ++ RW_TAC std_ss []
-       ++ Know `SUC n <= LENGTH l'` >> DECIDE_TAC
-       ++ Q.SPEC_TAC (`n`, `n`)
-       ++ MATCH_MP_TAC ALL_EL_BUTFIRSTN
-       ++ RW_TAC std_ss [])
-   ++ POP_ASSUM MP_TAC
-   ++ Q.PAT_ASSUM `accepting_path t a k l'` MP_TAC
-   ++ POP_ASSUM_LIST (K ALL_TAC)
-   ++ SIMP_TAC std_ss [AND_IMP_INTRO]
-   ++ Q.SPEC_TAC (`k`, `k`)
-   ++ Q.SPEC_TAC (`l'`, `l`)
-   ++ Induct_on `n`
-   ++ Cases
-   ++ RW_TAC arith_ss [LENGTH, BUTFIRSTN, EL, HD, TL, accepting_path_def]
-   ++ METIS_TAC []);
+   >> RW_TAC std_ss []
+   >> EQ_TAC
+   >- (Q.SPEC_TAC (`l'`, `l'`)
+       >> MATCH_MP_TAC EVERY_MONOTONIC
+       >> METIS_TAC [MEM_partition])
+   >> STRIP_TAC
+   >> Suff `EVERY (\k. ~(k = s)) l'`
+   >- (POP_ASSUM MP_TAC
+       >> SIMP_TAC std_ss [AND_IMP_INTRO, GSYM EVERY_CONJ]
+       >> Q.SPEC_TAC (`l'`, `l'`)
+       >> MATCH_MP_TAC EVERY_MONOTONIC
+       >> METIS_TAC [MEM_partition])
+   >> RW_TAC std_ss [EVERY_MEM, MEM_EL]
+   >> CCONTR_TAC
+   >> FULL_SIMP_TAC std_ss []
+   >> Q.PAT_X_ASSUM `!x. P x` (MP_TAC o Q.SPEC `BUTFIRSTN (SUC n) l'`)
+   >> RW_TAC std_ss []
+   >- (Q.PAT_X_ASSUM `EVERY P L` MP_TAC
+       >> Q.SPEC_TAC (`EL n l'`, `s`)
+       >> RW_TAC std_ss []
+       >> Know `SUC n <= LENGTH l'` >- DECIDE_TAC
+       >> Q.SPEC_TAC (`n`, `n`)
+       >> MATCH_MP_TAC ALL_EL_BUTFIRSTN
+       >> RW_TAC std_ss [])
+   >> POP_ASSUM MP_TAC
+   >> Q.PAT_X_ASSUM `accepting_path t a k l'` MP_TAC
+   >> POP_ASSUM_LIST (K ALL_TAC)
+   >> SIMP_TAC std_ss [AND_IMP_INTRO]
+   >> Q.SPEC_TAC (`k`, `k`)
+   >> Q.SPEC_TAC (`l'`, `l`)
+   >> Induct_on `n`
+   >> Cases
+   >> RW_TAC arith_ss [LENGTH, BUTFIRSTN, EL, HD, TL, accepting_path_def]
+   >> METIS_TAC []);
 
 val dijkstra_partition = store_thm
   ("dijkstra_partition",
@@ -398,9 +393,9 @@ val dijkstra_partition = store_thm
        (EXISTS a u \/ dijkstra t a u v =
         ?k ks. MEM k u /\ EVERY (\j. MEM j l) ks /\ accepting_path t a k ks)``,
    RW_TAC std_ss [dijkstra, MEM_APPEND]
-   ++ Suff `!j. MEM j l = MEM j u \/ MEM j v`
-   >> RW_TAC std_ss []
-   ++ METIS_TAC [MEM_partition]);
+   >> Suff `!j. MEM j l = MEM j u \/ MEM j v`
+   >- RW_TAC std_ss []
+   >> METIS_TAC [MEM_partition]);
 
 val dijkstra1 = store_thm
   ("dijkstra1",
@@ -409,14 +404,14 @@ val dijkstra1 = store_thm
        (a s \/ dijkstra t a [s] (FILTER (\x. ~(x = s)) l) =
         ?ks. EVERY (\j. MEM j l) ks /\ accepting_path t a s ks)``,
    RW_TAC std_ss []
-   ++ Know `a s = EXISTS a [s]` >> RW_TAC std_ss [EXISTS_DEF]
-   ++ DISCH_THEN (fn th => REWRITE_TAC [th])
-   ++ RW_TAC std_ss [dijkstra]
-   ++ RW_TAC std_ss [MEM, MEM_APPEND]
-   ++ Suff `!j. (j = s) \/ IS_EL j (FILTER (\x. ~(x = s)) l) = IS_EL j l`
-   >> RW_TAC std_ss []
-   ++ RW_TAC std_ss [MEM_FILTER]
-   ++ METIS_TAC []);
+   >> Know `a s = EXISTS a [s]` >- RW_TAC std_ss [EXISTS_DEF]
+   >> DISCH_THEN (fn th => REWRITE_TAC [th])
+   >> RW_TAC std_ss [dijkstra]
+   >> RW_TAC std_ss [MEM, MEM_APPEND]
+   >> Suff `!j. (j = s) \/ IS_EL j (FILTER (\x. ~(x = s)) l) = IS_EL j l`
+   >- RW_TAC std_ss []
+   >> RW_TAC std_ss [MEM_FILTER]
+   >> METIS_TAC []);
 
 (*---------------------------------------------------------------------------*)
 (* BIGLIST is designed to speed up evaluation of very long lists.            *)
@@ -429,29 +424,29 @@ val drop_def = pureDefine
 
 val BIGLIST_def = Define `BIGLIST l = drop 0 l`;
 
-val drop_nil = lemma
+val drop_nil = prove
   (``!i. drop i [] = []``,
-   Induct ++ RW_TAC std_ss [NULL_DEF, drop_def]);
+   Induct >> RW_TAC std_ss [NULL_DEF, drop_def]);
 
 val null_drop = store_thm
   ("null_drop",
    ``!i l. NULL (drop i l) = LENGTH l <= i``,
    Induct
-   >> (RW_TAC arith_ss [drop_def] ++ METIS_TAC [LENGTH_NIL, NULL_EQ_NIL])
-   ++ Cases_on `l`
-   ++ RW_TAC arith_ss [drop_def, LENGTH, NULL_DEF, TL]);
+   >- (RW_TAC arith_ss [drop_def] >> METIS_TAC [LENGTH_NIL, NULL_EQ_NIL])
+   >> Cases_on `l`
+   >> RW_TAC arith_ss [drop_def, LENGTH, NULL_DEF, TL]);
 
 val tl_drop = store_thm
   ("tl_drop",
    ``!i l.
        TL (drop i l) = if i < LENGTH l then drop (SUC i) l else TL (drop i l)``,
    Induct
-   >> (RW_TAC arith_ss [drop_def, NULL_EQ_NIL]
-       ++ FULL_SIMP_TAC arith_ss [LENGTH])
-   ++ Cases_on `l`
-   ++ RW_TAC arith_ss [drop_def, LENGTH, NULL_EQ_NIL, TL]
-   ++ Q.PAT_ASSUM `!l. P l` (fn th => ONCE_REWRITE_TAC [th])
-   ++ FULL_SIMP_TAC arith_ss [LENGTH, drop_def, NULL_EQ_NIL]);
+   >- (RW_TAC arith_ss [drop_def, NULL_EQ_NIL]
+       >> FULL_SIMP_TAC arith_ss [LENGTH])
+   >> Cases_on `l`
+   >> RW_TAC arith_ss [drop_def, LENGTH, NULL_EQ_NIL, TL]
+   >> Q.PAT_X_ASSUM `!l. P l` (fn th => ONCE_REWRITE_TAC [th])
+   >> FULL_SIMP_TAC arith_ss [LENGTH, drop_def, NULL_EQ_NIL]);
 
 val head_drop = store_thm
   ("head_drop",
@@ -461,18 +456,18 @@ val head_drop = store_thm
 val tail_drop = store_thm
   ("tail_drop",
    ``!l i h t. (drop i l = h :: t) ==> (drop (SUC i) l = t)``,
-   Induct >> RW_TAC bool_ss [drop_def, drop_nil]
-   ++ RW_TAC std_ss [drop_def, TL, NULL, drop_nil]
-   ++ POP_ASSUM MP_TAC
-   ++ Cases_on `i`
-   ++ RW_TAC std_ss [drop_def, NULL_EQ_NIL, TL]);
+   Induct >- RW_TAC bool_ss [drop_def, drop_nil]
+   >> RW_TAC std_ss [drop_def, TL, NULL, drop_nil]
+   >> POP_ASSUM MP_TAC
+   >> Cases_on `i`
+   >> RW_TAC std_ss [drop_def, NULL_EQ_NIL, TL]);
 
 val length_drop = store_thm
   ("length_drop",
    ``!i l h. (drop i l = [h]) ==> (LENGTH l = SUC i)``,
-   Induct >> RW_TAC arith_ss [drop_def, LENGTH]
-   ++ Cases
-   ++ RW_TAC std_ss [drop_def, TL, NULL_EQ_NIL, drop_nil, LENGTH]);
+   Induct >- RW_TAC arith_ss [drop_def, LENGTH]
+   >> Cases
+   >> RW_TAC std_ss [drop_def, TL, NULL_EQ_NIL, drop_nil, LENGTH]);
 
 (*---------------------------------------------------------------------------*)
 (* Non-deterministic and deterministic automata.                             *)
@@ -504,30 +499,30 @@ val da_accepts_def = Define
 val na2da_def = Define
   `na2da (n : ('a,'b) na) =
    ({initial n},
-    (\s c. {y | ?x. x IN s /\ transition n x c y}),
+    (\s c. {y | ?x. x IN s /\ (transition n) x c y}),
     (\s. ?x. x IN s /\ accept n x))`;
 
-val na2da_lemma = lemma
+val na2da_lemma = prove
   (``!n s l. da_step (na2da n) s l = ?x. x IN s /\ na_step n x l``,
    RW_TAC std_ss []
-   ++ Introduce `n = (i,trans,acc)`
-   ++ RW_TAC std_ss [na2da_def, initial_def, transition_def, accept_def]
-   ++ Q.SPEC_TAC (`s`, `s`)
-   ++ Induct_on `l`
-   >> (RW_TAC std_ss [da_step_def, na_step_def, IN_SING]
-       ++ METIS_TAC [])
-   ++ RW_TAC std_ss [da_step_def, na_step_def]
-   ++ RW_TAC std_ss [GSYM na2da_def, GSPECIFICATION]
-   ++ METIS_TAC []);
+   >> Introduce `n = (i,trans,acc)`
+   >> RW_TAC std_ss [na2da_def, initial_def, transition_def, accept_def]
+   >> Q.SPEC_TAC (`s`, `s`)
+   >> Induct_on `l`
+   >- (RW_TAC std_ss [da_step_def, na_step_def, IN_SING]
+       >> METIS_TAC [])
+   >> RW_TAC std_ss [da_step_def, na_step_def]
+   >> RW_TAC std_ss [GSYM na2da_def, GSPECIFICATION]
+   >> METIS_TAC []);
 
 val na2da = store_thm
   ("na2da",
    ``!n l. na_accepts n l = da_accepts (na2da n) l``,
    RW_TAC std_ss []
-   ++ Introduce `n = (i,trans,acc)`
-   ++ RW_TAC std_ss [na_accepts_def, da_accepts_def, na2da_def]
-   ++ RW_TAC std_ss [na2da_lemma, GSYM na2da_def, IN_SING]
-   ++ RW_TAC std_ss [initial_def]);
+   >> Introduce `n = (i,trans,acc)`
+   >> RW_TAC std_ss [na_accepts_def, da_accepts_def, na2da_def]
+   >> RW_TAC std_ss [na2da_lemma, GSYM na2da_def, IN_SING]
+   >> RW_TAC std_ss [initial_def]);
 
 (*---------------------------------------------------------------------------*)
 (* A checker that works by constructing a deterministic finite automata.     *)
@@ -553,7 +548,7 @@ val regexp2na_def = Define
         else if s' <= i2 then ?y. t1 (s - (i2 + 1)) x y /\ a1 y /\ t2 i2 x s'
         else t1 (s - (i2 + 1)) x (s' - (i2 + 1))),
      a2)) /\
-   (regexp2na (r1 | r2) =
+   (regexp2na (r1 || r2) =
     let (i1,t1,a1) = regexp2na r1 in
     let (i2,t2,a2) = regexp2na r2 in
     (i1 + i2 + 2,
@@ -594,153 +589,150 @@ val da_match_def = Define `da_match r = da_accepts (regexp2da r)`;
 (* Correctness of the finite automata matcher                                *)
 (*---------------------------------------------------------------------------*)
 
-val regexp2na_bounds = lemma
+val regexp2na_bounds = prove
   (``!r i trans acc.
        (regexp2na r = (i,trans,acc)) ==>
        (!s. acc s ==> s <= i) /\
        (!s x s'. trans s x s' ==> s <= i /\ s' <= i)``,
-   Induct
-   << [(* Atom *)
+   Induct (* 7 subgoals *)
+   >| [(* Atom *)
        FULL_SIMP_TAC std_ss [regexp2na_def],
        (* # *)
        Introduce `r = r1`
-       ++ Introduce `r' = r2`
-       ++ REPEAT GEN_TAC
-       ++ SIMP_TAC std_ss [regexp2na_def]
-       ++ Introduce `regexp2na r1 = (i1,t1,a1)`
-       ++ Introduce `regexp2na r2 = (i2,t2,a2)`
-       ++ STRIP_TAC
-       ++ REPEAT (POP_ASSUM MP_TAC)
-       ++ RW_TAC std_ss []
-       ++ POP_ASSUM MP_TAC
-       ++ RW_TAC std_ss []
-       ++ Know `!j. j - (i2 + 1) <= i1 ==> j <= i1 + i2 + 1` >> DECIDE_TAC
-       ++ METIS_TAC [LESS_EQ_TRANS, LESS_EQ_ADD, ADD_COMM, LESS_EQ_REFL],
+       >> Introduce `r' = r2`
+       >> REPEAT GEN_TAC
+       >> SIMP_TAC std_ss [regexp2na_def]
+       >> Introduce `regexp2na r1 = (i1,t1,a1)`
+       >> Introduce `regexp2na r2 = (i2,t2,a2)`
+       >> STRIP_TAC
+       >> REPEAT (POP_ASSUM MP_TAC)
+       >> RW_TAC std_ss [] (* 3 subgoals *)
+       >> POP_ASSUM MP_TAC
+       >> RW_TAC std_ss []
+       >> RES_TAC >> fs [],
        (* % *)
        Introduce `r = r1`
-       ++ Introduce `r' = r2`
-       ++ REPEAT GEN_TAC
-       ++ SIMP_TAC std_ss [regexp2na_def]
-       ++ Introduce `regexp2na r1 = (i1,t1,a1)`
-       ++ Introduce `regexp2na r2 = (i2,t2,a2)`
-       ++ REPEAT (POP_ASSUM MP_TAC)
-       ++ RW_TAC std_ss []
-       ++ POP_ASSUM MP_TAC
-       ++ RW_TAC std_ss []
-       ++ Know `!j. j - (i2 + 1) <= i1 ==> j <= i1 + i2 + 1` >> DECIDE_TAC
-       ++ METIS_TAC [LESS_EQ_TRANS, LESS_EQ_ADD, ADD_COMM],
-       (* | *)
+       >> Introduce `r' = r2`
+       >> REPEAT GEN_TAC
+       >> SIMP_TAC std_ss [regexp2na_def]
+       >> Introduce `regexp2na r1 = (i1,t1,a1)`
+       >> Introduce `regexp2na r2 = (i2,t2,a2)`
+       >> REPEAT (POP_ASSUM MP_TAC)
+       >> RW_TAC std_ss []
+       >> POP_ASSUM MP_TAC
+       >> RW_TAC std_ss []
+       >> RES_TAC >> fs [],
+       (* || *)
        Introduce `r = r1`
-       ++ Introduce `r' = r2`
-       ++ REPEAT GEN_TAC
-       ++ SIMP_TAC std_ss [regexp2na_def]
-       ++ Introduce `regexp2na r1 = (i1,t1,a1)`
-       ++ Introduce `regexp2na r2 = (i2,t2,a2)`
-       ++ REPEAT (POP_ASSUM MP_TAC)
-       ++ (RW_TAC std_ss [] ++ POP_ASSUM MP_TAC ++ RW_TAC std_ss [])
-       ++ Know `!j. j - (i1 + 1) <= i2 ==> j <= i1 + i2 + 2` >> DECIDE_TAC
-       ++ METIS_TAC [LESS_EQ_TRANS, LESS_EQ_ADD, ADD_COMM, LESS_EQ_REFL],
+       >> Introduce `r' = r2`
+       >> REPEAT GEN_TAC
+       >> SIMP_TAC std_ss [regexp2na_def]
+       >> Introduce `regexp2na r1 = (i1,t1,a1)`
+       >> Introduce `regexp2na r2 = (i2,t2,a2)`
+       >> REPEAT (POP_ASSUM MP_TAC)
+       >> (RW_TAC std_ss [] >> POP_ASSUM MP_TAC >> RW_TAC std_ss [])
+       >> RES_TAC >> fs [],
        (* & *)
        Introduce `r = r1`
-       ++ Introduce `r' = r2`
-       ++ REPEAT GEN_TAC
-       ++ SIMP_TAC std_ss [regexp2na_def]
-       ++ Introduce `regexp2na r1 = (i1,t1,a1)`
-       ++ Introduce `regexp2na r2 = (i2,t2,a2)`
-       ++ Q.PAT_ASSUM `!i. P i` (MP_TAC o Q.SPECL [`i2`,`t2`,`a2`])
-       ++ Q.PAT_ASSUM `!i. P i` (MP_TAC o Q.SPECL [`i1`,`t1`,`a1`])
-       ++ SIMP_TAC std_ss []
-       ++ REPEAT (DISCH_THEN STRIP_ASSUME_TAC)
-       ++ CONJ_TAC
-       << [REPEAT (POP_ASSUM MP_TAC)
-           ++ (RW_TAC std_ss [] ++ POP_ASSUM MP_TAC ++ RW_TAC std_ss [])
-           ++ MP_TAC (Q.SPEC `i2 + 1` DIVISION)
-           ++ DISCH_THEN (MP_TAC o Q.SPEC `s` o SIMP_RULE arith_ss [])
-           ++ DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
-           ++ MATCH_MP_TAC LESS_EQ_TRANS
-           ++ Q.EXISTS_TAC `(s DIV (i2 + 1)) * (i2 + 1) + i2`
-           ++ SIMP_TAC std_ss [ADD_MONO_LESS_EQ, LESS_EQ_MONO_ADD_EQ]
-           ++ CONJ_TAC >> METIS_TAC []
-           ++ Know `!m n. m * n + m = m * (n + 1)`
-           >> METIS_TAC [MULT_CLAUSES, ADD1, MULT_COMM]
-           ++ DISCH_THEN (fn th => REWRITE_TAC [th])
-           ++ MATCH_MP_TAC LESS_MONO_MULT
-           ++ METIS_TAC [],
+       >> Introduce `r' = r2`
+       >> REPEAT GEN_TAC
+       >> SIMP_TAC std_ss [regexp2na_def]
+       >> Introduce `regexp2na r1 = (i1,t1,a1)`
+       >> Introduce `regexp2na r2 = (i2,t2,a2)`
+       >> Q.PAT_X_ASSUM `!i. P i` (MP_TAC o Q.SPECL [`i2`,`t2`,`a2`])
+       >> Q.PAT_X_ASSUM `!i. P i` (MP_TAC o Q.SPECL [`i1`,`t1`,`a1`])
+       >> SIMP_TAC std_ss []
+       >> REPEAT (DISCH_THEN STRIP_ASSUME_TAC)
+       >> CONJ_TAC
+       >| [REPEAT (POP_ASSUM MP_TAC)
+           >> (RW_TAC std_ss [] >> POP_ASSUM MP_TAC >> RW_TAC std_ss [])
+           >> MP_TAC (Q.SPEC `i2 + 1` DIVISION)
+           >> DISCH_THEN (MP_TAC o Q.SPEC `s` o SIMP_RULE arith_ss [])
+           >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
+           >> MATCH_MP_TAC LESS_EQ_TRANS
+           >> Q.EXISTS_TAC `(s DIV (i2 + 1)) * (i2 + 1) + i2`
+           >> SIMP_TAC std_ss [ADD_MONO_LESS_EQ, LESS_EQ_MONO_ADD_EQ]
+           >> CONJ_TAC >- (RES_TAC >> fs [])
+           >> Know `!m n. m * n + m = m * (n + 1)`
+           >- METIS_TAC [MULT_CLAUSES, ADD1, MULT_COMM]
+           >> DISCH_THEN (fn th => REWRITE_TAC [th])
+           >> MATCH_MP_TAC LESS_MONO_MULT
+           >> METIS_TAC [],
            REPEAT (POP_ASSUM MP_TAC)
-           ++ (RW_TAC std_ss [] ++ POP_ASSUM MP_TAC ++ RW_TAC std_ss [])
-           << [MP_TAC (Q.SPEC `i2 + 1` DIVISION)
-               ++ DISCH_THEN (MP_TAC o Q.SPEC `s` o SIMP_RULE arith_ss [])
-               ++ DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
-               ++ MATCH_MP_TAC LESS_EQ_TRANS
-               ++ Q.EXISTS_TAC `(s DIV (i2 + 1)) * (i2 + 1) + i2`
-               ++ SIMP_TAC std_ss [ADD_MONO_LESS_EQ, LESS_EQ_MONO_ADD_EQ]
-               ++ CONJ_TAC >> METIS_TAC []
-               ++ Know `!m n. m * n + m = m * (n + 1)`
-               >> METIS_TAC [MULT_CLAUSES, ADD1, MULT_COMM]
-               ++ DISCH_THEN (fn th => REWRITE_TAC [th])
-               ++ MATCH_MP_TAC LESS_MONO_MULT
-               ++ METIS_TAC [],
+           >> (RW_TAC std_ss [] >> POP_ASSUM MP_TAC >> RW_TAC std_ss [])
+           >| [MP_TAC (Q.SPEC `i2 + 1` DIVISION)
+               >> DISCH_THEN (MP_TAC o Q.SPEC `s` o SIMP_RULE arith_ss [])
+               >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
+               >> MATCH_MP_TAC LESS_EQ_TRANS
+               >> Q.EXISTS_TAC `(s DIV (i2 + 1)) * (i2 + 1) + i2`
+               >> SIMP_TAC std_ss [ADD_MONO_LESS_EQ, LESS_EQ_MONO_ADD_EQ]
+               >> CONJ_TAC >- (RES_TAC >> fs [])
+               >> Know `!m n. m * n + m = m * (n + 1)`
+               >- METIS_TAC [MULT_CLAUSES, ADD1, MULT_COMM]
+               >> DISCH_THEN (fn th => REWRITE_TAC [th])
+               >> MATCH_MP_TAC LESS_MONO_MULT
+               >> METIS_TAC [],
                MP_TAC (Q.SPEC `i2 + 1` DIVISION)
-               ++ DISCH_THEN (MP_TAC o Q.SPEC `s'` o SIMP_RULE arith_ss [])
-               ++ DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
-               ++ MATCH_MP_TAC LESS_EQ_TRANS
-               ++ Q.EXISTS_TAC `(s' DIV (i2 + 1)) * (i2 + 1) + i2`
-               ++ SIMP_TAC std_ss [ADD_MONO_LESS_EQ, LESS_EQ_MONO_ADD_EQ]
-               ++ CONJ_TAC >> METIS_TAC []
-               ++ Know `!m n. m * n + m = m * (n + 1)`
-               >> METIS_TAC [MULT_CLAUSES, ADD1, MULT_COMM]
-               ++ DISCH_THEN (fn th => REWRITE_TAC [th])
-               ++ MATCH_MP_TAC LESS_MONO_MULT
-               ++ METIS_TAC []]],
+               >> DISCH_THEN (MP_TAC o Q.SPEC `s'` o SIMP_RULE arith_ss [])
+               >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
+               >> MATCH_MP_TAC LESS_EQ_TRANS
+               >> Q.EXISTS_TAC `(s' DIV (i2 + 1)) * (i2 + 1) + i2`
+               >> SIMP_TAC std_ss [ADD_MONO_LESS_EQ, LESS_EQ_MONO_ADD_EQ]
+               >> CONJ_TAC >- (RES_TAC >> fs [])
+               >> Know `!m n. m * n + m = m * (n + 1)`
+               >- METIS_TAC [MULT_CLAUSES, ADD1, MULT_COMM]
+               >> DISCH_THEN (fn th => REWRITE_TAC [th])
+               >> MATCH_MP_TAC LESS_MONO_MULT
+               >> METIS_TAC []]],
        (* Repeat *)
        REPEAT GEN_TAC
-       ++ SIMP_TAC std_ss [regexp2na_def]
-       ++ Introduce `regexp2na r = (i,t,a)`
-       ++ REPEAT (POP_ASSUM MP_TAC)
-       ++ (RW_TAC std_ss [] ++ POP_ASSUM MP_TAC ++ RW_TAC std_ss [])
-       ++ METIS_TAC [LESS_EQ_TRANS, LESS_EQ_ADD, ADD_COMM, LESS_EQ_REFL],
+       >> SIMP_TAC std_ss [regexp2na_def]
+       >> Introduce `regexp2na r = (i,t,a)`
+       >> REPEAT (POP_ASSUM MP_TAC)
+       >> (RW_TAC std_ss [] >> POP_ASSUM MP_TAC >> RW_TAC std_ss [])
+       >> METIS_TAC [LESS_EQ_TRANS, LESS_EQ_ADD, ADD_COMM, LESS_EQ_REFL],
        (* Prefix *)
        REPEAT GEN_TAC
-       ++ SIMP_TAC std_ss [regexp2na_def]
-       ++ Introduce `regexp2na r = (i,t,a)`
-       ++ REPEAT (POP_ASSUM MP_TAC)
-       ++ (RW_TAC std_ss [] ++ POP_ASSUM MP_TAC ++ RW_TAC std_ss [])
-       << [POP_ASSUM MP_TAC
-           ++ Cases_on `l`
-           ++ RW_TAC std_ss [accepting_path_def]
-           ++ METIS_TAC [],
+       >> SIMP_TAC std_ss [regexp2na_def]
+       >> Introduce `regexp2na r = (i,t,a)`
+       >> REPEAT (POP_ASSUM MP_TAC)
+       >> (RW_TAC std_ss [] >> POP_ASSUM MP_TAC >> RW_TAC std_ss [])
+       >| [POP_ASSUM MP_TAC
+           >> Cases_on `l`
+           >> RW_TAC std_ss [accepting_path_def]
+           >> METIS_TAC [],
            METIS_TAC [],
            METIS_TAC []]]);
 
-val regexp2na_acc = lemma
+val regexp2na_acc = prove
   (``!r i trans acc s. (regexp2na r = (i,trans,acc)) /\ acc s ==> s <= i``,
    METIS_TAC [regexp2na_bounds]);
 
-val regexp2na_trans = lemma
+val regexp2na_trans = prove
   (``!r i trans acc s x s'.
        (regexp2na r = (i,trans,acc)) /\ trans s x s' ==> s <= i /\ s' <= i``,
    METIS_TAC [regexp2na_bounds]);
 
-val na_match_atom = lemma
+val na_match_atom = prove
   (``!b l. na_accepts (regexp2na (Atom b)) l = sem (Atom b) l``,
    RW_TAC std_ss [regexp2na_def, sem_def, LENGTH_EQ_ONE, na_accepts_def]
-   ++ Cases_on `l`
-   ++ RW_TAC std_ss [na_step_def, HD]
-   ++ Cases_on `t`
-   ++ RW_TAC std_ss [na_step_def, HD]);
+   >> Cases_on `l`
+   >> RW_TAC std_ss [na_step_def, HD]
+   >> Cases_on `t`
+   >> RW_TAC std_ss [na_step_def, HD]);
 
-val na_match_concat = lemma
+val na_match_concat = prove
   (``!r1 r2.
        (!l. na_accepts (regexp2na r1) l = sem r1 l) /\
        (!l. na_accepts (regexp2na r2) l = sem r2 l) ==>
        !l. na_accepts (regexp2na (r1 # r2)) l = sem (r1 # r2) l``,
    REPEAT GEN_TAC
-   ++ Introduce `regexp2na r1 = (i1, t1, a1)`
-   ++ Introduce `regexp2na r2 = (i2, t2, a2)`
-   ++ NTAC 2 (RW_TAC std_ss [regexp2na_def, sem_def, na_accepts_def])
-   ++ RW_TAC std_ss [regexp2na_def, sem_def, na_accepts_def]
-   ++ REPEAT (Q.PAT_ASSUM `!x. P x` (fn th => REWRITE_TAC [GSYM th]))
-   ++ Suff
+   >> Introduce `regexp2na r1 = (i1, t1, a1)`
+   >> Introduce `regexp2na r2 = (i2, t2, a2)`
+   >> NTAC 2 (RW_TAC std_ss [regexp2na_def, sem_def, na_accepts_def])
+   >> RW_TAC std_ss [regexp2na_def, sem_def, na_accepts_def]
+   >> REPEAT (Q.PAT_X_ASSUM `!x. P x` (fn th => REWRITE_TAC [GSYM th]))
+   >> Suff
       `!k.
          na_step
            (i1 + i2 + 1,
@@ -753,64 +745,64 @@ val na_match_concat = lemma
          ?w1 w2.
            (l = w1 <> w2) /\ na_step (i1,t1,a1) k w1 /\
            na_step (i2,t2,a2) i2 w2`
-   >> METIS_TAC []
-   ++ Induct_on `l`
-   >> (RW_TAC std_ss [na_step_def, APPEND_eq_NIL]
-       ++ FULL_SIMP_TAC arith_ss []
-       ++ METIS_TAC [])
-   ++ RW_TAC std_ss []
-   ++ Know `!P Q. (Q = P [] \/ ?t h. P (h :: t)) ==> (Q = (?l. P l))`
-   >> (POP_ASSUM_LIST (K ALL_TAC) ++ METIS_TAC [list_CASES])
-   ++ DISCH_THEN HO_MATCH_MP_TAC
-   ++ RW_TAC arith_ss [APPEND, na_step_def]
-   ++ HO_MATCH_MP_TAC
+   >- METIS_TAC []
+   >> Induct_on `l`
+   >- (RW_TAC std_ss [na_step_def, APPEND_eq_NIL]
+       >> FULL_SIMP_TAC arith_ss []
+       >> METIS_TAC [])
+   >> RW_TAC std_ss []
+   >> Know `!P Q. (Q = P [] \/ ?t h. P (h :: t)) ==> (Q = (?l. P l))`
+   >- (POP_ASSUM_LIST (K ALL_TAC) >> METIS_TAC [list_CASES])
+   >> DISCH_THEN HO_MATCH_MP_TAC
+   >> RW_TAC arith_ss [APPEND, na_step_def]
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``!P Q R X Y Z.
            ((?x : num. P x /\ Q x /\ Z x) = X) /\
            ((?x. ~P x /\ R x /\ Z x) = Y) ==>
            ((?x. (if P x then Q x else R x) /\ Z x) = X \/ Y)``)
-   ++ REVERSE CONJ_TAC
-   >> (Suff
+   >> REVERSE CONJ_TAC
+   >- (Suff
        `!P Q.
           ((?x : num. P (x + i2 + 1)) = Q) ==>
           ((?x. ~(x <= i2) /\ P x) = Q)`
-       >> (DISCH_THEN HO_MATCH_MP_TAC
-           ++ POP_ASSUM MP_TAC
-           ++ RW_TAC arith_ss []
-           ++ POP_ASSUM (K ALL_TAC)
-           ++ METIS_TAC [])
-       ++ POP_ASSUM (K ALL_TAC)
-       ++ Suff `!x. ~(x <= i2) = (?y. x = y + i2 + 1)` >> METIS_TAC []
-       ++ RW_TAC arith_ss []
-       ++ REVERSE EQ_TAC >> RW_TAC arith_ss []
-       ++ RW_TAC arith_ss []
-       ++ Q.EXISTS_TAC `x - (i2 + 1)`
-       ++ DECIDE_TAC)
-   ++ POP_ASSUM (K ALL_TAC)
-   ++ HO_MATCH_MP_TAC
+       >- (DISCH_THEN HO_MATCH_MP_TAC
+           >> POP_ASSUM MP_TAC
+           >> RW_TAC arith_ss []
+           >> POP_ASSUM (K ALL_TAC)
+           >> METIS_TAC [])
+       >> POP_ASSUM (K ALL_TAC)
+       >> Suff `!x. ~(x <= i2) = (?y. x = y + i2 + 1)` >- METIS_TAC []
+       >> RW_TAC arith_ss []
+       >> REVERSE EQ_TAC >- RW_TAC arith_ss []
+       >> RW_TAC arith_ss []
+       >> Q.EXISTS_TAC `x - (i2 + 1)`
+       >> DECIDE_TAC)
+   >> POP_ASSUM (K ALL_TAC)
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``!A B C D E.
            (!x. E x ==> A x) /\ (!x. A x ==> (D x = E x)) ==>
            ((?x. A x /\ (B /\ C x) /\ D x) = B /\ ?x. C x /\ E x)``)
-   ++ CONJ_TAC
-   >> (Cases_on `l`
-       ++ RW_TAC std_ss [na_step_def]
-       ++ METIS_TAC [regexp2na_trans, regexp2na_acc])
-   ++ Induct_on `l` >> RW_TAC std_ss [na_step_def]
-   ++ RW_TAC std_ss [na_step_def]
-   ++ METIS_TAC [regexp2na_trans]);
+   >> CONJ_TAC
+   >- (Cases_on `l`
+       >> RW_TAC std_ss [na_step_def]
+       >> METIS_TAC [regexp2na_trans, regexp2na_acc])
+   >> Induct_on `l` >- RW_TAC std_ss [na_step_def]
+   >> RW_TAC std_ss [na_step_def]
+   >> METIS_TAC [regexp2na_trans]);
 
-val na_match_fuse = lemma
+val na_match_fuse = prove
   (``!r1 r2.
        (!l. na_accepts (regexp2na r1) l = sem r1 l) /\
        (!l. na_accepts (regexp2na r2) l = sem r2 l) ==>
        !l. na_accepts (regexp2na (r1 % r2)) l = sem (r1 % r2) l``,
    REPEAT GEN_TAC
-   ++ Introduce `regexp2na r1 = (i1, t1, a1)`
-   ++ Introduce `regexp2na r2 = (i2, t2, a2)`
-   ++ NTAC 2 (RW_TAC std_ss [regexp2na_def, sem_def, na_accepts_def])
-   ++ REPEAT (Q.PAT_ASSUM `!x. P x` (fn th => REWRITE_TAC [GSYM th]))
-   ++ Suff
+   >> Introduce `regexp2na r1 = (i1, t1, a1)`
+   >> Introduce `regexp2na r2 = (i2, t2, a2)`
+   >> NTAC 2 (RW_TAC std_ss [regexp2na_def, sem_def, na_accepts_def])
+   >> REPEAT (Q.PAT_X_ASSUM `!x. P x` (fn th => REWRITE_TAC [GSYM th]))
+   >> Suff
       `!k.
          na_step
          (i1 + i2 + 1,
@@ -822,144 +814,147 @@ val na_match_fuse = lemma
          ?w1 w2 c.
            (l = w1 <> [c] <> w2) /\ na_step (i1,t1,a1) k (w1 <> [c]) /\
            na_step (i2,t2,a2) i2 ([c] <> w2)`
-   >> METIS_TAC []
-   ++ Induct_on `l`
-   >> (RW_TAC std_ss [na_step_def, APPEND_eq_NIL]
-       ++ Suff `~(k + i2 + 1 <= i2)` >> METIS_TAC [regexp2na_acc]
-       ++ RW_TAC arith_ss [])
-   ++ RW_TAC std_ss []
-   ++ HO_MATCH_MP_TAC
+   >- METIS_TAC []
+   >> Induct_on `l`
+   >- (RW_TAC std_ss [na_step_def, APPEND_eq_NIL]
+       >> Suff `~(k + i2 + 1 <= i2)` >- METIS_TAC [regexp2na_acc]
+       >> RW_TAC arith_ss [])
+   >> RW_TAC std_ss []
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE [list_CASES]
        ``!P Q. (Q = P [] \/ ?t h. P (h :: t)) ==> (Q = (?l. P l))``)
-   ++ RW_TAC arith_ss [na_step_def]
-   ++ HO_MATCH_MP_TAC
+   >> RW_TAC arith_ss [na_step_def]
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``!P Q R X Y Z.
            ((?x : num. P x /\ Q x /\ Z x) = X) /\
            ((?x. ~P x /\ R x /\ Z x) = Y) ==>
            ((?x. (if P x then Q x else R x) /\ Z x) = X \/ Y)``)
-   ++ REVERSE CONJ_TAC
-   >> (Suff
+   >> REVERSE CONJ_TAC
+   >- (Suff
        `!P Q.
           ((?x : num. P (x + i2 + 1)) = Q) ==>
           ((?x. ~(x <= i2) /\ P x) = Q)`
-       >> (DISCH_THEN HO_MATCH_MP_TAC
-           ++ POP_ASSUM MP_TAC
-           ++ RW_TAC arith_ss []
-           ++ POP_ASSUM (K ALL_TAC)
-           ++ RW_TAC arith_ss [na_step_def, APPEND]
-           ++ METIS_TAC [])
-       ++ POP_ASSUM (K ALL_TAC)
-       ++ Suff `!x. ~(x <= i2) = (?y. x = y + i2 + 1)` >> METIS_TAC []
-       ++ RW_TAC arith_ss []
-       ++ REVERSE EQ_TAC >> RW_TAC arith_ss []
-       ++ RW_TAC arith_ss []
-       ++ Q.EXISTS_TAC `x - (i2 + 1)`
-       ++ DECIDE_TAC)
-   ++ POP_ASSUM (K ALL_TAC)
-   ++ RW_TAC std_ss [APPEND, na_step_def]
-   ++ HO_MATCH_MP_TAC
+       >- (DISCH_THEN HO_MATCH_MP_TAC
+           >> POP_ASSUM MP_TAC
+           >> RW_TAC arith_ss []
+           >> POP_ASSUM (K ALL_TAC)
+           >> RW_TAC arith_ss [na_step_def, APPEND]
+           >> METIS_TAC [])
+       >> POP_ASSUM (K ALL_TAC)
+       >> Suff `!x. ~(x <= i2) = (?y. x = y + i2 + 1)` >- METIS_TAC []
+       >> RW_TAC arith_ss []
+       >> REVERSE EQ_TAC >- RW_TAC arith_ss []
+       >> RW_TAC arith_ss []
+       >> Q.EXISTS_TAC `x - (i2 + 1)`
+       >> DECIDE_TAC)
+   >> POP_ASSUM (K ALL_TAC)
+   >> RW_TAC std_ss [APPEND, na_step_def]
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``!A B C D E G.
            (!x. G x ==> A x) /\ (!x. A x ==> (E x = G x)) ==>
            ((?x. A x /\ (?y. B y /\ C y /\ D x) /\ E x) =
             (?y. B y /\ C y) /\ (?x. D x /\ G x))``)
-   ++ CONJ_TAC
-   >> (Cases_on `l`
-       ++ RW_TAC std_ss [na_step_def]
-       ++ METIS_TAC [regexp2na_trans, regexp2na_acc])
-   ++ Induct_on `l` >> RW_TAC std_ss [na_step_def]
-   ++ RW_TAC std_ss [na_step_def]
-   ++ METIS_TAC [regexp2na_trans]);
+   >> CONJ_TAC
+   >- (Cases_on `l`
+       >> RW_TAC std_ss [na_step_def]
+       >> METIS_TAC [regexp2na_trans, regexp2na_acc])
+   >> Induct_on `l` >- RW_TAC std_ss [na_step_def]
+   >> RW_TAC std_ss [na_step_def]
+   >> METIS_TAC [regexp2na_trans]);
 
-val na_match_or = lemma
+val na_match_or = prove
   (``!r1 r2.
        (!l. na_accepts (regexp2na r1) l = sem r1 l) /\
        (!l. na_accepts (regexp2na r2) l = sem r2 l) ==>
-       !l. na_accepts (regexp2na (r1 | r2)) l = sem (r1 | r2) l``,
+       !l. na_accepts (regexp2na (r1 || r2)) l = sem (r1 || r2) l``,
    REPEAT GEN_TAC
-   ++ Introduce `regexp2na r1 = (i1, t1, a1)`
-   ++ Introduce `regexp2na r2 = (i2, t2, a2)`
-   ++ NTAC 2 (RW_TAC std_ss [regexp2na_def, sem_def, na_accepts_def])
-   ++ REPEAT (Q.PAT_ASSUM `!x. P x` (fn th => REWRITE_TAC [GSYM th]))
-   ++ Cases_on `l` >> RW_TAC std_ss [na_step_def]
-   ++ RW_TAC std_ss [na_step_def]
-   ++ HO_MATCH_MP_TAC
+   >> Introduce `regexp2na r1 = (i1, t1, a1)`
+   >> Introduce `regexp2na r2 = (i2, t2, a2)`
+   >> NTAC 2 (RW_TAC std_ss [regexp2na_def, sem_def, na_accepts_def])
+   >> REPEAT (Q.PAT_X_ASSUM `!x. P x` (fn th => REWRITE_TAC [GSYM th]))
+   >> Cases_on `l` >- RW_TAC std_ss [na_step_def]
+   >> RW_TAC std_ss [na_step_def]
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``!P Q R X Y Z.
            ((?x : num. Z x /\ P x /\ R x) = X) /\
            ((?x. ~Z x /\ Q x /\ R x) = Y) ==>
            ((?x. (if Z x then P x else Q x) /\ R x) = X \/ Y)``)
-   ++ CONJ_TAC
-   >> (HO_MATCH_MP_TAC
+   >> CONJ_TAC
+   >- (HO_MATCH_MP_TAC
        (METIS_PROVE []
         ``!P Q R X.
             (!x. P x ==> X x) /\ (!x : num. X x ==> (Q x = R x)) ==>
             ((?x. X x /\ P x /\ Q x) = (?x. P x /\ R x))``)
-       ++ CONJ_TAC >> METIS_TAC [regexp2na_trans]
-       ++ Induct_on `t`
+       >> CONJ_TAC >- METIS_TAC [regexp2na_trans]
+       >> Induct_on `t`
+       >- RW_TAC arith_ss [na_step_def]
        >> RW_TAC arith_ss [na_step_def]
-       ++ RW_TAC arith_ss [na_step_def]
-       ++ HO_MATCH_MP_TAC
+       >> HO_MATCH_MP_TAC
           (METIS_PROVE []
            ``!P Q R.
                (!x : num. P x ==> (Q x = R x)) ==>
                ((?x. P x /\ Q x) = (?x. P x /\ R x))``)
-       ++ RW_TAC std_ss []
-       ++ Know `s'' <= i1` >> METIS_TAC [regexp2na_trans]
-       ++ POP_ASSUM (K ALL_TAC)
-       ++ STRIP_TAC
-       ++ Q.PAT_ASSUM `!k. P k` (MP_TAC o Q.SPEC `s''`)
-       ++ RW_TAC arith_ss [])
-   ++ HO_MATCH_MP_TAC
+       >> RW_TAC std_ss []
+       >> rename1 `na_step _ s''' t = na_step (i1,t1,a1) s''' t`
+       >> Know `s''' <= i1` >- METIS_TAC [regexp2na_trans] (* was: s'' *)
+       >> POP_ASSUM (K ALL_TAC)
+       >> STRIP_TAC
+       >> Q.PAT_X_ASSUM `!k. P k` (MP_TAC o Q.SPEC `s'''`)
+       >> RW_TAC arith_ss [])
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``!P Q.
            (!x. P x ==> ?y. x = y + (i1 + 1)) /\
            (!x : num. P (x + (i1 + 1)) = Q x) ==>
            ((?x. P x) = (?x. Q x))``)
-   ++ CONJ_TAC
-   >> (RW_TAC std_ss []
-       ++ Q.EXISTS_TAC `s' - (i1 + 1)`
-       ++ POP_ASSUM (K ALL_TAC)
-       ++ DECIDE_TAC)
-   ++ RW_TAC arith_ss []
-   ++ MATCH_MP_TAC (PROVE [] ``!x y z. (x ==> (y = z)) ==> (x /\ y = x /\ z)``)
-   ++ STRIP_TAC
-   ++ Know `s' <= i2` >> METIS_TAC [regexp2na_trans]
-   ++ POP_ASSUM (K ALL_TAC)
-   ++ Q.SPEC_TAC (`s'`, `k`)
-   ++ Induct_on `t` >> RW_TAC arith_ss [na_step_def]
-   ++ RW_TAC arith_ss [na_step_def]
-   ++ HO_MATCH_MP_TAC
+   >> CONJ_TAC
+   >- (RW_TAC std_ss []
+       >> Q.EXISTS_TAC `s' - (i1 + 1)`
+       >> POP_ASSUM (K ALL_TAC)
+       >> DECIDE_TAC)
+   >> RW_TAC arith_ss []
+   >> MATCH_MP_TAC (PROVE [] ``!x y z. (x ==> (y = z)) ==> (x /\ y = x /\ z)``)
+   >> STRIP_TAC
+   >> rename1 `na_step _ (i1 + (s'' + 1)) t  = na_step (i2,t2,a2) s'' t`
+   >> Know `s'' <= i2` >- METIS_TAC [regexp2na_trans] (* was: s' *)
+   >> POP_ASSUM (K ALL_TAC)
+   >> Q.SPEC_TAC (`s''`, `k`)
+   >> Induct_on `t` >- RW_TAC arith_ss [na_step_def]
+   >> RW_TAC arith_ss [na_step_def]
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``!P Q.
            (!x. P x ==> ?y. x = y + (i1 + 1)) /\
            (!x : num. P (x + (i1 + 1)) = Q x) ==>
            ((?x. P x) = (?x. Q x))``)
-   ++ CONJ_TAC
-   >> (Q.PAT_ASSUM `!x. P x` (K ALL_TAC)
-       ++ RW_TAC std_ss []
-       ++ Q.EXISTS_TAC `s' - (i1 + 1)`
-       ++ POP_ASSUM (K ALL_TAC)
-       ++ DECIDE_TAC)
-   ++ RW_TAC arith_ss []
-   ++ MATCH_MP_TAC (PROVE [] ``!x y z. (x ==> (y = z)) ==> (x /\ y = x /\ z)``)
-   ++ STRIP_TAC
-   ++ Q.PAT_ASSUM `!x. P x` (MP_TAC o Q.SPEC `s'`)
-   ++ Know `s' <= i2` >> METIS_TAC [regexp2na_trans]
-   ++ RW_TAC arith_ss []);
+   >> CONJ_TAC
+   >- (Q.PAT_X_ASSUM `!x. P x` (K ALL_TAC)
+       >> RW_TAC std_ss []
+       >> Q.EXISTS_TAC `s' - (i1 + 1)`
+       >> POP_ASSUM (K ALL_TAC)
+       >> DECIDE_TAC)
+   >> RW_TAC arith_ss []
+   >> MATCH_MP_TAC (PROVE [] ``!x y z. (x ==> (y = z)) ==> (x /\ y = x /\ z)``)
+   >> STRIP_TAC
+   >> rename1 `na_step _ (i1 + (s'' + 1)) t  = na_step (i2,t2,a2) s'' t`
+   >> Q.PAT_X_ASSUM `!x. P x` (MP_TAC o Q.SPEC `s''`) (* was: s' *)
+   >> Know `s'' <= i2` >- METIS_TAC [regexp2na_trans]
+   >> RW_TAC arith_ss []);
 
-val na_match_and = lemma
+val na_match_and = prove
   (``!r1 r2.
        (!l. na_accepts (regexp2na r1) l = sem r1 l) /\
        (!l. na_accepts (regexp2na r2) l = sem r2 l) ==>
        !l. na_accepts (regexp2na (r1 & r2)) l = sem (r1 & r2) l``,
    REPEAT GEN_TAC
-   ++ Introduce `regexp2na r1 = (i1, t1, a1)`
-   ++ Introduce `regexp2na r2 = (i2, t2, a2)`
-   ++ NTAC 2 (RW_TAC std_ss [regexp2na_def, sem_def, na_accepts_def])
-   ++ REPEAT (Q.PAT_ASSUM `!x. P x` (fn th => REWRITE_TAC [GSYM th]))
-   ++ Suff
+   >> Introduce `regexp2na r1 = (i1, t1, a1)`
+   >> Introduce `regexp2na r2 = (i2, t2, a2)`
+   >> NTAC 2 (RW_TAC std_ss [regexp2na_def, sem_def, na_accepts_def])
+   >> REPEAT (Q.PAT_X_ASSUM `!x. P x` (fn th => REWRITE_TAC [GSYM th]))
+   >> Suff
       `!j k.
          j <= i1 /\ k <= i2 ==>
          (na_step
@@ -970,212 +965,216 @@ val na_match_and = lemma
            (\s. a1 (s DIV (i2 + 1)) /\ a2 (s MOD (i2 + 1))))
           (j * (i2 + 1) + k) l =
         na_step (i1,t1,a1) j l /\ na_step (i2,t2,a2) k l)`
-   >> (DISCH_THEN (MP_TAC o Q.SPECL [`i1`, `i2`])
-       ++ RW_TAC arith_ss [LEFT_ADD_DISTRIB])
-   ++ Know `0 < i2 + 1` >> DECIDE_TAC ++ STRIP_TAC
-   ++ Know `!k. k < i2 + 1 = k <= i2` >> DECIDE_TAC ++ STRIP_TAC
-   ++ Induct_on `l` >> RW_TAC std_ss [na_step_def, DIV_MULT, MOD_MULT]
-   ++ RW_TAC std_ss [na_step_def, DIV_MULT, MOD_MULT]
-   ++ CONV_TAC
+   >- (DISCH_THEN (MP_TAC o Q.SPECL [`i1`, `i2`])
+       >> RW_TAC arith_ss [LEFT_ADD_DISTRIB])
+   >> Know `0 < i2 + 1` >- DECIDE_TAC >> STRIP_TAC
+   >> Know `!k. k < i2 + 1 = k <= i2` >- DECIDE_TAC >> STRIP_TAC
+   >> Induct_on `l` >- RW_TAC std_ss [na_step_def, DIV_MULT, MOD_MULT]
+   >> RW_TAC std_ss [na_step_def, DIV_MULT, MOD_MULT]
+   >> CONV_TAC
       (REDEPTH_CONV (LEFT_AND_EXISTS_CONV ORELSEC RIGHT_AND_EXISTS_CONV))
-   ++ RW_TAC std_ss []
-   ++ MP_TAC (Q.SPEC `i2 + 1` DIVISION)
-   ++ ASM_REWRITE_TAC []
-   ++ HO_MATCH_MP_TAC
+   >> RW_TAC std_ss []
+   >> MP_TAC (Q.SPEC `i2 + 1` DIVISION)
+   >> ASM_REWRITE_TAC []
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``!P Q A B C.
            ((?x. A x /\ B (P x)) = C) ==>
            ((!x. (x = P x) /\ Q x) ==> ((?x. A x /\ B x) = C))``)
-   ++ HO_MATCH_MP_TAC
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``!P A B C.
            (!x. A x ==> P x) /\ ((?x. A x /\ (P x ==> B x)) = C) ==>
            ((?x. A x /\ B x) = C)``)
-   ++ Q.EXISTS_TAC `\x. x DIV (i2 + 1) <= i1 /\ x MOD (i2 + 1) <= i2`
-   ++ BETA_TAC
-   ++ CONJ_TAC >> METIS_TAC [regexp2na_trans]
-   ++ Q.PAT_ASSUM `!x. P x` (fn th => RW_TAC std_ss [th])
-   ++ HO_MATCH_MP_TAC
+   >> Q.EXISTS_TAC `\x. x DIV (i2 + 1) <= i1 /\ x MOD (i2 + 1) <= i2`
+   >> BETA_TAC
+   >> CONJ_TAC >- METIS_TAC [regexp2na_trans]
+   >> Q.PAT_X_ASSUM `!x. P x` (fn th => RW_TAC std_ss [th])
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``!P A B C.
            (!x. A x ==> P x) /\ ((?x. A x /\ B x) = C) ==>
            ((?x. A x /\ (P x ==> B x)) = C)``)
-   ++ CONJ_TAC >> METIS_TAC [regexp2na_trans]
-   ++ EQ_TAC >> METIS_TAC []
-   ++ RW_TAC std_ss []
-   ++ Q.EXISTS_TAC `s' * (i2 + 1) + s''`
-   ++ Know `s'' <= i2` >> METIS_TAC [regexp2na_trans]
-   ++ RW_TAC std_ss [DIV_MULT, MOD_MULT]);
+   >> CONJ_TAC >- METIS_TAC [regexp2na_trans]
+   >> EQ_TAC >- METIS_TAC []
+   >> RW_TAC std_ss []
+   >> rename1 `na_step (i2,t2,a2) s''' l`
+   >> rename1 `na_step (i1,t1,a1) s'' l`
+   >> Q.EXISTS_TAC `s'' * (i2 + 1) + s'''` (* was: s', s'' *)
+   >> Know `s''' <= i2` >- METIS_TAC [regexp2na_trans]
+   >> RW_TAC std_ss [DIV_MULT, MOD_MULT]);
 
-val na_match_repeat = lemma
+val na_match_repeat = prove
   (``!r.
        (!l. na_accepts (regexp2na r) l = sem r l) ==>
        !l. na_accepts (regexp2na (Repeat r)) l = sem (Repeat r) l``,
    REPEAT GEN_TAC
-   ++ Introduce `regexp2na r = (i, t, a)`
-   ++ (NTAC 2 (RW_TAC std_ss [regexp2na_def, sem_def, na_accepts_def])
-       ++ (REPEAT o Q.PAT_ASSUM `!x. P x`)
+   >> Introduce `regexp2na r = (i, t, a)`
+   >> (NTAC 2 (RW_TAC std_ss [regexp2na_def, sem_def, na_accepts_def])
+       >> (REPEAT o Q.PAT_X_ASSUM `!x. P x`)
           (fn th => REWRITE_TAC [GSYM (MATCH_MP EQ_EXT th)]))
-   >> (HO_MATCH_MP_TAC
+   >- (HO_MATCH_MP_TAC
        (METIS_PROVE [list_CASES]
         ``!P Q. (Q = P [] \/ ?w ws. P (w :: ws)) ==> (Q = (?l. P l))``)
-       ++ RW_TAC std_ss [CONCAT_def, ALL_EL]
-       ++ Cases_on `l = []` >> RW_TAC std_ss [na_step_def]
-       ++ RW_TAC std_ss []
-       ++ Suff
+       >> RW_TAC std_ss [CONCAT_def, ALL_EL]
+       >> Cases_on `l = []` >- RW_TAC std_ss [na_step_def]
+       >> RW_TAC std_ss []
+       >> Suff
           `!k.
              (na_step (i,(\s x s'. t s x s' \/ a s /\ t i x s'),a) k l =
               ?w ws.
                 (l = w <> CONCAT ws) /\ na_step (i,t,a) k w /\
                 ALL_EL (na_step (i,t,a) i) ws)`
+       >- RW_TAC std_ss []
+       >> POP_ASSUM (K ALL_TAC)
+       >> Induct_on `l`
+       >- (RW_TAC std_ss [na_step_def, APPEND_eq_NIL]
+           >> REVERSE (Cases_on `a k`) >- RW_TAC std_ss []
+           >> RW_TAC std_ss []
+           >> Q.EXISTS_TAC `[]`
+           >> RW_TAC std_ss [CONCAT_def, ALL_EL])
        >> RW_TAC std_ss []
-       ++ POP_ASSUM (K ALL_TAC)
-       ++ Induct_on `l`
-       >> (RW_TAC std_ss [na_step_def, APPEND_eq_NIL]
-           ++ REVERSE (Cases_on `a k`) >> RW_TAC std_ss []
-           ++ RW_TAC std_ss []
-           ++ Q.EXISTS_TAC `[]`
-           ++ RW_TAC std_ss [CONCAT_def, ALL_EL])
-       ++ RW_TAC std_ss []
-       ++ HO_MATCH_MP_TAC
+       >> HO_MATCH_MP_TAC
           (METIS_PROVE [list_CASES]
            ``!P Q. (Q = P [] \/ ?c cs. P (c :: cs)) ==> (Q = (?l. P l))``)
-       ++ RW_TAC std_ss [na_step_def, APPEND]
-       ++ RW_TAC std_ss [RIGHT_AND_OVER_OR, EXISTS_OR_THM]
-       ++ MATCH_MP_TAC (PROVE [] ``(a = d) /\ (b = c) ==> (a \/ b = c \/ d)``)
-       ++ CONJ_TAC >> METIS_TAC []
-       ++ POP_ASSUM (K ALL_TAC)
-       ++ REVERSE (Cases_on `a k`) >> RW_TAC std_ss []
-       ++ RW_TAC std_ss []
-       ++ POP_ASSUM (K ALL_TAC)
-       ++ EQ_TAC
-       >> (RW_TAC std_ss []
-           ++ Q.EXISTS_TAC `(h::w) :: ws`
-           ++ RW_TAC std_ss [ALL_EL, CONCAT_def, na_step_def, APPEND]
-           ++ PROVE_TAC [])
-       ++ RW_TAC std_ss []
-       ++ Induct_on `ws` >> RW_TAC std_ss [CONCAT_def]
-       ++ Cases >> RW_TAC std_ss [CONCAT_def, APPEND, ALL_EL, na_step_def]
-       ++ POP_ASSUM (K ALL_TAC)
-       ++ RW_TAC std_ss [CONCAT_def, APPEND, ALL_EL, na_step_def]
-       ++ PROVE_TAC [])
-   ++ HO_MATCH_MP_TAC
+       >> RW_TAC std_ss [na_step_def, APPEND]
+       >> RW_TAC std_ss [RIGHT_AND_OVER_OR, EXISTS_OR_THM]
+       >> MATCH_MP_TAC (PROVE [] ``(a = d) /\ (b = c) ==> (a \/ b = c \/ d)``)
+       >> CONJ_TAC >- METIS_TAC []
+       >> POP_ASSUM (K ALL_TAC)
+       >> REVERSE (Cases_on `a k`) >- RW_TAC std_ss []
+       >> RW_TAC std_ss []
+       >> POP_ASSUM (K ALL_TAC)
+       >> EQ_TAC
+       >- (RW_TAC std_ss []
+           >> Q.EXISTS_TAC `(h::w) :: ws`
+           >> RW_TAC std_ss [ALL_EL, CONCAT_def, na_step_def, APPEND]
+           >> PROVE_TAC [])
+       >> RW_TAC std_ss []
+       >> Induct_on `ws` >- RW_TAC std_ss [CONCAT_def]
+       >> Cases >- RW_TAC std_ss [CONCAT_def, APPEND, ALL_EL, na_step_def]
+       >> POP_ASSUM (K ALL_TAC)
+       >> RW_TAC std_ss [CONCAT_def, APPEND, ALL_EL, na_step_def]
+       >> PROVE_TAC [])
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE [list_CASES]
        ``!P Q. (Q = P [] \/ ?w ws. P (w :: ws)) ==> (Q = (?l. P l))``)
-   ++ RW_TAC std_ss [CONCAT_def, ALL_EL]
-   ++ Cases_on `l` >> RW_TAC std_ss [na_step_def]
-   ++ RW_TAC std_ss [na_step_def]
-   ++ HO_MATCH_MP_TAC
+   >> RW_TAC std_ss [CONCAT_def, ALL_EL]
+   >> Cases_on `l` >- RW_TAC std_ss [na_step_def]
+   >> RW_TAC std_ss [na_step_def]
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE [list_CASES]
        ``!P Q. (Q = P [] \/ ?x xs. P (x :: xs)) ==> (Q = (?l. P l))``)
-   ++ RW_TAC std_ss [CONCAT_def, ALL_EL, APPEND, na_step_def]
-   ++ HO_MATCH_MP_TAC
+   >> RW_TAC std_ss [CONCAT_def, ALL_EL, APPEND, na_step_def]
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``!P Q A B C.
            (!x. P x ==> x <= i) /\
            (!x. x <= i ==> (Q x = ?y z. A y z /\ B x y z /\ C y z)) ==>
            ((?x. P x /\ Q x) = ?y z. A y z /\ (?x. P x /\ B x y z) /\ C y z)``)
-   ++ CONJ_TAC >> METIS_TAC [regexp2na_trans]
-   ++ Induct_on `t'`
-   >> (RW_TAC arith_ss [na_step_def, APPEND_eq_NIL]
-       ++ REVERSE (Cases_on `a s'`) >> RW_TAC std_ss []
-       ++ RW_TAC std_ss []
-       ++ Q.EXISTS_TAC `[]`
-       ++ RW_TAC std_ss [CONCAT_def, ALL_EL])
-   ++ RW_TAC std_ss []
-   ++ HO_MATCH_MP_TAC
+   >> CONJ_TAC >- METIS_TAC [regexp2na_trans]
+   >> Induct_on `t'`
+   >- (RW_TAC arith_ss [na_step_def, APPEND_eq_NIL]
+       >> rename1 `s'' <= i`
+       >> REVERSE (Cases_on `a s''`) >- RW_TAC std_ss [] (* was: s' *)
+       >> RW_TAC std_ss []
+       >> Q.EXISTS_TAC `[]`
+       >> RW_TAC std_ss [CONCAT_def, ALL_EL])
+   >> RW_TAC std_ss []
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE [list_CASES]
        ``!P Q. (Q = P [] \/ ?x xs. P (x :: xs)) ==> (Q = (?l. P l))``)
-   ++ RW_TAC arith_ss [CONCAT_def, ALL_EL, APPEND, na_step_def]
-   ++ RW_TAC std_ss [RIGHT_AND_OVER_OR, EXISTS_OR_THM]
-   ++ MATCH_MP_TAC (PROVE [] ``(a = d) /\ (b = c) ==> (a \/ b = c \/ d)``)
-   ++ CONJ_TAC
-   >> (HO_MATCH_MP_TAC
+   >> RW_TAC arith_ss [CONCAT_def, ALL_EL, APPEND, na_step_def]
+   >> RW_TAC std_ss [RIGHT_AND_OVER_OR, EXISTS_OR_THM]
+   >> MATCH_MP_TAC (PROVE [] ``(a = d) /\ (b = c) ==> (a \/ b = c \/ d)``)
+   >> CONJ_TAC
+   >- (HO_MATCH_MP_TAC
        (METIS_PROVE []
         ``!P A B C.
             (!x. A x ==> P x) /\ ((?x. A x /\ (P x ==> B x)) = C) ==>
             ((?x. A x /\ B x) = C)``)
-       ++ Q.EXISTS_TAC `\x. x <= i`
-       ++ BETA_TAC
-       ++ CONJ_TAC >> METIS_TAC [regexp2na_trans]
-       ++ Q.PAT_ASSUM `!x. P x` (fn th => RW_TAC std_ss [th])
-       ++ HO_MATCH_MP_TAC
+       >> Q.EXISTS_TAC `\x. x <= i`
+       >> BETA_TAC
+       >> CONJ_TAC >- METIS_TAC [regexp2na_trans]
+       >> Q.PAT_X_ASSUM `!x. P x` (fn th => RW_TAC std_ss [th])
+       >> HO_MATCH_MP_TAC
           (METIS_PROVE []
            ``!P A B C.
                (!x. A x ==> P x) /\ ((?x. A x /\ B x) = C) ==>
                ((?x. A x /\ (P x ==> B x)) = C)``)
-       ++ CONJ_TAC >> METIS_TAC [regexp2na_trans]
-       ++ METIS_TAC [])
-   ++ REVERSE (Cases_on `a s'`) >> RW_TAC std_ss []
-   ++ RW_TAC std_ss []
-   ++ HO_MATCH_MP_TAC
+       >> CONJ_TAC >- METIS_TAC [regexp2na_trans]
+       >> METIS_TAC [])
+   >> rename1 `s'' <= i`
+   >> REVERSE (Cases_on `a s''`) >- RW_TAC std_ss [] (* was: s'' *)
+   >> RW_TAC std_ss []
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``!P Q R.
            (!x. P x ==> x <= i) /\ ((?x. P x /\ (x <= i ==> Q x)) = R) ==>
            ((?x. P x /\ Q x) = R)``)
-   ++ CONJ_TAC >> METIS_TAC [regexp2na_trans]
-   ++ RW_TAC std_ss []
-   ++ NTAC 3 (POP_ASSUM (K ALL_TAC))
-   ++ HO_MATCH_MP_TAC
+   >> CONJ_TAC >- METIS_TAC [regexp2na_trans]
+   >> RW_TAC std_ss []
+   >> NTAC 3 (POP_ASSUM (K ALL_TAC))
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``!P Q R.
            (!x. P x ==> x <= i) /\ ((?x. P x /\ Q x) = R) ==>
            ((?x. P x /\ (x <= i ==> Q x)) = R)``)
-   ++ CONJ_TAC >> METIS_TAC [regexp2na_trans]
-   ++ EQ_TAC
-   >> (RW_TAC std_ss []
-       ++ Q.EXISTS_TAC `(h::xs) :: ws`
-       ++ RW_TAC std_ss [ALL_EL, CONCAT_def, na_step_def, APPEND]
-       ++ PROVE_TAC [])
-   ++ RW_TAC std_ss []
-   ++ REPEAT (POP_ASSUM MP_TAC)
-   ++ Cases_on `ws` >> RW_TAC std_ss [CONCAT_def]
-   ++ Cases_on `h'` >> RW_TAC std_ss [na_step_def, ALL_EL]
-   ++ RW_TAC std_ss [CONCAT_def, APPEND, ALL_EL, na_step_def]
-   ++ METIS_TAC []);
+   >> CONJ_TAC >- METIS_TAC [regexp2na_trans]
+   >> EQ_TAC
+   >- (RW_TAC std_ss []
+       >> Q.EXISTS_TAC `(h::xs) :: ws`
+       >> RW_TAC std_ss [ALL_EL, CONCAT_def, na_step_def, APPEND]
+       >> PROVE_TAC [])
+   >> RW_TAC std_ss []
+   >> REPEAT (POP_ASSUM MP_TAC)
+   >> Cases_on `ws` >- RW_TAC std_ss [CONCAT_def]
+   >> Cases_on `h'` >- RW_TAC std_ss [na_step_def, ALL_EL]
+   >> RW_TAC std_ss [CONCAT_def, APPEND, ALL_EL, na_step_def]
+   >> METIS_TAC []);
 
-val na_match_prefix = lemma
+val na_match_prefix = prove
   (``!r.
        (!l. na_accepts (regexp2na r) l = sem r l) ==>
        !l. na_accepts (regexp2na (Prefix r)) l = sem (Prefix r) l``,
    REPEAT GEN_TAC
-   ++ Introduce `regexp2na r = (i, t, a)`
-   ++ (NTAC 2 (RW_TAC std_ss [regexp2na_def, sem_def, na_accepts_def])
-       ++ (REPEAT o Q.PAT_ASSUM `!x. P x`)
+   >> Introduce `regexp2na r = (i, t, a)`
+   >> (NTAC 2 (RW_TAC std_ss [regexp2na_def, sem_def, na_accepts_def])
+       >> (REPEAT o Q.PAT_X_ASSUM `!x. P x`)
           (fn th => REWRITE_TAC [GSYM (MATCH_MP EQ_EXT th)]))
-   ++ Suff
+   >> Suff
       `!k.
          na_step
          (i,t,(\s. ?l. accepting_path (\s s'. ?x. t s x s') a s l)) k l =
          ?w'. na_step (i,t,a) k (l <> w')`
-   >> RW_TAC std_ss []
-   ++ REVERSE (Induct_on `l`)
-   >> (RW_TAC std_ss [na_step_def, APPEND]
-       ++ HO_MATCH_MP_TAC
+   >- RW_TAC std_ss []
+   >> REVERSE (Induct_on `l`)
+   >- (RW_TAC std_ss [na_step_def, APPEND]
+       >> HO_MATCH_MP_TAC
           (METIS_PROVE []
            ``!P Q R.
                (!s. P s ==> (Q s = ?w. R w s)) ==>
                ((?s. P s /\ Q s) = ?w s. P s /\ R w s)``)
-       ++ POP_ASSUM (fn th => RW_TAC std_ss [GSYM th]))
-   ++ RW_TAC std_ss [APPEND, na_step_def]
-   ++ Suff
+       >> POP_ASSUM (fn th => RW_TAC std_ss [GSYM th]))
+   >> RW_TAC std_ss [APPEND, na_step_def]
+   >> Suff
       `!n k.
          (?l. (LENGTH l = n) /\ accepting_path (\s s'. ?x. t s x s') a k l) =
          ?w'. (LENGTH w' = n) /\ na_step (i,t,a) k w'`
-   >> METIS_TAC []
-   ++ Induct >> RW_TAC std_ss [LENGTH_NIL, accepting_path_def, na_step_def]
-   ++ RW_TAC std_ss [LENGTH_CONS, accepting_path_def, na_step_def,
+   >- METIS_TAC []
+   >> Induct >- RW_TAC std_ss [LENGTH_NIL, accepting_path_def, na_step_def]
+   >> RW_TAC std_ss [LENGTH_CONS, accepting_path_def, na_step_def,
                      GSYM LEFT_EXISTS_AND_THM]
-   ++ METIS_TAC []);
+   >> METIS_TAC []);
 
-val na_match = lemma
+val na_match = prove
   (``!r l. na_accepts (regexp2na r) l = sem r l``,
    Induct
-   ++ RW_TAC std_ss
+   >> RW_TAC std_ss
       [na_match_atom, na_match_concat, na_match_fuse,
        na_match_or, na_match_and, na_match_repeat, na_match_prefix]);
 
-val da_accepts_regexp2da = lemma
+val da_accepts_regexp2da = prove
   (``!r. sem r = da_accepts (regexp2da r)``,
    RW_TAC std_ss [FUN_EQ_THM, regexp2da_def, GSYM na2da, na_match]);
 
@@ -1217,10 +1216,10 @@ val (accept_regexp2na_prefix_def, accept_regexp2na_prefix_ind) = Defn.tprove
    `MLEX (sum_case (\ (_,l,w). 2 * (LENGTH l + LENGTH w))
           (\ (_,_,l,w,t). 2 * (LENGTH l + LENGTH w + LENGTH t) + 1))
     (measure (sum_case (\_. 0) (\ (_,_,_,_,t). LENGTH t)))`
-   ++ RW_TAC arith_ss [MLEX_def, LENGTH]
-   ++ RW_TAC std_ss [GSYM prim_recTheory.measure_thm]
-   ++ CONV_TAC (DEPTH_CONV ETA_CONV)
-   ++ METIS_TAC [WF_MLEX, prim_recTheory.WF_measure]);
+   >> RW_TAC arith_ss [MLEX_def, LENGTH]
+   >> RW_TAC std_ss [GSYM prim_recTheory.measure_thm]
+   >> CONV_TAC (DEPTH_CONV ETA_CONV)
+   >> METIS_TAC [WF_MLEX, prim_recTheory.WF_measure]);
 
 val accept_regexp2na_prefix_ind1 = hd (GCONJUNCTS accept_regexp2na_prefix_ind);
 *)
@@ -1233,13 +1232,13 @@ val transition_regexp2na_fuse_def = Define
    (transition_regexp2na_fuse a t (SUC s') =
     a s' /\ t s' \/ transition_regexp2na_fuse a t s')`;
 
-val transition_regexp2na_fuse = lemma
+val transition_regexp2na_fuse = prove
   (``!k r s x i t a.
        (regexp2na r = (i,t,a)) ==>
        (transition_regexp2na_fuse a (t s x) k = ?y. a y /\ y < k /\ t s x y)``,
    Induct
-   ++ RW_TAC arith_ss [transition_regexp2na_fuse_def]
-   ++ METIS_TAC [prim_recTheory.LESS_THM]);
+   >> RW_TAC arith_ss [transition_regexp2na_fuse_def]
+   >> METIS_TAC [prim_recTheory.LESS_THM]);
 
 val initial_regexp2na = store_thm
   ("initial_regexp2na",
@@ -1248,7 +1247,7 @@ val initial_regexp2na = store_thm
       initial_regexp2na r1 + initial_regexp2na r2 + 1) /\
      (initial_regexp2na (r1 % r2) =
       initial_regexp2na r1 + initial_regexp2na r2 + 1) /\
-     (initial_regexp2na (r1 | r2) =
+     (initial_regexp2na (r1 || r2) =
       initial_regexp2na r1 + initial_regexp2na r2 + 2) /\
      (initial_regexp2na (r1 & r2) =
       let i1 = initial_regexp2na r1 in
@@ -1258,9 +1257,9 @@ val initial_regexp2na = store_thm
       if accept_regexp2na r i then i else i + 1) /\
      (initial_regexp2na (Prefix r : 'a regexp) = initial_regexp2na r)``,
    Introduce `regexp2na r1 = (i1,t1,a1)`
-   ++ Introduce `regexp2na r2 = (i2,t2,a2)`
-   ++ Introduce `regexp2na r = (i,t,a)`
-   ++ NTAC 2
+   >> Introduce `regexp2na r2 = (i2,t2,a2)`
+   >> Introduce `regexp2na r = (i,t,a)`
+   >> NTAC 2
       (RW_TAC std_ss
        [regexp2na_def, initial_def, accept_def,
         initial_regexp2na_def, accept_regexp2na_def]));
@@ -1274,7 +1273,7 @@ val accept_regexp2na = store_thm
       else accept_regexp2na r2 i2 /\
            accept_regexp2na r1 (s - (i2 + 1))) /\
      (accept_regexp2na (r1 % r2) s = accept_regexp2na r2 s) /\
-     (accept_regexp2na (r1 | r2) s =
+     (accept_regexp2na (r1 || r2) s =
       let i1 = initial_regexp2na r1 in
       let i2 = initial_regexp2na r2 in
       if s = i1 + i2 + 2 then
@@ -1294,45 +1293,45 @@ val accept_regexp2na = store_thm
       dijkstra (exists_transition_regexp2na r) (accept_regexp2na r)
       [s] (FILTER (\x. ~(x = s)) (interval 0 (SUC (initial_regexp2na r)))))``,
    Introduce `regexp2na r1 = (i1,t1,a1)`
-   ++ Introduce `regexp2na r2 = (i2,t2,a2)`
-   ++ Introduce `regexp2na r = (i,t,a)`
-   ++ NTAC 2
+   >> Introduce `regexp2na r2 = (i2,t2,a2)`
+   >> Introduce `regexp2na r = (i,t,a)`
+   >> NTAC 2
       (RW_TAC std_ss
        [regexp2na_def, initial_def, accept_def,
         initial_regexp2na_def, accept_regexp2na_def])
-   >> METIS_TAC []
-   ++ Know `exists_transition_regexp2na r = \s s'. ?x. t s x s'`
-   >> RW_TAC std_ss
+   >- METIS_TAC []
+   >> Know `exists_transition_regexp2na r = \s s'. ?x. t s x s'`
+   >- RW_TAC std_ss
       [exists_transition_regexp2na_def, FUN_EQ_THM,
        transition_regexp2na_def, transition_def]
-   ++ DISCH_THEN (fn th => RW_TAC std_ss [th])
-   ++ REVERSE (Cases_on `s <= i`)
-   >> (MATCH_MP_TAC (PROVE [] ``~a /\ ~b ==> (a = b)``)
-       ++ RW_TAC std_ss []
-       << [Cases_on `l`
-           ++ RW_TAC std_ss [accepting_path_def]
-           ++ METIS_TAC [regexp2na_acc, regexp2na_trans],
+   >> DISCH_THEN (fn th => RW_TAC std_ss [th])
+   >> REVERSE (Cases_on `s <= i`)
+   >- (MATCH_MP_TAC (PROVE [] ``~a /\ ~b ==> (a = b)``)
+       >> RW_TAC std_ss []
+       >| [Cases_on `l`
+           >> RW_TAC std_ss [accepting_path_def]
+           >> METIS_TAC [regexp2na_acc, regexp2na_trans],
            METIS_TAC [regexp2na_acc],
            RW_TAC std_ss [dijkstra_def]
-           ++ Suff `!l. partition (\s'. ?x. t s x s') l = ([],l)`
-           >> (DISCH_THEN (fn th => FULL_SIMP_TAC std_ss [th])
-               ++ RW_TAC std_ss [EXISTS_DEF, APPEND, dijkstra_def])
-           ++ Induct
-           ++ RW_TAC std_ss [partition_def]
-           ++ METIS_TAC [regexp2na_trans]])
-   ++ Know `MEM s (interval 0 (SUC i))`
+           >> Suff `!l. partition (\s'. ?x. t s x s') l = ([],l)`
+           >- (DISCH_THEN (fn th => FULL_SIMP_TAC std_ss [th])
+               >> RW_TAC std_ss [EXISTS_DEF, APPEND, dijkstra_def])
+           >> Induct
+           >> RW_TAC std_ss [partition_def]
+           >> METIS_TAC [regexp2na_trans]])
+   >> Know `MEM s (interval 0 (SUC i))`
+   >- RW_TAC arith_ss [MEM_interval]
+   >> RW_TAC std_ss [dijkstra1]
+   >> REVERSE EQ_TAC >- METIS_TAC []
    >> RW_TAC arith_ss [MEM_interval]
-   ++ RW_TAC std_ss [dijkstra1]
-   ++ REVERSE EQ_TAC >> METIS_TAC []
-   ++ RW_TAC arith_ss [MEM_interval]
-   ++ Q.EXISTS_TAC `l`
-   ++ Know `!k. k < SUC i = k <= i` >> DECIDE_TAC
-   ++ DISCH_THEN (fn th => RW_TAC std_ss [th])
-   ++ POP_ASSUM MP_TAC
-   ++ Q.SPEC_TAC (`s`, `s`)
-   ++ Induct_on `l`
-   ++ RW_TAC std_ss [accepting_path_def, EVERY_DEF]
-   ++ METIS_TAC [regexp2na_trans]);
+   >> Q.EXISTS_TAC `l`
+   >> Know `!k. k < SUC i = k <= i` >- DECIDE_TAC
+   >> DISCH_THEN (fn th => RW_TAC std_ss [th])
+   >> POP_ASSUM MP_TAC
+   >> Q.SPEC_TAC (`s`, `s`)
+   >> Induct_on `l`
+   >> RW_TAC std_ss [accepting_path_def, EVERY_DEF]
+   >> METIS_TAC [regexp2na_trans]);
 
 val transition_regexp2na = store_thm
   ("transition_regexp2na",
@@ -1355,7 +1354,7 @@ val transition_regexp2na = store_thm
         transition_regexp2na_fuse (accept_regexp2na r1)
         (transition_regexp2na r1 (s - (i2 + 1)) x) (SUC i1)
       else transition_regexp2na r1 (s - (i2 + 1)) x (s' - (i2 + 1))) /\
-     (transition_regexp2na (r1 | r2) s x s' =
+     (transition_regexp2na (r1 || r2) s x s' =
       let i1 = initial_regexp2na r1 in
       let i2 = initial_regexp2na r2 in
       if s = i1 + i2 + 2 then
@@ -1379,22 +1378,22 @@ val transition_regexp2na = store_thm
      (transition_regexp2na (Prefix r : 'a regexp) s x s' =
       transition_regexp2na r s x s')``,
    Introduce `regexp2na r1 = (i1,t1,a1)`
-   ++ Introduce `regexp2na r2 = (i2,t2,a2)`
-   ++ Introduce `regexp2na r = (i,t,a)`
-   ++ NTAC 2
+   >> Introduce `regexp2na r2 = (i2,t2,a2)`
+   >> Introduce `regexp2na r = (i,t,a)`
+   >> NTAC 2
       (RW_TAC std_ss
        [regexp2na_def, initial_def, accept_def, transition_def,
         initial_regexp2na_def, accept_regexp2na_def, transition_regexp2na_def])
-   << [METIS_TAC [],
+   >| [METIS_TAC [],
        MP_TAC (Q.SPECL [`SUC i1`, `r1`, `s - (i2 + 1)`, `x`, `i1`, `t1`, `a1`]
                transition_regexp2na_fuse)
-       ++ RW_TAC std_ss []
-       ++ Know `!p q. p < SUC q = p <= q` >> DECIDE_TAC
-       ++ METIS_TAC [regexp2na_acc],
-       Know `!n. ~(n + 1 <= n)` >> DECIDE_TAC
-       ++ METIS_TAC [regexp2na_trans, regexp2na_acc],
-       Know `!n. ~(n + 1 <= n)` >> DECIDE_TAC
-       ++ METIS_TAC [regexp2na_trans, regexp2na_acc]]);
+       >> RW_TAC std_ss []
+       >> Know `!p q. p < SUC q = p <= q` >- DECIDE_TAC
+       >> METIS_TAC [regexp2na_acc],
+       Know `!n. ~(n + 1 <= n)` >- DECIDE_TAC
+       >> METIS_TAC [regexp2na_trans, regexp2na_acc],
+       Know `!n. ~(n + 1 <= n)` >- DECIDE_TAC
+       >> METIS_TAC [regexp2na_trans, regexp2na_acc]]);
 
 val eval_accepts_def = pureDefine
   `(eval_accepts (Prefix r) l =
@@ -1407,30 +1406,30 @@ val eval_accepts_def = pureDefine
 val eval_accepts = prove
   (``!r l. eval_accepts r l = EXISTS (accept_regexp2na r) l``,
    Cases
-   ++ RW_TAC std_ss [eval_accepts_def]
-   ++ normalForms.REMOVE_ABBR_TAC
-   ++ RW_TAC std_ss []
-   ++ Introduce `r' = r`
-   ++ Introduce `regexp2na r = (i,t,a)`
-   ++ RW_TAC std_ss [dijkstra]
-   ++ RW_TAC std_ss [MEM_APPEND, EXISTS_MEM, accept_regexp2na_def,
+   >> RW_TAC std_ss [eval_accepts_def]
+   >> normalForms.REMOVE_ABBR_TAC
+   >> RW_TAC std_ss []
+   >> Introduce `r' = r`
+   >> Introduce `regexp2na r = (i,t,a)`
+   >> RW_TAC std_ss [dijkstra]
+   >> RW_TAC std_ss [MEM_APPEND, EXISTS_MEM, accept_regexp2na_def,
                      accept_def, regexp2na_def]
-   ++ Know `exists_transition_regexp2na r = \s s'. ?x. t s x s'`
-   >> RW_TAC std_ss
+   >> Know `exists_transition_regexp2na r = \s s'. ?x. t s x s'`
+   >- RW_TAC std_ss
       [exists_transition_regexp2na_def, FUN_EQ_THM,
        transition_regexp2na_def, transition_def]
-   ++ DISCH_THEN (fn th => RW_TAC std_ss [th])
-   ++ RW_TAC arith_ss [MEM_FILTER, MEM_interval]
-   ++ HO_MATCH_MP_TAC
+   >> DISCH_THEN (fn th => RW_TAC std_ss [th])
+   >> RW_TAC arith_ss [MEM_FILTER, MEM_interval]
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE []
        ``(!l k. C k l ==> B k l) ==>
          ((?k l'. A k /\ B k l' /\ C k l') = (?e. A e /\ ?l. C e l))``)
-   ++ Know `!x y. x < SUC y = x <= y` >> DECIDE_TAC
-   ++ DISCH_THEN
+   >> Know `!x y. x < SUC y = x <= y` >- DECIDE_TAC
+   >> DISCH_THEN
       (fn th => ASM_SIMP_TAC std_ss [th, initial_regexp2na_def, initial_def])
-   ++ Induct
-   ++ RW_TAC std_ss [EVERY_DEF, accepting_path_def]
-   ++ METIS_TAC [regexp2na_trans]);
+   >> Induct
+   >> RW_TAC std_ss [EVERY_DEF, accepting_path_def]
+   >> METIS_TAC [regexp2na_trans]);
 
 val calc_transitions_def = Define
   `(calc_transitions r l c 0 a = a) /\
@@ -1465,14 +1464,14 @@ val acheck_def = Define
 (* Correctness of this version of the automata matcher.                      *)
 (*---------------------------------------------------------------------------*)
 
-val da_accepts_na2da = lemma
+val da_accepts_na2da = prove
   (``!n. da_accepts (na2da n) = da_step (na2da n) (set_of_list [initial n])``,
    STRIP_TAC
-   ++ Introduce `n = (i,t,a)`
-   ++ RW_TAC std_ss
+   >> Introduce `n = (i,t,a)`
+   >> RW_TAC std_ss
       [FUN_EQ_THM, na2da_def, da_accepts_def, initial_def, set_of_list_def]);
 
-val da_step_regexp2na = lemma
+val da_step_regexp2na = prove
   (``(da_step (na2da (regexp2na r)) (set_of_list l) [] =
       EXISTS (accept (regexp2na r)) l) /\
      (da_step (na2da (regexp2na r)) (set_of_list l) (c :: cs) =
@@ -1480,44 +1479,55 @@ val da_step_regexp2na = lemma
       let l' = calc_transitions r l c (SUC i) [] in
       da_step (na2da (regexp2na r)) (set_of_list l') cs)``,
    Introduce `regexp2na r = (i,t,a)`
-   ++ RW_TAC std_ss [da_step_def, na2da_def, EXISTS_MEM, set_of_list]
-   ++ REPEAT (AP_TERM_TAC || AP_THM_TAC)
-   ++ RW_TAC std_ss [EXTENSION, GSPECIFICATION, set_of_list, initial_def]
-   ++ Suff
+   >> RW_TAC std_ss [da_step_def, na2da_def, EXISTS_MEM, set_of_list]
+   >> REPEAT (AP_TERM_TAC ORELSE AP_THM_TAC)
+   >> RW_TAC std_ss [EXTENSION, GSPECIFICATION, set_of_list, initial_def]
+   >> Suff
       `!k.
          MEM x (calc_transitions r l c (SUC i) k) =
          IS_EL x k \/ (x < SUC i /\ ?y. IS_EL y l /\ transition (i,t,a) y c x)`
-   >> (DISCH_THEN (MP_TAC o Q.SPEC `[]`)
-       ++ Know `!x. x < SUC i = x <= i` >> DECIDE_TAC
-       ++ RW_TAC std_ss [MEM, transition_def]
-       ++ METIS_TAC [regexp2na_trans])
-   ++ Q.SPEC_TAC (`SUC i`, `n`)
-   ++ Induct
-   ++ RW_TAC arith_ss
+   >- (DISCH_THEN (MP_TAC o Q.SPEC `[]`)
+       >> Know `!x. x < SUC i = x <= i` >- DECIDE_TAC
+       >> RW_TAC std_ss [MEM, transition_def]
+       >> METIS_TAC [regexp2na_trans])
+   >> Q.SPEC_TAC (`SUC i`, `n`)
+   >> Induct (* 2 subgoals *)
+   >- RW_TAC arith_ss
       [calc_transitions_def, EXISTS_MEM, MEM, transition_regexp2na_def]
-   ++ Know `!a b. ~(a < b) /\ a < SUC b = (a = b)` >> DECIDE_TAC
-   ++ STRIP_TAC
-   ++ EQ_TAC
-   ++ RW_TAC arith_ss []
-   ++ RW_TAC arith_ss []
-   ++ METIS_TAC []);
+   >> GEN_TAC >> ONCE_REWRITE_TAC [calc_transitions_def]
+   >> RW_TAC arith_ss [EXISTS_MEM, MEM, transition_regexp2na_def] (* 2 subgoals *)
+   >| [ EQ_TAC >> rpt STRIP_TAC >> ASM_REWRITE_TAC [] >|
+        [ fs [] >> DISJ2_TAC >> Q.EXISTS_TAC `s` >> ASM_REWRITE_TAC [],
+          fs [] >> DISJ2_TAC >> Q.EXISTS_TAC `y` >> ASM_REWRITE_TAC [],
+          Cases_on `x = n` >- ASM_REWRITE_TAC [] \\
+          DISJ2_TAC \\
+          `!a b. ~(a < b) /\ a < SUC b = (a = b)` by DECIDE_TAC \\
+          `x < n` by PROVE_TAC [] >> ASM_REWRITE_TAC [] \\
+          Q.EXISTS_TAC `y` >> ASM_REWRITE_TAC [] ],
+        EQ_TAC >> rpt STRIP_TAC >> ASM_REWRITE_TAC [] >|
+        [ fs [] >> DISJ2_TAC >> Q.EXISTS_TAC `y` >> ASM_REWRITE_TAC [],
+          Cases_on `x < n`
+          >- (ASM_REWRITE_TAC [] >> DISJ2_TAC >> Q.EXISTS_TAC `y` >> ASM_REWRITE_TAC []) \\
+          `!a b. ~(a < b) /\ a < SUC b = (a = b)` by DECIDE_TAC \\
+          `x = n` by PROVE_TAC [] \\
+          METIS_TAC [] ] ]);
 
 val amatch = store_thm
   ("amatch",
    ``!r l. amatch r l = sem r l``,
    RW_TAC std_ss
    [GSYM da_match, da_match_def, regexp2da_def, da_accepts_na2da, amatch_def]
-   ++ normalForms.REMOVE_ABBR_TAC
-   ++ RW_TAC std_ss [initial_regexp2na_def]
-   ++ Suff `!k. astep r k l = da_step (na2da (regexp2na r)) (set_of_list k) l`
-   >> RW_TAC std_ss []
-   ++ Induct_on `l`
-   >> RW_TAC std_ss
+   >> normalForms.REMOVE_ABBR_TAC
+   >> RW_TAC std_ss [initial_regexp2na_def]
+   >> Suff `!k. astep r k l = da_step (na2da (regexp2na r)) (set_of_list k) l`
+   >- RW_TAC std_ss []
+   >> Induct_on `l`
+   >- RW_TAC std_ss
       [astep_def, da_step_def, na2da_def, eval_accepts, EXISTS_MEM,
        set_of_list, accept_regexp2na_def]
-   ++ ONCE_REWRITE_TAC [astep_def]
-   ++ SIMP_TAC std_ss [da_step_regexp2na, eval_transitions_def, NULL_DEF, TL]
-   ++ RW_TAC std_ss [initial_regexp2na_def, HD]);
+   >> ONCE_REWRITE_TAC [astep_def]
+   >> SIMP_TAC std_ss [da_step_regexp2na, eval_transitions_def, NULL_DEF, TL]
+   >> RW_TAC std_ss [initial_regexp2na_def, HD]);
 
 val acheck = store_thm
   ("acheck",
@@ -1526,19 +1536,19 @@ val acheck = store_thm
        !n. n < LENGTH l /\ sem r (FIRSTN (SUC n) l) ==> f (BUTFIRSTN n l)``,
    RW_TAC std_ss
    [acheck_def, GSYM da_match, da_match_def, regexp2da_def, da_accepts_na2da]
-   ++ normalForms.REMOVE_ABBR_TAC
-   ++ RW_TAC std_ss [initial_regexp2na_def]
-   ++ Q.SPEC_TAC (`[initial (regexp2na r)]`, `k`)
-   ++ Q.SPEC_TAC (`[]`, `h`)
-   ++ Induct_on `l` >> RW_TAC arith_ss [acheckpt_def, LENGTH]
-   ++ ONCE_REWRITE_TAC [acheckpt_def]
-   ++ RW_TAC std_ss []
-   ++ normalForms.REMOVE_ABBR_TAC
-   ++ RW_TAC std_ss []
-   ++ HO_MATCH_MP_TAC
+   >> normalForms.REMOVE_ABBR_TAC
+   >> RW_TAC std_ss [initial_regexp2na_def]
+   >> Q.SPEC_TAC (`[initial (regexp2na r)]`, `k`)
+   >> Q.SPEC_TAC (`[]`, `h`)
+   >> Induct_on `l` >- RW_TAC arith_ss [acheckpt_def, LENGTH]
+   >> ONCE_REWRITE_TAC [acheckpt_def]
+   >> RW_TAC std_ss []
+   >> normalForms.REMOVE_ABBR_TAC
+   >> RW_TAC std_ss []
+   >> HO_MATCH_MP_TAC
       (METIS_PROVE [num_CASES]
        ``(P = Q 0 /\ !n. Q (SUC n)) ==> (P = !n. Q n)``)
-   ++ RW_TAC arith_ss
+   >> RW_TAC arith_ss
       [LENGTH, FIRSTN, BUTFIRSTN, da_step_regexp2na, areport_def, eval_accepts,
        accept_regexp2na_def, eval_transitions_def, initial_regexp2na_def]);
 

--- a/examples/PSL/regexp/regexpScript.sml
+++ b/examples/PSL/regexp/regexpScript.sml
@@ -18,12 +18,8 @@ val () = new_theory "regexp";
 (* Symbolic tacticals.                                                       *)
 (*---------------------------------------------------------------------------*)
 
-infixr 0 ++ << || THENC ORELSEC ORELSER ##;
-infix 1 >>;
+infixr 0 || THENC ORELSEC ORELSER;
 
-val op ++ = op THEN;
-val op << = op THENL;
-val op >> = op THEN1;
 val op || = op ORELSE;
 val Know = Q_TAC KNOW_TAC;
 val Suff = Q_TAC SUFF_TAC;
@@ -222,13 +218,13 @@ val One_def  = Define `One = Repeat Zero`;
 (* from the grammar and thus allow | to be used for "or" patterns.           *)
 (*---------------------------------------------------------------------------*)
 
-val _ = remove_termtok{term_name = "COND",tok="=>"};
-val _ = overload_on ("|", Term`$Or`);
+(* "|" is conflicting with pred_setTheory and many other things, use "||". *)
+val _ = overload_on ("||", Term`$Or`);
 val _ = overload_on ("&", Term`$And`);
 val _ = overload_on ("#", Term`$Cat`);
 val _ = overload_on ("%", Term`$Fuse`);
 
-val _ = set_fixity "|" (Infixr 501);
+val _ = set_fixity "||" (Infixr 501);
 val _ = set_fixity "&" (Infixr 511);
 val _ = set_fixity "#" (Infixr 601);
 val _ = set_fixity "%" (Infixr 602);
@@ -247,7 +243,7 @@ val sem_def =
      ?w1 w2. (w = w1<>w2) /\ sem r1 w1 /\ sem r2 w2)                      /\
    (sem (r1%r2) w    =
      ?w1 w2 l. (w = w1<>[l]<>w2) /\ sem r1 (w1<>[l]) /\ sem r2 ([l]<>w2)) /\
-   (sem (r1|r2) w    =
+   (sem (r1||r2) w    =
      sem r1 w \/ sem r2 w)                                                /\
    (sem (r1&r2) w    =
      sem r1 w /\ sem r2 w)                                                /\
@@ -270,14 +266,14 @@ val sem_One = store_thm
   ("sem_One",
    ``!l. sem One l = (l = [])``,
    RW_TAC std_ss [sem_def, One_def]
-   ++ REVERSE EQ_TAC
-   >> (RW_TAC std_ss []
-       ++ Q.EXISTS_TAC `[]`
-       ++ RW_TAC std_ss [CONCAT_def, ALL_EL])
-   ++ RW_TAC std_ss []
-   ++ POP_ASSUM MP_TAC
-   ++ Cases_on `wlist`
-   ++ RW_TAC std_ss [CONCAT_def, ALL_EL, sem_Zero]);
+   >> REVERSE EQ_TAC
+   >- (RW_TAC std_ss []
+       >> Q.EXISTS_TAC `[]`
+       >> RW_TAC std_ss [CONCAT_def, ALL_EL])
+   >> RW_TAC std_ss []
+   >> POP_ASSUM MP_TAC
+   >> Cases_on `wlist`
+   >> RW_TAC std_ss [CONCAT_def, ALL_EL, sem_Zero]);
 
 (*---------------------------------------------------------------------------*)
 (* Misc. semantics lemmas                                                    *)
@@ -327,7 +323,7 @@ val Then_ASSOC = Count.apply Q.prove
 *)
 
 val Or_lemma = prove
-  (``!r1 r2 r3. sem ((r1 | r2) # r3) w = sem (r1 # r3) w \/ sem (r2 # r3) w``,
+  (``!r1 r2 r3. sem ((r1 || r2) # r3) w = sem (r1 # r3) w \/ sem (r2 # r3) w``,
    RW_TAC list_ss [sem_def] THEN PROVE_TAC []);
 
 (*---------------------------------------------------------------------------*)
@@ -337,7 +333,7 @@ val Or_lemma = prove
 val match_defn = Hol_defn
    "match"
   `(match (Atom b) l = (LENGTH l = 1) /\ b(HD l))
-/\ (match (r1|r2) l  = match r1 l \/ match r2 l)
+/\ (match (r1||r2) l  = match r1 l \/ match r2 l)
 /\ (match (r1&r2) l  = match r1 l /\ match r2 l)
 /\ (match (r1#r2) l  =
      EXISTS (\(s1,s2). match r1 s1 /\ match r2 s2) (SPLITS l))
@@ -368,7 +364,7 @@ val sem_match = store_thm
    ``!r w. sem r w = match r w``,
    recInduct match_ind THEN REPEAT CONJ_TAC THENL
    [(* Atom c *) RW_TAC list_ss [sem_def,match_def],
-    (* r | r' *) RW_TAC list_ss [sem_def,match_def],
+    (* r || r' *) RW_TAC list_ss [sem_def,match_def],
     (* r & r' *) RW_TAC list_ss [sem_def,match_def],
     (* r # r' *) RW_TAC list_ss [sem_def,match_def,EXISTS_ELIM_THM]
     THEN EQ_TAC THEN RW_TAC list_ss [] THENL

--- a/tools/sequences/more-theories
+++ b/tools/sequences/more-theories
@@ -51,3 +51,5 @@ src/datatype/inftree
 src/search
 !examples/CCS
 !examples/formal-languages/lambek
+!examples/PSL/1.01/executable-semantics
+!examples/PSL/1.1/official-semantics


### PR DESCRIPTION
Hi,

The PSL (Property Specification Language) formal theory (`examples/PSL`) is a huge formalization work done by Thomas Tuerk, Klaus Schneider and Mike Gordon [1], currently it doesn't build in HOL from at least K10 to K12 releases.

In this PR, I have successfully fixed most scripts, under the following top-level directories (and their dependencies):

- `examples/PSL/1.01/official-semantics`
- `examples/PSL/1.01/executable-semantics`
- `examples/PSL/1.1/official-semantics`

I have tested and fixed the builds in Poly/ML with both stdknl and expk, using `rename1` tactic that I've learnt from Thomas Tuerk occasionally, yesterday:) 

In PSL's `regexpTheory`, special term syntax ``p | q`` has broken the GSPEC of `pred_setTheory`  and maybe others. I changed it to "p || q", just like what I did in CCS theory.

A single script `ExecuteSemanticsScript.sml` under `examples/PSL/1.1/executable-semantics` doesn't work. The last big changes were done by Joe Hurd. But in his commits, at least one newly added theorem `S_ANY` has something missing:

```
val S_ANY = store_thm
  ("S_ANY",
   ``!p. US_SEM p S_ANY = BOTTOM_FREE_LIST p``,
   RW_TAC std_ss [S_ANY_def, BOTTOM_FREE_LIST_def]
   ++ Induct_on `p`
   ++ ONCE_REWRITE_TAC [US_SEM]
   ++ RW_TAC std_ss [S_EMPTY, EVERY_DEF, LENGTH_NIL]
   ++ RW_TAC std_ss [S_TRUE_def]
   ++ Cases_on `p = []` >> RW_TAC std_ss [EVERY_DEF]
   ++ RW_TAC std_ss []
   ++ REVERSE EQ_TAC
   >> (RW_TAC std_ss []
       ++ Q.EXISTS_TAC `METIS_TAC [APPEND]
  ...
```

(After `Q.EXISTS_TAC`, a term is missing.)  I don't really understand these theories currently, thus I have no way to fix it. (If  Prof. Joe Hurd could see this message, please help)

Actually my initial goal was to fix `examples/temporal_deep` (it depends on `examples/PSL/1.1/official-semantics`), but it is much harder to fix this example. A partial work is at [2]. I hope their original author (Thomas Tuerk) could help me in fixing them.   (My ultimate plan is to formalize some of my results in LTL Runtime Verification based on these scripts.)

Regards,

Chun Tian

[1] Tuerk, T., Schneider, K., Gordon, M.: Model Checking PSL Using HOL and SMV. In: Hardware and Software, Verification and Testing. pp. 1–15. Springer, Berlin, Heidelberg, Berlin, Heidelberg (2006).
[2] https://github.com/binghe/HOL/tree/temporal_deep_fix