### PR TITLE
Updated CCS example with some fixed definitions and other small changes

### DIFF
--- a/examples/CCS/CoarsestCongrScript.sml
+++ b/examples/CCS/CoarsestCongrScript.sml
@@ -850,6 +850,10 @@ val COARSEST_CONGR_FINITE = store_thm ((* NEW *)
  >> MP_TAC (Q.SPECL [`p`, `q`] KLOP_LEMMA_FINITE)
  >> RW_TAC std_ss [PROP3_COMMON]);
 
+(* unused *)
+val KLOP_INF_def = Define `
+    KLOP_INF X a = rec X (sum (var X) (prefix (label a) (var X)))`;
+
 (** Bibliography:
 
 [Den07] Y. Deng, “A simple completeness proof for the axiomatisations of weak behavioural

--- a/examples/CCS/ContractionScript.sml
+++ b/examples/CCS/ContractionScript.sml
@@ -893,7 +893,7 @@ val contracts_SUBST_GCONTEXT = store_thm (
 
 val contracts_precongruence = store_thm (
    "contracts_precongruence", ``precongruence1 $contracts``,
-    PROVE_TAC [precongruence1_def, contracts_SUBST_GCONTEXT]);
+    PROVE_TAC [precongruence1_def, contracts_PreOrder, contracts_SUBST_GCONTEXT]);
 
 (******************************************************************************)
 (*                                                                            *)
@@ -1009,6 +1009,15 @@ val contracts_AND_TRACE_tau = store_thm (
  >> MP_TAC (Q.SPECL [`E`, `xs`, `E1`] contracts_AND_TRACE_tau_lemma)
  >> RW_TAC std_ss []);
 
+(* the version shown in the paper using P and Q *)
+val contracts_AND_TRACE_tau' = store_thm (
+   "contracts_AND_TRACE_tau'",
+  ``!P Q. P contracts Q ==>
+	!xs P'. TRACE P xs P' /\ NO_LABEL xs ==>
+	    ?xs' Q'. TRACE Q xs' Q' /\ P' contracts Q' /\
+		(LENGTH xs' <= LENGTH xs) /\ NO_LABEL xs'``,
+    METIS_TAC [contracts_AND_TRACE_tau]);
+
 val contracts_AND_TRACE_label_lemma = Q.prove (
    `!E xs E1. TRACE E xs E1 ==> !l. UNIQUE_LABEL (label l) xs ==>
 	!E'. E contracts E' ==>
@@ -1053,6 +1062,15 @@ val contracts_AND_TRACE_label = store_thm (
     NTAC 2 (rpt GEN_TAC >> STRIP_TAC)
  >> MP_TAC (Q.SPECL [`E`, `xs`, `E1`] contracts_AND_TRACE_label_lemma)
  >> RW_TAC std_ss []);
+
+(* the version shown in the paper using P and Q *)
+val contracts_AND_TRACE_label' = store_thm (
+   "contracts_AND_TRACE_label'",
+  ``!P Q. P contracts Q ==>
+	!xs l P'. TRACE P xs P' /\ UNIQUE_LABEL (label l) xs ==>
+	    ?xs' Q'. TRACE Q xs' Q' /\ P contracts Q /\
+		(LENGTH xs' <= LENGTH xs) /\ UNIQUE_LABEL (label l) xs'``,
+    METIS_TAC [contracts_AND_TRACE_label]);
 
 (******************************************************************************)
 (*                                                                            *)
@@ -1597,7 +1615,8 @@ val OBS_contracts_SUBST_CONTEXT = store_thm (
 
 val OBS_contracts_precongruence = store_thm (
    "OBS_contracts_precongruence", ``precongruence OBS_contracts``,
-    PROVE_TAC [precongruence_def, OBS_contracts_SUBST_CONTEXT]);
+    PROVE_TAC [precongruence_def, OBS_contracts_PreOrder,
+	       OBS_contracts_SUBST_CONTEXT]);
 
 (******************************************************************************)
 (*                                                                            *)
@@ -1713,7 +1732,7 @@ val C_contracts_thm = save_thm (
 
 val C_contracts_precongruence = store_thm (
    "C_contracts_precongruence", ``precongruence $C_contracts``,
-    REWRITE_TAC [C_contracts, CC_precongruence]);
+    PROVE_TAC [C_contracts, CC_precongruence, contracts_PreOrder]);
 
 val OBS_contracts_IMP_C_contracts = store_thm (
    "OBS_contracts_IMP_C_contracts", ``!p q. OBS_contracts p q ==> C_contracts p q``,
@@ -1857,6 +1876,10 @@ val SUM_contracts_IMP_OBS_contracts = store_thm (
 	  `TRANS p (label a) E1` by RW_TAC std_ss [] \\
 	  POP_ASSUM (ASSUME_TAC o (MATCH_MP TRANS_IMP_WEAK_TRANS)) \\
 	  RES_TAC ] ] ]);			(* initial assumption of `p` is used here *)
+
+val COARSEST_PRECONGR_RL = save_thm (
+   "COARSEST_PRECONGR_RL",
+    BETA_RULE (REWRITE_RULE [SUM_contracts] SUM_contracts_IMP_OBS_contracts));
 
 (* Assuming p & q have free actions, OBS_contracts is the coarsest precongruence
    contained in `contracts`! *)

--- a/examples/CCS/ExampleScript.sml
+++ b/examples/CCS/ExampleScript.sml
@@ -24,6 +24,12 @@ open BisimulationUptoTheory UniqueSolutionsTheory;
 val _ = new_theory "Example";
 val _ = temp_loose_equality ();
 
+(* For paper generating purposes, some type abbreviations are disabled *)
+val _ = disable_tyabbrev_printing "transition";
+val _ = disable_tyabbrev_printing "context";
+val _ = disable_tyabbrev_printing "simulation";
+val _ = disable_tyabbrev_printing "list_simulation";
+
 (******************************************************************************)
 (*                                                                            *)
 (*          The proof of PROPERTY_STAR (old way as in Milner's book)          *)
@@ -200,6 +206,59 @@ in
   val [ex_A1, ex_A2, ex_A3] = map (fn (n, (thm, _)) => save_thm (n, thm))
 				(combine (["ex_A1", "ex_A2", "ex_A3"], nodes))
 end;
+
+val (WB_rules, WB_coind, WB_cases) = Hol_coreln `
+    (!(P :('a, 'b) CCS) (Q :('a, 'b) CCS).
+       (!l.
+	 (!P'. TRANS P (label l) P' ==>
+	       (?Q'. WEAK_TRANS Q (label l) Q' /\ WB P' Q')) /\
+	 (!Q'. TRANS Q (label l) Q' ==>
+	       (?P'. WEAK_TRANS P (label l) P' /\ WB P' Q'))) /\
+       (!P'. TRANS P tau P' ==> (?Q'. EPS Q Q' /\ WB P' Q')) /\
+       (!Q'. TRANS Q tau Q' ==> (?P'. EPS P P' /\ WB P' Q'))
+     ==> WB P Q)`;
+
+(* SOS rules with changed variable names *)
+val PREFIX' = store_thm (
+   "PREFIX'", ``!P u. TRANS (prefix u P) u P``,
+    PROVE_TAC [PREFIX]);
+
+val SUM1' = store_thm (
+   "SUM1'", ``!P u P' Q.    TRANS P u P' ==> TRANS (sum P Q) u P'``,
+    PROVE_TAC [SUM1]);
+
+val SUM2' = store_thm (
+   "SUM2'", ``!P u P' Q.    TRANS P u P' ==> TRANS (sum Q P) u P'``,
+    PROVE_TAC [SUM2]);
+
+val PAR1' = store_thm (
+   "PAR1'", ``!P u P' Q.    TRANS P u P' ==> TRANS (par P Q) u (par P' Q)``,
+    PROVE_TAC [PAR1]);
+
+val PAR2' = store_thm (
+   "PAR2'", ``!P u P' Q.    TRANS P u P' ==> TRANS (par Q P) u (par Q P')``,
+    PROVE_TAC [PAR2]);
+
+val PAR3' = store_thm (
+   "PAR3'", ``!P l P' Q P2. TRANS P (label l) P' /\ TRANS Q (label (COMPL l)) Q'
+		==> TRANS (par P Q) tau (par P' Q')``,
+    PROVE_TAC [PAR3]);
+
+val RESTR' = store_thm (
+   "RESTR'", ``!P u Q l L.   TRANS P u Q /\ ((u = tau) \/
+				     ((u = label l) /\ l NOTIN L /\ (COMPL l) NOTIN L))
+		==> TRANS (restr L P) u (restr L Q)``,
+    PROVE_TAC [RESTR]);
+
+val RELABELING' = store_thm (
+   "RELABELING'", ``!P u Q rf.    TRANS P u Q
+		==> TRANS (relab P rf) (relabel rf u) (relab Q rf)``,
+    PROVE_TAC [RELABELING]);
+
+val REC' = store_thm (
+   "REC'", ``!P u A P'.     TRANS (CCS_Subst P (rec A P) A) u P'
+		==> TRANS (rec A P) u P'``,
+    PROVE_TAC [REC]);
 
 val _ = export_theory ();
 val _ = html_theory "Example";

--- a/examples/CCS/ExpansionScript.sml
+++ b/examples/CCS/ExpansionScript.sml
@@ -848,7 +848,7 @@ val expands_SUBST_GCONTEXT = store_thm (
 
 val expands_precongruence = store_thm (
    "expands_precongruence", ``precongruence1 $expands``,
-    PROVE_TAC [precongruence1_def, expands_SUBST_GCONTEXT]);
+    PROVE_TAC [precongruence1_def, expands_PreOrder, expands_SUBST_GCONTEXT]);
 
 (******************************************************************************)
 (*                                                                            *)

--- a/examples/CCS/UniqueSolutionsScript.sml
+++ b/examples/CCS/UniqueSolutionsScript.sml
@@ -123,7 +123,7 @@ val STRONG_UNIQUE_SOLUTION_LEMMA = store_thm (
       CONJ_TAC >- ( MATCH_MP_TAC CONTEXT7 >> art [] ) \\
       GEN_TAC >> MATCH_MP_TAC RELABELING >> art [] ]);
 
-(* Proposition 3.14 in Milner's book [1]:
+(* Proposition 4.14 in Milner's book [1]:
    Let the expression E contains at most the variable X, and let X be weakly guarded in E,
    then:
 	If P ~ E{P/X} and Q ~ E{Q/X} then P ~ Q.

--- a/examples/CCS/WeakEQScript.sml
+++ b/examples/CCS/WeakEQScript.sml
@@ -681,6 +681,18 @@ val (WEAK_EQUIV_rules, WEAK_EQUIV_coind, WEAK_EQUIV_cases) = Hol_coreln `
        (!E1. TRANS E  tau E1 ==> (?E2. EPS E' E2 /\ WEAK_EQUIV E1 E2)) /\
        (!E2. TRANS E' tau E2 ==> (?E1. EPS E  E1 /\ WEAK_EQUIV E1 E2))
       ==> WEAK_EQUIV E E')`;
+(* next version
+val (WEAK_EQUIV_rules, WEAK_EQUIV_coind, WEAK_EQUIV_cases) = Hol_coreln `
+    (!(P :('a, 'b) CCS) (Q :('a, 'b) CCS).
+       (!l.
+	 (!P'. TRANS P (label l) P' ==>
+	       (?Q'. WEAK_TRANS Q (label l) Q' /\ WEAK_EQUIV P' Q')) /\
+	 (!Q'. TRANS Q (label l) Q' ==>
+	       (?P'. WEAK_TRANS P (label l) P' /\ WEAK_EQUIV P' Q'))) /\
+       (!P'. TRANS P tau P' ==> (?Q'. EPS Q Q' /\ WEAK_EQUIV P' Q')) /\
+       (!Q'. TRANS Q tau Q' ==> (?P'. EPS P P' /\ WEAK_EQUIV P' Q'))
+      ==> WEAK_EQUIV P Q)`;
+ *)
 
 val _ = add_rule { block_style = (AroundEachPhrase, (PP.CONSISTENT, 0)),
                    fixity = Infix (NONASSOC, 450),
@@ -847,6 +859,11 @@ val _ = hide "STABLE"; (* conflicted with sortingTheory *)
 
 val STABLE = new_definition ("STABLE",
   ``STABLE (E :('a, 'b) CCS) = (!u E'. TRANS E u E' ==> ~(u = tau))``);
+
+(* Alternative definition using P, Q, p, q as process variables *)
+val STABLE' = store_thm (
+   "STABLE'", ``STABLE p = (!u p'. TRANS p u p' ==> ~(u = tau))``,
+    PROVE_TAC [STABLE]);
 
 val STABLE_NO_TRANS_TAU = store_thm (
    "STABLE_NO_TRANS_TAU", ``!E. STABLE E ==> !E'. ~(TRANS E tau E')``,

--- a/examples/CCS/tokens.tex
+++ b/examples/CCS/tokens.tex
@@ -2,16 +2,16 @@
 
 \newcommand{\HOLTokenStrongEQ}{$\sim$}
 \newcommand{\HOLTokenWeakEQ}{$\approx$}
-\newcommand{\HOLTokenObsCongr}{$\approx^c$}
+\newcommand{\HOLTokenObsCongr}{$\approx^c\!$}
 \newcommand{\HOLTokenEPS}{$\overset{\epsilon}{\Rightarrow}$}
 \newcommand{\HOLTokenTransBegin}{$-$}
 \newcommand{\HOLTokenTransEnd}{$\rightarrow$}
 \newcommand{\HOLTokenWeakTransBegin}{$=$}
 \newcommand{\HOLTokenWeakTransEnd}{$\Rightarrow$}
-\newcommand{\HOLTokenExpands}{$\succeq_e$}
-\newcommand{\HOLTokenContracts}{$\succeq_{bis}$}
-\newcommand{\HOLTokenObsContracts}{$\succeq^c_{bis}$}
-\renewcommand{\HOLTokenImp}{\ensuremath{\Longrightarrow}}
+\newcommand{\HOLTokenExpands}{$\succeq_e\!$}
+\newcommand{\HOLTokenContracts}{$\succeq_{bis}\!$}
+\newcommand{\HOLTokenObsContracts}{$\succeq^c_{bis}\!$}
+%\renewcommand{\HOLTokenImp}{\ensuremath{\Longrightarrow}}
 
 % Experimental environments
 \usepackage{environ}


### PR DESCRIPTION
Hi,

this PR contains the latest version of CCS example, aligned with my recently published paper [1].

The major fixes are the definitions of  `precongruence` and `precongruence1` which were previously wrong with PreOrder requirements missing. All other changes are minor, with some duplicated small theorems using different variable names.

--Chun

[1]	C. Tian, D. Sangiorgi, Unique Solutions of Contractions, CCS, and their HOL Formalisation, 276 (2018) 122–139. doi:10.4204/EPTCS.276.10.
