### PR TITLE
Local Program Variables?

### DIFF
--- a/src/0/Term.sml
+++ b/src/0/Term.sml
@@ -717,6 +717,7 @@ fun strip_binder opt =
                                     end handle HOL_ERR _ => NONE)
  in fn tm =>
    let
+     open Unsynchronized
      val (prefixl,body) = peel f tm []
      val AV = ref (Redblackmap.mkDict String.compare) : ((string,occtype)Redblackmap.dict) ref
      fun peekInsert (key,data) =

--- a/src/HolSat/def_cnf.sml
+++ b/src/HolSat/def_cnf.sml
@@ -76,7 +76,8 @@ val GCONJUNCTS  =
             total (HolKernel.find_term (fn t => is_T t orelse is_F t)) tm
         fun GCONJUNCTS'' th = GCONJUNCTS' th []
     in fn tm => fn th =>
-          let val ths0 = if is_neg tm andalso is_neg (rand tm)
+          let open Unsynchronized
+              val ths0 = if is_neg tm andalso is_neg (rand tm)
                          then CONJUNCTSR (CONV_RULE NOT_NOT_CONV th) else [th]
               val ths1 = List.map GCONJUNCTS'' ths0
               val is_cnf = ref true

--- a/src/meson/src/mesonLib.sml
+++ b/src/meson/src/mesonLib.sml
@@ -398,13 +398,13 @@ fun fol_atom_eq insts (p1,args1) (p2,args2) =
 
 fun cacheconts f =
  if !cache
- then let val memory = ref []
+ then let val memory = Unsynchronized.ref []
       in fn input as (gg, (insts,offset,(size:int))) =>
            if exists (fn (_,(insts',_,size')) =>
                        insts=insts' andalso (size <= size' orelse !depth))
-                     (!memory)
+                     (Unsynchronized.!memory)
            then failwith "cachecont"
-           else (memory := input::(!memory); f input)
+           else (Unsynchronized.:=(memory,input::(Unsynchronized.!memory)); f input)
       end
  else f;;
 

--- a/src/metis/mlibMeter.sml
+++ b/src/metis/mlibMeter.sml
@@ -85,6 +85,7 @@ fun new_time_meter () =
 
 fun new_inference_meter () =
   let
+    open Unsynchronized
     val infs = ref 0
     fun read () = !infs
   in

--- a/src/parse/parse_term.sig
+++ b/src/parse/parse_term.sig
@@ -21,6 +21,6 @@ sig
   datatype mx_order = datatype parse_term_dtype.mx_order
   val mk_prec_matrix :
       term_grammar.grammar ->
-      ((stack_terminal * bool) * stack_terminal, mx_order) Binarymap.dict ref
+      ((stack_terminal * bool) * stack_terminal, mx_order) Binarymap.dict Unsynchronized.ref
 
 end

--- a/src/parse/parse_term.sml
+++ b/src/parse/parse_term.sml
@@ -86,6 +86,7 @@ val complained_already = ref false;
 
 structure Polyhash =
 struct
+  open Unsynchronized
    fun peek (dict) k = Binarymap.peek(!dict,k)
    fun peekInsert r (k,v) =
        let val dict = !r in
@@ -193,7 +194,7 @@ fun mk_prec_matrix G = let
   exception NotFound = Binarymap.NotFound
   exception BadTokList
   type dict = ((stack_terminal * bool) * stack_terminal,
-               mx_order) Binarymap.dict ref
+               mx_order) Binarymap.dict Unsynchronized.ref
   val {lambda, endbinding, type_intro, restr_binders, ...} = specials G
   val specs = grammar_tokens G
   val Grules = term_grammar.grammar_rules G
@@ -556,7 +557,7 @@ fun suffix_rule (rels,nm) =
 
 fun mk_ruledb (G:grammar) = let
   val Grules = term_grammar.grammar_rules G
-  val table:(rule_element list, rule_summary)Binarymap.dict ref =
+  val table:(rule_element list, rule_summary)Binarymap.dict Unsynchronized.ref =
        Polyhash.mkDict (Lib.list_compare RE_compare)
   fun insert_rule mkfix (rr:rule_record) =
     let

--- a/src/parse/qbuf.sml
+++ b/src/parse/qbuf.sml
@@ -1,7 +1,7 @@
 structure qbuf :> qbuf =
 struct
 
-  open base_tokens locn Portable Lib
+  open base_tokens locn Portable Lib Unsynchronized
 
 (* For SML/NJ *)
 

--- a/src/parse/term_tokens.sml
+++ b/src/parse/term_tokens.sml
@@ -529,6 +529,7 @@ fun user_split_ident keywords = let
   val split = split_ident mixedset (!base_tokens.allow_octal_input)
 in
   fn s => let
+       open Unsynchronized
        val pushback = ref ""
        fun rc (btid, _) =
            case btid of

--- a/src/portableML/Redblackmap.sml
+++ b/src/portableML/Redblackmap.sml
@@ -49,6 +49,7 @@ struct
 
   exception GETOUT
 
+  local open Unsynchronized in
   fun update (set as (compare, tree, n), key, data) =
       let val addone = ref true
           fun ins LEAF = RED(key,data NONE,LEAF,LEAF)
@@ -67,6 +68,7 @@ struct
                 RED x => BLACK x
               | tree  => tree
           , if !addone then n+1 else n) end
+  end
 
   local fun K x _ = x in
     fun insert (set, key, data) = update (set, key, K data)

--- a/src/postkernel/HolKernel.sml
+++ b/src/postkernel/HolKernel.sml
@@ -356,6 +356,7 @@ fun bvk_find_term P k =
 
 fun find_terms P =
    let
+      open Unsynchronized
       val tms = ref []
       fun find_tms tm =
          (if P tm then tms := tm :: (!tms) else ()


### PR DESCRIPTION
I know that dealing with references and synchronization is a very subtle business, so this pull request is mostly meant as a starting point for discussion.

Some of the refs in HOL4 track global state, whereas some are private program variables.
The refs affected in this commit are the ones that are heavily allocated while building HOL and looked (upon superficial inspection) reasonably local

Would it make sense to mark them explicitly as private program variables?

Best regards,
Fabian