### PR TITLE
Fixed hol-unicode-replacements (hol-mode.el) for UNIV, added "o"; ...

### DIFF
--- a/src/num/theories/arithmeticScript.sml
+++ b/src/num/theories/arithmeticScript.sml
@@ -105,8 +105,7 @@ val _ = ot0 "BIT2" "bit2"
 val _ = add_numeral_form (#"n", NONE);
 
 val _ = set_fixity "-" (Infixl 500);
-val _ = Unicode.unicode_version {u = UTF8.chr 0x2212, tmnm = "-"};
-val _ = TeX_notation {hol = UTF8.chr 0x2212, TeX = ("\\ensuremath{-}", 1)}
+val _ = TeX_notation {hol = "-", TeX = ("\\ensuremath{-}", 1)}
 
 val SUB = new_recursive_definition
    {name = "SUB",

--- a/tools/hol-mode.src
+++ b/tools/hol-mode.src
@@ -1595,8 +1595,8 @@ second is to show the new term.
   (t "⊆ᵣ" "RSUBSET")
   (t "∪ᵣ" "RUNION")
   (t "∩ᵣ" "RINTER")
-  (t "∅" "EMPTY")
-  (t "𝕌" "UNIV")
+  (t "∅" "{}")
+  (nil "𝕌" "univ")
   (t "⊆" "SUBSET")
   (t "∪" "UNION")
   (t "∩" "INTER")
@@ -1607,6 +1607,7 @@ second is to show the new term.
   (t "⋙" ">>>")
   (t "⇄" "#>>")
   (t "⇆" "#<<")
+  (t "∘" "o")
 ))
 
 


### PR DESCRIPTION
Hi,

currently in hol-mode.el, the feature "Replace common HOL Unicode symbols" replaces universal set symbol 𝕌 into `UNIV`, but this is wrong, it should be `univ`, because 𝕌 always appear with the underlying set element type, e.g. 𝕌(:α) or 𝕌(:num), with the corresponding ASCII term `univ(:'a)` or `univ(:num)`. There should be no space after `univ` before the type part.

Beside, the functional composition symbol ∘ isn't handled. I added this one with replacement `o`.

Also, I don't understand why the subtraction symbol `-` has also a Unicode char `UTF8.chr 0x2212` (which looks almost the same as `-`). This was done in commit eb606344 but the commit message looks irrelevant.  In my proof scripts, sometimes I copied some term from HOL's output back to script file, then all the subtraction symbols being copied are the Unicode version, and of course it's not handled by "Replace common HOL Unicode symbols". I was trying hard to figure out those `UTF8.chr 0x2212` chars.   If there's no particular reason, I hope it can be removed as the current PR does.

--Chun

