### PR TITLE
Give mp_then a signature

### DIFF
--- a/help/Docfiles/mp_then.mp_then.doc
+++ b/help/Docfiles/mp_then.mp_then.doc
@@ -1,6 +1,6 @@
 \DOC
 
-\TYPE {mp_then : thm_tactic -> match_position -> thm -> thm -> tactic}
+\TYPE {mp_then : match_position -> thm_tactic -> thm -> thm -> tactic}
 
 \SYNOPSIS
 Matches two theorems against each other and then continues

--- a/src/1/mp_then.sig
+++ b/src/1/mp_then.sig
@@ -9,6 +9,6 @@ sig
     | Pos of (term list -> term)
     | Concl
 
-  val mp_then : thm_tactic -> match_position -> thm -> thm -> tactic
+  val mp_then : match_position -> thm_tactic -> thm -> thm -> tactic
 
 end

--- a/src/1/mp_then.sig
+++ b/src/1/mp_then.sig
@@ -1,0 +1,14 @@
+signature mp_then =
+sig
+
+  include Abbrev
+
+  datatype match_position
+    = Any
+    | Pat of term quotation
+    | Pos of (term list -> term)
+    | Concl
+
+  val mp_then : thm_tactic -> match_position -> thm -> thm -> tactic
+
+end

--- a/src/1/mp_then.sml
+++ b/src/1/mp_then.sml
@@ -1,8 +1,7 @@
-structure mp_then =
+structure mp_then :> mp_then =
 struct
 
-local
-  open HolKernel Drule Conv Parse boolTheory boolSyntax
+open HolKernel Drule Conv Parse boolTheory boolSyntax
 
 fun avSPEC_ALL avds th =
   let
@@ -43,8 +42,6 @@ val notT = el 2 (CONJUNCTS NOT_CLAUSES)
 val imp_clauses = IMP_CLAUSES |> SPEC_ALL |> CONJUNCTS
 val Timp = el 1 imp_clauses
 val impF = last imp_clauses
-
-in
 
 datatype match_position =
   Any
@@ -116,7 +113,5 @@ fun mp_then pos (ttac : thm_tactic) ith0 rth (g as (asl,w)) =
                    (fn _ => raise fail)
                    (dest_neg t handle HOL_ERR _ => mk_neg t)
   end
-
-end (* local *)
 
 end


### PR DESCRIPTION
The purpose of this pull request is to ensure that `mp_then` documentation is linked to from the auto-generated HTML index (`$HOLDIR/help/HOLindex.html`). This is achieved by giving `mp_then` a signature.

Additionally, this fixes a typo in the type-signature shown in the mp_then Docfile.