### PR TITLE
Added univ to polyscripter's umap; fixed Makefile (Manual)

### DIFF
--- a/Manual/Makefile
+++ b/Manual/Makefile
@@ -29,7 +29,7 @@ Reference/reference.pdf:
 	@echo "====> REFERENCE made"
 
 Interaction/HOL-interaction.pdf:
-	(cd Interaction; make; cd ..)
+	(cd Interaction; Holmake; cd ..)
 	@echo "====> Quick Reference made"
 
 Quick/quick.pdf:

--- a/Manual/Tools/umap
+++ b/Manual/Tools/umap
@@ -41,3 +41,4 @@
 ⦈ \(\rrparenthesis\)
 ↦ \(\mapsto\)
 ` \`{}
+𝕌 \(\cal{U}\)


### PR DESCRIPTION
In `Manual/Description/libraries.stex`, some code expansion contain `FINITE 𝕌(:32)` in which Unicode char `𝕌` is not converted into ASCII. I added it into polyscripter's umap.

In `Manual/Interaction` there's no `Makefile` any more, the toplevel `make` should call `Holmake` in `Manual/Interaction`.

With these trivial fixes, now again I can build all HOL's manual PDFs on Mac OS X with TeXlive 2018.