### PR TITLE
remove-term-eqtype in EquivType

### DIFF
--- a/src/HolSat/vector_def_CNF/defCNF.sml
+++ b/src/HolSat/vector_def_CNF/defCNF.sml
@@ -62,7 +62,7 @@ fun sub_cnf f con defs (a, b) =
     end;
 
 fun def_step (defs as (vec, n, ds), tm) =
-  case List.find (fn (_, b) => b = tm) ds of NONE =>
+  case List.find (fn (_, b) => b ~~ tm) ds of NONE =>
     let
       val g = mk_comb (vec, n)
       val n = rhs (concl (REDUCE_CONV (mk_comb (suc, n))))

--- a/src/datatype/equiv/EquivType.sml
+++ b/src/datatype/equiv/EquivType.sml
@@ -194,10 +194,10 @@ fun define_equivalence_type{name=tyname, equiv, defs = fnlist,
     if is_abs tm then (mk_abs o (I ## transconv) o dest_abs) tm
     else
       let val (opp,tms) = (I ## map transconv) (strip_comb tm) in
-      if (mem opp (map #func fnlist) andalso (type_of tm = repty)) then
+      if (memt (map #func fnlist) opp andalso (type_of tm = repty)) then
         “$@(^rep(^abs(^eqv ^(list_mk_comb(opp,tms)))))”
-      else if tms = [] then opp
-      else list_mk_comb(transconv opp,tms) end
+      else case tms of [] => opp
+        | _ => list_mk_comb(transconv opp,tms) end
 
   fun TRANSFORM_CONV tm =
     let val th1 =

--- a/src/quantHeuristics/quantHeuristicsLibAbbrev.sml
+++ b/src/quantHeuristics/quantHeuristicsLibAbbrev.sml
@@ -87,7 +87,7 @@ let
       val sfs = flatten (map sf tL)
       val fsfs = filter (fn (tt, _) => no_var_const_filter tt) sfs
 
-      fun my_insert ((tt, n), l) = if (exists (fn (tt', _) => tt' = tt) l) then l else (tt,n)::l
+      fun my_insert ((tt, n), l) = if (exists (fn (tt', _) => tt' ~~ tt) l) then l else (tt,n)::l
       val fsfs_unique = rev (foldl my_insert [] fsfs)
    in fsfs_unique end
    val fvL = ref (all_vars t);
@@ -102,8 +102,8 @@ let
       val s = [st |-> new_v];
       val _ = fvL := new_v :: (!fvL);
 
-      fun v_inst_filter v t i fvL = not (i = st)
-      fun v_filter v t = v = new_v
+      fun v_inst_filter v t i fvL = not (i ~~ st)
+      fun v_filter v t = v ~~ new_v
       val v_qps = [inst_filter_qp [v_inst_filter], filter_qp [v_filter]]
 
 (*
@@ -118,7 +118,7 @@ val t0 = snd (strip_forall t)
          val t' = subst s t0
          val is_top' = (is_top andalso is_forall t0)
       in
-         if (t0 = t') then (if (only_top andalso (not is_top')) then fail() else
+         if (t0 ~~ t') then (if (only_top andalso (not is_top')) then fail() else
                                (if is_top' then QUANT_CONV (try_subst true) t0 else
                                                 (SUB_CONV (try_subst false) t0))) else
          let


### PR DESCRIPTION
Apparently bin/build does not complain when "Building directory src/datatype/equiv", but I do not understand why. I believe the attached change should be necessary...

Is there something else going on?