### PR TITLE
Add Hol_list_reln, which defines a relation from a list of quotations.

### DIFF
--- a/src/IndDef/IndDefLib.sig
+++ b/src/IndDef/IndDefLib.sig
@@ -10,6 +10,7 @@ sig
 
   val Hol_reln      : term quotation -> thm * thm * thm
   val xHol_reln     : string -> term quotation -> thm * thm * thm
+  val Hol_list_reln : string -> term quotation list -> thm * thm * thm
   val Hol_mono_reln : string -> monoset ->
                       (term * locn.locn list) -> thm * thm * thm
 

--- a/src/IndDef/IndDefLib.sig
+++ b/src/IndDef/IndDefLib.sig
@@ -7,6 +7,7 @@ sig
   val term_of_absyn : Absyn.absyn -> term * locn.locn list
 
   val name_from_def : term -> string
+  val destl_forall  : term list -> term * term list
 
   val Hol_reln      : term quotation -> thm * thm * thm
   val xHol_reln     : string -> term quotation -> thm * thm * thm

--- a/src/IndDef/IndDefLib.sml
+++ b/src/IndDef/IndDefLib.sml
@@ -183,7 +183,7 @@ handle e => raise (wrap_exn "IndDefLib" "Hol_mono_reln" e);
 fun xHol_reln name q = Hol_mono_reln name (!the_monoset) (term_of q)
 
 fun destl_forall l = let
-  val ldf = map dest_forall l
+  val ldf = map boolSyntax.dest_forall l
 in
   (fst (hd ldf), map snd ldf)
 end
@@ -193,7 +193,7 @@ fun Hol_list_reln name ql = let
   val (tml, locll) = (map fst toql, map snd toql)
   val locl = List.concat locll
   val (rel, l) = destl_forall tml
-  val conj_tm = list_mk_conj l
+  val conj_tm = boolSyntax.list_mk_conj l
   val new_rel = mk_var (name, type_of rel)
   val new_rel_conj = subst [rel |-> new_rel] conj_tm
   val reln_tm = (new_rel_conj, locl)

--- a/src/IndDef/IndDefLib.sml
+++ b/src/IndDef/IndDefLib.sml
@@ -182,6 +182,26 @@ handle e => raise (wrap_exn "IndDefLib" "Hol_mono_reln" e);
 
 fun xHol_reln name q = Hol_mono_reln name (!the_monoset) (term_of q)
 
+fun destl_forall l = let
+  val ldf = map dest_forall l
+in
+  (fst (hd ldf), map snd ldf)
+end
+
+fun Hol_list_reln name ql = let
+  val toql = map term_of ql
+  val (tml, locll) = (map fst toql, map snd toql)
+  val locl = List.concat locll
+  val (rel, l) = destl_forall tml
+  val conj_tm = list_mk_conj l
+  val new_rel = mk_var (name, type_of rel)
+  val new_rel_conj = subst [rel |-> new_rel] conj_tm
+  val reln_tm = (new_rel_conj, locl)
+in
+  Hol_mono_reln name (!the_monoset) reln_tm
+end
+handle e => raise (wrap_exn "IndDefLib" "Hol_list_reln" e);
+
 fun name_from_def t = let
   open boolSyntax
   val cs = strip_conj t


### PR DESCRIPTION
When defining relations which build upon each other, at the moment a lot of redundancy is introduced. With this function, you make a list of quotations, each of which is a rule for the relation, but with a universally quantified relation name. You call the function with a new name which is used in place of the old one, plus the list of rules, and get a relation just like when using Hol_reln.

You could write, for example:
```sml
val base_rule_list = [`!R. <rule1 def>`,`!R. <rule2 def>`]
val ext_rule_list = `!R. <rule3 def>` :: base_rules

val (base_rules, base_ind, base_cases) = Hol_list_reln "base" base_rule_list
val (ext_rules, ext_ind, ext_cases) = Hol_list_reln "ext" ext_rule_list
```

I would have found this useful when I was defining proof calculi for different logics, i.e., minimal logic, intuitionistic logic, classical logic, which build on each other for some calculi like natural deduction.

Let me know what you think, and if you think it would be useful for anyone other than me.