### PR TITLE
Add type unification and mk_ucomb to boolSyntax

### DIFF
--- a/help/Docfiles/boolSyntax.list_mk_ucomb.doc
+++ b/help/Docfiles/boolSyntax.list_mk_ucomb.doc
@@ -1,0 +1,28 @@
+\DOC list_mk_ucomb
+
+\TYPE {list_mk_ucomb : term * term list -> term}
+
+\SYNOPSIS
+Folds {mk_ucomb} over a series of arguments.
+
+\DESCRIBE
+A call to {list_mk_ucomb(f, args)} combines {f} with each of the
+elements of the list {args} in turn, moving from left to right.  If
+{args} is empty, then the result is simply {f}.  When {args} is
+non-empty, the growing application-term is created with successive
+calls to {mk_ucomb}, possibly causing type variables in any of the
+terms to become instantiated.
+
+\FAILURE
+Fails if any of the underlying calls to {mk_ucomb} fails, which will
+occur if the type of the accumulating term (starting with {f}) is not
+of a function type, or if it has a domain type that can not be
+instantiated to equal the type of some instantiation of the next argument term.
+
+\COMMENTS
+{list_mk_ucomb} is to {mk_ucomb} what {list_mk_comb} is to {mk_comb}.
+
+\SEEALSO
+Term.list_mk_comb, Term.mk_comb, boolSyntax.mk_ucomb.
+
+\ENDDOC

--- a/help/Docfiles/boolSyntax.mk_ucomb.doc
+++ b/help/Docfiles/boolSyntax.mk_ucomb.doc
@@ -1,0 +1,71 @@
+\DOC mk_ucomb
+
+\TYPE {mk_ucomb : term * term -> term}
+
+\SYNOPSIS Forms an application term, possibly instantiating both the
+function and the argument types.
+
+\DESCRIBE
+A call to {mk_ucomb(f,x)} checks to see if the term {f} (which must
+have a function type) can have its type variables instantiated to
+make the domain of the function match some instantiation of the
+type of {x}.  If so, then the call returns the application of the
+instantiated {f} to the instantiated {x}.
+
+\FAILURE
+Fails if there is no way to instantiate the types to make the function domain
+match the argument type.
+
+\EXAMPLE
+
+Note how both the FOLDR combinator and the argument (the K combinator)
+have type variables invented for them when the two quotations are parsed.
+{
+   - val t = mk_ucomb(``FOLDR``, ``K``);
+  <<HOL message: inventing new type variable names: 'a, 'b>>
+  <<HOL message: inventing new type variable names: 'a, 'b>>
+   > val t = ``FOLDR K`` : term
+}
+The resulting term {t} has only the type variable {:'a} left after
+instantiation.
+{
+   - type_of t;
+   > val it = ``:'a -> 'a list -> 'a`` : hol_type
+}
+This term can now be combined with an argument and the final type
+variable instantiated:
+{
+   - mk_ucomb(t, ``T``);
+   > val it = ``FOLDR K T`` : term
+
+   - type_of it;
+   > val it = ``:bool list -> bool``;
+}
+Attempting to use {mk_icomb} in the first example above results in immediate
+error because it can only instantiate the function type:
+{
+   - mk_icomb(``FOLDR``, ``K``) handle e => Raise e;
+   <<HOL message: inventing new type variable names: 'a, 'b>>
+   <<HOL message: inventing new type variable names: 'a, 'b>>
+
+   Exception raised at HolKernel.list_mk_icomb:
+   double bind on type variable 'b
+   Exception-
+      HOL_ERR
+        {message = "double bind on type variable 'b", origin_function =
+         "list_mk_icomb", origin_structure = "HolKernel"} raised
+}
+However it can be used in the second example, as only the function type
+requires instantiation:
+{
+   - mk_icomb(t, ``T``);
+   > val it = ``FOLDR K T`` : term
+}
+
+\COMMENTS
+{mk_ucomb} makes use of {sep_type_unify}.
+
+\SEEALSO
+boolSyntax.list_mk_ucomb, boolSyntax.sep_type_unify, Term.mk_icomb, Term.mk_comb.
+
+\ENDDOC

--- a/help/Docfiles/boolSyntax.sep_type_unify.doc
+++ b/help/Docfiles/boolSyntax.sep_type_unify.doc
@@ -1,0 +1,66 @@
+\DOC sep_type_unify
+
+\TYPE {sep_type_unify : hol_type -> hol_type ->
+        (hol_type,hol_type) subst * (hol_type,hol_type) subst}
+
+\SYNOPSIS
+Calculates a pair of substitutions {(theta1, theta2)} such that instantiating
+the first argument with {theta1} equals the second argument instatiated with
+{theta2}.
+
+\DESCRIBE
+If {sep_type_unify ty1 ty2} succeeds, then
+{
+    type_subst (sep_type_unify ty1 ty2 |> fst) ty1 =
+      type_subst (sep_type_unify ty1 ty2 |> snd) ty2
+}
+
+\FAILURE
+If no such substitution can be found.
+
+\EXAMPLE
+{
+- let val alpha_list = Type `:'a list`
+  in
+     sep_type_unify alpha alpha_list
+  end;
+> val it = ([{redex = “:α”, residue = “:α list”}], []):
+   (hol_type, hol_type) Lib.subst * (hol_type, hol_type) subst
+
+- let val ty1 = Type `:'a -> 'b -> 'b`
+      val ty2 = Type `:'a list -> 'b list -> 'a list`
+  in
+    sep_type_unify ty1 ty2
+  end;
+> val it =
+   ([{redex = “:β”, residue = “:α list”},
+     {redex = “:α”, residue = “:α list”}], [{redex = “:β”, residue = “:α”}]):
+   (hol_type, hol_type) Lib.subst * (hol_type, hol_type) subst
+}
+
+Note that in these examples, {type_unify} would fail due to an occurs
+check:
+{
+- let val ty1 = Type `:'a -> 'b -> 'b`
+      val ty2 = Type `:'a list -> 'b list -> 'a list`
+  in
+    type_unify ty1 ty2
+  end;
+
+  Exception raised at boolSyntax.type_unify:
+  occurs check
+  Exception-
+     HOL_ERR
+       {message = "occurs check", origin_function = "type_unify",
+        origin_structure = "boolSyntax"} raised
+}
+
+\COMMENTS
+{sep_type_unify} is similar to {type_unify}, but does not run into problems with
+occurs checks. It first renames all type variables, then attempt to unify the
+argument types, returning two separate substitutions as a result.
+
+\SEEALSO
+boolSyntax.type_unify, Type.type_subst, Term.inst.
+
+\ENDDOC

--- a/help/Docfiles/boolSyntax.type_unify.doc
+++ b/help/Docfiles/boolSyntax.type_unify.doc
@@ -1,0 +1,65 @@
+\DOC type_unify
+
+\TYPE {type_unify : hol_type -> hol_type -> (hol_type,hol_type) subst}
+
+\SYNOPSIS
+Performs classical type unification.
+
+\DESCRIBE
+Calculates a substitution {theta} such that instantiating each of the arguments
+with {theta} gives the same result type.
+
+If {type_unify ty1 ty2} succeeds, then
+{
+    type_subst (type_unify ty1 ty2) ty1 = type_subst (type_unify ty1 ty2) ty2
+}
+
+
+\FAILURE
+If no such substitution can be found. This could be due to incompatible type
+constructors, or the failing of an occurs check.
+
+\EXAMPLE
+{
+- let val ty1 = Type `:'a -> 'b -> 'a`
+      val ty2 = Type `:'a -> 'b -> 'b`
+  in
+     type_subst (type_unify ty1 ty2) ty1 = type_subst (type_unify ty1 ty2) ty2
+  end;
+> val it = true : bool
+
+- let val alpha_list = Type `:'a list`
+  in
+     type_unify alpha alpha_list handle e => Raise e
+  end;
+
+  Exception raised at boolSyntax.type_unify:
+  occurs check
+  Exception-
+     HOL_ERR
+       {message = "occurs check", origin_function = "type_unify",
+        origin_structure = "boolSyntax"} raised
+}
+
+Note that attempting to use {Type.match_type} in the first example
+results in immediate error, as it can only attempt to substitute the first
+argument to match the second:
+{
+- let val ty1 = Type `:'a -> 'b -> 'a`
+      val ty2 = Type `:'a -> 'b -> 'b`
+  in
+     match_type ty1 ty2 handle e => Raise e
+  end;
+
+  Exception raised at Type.raw_match_type:
+  double bind on type variable 'a
+  Exception-
+   HOL_ERR
+     {message = "double bind on type variable 'a", origin_function =
+      "raw_match_type", origin_structure = "Type"} raised
+}
+
+\SEEALSO
+boolSyntax.sep_type_unify, Type.match_type, Type.type_subst, Term.inst.
+
+\ENDDOC

--- a/src/1/boolSyntax.sig
+++ b/src/1/boolSyntax.sig
@@ -56,6 +56,7 @@ sig
   val mk_res_abstract        : term * term * term -> term
   val mk_icomb               : term * term -> term
   val mk_IN                  : term * term -> term
+  val mk_ucomb               : term * term -> term
 
   (* Destruction routines *)
 
@@ -126,7 +127,7 @@ sig
   val list_mk_res_forall     : (term * term) list * term -> term
   val list_mk_res_exists     : (term * term) list * term -> term
   val list_mk_icomb          : term * term list -> term
-
+  val list_mk_ucomb          : term * term list -> term
   val gen_all                : term -> term
 
   (* Destructing a term to a list of terms *)
@@ -184,5 +185,9 @@ sig
   val FVLset : term list -> term HOLset.set
   val ES : term HOLset.set
 
+  (* Type unification *)
+  val type_unify : hol_type -> hol_type -> (hol_type, hol_type) Lib.subst
+  val sep_type_unify : hol_type -> hol_type ->
+              (hol_type, hol_type) Lib.subst * (hol_type, hol_type) Lib.subst
 
 end


### PR DESCRIPTION
Expose four new functions in `boolSyntax`:
 - `type_unify : hol_type -> hol_type -> (hol_type,hol_type) subst` - classical type unification.
 - `sep_type_unify : hol_type -> hol_type -> (hol_type,hol_type) subst * (hol_type,hol_type) subst` - type "unification" which returns two separate substitutions (one for each argument), avoiding problems with occurs checks and so on. In other words, gives separate substitutions for each argument, to "unify" them to some common type - particularly useful when the types have type variables in common.
 - `mk_ucomb : term * term -> term` - a version of `mk_comb` which first uses `sep_type_unify` to allow type instantiation of both function and argument types, reducing the need for manual type instantiations.
 - `list_mk_ucomb : term * term list -> term` - folds `mk_ucomb` over a list of arguments.

Help docfiles are included for these four new functions. The functions `type_unify` and `sep_type_unify` are adapted from `examples/miller`.