### PR TITLE
Expand message from Define failure.

### DIFF
--- a/src/num/termination/TotalDefn.sml
+++ b/src/num/termination/TotalDefn.sml
@@ -535,7 +535,8 @@ local open Defn
      end
   val msg1 = "\nUnable to prove termination!\n\n\
               \Try using \"TotalDefn.tDefine <name> <quotation> <tac>\".\n"
-  val msg2 = "\nThe termination goal has been set up using Defn.tgoal <defn>.\n"
+  val msg2 = "\nThe termination goal has been set up using Defn.tgoal <defn>.\n\
+              \Solve the current proof goal (try e.g. p(), WF_REL_TAC).\n"
   fun termination_proof_failed defn =
      let
         val s =


### PR DESCRIPTION
Adds one more line to the output message to make it a little
clearer that "goal has been set up with ..." implies that it this goal
is now in the proof manager state, and you should look there.

(I appreciate that this might be a bad time to print the proof
manager state, since that might be long enough to hide what
has happened.)