### PR TITLE
Make impl_tac work with universally quantified implications

### DIFF
--- a/help/Docfiles/Thm_cont.PROVEHYP_THEN.doc
+++ b/help/Docfiles/Thm_cont.PROVEHYP_THEN.doc
@@ -15,8 +15,6 @@ requires that {th} be an (universally quantified) implication
 Given an implication {|- !x1..xn. l ==> r x1..xn}, the result is a new
 sub-goal requiring the user to prove {l}, and the application of {th2tac}
 to the theorems with conclusion {l} and {!x1..xn. r x1..xn}.
-(The former has just been proved by the user; the latter is the result
-of applying {MATCH_MP} to {th} and {l}.)
 
 Diagrammatically, one might see this as
 {

--- a/help/Docfiles/Thm_cont.PROVEHYP_THEN.doc
+++ b/help/Docfiles/Thm_cont.PROVEHYP_THEN.doc
@@ -10,12 +10,13 @@ Theorem-tactical.
 
 \DESCRIBE
 An application of the tactic {PROVEHYP_THEN th2tac th} to a goal {g}
-requires that {th} be an implication (or a negation, in which case
-{~p} is treated as {p ==> F}). Given an implication {|- l ==> r},
-the result is a new sub-goal requiring the user to prove {l}, and the
-application of {th2tac} to the theorems with conclusion {l} and {r}.
+requires that {th} be an (universally quantified) implication
+(or a negation, in which case {~p} is treated as {p ==> F}).
+Given an implication {|- !x1..xn. l ==> r x1..xn}, the result is a new
+sub-goal requiring the user to prove {l}, and the application of {th2tac}
+to the theorems with conclusion {l} and {!x1..xn. r x1..xn}.
 (The former has just been proved by the user; the latter is the result
-of applying {MP} to {th} and {l}.)
+of applying {MATCH_MP} to {th} and {l}.)
 
 Diagrammatically, one might see this as
 {

--- a/src/1/Thm_cont.sml
+++ b/src/1/Thm_cont.sml
@@ -438,18 +438,24 @@ end
 (* ----------------------------------------------------------------------
     PROVEHYP_THEN ttac th
 
-    th must be of form |- l ==> r
+    th must be of form |- !x1..xn. l ==> r x1..xn
 
     Application of tactic sets up l as a subgoal, and in the second
-    branch applies ttac to |- r
+    branch applies ttac to |- !x1..xn. r x1..xn
    ---------------------------------------------------------------------- *)
 
-fun PROVEHYP_THEN t2tac th g =
-  let
-    val (l, _) = dest_imp (concl th)
-  in
-    Tactical.SUBGOAL_THEN l (fn lth => t2tac lth (MP th lth))
-  end g
+local
+ fun occurs_check [] tm = ()
+   | occurs_check (v::vs) tm = if free_in v tm then raise (ERR "PROVEHYP_THEN" "") else occurs_check vs tm
+in
+ fun PROVEHYP_THEN t2tac th g = let
+  val (vs, tm) = strip_forall (concl th)
+  val (l, _) = dest_imp tm
+  val () = occurs_check vs l
+ in
+  Tactical.SUBGOAL_THEN l (fn lth => t2tac lth (MATCH_MP th lth))
+ end g
+end
 
 val provehyp_then = PROVEHYP_THEN
 

--- a/src/1/Thm_cont.sml
+++ b/src/1/Thm_cont.sml
@@ -27,7 +27,7 @@
 structure Thm_cont :> Thm_cont =
 struct
 
-open Feedback HolKernel Drule boolSyntax Abbrev;
+open Feedback HolKernel Drule boolSyntax Abbrev Conv;
 
 val ERR = mk_HOL_ERR "Thm_cont"
 
@@ -447,13 +447,16 @@ end
 local
  fun occurs_check [] tm = ()
    | occurs_check (v::vs) tm = if free_in v tm then raise (ERR "PROVEHYP_THEN" "") else occurs_check vs tm
+ val IMP_CLAUSES1 = boolTheory.IMP_CLAUSES |> SPEC_ALL |> CONJUNCT1 |> GEN_ALL
+ fun lth_mp th lth = CONV_RULE (STRIP_QUANT_CONV (LAND_CONV (K (EQT_INTRO lth)) THENC
+                                                  REWR_CONV IMP_CLAUSES1)) th
 in
  fun PROVEHYP_THEN t2tac th g = let
   val (vs, tm) = strip_forall (concl th)
   val (l, _) = dest_imp tm
   val () = occurs_check vs l
  in
-  Tactical.SUBGOAL_THEN l (fn lth => t2tac lth (MATCH_MP th lth))
+  Tactical.SUBGOAL_THEN l (fn lth => t2tac lth (lth_mp th lth))
  end g
 end
 


### PR DESCRIPTION
As suggested in #727, `impl_tac` now handles universally quantified implications:

```
(* Example 1, works as expected: *)
Theorem thm1:
 a ==> (!x. a ==> b x) ==> b y
Proof
 strip_tac \\ impl_tac >- first_assum MATCH_ACCEPT_TAC \\ disch_then MATCH_ACCEPT_TAC
QED

(* Example 2, impl_tac dies (as it should) because x occurs in hypo: *)
Theorem thm2:
 a 5 ==> (!x. a x ==> b x) ==> b 5
Proof
 strip_tac \\ impl_tac (* <-- dies *)
QED

(* Example 3, MATCH_MP does "too much": *)
Theorem thm3:
 a ==> (!x y. a ==> b x) ==> b 5
Proof
 strip_tac \\ impl_tac >- first_assum MATCH_ACCEPT_TAC \\
 (* goal here: "(∀x. b x) ⇒ b 5", i.e. not "(∀x y. b x) ⇒ b 5"! *)
 disch_then MATCH_ACCEPT_TAC
QED
```

(Not well-tested and there's probably a prettier way/more efficient way to do the free vars check in `PROVEHYP_THEN`.)