### PR TITLE
Fixed duplicated definition of "inf" in iterateTheory

### DIFF
--- a/src/probability/iterateScript.sml
+++ b/src/probability/iterateScript.sml
@@ -43,6 +43,18 @@ fun ASSERT_TAC tm = SUBGOAL_THEN tm STRIP_ASSUME_TAC;
 val ASM_ARITH_TAC = REPEAT (POP_ASSUM MP_TAC) THEN ARITH_TAC;
 val ASM_REAL_ARITH_TAC = REPEAT (POP_ASSUM MP_TAC) THEN REAL_ARITH_TAC;
 
+fun wrap a = [a];
+val Rewr = DISCH_THEN (REWRITE_TAC o wrap);
+val Know = Q_TAC KNOW_TAC;
+val Suff = Q_TAC SUFF_TAC;
+val POP_ORW = POP_ASSUM (fn thm => ONCE_REWRITE_TAC [thm]);
+
+local
+  val th = prove (``!a b. a /\ (a ==> b) ==> a /\ b``, PROVE_TAC [])
+in
+  val STRONG_CONJ_TAC :tactic = MATCH_MP_TAC th >> CONJ_TAC
+end;
+
 (* ------------------------------------------------------------------------- *)
 (* misc.                                                                     *)
 (* ------------------------------------------------------------------------- *)
@@ -585,20 +597,70 @@ val SUP_UNION = store_thm ("SUP_UNION",
   REPEAT STRIP_TAC THEN MATCH_MP_TAC SUP_UNIQUE THEN
   SIMP_TAC real_ss [FORALL_IN_UNION, REAL_MAX_LE] THEN METIS_TAC[SUP, REAL_LE_TRANS]);
 
-val inf = new_definition ("inf",
-  ``inf s = @a:real. (!x. x IN s ==> a <= x) /\
-                    !b. (!x. x IN s ==> b <= x) ==> b <= a``);
+(* The original definition of "inf" in HOL Light (sets.ml) *)
+val inf_tm = ``@a:real. (!x. x IN s ==> a <= x) /\
+                        !b. (!x. x IN s ==> b <= x) ==> b <= a``;
 
-val INF_EQ = store_thm ("INF_EQ",
- ``!s t:real->bool. (!a. (!x. x IN s ==> a <= x) <=> (!x. x IN t ==> a <= x))
-         ==> (inf s = inf t)``,
-  SIMP_TAC std_ss [inf]);
+(* `inf s` exists iff s is non-empty and has a lower bound b *)
+val inf_criteria = ``s <> {} /\ (?b. !x. x IN s ==> b <= x)``;
+
+(* renamed `inf` to `inf'`, a local definition *)
+val inf' = new_definition ("inf'", ``inf' s = ^inf_tm``);
+
+val inf_convert = Q.prove (
+   `!s. ^inf_criteria ==> (inf s = inf' s)`,
+    RW_TAC std_ss [inf']
+ >> Suff `(\f. inf s = f) (^inf_tm)` >- METIS_TAC []
+ >> MATCH_MP_TAC SELECT_ELIM_THM
+ >> RW_TAC std_ss []
+ >- (Q.EXISTS_TAC `inf s` >> CONJ_TAC
+     >- (Know `(?y. s y) /\ (?y. !z. s z ==> y <= z)`
+         >- (STRONG_CONJ_TAC >- METIS_TAC [MEMBER_NOT_EMPTY, IN_APP] \\
+             STRIP_TAC >> `y IN s` by fs [IN_APP] >> RES_TAC \\
+             Q.EXISTS_TAC `b` >> rpt STRIP_TAC \\
+             FIRST_X_ASSUM MATCH_MP_TAC >> PROVE_TAC [IN_APP]) \\
+         DISCH_THEN (MP_TAC o (MATCH_MP REAL_INF_LE)) >> Rewr \\
+         Q.X_GEN_TAC `z` >> rpt STRIP_TAC \\
+         FIRST_X_ASSUM MATCH_MP_TAC >> fs [IN_APP]) \\
+     rpt STRIP_TAC >> MATCH_MP_TAC REAL_IMP_LE_INF \\
+     CONJ_TAC >- METIS_TAC [MEMBER_NOT_EMPTY, IN_APP] \\
+     fs [IN_APP])
+ >> RW_TAC std_ss [GSYM REAL_LE_ANTISYM]
+ >- (Know `(?y. s y) /\ (?y. !z. s z ==> y <= z)`
+     >- (STRONG_CONJ_TAC >- METIS_TAC [MEMBER_NOT_EMPTY, IN_APP] \\
+         STRIP_TAC >> `y IN s` by fs [IN_APP] >> RES_TAC \\
+         Q.EXISTS_TAC `b` >> rpt STRIP_TAC \\
+         FIRST_X_ASSUM MATCH_MP_TAC >> PROVE_TAC [IN_APP]) \\
+     DISCH_THEN (MP_TAC o (MATCH_MP REAL_INF_LE)) >> Rewr \\
+     rpt STRIP_TAC \\
+     Q.PAT_X_ASSUM `!b. (!x. x IN s ==> b <= x) ==> b <= x`
+       MATCH_MP_TAC >> fs [IN_APP])
+ >> MATCH_MP_TAC REAL_IMP_LE_INF
+ >> CONJ_TAC >- METIS_TAC [MEMBER_NOT_EMPTY, IN_APP]
+ >> fs [IN_APP]);
+
+(* added `s <> EMPTY /\ (?b. !x. x IN s ==> b <= x) /\
+          t <> EMPTY /\ (?b. !x. x IN t ==> b <= x)`
+   to make sure that both `inf s` and `inf t` exist. *)
+Theorem INF_EQ :
+    !s t:real->bool. s <> EMPTY /\ (?b. !x. x IN s ==> b <= x) /\
+                     t <> EMPTY /\ (?b. !x. x IN t ==> b <= x) /\
+                    (!a. (!x. x IN s ==> a <= x) <=> (!x. x IN t ==> a <= x))
+                ==> (inf s = inf t)
+Proof
+    rpt STRIP_TAC
+ >> `(inf s = inf' s) /\ (inf t = inf' t)` by METIS_TAC [inf_convert]
+ >> ASM_SIMP_TAC std_ss [inf']
+QED
 
 val INF = store_thm ("INF",
  ``!s:real->bool. ~(s = {}) /\ (?b. !x. x IN s ==> b <= x)
        ==> (!x. x IN s ==> inf s <= x) /\
            !b. (!x. x IN s ==> b <= x) ==> b <= inf s``,
-  GEN_TAC THEN STRIP_TAC THEN REWRITE_TAC[inf] THEN
+  GEN_TAC THEN STRIP_TAC THEN
+ `inf s = inf' s` by METIS_TAC [inf_convert]
+  THEN POP_ORW THEN
+  REWRITE_TAC[inf'] THEN
   CONV_TAC(ONCE_DEPTH_CONV SELECT_CONV) THEN
   ONCE_REWRITE_TAC[GSYM REAL_LE_NEG2] THEN
   EXISTS_TAC ``-(sup (IMAGE (\x:real. -x) s))`` THEN
@@ -644,7 +706,14 @@ val REAL_INF_UNIQUE = store_thm ("REAL_INF_UNIQUE",
  ``!s b:real. (!x. x IN s ==> b <= x) /\
          (!b'. b < b' ==> ?x. x IN s /\ x < b')
          ==> (inf s = b)``,
-  REPEAT STRIP_TAC THEN REWRITE_TAC[inf] THEN MATCH_MP_TAC SELECT_UNIQUE THEN
+  rpt STRIP_TAC THEN
+  Know `s <> EMPTY`
+  >- (REWRITE_TAC [GSYM MEMBER_NOT_EMPTY] \\
+      POP_ASSUM (MP_TAC o (Q.SPEC `b + 1`)) \\
+      RW_TAC real_ss [REAL_LT_ADDR, REAL_LT_01] \\
+      Q.EXISTS_TAC `x` >> ASM_REWRITE_TAC []) >> DISCH_TAC \\
+ `inf s = inf' s` by METIS_TAC [inf_convert] >> POP_ORW \\
+  REWRITE_TAC[inf'] THEN MATCH_MP_TAC SELECT_UNIQUE THEN
   METIS_TAC[REAL_NOT_LE, REAL_LE_ANTISYM]);
 
 val REAL_LE_INF = store_thm ("REAL_LE_INF",

--- a/src/probability/real_topologyScript.sml
+++ b/src/probability/real_topologyScript.sml
@@ -19629,7 +19629,22 @@ val SETDIST_SUBSETS_EQ = store_thm ("SETDIST_SUBSETS_EQ",
   ASM_CASES_TAC ``s':real->bool = {}`` THENL [ASM_SET_TAC[], ALL_TAC] THEN
   ASM_CASES_TAC ``t':real->bool = {}`` THENL [ASM_SET_TAC[], ALL_TAC] THEN
   ASM_REWRITE_TAC[setdist] THEN MATCH_MP_TAC INF_EQ THEN
-  SIMP_TAC std_ss [FORALL_IN_GSPEC] THEN ASM_MESON_TAC[SUBSET_DEF, REAL_LE_TRANS]);
+  SIMP_TAC std_ss [FORALL_IN_GSPEC] THEN
+  CONJ_TAC >- (SIMP_TAC std_ss [EXTENSION, GSPECIFICATION,
+                                EXISTS_PROD, NOT_IN_EMPTY] \\
+               fs [GSYM MEMBER_NOT_EMPTY] \\
+               rename1 `a IN s'` >> Q.EXISTS_TAC `a` \\
+               rename1 `b IN t'` >> Q.EXISTS_TAC `b` \\
+               ASM_REWRITE_TAC []) \\
+  CONJ_TAC >- (Q.EXISTS_TAC `0` >> rw [DIST_POS_LE]) \\
+  CONJ_TAC >- (SIMP_TAC std_ss [EXTENSION, GSPECIFICATION,
+                                EXISTS_PROD, NOT_IN_EMPTY] \\
+               fs [GSYM MEMBER_NOT_EMPTY] \\
+               rename1 `a IN s` >> Q.EXISTS_TAC `a` \\
+               rename1 `b IN t` >> Q.EXISTS_TAC `b` \\
+               ASM_REWRITE_TAC []) \\
+  CONJ_TAC >- (Q.EXISTS_TAC `0` >> rw [DIST_POS_LE]) \\
+  ASM_MESON_TAC[SUBSET_DEF, REAL_LE_TRANS]);
 
 val REAL_LE_SETDIST = store_thm ("REAL_LE_SETDIST",
   ``!s t:real->bool d.


### PR DESCRIPTION
Hi,

this PR fixed a long-standing issue in `iterateTheory` since it was ported to HOL. In it, the infimum (`inf`) of real sets in `realTheory`:

```
   [inf_def]  Definition
      ⊢ ∀p. inf p = -sup (λr. p (-r))
```

has been redefined here in a different (but correct) way:

```
   [inf]  Definition
      ⊢ ∀s. inf s = @a. (∀x. x ∈ s ⇒ a ≤ x) ∧ ∀b. (∀x. x ∈ s ⇒ b ≤ x) ⇒ b ≤ a
```

As the consequence, if any user theory imported `iterateTheory` after `realTheory`, all theorems using the original `inf` in `realTheory` won't work any more.

`inf` is not a total function, in the sense that the infimum of real sets only exists if the set is not empty and there's a lower bound of it, i.e. the following criteria:

```
val inf_criteria = “s ≠ ∅ ∧ ∃b. ∀x. x ∈ s ⇒ b ≤ x”;
```

The two definitions are equivalent, only under the above criteria, as Micheal Norrish ever explained in HOL-info. Now I first renamed the `inf` of `iterateTheory` to `inf'`, then I proved a local theorem showing their conditional equivalence:

```
 ⊢ ∀s. s ≠ ∅ ∧ (∃b. ∀x. x ∈ s ⇒ b ≤ x) ⇒ (inf s = inf' s)
```

Once this is done, I only needed to fix a small number of proofs in which the original definition of `inf'` is directly used, by rewriting `inf` to `inf'`, then the existing proof steps still work.

The theorem `INF_EQ` holds only under the definition of `inf'`. Now I have to add some more antecedents to make sure the `inf` exist.  Fortunately only one theorem in `real_topologyTheory` needs `INF_EQ`, and I fixed that proof by further showing the involved infimums indeed exist.

Maybe with a more careful work we can even completely remove the global definition of `inf'`, to define it by `Q.ABBREV_TAC` only in those involved proofs, but this is not urgent and optional.

--Chun
