### PR TITLE
[mosml] fixed HolBdd (and examples) due to "equality type" changes

### DIFF
--- a/examples/HolBdd/DerivedBddRules.sml
+++ b/examples/HolBdd/DerivedBddRules.sml
@@ -147,9 +147,9 @@ fun fn3(f1,f2,f3)(x1,x2,x3) = (f1 x1, f2 x2, f3 x3)
 in
 fun GenTermToTermBdd leaffn vm tm =
  let fun recfn tm =
-  if tm = T
+  if tm ~~ T
    then BddCon true vm else
-  if tm = F
+  if tm ~~ F
    then BddCon false vm else
   if is_var tm
    then BddVar true vm tm else
@@ -418,8 +418,8 @@ fun BddApRestrict tb tm =
      val sub_tb = List.map
                    (fn {redex = v, residue = c} =>
                     (BddVar true vm v,
-                     if c=T then BddCon true  vm else
-                     if c=F then BddCon false vm
+                     if c ~~ T then BddCon true  vm else
+                     if c ~~ F then BddCon false vm
                             else (print_term c;
                                   print " not a boolean constant\n";
                                   raise BddApRestrictError)))
@@ -485,7 +485,7 @@ val split_subst =
   (fn (tb,tb')=>
     let val tm' = getTerm tb'
     in
-     (tm'=T) orelse (tm'=F)
+     (tm' ~~ T) orelse (tm' ~~ F)
     end);
 
 (*****************************************************************************)
@@ -757,7 +757,7 @@ val trl = computeTrace report vm pth (th0,thsuc);
 
 fun extendSat varlist vm tbl =
  List.map
-  (fn v => case List.find (fn (tb,tb') => getTerm tb = v) tbl of
+  (fn v => case List.find (fn (tb,tb') => getTerm tb ~~ v) tbl of
               SOME tb_tb' => tb_tb'
             | NONE        => (BddVar true vm v, BddCon true vm))
   varlist;

--- a/examples/HolBdd/Examples/KatiPuzzle/KatiPuzzleScript.sml
+++ b/examples/HolBdd/Examples/KatiPuzzle/KatiPuzzleScript.sml
@@ -85,7 +85,7 @@ val basic_varmap =
 val Init_def =
  Define
   `Init(v0,v1,v2,v3,v4,v5,v6,v7,v8,c0:bool,c1:bool,c2:bool,c3:bool) =
-    ~v0 /\ v1 /\ ~v2 /\ v3 /\ ~v4 /\ v5 /\ ~v6 /\ v7 /\ ~v8`;
+    (~v0 /\ v1 /\ ~v2 /\ v3 /\ ~v4 /\ v5 /\ ~v6 /\ v7 /\ ~v8)`;
 
 (*****************************************************************************)
 (* Transition relation                                                       *)
@@ -95,7 +95,7 @@ val Trans_def =
  Define
   `Trans((v0,v1,v2,v3,v4,v5,v6,v7,v8,c0:bool,c1:bool,c2:bool,c3:bool),
          (v0',v1',v2',v3',v4',v5',v6',v7',v8',c0',c1',c2',c3')) =
-    ((v0'=~v0)/\(v1'=~v1)/\(v2'=v2)/\(v3'=~v3)/\(v4'=v4)/\    (* toggle 0 *)
+    (((v0'=~v0)/\(v1'=~v1)/\(v2'=v2)/\(v3'=~v3)/\(v4'=v4)/\    (* toggle 0 *)
      (v5'=v5)/\(v6'=v6)/\(v7'=v7)/\(v8'=v8) /\ ~c3' /\ ~c2' /\ ~c1' /\~c0')
     \/
     ((v0'=~v0)/\(v1'=~v1)/\(v2'=~v2)/\(v3'=v3)/\(v4'=~v4)/\   (* toggle 1 *)
@@ -120,7 +120,7 @@ val Trans_def =
      (v5'=v5)/\(v6'=~v6)/\(v7'=~v7)/\(v8'=~v8) /\ ~c3' /\ c2' /\ c1' /\ c0')
     \/
     ((v0'=v0)/\(v1'=v1)/\(v2'=v2)/\(v3'=v3)/\(v4'=v4)/\       (* toggle 8 *)
-     (v5'=~v5)/\(v6'=v6)/\(v7'=~v7)/\(v8'=~v8) /\ c3' /\ ~c2' /\ ~c1' /\ ~c0')`;
+     (v5'=~v5)/\(v6'=v6)/\(v7'=~v7)/\(v8'=~v8) /\ c3' /\ ~c2' /\ ~c1' /\ ~c0'))`;
 
 (*****************************************************************************)
 (* Final state                                                               *)
@@ -129,7 +129,7 @@ val Trans_def =
 val Final_def =
  Define
   `Final(v0,v1,v2,v3,v4,v5,v6,v7,v8,c0:bool,c1:bool,c2:bool,c3:bool) =
-    ~v0 /\ ~v1 /\ ~v2 /\ ~v3 /\ ~v4 /\ ~v5 /\ ~v6 /\ ~v7 /\ ~v8`;
+    (~v0 /\ ~v1 /\ ~v2 /\ ~v3 /\ ~v4 /\ ~v5 /\ ~v6 /\ ~v7 /\ ~v8)`;
 
 val (_,thl,thfin) = findTrace basic_varmap Trans_def Init_def Final_def;
 
@@ -203,7 +203,7 @@ fun PrintState flag tm =
      fun p n   = print_term(s n)
      fun sp () = print " --- "
      fun nl () = print"\n"
-     fun bv b = if b=T then 1 else 0
+     fun bv b = if b ~~ T then 1 else 0
      fun pb(c3,c2,c1,c0) = print_term(intToTerm(8*(bv c3) + 4*(bv c2) + 2*(bv c1) + (bv c0)))
  in
   (nl();

--- a/examples/HolBdd/Examples/Solitaire/MiniTLHexSolitaireScript.sml
+++ b/examples/HolBdd/Examples/Solitaire/MiniTLHexSolitaireScript.sml
@@ -217,8 +217,8 @@ val Eval_def =
  Define
   `(Eval (ATOM p)     R s = p s)                                        /\
    (Eval (NOT f)      R s = ~(Eval f R s))                              /\
-   (Eval (AND f1 f2)  R s = Eval f1 R s /\ Eval f2 R s)                 /\
-   (Eval (OR f1 f2)   R s = Eval f1 R s \/ Eval f2 R s)                 /\
+   (Eval (AND f1 f2)  R s = (Eval f1 R s /\ Eval f2 R s))               /\
+   (Eval (OR f1 f2)   R s = (Eval f1 R s \/ Eval f2 R s))               /\
    (Eval (SOMETIME f) R s = ?s'. Reachable R (Eq s) s' /\  Eval f R s') /\
    (Eval (ALWAYS f)   R s = !s'. Reachable R (Eq s) s' ==> Eval f R s')`;
 
@@ -304,8 +304,8 @@ val aEval_def =
  Define
   `(aEval (aATOM a)     (R,L) s = L a s)                                           /\
    (aEval (aNOT f)      (R,L) s = ~(aEval f (R,L) s))                              /\
-   (aEval (aAND f1 f2)  (R,L) s = aEval f1 (R,L) s /\ aEval f2 (R,L) s)            /\
-   (aEval (aOR f1 f2)   (R,L) s = aEval f1 (R,L) s \/ aEval f2 (R,L) s)            /\
+   (aEval (aAND f1 f2)  (R,L) s = (aEval f1 (R,L) s /\ aEval f2 (R,L) s))          /\
+   (aEval (aOR f1 f2)   (R,L) s = (aEval f1 (R,L) s \/ aEval f2 (R,L) s))          /\
    (aEval (aSOMETIME f) (R,L) s = ?s'. Reachable R (Eq s) s' /\  aEval f (R,L) s') /\
    (aEval (aALWAYS f)   (R,L) s = !s'. Reachable R (Eq s) s' ==> aEval f (R,L) s')`;
 

--- a/examples/HolBdd/Examples/Solitaire/SolitaireScript.sml
+++ b/examples/HolBdd/Examples/Solitaire/SolitaireScript.sml
@@ -226,7 +226,7 @@ val (tb1,tb1') = time (computeFixedpoint report solitaire_varmap) (in_th0,in_ths
 
 fun PrintState tm =
  let val cl    = strip_pair tm
-     fun p n   = if el n cl = ``T`` then print "1" else print "0"
+     fun p n   = if el n cl ~~ T then print "1" else print "0"
      fun sp () = print "   "
      fun nl () = print"\n"
  in

--- a/examples/HolBdd/PrimitiveBddRules.sml
+++ b/examples/HolBdd/PrimitiveBddRules.sml
@@ -178,7 +178,7 @@ fun BddExtendVarmap vm2 (TermBdd(tg,ass,vm1,tm,b)) =
 exception BddFreevarsContractVarmapError;
 
 fun BddFreevarsContractVarmap v (TermBdd(tg,ass,vm,tm,b)) =
- if mem v (free_vars tm)
+ if memt (free_vars tm) v
   then (print_term v; print " not in free_vars of\n"; print_term tm; print "\n";
         raise BddFreevarsContractVarmapError)
   else TermBdd(tg,ass,Varmap.remove (name v) vm, tm, b);
@@ -273,10 +273,10 @@ fun BddReplace tbl (TermBdd(tg,ass,vm,tm,b)) =
            if not(is_var v')
             then (print_term v' ; print " should be a variable\n";
                                   raise BddReplaceError) else
-           if mem v l
+           if memt l v
             then (print_term v  ; print" repeated\n";
                                   raise BddReplaceError) else
-           if mem v' l'
+           if memt l' v'
             then (print_term v' ; print" repeated\n";
                                   raise BddReplaceError)
             else (Tag.merge tg (Tag.merge tg1 tg2),
@@ -373,7 +373,7 @@ fun BddListCompose tbl (TermBdd(tg,ass,vm,tm,b)) =
            if not(is_var v)
             then (print_term v  ; print " should be a variable\n";
                                   raise BddListComposeError) else
-           if mem v l
+           if memt l v
             then (print_term v  ; print" repeated\n";
                                   raise BddListComposeError)
             else (Tag.merge tg (Tag.merge tg1 tg2),
@@ -449,9 +449,9 @@ exception BddRestrictError;
 local
 
 fun mlval tm =
- if tm=T
+ if tm ~~ T
   then true
-  else if tm=F then false else raise BddRestrictError
+  else if tm ~~ F then false else raise BddRestrictError
 
 in
 
@@ -468,7 +468,7 @@ fun BddRestrict tbl tb =
            if not(is_var v)
             then (print_term v  ; print " should be a variable\n";
                                   raise BddRestrictError) else
-           if mem v l
+           if memt l v
             then (print_term v  ; print" repeated\n";
                                   raise BddRestrictError)
             else (Tag.merge tg (Tag.merge tg1 tg2),


### PR DESCRIPTION
This PR fixes the mosml-only HolBdd library (and examples) due to the "equality type" (and "tight equality") changes in K13 release.