### PR TITLE
Fixed normalForms due to "tight equality" changes

### DIFF
--- a/src/metis/selftest.sml
+++ b/src/metis/selftest.sml
@@ -40,8 +40,10 @@ val test_cases =
    ``?v x. (x \/ p \/ q) /\ (x \/ ~p \/ ~q) /\ (p \/ ~q \/ ~x) /\
            (q \/ ~p \/ ~x) /\ (v \/ ~q \/ ~r) /\ (r \/ ~v) /\ (q \/ ~v) /\
            (v \/ x)``),
+(* "No numerals currently allowed"
    ("SKI_CONV", SKI_CONV, ``?f. !y. f y = y + 1``,
     ``$? (S (K $!) (S (S (K S) (S (K (S (K $=))) I)) (K (S $+ (K 1)))))``),
+ *)
    ("SKI_CONV", SKI_CONV, ``\x:'a. ((f :'a->'a->'a) x o (g :'a->'a))``,
     ``S (S (K $o) (f :'a->'a->'a)) (K (g :'a->'a))``),
    ("SKI_CONV", SKI_CONV, ``\x y. (f :'a->'a->'a) x y``,
@@ -56,8 +58,10 @@ val test_cases =
     ``$! (S (K $!) (S (K (S (P :'a->'a->bool))) K))``),
    ("SKI_CONV", SKI_CONV, ``(P = Q) <=> (!x. P x <=> Q x)``,
     ``(P = Q <=> $! (S (S (K $<=>) P) Q))``),
+(* "No numerals currently allowed"
    ("SKICo_CONV", SKICo_CONV, ``?f. !y. f y = y + 1``,
     ``$? ($! o C (S o $o $=) (C $+ 1))``),
+ *)
    ("SKICo_CONV", SKICo_CONV, ``\x:'a. ((f :'a->'a->'a) x o (g :'a->'a))``,
     ``C ($o o (f :'a->'a->'a)) (g :'a->'a)``),
    ("SKICo_CONV", SKICo_CONV, ``\x y. (f :'a->'a->'a) x y``,

--- a/src/metis/selftest.sml
+++ b/src/metis/selftest.sml
@@ -1,4 +1,6 @@
-open HolKernel Parse boolLib testutils normalForms
+open HolKernel Parse boolLib normalForms;
+
+open testutils;
 
 val _ = let
   val p = mk_var("p", bool)
@@ -15,3 +17,78 @@ in
             (v1, v1), (gt1, ``\v. v /\ p``),
             (gt2, ``\q v v0. p /\ q /\ v /\ q /\ v0``)]
 end
+
+val _ = Parse.reveal "C";
+
+fun normalForms_test (fname, function :conv, problem, result) = let
+  val padr = StringCvt.padRight #" ";
+  val padl = StringCvt.padLeft #" ";
+  val f_s = padr 16 fname;
+  val p_s = padr 25 (term_to_string problem);
+  val r_s = padl 10 (term_to_string result);
+  val _ = tprint (f_s ^ p_s ^ " = " ^ r_s);
+in
+    require_msg (check_result (fn tm => (result ~~ (rhs (concl tm)))))
+                (term_to_string o rhs o concl)
+                function (* 'b -> 'a *)
+                problem  (* 'b *)
+end;
+
+val test_cases =
+  [("PRETTIFY_VARS_CONV", PRETTIFY_VARS_CONV,
+    (rhs (concl (DEF_CNF_CONV ``~(p <=> q) ==> q /\ r``))),
+   ``?v x. (x \/ p \/ q) /\ (x \/ ~p \/ ~q) /\ (p \/ ~q \/ ~x) /\
+           (q \/ ~p \/ ~x) /\ (v \/ ~q \/ ~r) /\ (r \/ ~v) /\ (q \/ ~v) /\
+           (v \/ x)``),
+   ("SKI_CONV", SKI_CONV, ``?f. !y. f y = y + 1``,
+    ``$? (S (K $!) (S (S (K S) (S (K (S (K $=))) I)) (K (S $+ (K 1)))))``),
+   ("SKI_CONV", SKI_CONV, ``\x:'a. ((f :'a->'a->'a) x o (g :'a->'a))``,
+    ``S (S (K $o) (f :'a->'a->'a)) (K (g :'a->'a))``),
+   ("SKI_CONV", SKI_CONV, ``\x y. (f :'a->'a->'a) x y``,
+    ``S (S (K S) (S (K K) (f :'a->'a->'a))) (K I)``),
+   ("SKI_CONV", SKI_CONV, ``$? = \P. P ($@ P)``, ``$? = S I $@``),
+   ("SKI_CONV", SKI_CONV, ``$==> = \a b. ~a \/ b``,
+    ``$==> = S (S (K S) (S (K K) (S (K $\/) $~))) (K I)``),
+   ("SKI_CONV", SKI_CONV, ``$! = \P. K T = P``, ``$! = S (K ($= (K T))) I``),
+   ("SKI_CONV", SKI_CONV, ``!x:'a y:'a. P x y``,
+    ``$! (S (K $!) (S (S (K S) (S (K K) (P :'a->'a->bool))) (K I)))``),
+   ("SKI_CONV", SKI_CONV, ``!x:'a y:'a. P y x``,
+    ``$! (S (K $!) (S (K (S (P :'a->'a->bool))) K))``),
+   ("SKI_CONV", SKI_CONV, ``(P = Q) <=> (!x. P x <=> Q x)``,
+    ``(P = Q <=> $! (S (S (K $<=>) P) Q))``),
+   ("SKICo_CONV", SKICo_CONV, ``?f. !y. f y = y + 1``,
+    ``$? ($! o C (S o $o $=) (C $+ 1))``),
+   ("SKICo_CONV", SKICo_CONV, ``\x:'a. ((f :'a->'a->'a) x o (g :'a->'a))``,
+    ``C ($o o (f :'a->'a->'a)) (g :'a->'a)``),
+   ("SKICo_CONV", SKICo_CONV, ``\x y. (f :'a->'a->'a) x y``,
+    ``C ($o o (f :'a->'a->'a)) I``),
+   ("SKICo_CONV", SKICo_CONV, ``$? = \P. P ($@ P)``, ``$? = S I $@``),
+   ("SKICo_CONV", SKICo_CONV, ``$==> = \a b. ~a \/ b``,
+    ``$==> = C ($o o $\/ o $~) I``),
+   ("SKICo_CONV", SKICo_CONV, ``$! = \P. K T = P``, ``$! = $= (K T)``),
+   ("SKICo_CONV", SKICo_CONV, ``!x y. (P :'a->'a->bool) x y``,
+    ``$! ($! o C ($o o (P :'a->'a->bool)) I)``),
+   ("SKICo_CONV", SKICo_CONV, ``!x y. (P :'a->'a->bool) y x``,
+    ``$! ($! o C (P :'a->'a->bool))``),
+   ("SKICo_CONV", SKICo_CONV, ``(P = Q) = (!x. P x = Q x)``,
+    ``(P = Q <=> $! (S ($= o P) Q))``),
+   ("SIMPLIFY_CONV", SIMPLIFY_CONV, ``(!x y. P x \/ (P y /\ F)) ==> ?z. P z``,
+    ``(!x. P x) ==> ?z. P z``),
+   ("NNF_CONV", NNF_CONV, ``(!x. P(x)) ==> ((?y. Q(y)) = (?z. P(z) /\ Q(z)))``,
+    ``((?y. Q y) \/ !z. ~P z \/ ~Q z) /\ ((!y. ~Q y) \/ ?z. P z /\ Q z) \/
+      ?x. ~P x``),
+   ("NNF_CONV", NNF_CONV, ``~(~(x = y) = z) = ~(x = ~(y = z))``,
+    ``(((x \/ y) /\ (~x \/ ~y) \/ z) /\ ((x \/ ~y) /\ (~x \/ y) \/ ~z) \/
+       (x \/ (y \/ ~z) /\ (~y \/ z)) /\ (~x \/ (y \/ z) /\ (~y \/ ~z))) /\
+      (((x \/ y) /\ (~x \/ ~y) \/ ~z) /\ ((x \/ ~y) /\ (~x \/ y) \/ z) \/
+       (x \/ (y \/ z) /\ (~y \/ ~z)) /\ (~x \/ (y \/ ~z) /\ (~y \/ z)))``),
+   ("SKOLEMIZE_CONV", SKOLEMIZE_CONV,
+    ``!x. (?y. Q y \/ !z. ~P z \/ ~Q z) \/ ~P x``,
+    ``?y. !x. (Q (y x) \/ !z. ~P z \/ ~Q z) \/ ~P x``),
+   ("TAUTOLOGY_CONV", TAUTOLOGY_CONV, ``p \/ r \/ ~p \/ ~q``, T),
+   ("CONTRACT_CONV", CONTRACT_CONV, ``(p \/ r) \/ p \/ ~q``, ``r \/ p \/ ~q``)
+  ];
+
+val _ = List.app (ignore o normalForms_test) test_cases;
+
+val _ = Process.exit Process.success;


### PR DESCRIPTION
This PR fixes `normalForms` (in `src/metis`) due to "tight equality" changes. Some test cases in comments are moved into `selftest.sml` (to make sure they're not broken again).
