### PR TITLE
Add DROP_TAKE and TAKE_DROP_SWAP theorems

### DIFF
--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -4136,6 +4136,21 @@ val TAKE_compute =
 val DROP_compute =
    Theory.save_thm("DROP_compute", numLib.SUC_RULE DROP_compute);
 
+Theorem DROP_TAKE:
+  !xs n k. DROP n (TAKE k xs) = TAKE (k - n) (DROP n xs)
+Proof
+  Induct \\ simp_tac bool_ss [TAKE_def,DROP_def]
+  \\ rpt strip_tac \\ rpt IF_CASES_TAC
+  \\ asm_simp_tac bool_ss [TAKE_def,DROP_def,TAKE_0,arithmeticTheory.SUB_0]
+  \\ AP_THM_TAC \\ AP_TERM_TAC \\ numLib.DECIDE_TAC
+QED
+
+Theorem TAKE_DROP_SWAP:
+  !xs k n. TAKE k (DROP n xs) = DROP n (TAKE (k + n) xs)
+Proof
+  rewrite_tac [DROP_TAKE,arithmeticTheory.ADD_SUB]
+QED
+
 (* ----------------------------------------------------------------------
     versions of constants with option outputs rather than unspecified
 


### PR DESCRIPTION
I think `DROP_TAKE` and `TAKE_DROP` would be the most natural names for these theorems. Unfortunately, `TAKE_DROP` was already taken. 

I decided to call the clashing one `TAKE_DROP_SWAP`. 

Alternatively, one could go through the whole development and rename `TAKE_DROP` to `TAKE_APPEND_DROP` and call the current `TAKE_DROP_SWAP` simply `TAKE_DROP` instead. 

Which is preferred?