### PR TITLE
Fixed Coble's `diningcryptos` example, finally

### DIFF
--- a/examples/diningcryptos/README
+++ b/examples/diningcryptos/README
@@ -1,5 +1,7 @@
-This example is a verification of the dining cryptographers (DC) protocol. [1]
+This example is a verification of the dining cryptographers (DC) protocol.
 
-Aaron R. Coble, July 2010
+by Aaron R. Coble, July 2010 [1]
+maintained by Chun Tian, October 2019
 
-[1] Coble, A.R.: Anonymity, information, and machine-assisted proof, (2010). https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-785.pdf
+[1] Coble, A.R.: Anonymity, information, and machine-assisted proof,
+    University of Cambridge (2010). https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-785.pdf

--- a/examples/diningcryptos/dining_cryptosScript.sml
+++ b/examples/diningcryptos/dining_cryptosScript.sml
@@ -7,15 +7,14 @@ open HolKernel Parse boolLib bossLib;
 open metisLib arithmeticTheory pred_setTheory pred_setLib
      state_transformerTheory combinTheory pairTheory realTheory realLib jrhUtils
      extra_pred_setTheory realSimps numTheory simpLib seqTheory subtypeTheory
-     transcTheory limTheory stringTheory stringSimps
+     transcTheory limTheory stringTheory stringSimps real_sigmaTheory
      informationTheory leakageTheory listTheory rich_listTheory listSimps;
 
 open extra_boolTheory extra_numTheory extra_listTheory extra_stringLib
-     extra_stringTheory extra_realTheory;
+     extra_stringTheory extra_realTheory leakageLib;
 
-open real_sigmaTheory leakageLib;
-open hurdUtils util_probTheory real_measureTheory real_lebesgueTheory
-     real_probabilityTheory;
+open hurdUtils util_probTheory sigma_algebraTheory
+     real_measureTheory real_lebesgueTheory real_probabilityTheory;
 
 (* ------------------------------------------------------------------------- *)
 (* Start a new theory called "information"                                   *)
@@ -138,17 +137,16 @@ val dc_random_states_finite = prove  (``!n. FINITE (dc_random_states n)``,
    >> FULL_SIMP_TAC safe_set_ss [dc_random_states_def]);
 
 val IN_dc_high_states_set = store_thm  ("IN_dc_high_states_set",
-   ``!n x. x IN (dc_high_states_set n) =
+   ``!n x. x IN (dc_high_states_set n) <=>
            (?i. i <= n /\ (x = (\s. s = STRCAT "pays" (toString i))))``,
    Induct
    >> RW_TAC set_ss [dc_high_states_set_def]
-   >> METIS_TAC [DECIDE ``!(x:num) y. x <= SUC y = x <= y \/ (x = SUC y)``, STRCAT_toString_inj]);
+   >> METIS_TAC [DECIDE ``!(x:num) y. x <= SUC y <=> x <= y \/ (x = SUC y)``, STRCAT_toString_inj]);
 
 val IN_dc_random_states = store_thm
   ("IN_dc_random_states",
-   ``!n s. s IN (dc_random_states n) = !x. (~(?i. i <= n /\
-                                        (x = STRCAT "coin" (toString i)))) ==>
-                                        (~(s x))``,
+   ``!n s. s IN (dc_random_states n) <=>
+           !x. ~(?i. i <= n /\ (x = STRCAT "coin" (toString i))) ==> (~(s x))``,
    Induct
    >- (RW_TAC set_ss [dc_random_states_def] >> METIS_TAC [])
    >> RW_TAC set_ss [Once dc_random_states_def]
@@ -158,10 +156,10 @@ val IN_dc_random_states = store_thm
    >> Cases_on `s (STRCAT "coin" (toString (SUC n)))`
    >- (DISJ1_TAC >> Q.EXISTS_TAC `(\x. if x = STRCAT "coin" (toString (SUC n)) then F else s x)`
        >> RW_TAC std_ss [FUN_EQ_THM] >- METIS_TAC []
-       >> METIS_TAC [DECIDE ``!(i:num) n. i <= SUC n = ((i = SUC n) \/ i <= n)``])
+       >> METIS_TAC [DECIDE ``!(i:num) n. i <= SUC n <=> ((i = SUC n) \/ i <= n)``])
    >> DISJ2_TAC >> Q.EXISTS_TAC `s`
    >> RW_TAC std_ss [FUN_EQ_THM] >- METIS_TAC []
-   >> METIS_TAC [DECIDE ``!(i:num) n. i <= SUC n = ((i = SUC n) \/ i <= n)``]);
+   >> METIS_TAC [DECIDE ``!(i:num) n. i <= SUC n <=> ((i = SUC n) \/ i <= n)``]);
 
 val dc_high_states_set_not_empty = store_thm
   ("dc_high_states_set_not_empty",
@@ -232,7 +230,7 @@ val dc_prog_space_T_set_thm = store_thm
 (* Case Study: The Dining Cryptographers - Computation for 3 cryptos         *)
 (* ************************************************************************* *)
 
-val fun_eq_lem = METIS_PROVE [] ``!y z. (!x. (x = y) = (x = z)) = (y = z)``;
+val fun_eq_lem = METIS_PROVE [] ``!y z. (!x. (x = y) <=> (x = z)) <=> (y = z)``;
 
 val card_dc_high_states_set3 = store_thm
   ("card_dc_high_states_set3",
@@ -240,7 +238,7 @@ val card_dc_high_states_set3 = store_thm
    RW_TAC set_ss [dc_high_states_set_def, FUN_EQ_THM, fun_eq_lem, STRCAT_toString_inj]);
 
 val fun_eq_lem5 = METIS_PROVE []
-        ``!x a b P Q. (x = a) \/ ~ (x = b) /\ P \/ Q = (a = b) /\ ((x = a) \/ P)
+        ``!x a b P Q. (x = a) \/ ~ (x = b) /\ P \/ Q <=> (a = b) /\ ((x = a) \/ P)
                         \/ ~(x = b) /\ ((x = a) \/ P) \/ Q``;
 
 val CARD_dc_set_cross = store_thm
@@ -321,9 +319,10 @@ val dc_states3_cross_not_empty = store_thm
    >> RW_TAC std_ss [FST,SND]);
 
 val fun_eq_lem6 = METIS_PROVE []
-  ``!x a b P Q. (x = a) \/ ~ (x = b) /\ P =
+  ``!x a b P Q. (x = a) \/ ~ (x = b) /\ P <=>
         (a = b) /\ ((x = a) \/ P) \/ ~(x = b) /\ ((x = a) \/ P)``;
 
+(* NOTE: this theorem needs a long time (~10min) to finish *)
 val dc3_leakage_result = store_thm
   ("dc3_leakage_result",
    ``leakage (dc_prog_space (SUC (SUC (SUC 0))) F) (dcprog (SUC(SUC(SUC 0)))) = 0``,
@@ -373,15 +372,16 @@ val hl_dups_lemma = prove
     METIS_TAC []);
 
 val fun_eq_lem6 = METIS_PROVE []
-        ``!x a b P Q. (x = a) \/ ~ (x = b) /\ P = (a = b) /\ ((x = a) \/ P) \/ ~(x = b) /\ ((x = a) \/ P)``;
+  ``!x a b P Q. (x = a) \/ ~ (x = b) /\ P <=> (a = b) /\ ((x = a) \/ P) \/ ~(x = b) /\ ((x = a) \/ P)``;
 
-val dc_dup_conv = SIMP_CONV arith_ss [FUN_EQ_THM, PAIR_EQ, COND_EXPAND, EQ_IMP_THM, FORALL_AND_THM, DISJ_IMP_THM]
-                                              THENC EVAL
-                                              THENC SIMP_CONV bool_ss [COND_EXPAND, LEFT_AND_OVER_OR, FORALL_AND_THM, DISJ_IMP_THM]
-                                              THENC EVAL
-                                              THENC (REPEATC (T_F_UNCHANGED_CONV
-                                                        (SIMP_CONV bool_ss [fun_eq_lem6, GSYM LEFT_AND_OVER_OR, FORALL_AND_THM]
-                                                         THENC EVAL)));
+val dc_dup_conv =
+  SIMP_CONV arith_ss [FUN_EQ_THM, PAIR_EQ, COND_EXPAND, EQ_IMP_THM, FORALL_AND_THM, DISJ_IMP_THM]
+  THENC EVAL
+  THENC SIMP_CONV bool_ss [COND_EXPAND, LEFT_AND_OVER_OR, FORALL_AND_THM, DISJ_IMP_THM]
+  THENC EVAL
+  THENC (REPEATC (T_F_UNCHANGED_CONV
+                  (SIMP_CONV bool_ss [fun_eq_lem6, GSYM LEFT_AND_OVER_OR, FORALL_AND_THM]
+                   THENC EVAL)));
 
 val dc_hl_dup_conv = SIMP_CONV arith_ss [hl_dups_lemma, STRCAT_toString_inj];
 
@@ -394,18 +394,21 @@ fun dc_input_unroll (remove_dups_conv:Abbrev.term->Abbrev.thm) =
                 THENC SIMP_CONV bool_ss [])
          THENC SIMP_CONV arith_ss []));
 
-
+(* NOTE: this theorem needs a long time (~10min) to finish *)
 val new_dc3_leakage_result = store_thm
   ("new_dc3_leakage_result",
    ``leakage (dc_prog_space (SUC (SUC (SUC 0))) F) (dcprog (SUC(SUC(SUC 0)))) = 0``,
-   CONV_TAC (SIMP_CONV bool_ss [dc_prog_space_F_set_thm] THENC
-             RATOR_CONV (RAND_CONV (
-             LEAKAGE_COMPUTE_CONV (``dc_high_states_set (SUC(SUC 0))``,``dc_low_states``,``dc_random_states (SUC(SUC 0))``)
-                                  [dc_high_states_set_def, dc_low_states_def, dc_random_states_def]
-                                  [dcprog_def, compute_result_alt, XOR_announces_def, set_announcements_alt, FST, SND, xor_def]
-                                  (dc_input_unroll dc_hl_dup_conv) (dc_input_unroll dc_hl_dup_conv) (dc_input_unroll dc_dup_conv)
-                                  dc_hl_dup_conv dc_hl_dup_conv dc_dup_conv dc_dup_conv))
-             THENC SIMP_CONV real_ss [REAL_ADD_ASSOC, GSYM REAL_NEG_ADD, GSYM REAL_ADD_RDISTRIB, REAL_MUL_ASSOC]));
+   CONV_TAC
+    (SIMP_CONV bool_ss [dc_prog_space_F_set_thm] THENC
+     RATOR_CONV (RAND_CONV (
+     LEAKAGE_COMPUTE_CONV (``dc_high_states_set (SUC(SUC 0))``,
+                           ``dc_low_states``,``dc_random_states (SUC(SUC 0))``)
+      [dc_high_states_set_def, dc_low_states_def, dc_random_states_def]
+      [dcprog_def, compute_result_alt, XOR_announces_def, set_announcements_alt, FST, SND, xor_def]
+      (dc_input_unroll dc_hl_dup_conv) (dc_input_unroll dc_hl_dup_conv) (dc_input_unroll dc_dup_conv)
+       dc_hl_dup_conv dc_hl_dup_conv dc_dup_conv dc_dup_conv))
+    THENC SIMP_CONV real_ss [REAL_ADD_ASSOC, GSYM REAL_NEG_ADD,
+                             GSYM REAL_ADD_RDISTRIB, REAL_MUL_ASSOC]));
 
 (* ************************************************************************* *)
 (* Case Study: The Dining Cryptographers - Proofs                            *)
@@ -477,7 +480,7 @@ val dc_XOR_announces_result1 = store_thm
    >> Induct
    >- (SIMP_TAC bool_ss [XOR_announces_def, dc_set_announcements_result2]
        >> POP_ASSUM (ASSUME_TAC o Q.SPEC `0`)
-       >> RW_TAC arith_ss [DECIDE ``!n:num. 0 < n = ~(n = 0)``, xor_F])
+       >> RW_TAC arith_ss [DECIDE ``!n:num. 0 < n <=> ~(n = 0)``, xor_F])
    >> STRIP_TAC >> FULL_SIMP_TAC arith_ss []
    >> RW_TAC arith_ss [XOR_announces_def, dc_set_announcements_result4, xor_F]
    >> METIS_TAC [DECIDE ``!(n:num) m. n < m ==> ~(n = m)``, xor_def]);
@@ -493,7 +496,7 @@ val dc_XOR_announces_result2 = store_thm
    >> ONCE_REWRITE_TAC [XOR_announces_def]
    >> (ASSUME_TAC o REWRITE_RULE [DECIDE ``!n:num. n < SUC n``] o Q.SPEC `n'` o UNDISCH_ALL o REWRITE_RULE [GSYM AND_IMP_INTRO]
        o Q.SPECL [`high`, `low`, `random`, `n`, `(SUC n')`]) dc_XOR_announces_result1
-   >> FULL_SIMP_TAC bool_ss [DECIDE ``!(n:num) m. n <= m = n < SUC m``, dc_set_announcements_result4, DECIDE ``!(n:num) m. SUC n < m ==> n < m``]
+   >> FULL_SIMP_TAC bool_ss [DECIDE ``!(n:num) m. n <= m <=> n < SUC m``, dc_set_announcements_result4, DECIDE ``!(n:num) m. SUC n < m ==> n < m``]
    >> RW_TAC bool_ss [xor_def] >> DECIDE_TAC);
 
 val dc_XOR_announces_result3 = store_thm
@@ -682,7 +685,7 @@ val dc_valid_outputs_eq_outputs = store_thm
             >> ONCE_REWRITE_TAC [dc_random_witness_def]
             >> RW_TAC bool_ss []
             >> METIS_TAC [LESS_EQ_REFL, STRCAT_toString_inj,
-                          DECIDE ``!(i:num) n. i <= SUC n = ((i = SUC n) \/ i <= n)``])
+                          DECIDE ``!(i:num) n. i <= SUC n <=> ((i = SUC n) \/ i <= n)``])
    >> ASM_REWRITE_TAC [FST, SND]
    >> RW_TAC std_ss [FUN_EQ_THM]
    >> Q.PAT_X_ASSUM `!x'. b` (ASSUME_TAC o Q.SPEC `x'`)
@@ -700,7 +703,7 @@ val n_minus_1_announces_list = Define
                                               (\x:string. if x = (STRCAT "announces" (toString (SUC n))) then
                                                                 T
                                                           else s x))
-                                          (n_minus_1_announces_list n)) >>
+                                          (n_minus_1_announces_list n)) ++
                                      (MAP (\s:bool state.
                                               (\x:string. if x = (STRCAT "announces" (toString (SUC n))) then
                                                                 F
@@ -723,22 +726,24 @@ val MEM_n_minus_1_announces_list = prove
    >- (RW_TAC std_ss [n_minus_1_announces_list, MEM] >> METIS_TAC [])
    >> RW_TAC list_ss [n_minus_1_announces_list, MEM_MAP]
    >> EQ_TAC
-   >- (RW_TAC std_ss [] >> RW_TAC std_ss [] >> Q.PAT_X_ASSUM `!s'. b ==> ~s s'` MATCH_MP_TAC >> STRIP_TAC >> FULL_SIMP_TAC arith_ss [])
+   >- (RW_TAC std_ss [] >> RW_TAC std_ss [] \\
+       Q.PAT_X_ASSUM `!s'. b ==> ~s s'` MATCH_MP_TAC \\
+       STRIP_TAC >> FULL_SIMP_TAC arith_ss [])
    >> RW_TAC std_ss [] >> Cases_on `x (STRCAT "announces" (toString (SUC n)))`
    >- (DISJ1_TAC >> Q.EXISTS_TAC `(\x'. if (x' = STRCAT "announces" (toString (SUC n))) then F else x x')`
        >> RW_TAC std_ss [] >- (FULL_SIMP_TAC string_ss [] >> METIS_TAC [])
        >> Cases_on `(s' = STRCAT "announces" (toString (SUC n)))` >> ASM_REWRITE_TAC []
        >> Q.PAT_X_ASSUM `!s. b ==> ~x s` MATCH_MP_TAC
-       >> RW_TAC std_ss [DECIDE ``!(n:num) m. n <= SUC m = ((n = SUC m) \/ n < SUC m)``] >> FULL_SIMP_TAC string_ss [])
+       >> RW_TAC std_ss [DECIDE ``!(n:num) m. n <= SUC m <=> ((n = SUC m) \/ n < SUC m)``] >> FULL_SIMP_TAC string_ss [])
    >> DISJ2_TAC >> Q.EXISTS_TAC `x` >> RW_TAC std_ss [] >- (FULL_SIMP_TAC string_ss [] >> METIS_TAC [])
    >> Cases_on `(s' = STRCAT "announces" (toString (SUC n)))` >> ASM_REWRITE_TAC []
    >> Q.PAT_X_ASSUM `!s. b ==> ~x s` MATCH_MP_TAC
-   >> RW_TAC std_ss [DECIDE ``!(n:num) m. n <= SUC m = ((n = SUC m) \/ n < SUC m)``] >> FULL_SIMP_TAC string_ss []);
+   >> RW_TAC std_ss [DECIDE ``!(n:num) m. n <= SUC m <=> ((n = SUC m) \/ n < SUC m)``] >> FULL_SIMP_TAC string_ss []);
 
 val dc_valid_outputs_eq_dc_valid_outputs_list = prove
   (``!n. dc_valid_outputs (SUC(SUC n)) = set (dc_valid_outputs_list (SUC(SUC(SUC n))))``,
    REPEAT STRIP_TAC
-   >> SIMP_TAC std_ss [EXTENSION, IN_LIST_TO_SET, dc_valid_outputs_def, GSPECIFICATION]
+   >> SIMP_TAC std_ss [EXTENSION, dc_valid_outputs_def, GSPECIFICATION]
    >> SIMP_TAC std_ss [GSYM EXTENSION, dc_valid_outputs_list, MEM_MAP, MEM_n_minus_1_announces_list]
    >> STRIP_TAC
    >> EQ_TAC
@@ -837,19 +842,23 @@ val CARD_dc_valid_outputs = store_thm
                (dc_high_states F (SUC (SUC (SUC n))) CROSS
                 dc_random_states (SUC (SUC n)))) =
           2 ** (SUC(SUC n))``,
-   RW_TAC std_ss [dc_valid_outputs_eq_outputs, dc_valid_outputs_eq_dc_valid_outputs_list, GSYM LENGTH_dc_valid_outputs_list,
-                  CARD_LIST_TO_SET, ALL_DISTINCT_dc_valid_outputs_list, MAKE_ALL_DISTINCT_ALL_DISTINCT]);
+   RW_TAC std_ss [dc_valid_outputs_eq_outputs,
+                  dc_valid_outputs_eq_dc_valid_outputs_list,
+                  GSYM LENGTH_dc_valid_outputs_list,
+                  ALL_DISTINCT_CARD_LIST_TO_SET,
+                  ALL_DISTINCT_dc_valid_outputs_list,
+                  MAKE_ALL_DISTINCT_ALL_DISTINCT]);
 
 (* ------------------------------------------------------------------------- *)
 
 val valid_coin_assignment = Define
   `(valid_coin_assignment r out h n (0:num) =
-        (r (STRCAT "coin" (toString 0)) =
-                ((r (STRCAT "coin" (toString (SUC (SUC n))))) xor (XOR_announces out (0:num)) xor ~((0:num) < h)))) /\
-    (valid_coin_assignment r out h n (SUC i) =
-        (r (STRCAT "coin" (toString (SUC i))) =
-                ((r (STRCAT "coin" (toString (SUC (SUC n))))) xor (XOR_announces out (SUC i)) xor ~((SUC i) < h))) /\
-        valid_coin_assignment r out h n i)`;
+    (r (STRCAT "coin" (toString 0)) <=>
+       ((r (STRCAT "coin" (toString (SUC (SUC n))))) xor (XOR_announces out (0:num)) xor ~((0:num) < h)))) /\
+   (valid_coin_assignment r out h n (SUC i) =
+       ((r (STRCAT "coin" (toString (SUC i))) <=>
+        ((r (STRCAT "coin" (toString (SUC (SUC n))))) xor (XOR_announces out (SUC i)) xor ~((SUC i) < h))) /\
+        (valid_coin_assignment r out h n i)))`;
 
 val valid_coin_assignment_result1 = prove
   (``!x out p n i j. j <= i /\ valid_coin_assignment x out p n i ==> valid_coin_assignment x out p n j``,
@@ -1719,20 +1728,86 @@ val dc_leakage_result = store_thm
 (* arbitrary.                                                                *)
 (* ************************************************************************* *)
 
-val insider_high_states_set_def = Define   `(insider_high_states_set (0:num) = {}) /\    (insider_high_states_set (SUC n) = (\s:string. s = (STRCAT "pays" (toString (SUC n))))
-                                                        INSERT (insider_high_states_set n))`;val insider_high_states_def = Define   `insider_high_states nsapays (SUC(SUC n)) = if nsapays then                                         {(\s: string. s = STRCAT "pays" (toString (SUC(SUC n))))}                                         else                                          insider_high_states_set (SUC n)`;val insider_low_states_def = Define   `insider_low_states = {(\s:string. s = (STRCAT "coin" (toString 0))); (\s:string. F)}`;
+val insider_high_states_set_def = Define
+  `(insider_high_states_set (0:num) = {}) /\
+   (insider_high_states_set (SUC n) = (\s:string. s = (STRCAT "pays" (toString (SUC n))))
+                                      INSERT (insider_high_states_set n))`;
 
-val insider_random_states_def = Define   `(insider_random_states (0:num) = {(\s:string. F)}) /\    (insider_random_states (SUC n) = (IMAGE (\s:bool state.                                            (\x:string. if x = (STRCAT "coin" (toString (SUC n))) then                                                                T                                                         else s x))                                      (insider_random_states n)) UNION                                   (IMAGE (\s:bool state.                                           (\x:string. if x = (STRCAT "coin" (toString (SUC n))) then                                                                F                                                         else s x))                                      (insider_random_states n)))`;
+val insider_high_states_def = Define
+   `insider_high_states nsapays (SUC(SUC n)) =
+     if nsapays then {(\s: string. s = STRCAT "pays" (toString (SUC(SUC n))))}
+     else insider_high_states_set (SUC n)`;
 
-val insider_set_announcements_def = Define   `(insider_set_announcements (high: bool state) (low:bool state) (random:bool state) (n:num) (0:num) (s:string) =           if (s = (STRCAT "announces" (toString 0))) then                 ((high (STRCAT "pays" (toString 0)))) xor                       ((low (STRCAT "coin" (toString 0))) xor (random (STRCAT "coin" (toString n))))          else                    low s) /\
-    (insider_set_announcements (high: bool state) (low:bool state) (random:bool state) (n:num) (SUC(0:num)) (s:string) =                if (s = (STRCAT "announces" (toString (SUC 0)))) then                   ((high (STRCAT "pays" (toString (SUC 0))))) xor                 ((random (STRCAT "coin" (toString (SUC 0)))) xor (low (STRCAT "coin" (toString 0))))            else                    (insider_set_announcements high low random n 0) s) /\    (insider_set_announcements high low random n (SUC (SUC i)) s =         if (s = (STRCAT "announces" (toString (SUC (SUC i))))) then                     ((high (STRCAT "pays" (toString (SUC (SUC i)))))) xor                   ((random (STRCAT "coin" (toString (SUC (SUC i))))) xor (random (STRCAT "coin" (toString (SUC i)))))             else                    (insider_set_announcements high low random n (SUC i)) s)`;
+val insider_low_states_def = Define
+   `insider_low_states = {(\s:string. s = (STRCAT "coin" (toString 0))); (\s:string. F)}`;
 
-val insider_set_announcements_alt = store_thm  ("insider_set_announcements_alt",   ``!high low random n i.      (insider_set_announcements high low random n 0 =         (\s. if (s = (STRCAT "announces" (toString 0))) then                   ((high (STRCAT "pays" (toString 0)))) xor                       ((low (STRCAT "coin" (toString 0))) xor (random (STRCAT "coin" (toString n))))          else                    low s)) /\
-        (insider_set_announcements high low random n (SUC 0) =   (\s. if (s = (STRCAT "announces" (toString (SUC 0)))) then                     ((high (STRCAT "pays" (toString (SUC 0))))) xor                 ((random (STRCAT "coin" (toString (SUC 0)))) xor (low (STRCAT "coin" (toString 0))))            else                    (insider_set_announcements high low random n 0) s)) /\  (insider_set_announcements high low random n (SUC(SUC i)) =      (\s. if (s = (STRCAT "announces" (toString (SUC(SUC i))))) then                        ((high (STRCAT "pays" (toString (SUC(SUC i)))))) xor                    ((random (STRCAT "coin" (toString (SUC(SUC i))))) xor (random (STRCAT "coin" (toString (SUC i)))))              else                    (insider_set_announcements high low random n (SUC i)) s))``,
-  RW_TAC std_ss [FUN_EQ_THM, insider_set_announcements_def]);
-val insider_dcprog_def = Define   `insider_dcprog (SUC(SUC(SUC n))) = (\((high:bool state, low:bool state), random:bool state). compute_result (insider_set_announcements high low random (SUC(SUC n)) (SUC(SUC n)))                   (SUC(SUC n)))`;
+val insider_random_states_def = Define
+  `(insider_random_states (0:num) = {(\s:string. F)}) /\
+   (insider_random_states (SUC n) =
+     (IMAGE (\s:bool state. (\x:string. if x = (STRCAT "coin" (toString (SUC n))) then T
+                                        else s x))
+            (insider_random_states n)) UNION
+     (IMAGE (\s:bool state. (\x:string. if x = (STRCAT "coin" (toString (SUC n))) then F
+                                        else s x))
+            (insider_random_states n)))`;
 
-val insider_dc_prog_space_def = Define   `insider_dc_prog_space (SUC(SUC n)) nsapays =  unif_prog_space         (insider_high_states nsapays (SUC(SUC n)))              insider_low_states              (insider_random_states (SUC n))`;
+val insider_set_announcements_def = Define
+  `(insider_set_announcements (high: bool state) (low:bool state)
+                              (random:bool state) (n:num) (0:num) (s:string) =
+       if (s = (STRCAT "announces" (toString 0))) then
+          ((high (STRCAT "pays" (toString 0)))) xor
+          ((low (STRCAT "coin" (toString 0))) xor (random (STRCAT "coin" (toString n))))
+       else low s) /\
+   (insider_set_announcements (high: bool state) (low:bool state)
+                              (random:bool state) (n:num) (SUC(0:num)) (s:string) =
+       if (s = (STRCAT "announces" (toString (SUC 0)))) then
+          ((high (STRCAT "pays" (toString (SUC 0))))) xor
+          ((random (STRCAT "coin" (toString (SUC 0)))) xor (low (STRCAT "coin" (toString 0))))
+       else
+          (insider_set_announcements high low random n 0) s) /\
+   (insider_set_announcements high low random n (SUC (SUC i)) s =
+       if (s = (STRCAT "announces" (toString (SUC (SUC i))))) then
+          ((high (STRCAT "pays" (toString (SUC (SUC i)))))) xor
+          ((random (STRCAT "coin" (toString (SUC (SUC i))))) xor
+           (random (STRCAT "coin" (toString (SUC i)))))
+       else
+          (insider_set_announcements high low random n (SUC i)) s)`;
+
+val insider_set_announcements_alt = store_thm
+  ("insider_set_announcements_alt",
+   ``!high low random n i.
+      (insider_set_announcements high low random n 0 =
+         (\s. if (s = (STRCAT "announces" (toString 0))) then
+                 ((high (STRCAT "pays" (toString 0)))) xor
+                 ((low (STRCAT "coin" (toString 0))) xor (random (STRCAT "coin" (toString n))))
+              else low s)) /\
+      (insider_set_announcements high low random n (SUC 0) =
+         (\s. if (s = (STRCAT "announces" (toString (SUC 0)))) then
+                 ((high (STRCAT "pays" (toString (SUC 0))))) xor
+                 ((random (STRCAT "coin" (toString (SUC 0)))) xor (low (STRCAT "coin" (toString 0))))
+              else
+                 (insider_set_announcements high low random n 0) s)) /\
+      (insider_set_announcements high low random n (SUC(SUC i)) =
+         (\s. if (s = (STRCAT "announces" (toString (SUC(SUC i))))) then
+                 ((high (STRCAT "pays" (toString (SUC(SUC i)))))) xor
+                 ((random (STRCAT "coin" (toString (SUC(SUC i))))) xor
+                  (random (STRCAT "coin" (toString (SUC i)))))
+              else
+                 (insider_set_announcements high low random n (SUC i)) s))``,
+     RW_TAC std_ss [FUN_EQ_THM, insider_set_announcements_def]);
+
+val insider_dcprog_def = Define
+   `insider_dcprog (SUC(SUC(SUC n))) =
+      (\((high:bool state, low:bool state), random:bool state).
+         compute_result (insider_set_announcements high low random (SUC(SUC n)) (SUC(SUC n)))
+                        (SUC(SUC n)))`;
+
+val insider_dc_prog_space_def = Define
+   `insider_dc_prog_space (SUC(SUC n)) nsapays =
+    unif_prog_space
+      (insider_high_states nsapays (SUC(SUC n)))
+      insider_low_states
+      (insider_random_states (SUC n))`;
 
 val insider_dc_prog_space_F_set_thm = store_thm
   ("insider_dc_prog_space_F_set_thm",
@@ -1741,6 +1816,7 @@ val insider_dc_prog_space_F_set_thm = store_thm
                          insider_low_states
                          (insider_random_states (SUC n))``,
    RW_TAC std_ss [insider_dc_prog_space_def, insider_high_states_def]);
+
 (* ------------------------------------------------------------------------- *)
 
 val hl_dups_lemma = prove
@@ -1751,26 +1827,27 @@ val hl_dups_lemma2 = prove
    (``!(s:string). ~((\x. x = s) = (\x. F))``,
     METIS_TAC []);
 
-
 val fun_eq_lem6 = METIS_PROVE []
-        ``!x a b P Q. (x = a) \/ ~ (x = b) /\ P = (a = b) /\ ((x = a) \/ P) \/ ~(x = b) /\ ((x = a) \/ P)``;
+  ``!x a b P Q. (x = a) \/ ~ (x = b) /\ P <=> (a = b) /\ ((x = a) \/ P) \/ ~(x = b) /\ ((x = a) \/ P)``;
 
 fun insider_input_unroll (remove_dups_conv:Abbrev.term->Abbrev.thm) =
-        (REPEATC (SIMP_CONV bool_ss [insider_high_states_set_def, insider_low_states_def, insider_random_states_def,
-                                     CARD_DEF, FINITE_INSERT, FINITE_EMPTY, FINITE_SING,
-                                     IMAGE_UNION, IMAGE_IMAGE, combinTheory.o_DEF, IMAGE_INSERT, IMAGE_EMPTY,
-                                     INSERT_UNION, UNION_EMPTY, IN_UNION]
-         THENC (FIND_CONV ``x IN y`` (IN_CONV remove_dups_conv)
-                THENC SIMP_CONV bool_ss [])
-         THENC SIMP_CONV arith_ss []));
+   (REPEATC (SIMP_CONV bool_ss [insider_high_states_set_def,
+                                insider_low_states_def, insider_random_states_def,
+                                CARD_DEF, FINITE_INSERT, FINITE_EMPTY, FINITE_SING,
+                                IMAGE_UNION, IMAGE_IMAGE, combinTheory.o_DEF, IMAGE_INSERT, IMAGE_EMPTY,
+                                INSERT_UNION, UNION_EMPTY, IN_UNION]
+   THENC (FIND_CONV ``x IN y`` (IN_CONV remove_dups_conv)
+          THENC SIMP_CONV bool_ss [])
+   THENC SIMP_CONV arith_ss []));
 
-val dc_dup_conv = SIMP_CONV arith_ss [FUN_EQ_THM, PAIR_EQ, COND_EXPAND, EQ_IMP_THM, FORALL_AND_THM, DISJ_IMP_THM]
-                                              THENC EVAL
-                                              THENC SIMP_CONV bool_ss [COND_EXPAND, LEFT_AND_OVER_OR, FORALL_AND_THM, DISJ_IMP_THM]
-                                              THENC EVAL
-                                              THENC (REPEATC (T_F_UNCHANGED_CONV
-                                                        (SIMP_CONV bool_ss [fun_eq_lem6, GSYM LEFT_AND_OVER_OR, FORALL_AND_THM]
-                                                         THENC EVAL)));
+val dc_dup_conv =
+    SIMP_CONV arith_ss [FUN_EQ_THM, PAIR_EQ, COND_EXPAND, EQ_IMP_THM, FORALL_AND_THM, DISJ_IMP_THM]
+    THENC EVAL
+    THENC SIMP_CONV bool_ss [COND_EXPAND, LEFT_AND_OVER_OR, FORALL_AND_THM, DISJ_IMP_THM]
+    THENC EVAL
+    THENC (REPEATC (T_F_UNCHANGED_CONV
+                    (SIMP_CONV bool_ss [fun_eq_lem6, GSYM LEFT_AND_OVER_OR, FORALL_AND_THM]
+                     THENC EVAL)));
 
 val insider_hl_dup_conv = SIMP_CONV arith_ss [hl_dups_lemma, hl_dups_lemma2, STRCAT_toString_inj];
 
@@ -1779,12 +1856,17 @@ val insider_dc3_leakage_result = store_thm
    ``leakage (insider_dc_prog_space (SUC (SUC (SUC 0))) F) (insider_dcprog (SUC(SUC(SUC 0)))) = 0``,
    CONV_TAC (SIMP_CONV bool_ss [insider_dc_prog_space_F_set_thm] THENC
              RATOR_CONV (RAND_CONV (
-             LEAKAGE_COMPUTE_CONV (``insider_high_states_set (SUC(SUC 0))``,``insider_low_states``,``insider_random_states (SUC(SUC 0))``)
-[insider_high_states_set_def, insider_low_states_def, insider_random_states_def]
-[insider_dcprog_def, compute_result_alt, XOR_announces_def, insider_set_announcements_alt, FST, SND, xor_def]
-(insider_input_unroll insider_hl_dup_conv) (insider_input_unroll insider_hl_dup_conv) (insider_input_unroll dc_dup_conv)
-insider_hl_dup_conv insider_hl_dup_conv dc_dup_conv dc_dup_conv))
-             THENC SIMP_CONV real_ss [REAL_ADD_ASSOC, GSYM REAL_NEG_ADD, GSYM REAL_ADD_RDISTRIB, REAL_MUL_ASSOC])
+             LEAKAGE_COMPUTE_CONV (``insider_high_states_set (SUC(SUC 0))``,
+                                   ``insider_low_states``,``insider_random_states (SUC(SUC 0))``)
+              [insider_high_states_set_def, insider_low_states_def, insider_random_states_def]
+              [insider_dcprog_def, compute_result_alt, XOR_announces_def,
+               insider_set_announcements_alt, FST, SND, xor_def]
+              (insider_input_unroll insider_hl_dup_conv)
+              (insider_input_unroll insider_hl_dup_conv)
+              (insider_input_unroll dc_dup_conv)
+               insider_hl_dup_conv insider_hl_dup_conv dc_dup_conv dc_dup_conv))
+             THENC SIMP_CONV real_ss [REAL_ADD_ASSOC, GSYM REAL_NEG_ADD,
+                                      GSYM REAL_ADD_RDISTRIB, REAL_MUL_ASSOC])
 >> RW_TAC real_ss [lg_1, lg_inv, GSYM REAL_INV_1OVER]
 >> `lg 4 = 2` by (`4 = 2 pow 2` by RW_TAC real_ss [pow] >> POP_ORW >> RW_TAC std_ss [lg_pow])
 >> RW_TAC real_ss []);
@@ -1824,10 +1906,12 @@ val biased_dist_def = Define
              else
                 (3 / 2) * (unif_prog_dist high low random s))`;
 
-val biased_dc_prog_space_def = Define   `biased_dc_prog_space (SUC(SUC n)) =
+val biased_dc_prog_space_def = Define
+   `biased_dc_prog_space (SUC(SUC n)) =
         (((biased_high_states (SUC(SUC n))) CROSS biased_low_states) CROSS (biased_random_states (SUC (SUC n))),
          POW (((biased_high_states (SUC(SUC n))) CROSS biased_low_states) CROSS (biased_random_states (SUC (SUC n)))),
          (\s. SIGMA (biased_dist (biased_high_states (SUC(SUC n))) biased_low_states (biased_random_states (SUC (SUC n)))) s))`;
+
 val prob_space_biased_dc_prog_space3 = store_thm
   ("prob_space_biased_dc_prog_space3",
    ``prob_space (biased_dc_prog_space (SUC(SUC 0)))``,
@@ -3304,7 +3388,9 @@ val biased_dc3_leakage_result = store_thm
    >> POP_ORW
    >> RW_TAC real_ss []);
 
-(* ************************************************************************* *)(* Biasing a hidden coin creates a partial leak                              *)(* ************************************************************************* *)
+(* ************************************************************************* *)
+(* Biasing a hidden coin creates a partial leak                              *)
+(* ************************************************************************* *)
 
 val biased_dist2_def = Define
    `biased_dist2 high low random =
@@ -3313,10 +3399,13 @@ val biased_dist2_def = Define
              else
                 (3 / 2) * (unif_prog_dist high low random s))`;
 
-val biased_dc_prog_space2_def = Define   `biased_dc_prog_space2 (SUC(SUC n)) =
+val biased_dc_prog_space2_def = Define
+   `biased_dc_prog_space2 (SUC(SUC n)) =
         (((biased_high_states (SUC(SUC n))) CROSS biased_low_states) CROSS (biased_random_states (SUC (SUC n))),
          POW (((biased_high_states (SUC(SUC n))) CROSS biased_low_states) CROSS (biased_random_states (SUC (SUC n)))),
-         (\s. SIGMA (biased_dist2 (biased_high_states (SUC(SUC n))) biased_low_states (biased_random_states (SUC (SUC n)))) s))`;
+         (\s. SIGMA (biased_dist2 (biased_high_states (SUC(SUC n)))
+   biased_low_states (biased_random_states (SUC (SUC n)))) s))`;
+
 val prob_space_biased_dc_prog_space23 = store_thm
   ("prob_space_biased_dc_prog_space23",
    ``prob_space (biased_dc_prog_space2 (SUC(SUC 0)))``,
@@ -5264,4 +5353,5 @@ val biased_dc3_leakage_result2 = store_thm
    >> RW_TAC real_ss [REAL_SUB_LDISTRIB, REAL_MUL_ASSOC, REAL_INV_1OVER,
                       REAL_ARITH ``!(x:real) y z a. x + (y - z) - a = y + (x - (z + a))``, GSYM real_sub]
    >> Q.UNABBREV_TAC `v` >> RW_TAC std_ss []);
+
 val _ = export_theory ();

--- a/examples/diningcryptos/extra_boolScript.sml
+++ b/examples/diningcryptos/extra_boolScript.sml
@@ -30,39 +30,39 @@ val SELECT_EXISTS_UNIQUE = store_thm
 
 val CONJ_EQ_IMP = store_thm
   ("CONJ_EQ_IMP",
-   ``!a b c. (a ==> (b = c)) ==> (a /\ b = a /\ c)``,
+   ``!a b c. (a ==> (b <=> c)) ==> (a /\ b <=> a /\ c)``,
    PROVE_TAC []);
 
 (* ------------------------------------------------------------------------- *)
 
 val xor_comm = store_thm
   ("xor_comm",
-   ``!x y. x xor y = y xor x``,
+   ``!x y. x xor y <=> y xor x``,
    RW_TAC bool_ss [xor_def] THEN DECIDE_TAC);
 
 val xor_assoc = store_thm
   ("xor_assoc",
-   ``!x y z. (x xor y) xor z = x xor (y xor z)``,
+   ``!x y z. (x xor y) xor z <=> x xor (y xor z)``,
    RW_TAC bool_ss [xor_def] THEN DECIDE_TAC);
 
 val xor_F = store_thm
   ("xor_F",
-   ``!x. x xor F = x``,
+   ``!x. x xor F <=> x``,
    RW_TAC bool_ss [xor_def]);
 
 val xor_F = store_thm
   ("xor_F",
-   ``!x. F xor x = x``,
+   ``!x. F xor x <=> x``,
    RW_TAC bool_ss [xor_def]);
 
 val xor_T = store_thm
   ("xor_T",
-   ``!x. x xor T = ~x``,
+   ``!x. x xor T <=> ~x``,
    RW_TAC bool_ss [xor_def]);
 
 val T_xor = store_thm
   ("T_xor",
-   ``!x. T xor x = ~x``,
+   ``!x. T xor x <=> ~x``,
    RW_TAC bool_ss [xor_def]);
 
 val xor_refl = store_thm

--- a/examples/diningcryptos/extra_listScript.sml
+++ b/examples/diningcryptos/extra_listScript.sml
@@ -1,38 +1,10 @@
-(* non-interactive mode
-*)
-open HolKernel Parse boolLib;
-val _ = new_theory "extra_list";
+open HolKernel Parse boolLib bossLib;
 
-(* interactive mode
-val () = loadPath := union ["..", "../finished"] (!loadPath);
-val () = app load
-  ["bossLib",
-   "pred_setTheory",
-   "realLib",
-   "pairTheory",
-   "combinTheory",
-   "res_quanLib",
-   "dividesTheory",
-   "primeTheory",
-   "gcdTheory",
-   "prob_extraTools",
-   "millerTools"];
-val () = show_assums := true;
-*)
-
-open bossLib listTheory numTheory arithmeticTheory hurdUtils
+open listTheory numTheory arithmeticTheory hurdUtils
      pred_setTheory subtypeTheory extra_numTheory rich_listTheory
      realTheory realLib pairTheory;
 
-infixr 0 ++ << || THENC ORELSEC ORELSER ##;
-infix 1 >>;
-
-val op++ = op THEN;
-val op<< = op THENL;
-val op|| = op ORELSE;
-val op>> = op THEN1;
-
-val POP_ORW = POP_ASSUM (fn thm => ONCE_REWRITE_TAC [thm]);
+val _ = new_theory "extra_list";
 
 (* ------------------------------------------------------------------------- *)
 (* Definitions.                                                              *)
@@ -47,7 +19,7 @@ val kill_dups_def = Define
 
 val list_def = Define `list = (EVERY : ('a -> bool) -> 'a list -> bool)`;
 
-val gtlist_def = Define `gtlist n l = n < LENGTH l`;
+val gtlist_def = Define `gtlist n l <=> n < LENGTH l`;
 
 (* ------------------------------------------------------------------------- *)
 (* Theorems.                                                                 *)
@@ -55,220 +27,220 @@ val gtlist_def = Define `gtlist n l = n < LENGTH l`;
 
 val MEM_NIL = store_thm
   ("MEM_NIL",
-   ``!l. (!(x:'a). ~MEM x l) = (l = [])``,
-   Cases >> RW_TAC std_ss [MEM]
-   ++ RW_TAC std_ss [MEM]
-   ++ PROVE_TAC []);
+   ``!l. (!(x:'a). ~MEM x l) <=> (l = [])``,
+   Cases >- RW_TAC std_ss [MEM]
+   >> RW_TAC std_ss [MEM]
+   >> PROVE_TAC []);
 
 val MAP_ID = store_thm
   ("MAP_ID",
    ``!(l:'a list). MAP (\x. x) l = l``,
-   Induct >> RW_TAC list_ss []
-   ++ RW_TAC list_ss []);
+   Induct >- RW_TAC list_ss []
+   >> RW_TAC list_ss []);
 
 val MAP_MEM = store_thm
   ("MAP_MEM",
-   ``!(f:'a->'b) l x. MEM x (MAP f l) = ?y. MEM y l /\ (x = f y)``,
-   Induct_on `l` >> RW_TAC list_ss [MEM]
-   ++ RW_TAC list_ss [MEM]
-   ++ EQ_TAC <<
-   [RW_TAC list_ss [] <<
+   ``!(f:'a->'b) l x. MEM x (MAP f l) <=> ?y. MEM y l /\ (x = f y)``,
+   Induct_on `l` >- RW_TAC list_ss [MEM]
+   >> RW_TAC list_ss [MEM]
+   >> EQ_TAC >|
+   [RW_TAC list_ss [] >|
     [PROVE_TAC [],
      PROVE_TAC []],
     PROVE_TAC []]);
 
 val APPEND_MEM = store_thm
   ("APPEND_MEM",
-   ``!(x:'a) l1 l2. MEM x (APPEND l1 l2) = (MEM x l1 \/ MEM x l2)``,
-   Induct_on `l1` >> RW_TAC list_ss [MEM]
-   ++ RW_TAC list_ss [MEM]
-   ++ PROVE_TAC []);
+   ``!(x:'a) l1 l2. MEM x (APPEND l1 l2) <=> (MEM x l1 \/ MEM x l2)``,
+   Induct_on `l1` >- RW_TAC list_ss [MEM]
+   >> RW_TAC list_ss [MEM]
+   >> PROVE_TAC []);
 
 val MEM_NIL_MAP_CONS = store_thm
   ("MEM_NIL_MAP_CONS",
    ``!(x:'a) l. ~MEM [] (MAP (CONS x) l)``,
    STRIP_TAC
-   ++ Induct >> RW_TAC list_ss [MEM]
-   ++ RW_TAC list_ss [MEM]);
+   >> Induct >- RW_TAC list_ss [MEM]
+   >> RW_TAC list_ss [MEM]);
 
 val FILTER_TRUE = store_thm
   ("FILTER_TRUE",
    ``!(l:'a list). FILTER (\x. T) l = l``,
-   Induct >> RW_TAC list_ss [FILTER]
-   ++ RW_TAC list_ss [FILTER]);
+   Induct >- RW_TAC list_ss [FILTER]
+   >> RW_TAC list_ss [FILTER]);
 
 val FILTER_FALSE = store_thm
   ("FILTER_FALSE",
    ``!(l:'a list). FILTER (\x. F) l = []``,
-   Induct >> RW_TAC list_ss [FILTER]
-   ++ RW_TAC list_ss [FILTER]);
+   Induct >- RW_TAC list_ss [FILTER]
+   >> RW_TAC list_ss [FILTER]);
 
 val LENGTH_FILTER = store_thm
   ("LENGTH_FILTER",
    ``!P (l:'a list). LENGTH (FILTER P l) <= LENGTH l``,
    GEN_TAC
-   ++ Induct_on `l`
-   ++ RW_TAC list_ss [FILTER]);
+   >> Induct_on `l`
+   >> RW_TAC list_ss [FILTER]);
 
 val FILTER_MEM = store_thm
   ("FILTER_MEM",
    ``!P (x:'a) l. MEM x (FILTER P l) ==> P x``,
    NTAC 2 STRIP_TAC
-   ++ Induct >> RW_TAC std_ss [MEM, FILTER]
-   ++ (RW_TAC std_ss [MEM, FILTER] ++ PROVE_TAC []));
+   >> Induct >- RW_TAC std_ss [MEM, FILTER]
+   >> (RW_TAC std_ss [MEM, FILTER] >> PROVE_TAC []));
 
 val MEM_FILTER = store_thm
   ("MEM_FILTER",
    ``!P l (x:'a). MEM x (FILTER P l) ==> MEM x l``,
    STRIP_TAC
-   ++ Induct >> RW_TAC list_ss [FILTER]
-   ++ RW_TAC list_ss [FILTER, MEM]
-   ++ PROVE_TAC []);
+   >> Induct >- RW_TAC list_ss [FILTER]
+   >> RW_TAC list_ss [FILTER, MEM]
+   >> PROVE_TAC []);
 
 val FILTER_OUT_ELT = store_thm
   ("FILTER_OUT_ELT",
    ``!(x:'a) l. MEM x l \/ (FILTER (\y. ~(y = x)) l = l)``,
    STRIP_TAC
-   ++ Induct >> RW_TAC list_ss [FILTER]
-   ++ (RW_TAC list_ss [MEM, FILTER]
-         ++ PROVE_TAC []));
+   >> Induct >- RW_TAC list_ss [FILTER]
+   >> (RW_TAC list_ss [MEM, FILTER]
+         >> PROVE_TAC []));
 
 val IS_PREFIX_NIL = store_thm
   ("IS_PREFIX_NIL",
-   ``!(x:'a list). IS_PREFIX x [] /\ (IS_PREFIX [] x = (x = []))``,
+   ``!(x:'a list). IS_PREFIX x [] /\ (IS_PREFIX [] x <=> (x = []))``,
    STRIP_TAC
-   ++ Cases_on `x`
-   ++ RW_TAC list_ss [IS_PREFIX]);
+   >> Cases_on `x`
+   >> RW_TAC list_ss [IS_PREFIX]);
 
 val IS_PREFIX_REFL = store_thm
   ("IS_PREFIX_REFL",
    ``!(x:'a list). IS_PREFIX x x``,
-   Induct ++ RW_TAC list_ss [IS_PREFIX]);
+   Induct >> RW_TAC list_ss [IS_PREFIX]);
 
 val IS_PREFIX_ANTISYM = store_thm
   ("IS_PREFIX_ANTISYM",
    ``!(x:'a list) y. IS_PREFIX y x /\ IS_PREFIX x y ==> (x = y)``,
-    Induct >> RW_TAC list_ss [IS_PREFIX_NIL]
-    ++ Cases_on `y` >> RW_TAC list_ss [IS_PREFIX_NIL]
-    ++ ONCE_REWRITE_TAC [IS_PREFIX]
-    ++ PROVE_TAC []);
+    Induct >- RW_TAC list_ss [IS_PREFIX_NIL]
+    >> Cases_on `y` >- RW_TAC list_ss [IS_PREFIX_NIL]
+    >> ONCE_REWRITE_TAC [IS_PREFIX]
+    >> PROVE_TAC []);
 
 val IS_PREFIX_TRANS = store_thm
   ("IS_PREFIX_TRANS",
    ``!(x:'a list) y z. IS_PREFIX x y /\ IS_PREFIX y z ==> IS_PREFIX x z``,
-   Induct >> PROVE_TAC [IS_PREFIX_NIL]
-   ++ Cases_on `y` >> RW_TAC list_ss [IS_PREFIX_NIL, IS_PREFIX]
-   ++ Cases_on `z` >> RW_TAC list_ss [IS_PREFIX_NIL, IS_PREFIX]
-   ++ RW_TAC list_ss [IS_PREFIX]
-   ++ PROVE_TAC []);
+   Induct >- PROVE_TAC [IS_PREFIX_NIL]
+   >> Cases_on `y` >- RW_TAC list_ss [IS_PREFIX_NIL, IS_PREFIX]
+   >> Cases_on `z` >- RW_TAC list_ss [IS_PREFIX_NIL, IS_PREFIX]
+   >> RW_TAC list_ss [IS_PREFIX]
+   >> PROVE_TAC []);
 
 val IS_PREFIX_BUTLAST = store_thm
   ("IS_PREFIX_BUTLAST",
    ``!x:'a y. IS_PREFIX (x::y) (BUTLAST (x::y))``,
    Induct_on `y`
-     >> RW_TAC list_ss [BUTLAST_CONS, IS_PREFIX]
-   ++ RW_TAC list_ss [BUTLAST_CONS, IS_PREFIX]);
+     >- RW_TAC list_ss [BUTLAST_CONS, IS_PREFIX]
+   >> RW_TAC list_ss [BUTLAST_CONS, IS_PREFIX]);
 
 val IS_PREFIX_LENGTH = store_thm
   ("IS_PREFIX_LENGTH",
    ``!(x:'a list) y. IS_PREFIX y x ==> LENGTH x <= LENGTH y``,
-   Induct >> RW_TAC list_ss [LENGTH]
-   ++ Cases_on `y` >> RW_TAC list_ss [IS_PREFIX_NIL]
-   ++ RW_TAC list_ss [IS_PREFIX, LENGTH]);
+   Induct >- RW_TAC list_ss [LENGTH]
+   >> Cases_on `y` >- RW_TAC list_ss [IS_PREFIX_NIL]
+   >> RW_TAC list_ss [IS_PREFIX, LENGTH]);
 
 val IS_PREFIX_LENGTH_ANTI = store_thm
   ("IS_PREFIX_LENGTH_ANTI",
    ``!(x:'a list) y. IS_PREFIX y x /\ (LENGTH x = LENGTH y) ==> (x = y)``,
-   Induct >> PROVE_TAC [LENGTH_NIL]
-   ++ Cases_on `y` >> RW_TAC list_ss [LENGTH_NIL]
-   ++ RW_TAC list_ss [IS_PREFIX, LENGTH]);
+   Induct >- PROVE_TAC [LENGTH_NIL]
+   >> Cases_on `y` >- RW_TAC list_ss [LENGTH_NIL]
+   >> RW_TAC list_ss [IS_PREFIX, LENGTH]);
 
 val IS_PREFIX_SNOC = store_thm
   ("IS_PREFIX_SNOC",
-   ``!(x:'a) y z. IS_PREFIX (SNOC x y) z = IS_PREFIX y z \/ (z = SNOC x y)``,
+   ``!(x:'a) y z. IS_PREFIX (SNOC x y) z <=> IS_PREFIX y z \/ (z = SNOC x y)``,
    Induct_on `y`
-     >> (Cases_on `z`
-         ++ RW_TAC list_ss [SNOC, IS_PREFIX_NIL, IS_PREFIX]
-         ++ PROVE_TAC [])
-   ++ Cases_on `z` >> RW_TAC list_ss [IS_PREFIX]
-   ++ RW_TAC list_ss [SNOC, IS_PREFIX]
-   ++ PROVE_TAC []);
+     >- (Cases_on `z`
+         >> RW_TAC list_ss [SNOC, IS_PREFIX_NIL, IS_PREFIX]
+         >> PROVE_TAC [])
+   >> Cases_on `z` >- RW_TAC list_ss [IS_PREFIX]
+   >> RW_TAC list_ss [SNOC, IS_PREFIX]
+   >> PROVE_TAC []);
 
 val FOLDR_MAP = store_thm
   ("FOLDR_MAP",
    ``!(f :'b -> 'c -> 'c) (e :'c) (g :'a -> 'b) (l :'a list).
          FOLDR f e (MAP g l) = FOLDR (\x y. f (g x) y) e l``,
    RW_TAC list_ss []
-   ++ Induct_on `l` >> RW_TAC list_ss [MAP, FOLDR]
-   ++ RW_TAC list_ss [MAP, FOLDR]);
+   >> Induct_on `l` >- RW_TAC list_ss [MAP, FOLDR]
+   >> RW_TAC list_ss [MAP, FOLDR]);
 
 val LAST_MEM = store_thm
   ("LAST_MEM",
    ``!(h:'a) t. MEM (LAST (h::t)) (h::t)``,
-   Induct_on `t` >> RW_TAC list_ss [MEM, LAST_CONS]
-   ++ RW_TAC std_ss [LAST_CONS]
-   ++ ONCE_REWRITE_TAC [MEM]
-   ++ RW_TAC std_ss []);
+   Induct_on `t` >- RW_TAC list_ss [MEM, LAST_CONS]
+   >> RW_TAC std_ss [LAST_CONS]
+   >> ONCE_REWRITE_TAC [MEM]
+   >> RW_TAC std_ss []);
 
 val LAST_MAP_CONS = store_thm
   ("LAST_MAP_CONS",
    ``!(b:bool) h t. ?x. LAST (MAP (CONS b) (h::t)) = b::x``,
-   Induct_on `t` >> RW_TAC list_ss [LAST_CONS]
-   ++ POP_ASSUM MP_TAC
-   ++ RW_TAC list_ss [LAST_CONS]);
+   Induct_on `t` >- RW_TAC list_ss [LAST_CONS]
+   >> POP_ASSUM MP_TAC
+   >> RW_TAC list_ss [LAST_CONS]);
 
 val EXISTS_LONGEST = store_thm
   ("EXISTS_LONGEST",
    ``!(x:'a list) y. ?z. MEM z (x::y)
                     /\ (!w. MEM w (x::y) ==> LENGTH w <= LENGTH z)``,
-   Induct_on `y` >> RW_TAC list_ss [MEM]
-   ++ ONCE_REWRITE_TAC [MEM]
-   ++ REPEAT STRIP_TAC
-   ++ POP_ASSUM (MP_TAC o SPEC ``h:'a list``)
-   ++ STRIP_TAC
-   ++ EXISTS_TAC ``if LENGTH z <= LENGTH x then x else (z:'a list)``
-   ++ ZAP_TAC std_ss [LESS_EQ_TRANS]);
+   Induct_on `y` >- RW_TAC list_ss [MEM]
+   >> ONCE_REWRITE_TAC [MEM]
+   >> REPEAT STRIP_TAC
+   >> POP_ASSUM (MP_TAC o SPEC ``h:'a list``)
+   >> STRIP_TAC
+   >> EXISTS_TAC ``if LENGTH z <= LENGTH x then x else (z:'a list)``
+   >> ZAP_TAC std_ss [LESS_EQ_TRANS]);
 
 val SUM_CONST = store_thm
   ("SUM_CONST",
    ``!l c. (!x. MEM x l ==> (x = c)) ==> (sum l = LENGTH l * c)``,
-   Induct >> RW_TAC arith_ss [LENGTH, sum_def]
-   ++ RW_TAC std_ss [LENGTH, sum_def, MEM, MULT]
-   ++ PROVE_TAC [ADD_COMM]);
+   Induct >- RW_TAC arith_ss [LENGTH, sum_def]
+   >> RW_TAC std_ss [LENGTH, sum_def, MEM, MULT]
+   >> PROVE_TAC [ADD_COMM]);
 
 val MEM_KILL_DUPS = store_thm
   ("MEM_KILL_DUPS",
-   ``!l (x:'a). MEM x (kill_dups l) = MEM x l``,
-   Induct >> RW_TAC list_ss [MEM, kill_dups_def, FOLDR]
-   ++ REWRITE_TAC [kill_dups_def, FOLDR]
-   ++ RW_TAC std_ss [GSYM kill_dups_def, MEM]
-   ++ Cases_on `x = h` >> RW_TAC std_ss []
-   ++ RW_TAC std_ss []);
+   ``!l (x:'a). MEM x (kill_dups l) <=> MEM x l``,
+   Induct >- RW_TAC list_ss [MEM, kill_dups_def, FOLDR]
+   >> REWRITE_TAC [kill_dups_def, FOLDR]
+   >> RW_TAC std_ss [GSYM kill_dups_def, MEM]
+   >> Cases_on `x = h` >- RW_TAC std_ss []
+   >> RW_TAC std_ss []);
 
 val IN_LIST = store_thm
   ("IN_LIST",
    ``!(h:'a) t p.
-       ([] IN list p) /\ ((h::t) IN list p = h IN p /\ t IN list p)``,
+       ([] IN list p) /\ ((h::t) IN list p <=> h IN p /\ t IN list p)``,
    RW_TAC std_ss [list_def, SPECIFICATION, EVERY_DEF]);
 
 val IN_GTLIST = store_thm
   ("IN_GTLIST",
-   ``!n (l:'a list). l IN gtlist n = n < LENGTH l``,
+   ``!n (l:'a list). l IN gtlist n <=> n < LENGTH l``,
    RW_TAC std_ss [gtlist_def, SPECIFICATION]);
 
 val LIST_UNIV = store_thm
   ("LIST_UNIV",
    ``list (UNIV : 'a -> bool) = UNIV``,
    SET_EQ_TAC
-   ++ Induct >> RW_TAC std_ss [IN_LIST, IN_UNIV]
-   ++ RW_TAC std_ss [IN_LIST, IN_UNIV]);
+   >> Induct >- RW_TAC std_ss [IN_LIST, IN_UNIV]
+   >> RW_TAC std_ss [IN_LIST, IN_UNIV]);
 
 val LIST_SUBSET = store_thm
   ("LIST_SUBSET",
    ``!p q. p SUBSET q ==> list p SUBSET list q``,
    RW_TAC std_ss [SUBSET_DEF]
-   ++ Induct_on `x` >> RW_TAC std_ss [IN_LIST]
-   ++ RW_TAC std_ss [IN_LIST]);
+   >> Induct_on `x` >- RW_TAC std_ss [IN_LIST]
+   >> RW_TAC std_ss [IN_LIST]);
 
 val NIL_SUBTYPE = store_thm
   ("NIL_SUBTYPE",
@@ -288,33 +260,33 @@ val MAP_SUBTYPE = store_thm
        MAP IN (((x -> y) -> list x -> list y) INTER
                (UNIV -> gtlist n -> gtlist n))``,
    RW_TAC std_ss [IN_FUNSET, IN_INTER, IN_GTLIST, LENGTH_MAP]
-   ++ Induct_on `x''` >> RW_TAC std_ss [MAP, IN_LIST]
-   ++ RW_TAC std_ss [MAP, IN_LIST]);
+   >> Induct_on `x''` >- RW_TAC std_ss [MAP, IN_LIST]
+   >> RW_TAC std_ss [MAP, IN_LIST]);
 
 val HD_SUBTYPE = store_thm
   ("HD_SUBTYPE",
    ``!x.  HD IN ((gtlist 0 INTER list x) -> x)``,
    RW_TAC std_ss [IN_FUNSET, IN_INTER, IN_GTLIST]
-   ++ Cases_on `x'`
-   >> (Q.PAT_X_ASSUM `0 < LENGTH []` MP_TAC
-       ++ RW_TAC arith_ss [LENGTH])
-   ++ POP_ASSUM MP_TAC
-   ++ RW_TAC std_ss [IN_LIST, HD]);
+   >> Cases_on `x'`
+   >- (Q.PAT_X_ASSUM `0 < LENGTH []` MP_TAC
+       >> RW_TAC arith_ss [LENGTH])
+   >> POP_ASSUM MP_TAC
+   >> RW_TAC std_ss [IN_LIST, HD]);
 
 val TL_SUBTYPE = store_thm
   ("TL_SUBTYPE",
    ``!x.  TL IN (((gtlist 0 INTER list x) -> list x) INTER
                  (gtlist 1 -> gtlist 0))``,
-   RW_TAC std_ss [IN_FUNSET, IN_INTER, IN_GTLIST] <<
+   RW_TAC std_ss [IN_FUNSET, IN_INTER, IN_GTLIST] >|
    [Cases_on `x'`
-   >> (Q.PAT_X_ASSUM `0 < LENGTH []` MP_TAC
-       ++ RW_TAC arith_ss [LENGTH])
-    ++ POP_ASSUM MP_TAC
-    ++ RW_TAC std_ss [IN_LIST, TL],
+   >- (Q.PAT_X_ASSUM `0 < LENGTH []` MP_TAC
+       >> RW_TAC arith_ss [LENGTH])
+    >> POP_ASSUM MP_TAC
+    >> RW_TAC std_ss [IN_LIST, TL],
     POP_ASSUM MP_TAC
-    ++ Cases_on `x` >> RW_TAC arith_ss [LENGTH]
-    ++ Cases_on `t` >> RW_TAC arith_ss [LENGTH]
-    ++ RW_TAC arith_ss [LENGTH, TL]]);
+    >> Cases_on `x` >- RW_TAC arith_ss [LENGTH]
+    >> Cases_on `t` >- RW_TAC arith_ss [LENGTH]
+    >> RW_TAC arith_ss [LENGTH, TL]]);
 
 val LENGTH_SUBTYPE = store_thm
   ("LENGTH_SUBTYPE",
@@ -325,34 +297,34 @@ val GTLIST0_SUBTYPE_REWRITE = store_thm
   ("GTLIST0_SUBTYPE_REWRITE",
    ``!l. l IN gtlist 0 ==> ~(l = []) /\ ~([] = l)``,
    Cases
-   ++ RW_TAC arith_ss [IN_GTLIST, LENGTH]);
+   >> RW_TAC arith_ss [IN_GTLIST, LENGTH]);
 
 val GTLIST1_SUBTYPE_REWRITE = store_thm
   ("GTLIST1_SUBTYPE_REWRITE",
    ``!l h. l IN gtlist 1 ==> ~(l = [h]) /\ ~([h] = l)``,
-   Cases >> RW_TAC arith_ss [IN_GTLIST, LENGTH]
-   ++ Cases_on `t`
-   ++ RW_TAC arith_ss [IN_GTLIST, LENGTH]);
+   Cases >- RW_TAC arith_ss [IN_GTLIST, LENGTH]
+   >> Cases_on `t`
+   >> RW_TAC arith_ss [IN_GTLIST, LENGTH]);
 
 val GTLIST0_SUBTYPE_JUDGEMENT = store_thm
   ("GTLIST0_SUBTYPE_JUDGEMENT",
    ``!l m.
        LENGTH l IN gtnum 0 \/ ~([] = l) \/ ~(l = []) ==> l IN gtlist 0``,
    Cases
-   ++ RW_TAC std_ss [IN_GTLIST, IN_GTNUM, LENGTH]
-   ++ DECIDE_TAC);
+   >> RW_TAC std_ss [IN_GTLIST, IN_GTNUM, LENGTH]
+   >> DECIDE_TAC);
 
 val GTLIST1_SUBTYPE_JUDGEMENT = store_thm
   ("GTLIST1_SUBTYPE_JUDGEMENT",
    ``!l m. LENGTH l IN gtnum 1 ==> l IN gtlist 1``,
    RW_TAC std_ss [IN_GTLIST, IN_GTNUM]
-   ++ DECIDE_TAC);
+   >> DECIDE_TAC);
 
 val GTLIST1_SUBSET_GTLIST0 = store_thm
   ("GTLIST1_SUBSET_GTLIST0",
    ``gtlist 1 SUBSET gtlist 0``,
    RW_TAC std_ss [SUBSET_DEF, IN_GTLIST]
-   ++ DECIDE_TAC);
+   >> DECIDE_TAC);
 
 val REAL_SUM = Define`
   (REAL_SUM [] = 0:real) /\
@@ -361,13 +333,112 @@ val REAL_SUM = Define`
 
 val REAL_SUM_MAP_CMUL = store_thm  ("REAL_SUM_MAP_CMUL",
   ``!f c l. REAL_SUM (MAP (\x. c * f x) l) = c * REAL_SUM (MAP f l)``,
-  STRIP_TAC ++ STRIP_TAC ++ Induct ++
+  STRIP_TAC >> STRIP_TAC >> Induct >>
   RW_TAC real_ss [REAL_SUM, MAP, REAL_ADD_LDISTRIB]);
 
-val LIST_COMBS = Define  `(LIST_COMBS [] _ = []) /\   (LIST_COMBS (x::xs) l = (MAP (\y. (x, y)) l) ++ (LIST_COMBS xs l))`;val MEM_LIST_COMBS = store_thm  ("MEM_LIST_COMBS",   ``!l l' x. MEM x (LIST_COMBS l l') = (MEM (FST x) l /\ MEM (SND x) l')``,   Induct   ++ RW_TAC list_ss [LIST_COMBS]   ++ `?f s. x = (f, s)` by METIS_TAC [pair_CASES]   ++ RW_TAC list_ss [MEM_MAP, FST, SND]   ++ DECIDE_TAC);val LENGTH_LIST_COMBS = store_thm  ("LENGTH_LIST_COMBS",   ``!x y. LENGTH (LIST_COMBS x y) = LENGTH x * LENGTH y``,   Induct ++ RW_TAC real_ss [LENGTH, LIST_COMBS, LENGTH_APPEND, LENGTH_MAP]   ++ `LENGTH y + LENGTH x * LENGTH y = 1 * LENGTH y + LENGTH x * LENGTH y` by RW_TAC arith_ss []   ++ POP_ORW ++ RW_TAC arith_ss [GSYM RIGHT_ADD_DISTRIB, ADD1]);val LIST_COMBS_EQ_NIL = store_thm  ("LIST_COMBS_EQ_NIL",   ``!x y. (LIST_COMBS x y = []) = ((x = []) \/ (y = []))``,   Induct ++ RW_TAC list_ss [LIST_COMBS]   ++ DECIDE_TAC);
+val LIST_COMBS = Define
+  `(LIST_COMBS [] _ = []) /\
+   (LIST_COMBS (x::xs) l = (MAP (\y. (x, y)) l) ++ (LIST_COMBS xs l))`;
 
-val ALL_DISTINCT_APPEND = store_thm  ("ALL_DISTINCT_APPEND",   ``!l l'. ALL_DISTINCT l /\ ALL_DISTINCT l' /\ (!x. ~(MEM x l /\ MEM x l')) ==>           ALL_DISTINCT (l ++ l')``,   Induct   >> RW_TAC std_ss [APPEND_NIL]   ++ RW_TAC std_ss [APPEND, ALL_DISTINCT, MEM, MEM_APPEND]   ++ METIS_TAC [APPEND, ALL_DISTINCT, MEM, MEM_APPEND]);val ALL_DISTINCT_MAP = store_thm  ("ALL_DISTINCT_MAP",   ``!l f. ALL_DISTINCT l /\ (!x y. (f x = f y) = (x = y)) ==>              ALL_DISTINCT (MAP f l)``,   Induct   ++ RW_TAC std_ss [MAP, ALL_DISTINCT, MEM_MAP]);val ALL_DISTINCT_MAP2 = store_thm  ("ALL_DISTINCT_MAP2",   ``!l f. ALL_DISTINCT l /\ (!x y. MEM x l /\ MEM y l /\ (f x = f y) ==> (x = y)) ==>              ALL_DISTINCT (MAP f l)``,   Induct ++ RW_TAC std_ss [MAP, ALL_DISTINCT, MEM_MAP, MEM]   ++ METIS_TAC []);val ALL_DISTINCT_LIST_COMBS = store_thm  ("ALL_DISTINCT_LIST_COMBS",   ``!l l'. ALL_DISTINCT l /\ ALL_DISTINCT l' ==> ALL_DISTINCT (LIST_COMBS l l')``,   Induct   ++ RW_TAC std_ss [LIST_COMBS, ALL_DISTINCT]   ++ MATCH_MP_TAC ALL_DISTINCT_APPEND   ++ CONJ_TAC >> (MATCH_MP_TAC ALL_DISTINCT_MAP ++ RW_TAC std_ss [])   ++ RW_TAC std_ss [MEM_MAP, MEM_LIST_COMBS]   ++ (ASSUME_TAC o Q.SPEC `x`) pair_CASES   ++ FULL_SIMP_TAC std_ss []   ++ Cases_on `q = h` ++ RW_TAC std_ss []);val MAKE_ALL_DISTINCT = Define   `(MAKE_ALL_DISTINCT [] = []) /\    (MAKE_ALL_DISTINCT (h::t) = if MEM h t then MAKE_ALL_DISTINCT t else h::(MAKE_ALL_DISTINCT t))`;val MAKE_ALL_DISTINCT_ALL_DISTINCT = store_thm  ("MAKE_ALL_DISTINCT_ALL_DISTINCT",   ``!l. ALL_DISTINCT l ==> (MAKE_ALL_DISTINCT l = l)``,   Induct ++ RW_TAC std_ss [MAKE_ALL_DISTINCT, ALL_DISTINCT]);val MEM_MAKE_ALL_DISTINCT = store_thm  ("MEM_MAKE_ALL_DISTINCT",   ``!l x. MEM x (MAKE_ALL_DISTINCT l) = MEM x l``,    Induct ++ RW_TAC std_ss [MAKE_ALL_DISTINCT, MEM]    ++ METIS_TAC []);val ALL_DISTINCT_MAKE_ALL_DISTINCT = store_thm  ("ALL_DISTINCT_MAKE_ALL_DISTINCT",   ``!l. ALL_DISTINCT (MAKE_ALL_DISTINCT l)``,   Induct ++ RW_TAC std_ss [ALL_DISTINCT, MAKE_ALL_DISTINCT, MEM_MAKE_ALL_DISTINCT]);val MAKE_ALL_DISTINCT_EQ_NIL = store_thm  ("MAKE_ALL_DISTINCT_EQ_NIL",   ``!l. (MAKE_ALL_DISTINCT l = []) = (l = [])``,   Induct ++ RW_TAC list_ss [MAKE_ALL_DISTINCT]   ++ SPOSE_NOT_THEN STRIP_ASSUME_TAC   ++ FULL_SIMP_TAC list_ss []);
+Theorem MEM_LIST_COMBS :
+    !l l' x. MEM x (LIST_COMBS l l') <=> (MEM (FST x) l /\ MEM (SND x) l')
+Proof
+    Induct
+ >> RW_TAC list_ss [LIST_COMBS]
+ >> `?f s. x = (f, s)` by METIS_TAC [pair_CASES]
+ >> RW_TAC list_ss [MEM_MAP, FST, SND]
+ >> DECIDE_TAC
+QED
 
-(* non-interactive mode
-*)
+Theorem LENGTH_LIST_COMBS :
+    !x y. LENGTH (LIST_COMBS x y) = LENGTH x * LENGTH y
+Proof
+    Induct
+ >> RW_TAC real_ss [LENGTH, LIST_COMBS, LENGTH_APPEND, LENGTH_MAP]
+ >> `LENGTH y + LENGTH x * LENGTH y =
+       1 * LENGTH y + LENGTH x * LENGTH y`
+    by RW_TAC arith_ss []
+ >> POP_ORW
+ >> RW_TAC arith_ss [GSYM RIGHT_ADD_DISTRIB, ADD1]
+QED
+
+Theorem LIST_COMBS_EQ_NIL :
+    !x y. (LIST_COMBS x y = []) <=> ((x = []) \/ (y = []))
+Proof
+    Induct >> RW_TAC list_ss [LIST_COMBS]
+ >> DECIDE_TAC
+QED
+
+Theorem ALL_DISTINCT_APPEND :
+    !l l'. ALL_DISTINCT l /\ ALL_DISTINCT l' /\ (!x. ~(MEM x l /\ MEM x l')) ==>
+           ALL_DISTINCT (l ++ l')
+Proof
+    Induct
+ >- RW_TAC std_ss [APPEND_NIL]
+ >> RW_TAC std_ss [APPEND, ALL_DISTINCT, MEM, MEM_APPEND]
+ >> METIS_TAC [APPEND, ALL_DISTINCT, MEM, MEM_APPEND]
+QED
+
+Theorem ALL_DISTINCT_MAP :
+    !l f. ALL_DISTINCT l /\ (!x y. (f x = f y) = (x = y)) ==>
+          ALL_DISTINCT (MAP f l)
+Proof
+    Induct
+ >> RW_TAC std_ss [MAP, ALL_DISTINCT, MEM_MAP]
+QED
+
+Theorem ALL_DISTINCT_MAP2 :
+    !l f. ALL_DISTINCT l /\ (!x y. MEM x l /\ MEM y l /\ (f x = f y) ==> (x = y)) ==>
+          ALL_DISTINCT (MAP f l)
+Proof
+    Induct >> RW_TAC std_ss [MAP, ALL_DISTINCT, MEM_MAP, MEM]
+ >> METIS_TAC []
+QED
+
+Theorem ALL_DISTINCT_LIST_COMBS :
+    !l l'. ALL_DISTINCT l /\ ALL_DISTINCT l' ==> ALL_DISTINCT (LIST_COMBS l l')
+Proof
+    Induct
+ >> RW_TAC std_ss [LIST_COMBS, ALL_DISTINCT]
+ >> MATCH_MP_TAC ALL_DISTINCT_APPEND
+ >> CONJ_TAC >- (MATCH_MP_TAC ALL_DISTINCT_MAP >> RW_TAC std_ss [])
+ >> RW_TAC std_ss [MEM_MAP, MEM_LIST_COMBS]
+ >> (ASSUME_TAC o Q.SPEC `x`) pair_CASES
+ >> FULL_SIMP_TAC std_ss []
+ >> Cases_on `q = h` >> RW_TAC std_ss []
+QED
+
+val MAKE_ALL_DISTINCT = Define
+  `(MAKE_ALL_DISTINCT [] = []) /\
+   (MAKE_ALL_DISTINCT (h::t) =
+     if MEM h t then MAKE_ALL_DISTINCT t else h::(MAKE_ALL_DISTINCT t))`;
+
+Theorem MAKE_ALL_DISTINCT_ALL_DISTINCT :
+    !l. ALL_DISTINCT l ==> (MAKE_ALL_DISTINCT l = l)
+Proof
+    Induct >> RW_TAC std_ss [MAKE_ALL_DISTINCT, ALL_DISTINCT]
+QED
+
+Theorem MEM_MAKE_ALL_DISTINCT :
+    !l x. MEM x (MAKE_ALL_DISTINCT l) = MEM x l
+Proof
+    Induct >> RW_TAC std_ss [MAKE_ALL_DISTINCT, MEM]
+ >> METIS_TAC []
+QED
+
+Theorem ALL_DISTINCT_MAKE_ALL_DISTINCT :
+    !l. ALL_DISTINCT (MAKE_ALL_DISTINCT l)
+Proof
+    Induct
+ >> RW_TAC std_ss [ALL_DISTINCT, MAKE_ALL_DISTINCT, MEM_MAKE_ALL_DISTINCT]
+QED
+
+Theorem MAKE_ALL_DISTINCT_EQ_NIL :
+    !l. (MAKE_ALL_DISTINCT l = []) <=> (l = [])
+Proof
+    Induct >> RW_TAC list_ss [MAKE_ALL_DISTINCT]
+ >> SPOSE_NOT_THEN STRIP_ASSUME_TAC
+ >> FULL_SIMP_TAC list_ss []
+QED
+
 val _ = export_theory ();

--- a/examples/diningcryptos/extra_numScript.sml
+++ b/examples/diningcryptos/extra_numScript.sml
@@ -505,7 +505,7 @@ val LT_LE_1_MULT = store_thm
 Theorem EXP_MONO :
     !p a b. 1 < p ==> (p EXP a < p EXP b <=> a < b)
 Proof
-    Induct_on `b` >- RW_TAC arith_ss [EXP]       
+    Induct_on `b` >- RW_TAC arith_ss [EXP]
  >> rpt STRIP_TAC
  >> Cases_on `a`
  >> RW_TAC arith_ss [EXP]

--- a/examples/diningcryptos/extra_numScript.sml
+++ b/examples/diningcryptos/extra_numScript.sml
@@ -1,36 +1,15 @@
-(* interactive mode
-loadPath := ["../ho_prover","../subtypes","../rsa"] @ !loadPath;
-app load ["bossLib","subtypeTheory","hurdUtils","extra_boolTheory"];
-quietdec := true;
-*)
+open HolKernel Parse boolLib bossLib;
 
-open HolKernel Parse boolLib bossLib arithmeticTheory hurdUtils
+open arithmeticTheory hurdUtils
      pred_setTheory subtypeTheory extra_boolTheory combinTheory;
 
-(*
-quietdec := false;
-*)
-
 val _ = new_theory "extra_num";
-
-infixr 0 ++ << || THENC ORELSEC ORELSER ##;
-infix 1 >>;
-
-val op!! = op REPEAT;
-val op++ = op THEN;
-val op<< = op THENL;
-val op|| = op ORELSE;
-val op>> = op THEN1;
 
 (* ------------------------------------------------------------------------- *)
 (* Tools.                                                                    *)
 (* ------------------------------------------------------------------------- *)
 
-val Strip = !! STRIP_TAC;
 val Simplify = RW_TAC arith_ss;
-val Suff = PARSE_TAC SUFF_TAC;
-val Know = PARSE_TAC KNOW_TAC;
-val bool_ss = boolSimps.bool_ss;
 
 (* ------------------------------------------------------------------------- *)
 (* Needed for definitions.                                                   *)
@@ -40,36 +19,32 @@ val DIV_THEN_MULT = store_thm
   ("DIV_THEN_MULT",
    ``!p q. SUC q * (p DIV SUC q) <= p``,
    NTAC 2 STRIP_TAC
-   ++ Know `?r. p = (p DIV SUC q) * SUC q + r`
-   >> (Know `0 < SUC q` >> DECIDE_TAC
-       ++ PROVE_TAC [DIVISION])
-   ++ STRIP_TAC
-   ++ Suff `p = SUC q * (p DIV SUC q) + r`
-   >> (KILL_TAC ++ DECIDE_TAC)
-   ++ PROVE_TAC [MULT_COMM]);
+   >> Know `?r. p = (p DIV SUC q) * SUC q + r`
+   >- (Know `0 < SUC q` >- DECIDE_TAC
+       >> PROVE_TAC [DIVISION])
+   >> STRIP_TAC
+   >> Suff `p = SUC q * (p DIV SUC q) + r`
+   >- (KILL_TAC >> DECIDE_TAC)
+   >> PROVE_TAC [MULT_COMM]);
 
 (* ------------------------------------------------------------------------- *)
 (* Definitions.                                                              *)
 (* ------------------------------------------------------------------------- *)
 
+val _ = hide "min"; (* already defined for real numbers *)
 val min_def = Define `min (m:num) n = if m <= n then m else n`;
 
 val minimal_def = Define
-  `minimal p = @(n:num). p n /\ (!m. m < n ==> ~(p m))`;
+   `minimal p = @(n:num). p n /\ (!m. m < n ==> ~(p m))`;
 
-val gtnum_def = Define `gtnum (n : num) x = n < x`;
+val gtnum_def = Define `gtnum (n : num) x = (n < x)`;
 
 val (log2_def, log2_ind) = Defn.tprove
   let val d = Hol_defn "log2"
         `(log2 0 = 0)
          /\ (log2 n = SUC (log2 (n DIV 2)))`
       val g = `measure (\x. x)`
-  in (d,
-      WF_REL_TAC g
-      ++ STRIP_TAC
-      ++ Know `2 * (SUC v DIV 2) <= SUC v`
-      >> PROVE_TAC [TWO, DIV_THEN_MULT]
-      ++ DECIDE_TAC)
+  in (d, WF_REL_TAC g)
   end;
 
 val _ = save_thm ("log2_def", log2_def);
@@ -86,33 +61,33 @@ val SUC_0 = store_thm
 
 val LESS_0_MULT2 = store_thm
   ("LESS_0_MULT2",
-   ``!m n : num. 0 < m * n = 0 < m /\ 0 < n``,
-   !! STRIP_TAC
-   ++ Cases_on `m` >> RW_TAC arith_ss []
-   ++ Cases_on `n` >> RW_TAC arith_ss []
-   ++ RW_TAC arith_ss [MULT]);
+   ``!m n : num. 0 < m * n <=> 0 < m /\ 0 < n``,
+   rpt STRIP_TAC
+   >> Cases_on `m` >- RW_TAC arith_ss []
+   >> Cases_on `n` >- RW_TAC arith_ss []
+   >> RW_TAC arith_ss [MULT]);
 
 val LESS_1_MULT2 = store_thm
   ("LESS_1_MULT2",
    ``!m n : num. 1 < m /\ 1 < n ==> 1 < m * n``,
-   !! STRIP_TAC
-   ++ Suff `~(m * n = 0) /\ ~(m * n = 1)` >> DECIDE_TAC
-   ++ CONJ_TAC
-   ++ ONCE_REWRITE_TAC [MULT_EQ_0, MULT_EQ_1]
-   ++ DECIDE_TAC);
+   rpt STRIP_TAC
+   >> Suff `~(m * n = 0) /\ ~(m * n = 1)` >- DECIDE_TAC
+   >> CONJ_TAC
+   >> ONCE_REWRITE_TAC [MULT_EQ_0, MULT_EQ_1]
+   >> DECIDE_TAC);
 
 val FUNPOW_SUC = store_thm
   ("FUNPOW_SUC",
    ``!f n x. FUNPOW f (SUC n) x = f (FUNPOW f n x)``,
-   Induct_on `n` >> RW_TAC std_ss [FUNPOW]
-   ++ ONCE_REWRITE_TAC [FUNPOW]
-   ++ RW_TAC std_ss []);
+   Induct_on `n` >- RW_TAC std_ss [FUNPOW]
+   >> ONCE_REWRITE_TAC [FUNPOW]
+   >> RW_TAC std_ss []);
 
 val EVEN_ODD_BASIC = store_thm
   ("EVEN_ODD_BASIC",
    ``EVEN 0 /\ ~EVEN 1 /\ EVEN 2 /\ ~ODD 0 /\ ODD 1 /\ ~ODD 2``,
    CONV_TAC (TOP_DEPTH_CONV Num_conv.num_CONV)
-   ++ RW_TAC arith_ss [EVEN, ODD]);
+   >> RW_TAC arith_ss [EVEN, ODD]);
 
 val EVEN_ODD_EXISTS_EQ = store_thm
   ("EVEN_ODD_EXISTS_EQ",
@@ -122,20 +97,20 @@ val EVEN_ODD_EXISTS_EQ = store_thm
 val MINIMAL_EXISTS0 = store_thm
   ("MINIMAL_EXISTS0",
    ``(?(n:num). P n) = (?n. P n /\ (!m. m < n ==> ~(P m)))``,
-   REVERSE EQ_TAC >> PROVE_TAC []
-   ++ RW_TAC std_ss []
-   ++ CCONTR_TAC
-   ++ Suff `!n. ~P n` >> PROVE_TAC []
-   ++ STRIP_TAC
-   ++ completeInduct_on `n'`
-   ++ PROVE_TAC []);
+   REVERSE EQ_TAC >- PROVE_TAC []
+   >> RW_TAC std_ss []
+   >> CCONTR_TAC
+   >> Suff `!n. ~P n` >- PROVE_TAC []
+   >> STRIP_TAC
+   >> completeInduct_on `n'`
+   >> PROVE_TAC []);
 
 val MINIMAL_EXISTS = store_thm
   ("MINIMAL_EXISTS",
    ``!P. (?n. P n) = (P (minimal P) /\ !n. n < minimal P ==> ~P n)``,
    REWRITE_TAC [MINIMAL_EXISTS0, EXISTS_DEF]
-   ++ CONV_TAC (DEPTH_CONV BETA_CONV)
-   ++ REWRITE_TAC [GSYM minimal_def]);
+   >> CONV_TAC (DEPTH_CONV BETA_CONV)
+   >> REWRITE_TAC [GSYM minimal_def]);
 
 val MOD_1 = store_thm
   ("MOD_1",
@@ -160,24 +135,24 @@ val LESS_MOD_EQ = store_thm
   ("LESS_MOD_EQ",
    ``!x n. x < n ==> (x MOD n = x)``,
    REPEAT STRIP_TAC
-   ++ MP_TAC (Q.SPECL [`x`, `n`] LESS_DIV_EQ_ZERO)
-   ++ ASM_REWRITE_TAC []
-   ++ STRIP_TAC
-   ++ MP_TAC (Q.SPEC `n` DIVISION)
-   ++ Know `0 < n` >> DECIDE_TAC
-   ++ STRIP_TAC
-   ++ ASM_REWRITE_TAC []
-   ++ DISCH_THEN (MP_TAC o Q.SPEC `x`)
-   ++ RW_TAC arith_ss []);
+   >> MP_TAC (Q.SPECL [`x`, `n`] LESS_DIV_EQ_ZERO)
+   >> ASM_REWRITE_TAC []
+   >> STRIP_TAC
+   >> MP_TAC (Q.SPEC `n` DIVISION)
+   >> Know `0 < n` >- DECIDE_TAC
+   >> STRIP_TAC
+   >> ASM_REWRITE_TAC []
+   >> DISCH_THEN (MP_TAC o Q.SPEC `x`)
+   >> RW_TAC arith_ss []);
 
 val MOD_PLUS1 = store_thm
   ("MOD_PLUS1",
    ``!n a b. 0 < n ==> ((a MOD n + b) MOD n = (a + b) MOD n)``,
    RW_TAC arith_ss []
-   ++ MP_TAC (Q.SPEC `n` MOD_PLUS)
-   ++ ASM_REWRITE_TAC []
-   ++ DISCH_THEN (fn th => ONCE_REWRITE_TAC [GSYM th])
-   ++ RW_TAC arith_ss [MOD_MOD]);
+   >> MP_TAC (Q.SPEC `n` MOD_PLUS)
+   >> ASM_REWRITE_TAC []
+   >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [GSYM th])
+   >> RW_TAC arith_ss [MOD_MOD]);
 
 val MOD_PLUS2 = store_thm
   ("MOD_PLUS2",
@@ -188,16 +163,16 @@ val MOD_MULT1 = store_thm
   ("MOD_MULT1",
    ``!n a b. 0 < n ==> ((a MOD n * b) MOD n = (a * b) MOD n)``,
    RW_TAC std_ss []
-   ++ Induct_on `b` >> RW_TAC arith_ss [MULT_CLAUSES]
-   ++ RW_TAC std_ss [MULT_CLAUSES]
-   ++ MP_TAC (Q.SPEC `n` (GSYM MOD_PLUS2))
-   ++ ASM_REWRITE_TAC []
-   ++ DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
-   ++ RW_TAC std_ss []
-   ++ MP_TAC (Q.SPEC `n` MOD_PLUS1)
-   ++ ASM_REWRITE_TAC []
-   ++ DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
-   ++ RW_TAC std_ss []);
+   >> Induct_on `b` >- RW_TAC arith_ss [MULT_CLAUSES]
+   >> RW_TAC std_ss [MULT_CLAUSES]
+   >> MP_TAC (Q.SPEC `n` (GSYM MOD_PLUS2))
+   >> ASM_REWRITE_TAC []
+   >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
+   >> RW_TAC std_ss []
+   >> MP_TAC (Q.SPEC `n` MOD_PLUS1)
+   >> ASM_REWRITE_TAC []
+   >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
+   >> RW_TAC std_ss []);
 
 val MOD_MULT2 = store_thm
   ("MOD_MULT2",
@@ -211,54 +186,54 @@ val DIVISION_ALT = store_thm
 
 val MOD_EQ_X = store_thm
   ("MOD_EQ_X",
-   ``!n r. 0 < n ==> ((r MOD n = r) = r < n)``,
-   !! STRIP_TAC
-   ++ REVERSE EQ_TAC >> PROVE_TAC [LESS_MOD]
-   ++ DISCH_THEN (fn th => ONCE_REWRITE_TAC [SYM th])
-   ++ RW_TAC std_ss [MOD_LESS]);
+   ``!n r. 0 < n ==> ((r MOD n = r) <=> r < n)``,
+   rpt STRIP_TAC
+   >> REVERSE EQ_TAC >- PROVE_TAC [LESS_MOD]
+   >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [SYM th])
+   >> RW_TAC std_ss [MOD_LESS]);
 
 val DIV_EQ_0 = store_thm
   ("DIV_EQ_0",
-   ``!n r. 0 < n ==> ((r DIV n = 0) = r < n)``,
-   !! STRIP_TAC
-   ++ REVERSE EQ_TAC >> PROVE_TAC [LESS_DIV_EQ_ZERO]
-   ++ STRIP_TAC
-   ++ Know `r DIV n * n + r MOD n = r`
-   >> RW_TAC std_ss [DIVISION_ALT]
-   ++ RW_TAC arith_ss [MOD_EQ_X]);
+   ``!n r. 0 < n ==> ((r DIV n = 0) <=> r < n)``,
+   rpt STRIP_TAC
+   >> REVERSE EQ_TAC >- PROVE_TAC [LESS_DIV_EQ_ZERO]
+   >> STRIP_TAC
+   >> Know `r DIV n * n + r MOD n = r`
+   >- RW_TAC std_ss [DIVISION_ALT]
+   >> RW_TAC arith_ss [MOD_EQ_X]);
 
 val MOD_EXP = store_thm
   ("MOD_EXP",
    ``!n a b. 0 < n ==> ((a MOD n) EXP b MOD n = a EXP b MOD n)``,
    NTAC 2 STRIP_TAC
-   ++ Induct >> RW_TAC std_ss [EXP]
-   ++ STRIP_TAC
-   ++ RES_TAC
-   ++ RW_TAC std_ss
+   >> Induct >- RW_TAC std_ss [EXP]
+   >> STRIP_TAC
+   >> RES_TAC
+   >> RW_TAC std_ss
       [EXP, GSYM (Q.SPECL [`n`, `a MOD n`, `(a MOD n) EXP b`] MOD_MULT2)]
-   ++ RW_TAC std_ss [MOD_MULT1, MOD_MULT2]);
+   >> RW_TAC std_ss [MOD_MULT1, MOD_MULT2]);
 
 val DIV_TWO_UNIQUE = store_thm
   ("DIV_TWO_UNIQUE",
    ``!n q r. (n = 2 * q + r) /\ ((r = 0) \/ (r = 1))
              ==> (q = n DIV 2) /\ (r = n MOD 2)``,
    NTAC 3 STRIP_TAC
-   ++ MP_TAC (Q.SPECL [`2`, `n`, `q`] DIV_UNIQUE)
-   ++ MP_TAC (Q.SPECL [`2`, `n`, `r`] MOD_UNIQUE)
-   ++ Know `((r = 0) \/ (r = 1)) = r < 2` >> DECIDE_TAC
-   ++ DISCH_THEN (fn th => REWRITE_TAC [th])
-   ++ RW_TAC std_ss []
-   ++ PROVE_TAC [MULT_COMM]);
+   >> MP_TAC (Q.SPECL [`2`, `n`, `q`] DIV_UNIQUE)
+   >> MP_TAC (Q.SPECL [`2`, `n`, `r`] MOD_UNIQUE)
+   >> Know `((r = 0) \/ (r = 1)) <=> r < 2` >- DECIDE_TAC
+   >> DISCH_THEN (fn th => REWRITE_TAC [th])
+   >> RW_TAC std_ss []
+   >> PROVE_TAC [MULT_COMM]);
 
 val DIVISION_TWO = store_thm
   ("DIVISION_TWO",
    ``!n. (n = 2 * (n DIV 2) + (n MOD 2)) /\ ((n MOD 2 = 0) \/ (n MOD 2 = 1))``,
    STRIP_TAC
-   ++ MP_TAC (Q.SPEC `2` DIVISION)
-   ++ Know `0:num < 2` >> DECIDE_TAC
-   ++ DISCH_THEN (fn th => REWRITE_TAC [th])
-   ++ DISCH_THEN (MP_TAC o Q.SPEC `n`)
-   ++ RW_TAC bool_ss [] <<
+   >> MP_TAC (Q.SPEC `2` DIVISION)
+   >> Know `0:num < 2` >- DECIDE_TAC
+   >> DISCH_THEN (fn th => REWRITE_TAC [th])
+   >> DISCH_THEN (MP_TAC o Q.SPEC `n`)
+   >> RW_TAC bool_ss [] >|
    [PROVE_TAC [MULT_COMM],
     DECIDE_TAC]);
 
@@ -271,55 +246,55 @@ val MOD_TWO = store_thm
   ("MOD_TWO",
    ``!n. n MOD 2 = if EVEN n then 0 else 1``,
    STRIP_TAC
-   ++ MP_TAC (Q.SPEC `n` DIVISION_TWO)
-   ++ STRIP_TAC <<
+   >> MP_TAC (Q.SPEC `n` DIVISION_TWO)
+   >> STRIP_TAC >|
    [Q.PAT_ASSUM `n = X` MP_TAC
-    ++ RW_TAC std_ss []
-    ++ PROVE_TAC [EVEN_DOUBLE, ODD_EVEN, ADD_CLAUSES],
+    >> RW_TAC std_ss []
+    >> PROVE_TAC [EVEN_DOUBLE, ODD_EVEN, ADD_CLAUSES],
     Q.PAT_ASSUM `n = X` MP_TAC
-    ++ RW_TAC std_ss []
-    ++ PROVE_TAC [ODD_DOUBLE, ODD_EVEN, ADD1]]);
+    >> RW_TAC std_ss []
+    >> PROVE_TAC [ODD_DOUBLE, ODD_EVEN, ADD1]]);
 
 val DIV_TWO_BASIC = store_thm
   ("DIV_TWO_BASIC",
    ``(0 DIV 2 = 0) /\ (1 DIV 2 = 0) /\ (2 DIV 2 = 1)``,
    Know `(0:num = 2 * 0 + 0) /\ (1:num = 2 * 0 + 1) /\ (2:num = 2 * 1 + 0)`
-   >> RW_TAC arith_ss []
-   ++ PROVE_TAC [DIV_TWO_UNIQUE]);
+   >- RW_TAC arith_ss []
+   >> PROVE_TAC [DIV_TWO_UNIQUE]);
 
 val DIV_TWO_MONO = store_thm
   ("DIV_TWO_MONO",
    ``!m n. m DIV 2 < n DIV 2 ==> m < n``,
    NTAC 2 STRIP_TAC
-   ++ (CONV_TAC o RAND_CONV o ONCE_REWRITE_CONV) [DIV_TWO]
-   ++ Q.SPEC_TAC (`m DIV 2`, `p`)
-   ++ Q.SPEC_TAC (`n DIV 2`, `q`)
-   ++ REPEAT STRIP_TAC
-   ++ Know `(m MOD 2 = 0) \/ (m MOD 2 = 1)` >> PROVE_TAC [MOD_TWO]
-   ++ Know `(n MOD 2 = 0) \/ (n MOD 2 = 1)` >> PROVE_TAC [MOD_TWO]
-   ++ DECIDE_TAC);
+   >> (CONV_TAC o RAND_CONV o ONCE_REWRITE_CONV) [DIV_TWO]
+   >> Q.SPEC_TAC (`m DIV 2`, `p`)
+   >> Q.SPEC_TAC (`n DIV 2`, `q`)
+   >> REPEAT STRIP_TAC
+   >> Know `(m MOD 2 = 0) \/ (m MOD 2 = 1)` >- PROVE_TAC [MOD_TWO]
+   >> Know `(n MOD 2 = 0) \/ (n MOD 2 = 1)` >- PROVE_TAC [MOD_TWO]
+   >> DECIDE_TAC);
 
 val DIV_TWO_MONO_EVEN = store_thm
   ("DIV_TWO_MONO_EVEN",
-   ``!m n. EVEN n ==> (m DIV 2 < n DIV 2 = m < n)``,
+   ``!m n. EVEN n ==> (m DIV 2 < n DIV 2 <=> m < n)``,
    RW_TAC std_ss []
-   ++ EQ_TAC >> PROVE_TAC [DIV_TWO_MONO]
-   ++ (CONV_TAC o RATOR_CONV o ONCE_REWRITE_CONV) [DIV_TWO]
-   ++ Q.SPEC_TAC (`m DIV 2`, `p`)
-   ++ Q.SPEC_TAC (`n DIV 2`, `q`)
-   ++ REPEAT STRIP_TAC
-   ++ Know `n MOD 2 = 0` >> PROVE_TAC [MOD_TWO]
-   ++ Know `(m MOD 2 = 0) \/ (m MOD 2 = 1)` >> PROVE_TAC [MOD_TWO]
-   ++ DECIDE_TAC);
+   >> EQ_TAC >- PROVE_TAC [DIV_TWO_MONO]
+   >> (CONV_TAC o RATOR_CONV o ONCE_REWRITE_CONV) [DIV_TWO]
+   >> Q.SPEC_TAC (`m DIV 2`, `p`)
+   >> Q.SPEC_TAC (`n DIV 2`, `q`)
+   >> REPEAT STRIP_TAC
+   >> Know `n MOD 2 = 0` >- PROVE_TAC [MOD_TWO]
+   >> Know `(m MOD 2 = 0) \/ (m MOD 2 = 1)` >- PROVE_TAC [MOD_TWO]
+   >> DECIDE_TAC);
 
 val DIV_TWO_CANCEL = store_thm
   ("DIV_TWO_CANCEL",
    ``!n. (2 * n DIV 2 = n) /\ (SUC (2 * n) DIV 2 = n)``,
-   RW_TAC std_ss [] <<
+   RW_TAC std_ss [] >|
    [MP_TAC (Q.SPEC `2 * n` DIV_TWO)
-    ++ RW_TAC arith_ss [MOD_TWO, EVEN_DOUBLE],
+    >> RW_TAC arith_ss [MOD_TWO, EVEN_DOUBLE],
     MP_TAC (Q.SPEC `SUC (2 * n)` DIV_TWO)
-    ++ RW_TAC arith_ss [MOD_TWO, ODD_DOUBLE]]);
+    >> RW_TAC arith_ss [MOD_TWO, ODD_DOUBLE]]);
 
 val EXP_DIV_TWO = store_thm
   ("EXP_DIV_TWO",
@@ -329,16 +304,16 @@ val EXP_DIV_TWO = store_thm
 val EVEN_EXP_TWO = store_thm
   ("EVEN_EXP_TWO",
    ``!n. EVEN (2 EXP n) = ~(n = 0)``,
-   Cases >> RW_TAC arith_ss [EXP, EVEN_ODD_BASIC]
-   ++ RW_TAC arith_ss [EXP, EVEN_DOUBLE]);
+   Cases >- RW_TAC arith_ss [EXP, EVEN_ODD_BASIC]
+   >> RW_TAC arith_ss [EXP, EVEN_DOUBLE]);
 
 val DIV_TWO_EXP = store_thm
   ("DIV_TWO_EXP",
-   ``!n k. k DIV 2 < 2 EXP n = k < 2 EXP SUC n``,
+   ``!n k. k DIV 2 < 2 EXP n <=> k < 2 EXP SUC n``,
    RW_TAC std_ss []
-   ++ (CONV_TAC o RATOR_CONV o ONCE_REWRITE_CONV) [GSYM EXP_DIV_TWO]
-   ++ MATCH_MP_TAC DIV_TWO_MONO_EVEN
-   ++ RW_TAC std_ss [EVEN_EXP_TWO]);
+   >> (CONV_TAC o RATOR_CONV o ONCE_REWRITE_CONV) [GSYM EXP_DIV_TWO]
+   >> MATCH_MP_TAC DIV_TWO_MONO_EVEN
+   >> RW_TAC std_ss [EVEN_EXP_TWO]);
 
 val MIN_0L = store_thm
   ("MIN_0L",
@@ -382,7 +357,7 @@ val LESS_MINR = store_thm
 
 val IN_GTNUM = store_thm
   ("IN_GTNUM",
-   ``!x n : num. x IN gtnum n = n < x``,
+   ``!x n : num. x IN gtnum n <=> n < x``,
    RW_TAC std_ss [gtnum_def, SPECIFICATION]);
 
 val GTNUM0_SUBTYPE_JUDGEMENT = store_thm
@@ -391,89 +366,89 @@ val GTNUM0_SUBTYPE_JUDGEMENT = store_thm
        SUC m <= n \/ m < n \/ ~(0 = n) \/ ~(n = 0) \/
        (n = SUC m) \/ (SUC m = n) ==> n IN gtnum 0``,
    RW_TAC std_ss [IN_GTNUM]
-   ++ DECIDE_TAC);
+   >> DECIDE_TAC);
 
 val GTNUM1_SUBTYPE_JUDGEMENT = store_thm
   ("GTNUM1_SUBTYPE_JUDGEMENT",
    ``!m n. SUC (SUC m) <= n \/ SUC m < n \/ 1 < n \/
            (n = SUC (SUC m)) \/ (SUC (SUC m) = n) ==> n IN gtnum 1``,
    RW_TAC std_ss [IN_GTNUM]
-   ++ DECIDE_TAC);
+   >> DECIDE_TAC);
 
 val GTNUM1_SUBSET_GTNUM0 = store_thm
   ("GTNUM1_SUBSET_GTNUM0",
    ``gtnum 1 SUBSET gtnum 0``,
    RW_TAC std_ss [SUBSET_DEF, IN_GTNUM]
-   ++ DECIDE_TAC);
+   >> DECIDE_TAC);
 
 val SUC_SUBTYPE = store_thm
   ("SUC_SUBTYPE",
    ``SUC IN ((UNIV -> gtnum 0) INTER (gtnum 0 -> gtnum 1))``,
    RW_TAC std_ss [IN_FUNSET, IN_INTER, IN_UNIV, IN_GTNUM]
-   ++ DECIDE_TAC);
+   >> DECIDE_TAC);
 
 val ADD_SUBTYPE = store_thm
   ("ADD_SUBTYPE",
    ``!n. $+ IN ((UNIV -> gtnum n -> gtnum n) INTER (gtnum n -> UNIV -> gtnum n)
                 INTER (gtnum 0 -> gtnum 0 -> gtnum 1))``,
    RW_TAC std_ss [IN_FUNSET, IN_INTER, IN_UNIV, IN_GTNUM]
-   ++ DECIDE_TAC);
+   >> DECIDE_TAC);
 
 val MULT_SUBTYPE = store_thm
   ("MULT_SUBTYPE",
    ``$* IN ((gtnum 0 -> gtnum 0 -> gtnum 0) INTER
             (gtnum 1 -> gtnum 0 -> gtnum 1) INTER
             (gtnum 0 -> gtnum 1 -> gtnum 1))``,
-   RW_TAC std_ss [IN_FUNSET, IN_INTER, IN_UNIV, IN_GTNUM, LESS_MULT2] <<
-   [Cases_on `x' = 1` >> RW_TAC arith_ss []
-    ++ Know `1 < x'` >> DECIDE_TAC
-    ++ RW_TAC std_ss [LESS_1_MULT2],
-    Cases_on `x = 1` >> RW_TAC arith_ss []
-    ++ Know `1 < x` >> DECIDE_TAC
-    ++ RW_TAC std_ss [LESS_1_MULT2]]);
+   RW_TAC std_ss [IN_FUNSET, IN_INTER, IN_UNIV, IN_GTNUM, LESS_MULT2] >|
+   [Cases_on `x' = 1` >- RW_TAC arith_ss []
+    >> Know `1 < x'` >- DECIDE_TAC
+    >> RW_TAC std_ss [LESS_1_MULT2],
+    Cases_on `x = 1` >- RW_TAC arith_ss []
+    >> Know `1 < x` >- DECIDE_TAC
+    >> RW_TAC std_ss [LESS_1_MULT2]]);
 
 val MIN_SUBTYPE = store_thm
   ("MIN_SUBTYPE",
    ``!x. min IN (x -> x -> x)``,
    RW_TAC arith_ss [IN_FUNSET, min_def]
-   ++ PROVE_TAC []);
+   >> PROVE_TAC []);
 
 val EXP_SUBTYPE = store_thm
   ("EXP_SUBTYPE",
    ``$EXP IN ((gtnum 0 -> UNIV -> gtnum 0) INTER
               (gtnum 1 -> gtnum 0 -> gtnum 1))``,
    RW_TAC std_ss [IN_FUNSET, IN_INTER, IN_UNIV, IN_GTNUM]
-   ++ Cases_on `x` >> DECIDE_TAC
-    ++ Cases_on `n` >> DECIDE_TAC
-    ++ Cases_on `x'` >> DECIDE_TAC
-    ++ KILL_TAC
-    ++ Induct_on `n` >> RW_TAC arith_ss [EXP]
-    ++ ONCE_REWRITE_TAC [EXP]
-    ++ MATCH_MP_TAC LESS_1_MULT2
-    ++ RW_TAC arith_ss []);
+   >> Cases_on `x` >- DECIDE_TAC
+    >> Cases_on `n` >- DECIDE_TAC
+    >> Cases_on `x'` >- DECIDE_TAC
+    >> KILL_TAC
+    >> Induct_on `n` >- RW_TAC arith_ss [EXP]
+    >> ONCE_REWRITE_TAC [EXP]
+    >> MATCH_MP_TAC LESS_1_MULT2
+    >> RW_TAC arith_ss []);
 
 val FUNPOW_SUBTYPE = store_thm
   ("FUNPOW_SUBTYPE",
    ``!(x:'a->bool). FUNPOW IN ((x -> x) -> UNIV -> x -> x)``,
    RW_TAC std_ss [IN_FUNSET, IN_UNIV]
-   ++ POP_ASSUM MP_TAC
-   ++ Q.SPEC_TAC (`x'''`, `y`)
-   ++ Induct_on `x''` >> RW_TAC std_ss [FUNPOW]
-   ++ RW_TAC std_ss [FUNPOW]);
+   >> POP_ASSUM MP_TAC
+   >> Q.SPEC_TAC (`x'''`, `y`)
+   >> Induct_on `x''` >- RW_TAC std_ss [FUNPOW]
+   >> RW_TAC std_ss [FUNPOW]);
 
 val NUMERAL_BIT1_SUBTYPE = store_thm
   ("NUMERAL_BIT1_SUBTYPE",
    ``BIT1 IN ((UNIV -> gtnum 0) INTER (gtnum 0 -> gtnum 1))``,
    RW_TAC bool_ss [IN_FUNSET, IN_GTNUM, BIT1, IN_INTER, IN_UNIV,
                    NUMERAL_DEF, ALT_ZERO, BIT2]
-   ++ DECIDE_TAC);
+   >> DECIDE_TAC);
 
 val NUMERAL_BIT2_SUBTYPE = store_thm
   ("NUMERAL_BIT2_SUBTYPE",
    ``BIT2 IN (UNIV -> gtnum 1)``,
    RW_TAC bool_ss [IN_FUNSET, IN_GTNUM, BIT1, IN_INTER, IN_UNIV,
                    NUMERAL_DEF, ALT_ZERO, BIT2]
-   ++ DECIDE_TAC);
+   >> DECIDE_TAC);
 
 val NUMERAL_SUBTYPE = store_thm
   ("NUMERAL_SUBTYPE",
@@ -492,93 +467,81 @@ val GTNUM1_SUBTYPE_REWRITE = store_thm
 
 val SQUARED_GT_1 = store_thm
   ("SQUARED_GT_1",
-   ``!n : num. (n * n = n) = ~(1 < n)``,
-   Cases >> RW_TAC arith_ss []
-   ++ Cases_on `n'` >> RW_TAC arith_ss []
-   ++ RW_TAC std_ss [MULT]
-   ++ DECIDE_TAC);
+   ``!n : num. (n * n = n) <=> ~(1 < n)``,
+   Cases >- RW_TAC arith_ss []
+   >> Cases_on `n'` >- RW_TAC arith_ss []
+   >> RW_TAC std_ss [MULT]
+   >> DECIDE_TAC);
 
 val MOD_LESS_1 = store_thm
   ("MOD_LESS_1",
    ``!a n. 0 < n ==> (a MOD n <= a)``,
-   !! STRIP_TAC
-   ++ MP_TAC (Q.SPECL [`n`, `a`] DIVISION_ALT)
-   ++ DECIDE_TAC);
+   rpt STRIP_TAC
+   >> MP_TAC (Q.SPECL [`n`, `a`] DIVISION_ALT)
+   >> DECIDE_TAC);
 
 val MULT_EXP = store_thm
   ("MULT_EXP",
    ``!a b n. (a * b) EXP n = a EXP n * b EXP n``,
-   Induct_on `n` >> RW_TAC arith_ss [EXP]
-   ++ RW_TAC arith_ss [EXP]
-   ++ KILL_TAC
-   ++ PROVE_TAC [MULT_COMM, MULT_ASSOC]);
+   Induct_on `n` >- RW_TAC arith_ss [EXP]
+   >> RW_TAC arith_ss [EXP]
+   >> KILL_TAC
+   >> PROVE_TAC [MULT_COMM, MULT_ASSOC]);
 
 val EXP_MULT = store_thm
   ("EXP_MULT",
    ``!n a b. (n EXP a) EXP b = n EXP (a * b)``,
-   !! STRIP_TAC
-   ++ Induct_on `b` >> RW_TAC arith_ss [EXP]
-   ++ RW_TAC arith_ss [EXP, MULT_CLAUSES, EXP_ADD]);
+   rpt STRIP_TAC
+   >> Induct_on `b` >- RW_TAC arith_ss [EXP]
+   >> RW_TAC arith_ss [EXP, MULT_CLAUSES, EXP_ADD]);
 
 val LT_LE_1_MULT = store_thm
   ("LT_LE_1_MULT",
    ``!m n : num. 1 < m /\ 0 < n ==> 1 < m * n``,
-   !! STRIP_TAC
-   ++ Suff `~(m * n = 0) /\ ~(m * n = 1)` >> DECIDE_TAC
-   ++ RW_TAC arith_ss []);
+   rpt STRIP_TAC
+   >> Suff `~(m * n = 0) /\ ~(m * n = 1)` >- DECIDE_TAC
+   >> RW_TAC arith_ss []);
 
-val EXP_MONO = store_thm
-  ("EXP_MONO",
-   ``!p a b. 1 < p ==> (p EXP a < p EXP b = a < b)``,
-   Induct_on `b`
-   >> (RW_TAC arith_ss [EXP]
-       ++ STRIP_TAC
-       ++ Suff `~(p EXP a = 0)` >> DECIDE_TAC
-       ++ RW_TAC arith_ss [EXP_EQ_0])
-   ++ !! STRIP_TAC
-   ++ Cases_on `a`
-   >> (RW_TAC arith_ss [EXP]
-       ++ MATCH_MP_TAC LT_LE_1_MULT
-       ++ RW_TAC arith_ss []
-       ++ Cases_on `p`
-       >> (Suff `~(1:num < 0)` >> PROVE_TAC [] ++ KILL_TAC ++ DECIDE_TAC)
-       ++ RW_TAC arith_ss [ZERO_LESS_EXP])
-   ++ RW_TAC arith_ss [EXP]
-   ++ Cases_on `p`
-   >> (Suff `~(1:num < 0)` >> PROVE_TAC [] ++ KILL_TAC ++ DECIDE_TAC)
-   ++ RW_TAC arith_ss []);
+Theorem EXP_MONO :
+    !p a b. 1 < p ==> (p EXP a < p EXP b <=> a < b)
+Proof
+    Induct_on `b` >- RW_TAC arith_ss [EXP]       
+ >> rpt STRIP_TAC
+ >> Cases_on `a`
+ >> RW_TAC arith_ss [EXP]
+QED
 
 val MINUS_1_SQUARED_MOD = store_thm
   ("MINUS_1_SQUARED_MOD",
    ``!n. 1 < n ==> (((n - 1) * (n - 1)) MOD n = 1)``,
-   !! STRIP_TAC
-   ++ Know `0 < n` >> DECIDE_TAC
-   ++ STRIP_TAC
-   ++ RW_TAC std_ss [LEFT_SUB_DISTRIB]
-   ++ Suff `(n + ((n - 1) * n - (n - 1) * 1)) MOD n = 1`
-   >> (Suff `!a. (n + a) MOD n = a MOD n`
-       >> DISCH_THEN (fn th => REWRITE_TAC [th] ++ RW_TAC std_ss [])
-       ++ Suff `!a. (n MOD n + a) MOD n = a MOD n`
-       >> RW_TAC std_ss [MOD_PLUS1]
-       ++ RW_TAC arith_ss [X_MOD_X])
-   ++ Know `!a. n - 1 <= a ==> (n + (a - (n - 1)) = a + (n - (n - 1)))`
-   >> DECIDE_TAC
-   ++ DISCH_THEN (MP_TAC o Q.SPEC `(n - 1) * n`)
-   ++ Know `n - 1 <= (n - 1) * n`
-   >> (Cases_on `n` >> DECIDE_TAC
-       ++ RW_TAC arith_ss [MULT_CLAUSES])
-   ++ STRIP_TAC
-   ++ ASM_REWRITE_TAC []
-   ++ STRIP_TAC
-   ++ ASM_REWRITE_TAC [MULT_RIGHT_1]
-   ++ Suff `(((n - 1) * (n MOD n)) MOD n + (n - (n - 1))) MOD n = 1`
-   >> (EVERY (map (MP_TAC o Q.SPEC `n`) [MOD_PLUS1, MOD_MULT2])
-       ++ ASM_REWRITE_TAC []
-       ++ DISCH_THEN (REWRITE_TAC o wrap)
-       ++ DISCH_THEN (REWRITE_TAC o wrap))
-   ++ NTAC 2 (POP_ASSUM K_TAC)
-   ++ Know `n - (n - 1) = 1` >> DECIDE_TAC
-   ++ DISCH_THEN (fn th => RW_TAC arith_ss [th, X_MOD_X, LESS_MOD]));
+   rpt STRIP_TAC
+   >> Know `0 < n` >- DECIDE_TAC
+   >> STRIP_TAC
+   >> RW_TAC std_ss [LEFT_SUB_DISTRIB]
+   >> Suff `(n + ((n - 1) * n - (n - 1) * 1)) MOD n = 1`
+   >- (Suff `!a. (n + a) MOD n = a MOD n`
+       >- DISCH_THEN (fn th => REWRITE_TAC [th] >> RW_TAC std_ss [])
+       >> Suff `!a. (n MOD n + a) MOD n = a MOD n`
+       >- RW_TAC std_ss [MOD_PLUS1]
+       >> RW_TAC arith_ss [X_MOD_X])
+   >> Know `!a. n - 1 <= a ==> (n + (a - (n - 1)) = a + (n - (n - 1)))`
+   >- DECIDE_TAC
+   >> DISCH_THEN (MP_TAC o Q.SPEC `(n - 1) * n`)
+   >> Know `n - 1 <= (n - 1) * n`
+   >- (Cases_on `n` >- DECIDE_TAC
+       >> RW_TAC arith_ss [MULT_CLAUSES])
+   >> STRIP_TAC
+   >> ASM_REWRITE_TAC []
+   >> STRIP_TAC
+   >> ASM_REWRITE_TAC [MULT_RIGHT_1]
+   >> Suff `(((n - 1) * (n MOD n)) MOD n + (n - (n - 1))) MOD n = 1`
+   >- (EVERY (map (MP_TAC o Q.SPEC `n`) [MOD_PLUS1, MOD_MULT2])
+       >> ASM_REWRITE_TAC []
+       >> DISCH_THEN (REWRITE_TAC o wrap)
+       >> DISCH_THEN (REWRITE_TAC o wrap))
+   >> NTAC 2 (POP_ASSUM K_TAC)
+   >> Know `n - (n - 1) = 1` >- DECIDE_TAC
+   >> DISCH_THEN (fn th => RW_TAC arith_ss [th, X_MOD_X, LESS_MOD]));
 
 val NUM_DOUBLE = store_thm
   ("NUM_DOUBLE",
@@ -590,11 +553,11 @@ val MOD_POWER_EQ_1 = store_thm
    ``!n x a b.
        1 < n /\ (x EXP a MOD n = 1) ==> (x EXP (a * b) MOD n = 1)``,
    Strip
-   ++ Simplify [GSYM EXP_MULT]
-   ++ Suff `((x EXP a) MOD n) EXP b MOD n = 1`
-   >> RW_TAC arith_ss [MOD_EXP]
-   ++ ASM_REWRITE_TAC []
-   ++ RW_TAC arith_ss [EXP_1, LESS_MOD]);
+   >> Simplify [GSYM EXP_MULT]
+   >> Suff `((x EXP a) MOD n) EXP b MOD n = 1`
+   >- RW_TAC arith_ss [MOD_EXP]
+   >> ASM_REWRITE_TAC []
+   >> RW_TAC arith_ss [EXP_1, LESS_MOD]);
 
 val MINIMAL_EXISTS_IMP = store_thm
   ("MINIMAL_EXISTS_IMP",
@@ -605,68 +568,60 @@ val ODD_EXP = store_thm
   ("ODD_EXP",
    ``!n a. 0 < a ==> (ODD (n EXP a) = ODD n)``,
    STRIP_TAC
-   ++ Induct >> RW_TAC arith_ss []
-   ++ RW_TAC arith_ss [EXP, ODD_MULT]
-   ++ Cases_on `a` >> RW_TAC arith_ss [EVEN_ODD_BASIC, EXP]
-   ++ RW_TAC arith_ss []);
+   >> Induct >- RW_TAC arith_ss []
+   >> RW_TAC arith_ss [EXP, ODD_MULT]
+   >> Cases_on `a` >- RW_TAC arith_ss [EVEN_ODD_BASIC, EXP]
+   >> RW_TAC arith_ss []);
 
 val ODD_GT_1 = store_thm
   ("ODD_GT_1",
    ``!n. 1 < n /\ ODD n ==> 2 < n``,
-   Cases >> Simplify []
-   ++ Cases_on `n'` >> Simplify []
-   ++ Cases_on `n` >> Simplify [GSYM ONE, GSYM TWO, EVEN_ODD_BASIC]
-   ++ DISCH_THEN K_TAC
-   ++ DECIDE_TAC);
+   Cases >- Simplify []
+   >> Cases_on `n'` >- Simplify []
+   >> Cases_on `n` >- Simplify [GSYM ONE, GSYM TWO, EVEN_ODD_BASIC]
+   >> DISCH_THEN K_TAC
+   >> DECIDE_TAC);
 
 val MINUS_1_MULT_MOD = store_thm
   ("MINUS_1_MULT_MOD",
    ``!a b. 0 < a /\ 0 < b ==> ((a * b - 1) MOD b = b - 1)``,
    Strip
-   ++ Cases_on `a` >> DECIDE_TAC
-   ++ RW_TAC std_ss [MULT]
-   ++ Know `!c. c + b - 1 = c + (b - 1)` >> DECIDE_TAC
-   ++ RW_TAC std_ss []
-   ++ POP_ASSUM K_TAC
-   ++ Suff `((n * b) MOD b + (b - 1)) MOD b = b - 1`
-   >> RW_TAC std_ss [MOD_PLUS1]
-   ++ RW_TAC std_ss [MOD_EQ_0]
-   ++ RW_TAC arith_ss [MOD_EQ_X]);
+   >> Cases_on `a` >- DECIDE_TAC
+   >> RW_TAC std_ss [MULT]
+   >> Know `!c. c + b - 1 = c + (b - 1)` >- DECIDE_TAC
+   >> RW_TAC std_ss []
+   >> POP_ASSUM K_TAC
+   >> Suff `((n * b) MOD b + (b - 1)) MOD b = b - 1`
+   >- RW_TAC std_ss [MOD_PLUS1]
+   >> RW_TAC std_ss [MOD_EQ_0]
+   >> RW_TAC arith_ss [MOD_EQ_X]);
 
-val EXP2_MONO_LE = store_thm
-  ("EXP2_MONO_LE",
-   ``!a b n. 0 < n /\ a <= b ==> a EXP n <= b EXP n``,
-   Strip
-   ++ Induct_on `n` >> DECIDE_TAC
-   ++ RW_TAC arith_ss [EXP]
-   ++ Cases_on `n` >> RW_TAC arith_ss [EXP]
-   ++ POP_ASSUM MP_TAC
-   ++ Simplify []
-   ++ Know `a * a EXP SUC n' <= a * b EXP SUC n'`
-   >> (Cases_on `a` >> RW_TAC arith_ss []
-       ++ Simplify [GSYM MULT_LESS_EQ_SUC])
-   ++ Suff `a * b EXP SUC n' <= b * b EXP SUC n'` >> DECIDE_TAC
-   ++ Cases_on `b EXP SUC n'`
-   ++ Simplify [ONCE_REWRITE_RULE [MULT_COMM] (GSYM MULT_LESS_EQ_SUC)]);
+Theorem EXP2_MONO_LE :
+    !a b n. 0 < n /\ a <= b ==> a EXP n <= b EXP n
+Proof
+    Strip
+ >> Induct_on `n` >- DECIDE_TAC
+ >> RW_TAC arith_ss [EXP]
+QED
 
 val EXP1_MONO_LE = store_thm
   ("EXP1_MONO_LE",
    ``!n a b. 0 < n /\ a <= b ==> n EXP a <= n EXP b``,
    Strip
-   ++ Cases_on `a = b` >> Simplify []
-   ++ Cases_on `n = 1` >> Simplify [EXP_1]
-   ++ Suff `n EXP a < n EXP b` >> DECIDE_TAC
-   ++ Know `1 < n /\ a < b` >> DECIDE_TAC
-   ++ RW_TAC std_ss [EXP_MONO]);
+   >> Cases_on `a = b` >- Simplify []
+   >> Cases_on `n = 1` >- Simplify [EXP_1]
+   >> Suff `n EXP a < n EXP b` >- DECIDE_TAC
+   >> Know `1 < n /\ a < b` >- DECIDE_TAC
+   >> RW_TAC std_ss [EXP_MONO]);
 
 val LT_SUC = store_thm
   ("LT_SUC",
-   ``!a b. a < SUC b = a < b \/ (a = b)``,
+   ``!a b. a < SUC b <=> a < b \/ (a = b)``,
    DECIDE_TAC);
 
 val LE_SUC = store_thm
   ("LE_SUC",
-   ``!a b. a <= SUC b = a <= b \/ (a = SUC b)``,
+   ``!a b. a <= SUC b <=> a <= b \/ (a = SUC b)``,
    DECIDE_TAC);
 
 val TRANSFORM_2D_NUM = store_thm
@@ -674,122 +629,122 @@ val TRANSFORM_2D_NUM = store_thm
    ``!P.
        (!m n : num. P m n ==> P n m) /\ (!m n. P m (m + n)) ==> (!m n. P m n)``,
    Strip
-   ++ Know `m <= n \/ n <= m` >> DECIDE_TAC
-   ++ RW_TAC std_ss [LESS_EQ_EXISTS]
-   ++ PROVE_TAC []);
+   >> Know `m <= n \/ n <= m` >- DECIDE_TAC
+   >> RW_TAC std_ss [LESS_EQ_EXISTS]
+   >> PROVE_TAC []);
 
 val TRIANGLE_2D_NUM = store_thm
   ("TRIANGLE_2D_NUM",
    ``!P. (!d n. P n (d + n)) ==> (!m n : num. m <= n ==> P m n)``,
    RW_TAC std_ss [LESS_EQ_EXISTS]
-   ++ PROVE_TAC [ADD_COMM]);
+   >> PROVE_TAC [ADD_COMM]);
 
 val MAX_LE_X = store_thm
   ("MAX_LE_X",
-   ``!m n k. MAX m n <= k = m <= k /\ n <= k``,
+   ``!m n k. MAX m n <= k <=> m <= k /\ n <= k``,
    RW_TAC arith_ss [MAX_DEF]);
 
 val X_LE_MAX = store_thm
   ("X_LE_MAX",
-   ``!m n k. k <= MAX m n = k <= m \/ k <= n``,
+   ``!m n k. k <= MAX m n <=> k <= m \/ k <= n``,
    RW_TAC arith_ss [MAX_DEF]);
 
 val SUC_DIV_TWO_ZERO = store_thm
   ("SUC_DIV_TWO_ZERO",
-   ``!n. (SUC n DIV 2 = 0) = (n = 0)``,
+   ``!n. (SUC n DIV 2 = 0) <=> (n = 0)``,
    RW_TAC std_ss []
-   ++ REVERSE EQ_TAC
-   >> (MP_TAC DIV_TWO_BASIC
-       ++ Know `SUC 0 = 1` >> DECIDE_TAC
-       ++ RW_TAC arith_ss [])
-   ++ RW_TAC std_ss []
-   ++ MP_TAC (Q.SPEC `SUC n` DIV_TWO)
-   ++ RW_TAC arith_ss [MULT_CLAUSES, MOD_TWO]);
+   >> REVERSE EQ_TAC
+   >- (MP_TAC DIV_TWO_BASIC
+       >> Know `SUC 0 = 1` >- DECIDE_TAC
+       >> RW_TAC arith_ss [])
+   >> RW_TAC std_ss []
+   >> MP_TAC (Q.SPEC `SUC n` DIV_TWO)
+   >> RW_TAC arith_ss [MULT_CLAUSES, MOD_TWO]);
 
 val LOG2_LOWER = store_thm
   ("LOG2_LOWER",
    ``!n. n < 2 EXP log2 n``,
    recInduct log2_ind
-   ++ RW_TAC arith_ss [log2_def, EXP]
-   ++ POP_ASSUM MP_TAC
-   ++ RW_TAC std_ss [DIV_TWO_EXP, EXP]);
+   >> RW_TAC arith_ss [log2_def, EXP]
+   >> POP_ASSUM MP_TAC
+   >> RW_TAC std_ss [DIV_TWO_EXP, EXP]);
 
 val LOG2_LOWER_SUC = store_thm
   ("LOG2_LOWER_SUC",
    ``!n. SUC n <= 2 EXP log2 n``,
    RW_TAC std_ss []
-   ++ MP_TAC (Q.SPEC `n` LOG2_LOWER)
-   ++ DECIDE_TAC);
+   >> MP_TAC (Q.SPEC `n` LOG2_LOWER)
+   >> DECIDE_TAC);
 
 val LOG2_UPPER = store_thm
   ("LOG2_UPPER",
    ``!n. ~(n = 0) ==> 2 EXP log2 n <= 2 * n``,
    recInduct log2_ind
-   ++ RW_TAC arith_ss [log2_def, EXP]
-   ++ Cases_on `SUC v DIV 2 = 0`
-   >> (POP_ASSUM MP_TAC
-       ++ RW_TAC std_ss [SUC_DIV_TWO_ZERO]
-       ++ RW_TAC arith_ss [DECIDE ``SUC 0 = 1``, DIV_TWO_BASIC,
+   >> RW_TAC arith_ss [log2_def, EXP]
+   >> Cases_on `SUC v DIV 2 = 0`
+   >- (POP_ASSUM MP_TAC
+       >> RW_TAC std_ss [SUC_DIV_TWO_ZERO]
+       >> RW_TAC arith_ss [DECIDE ``SUC 0 = 1``, DIV_TWO_BASIC,
                            log2_def, EXP])
-   ++ RES_TAC
-   ++ POP_ASSUM MP_TAC
-   ++ KILL_TAC
-   ++ Q.SPEC_TAC (`SUC v`, `n`)
-   ++ GEN_TAC
-   ++ Q.SPEC_TAC (`2 EXP log2 (n DIV 2)`, `m`)
-   ++ GEN_TAC
-   ++ Suff `2 * (n DIV 2) <= n` >> DECIDE_TAC
-   ++ MP_TAC (Q.SPEC `n` DIV_TWO)
-   ++ DECIDE_TAC);
+   >> RES_TAC
+   >> POP_ASSUM MP_TAC
+   >> KILL_TAC
+   >> Q.SPEC_TAC (`SUC v`, `n`)
+   >> GEN_TAC
+   >> Q.SPEC_TAC (`2 EXP log2 (n DIV 2)`, `m`)
+   >> GEN_TAC
+   >> Suff `2 * (n DIV 2) <= n` >- DECIDE_TAC
+   >> MP_TAC (Q.SPEC `n` DIV_TWO)
+   >> DECIDE_TAC);
 
 val LOG2_UPPER_SUC = store_thm
   ("LOG2_UPPER_SUC",
    ``!n. 2 EXP log2 n <= SUC (2 * n)``,
    STRIP_TAC
-   ++ MP_TAC (Q.SPEC `n` LOG2_UPPER)
-   ++ REVERSE (Cases_on `n = 0`) >> RW_TAC arith_ss []
-   ++ RW_TAC arith_ss [log2_def, EXP]);
+   >> MP_TAC (Q.SPEC `n` LOG2_UPPER)
+   >> REVERSE (Cases_on `n = 0`) >- RW_TAC arith_ss []
+   >> RW_TAC arith_ss [log2_def, EXP]);
 
 val MINIMAL_EQ_IMP = store_thm
   ("MINIMAL_EQ_IMP",
    ``!m p. (p m) /\ (!n. n < m ==> ~p n) ==> (m = minimal p)``,
    RW_TAC std_ss []
-   ++ MP_TAC (Q.SPEC `p` MINIMAL_EXISTS)
-   ++ Know `?n. p n` >> PROVE_TAC []
-   ++ RW_TAC std_ss []
-   ++ Suff `~(m < minimal p) /\ ~(minimal p < m)` >> DECIDE_TAC
-   ++ PROVE_TAC []);
+   >> MP_TAC (Q.SPEC `p` MINIMAL_EXISTS)
+   >> Know `?n. p n` >- PROVE_TAC []
+   >> RW_TAC std_ss []
+   >> Suff `~(m < minimal p) /\ ~(minimal p < m)` >- DECIDE_TAC
+   >> PROVE_TAC []);
 
 val MINIMAL_SUC = store_thm
   ("MINIMAL_SUC",
    ``!n p.
-       (SUC n = minimal p) /\ p (SUC n) =
+       (SUC n = minimal p) /\ p (SUC n) <=>
        ~p 0 /\ (n = minimal (p o SUC)) /\ p (SUC n)``,
    RW_TAC std_ss []
-   ++ EQ_TAC <<
-   [RW_TAC std_ss [] <<
-    [Know `0 < SUC n` >> DECIDE_TAC
-     ++ PROVE_TAC [MINIMAL_EXISTS],
+   >> EQ_TAC >|
+   [RW_TAC std_ss [] >|
+    [Know `0 < SUC n` >- DECIDE_TAC
+     >> PROVE_TAC [MINIMAL_EXISTS],
      MATCH_MP_TAC MINIMAL_EQ_IMP
-     ++ RW_TAC std_ss [o_THM]
-     ++ Know `SUC n' < SUC n` >> DECIDE_TAC
-     ++ PROVE_TAC [MINIMAL_EXISTS]],
+     >> RW_TAC std_ss [o_THM]
+     >> Know `SUC n' < SUC n` >- DECIDE_TAC
+     >> PROVE_TAC [MINIMAL_EXISTS]],
     RW_TAC std_ss []
-    ++ MATCH_MP_TAC MINIMAL_EQ_IMP
-    ++ RW_TAC std_ss []
-    ++ Cases_on `n` >> RW_TAC std_ss []
-    ++ Suff `~((p o SUC) n')` >> RW_TAC std_ss [o_THM]
-    ++ Know `n' < minimal (p o SUC)` >> DECIDE_TAC
-    ++ PROVE_TAC [MINIMAL_EXISTS]]);
+    >> MATCH_MP_TAC MINIMAL_EQ_IMP
+    >> RW_TAC std_ss []
+    >> Cases_on `n` >- RW_TAC std_ss []
+    >> Suff `~((p o SUC) n')` >- RW_TAC std_ss [o_THM]
+    >> Know `n' < minimal (p o SUC)` >- DECIDE_TAC
+    >> PROVE_TAC [MINIMAL_EXISTS]]);
 
 val MINIMAL_EQ = store_thm
   ("MINIMAL_EQ",
-   ``!p m. p m /\ (m = minimal p) = p m /\ (!n. n < m ==> ~p n)``,
+   ``!p m. p m /\ (m = minimal p) <=> p m /\ (!n. n < m ==> ~p n)``,
    RW_TAC std_ss []
-   ++ REVERSE EQ_TAC >> PROVE_TAC [MINIMAL_EQ_IMP]
-   ++ RW_TAC std_ss []
-   ++ Know `?n. p n` >> PROVE_TAC []
-   ++ RW_TAC std_ss [MINIMAL_EXISTS]);
+   >> REVERSE EQ_TAC >- PROVE_TAC [MINIMAL_EQ_IMP]
+   >> RW_TAC std_ss []
+   >> Know `?n. p n` >- PROVE_TAC []
+   >> RW_TAC std_ss [MINIMAL_EXISTS]);
 
 val MINIMAL_SUC_IMP = store_thm
   ("MINIMAL_SUC_IMP",
@@ -797,6 +752,4 @@ val MINIMAL_SUC_IMP = store_thm
        p (SUC n) /\ ~p 0 /\ (n = minimal (p o SUC)) ==> (SUC n = minimal p)``,
    PROVE_TAC [MINIMAL_SUC]);
 
-(* non-interactive mode
-*)
 val _ = export_theory ();

--- a/examples/diningcryptos/extra_pred_setScript.sml
+++ b/examples/diningcryptos/extra_pred_setScript.sml
@@ -1115,7 +1115,7 @@ val FINITE_LIST_TO_SET = store_thm
    Induct
    >> RW_TAC std_ss [FINITE_EMPTY, FINITE_INSERT, LIST_TO_SET_THM]);
 
-val ALL_DISTINCT_imp_REAL_SUM_IMAGE_of_LIST_TO_SET_eq_REAL_SUM = store_thm  
+val ALL_DISTINCT_imp_REAL_SUM_IMAGE_of_LIST_TO_SET_eq_REAL_SUM = store_thm
   ("ALL_DISTINCT_imp_REAL_SUM_IMAGE_of_LIST_TO_SET_eq_REAL_SUM",
    ``!l. ALL_DISTINCT l ==>
          (REAL_SUM_IMAGE f (LIST_TO_SET l) = REAL_SUM (MAP f l))``,

--- a/examples/diningcryptos/leakageLib.sml
+++ b/examples/diningcryptos/leakageLib.sml
@@ -21,7 +21,7 @@ val Suff = PARSE_TAC SUFF_TAC;
 
 fun REPEAT_SAFE_EVAL tm =
         let val t = EVAL tm in
-        if (snd (dest_thm t)) = (mk_eq (tm,tm)) then
+        if (snd (dest_thm t)) ~~ (mk_eq (tm,tm)) then
                 ALL_CONV tm
         else
                 t
@@ -45,14 +45,13 @@ fun MEM_CONV (c:term->thm) =
         UNFOLD_CONV [MEM] c;
 
 fun F_UNCHANGED_CONV (conv:term->thm) tm =
-        if tm = ``F`` then ALL_CONV tm else conv tm;
+        if tm ~~ F then ALL_CONV tm else conv tm;
 
 fun T_UNCHANGED_CONV (conv:term->thm) tm =
-        if tm = ``T`` then ALL_CONV tm else conv tm;
+        if tm ~~ T then ALL_CONV tm else conv tm;
 
 fun T_F_UNCHANGED_CONV (conv:term->thm) tm =
         T_UNCHANGED_CONV (F_UNCHANGED_CONV conv) tm;
-
 
 val CROSS_NON_EMPTY_IMP = prove
    (``!P Q. FINITE P /\ FINITE Q /\ ~(P={}) /\ ~(Q={}) ==> ~(P CROSS Q = {})``,
@@ -70,11 +69,18 @@ val CROSS_HLR_NON_EMPTY_IMP = prove
    (``!h l r. FINITE h /\ FINITE l /\ FINITE r /\ ~(h={}) /\ ~(l={}) /\ ~(r={}) ==> ~((h CROSS l) CROSS r = {})``,
     METIS_TAC [CROSS_NON_EMPTY_IMP, FINITE_CROSS]);
 
-val unif_prog_space_leakage_computation_reduce_COMPUTE = prove  (``!high low random f. FINITE high /\ FINITE low /\ FINITE random /\       ~((high CROSS low) CROSS random={}) ==>         (leakage (unif_prog_space high low random) f =           (1/(&(CARD high * CARD low * CARD random)))*            (SIGMA (\(out,h,l). (\x. x * lg (((1/(&(CARD random)))* x))) (SIGMA (\r. if (f((h,l),r)=out) then 1 else 0) random))
-                  (IMAGE (\s. (f s,FST s)) (high CROSS low CROSS random)) -
+val unif_prog_space_leakage_computation_reduce_COMPUTE = prove
+  (``!high low random f. FINITE high /\ FINITE low /\ FINITE random /\
+       ~((high CROSS low) CROSS random={}) ==>
+         (leakage (unif_prog_space high low random) f =
+           (1/(&(CARD high * CARD low * CARD random)))*
+            (SIGMA (\(out,h,l). (\x. x * lg (((1/(&(CARD random)))* x)))
+                                (SIGMA (\r. if (f((h,l),r)=out) then 1 else 0) random))
+            (IMAGE (\s. (f s,FST s)) (high CROSS low CROSS random)) -
              SIGMA (\(out,l). (\x. x * lg (((1/(&(CARD high * CARD random)))* x)))
                         (SIGMA (\(h,r). if (f((h,l),r)=out) then 1 else 0) (high CROSS random)))
-                  (IMAGE (\s. (f s,SND (FST s))) (high CROSS low CROSS random))))``,   METIS_TAC [unif_prog_space_leakage_computation_reduce]);
+                  (IMAGE (\s. (f s,SND (FST s))) (high CROSS low CROSS random))))``,
+   METIS_TAC [unif_prog_space_leakage_computation_reduce]);
 
 fun LEAKAGE_COMPUTE_PROVE_FINITE (t:term) (tl:Abbrev.thm list) =
         (prove ((mk_comb ((inst [alpha |-> fst(dom_rng(type_of t))]``FINITE``),t)),
@@ -173,7 +179,7 @@ fun LEAKAGE_COMPUTE_IMAGE_HLR_CROSS ((h:term),(l:term),(r:term)) (tl:Abbrev.thm 
                                                 (UNION_CONV (SIMP_CONV bool_ss [] THENC r_dups_conv)))))))))));
 
 fun RECURSIVE_UNWIND_SUM (dups_conv:Abbrev.term->Abbrev.thm) (item_conv:Abbrev.term->Abbrev.thm) (tm:term) =
-        if (rand tm) = (inst [alpha |-> fst(dom_rng(type_of (rand tm)))] ``{}``) then REWRITE_CONV [REAL_SUM_IMAGE_THM] tm else
+        if (rand tm) ~~ (inst [alpha |-> fst(dom_rng(type_of (rand tm)))] ``{}``) then REWRITE_CONV [REAL_SUM_IMAGE_THM] tm else
         ((fn (tm:term) => (let val s = snd(dest_comb(snd (dest_comb tm))) in
                                           let val f = snd(dest_comb (fst(dest_comb tm))) in
                                           let val fin_thm = prove (mk_comb((inst [alpha |-> fst(dom_rng(type_of s))] ``FINITE``),s),

--- a/examples/diningcryptos/leakageScript.sml
+++ b/examples/diningcryptos/leakageScript.sml
@@ -67,7 +67,6 @@ val visible_leakage_def = Define
 (*      sets of possible initial input states                                *)
 (* ************************************************************************* *)
 
-
 val unif_prog_dist_def = Define
    `unif_prog_dist high low random =
         (\s. if s IN (high CROSS low) CROSS random then
@@ -80,18 +79,9 @@ val unif_prog_space_def = Define
          POW ((high CROSS low) CROSS random),
          (\s. SIGMA (unif_prog_dist high low random) s))`;
 
-
-(* ************************************************************************* *)
-
-
-
-
-(* ************************************************************************* *)
 (* ************************************************************************* *)
 (* Proofs                                                                    *)
 (* ************************************************************************* *)
-(* ************************************************************************* *)
-
 
 val prob_space_unif_prog_space = store_thm
   ("prob_space_unif_prog_space",
@@ -550,7 +540,7 @@ val unif_prog_space_leakage_reduce = store_thm
                ((f :('a, 'b, 'c, 'd) prog) s,FST s))
             ((high :'a state -> bool) CROSS
              (low :'b state -> bool) CROSS (random :'c state -> bool)))`) REAL_SUM_IMAGE_IN_IF]
-   >> `(\x. (if x IN IMAGE (\s. (f s,FST s)) (high CROSS low CROSS random) then
+   >> Know `(\x. (if x IN IMAGE (\s. (f s,FST s)) (high CROSS low CROSS random) then
             (\(x,y,z). joint_distribution (unif_prog_space high low random) f (\x. (H x,L x)) {(x,y,z)} *
            lg (joint_distribution (unif_prog_space high low random) f (\x. (H x,L x)) {(x,y,z)} /
                distribution (unif_prog_space high low random) (\x. (H x,L x)) {(y,z)})) x else 0)) =
@@ -558,10 +548,12 @@ val unif_prog_space_leakage_reduce = store_thm
             (\(x,y,z). joint_distribution (unif_prog_space high low random) f (\x. (H x,L x)) {(x,y,z)} *
            lg (joint_distribution (unif_prog_space high low random) f (\x. (H x,L x)) {(x,y,z)} *
                (&((CARD high)*(CARD low))))) x else 0))`
-         by (RW_TAC std_ss [FUN_EQ_THM, IN_IMAGE, IN_CROSS] >> RW_TAC std_ss []
-             >> `FST s' = (FST (FST s'), SND (FST s'))` by RW_TAC std_ss [PAIR] >> POP_ORW
-             >> RW_TAC std_ss [unif_prog_space_highlow_distribution, GSYM REAL_INV_1OVER, real_div, REAL_INV_INV])
-   >> POP_ORW
+   >- (RW_TAC std_ss [FUN_EQ_THM, IN_IMAGE, IN_CROSS] >> RW_TAC std_ss []
+       >> rename1 `FST (FST s') IN high`
+       >> `FST s' = (FST (FST s'), SND (FST s'))` by RW_TAC std_ss [PAIR] >> POP_ORW
+       >> RW_TAC std_ss [unif_prog_space_highlow_distribution,
+                         GSYM REAL_INV_1OVER, real_div, REAL_INV_INV])
+   >> Rewr'
    >> ASM_SIMP_TAC std_ss [GSYM REAL_SUM_IMAGE_IN_IF]
    >> ONCE_REWRITE_TAC [REAL_ADD_COMM] >> RW_TAC std_ss [GSYM real_sub]
    >> Q.UNABBREV_TAC `foo` >> RW_TAC std_ss []);
@@ -860,7 +852,6 @@ SIGMA
    >> ONCE_REWRITE_TAC [REAL_ADD_COMM] >> RW_TAC std_ss [GSYM real_sub]
    >> Q.UNABBREV_TAC `foo` >> RW_TAC std_ss []);
 
-
 val unif_prog_space_leakage_lemma1 = store_thm
   ("unif_prog_space_leakage_lemma1",
    ``!high low random (f :('a, 'b, 'c, 'd) prog). FINITE high /\ FINITE low /\ FINITE random /\
@@ -902,7 +893,8 @@ val unif_prog_space_leakage_lemma1 = store_thm
                        & (CARD low))) x) x else 0))`
    >- RW_TAC std_ss []
    >> ONCE_REWRITE_TAC [FUN_EQ_THM] >> RW_TAC std_ss [IN_IMAGE, IN_CROSS]
-   >> RW_TAC std_ss [] >> RW_TAC std_ss []
+   >> RW_TAC std_ss []
+   >> rename1 `FST (FST s') IN high`
    >> Q.ABBREV_TAC `j = joint_distribution (unif_prog_space high low random) f L {(f s',SND (FST s'))}`
    >> Q.ABBREV_TAC `s = 1 / & (CARD high * CARD low * CARD random) *
                                  SIGMA (\(h,r). (if f ((h,SND (FST s')),r) = f s' then 1 else 0))
@@ -1006,7 +998,6 @@ val unif_prog_space_leakage_lemma1 = store_thm
    >> Q.UNABBREV_TAC `c`
    >> RW_TAC std_ss [REAL_SUM_IMAGE_EQ_CARD]);
 
-
 val unif_prog_space_visible_leakage_lemma1 = store_thm
   ("unif_prog_space_visible_leakage_lemma1",
    ``!high low random (f :('a, 'b, 'c, 'd) prog). FINITE high /\ FINITE low /\ FINITE random /\
@@ -1046,7 +1037,8 @@ val unif_prog_space_visible_leakage_lemma1 = store_thm
                        & (CARD low * CARD random))) x) x else 0))`
    >- RW_TAC std_ss []
    >> ONCE_REWRITE_TAC [FUN_EQ_THM] >> RW_TAC std_ss [IN_IMAGE, IN_CROSS]
-   >> RW_TAC std_ss [] >> RW_TAC std_ss []
+   >> RW_TAC std_ss []
+   >> rename1 `FST (FST s') IN high`
    >> Q.ABBREV_TAC `j = joint_distribution (unif_prog_space high low random) f (\s. (L s,R s)) {(f s',(SND (FST s'),SND s'))}`
    >> Q.ABBREV_TAC `s = 1 / & (CARD high * CARD low * CARD random) *
                                  SIGMA (\h. (if f ((h,SND (FST s')),SND s') = f s' then 1 else 0)) high`
@@ -1151,7 +1143,6 @@ val unif_prog_space_visible_leakage_lemma1 = store_thm
    >> Q.UNABBREV_TAC `c`
    >> RW_TAC std_ss [REAL_SUM_IMAGE_EQ_CARD]);
 
-
 val unif_prog_space_leakage_lemma2 = store_thm
   ("unif_prog_space_leakage_lemma2",
    ``!high low random (f :('a, 'b, 'c, 'd) prog). FINITE high /\ FINITE low /\ FINITE random /\
@@ -1193,7 +1184,8 @@ val unif_prog_space_leakage_lemma2 = store_thm
                    random * & (CARD high * CARD low))) x) x else 0))`
    >- RW_TAC std_ss []
    >> ONCE_REWRITE_TAC [FUN_EQ_THM] >> RW_TAC std_ss [IN_IMAGE, IN_CROSS]
-   >> RW_TAC std_ss [] >> `FST s' = (FST(FST s'),SND(FST s'))` by RW_TAC std_ss [PAIR]
+   >> rename1 `FST (FST s') IN high`
+   >> `FST s' = (FST(FST s'),SND(FST s'))` by RW_TAC std_ss [PAIR]
    >> POP_ORW >> RW_TAC std_ss []
    >> Q.ABBREV_TAC `j = joint_distribution (unif_prog_space high low random) f (\x. (H x,L x)) {(f s',FST s')}`
    >> Q.ABBREV_TAC `s = 1 / & (CARD high * CARD low * CARD random) *
@@ -1343,7 +1335,6 @@ val unif_prog_space_leakage_lemma2 = store_thm
    >> Q.UNABBREV_TAC `c`
    >> RW_TAC std_ss [REAL_SUM_IMAGE_EQ_CARD]);
 
-
 val unif_prog_space_visible_leakage_lemma2 = store_thm
   ("unif_prog_space_visible_leakage_lemma2",
    ``!high low random (f :('a, 'b, 'c, 'd) prog). FINITE high /\ FINITE low /\ FINITE random /\
@@ -1385,7 +1376,9 @@ val unif_prog_space_visible_leakage_lemma2 = store_thm
                     (if f ((h,l),r) = out then 1 else 0) * & (CARD high * CARD low * CARD random))) x) x else 0))`
    >- RW_TAC std_ss []
    >> ONCE_REWRITE_TAC [FUN_EQ_THM] >> RW_TAC std_ss [IN_IMAGE, IN_CROSS]
-   >> RW_TAC std_ss [] >> `FST s' = (FST(FST s'),SND(FST s'))` by RW_TAC std_ss [PAIR]
+   >> RW_TAC std_ss []
+   >> rename1 `FST (FST s') IN high`
+   >> `FST s' = (FST(FST s'),SND(FST s'))` by RW_TAC std_ss [PAIR]
    >> POP_ORW >> RW_TAC real_ss []
    >> Suff `joint_distribution (unif_prog_space high low random) f (\s. (H s,L s,R s)) {(f s',FST (FST s'),SND (FST s'),SND s')} =
                 1 / & (CARD high * CARD low * CARD random)`
@@ -1424,7 +1417,6 @@ val unif_prog_space_visible_leakage_lemma2 = store_thm
                            low_state_def, random_state_def, IN_CROSS]
             >> METIS_TAC [PAIR, FST, SND])
    >> RW_TAC std_ss [REAL_SUM_IMAGE_SING, IN_CROSS]);
-
 
 val unif_prog_space_leakage_lemma3 = store_thm
   ("unif_prog_space_leakage_lemma3",
@@ -1519,7 +1511,6 @@ val unif_prog_space_leakage_lemma3 = store_thm
    >> RW_TAC real_ss [CARD_EQ_0]
    >> SPOSE_NOT_THEN STRIP_ASSUME_TAC
    >> FULL_SIMP_TAC std_ss [CROSS_EMPTY]);
-
 
 val unif_prog_space_visible_leakage_lemma3 = store_thm
   ("unif_prog_space_visible_leakage_lemma3",
@@ -1624,7 +1615,6 @@ val unif_prog_space_visible_leakage_lemma3 = store_thm
    >> SPOSE_NOT_THEN STRIP_ASSUME_TAC
    >> FULL_SIMP_TAC std_ss [CROSS_EMPTY]);
 
-
 val unif_prog_space_leakage_lemma4 = store_thm
   ("unif_prog_space_leakage_lemma4",
    ``!high low random (f :('a, 'b, 'c, 'd) prog). FINITE high /\ FINITE low /\ FINITE random /\
@@ -1705,7 +1695,6 @@ val unif_prog_space_leakage_lemma4 = store_thm
    >> RW_TAC real_ss [CARD_EQ_0]
    >> SPOSE_NOT_THEN STRIP_ASSUME_TAC
    >> FULL_SIMP_TAC std_ss [CROSS_EMPTY]);
-
 
 val unif_prog_space_visible_leakage_lemma4 = store_thm
   ("unif_prog_space_visible_leakage_lemma4",

--- a/examples/diningcryptos/leakageScript.sml
+++ b/examples/diningcryptos/leakageScript.sml
@@ -2,19 +2,19 @@
 (* Create "leakageTheory" setting up the theory of information leakage       *)
 (* ========================================================================= *)
 
-open HolKernel Parse boolLib bossLib metisLib arithmeticTheory pred_setTheory
+open HolKernel Parse boolLib bossLib;
+
+open metisLib arithmeticTheory pred_setTheory
      listTheory state_transformerTheory combinTheory pairTheory realTheory
      realLib jrhUtils realSimps numTheory simpLib seqTheory subtypeTheory
      transcTheory limTheory stringTheory rich_listTheory stringSimps listSimps
-     informationTheory;
+     informationTheory real_sigmaTheory;
 
 open extra_boolTheory extra_numTheory extra_pred_setTheory extra_realTheory
      extra_listTheory extra_stringTheory extra_stringLib;
 
-open real_sigmaTheory;
-
-open hurdUtils util_probTheory real_measureTheory real_lebesgueTheory
-     real_probabilityTheory;
+open hurdUtils util_probTheory sigma_algebraTheory
+     real_measureTheory real_lebesgueTheory real_probabilityTheory;
 
 (* ------------------------------------------------------------------------- *)
 (* Start a new theory called "information"                                   *)

--- a/tools/sequences/final-examples
+++ b/tools/sequences/final-examples
@@ -30,3 +30,5 @@
 !!!examples/l3-machine-code/cheri/step
 [poly]!!!examples/theorem-prover
 [poly]!!!examples/machine-code
+
+!!!examples/diningcryptos


### PR DESCRIPTION
Hi,

This PR continues #443 (two years ago), and I'm glad to report that, Coble's formalization of the dining cryptographers protocol [1] has been finally fixed, also ported to `real_probabilityTheory`. I don't really understand Coble's this complex work, and all what I did are some routine fixes due to 1) the difference between std/expk kernals, 2) tight equality defaults, 3) term equality (`~~`) changes, and 4) minor HOL core theory changes, etc.

I ever reported that, the building process of this example was blocked at the theorem `dc3_leakage_result`. I thought there was an infinite-loop, but actually this theorem needs a longer time to finish (at least 10 minutes) but I interrupted HOL before I could see the result. Now `dining_cryptosTheory` can indeed be built, but it took about 40 minutes to finish, on my laptop (2.6GHz Intel Core i7, using PolyML, I don't know how long Moscow ML will take). I attached the resulting signature file as an evidence.

[dining_cryptosTheory.txt](https://github.com/HOL-Theorem-Prover/HOL/files/3765038/dining_cryptosTheory.txt)

Any way,  both HOL's official probability examples (`miller` and `diningcryptos`) are fixed now. Students who try to learn from Hurd and Coble's PhD thesis now have working HOL scripts to check and run.

Chun Tian
Fondazione Bruno Kessler, Italy and University of Trento, Italy
(supervisor: Alessandro Cimatti)

[1] Coble, A.R.: Anonymity, information, and machine-assisted proof, University of Cambridge (2010).