### PR TITLE
Register llist as a datatype in TypeBase

### DIFF
--- a/src/coalgebras/llistScript.sml
+++ b/src/coalgebras/llistScript.sml
@@ -2648,7 +2648,7 @@ val LLENGTH_LREPEAT = Q.store_thm(
    Case constant, distinctness etc. for TypeBase
    -------------------------------------------------------------------------- *)
 
-Definition llist_CASE_def:
+Definition llist_CASE_def[nocompute]:
   llist_CASE ll b f =
     case LTL_HD ll of
       NONE => b

--- a/src/coalgebras/llistScript.sml
+++ b/src/coalgebras/llistScript.sml
@@ -2678,7 +2678,7 @@ Proof
 QED
 
 Theorem LLIST_CASE_EQ:
-  llist_CASE (x:'a llist) v f = v' ⇔ x = [||] /\ v = v' ∨ ∃a l. x = a:::l /\ f a l = v'
+  (llist_CASE (x:'a llist) v f = v') = (x = [||] /\ v = v' \/ ?a l. x = a:::l /\ f a l = v')
 Proof
   llist_CASE_TAC ``x:'a llist`` >> rw[]
 QED


### PR DESCRIPTION
This is slightly abusive because some of the `TypeBase` entries are the
dual of what you would expect, but on the positive side, it should
allow one to use lazy lists in case expressions, with `CaseEq`, and so
on.

Seems to play nicely with `Cases_on`, but not with `Induct_on`.

An alternative to this approach would be to redesign TypeBase so that
non-datatypes can have case theorems.