### PR TITLE
Elementary "conditional probability" ported from HVG's cond_probTheory

### DIFF
--- a/src/probability/extrealScript.sml
+++ b/src/probability/extrealScript.sml
@@ -1733,7 +1733,7 @@ Proof
 QED
 
 Theorem ldiv_le_imp :
-    !x y (z :extreal). 0 < z /\ z <> PosInf /\ x <= y ==> x / z <= y / z 
+    !x y (z :extreal). 0 < z /\ z <> PosInf /\ x <= y ==> x / z <= y / z
 Proof
     RW_TAC std_ss []
  >> `z <> NegInf` by METIS_TAC [lt_imp_le, pos_not_neginf]

--- a/src/probability/extrealScript.sml
+++ b/src/probability/extrealScript.sml
@@ -9,7 +9,7 @@
 
 open HolKernel Parse boolLib bossLib;
 
-open metisLib combinTheory pred_setTheory res_quanTools pairTheory
+open metisLib combinTheory pred_setTheory res_quanTools pairTheory RealArith
      prim_recTheory arithmeticTheory realTheory realLib real_sigmaTheory
      seqTheory limTheory Diff transcTheory jrhUtils pred_setLib;
 
@@ -18,6 +18,7 @@ open hurdUtils util_probTheory cardinalTheory;
 val _ = new_theory "extreal";
 
 val DISC_RW_KILL = DISCH_TAC >> ONCE_ASM_REWRITE_TAC [] >> POP_ASSUM K_TAC;
+val ASM_REAL_ARITH_TAC = REAL_ASM_ARITH_TAC; (* RealArith *)
 fun METIS ths tm = prove(tm, METIS_TAC ths);
 val set_ss = std_ss ++ PRED_SET_ss;
 
@@ -1371,25 +1372,18 @@ val add_rdistrib_normal = store_thm
 val add_rdistrib_normal2 = save_thm (* for backward compatibility *)
   ("add_rdistrib_normal2", add_rdistrib_normal);
 
-(* more antecedents added *)
-val add_ldistrib = store_thm
-  ("add_ldistrib",
-  ``!x y z. (0 <= y /\ 0 <= z) \/
-            (y <= 0 /\ z <= 0) \/
-            (y <> NegInf /\ z <> NegInf /\ y <= 0 /\ z <= 0) \/
-            (y <> PosInf /\ z <> PosInf /\ 0 <= y /\ 0 <= z)
-        ==> (x * (y + z) = x * y + x * z)``,
-    METIS_TAC [add_ldistrib_pos, add_ldistrib_neg_neg, add_ldistrib_pos_pos, add_ldistrib_neg]);
+Theorem add_ldistrib :
+    !x y z. (0 <= y /\ 0 <= z) \/ (y <= 0 /\ z <= 0) ==> (x * (y + z) = x * y + x * z)
+Proof
+    METIS_TAC [add_ldistrib_pos, add_ldistrib_neg_neg,
+               add_ldistrib_pos_pos, add_ldistrib_neg]
+QED
 
-(* more antecedents added *)
-val add_rdistrib = store_thm
-  ("add_rdistrib",
-  ``!x y z. (0 <= y /\ 0 <= z) \/
-            (y <= 0 /\ z <= 0) \/
-            (y <> NegInf /\ z <> NegInf /\ y <= 0 /\ z <= 0) \/
-            (y <> PosInf /\ z <> PosInf /\ 0 <= y /\ 0 <= z)
-        ==> ((y + z) * x = y * x + z * x)``,
-    METIS_TAC [add_ldistrib, mul_comm]);
+Theorem add_rdistrib :
+    !x y z. (0 <= y /\ 0 <= z) \/ (y <= 0 /\ z <= 0) ==> ((y + z) * x = y * x + z * x)
+Proof
+    METIS_TAC [add_ldistrib, mul_comm]
+QED
 
 val mul_lneg = store_thm
   ("mul_lneg", ``!x y. -x * y = -(x * y)``,
@@ -1546,6 +1540,14 @@ val lt_rdiv = store_thm
  >> RW_TAC std_ss [REAL_INV_EQ_0, REAL_INV_POS, extreal_lt_eq, REAL_LT_RDIV_EQ, GSYM real_div,
                    REAL_LT_REFL, lt_refl, lt_infty, le_infty, extreal_div_def, extreal_inv_def,
                    extreal_div_eq, extreal_mul_def, REAL_LT_IMP_NE]);
+
+Theorem lt_div : (* cf. REAL_LT_DIV *)
+    !y z. 0 < y /\ 0 < z ==> 0 < y / Normal z
+Proof
+    rpt STRIP_TAC
+ >> MP_TAC (REWRITE_RULE [mul_lzero] (Q.SPECL [`0`, `y`, `z`] lt_rdiv))
+ >> RW_TAC std_ss []
+QED
 
 val lt_ldiv = store_thm
   ("lt_ldiv", ``!x y z. 0 < z ==> (x / Normal z < y <=> x < y * Normal z)``,
@@ -1708,6 +1710,56 @@ Theorem div_mul_refl :
 Proof
     RW_TAC std_ss [extreal_div_def, extreal_inv_def, GSYM mul_assoc, extreal_mul_def]
  >> RW_TAC real_ss [REAL_MUL_LINV, GSYM extreal_of_num_def, mul_rone]
+QED
+
+Theorem mul_div_refl :
+    !(x :extreal) r. x <> PosInf /\ x <> NegInf /\ 0 < r ==>
+                    (x = x * (Normal r) / (Normal r))
+Proof
+    rpt STRIP_TAC
+ >> Know `x * (Normal r) / (Normal r) = (inv (Normal r)) * (x * (Normal r))`
+ >- (MATCH_MP_TAC div_eq_mul_linv \\
+    `?a. x = Normal a` by METIS_TAC [extreal_cases] \\
+     RW_TAC std_ss [extreal_not_infty, extreal_mul_def, extreal_of_num_def,
+                    extreal_lt_eq]) >> Rewr'
+ >> ONCE_REWRITE_TAC [mul_comm]
+ >> ONCE_REWRITE_TAC [GSYM mul_assoc]
+ >> `Normal r * inv (Normal r) = inv (Normal r) * Normal r`
+      by PROVE_TAC [mul_comm] >> POP_ORW
+ >> Know `inv (Normal r) * Normal r = 1`
+ >- (MATCH_MP_TAC mul_linv_pos \\
+     RW_TAC std_ss [extreal_of_num_def, extreal_lt_eq, extreal_not_infty])
+ >> Rewr' >> REWRITE_TAC [mul_rone]
+QED
+
+Theorem ldiv_le_imp :
+    !x y (z :extreal). 0 < z /\ z <> PosInf /\ x <= y ==> x / z <= y / z 
+Proof
+    RW_TAC std_ss []
+ >> `z <> NegInf` by METIS_TAC [lt_imp_le, pos_not_neginf]
+ >> `?r. z = Normal r` by METIS_TAC [extreal_cases]
+ >> `0 < r` by METIS_TAC [extreal_of_num_def, extreal_lt_eq]
+ >> `r <> 0` by METIS_TAC [REAL_LT_LE]
+ >> Cases_on `x` >> Cases_on `y`
+ >> fs [le_infty, extreal_div_eq, infty_div, le_refl, extreal_le_eq]
+ >> fs [REAL_LE_LT] >> DISJ1_TAC >> rw [REAL_LT_RDIV]
+QED
+
+val extreal_distinct = DB.fetch "extreal" "extreal_distinct";
+
+(* cf. REAL_EQ_MUL_LCANCEL *)
+Theorem mul_lcancel :
+    !x y (z :extreal). x <> PosInf /\ x <> NegInf ==>
+                     ((x * y = x * z) <=> (x = 0) \/ (y = z))
+Proof
+    rpt STRIP_TAC
+ >> `?r. x = Normal r` by METIS_TAC [extreal_cases]
+ >> POP_ORW >> KILL_TAC
+ >> Cases_on `y` >> Cases_on `z`
+ >> RW_TAC std_ss [extreal_mul_def, extreal_not_infty, extreal_of_num_def,
+                   extreal_11, extreal_distinct,
+                   REAL_MUL_LZERO, REAL_MUL_RZERO]
+ >> REWRITE_TAC [REAL_EQ_MUL_LCANCEL]
 QED
 
 (***************************)

--- a/src/probability/probabilityScript.sml
+++ b/src/probability/probabilityScript.sml
@@ -13,8 +13,8 @@
 open HolKernel Parse boolLib bossLib;
 
 open pairTheory combinTheory optionTheory prim_recTheory arithmeticTheory
-     res_quanTheory res_quanTools pred_setTheory realTheory realLib
-     seqTheory transcTheory real_sigmaTheory real_topologyTheory;
+     res_quanTheory res_quanTools pred_setTheory pred_setLib realTheory realLib
+     seqTheory transcTheory real_sigmaTheory real_topologyTheory mesonLib;
 
 open hurdUtils util_probTheory extrealTheory sigma_algebraTheory
      measureTheory borelTheory lebesgueTheory martingaleTheory;
@@ -37,6 +37,11 @@ val _ = new_theory "probability";
     probabilities and conditional expectations (Chapter V). ..."
 
   -- A. N. Kolmogorov, "Foundations of the Theory of Probability." [1] *)
+
+val COUNTABLE_IMAGE = image_countable;
+val FINITE_COUNTABLE = finite_countable;
+val set_ss = std_ss ++ PRED_SET_ss;
+val std_ss' = std_ss ++ boolSimps.ETA_ss;
 
 val _ = hide "S";
 
@@ -96,6 +101,7 @@ val conditional_distribution_def = Define
 val expectation_def = Define
    `expectation = integral`;
 
+(* not used *)
 val conditional_expectation_def = Define
    `conditional_expectation p X s =
         @f. real_random_variable f p /\
@@ -103,10 +109,15 @@ val conditional_expectation_def = Define
                (expectation p (\x. f x * indicator_fn g x) =
                 expectation p (\x. X x * indicator_fn g x))`;
 
+(* not used *)
 val conditional_prob_def = Define
    `conditional_prob p e1 e2 =
     conditional_expectation p (indicator_fn e1) e2`;
 
+val cond_prob_def = Define
+   `cond_prob p e1 e2 = (prob p (e1 INTER e2)) / (prob p e2)`;
+
+(* not used *)
 val rv_conditional_expectation_def = Define
    `rv_conditional_expectation (p :'a p_space) s X Y =
        conditional_expectation p X (IMAGE (\a. (PREIMAGE Y a) INTER p_space p) (subsets s))`;
@@ -1810,12 +1821,6 @@ val expectation_posinf = store_thm
   ``!p. prob_space p ==> (expectation p (\x. PosInf) = PosInf)``,
     RW_TAC std_ss [prob_space_def, p_space_def, expectation_def]
  >> MATCH_MP_TAC integral_posinf >> art [lt_01]);
-
-val expectation_indicator = store_thm
-  ("expectation_indicator",
-  ``!p s. prob_space p /\ s IN events p ==> (expectation p (indicator_fn s) = prob p s)``,
-    RW_TAC std_ss [expectation_def, events_def, prob_space_def, prob_def]
- >> MATCH_MP_TAC integral_indicator >> art []);
 
 (* a deep lemma: all second moments are finite iff one of them is finite *)
 val finite_second_moments_all = store_thm (* new *)
@@ -3586,8 +3591,8 @@ val PROB_LIMINF = store_thm
     RW_TAC std_ss [prob_space_def, p_space_def, events_def, prob_def]
  >> MATCH_MP_TAC measure_liminf >> art []);
 
-val expectation_indicator_fn = store_thm
-  ("expectation_indicator_fn",
+val expectation_indicator = store_thm
+  ("expectation_indicator",
   ``!p s. prob_space p /\ s IN events p ==> (expectation p (indicator_fn s) = prob p s)``,
     RW_TAC std_ss [prob_space_def, events_def, expectation_def, prob_def]
  >> MATCH_MP_TAC integral_indicator >> art []);
@@ -3616,7 +3621,7 @@ val Borel_Cantelli_Lemma1 = store_thm
  >> Q.PAT_X_ASSUM `suminf (\x. prob p (E x)) < PosInf` MP_TAC
  >> Know `!x. prob p (E x) = integral p (indicator_fn (E x))`
  >- (GEN_TAC >> MATCH_MP_TAC EQ_SYM \\
-     MATCH_MP_TAC (REWRITE_RULE [expectation_def] expectation_indicator_fn) >> art [])
+     MATCH_MP_TAC (REWRITE_RULE [expectation_def] expectation_indicator) >> art [])
  >> Rewr'
  >> Know `!x. integral p (indicator_fn (E x)) = pos_fn_integral p (indicator_fn (E x))`
  >- (GEN_TAC >> MATCH_MP_TAC integral_pos_fn \\
@@ -3678,7 +3683,7 @@ val finite_second_moments_indicator_fn = store_thm
  >- (fs [prob_space_def, p_space_def, expectation_def, events_def] \\
      MATCH_MP_TAC integral_indicator_pow_eq >> ASM_SIMP_TAC arith_ss []) >> Rewr'
  >> Know `expectation p (indicator_fn s) = prob p s`
- >- (MATCH_MP_TAC expectation_indicator_fn >> art []) >> Rewr'
+ >- (MATCH_MP_TAC expectation_indicator >> art []) >> Rewr'
  >> MATCH_MP_TAC let_trans >> Q.EXISTS_TAC `1`
  >> METIS_TAC [PROB_LE_1, extreal_of_num_def, lt_infty]);
 
@@ -3749,7 +3754,7 @@ val Borel_Cantelli_Lemma2p = store_thm
  >> Know `!n. (prob p o E) n = expectation p (X n)`
  >- (Q.UNABBREV_TAC `X` \\
      RW_TAC std_ss [o_DEF] >> MATCH_MP_TAC EQ_SYM \\
-     MATCH_MP_TAC expectation_indicator_fn >> art []) >> DISCH_TAC
+     MATCH_MP_TAC expectation_indicator >> art []) >> DISCH_TAC
  (* this result can be also derived directly from independence (for any events) *)
  >> Know `!i j. i <> j ==> (expectation p (\x. (X i) x * (X j) x) =
                             expectation p (X i) * expectation p (X j))`
@@ -4152,6 +4157,598 @@ val Borel_0_1_Law = store_thm
       fs [GSYM lt_infty, pairwise_indep_events_def] ]);
 
 (* TO BE CONTINUED *)
+
+(* ========================================================================= *)
+(*                      Condition Probability Library                        *)
+(* ========================================================================= *)
+
+Theorem EVENTS_BIGUNION :
+    !p f n. prob_space p /\ (f IN ((count n) -> events p)) ==>
+            BIGUNION (IMAGE f (count n)) IN events p
+Proof
+    RW_TAC std_ss [IN_FUNSET, IN_COUNT]
+ >> `BIGUNION (IMAGE f (count n)) = BIGUNION (IMAGE (\m. (if m < n then f m else {})) UNIV)`
+     by (RW_TAC std_ss [EXTENSION,IN_BIGUNION_IMAGE, IN_COUNT, IN_UNIV] >> METIS_TAC [NOT_IN_EMPTY])
+ >> POP_ORW
+ >> (MATCH_MP_TAC o REWRITE_RULE [subsets_def, space_def] o
+        Q.SPECL [`(p_space p, events p)`,`(\m. if m < n then A m else {})`]) SIGMA_ALGEBRA_ENUM
+ >> RW_TAC std_ss [EVENTS_SIGMA_ALGEBRA] >> RW_TAC std_ss [IN_FUNSET, IN_UNIV, DISJOINT_EMPTY]
+ >> METIS_TAC [EVENTS_EMPTY]
+QED
+
+Theorem PROB_INTER_ZERO :
+    !p A B. prob_space p /\ A IN events p /\ B IN events p /\ (prob p B = 0) ==>
+           (prob p (A INTER B) = 0)
+Proof
+    RW_TAC std_ss []
+ >> `(A INTER B) SUBSET B` by RW_TAC std_ss [INTER_SUBSET]
+ >> `prob p (A INTER B) <= prob p B` by FULL_SIMP_TAC std_ss [PROB_INCREASING, EVENTS_INTER]
+ >> `0 <= prob p (A INTER B)` by FULL_SIMP_TAC std_ss [PROB_POSITIVE, EVENTS_INTER]
+ >> METIS_TAC [le_antisym]
+QED
+
+Theorem PROB_ZERO_INTER :
+    !p A B. prob_space p /\ A IN events p /\ B IN events p /\ (prob p A = 0) ==>
+           (prob p (A INTER B) = 0)
+Proof
+    RW_TAC std_ss [] >> (MP_TAC o Q.SPECL [`p`, `B`, `A`]) PROB_INTER_ZERO
+ >> RW_TAC std_ss [INTER_COMM]
+QED
+
+Theorem COND_PROB_ZERO :
+    !p A B. prob_space p /\ A IN events p /\ B IN events p /\
+           (prob p A = 0) /\ prob p B <> 0 ==> (cond_prob p A B = 0)
+Proof
+    RW_TAC std_ss [cond_prob_def, PROB_ZERO_INTER, zero_div]
+QED
+
+Theorem COND_PROB_ZERO_INTER :
+    !p A B. prob_space p /\ A IN events p /\ B IN events p /\
+           (prob p (A INTER B) = 0) /\ prob p B <> 0 ==> (cond_prob p A B = 0)
+Proof
+    RW_TAC std_ss [cond_prob_def, zero_div]
+QED
+
+Theorem COND_PROB_INCREASING :
+    !p A B C. prob_space p /\ A IN events p /\ B IN events p /\ C IN events p /\
+              prob p C <> 0 ==> cond_prob p (A INTER B) C <= cond_prob p A C
+Proof
+    RW_TAC std_ss [cond_prob_def, real_div]
+ >> `(A INTER B INTER C) SUBSET (A INTER C)` by SET_TAC []
+ >> `A INTER C IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `A INTER B INTER C IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `0 < prob p C` by METIS_TAC [le_lt, PROB_POSITIVE]
+ >> MATCH_MP_TAC ldiv_le_imp
+ >> ASM_SIMP_TAC std_ss [PROB_FINITE]
+ >> MATCH_MP_TAC PROB_INCREASING >> art []
+QED
+
+Theorem POS_COND_PROB_IMP_POS_PROB :
+    !A B p. prob_space p /\ A IN events p /\ B IN events p /\
+            0 < cond_prob p A B /\ prob p B <> 0 ==> prob p (A INTER B) <> 0
+Proof
+    RW_TAC std_ss []
+ >> `0 < prob p B` by METIS_TAC [lt_le, PROB_POSITIVE]
+ >> FULL_SIMP_TAC std_ss [cond_prob_def]
+ >> CCONTR_TAC >> fs []
+ >> `0 / prob p B = 0` by METIS_TAC [zero_div]
+ >> METIS_TAC [lt_refl]
+QED
+
+Theorem COND_PROB_BOUNDS :
+    !p A B. prob_space p /\ A IN events p /\ B IN events p /\
+            prob p B <> 0 ==> 0 <= cond_prob p A B /\ cond_prob p A B <= 1
+Proof
+    rpt GEN_TAC >> STRIP_TAC
+ >> `0 < prob p B` by METIS_TAC [lt_le, PROB_POSITIVE]
+ >> `prob p B <> 0` by METIS_TAC [lt_le]
+ >> `prob p B <> PosInf /\ prob p B <> NegInf` by METIS_TAC [PROB_FINITE]
+ >> `?r. prob p B = Normal r` by METIS_TAC [extreal_cases]
+ >> `0 < r` by METIS_TAC [extreal_of_num_def, extreal_lt_eq]
+ >> `A INTER B IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `0 <= prob p (A INTER B)` by METIS_TAC [PROB_POSITIVE]
+ >> REWRITE_TAC [cond_prob_def]
+ >> CONJ_TAC
+ >- (`(prob p (A INTER B) = 0) \/ 0 < prob p (A INTER B)` by METIS_TAC [le_lt]
+     >- (POP_ORW >> Suff `0 / prob p B = 0` >- rw [le_refl] \\
+         MATCH_MP_TAC zero_div >> art []) \\
+     MATCH_MP_TAC lt_imp_le >> art [] \\
+     MATCH_MP_TAC lt_div >> art [])
+ >> ASM_SIMP_TAC std_ss [GSYM le_ldiv, mul_lone]
+ >> Q.PAT_X_ASSUM `prob p B = Normal r` (ONCE_REWRITE_TAC o wrap o SYM)
+ >> MATCH_MP_TAC PROB_INCREASING
+ >> ASM_SIMP_TAC std_ss [INTER_SUBSET]
+QED
+
+Theorem COND_PROB_FINITE : (* new *)
+    !p A B. prob_space p /\ A IN events p /\ B IN events p /\
+            prob p B <> 0 ==> cond_prob p A B <> PosInf /\ cond_prob p A B <> NegInf
+Proof
+    rpt GEN_TAC >> STRIP_TAC
+ >> `0 <= cond_prob p A B /\ cond_prob p A B <= 1` by METIS_TAC [COND_PROB_BOUNDS]
+ >> Reverse CONJ_TAC
+ >- (MATCH_MP_TAC pos_not_neginf >> art [])
+ >> REWRITE_TAC [lt_infty]
+ >> MATCH_MP_TAC let_trans
+ >> Q.EXISTS_TAC `1` >> art [num_not_infty, GSYM lt_infty]
+QED
+
+Theorem COND_PROB_ITSELF :
+    !p B. prob_space p /\ B IN events p /\ prob p B <> 0 ==> (cond_prob p B B = 1)
+Proof
+    RW_TAC real_ss [cond_prob_def, INTER_IDEMPOT]
+ >> `0 < prob p B` by METIS_TAC [le_lt, PROB_POSITIVE]
+ >> MATCH_MP_TAC div_refl
+ >> METIS_TAC [PROB_FINITE]
+QED
+
+Theorem COND_PROB_COMPL :
+    !p A B. prob_space p /\ A IN events p /\ COMPL A IN events p /\
+            B IN events p /\ prob p B <> 0 ==>
+           (cond_prob p (COMPL A) B = 1 - cond_prob p A B)
+Proof
+    RW_TAC std_ss [cond_prob_def]
+ >> `prob p B <> PosInf /\ prob p B <> NegInf` by METIS_TAC [PROB_FINITE]
+ >> `prob p B < PosInf` by METIS_TAC [lt_infty]
+ >> `0 < prob p B` by METIS_TAC [le_lt, PROB_POSITIVE]
+ >> ASM_SIMP_TAC std_ss [ldiv_eq]
+ >> `A INTER B IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `prob p (A INTER B) <> PosInf /\
+     prob p (A INTER B) <> NegInf` by METIS_TAC [PROB_FINITE]
+ >> Know `prob p (A INTER B) / prob p B <> PosInf /\
+          prob p (A INTER B) / prob p B <> NegInf`
+ >- (`?a. prob p (A INTER B) = Normal a` by METIS_TAC [extreal_cases] \\
+     `?b. prob p B = Normal b` by METIS_TAC [extreal_cases] \\
+     `b <> 0` by METIS_TAC [extreal_of_num_def, extreal_11] \\
+     ASM_SIMP_TAC std_ss [extreal_div_eq, extreal_not_infty])
+ >> STRIP_TAC
+ >> ASM_SIMP_TAC std_ss [sub_rdistrib, num_not_infty, mul_lone]
+ >> Know `prob p (A INTER B) / prob p B * prob p B = prob p (A INTER B)`
+ >- (MATCH_MP_TAC EQ_SYM \\
+    `?b. prob p B = Normal b` by METIS_TAC [extreal_cases] \\
+    `b <> 0` by METIS_TAC [extreal_of_num_def, extreal_11] >> art [] \\
+     MATCH_MP_TAC div_mul_refl >> art []) >> Rewr'
+ >> ASM_SIMP_TAC std_ss [eq_sub_ladd]
+ >> `prob p ((COMPL A) INTER B) + prob p (A INTER B) =
+     prob p (((COMPL A) INTER B) UNION (A INTER B))`
+       by (ONCE_REWRITE_TAC [EQ_SYM_EQ] >> MATCH_MP_TAC PROB_ADDITIVE
+          >> RW_TAC std_ss [EVENTS_INTER, DISJOINT_DEF, EXTENSION]
+          >> RW_TAC std_ss [NOT_IN_EMPTY, IN_COMPL, IN_INTER] >> METIS_TAC []) >> POP_ORW
+ >> `(COMPL A INTER B UNION A INTER B) = B`
+        by (SET_TAC [EXTENSION, IN_INTER, IN_UNION, IN_COMPL] >> METIS_TAC [])
+ >> RW_TAC std_ss []
+QED
+
+Theorem COND_PROB_DIFF :
+    !p A1 A2 B. prob_space p /\ A1 IN events p /\ A2 IN events p /\
+                B IN events p /\ prob p B <> 0 ==>
+               (cond_prob p (A1 DIFF A2) B =
+                cond_prob p A1 B - cond_prob p (A1 INTER A2) B)
+Proof
+    RW_TAC std_ss [cond_prob_def]
+ >> `(A1 DIFF A2) INTER B IN events p` by METIS_TAC [EVENTS_INTER, EVENTS_DIFF]
+ >> `A1 INTER B IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `A1 INTER A2 INTER B IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `prob p B <> PosInf /\ prob p B <> NegInf` by METIS_TAC [PROB_FINITE]
+ >> `prob p B < PosInf` by METIS_TAC [lt_infty]
+ >> `0 < prob p B` by METIS_TAC [le_lt, PROB_POSITIVE]
+ >> ASM_SIMP_TAC std_ss [ldiv_eq]
+ >> `prob p (A1 INTER B) <> PosInf /\
+     prob p (A1 INTER B) <> NegInf` by METIS_TAC [PROB_FINITE]
+ >> `prob p (A1 INTER A2 INTER B) <> PosInf /\
+     prob p (A1 INTER A2 INTER B) <> NegInf` by METIS_TAC [PROB_FINITE]
+ >> Know `prob p (A1 INTER B) / prob p B <> PosInf /\
+          prob p (A1 INTER B) / prob p B <> NegInf`
+ >- (`?a. prob p (A1 INTER B) = Normal a` by METIS_TAC [extreal_cases] \\
+     POP_ORW >> METIS_TAC [div_not_infty]) >> STRIP_TAC
+ >> Know `prob p (A1 INTER A2 INTER B) / prob p B <> PosInf /\
+          prob p (A1 INTER A2 INTER B) / prob p B <> NegInf`
+ >- (`?a. prob p (A1 INTER A2 INTER B) = Normal a`
+          by METIS_TAC [extreal_cases] >> POP_ORW \\
+     METIS_TAC [div_not_infty]) >> STRIP_TAC
+ >> ASM_SIMP_TAC std_ss [sub_rdistrib]
+ >> Know `prob p (A1 INTER B) / prob p B * prob p B = prob p (A1 INTER B)`
+ >- (MATCH_MP_TAC EQ_SYM \\
+    `?b. prob p B = Normal b` by METIS_TAC [extreal_cases] \\
+    `b <> 0` by METIS_TAC [extreal_of_num_def, extreal_11] >> art [] \\
+     MATCH_MP_TAC div_mul_refl >> art []) >> Rewr'
+ >> Know `prob p (A1 INTER A2 INTER B) / prob p B * prob p B =
+          prob p (A1 INTER A2 INTER B)`
+ >- (MATCH_MP_TAC EQ_SYM \\
+    `?b. prob p B = Normal b` by METIS_TAC [extreal_cases] \\
+    `b <> 0` by METIS_TAC [extreal_of_num_def, extreal_11] >> art [] \\
+     MATCH_MP_TAC div_mul_refl >> art []) >> Rewr'
+ >> ASM_SIMP_TAC std_ss [eq_sub_ladd]
+ >> `prob p ((A1 DIFF A2) INTER B) + prob p (A1 INTER A2 INTER B) =
+        prob p (((A1 DIFF A2) INTER B) UNION (A1 INTER A2 INTER B))`
+        by (ONCE_REWRITE_TAC [EQ_SYM_EQ] >> MATCH_MP_TAC PROB_ADDITIVE
+           >> RW_TAC std_ss [EVENTS_INTER, EVENTS_DIFF, DISJOINT_DEF, EXTENSION]
+           >> RW_TAC std_ss [IN_DIFF, IN_INTER, NOT_IN_EMPTY] >> PROVE_TAC [])
+ >> `((A1 DIFF A2) INTER B UNION A1 INTER A2 INTER B) = (A1 INTER B)`
+        by (RW_TAC std_ss [EXTENSION, IN_INTER, IN_DIFF, IN_UNION] THEN PROVE_TAC [])
+ >> RW_TAC std_ss []
+QED
+
+Theorem COND_PROB_MUL_RULE :
+    !p A B. prob_space p /\ A IN events p /\ B IN events p /\ prob p B <> 0 ==>
+           (prob p (A INTER B) = (prob p B) * (cond_prob p A B))
+Proof
+    RW_TAC std_ss []
+ >> `prob p B <> PosInf /\ prob p B <> NegInf` by METIS_TAC [PROB_FINITE]
+ >> `prob p B < PosInf` by METIS_TAC [lt_infty]
+ >> `0 < prob p B` by METIS_TAC [le_lt, PROB_POSITIVE]
+ >> ASM_SIMP_TAC std_ss [cond_prob_def, ldiv_eq, Once mul_comm]
+ >> `?b. prob p B = Normal b` by METIS_TAC [extreal_cases]
+ >> `b <> 0` by METIS_TAC [extreal_of_num_def, extreal_11] >> art []
+ >> MATCH_MP_TAC div_mul_refl >> art []
+QED
+
+Theorem COND_PROB_MUL_EQ :
+    !p A B. prob_space p /\ A IN events p /\ B IN events p /\
+            prob p A <> 0 /\ prob p B <> 0 ==>
+           (cond_prob p A B * prob p B = cond_prob p B A * prob p A)
+Proof
+    RW_TAC std_ss [cond_prob_def, Once INTER_COMM]
+ >> `prob p A <> PosInf /\ prob p A <> NegInf` by METIS_TAC [PROB_FINITE]
+ >> `prob p A < PosInf` by METIS_TAC [lt_infty]
+ >> `0 < prob p A` by METIS_TAC [le_lt, PROB_POSITIVE]
+ >> `prob p B <> PosInf /\ prob p B <> NegInf` by METIS_TAC [PROB_FINITE]
+ >> `prob p B < PosInf` by METIS_TAC [lt_infty]
+ >> `0 < prob p B` by METIS_TAC [le_lt, PROB_POSITIVE]
+ >> Know `prob p (B INTER A) / prob p A * prob p A = prob p (B INTER A)`
+ >- (MATCH_MP_TAC EQ_SYM \\
+    `?a. prob p A = Normal a` by METIS_TAC [extreal_cases] \\
+    `a <> 0` by METIS_TAC [extreal_of_num_def, extreal_11] >> art [] \\
+     MATCH_MP_TAC div_mul_refl >> art []) >> Rewr'
+ >> Know `prob p (B INTER A) / prob p B * prob p B = prob p (B INTER A)`
+ >- (MATCH_MP_TAC EQ_SYM \\
+    `?b. prob p B = Normal b` by METIS_TAC [extreal_cases] \\
+    `b <> 0` by METIS_TAC [extreal_of_num_def, extreal_11] >> art [] \\
+     MATCH_MP_TAC div_mul_refl >> art []) >> Rewr
+QED
+
+Theorem COND_PROB_UNION :
+    !p A1 A2 B.
+       prob_space p /\ A1 IN events p /\ A2 IN events p /\ B IN events p /\
+       prob p B <> 0 ==>
+      (cond_prob p (A1 UNION A2) B =
+       (cond_prob p A1 B) + (cond_prob p A2 B) - (cond_prob p (A1 INTER A2) B))
+Proof
+    RW_TAC std_ss []
+ >> `cond_prob p A1 B <> PosInf /\ cond_prob p A1 B <> NegInf /\
+     cond_prob p A2 B <> PosInf /\ cond_prob p A2 B <> NegInf`
+      by METIS_TAC [COND_PROB_FINITE]
+ >> ASM_SIMP_TAC std_ss [Once add_comm]
+ >> `A1 INTER A2 IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `cond_prob p (A1 INTER A2) B <> PosInf /\
+     cond_prob p (A1 INTER A2) B <> NegInf` by METIS_TAC [COND_PROB_FINITE]
+ >> Know `cond_prob p A2 B + cond_prob p A1 B - cond_prob p (A1 INTER A2) B =
+          cond_prob p A2 B + (cond_prob p A1 B - cond_prob p (A1 INTER A2) B)`
+ >- (`?a. cond_prob p A2 B = Normal a` by METIS_TAC [extreal_cases] >> POP_ORW \\
+     `?b. cond_prob p A1 B = Normal b` by METIS_TAC [extreal_cases] >> POP_ORW \\
+     `?c. cond_prob p (A1 INTER A2) B = Normal c` by METIS_TAC [extreal_cases] \\
+     POP_ORW >> SIMP_TAC real_ss [extreal_add_def, extreal_sub_def, extreal_11] \\
+     REAL_ARITH_TAC) >> Rewr'
+ >> `cond_prob p A1 B - cond_prob p (A1 INTER A2) B = cond_prob p (A1 DIFF A2) B`
+        by PROVE_TAC [COND_PROB_DIFF] >> POP_ORW
+ >> `prob p B <> PosInf /\ prob p B <> NegInf` by METIS_TAC [PROB_FINITE]
+ >> `prob p B < PosInf` by METIS_TAC [lt_infty]
+ >> `0 < prob p B` by METIS_TAC [le_lt, PROB_POSITIVE]
+ >> ASM_SIMP_TAC std_ss [cond_prob_def, ldiv_eq]
+ >> Know `(prob p (A2 INTER B) / prob p B +
+           prob p ((A1 DIFF A2) INTER B) / prob p B) * prob p B =
+           prob p (A2 INTER B) / prob p B * prob p B +
+           prob p ((A1 DIFF A2) INTER B) / prob p B * prob p B`
+ >- (`?r. prob p B = Normal r` by METIS_TAC [extreal_cases] >> art [] \\
+     MATCH_MP_TAC add_rdistrib_normal >> DISJ1_TAC \\
+     POP_ASSUM (ONCE_REWRITE_TAC o wrap o SYM) \\
+     REWRITE_TAC [GSYM cond_prob_def] >> art [] \\
+    `A1 DIFF A2 IN events p` by METIS_TAC [EVENTS_DIFF] \\
+     METIS_TAC [COND_PROB_FINITE]) >> Rewr'
+ >> Know `prob p (A2 INTER B) / prob p B * prob p B = prob p (A2 INTER B)`
+ >- (MATCH_MP_TAC EQ_SYM \\
+    `?b. prob p B = Normal b` by METIS_TAC [extreal_cases] \\
+    `b <> 0` by METIS_TAC [extreal_of_num_def, extreal_11] >> art [] \\
+     MATCH_MP_TAC div_mul_refl >> art []) >> Rewr'
+ >> Know `prob p ((A1 DIFF A2) INTER B) / prob p B * prob p B =
+          prob p ((A1 DIFF A2) INTER B)`
+ >- (MATCH_MP_TAC EQ_SYM \\
+    `?b. prob p B = Normal b` by METIS_TAC [extreal_cases] \\
+    `b <> 0` by METIS_TAC [extreal_of_num_def, extreal_11] >> art [] \\
+     MATCH_MP_TAC div_mul_refl >> art []) >> Rewr'
+ >> `(A1 UNION A2) INTER B IN events p` by METIS_TAC [EVENTS_UNION, EVENTS_INTER]
+ >> `A2 INTER B IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `(A1 DIFF A2) INTER B IN events p` by METIS_TAC [EVENTS_INTER, EVENTS_DIFF]
+ >> `prob p (A2 INTER B) + prob p ((A1 DIFF A2) INTER B) =
+       prob p ((A2 INTER B) UNION ((A1 DIFF A2) INTER B))`
+       by (ONCE_REWRITE_TAC [EQ_SYM_EQ] >> MATCH_MP_TAC PROB_ADDITIVE
+          >> RW_TAC std_ss [EVENTS_INTER, EVENTS_DIFF, DISJOINT_DEF, EXTENSION]
+          >> RW_TAC std_ss [IN_INTER, IN_DIFF, NOT_IN_EMPTY] >> PROVE_TAC [])
+ >> `(A2 INTER B UNION (A1 DIFF A2) INTER B) = ((A1 UNION A2) INTER B)`
+        by (RW_TAC std_ss [EXTENSION, IN_INTER, IN_DIFF, IN_UNION] THEN PROVE_TAC [])
+ >> RW_TAC std_ss []
+QED
+
+val INSERT_THM1 = prove (``!(x:'a) s. x IN (x INSERT s)``,
+    RW_TAC std_ss [IN_INSERT]);
+
+val INSERT_THM2 = prove (``!(x:'a) y s. x IN s ==> x IN (y INSERT s)``,
+    RW_TAC std_ss [IN_INSERT]);
+
+Theorem PROB_FINITE_ADDITIVE :
+    !p s f t. prob_space p /\ FINITE s /\ (!x. x IN s ==> f x IN events p) /\
+             (!a b. (a:'b) IN s /\ b IN s /\ ~(a = b) ==> DISJOINT (f a) (f b)) /\
+             (t = BIGUNION (IMAGE f s)) ==> (prob p t = SIGMA (prob p o f) s)
+Proof
+    Suff `!s. FINITE (s:'b -> bool) ==>
+        ((\s. !p f t. prob_space p  /\ (!x. x IN s ==> f x IN events p) /\
+        (!a b. a IN s /\ b IN s /\ a <> b ==> DISJOINT (f a) (f b)) /\
+        (t = BIGUNION (IMAGE f s)) ==> (prob p t = SIGMA (prob p o f) s)) s)` >- METIS_TAC []
+ >> MATCH_MP_TAC FINITE_INDUCT >> RW_TAC std_ss [IMAGE_EMPTY]
+ >- RW_TAC std_ss [EXTREAL_SUM_IMAGE_EMPTY, BIGUNION_EMPTY, PROB_EMPTY]
+ >> Know `SIGMA (prob p o f) ((e:'b) INSERT s) =
+                (prob p o f) e + SIGMA (prob p o f) (s DELETE e)`
+ >- (irule EXTREAL_SUM_IMAGE_PROPERTY >> art [] \\
+     DISJ1_TAC >> GEN_TAC >> DISCH_TAC \\
+     SIMP_TAC std_ss [o_DEF] >> METIS_TAC [PROB_FINITE])
+ >> `s DELETE (e:'b) = s` by FULL_SIMP_TAC std_ss [DELETE_NON_ELEMENT]
+ >> RW_TAC std_ss [IMAGE_INSERT, BIGUNION_INSERT]
+ >> Know `DISJOINT (f e) (BIGUNION (IMAGE f s))`
+ >- (RW_TAC set_ss [DISJOINT_BIGUNION, IN_IMAGE] \\
+    `e IN e INSERT s` by FULL_SIMP_TAC std_ss [INSERT_THM1] \\
+    `x IN e INSERT s` by FULL_SIMP_TAC std_ss [INSERT_THM2] \\
+    `e <> x` by METIS_TAC [] \\
+     FULL_SIMP_TAC std_ss []) >> DISCH_TAC
+ >> `(f e) IN events p` by FULL_SIMP_TAC std_ss [IN_FUNSET, INSERT_THM1]
+ >> `BIGUNION (IMAGE f s) IN events p`
+        by (MATCH_MP_TAC EVENTS_COUNTABLE_UNION >> RW_TAC std_ss []
+           >- (RW_TAC std_ss [SUBSET_DEF,IN_IMAGE] THEN METIS_TAC [IN_INSERT])
+           >> MATCH_MP_TAC COUNTABLE_IMAGE >> RW_TAC std_ss [FINITE_COUNTABLE])
+ >> `(prob p (f e UNION BIGUNION (IMAGE f s))) = prob p (f e) + prob p (BIGUNION (IMAGE f s))`
+        by (MATCH_MP_TAC PROB_ADDITIVE >> FULL_SIMP_TAC std_ss [])
+ >> RW_TAC std_ss [INSERT_THM1, INSERT_THM2]
+QED
+
+val INTER_BIGUNION = prove (
+  ``(!s t. BIGUNION s INTER t = BIGUNION {x INTER t | x IN s}) /\
+    (!s t. t INTER BIGUNION s = BIGUNION {t INTER x | x IN s})``,
+    ONCE_REWRITE_TAC [EXTENSION]
+ >> SIMP_TAC std_ss [IN_BIGUNION, GSPECIFICATION, IN_INTER]
+ >> MESON_TAC [IN_INTER]);
+
+Theorem COND_PROB_FINITE_ADDITIVE :
+    !p A B n s. prob_space p /\ B IN events p /\ A IN ((count n) -> events p) /\
+                (s = BIGUNION (IMAGE A (count n))) /\ prob p B <> 0 /\
+                (!a b. a <> b ==> DISJOINT (A a) (A b)) ==>
+                (cond_prob p s B = SIGMA (\i. cond_prob p (A i) B) (count n))
+Proof
+    RW_TAC std_ss [IN_FUNSET, IN_COUNT]
+ >> `0 <= prob p (B:'a -> bool)` by RW_TAC std_ss [PROB_POSITIVE]
+ >> `BIGUNION (IMAGE A (count n)) IN events p` by METIS_TAC [EVENTS_BIGUNION, IN_FUNSET, IN_COUNT]
+ >> `prob p B <> PosInf /\ prob p B <> NegInf` by METIS_TAC [PROB_FINITE]
+ >> `prob p B < PosInf` by METIS_TAC [lt_infty]
+ >> `0 < prob p B` by METIS_TAC [le_lt, PROB_POSITIVE]
+ >> GEN_REWRITE_TAC (RATOR_CONV o ONCE_DEPTH_CONV) empty_rewrites [cond_prob_def]
+ >> ASM_SIMP_TAC std_ss [ldiv_eq, Once mul_comm]
+ >> Know `prob p B * SIGMA (\i. cond_prob p (A i) B) (count n) =
+          SIGMA (\i. prob p B * (\i. cond_prob p (A i) B) i) (count n)`
+ >- (`?r. prob p B = Normal r` by METIS_TAC [extreal_cases] >> POP_ORW \\
+     MATCH_MP_TAC EQ_SYM >> irule EXTREAL_SUM_IMAGE_CMUL \\
+     REWRITE_TAC [FINITE_COUNT] >> DISJ1_TAC \\
+     RW_TAC std_ss [IN_COUNT] >> METIS_TAC [COND_PROB_FINITE])
+ >> BETA_TAC >> Rewr'
+ >> REWRITE_TAC [cond_prob_def, Once mul_comm]
+ >> Know `!i. prob p (A i INTER B) / prob p B * prob p B = prob p (A i INTER B)`
+ >- (GEN_TAC >> MATCH_MP_TAC EQ_SYM \\
+    `?b. prob p B = Normal b` by METIS_TAC [extreal_cases] \\
+    `b <> 0` by METIS_TAC [extreal_of_num_def, extreal_11] >> art [] \\
+     MATCH_MP_TAC div_mul_refl >> art []) >> Rewr'
+ >> `SIGMA (\i. prob p (A i INTER B)) (count n) = SIGMA (prob p o (\i. A i INTER B)) (count n)`
+        by METIS_TAC [] >> POP_ORW
+ >> Know `BIGUNION (IMAGE A (count n)) INTER B = BIGUNION (IMAGE (\i. A i INTER B) (count n))`
+ >- (RW_TAC set_ss [INTER_COMM, INTER_BIGUNION, Once EXTENSION, IN_IMAGE] \\
+     EQ_TAC >> rpt STRIP_TAC >| (* 3 subgoals *)
+     [ (* goal 1 (of 3) *)
+       rename1 `s = A i` >> Q.EXISTS_TAC `B INTER (A i)` \\
+       Reverse CONJ_TAC >- (Q.EXISTS_TAC `i` >> art []) \\
+       METIS_TAC [IN_INTER],
+       (* goal 2 (of 3) *)
+       fs [IN_INTER] >> Q.EXISTS_TAC `A i` >> art [] \\
+       Q.EXISTS_TAC `i` >> art [],
+       (* goal 3 (of 3) *)
+       fs [IN_INTER] ]) >> Rewr'
+ >> MATCH_MP_TAC PROB_FINITELY_ADDITIVE
+ >> RW_TAC std_ss [IN_FUNSET, IN_COUNT]
+ >- METIS_TAC [EVENTS_INTER]
+ >> MATCH_MP_TAC DISJOINT_RESTRICT_L
+ >> PROVE_TAC []
+QED
+
+Theorem BAYES_RULE :
+    !p A B. prob_space p /\ A IN events p /\ B IN events p /\
+            prob p A <> 0 /\ prob p B <> 0 ==>
+           (cond_prob p B A = (cond_prob p A B) * (prob p B) / (prob p A))
+Proof
+    RW_TAC std_ss []
+ >> `prob p A <> PosInf /\ prob p A <> NegInf` by METIS_TAC [PROB_FINITE]
+ >> `prob p A < PosInf` by METIS_TAC [lt_infty]
+ >> `0 < prob p A` by METIS_TAC [le_lt, PROB_POSITIVE]
+ >> `prob p B <> PosInf /\ prob p B <> NegInf` by METIS_TAC [PROB_FINITE]
+ >> `prob p B < PosInf` by METIS_TAC [lt_infty]
+ >> `0 < prob p B` by METIS_TAC [le_lt, PROB_POSITIVE]
+ >> GEN_REWRITE_TAC (RATOR_CONV o ONCE_DEPTH_CONV) empty_rewrites [cond_prob_def]
+ >> ASM_SIMP_TAC std_ss [ldiv_eq]
+ >> Know `cond_prob p A B * prob p B / prob p A * prob p A =
+          cond_prob p A B * prob p B`
+ >- (MATCH_MP_TAC EQ_SYM \\
+    `?a. prob p A = Normal a` by METIS_TAC [extreal_cases] \\
+    `a <> 0` by METIS_TAC [extreal_of_num_def, extreal_11] >> art [] \\
+     MATCH_MP_TAC div_mul_refl >> art []) >> Rewr'
+ >> REWRITE_TAC [cond_prob_def]
+ >> Know `prob p (A INTER B) / prob p B * prob p B = prob p (A INTER B)`
+ >- (MATCH_MP_TAC EQ_SYM \\
+    `?b. prob p B = Normal b` by METIS_TAC [extreal_cases] \\
+    `b <> 0` by METIS_TAC [extreal_of_num_def, extreal_11] >> art [] \\
+     MATCH_MP_TAC div_mul_refl >> art []) >> Rewr'
+ >> REWRITE_TAC [Once INTER_COMM]
+QED
+
+Theorem TOTAL_PROB_SIGMA :
+    !p A B s. prob_space p /\ A IN events p /\ FINITE s /\
+             (!x. x IN s ==> B x IN events p /\ prob p (B x) <> 0) /\
+             (!a b. a IN s /\ b IN s /\ ~(a = b) ==> DISJOINT (B a) (B b)) /\
+             (BIGUNION (IMAGE B s) = p_space p) ==>
+             (prob p A = SIGMA (\i. (prob p (B i)) * (cond_prob p A (B i))) s)
+Proof
+    RW_TAC std_ss []
+ >> `!x. x IN s ==> prob p (B x) <> PosInf /\
+                    prob p (B x) <> NegInf` by METIS_TAC [PROB_FINITE]
+ >> `!x. x IN s ==> prob p (B x) < PosInf` by METIS_TAC [lt_infty]
+ >> `!x. x IN s ==> 0 < prob p (B x)` by METIS_TAC [le_lt, PROB_POSITIVE]
+ >> Know `SIGMA (\i. prob p (B i) * cond_prob p A (B i)) (s:'b -> bool) =
+          SIGMA (\i. prob p (A INTER (B i))) s`
+ >- (irule EXTREAL_SUM_IMAGE_EQ \\
+     STRONG_CONJ_TAC
+     >- (RW_TAC std_ss [cond_prob_def, Once mul_comm] \\
+         MATCH_MP_TAC EQ_SYM \\
+        `?b. prob p (B x) = Normal b` by METIS_TAC [extreal_cases] \\
+        `b <> 0` by METIS_TAC [extreal_of_num_def, extreal_11] >> art [] \\
+         MATCH_MP_TAC div_mul_refl >> art []) \\
+     RW_TAC std_ss [] >> DISJ1_TAC >> GEN_TAC >> DISCH_TAC \\
+    `A INTER B x IN events p` by METIS_TAC [EVENTS_INTER] \\
+     METIS_TAC [PROB_FINITE]) >> Rewr'
+ >> MATCH_MP_TAC PROB_EXTREAL_SUM_IMAGE_FN
+ >> RW_TAC std_ss [EVENTS_INTER, INTER_IDEMPOT]
+QED
+
+Theorem BAYES_RULE_GENERAL_SIGMA :
+    !p A B s k. prob_space p /\ A IN events p /\ prob p A <> 0 /\ FINITE s /\
+        (!x . x IN s ==> B x IN events p /\ prob p (B x) <> 0) /\
+         k IN s /\ (!a b. a IN s /\ b IN s /\ ~(a = b) ==> DISJOINT (B a) (B b)) /\
+        (BIGUNION (IMAGE B s) = p_space p) ==>
+        (cond_prob p (B k) A = ((cond_prob p A (B k)) * prob p (B k)) /
+                                (SIGMA (\i. (prob p (B i)) * (cond_prob p A (B i)))) s)
+Proof
+    RW_TAC std_ss [GSYM TOTAL_PROB_SIGMA]
+ >> MATCH_MP_TAC BAYES_RULE
+ >> RW_TAC std_ss []
+QED
+
+Theorem COND_PROB_ADDITIVE :
+    !p A B s. prob_space p /\ FINITE s /\ B IN events p /\
+             (!x. x IN s ==> A x IN events p) /\ prob p B <> 0 /\
+             (!x y. x IN s /\ y IN s /\ x <> y ==> DISJOINT (A x) (A y)) /\
+             (BIGUNION (IMAGE A s) = p_space p) ==>
+             (SIGMA (\i. cond_prob p (A i) B) s = 1)
+Proof
+    RW_TAC std_ss []
+ >> `prob p B <> PosInf /\ prob p B <> NegInf` by METIS_TAC [PROB_FINITE]
+ >> `prob p B < PosInf` by METIS_TAC [lt_infty]
+ >> `0 < prob p B` by METIS_TAC [le_lt, PROB_POSITIVE]
+ >> `(SIGMA (\i. cond_prob p (A i) B) (s:'b -> bool) = 1) <=>
+          (prob p B * SIGMA (\i. cond_prob p (A i) B) s = prob p B * 1)`
+     by METIS_TAC [mul_lcancel] >> POP_ORW
+ >> Know `prob p B * SIGMA (\i. cond_prob p (A i) B) (s:'b -> bool) =
+          SIGMA (\i. prob p B * (\i. cond_prob p (A i) B) i) s`
+ >- (`?r. prob p B = Normal r` by METIS_TAC [extreal_cases] >> POP_ORW \\
+     MATCH_MP_TAC EQ_SYM >> irule EXTREAL_SUM_IMAGE_CMUL \\
+     RW_TAC std_ss [COND_PROB_FINITE]) >> BETA_TAC >> Rewr'
+ >> RW_TAC std_ss [cond_prob_def, Once mul_comm]
+ >> Know `!i. prob p (A i INTER B) / prob p B * prob p B = prob p (A i INTER B)`
+ >- (GEN_TAC >> MATCH_MP_TAC EQ_SYM \\
+    `?b. prob p B = Normal b` by METIS_TAC [extreal_cases] \\
+    `b <> 0` by METIS_TAC [extreal_of_num_def, extreal_11] >> art [] \\
+     MATCH_MP_TAC div_mul_refl >> art []) >> Rewr'
+ >> REWRITE_TAC [mul_rone, Once EQ_SYM_EQ, Once INTER_COMM]
+ >> MATCH_MP_TAC PROB_EXTREAL_SUM_IMAGE_FN
+ >> RW_TAC std_ss [INTER_IDEMPOT, EVENTS_INTER]
+QED
+
+Theorem COND_PROB_SWAP :
+    !p A B C.
+       prob_space p /\ A IN events p /\ B IN events p /\ C IN events p /\
+       prob p (B INTER C) <> 0 /\ prob p (A INTER C) <> 0 ==>
+      (cond_prob p A (B INTER C) * cond_prob p B C =
+       cond_prob p B (A INTER C) * cond_prob p A C)
+Proof
+    RW_TAC std_ss []
+ >> `B INTER C IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `A INTER B IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `A INTER C IN events p` by METIS_TAC [EVENTS_INTER]
+ >> Know `prob p C <> 0`
+ >- (CCONTR_TAC >> fs [] \\
+    `0 < prob p (B INTER C)` by METIS_TAC [PROB_POSITIVE, le_lt] \\
+     Know `prob p (B INTER C) <= prob p C`
+     >- (MATCH_MP_TAC PROB_INCREASING >> ASM_SET_TAC [EVENTS_INTER]) \\
+     DISCH_TAC >> METIS_TAC [lte_trans, lt_refl]) >> DISCH_TAC
+ >> RW_TAC std_ss [cond_prob_def]
+ >> `A INTER (B INTER C) = B INTER (A INTER C)`
+       by METIS_TAC [GSYM INTER_ASSOC, INTER_COMM] >> POP_ORW
+ >> `B INTER (A INTER C) IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `?a. prob p (B INTER (A INTER C)) = Normal a` by METIS_TAC [PROB_FINITE, extreal_cases]
+ >> `?b. prob p (B INTER C) = Normal b` by METIS_TAC [PROB_FINITE, extreal_cases]
+ >> `?c. prob p (A INTER C) = Normal c` by METIS_TAC [PROB_FINITE, extreal_cases]
+ >> `?d. prob p C = Normal d` by METIS_TAC [PROB_FINITE, extreal_cases]
+ >> `b <> 0 /\ c <> 0 /\ d <> 0` by METIS_TAC [extreal_of_num_def, extreal_11]
+ >> ASM_SIMP_TAC std_ss [extreal_mul_def, extreal_div_eq, extreal_11]
+ >> `!(a:real) b c d. a * b * (c * d) = a * (b * c) * d` by METIS_TAC [REAL_MUL_ASSOC]
+ >> RW_TAC std_ss [real_div, REAL_MUL_LINV, REAL_MUL_LID, REAL_MUL_RID]
+QED
+
+Theorem PROB_INTER_SPLIT :
+    !p A B C.
+       prob_space p /\ A IN events p /\ B IN events p /\ C IN events p /\
+       prob p (B INTER C) <> 0 ==>
+      (prob p (A INTER B INTER C) =
+       cond_prob p A (B INTER C) * cond_prob p B C * prob p C)
+Proof
+    RW_TAC std_ss []
+ >> `B INTER C IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `A INTER B IN events p` by METIS_TAC [EVENTS_INTER]
+ >> Know `prob p C <> 0`
+ >- (CCONTR_TAC >> fs [] \\
+    `0 < prob p (B INTER C)` by METIS_TAC [PROB_POSITIVE, le_lt] \\
+     Know `prob p (B INTER C) <= prob p C`
+     >- (MATCH_MP_TAC PROB_INCREASING >> ASM_SET_TAC [EVENTS_INTER]) \\
+     DISCH_TAC >> METIS_TAC [lte_trans, lt_refl]) >> DISCH_TAC
+ >> RW_TAC std_ss [cond_prob_def]
+ >> `A INTER (B INTER C) = A INTER B INTER C` by SET_TAC [] >> POP_ORW
+ >> `A INTER B INTER C IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `?a. prob p (A INTER B INTER C) = Normal a` by METIS_TAC [PROB_FINITE, extreal_cases]
+ >> `?b. prob p (B INTER C) = Normal b` by METIS_TAC [PROB_FINITE, extreal_cases]
+ >> `?c. prob p C = Normal c` by METIS_TAC [PROB_FINITE, extreal_cases]
+ >> `b <> 0 /\ c <> 0` by METIS_TAC [extreal_of_num_def, extreal_11]
+ >> ASM_SIMP_TAC std_ss [extreal_mul_def, extreal_div_eq, extreal_11]
+ >> `!(a:real) b c d e. a * b * (c * d) * e = a * (b * c) * (d * e)` by METIS_TAC [REAL_MUL_ASSOC]
+ >> RW_TAC std_ss [real_div, REAL_MUL_LINV, REAL_MUL_LID, REAL_MUL_RID]
+QED
+
+Theorem COND_PROB_INTER_SPLIT :
+    !p A B C.
+        prob_space p /\ A IN events p /\ B IN events p /\ C IN events p /\
+        prob p (B INTER C) <> 0 ==>
+        (cond_prob p (A INTER B) C = cond_prob p A (B INTER C) * cond_prob p B C)
+Proof
+    RW_TAC std_ss []
+ >> `B INTER C IN events p` by METIS_TAC [EVENTS_INTER]
+ >> Know `prob p C <> 0`
+ >- (CCONTR_TAC >> fs [] \\
+    `0 < prob p (B INTER C)` by METIS_TAC [PROB_POSITIVE, le_lt] \\
+     Know `prob p (B INTER C) <= prob p C`
+     >- (MATCH_MP_TAC PROB_INCREASING >> ASM_SET_TAC [EVENTS_INTER]) \\
+     DISCH_TAC >> METIS_TAC [lte_trans, lt_refl]) >> DISCH_TAC
+ >> RW_TAC std_ss [cond_prob_def]
+ >> `A INTER (B INTER C) = A INTER B INTER C` by SET_TAC [] >> POP_ORW
+ >> `A INTER B INTER C IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `?a. prob p (A INTER B INTER C) = Normal a` by METIS_TAC [PROB_FINITE, extreal_cases]
+ >> `?b. prob p (B INTER C) = Normal b` by METIS_TAC [PROB_FINITE, extreal_cases]
+ >> `?c. prob p C = Normal c` by METIS_TAC [PROB_FINITE, extreal_cases]
+ >> `b <> 0 /\ c <> 0` by METIS_TAC [extreal_of_num_def, extreal_11]
+ >> ASM_SIMP_TAC std_ss [extreal_mul_def, extreal_div_eq, extreal_11]
+ >> `!(x:real) y z w. x * y * (z * w) = x * (y * z) * w`
+        by METIS_TAC [REAL_MUL_ASSOC, REAL_MUL_COMM]
+ >> RW_TAC std_ss [real_div, REAL_MUL_LINV, REAL_MUL_RID]
+QED
 
 val _ = export_theory ();
 

--- a/src/probability/real_probabilityScript.sml
+++ b/src/probability/real_probabilityScript.sml
@@ -1,17 +1,31 @@
 (* ------------------------------------------------------------------------- *)
-(* The old Probability Theory based on [0, PosInf) old_measureTheory         *)
+(* The old Probability Theory based on [0, PosInf) real_measureTheory        *)
 (* Authors: Tarek Mhamdi, Osman Hasan, Sofiene Tahar                         *)
 (* HVG Group, Concordia University, Montreal                                 *)
 (* ------------------------------------------------------------------------- *)
 (* Based on the work of Aaron Coble (and Joe Hurd), Cambridge University     *)
 (* ------------------------------------------------------------------------- *)
+(*                                                                           *)
+(*                      Condition Probability Library                        *)
+(*                                                                           *)
+(*                   (c) Copyright, Liya Liu, 2012                           *)
+(*                       Hardware Verification Group,                        *)
+(*                       Concordia University                                *)
+(*                                                                           *)
+(* ========================================================================= *)
 
-open HolKernel Parse boolLib bossLib arithmeticTheory realTheory prim_recTheory
-     seqTheory pred_setTheory res_quanTheory res_quanTools listTheory
-     rich_listTheory pairTheory combinTheory realLib optionTheory transcTheory
-     real_sigmaTheory hurdUtils;
+open HolKernel Parse boolLib bossLib;
+
+open arithmeticTheory prim_recTheory seqTheory res_quanTheory res_quanTools
+     listTheory rich_listTheory pairTheory combinTheory realTheory realLib
+     optionTheory transcTheory real_sigmaTheory pred_setTheory pred_setLib
+     mesonLib hurdUtils;
 
 open util_probTheory sigma_algebraTheory real_measureTheory real_lebesgueTheory;
+
+val COUNTABLE_IMAGE = image_countable;
+val FINITE_COUNTABLE = finite_countable;
+val set_ss = std_ss ++ PRED_SET_ss;
 
 val _ = new_theory "real_probability";
 
@@ -84,6 +98,9 @@ val conditional_expectation_def = Define
 
 val conditional_prob_def = Define
    `conditional_prob p e1 e2 = conditional_expectation p (indicator_fn e1) e2`;
+
+val cond_prob_def = Define
+   `cond_prob p e1 e2 = (prob p (e1 INTER e2)) / (prob p e2)`;
 
 val rv_conditional_expectation_def = Define
    `rv_conditional_expectation p s X Y =
@@ -1338,5 +1355,412 @@ Proof
  >> Suff `(\x. (f x) * distribution p X {x}) = (\x. distribution p X {x} * (f x))`
  >- RW_TAC std_ss []
  >> RW_TAC std_ss [FUN_EQ_THM, REAL_MUL_COMM]);
+
+(* ========================================================================= *)
+(*                      Condition Probability Library                        *)
+(* ========================================================================= *)
+
+val INTER_ASSOC' = GSYM INTER_ASSOC;
+
+val EVENTS_BIGUNION = store_thm
+  ("EVENTS_BIGUNION",
+  ``!p f n. prob_space p /\ (f IN ((count n) -> events p)) ==>
+    BIGUNION (IMAGE f (count n)) IN events p``,
+    RW_TAC std_ss [IN_FUNSET, IN_COUNT]
+ >> `BIGUNION (IMAGE f (count n)) = BIGUNION (IMAGE (\m. (if m < n then f m else {})) UNIV)`
+     by (RW_TAC std_ss [EXTENSION,IN_BIGUNION_IMAGE, IN_COUNT, IN_UNIV] >> METIS_TAC [NOT_IN_EMPTY])
+ >> POP_ORW
+ >> (MATCH_MP_TAC o REWRITE_RULE [subsets_def, space_def] o
+        Q.SPECL [`(p_space p, events p)`,`(\m. if m < n then A m else {})`]) SIGMA_ALGEBRA_ENUM
+ >> RW_TAC std_ss [EVENTS_SIGMA_ALGEBRA] >> RW_TAC std_ss [IN_FUNSET, IN_UNIV, DISJOINT_EMPTY]
+ >> METIS_TAC [EVENTS_EMPTY]);
+
+val PROB_INTER_ZERO = store_thm(
+   "PROB_INTER_ZERO",
+   ``!p A B.
+       (prob_space p) /\ (A IN events p) /\ (B IN events p) /\ (prob p B = 0) ==>
+         (prob p (A INTER B) = 0)``,
+       RW_TAC std_ss [] THEN POP_ASSUM (MP_TAC o SYM) THEN RW_TAC std_ss [] THEN
+       `(A INTER B) SUBSET B` by RW_TAC std_ss [INTER_SUBSET] THEN
+       `prob p (A INTER B) <= prob p B` by FULL_SIMP_TAC std_ss [PROB_INCREASING, EVENTS_INTER] THEN
+       `0 <= prob p (A INTER B)` by FULL_SIMP_TAC std_ss [PROB_POSITIVE, EVENTS_INTER] THEN
+       METIS_TAC [REAL_LE_ANTISYM]);
+
+val PROB_ZERO_INTER = store_thm
+  ("PROB_ZERO_INTER",
+   ``!p A B.
+       (prob_space p) /\ (A IN events p) /\ (B IN events p) /\ (prob p A = 0) ==>
+         (prob p (A INTER B) = 0)``,
+       RW_TAC std_ss [] >> (MP_TAC o Q.SPECL [`p`, `B`, `A`]) PROB_INTER_ZERO
+  >> RW_TAC std_ss [INTER_COMM]);
+
+val COND_PROB_ZERO = store_thm
+  ("COND_PROB_ZERO",
+   ``!p A B. prob_space p /\ A IN events p /\ B IN events p /\ (prob p B = 0) ==>
+     (cond_prob p A B = 0)``,
+     RW_TAC std_ss [cond_prob_def, PROB_INTER_ZERO, REAL_DIV_LZERO]);
+
+val COND_PROB_INTER_ZERO = store_thm
+  ("COND_PROB_INTER_ZERO",
+   ``!p A B. prob_space p /\ A IN events p /\ B IN events p /\ (prob p A = 0) ==>
+     (cond_prob p A B = 0)``,
+     RW_TAC std_ss [cond_prob_def] THEN
+     `prob p (A INTER B) = 0 ` by METIS_TAC [PROB_INTER_ZERO, INTER_COMM] THEN
+     RW_TAC std_ss [REAL_DIV_LZERO]);
+
+val COND_PROB_ZERO_INTER = store_thm
+  ("COND_PROB_ZERO_INTER",
+   ``!p A B. prob_space p /\ A IN events p /\ B IN events p /\ (prob p (A INTER B) = 0) ==>
+     (cond_prob p A B = 0)``,
+     RW_TAC std_ss [cond_prob_def, REAL_DIV_LZERO]);
+
+val COND_PROB_INCREASING = store_thm
+  ("COND_PROB_INCREASING",
+  ``!A B C p. prob_space p /\ A IN events p /\ B IN events p /\ C IN events p ==>
+   cond_prob p (A INTER B) C <= cond_prob p A C``,
+    RW_TAC std_ss []
+ >> Cases_on `prob p C = 0`
+ >- METIS_TAC [EVENTS_INTER, COND_PROB_ZERO, REAL_LE_REFL]
+ >> RW_TAC std_ss [cond_prob_def, real_div]
+ >> `(A INTER B INTER C) SUBSET (A INTER C)` by SET_TAC []
+ >> METIS_TAC [PROB_POSITIVE, REAL_LT_LE, REAL_INV_POS, PROB_INCREASING,
+    EVENTS_INTER, REAL_LE_RMUL]);
+
+val POS_COND_PROB_IMP_POS_PROB = store_thm
+  ("POS_COND_PROB_IMP_POS_PROB",
+  ``!A B p. prob_space p /\ A IN events p /\ B IN events p /\
+          (0 < cond_prob p A B) ==> (prob p (A INTER B) <> 0)``,
+    RW_TAC std_ss []
+ >> `0 <= prob p B` by RW_TAC std_ss [PROB_POSITIVE]
+ >> `prob p B <> 0` by (SPOSE_NOT_THEN STRIP_ASSUME_TAC
+         >> `cond_prob p A B = 0` by METIS_TAC [COND_PROB_ZERO]
+         >> METIS_TAC [REAL_LT_IMP_NE])
+ >> FULL_SIMP_TAC std_ss [cond_prob_def]
+ >> `0 / prob p B = 0` by METIS_TAC [REAL_DIV_LZERO]
+ >> METIS_TAC [REAL_LT_IMP_NE]);
+
+val COND_PROB_BOUNDS = store_thm
+    ("COND_PROB_BOUNDS",
+    ``!p A B. prob_space p /\ A IN events p /\ B IN events p ==>
+        0 <= cond_prob p A B /\ cond_prob p A B <= 1``,
+     RW_TAC std_ss []
+  >- METIS_TAC [cond_prob_def, EVENTS_INTER, PROB_POSITIVE, REAL_LE_DIV]
+  >> Cases_on `prob p B = 0` >- METIS_TAC [COND_PROB_ZERO, REAL_LE_01]
+  >> `0 < prob p B` by METIS_TAC [PROB_POSITIVE, REAL_LT_LE]
+  >> `(cond_prob p A B <= 1) = (cond_prob p A B * prob p B <= 1 * prob p B)`
+          by RW_TAC std_ss [REAL_LE_RMUL] >> POP_ORW
+  >> RW_TAC std_ss [REAL_MUL_LID, cond_prob_def, REAL_DIV_RMUL]
+  >> `(A INTER B) SUBSET B` by RW_TAC std_ss [INTER_SUBSET]
+  >> FULL_SIMP_TAC std_ss [PROB_INCREASING, EVENTS_INTER]);
+
+val COND_PROB_ITSELF = store_thm
+  ("COND_PROB_ITSELF",
+  ``!p B. (prob_space p) /\(B IN events p) /\ (0 < prob p B) ==>
+            ((cond_prob p B B = 1))``,
+        RW_TAC real_ss [cond_prob_def, INTER_IDEMPOT]
+ >> `prob p B <> 0` by METIS_TAC [REAL_NEG_NZ]
+ >> METIS_TAC [REAL_DIV_REFL]);
+
+val COND_PROB_COMPL = store_thm
+  ("COND_PROB_COMPL",
+  ``!A B p . (prob_space p) /\ (A IN events p) /\ (COMPL A IN events p) /\
+               (B IN events p) /\ (0 < (prob p B)) ==>
+        (cond_prob p (COMPL A) B = 1 - cond_prob p A B)``,
+    RW_TAC std_ss [cond_prob_def]
+ >> `prob p B <> 0` by METIS_TAC [REAL_NEG_NZ]
+ >> `(prob p (COMPL A INTER B) / prob p B = 1 - prob p (A INTER B) / prob p B) =
+     (prob p (COMPL A INTER B) / prob p B * prob p B = (1 - prob p (A INTER B) / prob p B) * prob p B)`
+     by METIS_TAC [REAL_EQ_RMUL] >> POP_ORW
+ >> RW_TAC std_ss [REAL_DIV_RMUL, REAL_SUB_RDISTRIB, REAL_MUL_LID, REAL_EQ_SUB_LADD]
+ >> `prob p ((COMPL A) INTER B) + prob p (A INTER B) =
+       prob p (((COMPL A) INTER B) UNION (A INTER B))`
+       by (ONCE_REWRITE_TAC [EQ_SYM_EQ] >> MATCH_MP_TAC PROB_ADDITIVE
+          >> RW_TAC std_ss [EVENTS_INTER, DISJOINT_DEF, EXTENSION]
+          >> RW_TAC std_ss [NOT_IN_EMPTY, IN_COMPL, IN_INTER] >> METIS_TAC []) >> POP_ORW
+ >> `(COMPL A INTER B UNION A INTER B) = B`
+        by (SET_TAC [EXTENSION, IN_INTER, IN_UNION, IN_COMPL] >> METIS_TAC [])
+ >> RW_TAC std_ss []);
+
+val COND_PROB_DIFF = store_thm
+  ("COND_PROB_DIFF",
+  ``!p A1 A2 B. prob_space p /\ A1 IN events p /\ A2 IN events p /\ B IN events p ==>
+        (cond_prob p (A1 DIFF A2) B =
+         cond_prob p A1 B - cond_prob p (A1 INTER A2) B)``,
+    RW_TAC std_ss []
+ >> Cases_on `prob p B = 0`
+ >- RW_TAC std_ss [COND_PROB_ZERO, REAL_SUB_RZERO, EVENTS_INTER, EVENTS_DIFF]
+ >> RW_TAC std_ss [cond_prob_def]
+ >> `(A1 DIFF A2) INTER B IN events p` by METIS_TAC [EVENTS_INTER, EVENTS_DIFF]
+ >> `(prob p ((A1 DIFF A2) INTER B) / prob p B =
+    prob p (A1 INTER B) / prob p B - prob p (A1 INTER A2 INTER B) / prob p B) =
+    (prob p ((A1 DIFF A2) INTER B) / prob p B * prob p B =
+    (prob p (A1 INTER B) / prob p B - prob p (A1 INTER A2 INTER B) / prob p B) * prob p B)`
+    by METIS_TAC [REAL_EQ_RMUL] >> POP_ORW
+ >> `A1 INTER B IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `A1 INTER A2 INTER B IN events p` by METIS_TAC [EVENTS_INTER]
+ >> RW_TAC std_ss [REAL_DIV_RMUL, REAL_SUB_RDISTRIB, REAL_EQ_SUB_LADD]
+ >> `prob p ((A1 DIFF A2) INTER B) + prob p (A1 INTER A2 INTER B) =
+        prob p (((A1 DIFF A2) INTER B) UNION (A1 INTER A2 INTER B))`
+        by (ONCE_REWRITE_TAC [EQ_SYM_EQ] >> MATCH_MP_TAC PROB_ADDITIVE
+           >> RW_TAC std_ss [EVENTS_INTER, EVENTS_DIFF, DISJOINT_DEF, EXTENSION]
+           >> RW_TAC std_ss [IN_DIFF, IN_INTER, NOT_IN_EMPTY] >> PROVE_TAC [])
+ >> `((A1 DIFF A2) INTER B UNION A1 INTER A2 INTER B) = (A1 INTER B)`
+        by (RW_TAC std_ss [EXTENSION, IN_INTER, IN_DIFF, IN_UNION] THEN PROVE_TAC [])
+ >> RW_TAC std_ss []);
+
+val COND_PROB_MUL_RULE = store_thm
+  ("COND_PROB_MUL_RULE",
+  ``!p A B. prob_space p /\ A IN events p /\ B IN events p ==>
+               (prob p (A INTER B) = (prob p B) * (cond_prob p A B))``,
+        RW_TAC std_ss [] THEN Cases_on `prob p B = 0` THEN1
+                RW_TAC std_ss [COND_PROB_ZERO, REAL_MUL_RZERO, PROB_INTER_ZERO] THEN
+        RW_TAC std_ss [cond_prob_def, REAL_DIV_LMUL]);
+
+val COND_PROB_MUL_EQ = store_thm
+  ("COND_PROB_MUL_EQ",
+  ``!A B p. prob_space p /\ A IN events p /\ B IN events p ==>
+        (cond_prob p A B * prob p B = cond_prob p B A * prob p A)``,
+    RW_TAC std_ss []
+ >> Cases_on `prob p B = 0`
+ >- RW_TAC std_ss [REAL_MUL_RZERO, COND_PROB_INTER_ZERO, REAL_MUL_LZERO]
+ >> Cases_on `prob p A = 0`
+ >- RW_TAC std_ss [REAL_MUL_LZERO, COND_PROB_INTER_ZERO, REAL_MUL_RZERO]
+ >> RW_TAC std_ss [cond_prob_def, REAL_DIV_RMUL, INTER_COMM]);
+
+val COND_PROB_UNION = prove
+  (``!p A1 A2 B.
+           prob_space p /\ A1 IN events p /\ A2 IN events p /\ B IN events p ==>
+        (cond_prob p (A1 UNION A2) B =
+        (cond_prob p A1 B) + (cond_prob p A2 B) - (cond_prob p (A1 INTER A2) B))``,
+    RW_TAC std_ss []
+ >> `cond_prob p A1 B + cond_prob p A2 B = cond_prob p A2 B + cond_prob p A1 B`
+        by RW_TAC std_ss [REAL_ADD_COMM] >> POP_ORW
+ >> `cond_prob p A2 B + cond_prob p A1 B - cond_prob p (A1 INTER A2) B =
+     cond_prob p A2 B + (cond_prob p A1 B - cond_prob p (A1 INTER A2) B)` by REAL_ARITH_TAC
+ >> `cond_prob p A1 B - cond_prob p (A1 INTER A2) B = cond_prob p (A1 DIFF A2) B`
+        by PROVE_TAC [COND_PROB_DIFF] >> RW_TAC std_ss []
+ >> Cases_on `prob p B = 0`
+ >- RW_TAC std_ss [COND_PROB_ZERO, EVENTS_DIFF, EVENTS_UNION, REAL_ADD_LID]
+ >> `(cond_prob p (A1 UNION A2) B = cond_prob p A2 B + cond_prob p (A1 DIFF A2) B) =
+     (cond_prob p (A1 UNION A2) B * prob p B =
+        (cond_prob p A2 B + cond_prob p (A1 DIFF A2) B) * prob p B)` by METIS_TAC [REAL_EQ_RMUL]
+ >> POP_ORW >> RW_TAC std_ss [REAL_DIV_RMUL, cond_prob_def, REAL_ADD_RDISTRIB]
+ >> `(A1 UNION A2) INTER B IN events p` by METIS_TAC [EVENTS_UNION, EVENTS_INTER]
+ >> `A2 INTER B IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `(A1 DIFF A2) INTER B IN events p` by METIS_TAC [EVENTS_INTER, EVENTS_DIFF]
+ >> `prob p (A2 INTER B) + prob p ((A1 DIFF A2) INTER B) =
+       prob p ((A2 INTER B) UNION ((A1 DIFF A2) INTER B))`
+       by (ONCE_REWRITE_TAC [EQ_SYM_EQ] >> MATCH_MP_TAC PROB_ADDITIVE
+          >> RW_TAC std_ss [EVENTS_INTER, EVENTS_DIFF, DISJOINT_DEF, EXTENSION]
+          >> RW_TAC std_ss [IN_INTER, IN_DIFF, NOT_IN_EMPTY] >> PROVE_TAC [])
+ >> `(A2 INTER B UNION (A1 DIFF A2) INTER B) = ((A1 UNION A2) INTER B)`
+        by (RW_TAC std_ss [EXTENSION, IN_INTER, IN_DIFF, IN_UNION] THEN PROVE_TAC [])
+ >> RW_TAC std_ss []);
+
+val INSERT_THM1 = prove (``!(x:'a) s. x IN (x INSERT s)``,
+    RW_TAC std_ss [IN_INSERT]);
+
+val INSERT_THM2 = prove (``!(x:'a) y s. x IN s ==> x IN (y INSERT s)``,
+    RW_TAC std_ss [IN_INSERT]);
+
+val PROB_FINITE_ADDITIVE = store_thm
+  ("PROB_FINITE_ADDITIVE",
+  ``!p s f t. prob_space p /\ FINITE s /\ (!x. x IN s ==> f x IN events p) /\
+       (!a b. (a:'b) IN s /\ b IN s /\ ~(a = b) ==> DISJOINT (f a) (f b)) /\
+       (t = BIGUNION (IMAGE f s)) ==> (prob p t = SIGMA (prob p o f) s)``,
+    Suff `!s. FINITE (s:'b -> bool) ==>
+        ((\s. !p f t. prob_space p  /\ (!x. x IN s ==> f x IN events p) /\
+        (!a b. a IN s /\ b IN s /\ a <> b ==> DISJOINT (f a) (f b)) /\
+        (t = BIGUNION (IMAGE f s)) ==> (prob p t = SIGMA (prob p o f) s)) s)` >- METIS_TAC []
+ >> MATCH_MP_TAC FINITE_INDUCT >> RW_TAC std_ss [IMAGE_EMPTY]
+ >- RW_TAC std_ss [REAL_SUM_IMAGE_THM, BIGUNION_EMPTY, PROB_EMPTY]
+ >> `SIGMA (prob p o f) ((e:'b) INSERT s) = (prob p o f) e + SIGMA (prob p o f) (s DELETE e)`
+        by RW_TAC std_ss [REAL_SUM_IMAGE_THM]
+ >> `s DELETE (e:'b) = s` by FULL_SIMP_TAC std_ss [DELETE_NON_ELEMENT]
+ >> RW_TAC std_ss [IMAGE_INSERT, BIGUNION_INSERT]
+ >> Know `DISJOINT (f e) (BIGUNION (IMAGE f s))`
+ >- (RW_TAC set_ss [DISJOINT_BIGUNION, IN_IMAGE] \\
+    `e IN e INSERT s` by FULL_SIMP_TAC std_ss [INSERT_THM1] \\
+    `x IN e INSERT s` by FULL_SIMP_TAC std_ss [INSERT_THM2] \\
+    `e <> x` by METIS_TAC [] \\
+     FULL_SIMP_TAC std_ss []) >> DISCH_TAC
+ >> `(f e) IN events p` by FULL_SIMP_TAC std_ss [IN_FUNSET, INSERT_THM1]
+ >> `BIGUNION (IMAGE f s) IN events p`
+        by (MATCH_MP_TAC EVENTS_COUNTABLE_UNION >> RW_TAC std_ss []
+           >- (RW_TAC std_ss [SUBSET_DEF,IN_IMAGE] THEN METIS_TAC [IN_INSERT])
+           >> MATCH_MP_TAC COUNTABLE_IMAGE >> RW_TAC std_ss [FINITE_COUNTABLE])
+ >> `(prob p (f e UNION BIGUNION (IMAGE f s))) = prob p (f e) + prob p (BIGUNION (IMAGE f s))`
+        by (MATCH_MP_TAC PROB_ADDITIVE >> FULL_SIMP_TAC std_ss [])
+ >> RW_TAC std_ss [INSERT_THM1, INSERT_THM2]);
+
+val INTER_BIGUNION = prove (
+ ``(!s t. BIGUNION s INTER t = BIGUNION {x INTER t | x IN s}) /\
+   (!s t. t INTER BIGUNION s = BIGUNION {t INTER x | x IN s})``,
+  ONCE_REWRITE_TAC[EXTENSION] THEN
+  SIMP_TAC std_ss [IN_BIGUNION, GSPECIFICATION, IN_INTER] THEN
+  MESON_TAC[IN_INTER]);
+
+val COND_PROB_FINITE_ADDITIVE = store_thm
+  ("COND_PROB_FINITE_ADDITIVE",
+  ``!p A B n s. prob_space p /\ B IN events p /\ A IN ((count n) -> events p) /\
+        (s = BIGUNION (IMAGE A (count n))) /\
+        (!a b. a <> b ==> DISJOINT (A a) (A b)) ==>
+        (cond_prob p s B = SIGMA (\i. cond_prob p (A i) B) (count n))``,
+    RW_TAC std_ss [IN_FUNSET, IN_COUNT]
+ >> `0 <= prob p (B:'a -> bool)` by RW_TAC std_ss [PROB_POSITIVE]
+ >> `BIGUNION (IMAGE A (count n)) IN events p` by METIS_TAC [EVENTS_BIGUNION, IN_FUNSET, IN_COUNT]
+ >> Cases_on `prob p (B:'a -> bool) = 0`
+ >- (`0 = SIGMA (\i. (0:real)) (count n)`
+        by ((MP_TAC o GSYM o Q.ISPEC `count n`) REAL_SUM_IMAGE_0 >> RW_TAC std_ss [FINITE_COUNT])
+    >> RW_TAC std_ss [COND_PROB_ZERO] >> POP_ORW
+    >> (MATCH_MP_TAC o Q.ISPEC `count n`) REAL_SUM_IMAGE_EQ
+    >> RW_TAC set_ss [FINITE_COUNT, IN_COUNT, COND_PROB_ZERO])
+ >> `prob p B * SIGMA (\i. cond_prob p (A i) B) (count n) =
+        SIGMA (\i. prob p B * cond_prob p (A i) B) (count n)`
+        by ((MP_TAC o Q.ISPEC `count n`) REAL_SUM_IMAGE_CMUL >> RW_TAC std_ss [FINITE_COUNT])
+ >> `(cond_prob p (BIGUNION (IMAGE A (count n))) B = SIGMA (\i. cond_prob p (A i) B) (count n)) =
+     (prob p B * cond_prob p (BIGUNION (IMAGE A (count n))) B =
+      prob p B * SIGMA (\i. cond_prob p (A i) B) (count n))`
+     by METIS_TAC [REAL_EQ_LMUL] >> RW_TAC std_ss [cond_prob_def, REAL_DIV_LMUL]
+ >> `SIGMA (\i. prob p (A i INTER B)) (count n) = SIGMA (prob p o (\i. A i INTER B)) (count n)`
+        by METIS_TAC [] >> POP_ORW
+ >> Know `BIGUNION (IMAGE A (count n)) INTER B = BIGUNION (IMAGE (\i. A i INTER B) (count n))`
+ >- (RW_TAC set_ss [INTER_COMM, INTER_BIGUNION, Once EXTENSION, IN_IMAGE] \\
+     EQ_TAC >> rpt STRIP_TAC >| (* 3 subgoals *)
+     [ (* goal 1 (of 3) *)
+       rename1 `s = A i` >> Q.EXISTS_TAC `B INTER (A i)` \\
+       Reverse CONJ_TAC >- (Q.EXISTS_TAC `i` >> art []) \\
+       METIS_TAC [IN_INTER],
+       (* goal 2 (of 3) *)
+       fs [IN_INTER] >> Q.EXISTS_TAC `A i` >> art [] \\
+       Q.EXISTS_TAC `i` >> art [],
+       (* goal 3 (of 3) *)
+       fs [IN_INTER] ]) >> DISCH_TAC
+ >> RW_TAC std_ss [GSYM REAL_SUM_IMAGE_EQ_sum]
+ >> `!(x:real) y. (x = y) = (y = x)` by RW_TAC std_ss [EQ_SYM_EQ] >> POP_ORW
+ >> MATCH_MP_TAC PROB_FINITELY_ADDITIVE
+ >> FULL_SIMP_TAC std_ss [DISJOINT_DEF, IN_FUNSET, IN_COUNT, EVENTS_INTER,
+                          THREE_SETS_INTER, INTER_EMPTY]);
+
+val BAYES_RULE = store_thm
+  ("BAYES_RULE",
+  ``!p A B. (prob_space p) /\ (A IN events p) /\ (B IN events p) ==>
+        (cond_prob p B A = ((cond_prob p A B) * prob p B)/(prob p A))``,
+    RW_TAC std_ss []
+ >> Cases_on `prob p B = 0`
+ >- RW_TAC std_ss [COND_PROB_ZERO, COND_PROB_INTER_ZERO, REAL_MUL_LZERO, REAL_DIV_LZERO]
+ >> `!(x:real) y z w. x * y * z * w = x * (y * z) * w` by METIS_TAC [REAL_MUL_ASSOC]
+ >> RW_TAC std_ss [cond_prob_def, real_div, REAL_DIV_RMUL, INTER_COMM, REAL_MUL_LINV, REAL_MUL_RID]);
+
+val TOTAL_PROB_SIGMA = store_thm
+  ("TOTAL_PROB_SIGMA",
+  ``!p A B s. (prob_space p) /\ (A IN events p) /\ FINITE s /\
+        (!x . x IN s ==> B x IN events p) /\
+        (!a b. a IN s /\ b IN s /\ ~(a = b) ==> DISJOINT (B a) (B b)) /\
+        (BIGUNION (IMAGE B s) = p_space p) ==>
+        (prob p A = SIGMA (\i. (prob p (B i))* (cond_prob p A (B i))) s)``,
+    RW_TAC std_ss []
+ >> `SIGMA (\i. prob p (B i) * cond_prob p A (B i)) (s:'b -> bool) =
+        SIGMA (\i. prob p (A INTER (B i))) s `
+        by ((MATCH_MP_TAC o Q.ISPEC `s:'b -> bool`) REAL_SUM_IMAGE_EQ >> RW_TAC std_ss []
+           >> Cases_on `prob p (B x) = 0` >- RW_TAC std_ss [REAL_MUL_LZERO, PROB_INTER_ZERO]
+           >> RW_TAC std_ss [cond_prob_def, REAL_DIV_LMUL])
+ >> RW_TAC std_ss [] >> MATCH_MP_TAC PROB_REAL_SUM_IMAGE_FN
+ >> RW_TAC std_ss [EVENTS_INTER, INTER_IDEMPOT]);
+
+val BAYES_RULE_GENERAL_SIGMA = store_thm
+  ("BAYES_RULE_GENERAL_SIGMA",
+  ``!p A B s k. (prob_space p) /\ (A IN events p) /\ FINITE s /\
+        (!x . x IN s ==> B x IN events p) /\ (k IN s) /\
+        (!a b. a IN s /\ b IN s /\ ~(a = b) ==> DISJOINT (B a) (B b)) /\
+        (BIGUNION (IMAGE B s) = p_space p) ==>
+        (cond_prob p (B k) A = ((cond_prob p A (B k)) * prob p (B k))/
+                (SIGMA (\i. (prob p (B i)) * (cond_prob p A (B i)))) s)``,
+        RW_TAC std_ss [GSYM TOTAL_PROB_SIGMA] THEN MATCH_MP_TAC BAYES_RULE THEN
+        RW_TAC std_ss [] THEN POP_ASSUM MP_TAC THEN NTAC 3 (POP_ASSUM K_TAC) THEN
+        POP_ASSUM MP_TAC THEN RW_TAC std_ss [IN_FUNSET, IN_COUNT]);
+
+val COND_PROB_ADDITIVE = store_thm
+  ("COND_PROB_ADDITIVE",
+  ``!p A B s. (prob_space p) /\ FINITE s /\ (B IN events p) /\
+        (!x. x IN s ==> A x IN events p) /\ (0 < prob p B) /\
+        (!x y. x IN s /\ y IN s /\ x <> y ==> DISJOINT (A x) (A y)) /\
+        (BIGUNION (IMAGE A s) = p_space p) ==>
+        (SIGMA (\i. cond_prob p (A i) B) s = 1)``,
+    RW_TAC std_ss [] >> `prob p B <> 0` by METIS_TAC [REAL_LT_LE]
+ >> `(SIGMA (\i. cond_prob p (A i) B) (s:'b -> bool) = 1) =
+     (prob p B * SIGMA (\i. cond_prob p (A i) B) s = prob p B * 1)`
+     by METIS_TAC [REAL_EQ_MUL_LCANCEL] >> POP_ORW
+ >> `prob p B * SIGMA (\i. cond_prob p (A i) B) (s:'b -> bool) =
+        SIGMA (\i. prob p B * cond_prob p (A i) B) s`
+        by ((MP_TAC o Q.ISPEC `s:'b -> bool`) REAL_SUM_IMAGE_CMUL >> RW_TAC std_ss [])
+ >> RW_TAC std_ss [cond_prob_def, REAL_DIV_LMUL, REAL_MUL_RID, EQ_SYM_EQ, INTER_COMM]
+ >> MATCH_MP_TAC PROB_REAL_SUM_IMAGE_FN
+ >> RW_TAC std_ss [INTER_IDEMPOT, EVENTS_INTER]);
+
+val COND_PROB_SWAP = store_thm
+  ("COND_PROB_SWAP",
+  ``!p A B C.
+        prob_space p /\ A IN events p /\ B IN events p /\ C IN events p ==>
+        (cond_prob p A (B INTER C) * cond_prob p B C =
+         cond_prob p B (A INTER C) * cond_prob p A C)``,
+    RW_TAC std_ss [] >> `B INTER C IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `A INTER B IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `A INTER C IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `A INTER (B INTER C) = B INTER (A INTER C)` by METIS_TAC [INTER_ASSOC', INTER_COMM]
+ >> Cases_on `prob p C = 0`
+ >- RW_TAC std_ss [COND_PROB_ZERO, REAL_MUL_RZERO]
+ >> `0 < prob p C` by METIS_TAC [PROB_POSITIVE, REAL_LT_LE]
+ >> Cases_on `prob p (B INTER C) = 0`
+ >- (`cond_prob p B C = 0` by RW_TAC std_ss [cond_prob_def, REAL_DIV_LZERO]
+    >> Cases_on `prob p (A INTER C) = 0`
+    >- RW_TAC std_ss [COND_PROB_ZERO, REAL_MUL_RZERO, REAL_MUL_LZERO]
+    >> `B INTER (A INTER C) = A INTER (B INTER C)` by METIS_TAC [INTER_ASSOC', INTER_COMM]
+    >> `0 < prob p (A INTER C)` by METIS_TAC [PROB_POSITIVE,  REAL_LT_LE]
+    >> `cond_prob p B (A INTER C) = 0`
+        by RW_TAC std_ss [cond_prob_def, PROB_INTER_ZERO, REAL_DIV_LZERO]
+    >> RW_TAC std_ss [REAL_MUL_LZERO, REAL_MUL_RZERO])
+ >> Cases_on `prob p (A INTER C) = 0`
+ >- (RW_TAC std_ss [COND_PROB_ZERO, REAL_MUL_LZERO]
+    >> `0 < prob p (B INTER C)` by METIS_TAC [PROB_POSITIVE, REAL_LT_LE]
+    >> `prob p (A INTER (B INTER C)) = 0` by METIS_TAC [PROB_INTER_ZERO]
+    >> RW_TAC std_ss [cond_prob_def, REAL_DIV_LZERO, REAL_MUL_LZERO])
+ >> `!(a:real) b c d. a * b * (c * d) = a * (b * c) * d` by METIS_TAC [REAL_MUL_ASSOC]
+ >> RW_TAC std_ss [cond_prob_def, real_div, REAL_MUL_LINV, REAL_MUL_RID]
+ >> METIS_TAC []);
+
+val PROB_INTER_SPLIT = store_thm
+  ("PROB_INTER_SPLIT",
+  ``!p A B C.
+        prob_space p /\ A IN events p /\ B IN events p /\ C IN events p ==>
+        (prob p (A INTER B INTER C) =
+         cond_prob p A (B INTER C) * cond_prob p B C * prob p C)``,
+    RW_TAC std_ss [] >> `B INTER C IN events p` by METIS_TAC [EVENTS_INTER]
+ >> `A INTER B IN events p` by METIS_TAC [EVENTS_INTER]
+ >> Cases_on `prob p C = 0`
+ >- RW_TAC std_ss [PROB_INTER_ZERO, REAL_MUL_RZERO]
+ >> Cases_on `prob p (B INTER C) = 0`
+ >- RW_TAC std_ss [INTER_ASSOC', PROB_INTER_ZERO, COND_PROB_ZERO, REAL_MUL_LZERO]
+ >> `!(a:real) b c d e. a * b * (c * d) * e = a * (b * c) * (d * e)` by METIS_TAC [REAL_MUL_ASSOC]
+ >> RW_TAC std_ss [cond_prob_def, real_div, REAL_MUL_LINV, REAL_MUL_LID, REAL_MUL_RID, INTER_ASSOC']);
+
+val COND_PROB_INTER_SPLIT = store_thm
+  ("COND_PROB_INTER_SPLIT",
+  ``!p A B C.
+        prob_space p /\ A IN events p /\ B IN events p /\ C IN events p ==>
+        (cond_prob p (A INTER B) C = cond_prob p A (B INTER C) * cond_prob p B C)``,
+    RW_TAC std_ss []
+ >> Cases_on `prob p C = 0`
+ >- (`A INTER B IN events p` by METIS_TAC [EVENTS_INTER]
+    >> RW_TAC std_ss [COND_PROB_ZERO, REAL_MUL_RZERO])
+ >> Cases_on `prob p (B INTER C) = 0`
+ >- (`A INTER B INTER C IN events p` by METIS_TAC [EVENTS_INTER]
+    >> `B INTER C IN events p` by METIS_TAC [EVENTS_INTER]
+    >> `0 < prob p C` by METIS_TAC [PROB_POSITIVE, REAL_LT_LE]
+    >> RW_TAC std_ss [COND_PROB_ZERO, REAL_MUL_LZERO, cond_prob_def, INTER_ASSOC',
+        PROB_INTER_ZERO, REAL_DIV_LZERO])
+ >> `!(x:real) y z w. x * y * (z * w) = x * (y * z) * w`
+        by METIS_TAC [REAL_MUL_ASSOC, REAL_MUL_COMM]
+ >> RW_TAC std_ss [cond_prob_def, real_div, INTER_ASSOC, REAL_MUL_LINV, REAL_MUL_RID]);
 
 val _ = export_theory ();

--- a/src/probability/real_probabilityScript.sml
+++ b/src/probability/real_probabilityScript.sml
@@ -1600,6 +1600,9 @@ val INTER_BIGUNION = prove (
   SIMP_TAC std_ss [IN_BIGUNION, GSPECIFICATION, IN_INTER] THEN
   MESON_TAC[IN_INTER]);
 
+val THREE_SETS_INTER = Q.prove (
+   `!A B C. A INTER B INTER (C INTER B) = A INTER C INTER B`, SET_TAC []);
+
 val COND_PROB_FINITE_ADDITIVE = store_thm
   ("COND_PROB_FINITE_ADDITIVE",
   ``!p A B n s. prob_space p /\ B IN events p /\ A IN ((count n) -> events p) /\

--- a/src/probability/util_probScript.sml
+++ b/src/probability/util_probScript.sml
@@ -1662,6 +1662,18 @@ val tail_countable = store_thm
  >- PROVE_TAC [COUNTABLE_IMAGE_NUM]
  >> RW_TAC std_ss [EXTENSION, IN_IMAGE, GSPECIFICATION]);
 
+Theorem THREE_SETS_INTER :
+    !A B C. A INTER B INTER (C INTER B) = A INTER C INTER B
+Proof
+    RW_TAC std_ss [GSYM INTER_ASSOC]
+ >> `B INTER (C INTER B) = B INTER (B INTER C)` by RW_TAC std_ss [INTER_COMM]
+ >> ONCE_ASM_REWRITE_TAC []
+ >> `B INTER (B INTER C) = B INTER C`
+       by RW_TAC std_ss [INTER_ASSOC, INTER_IDEMPOT]
+ >> ONCE_ASM_REWRITE_TAC []
+ >> FULL_SIMP_TAC std_ss [INTER_COMM]
+QED
+
 val _ = export_theory ();
 
 (* References:

--- a/src/probability/util_probScript.sml
+++ b/src/probability/util_probScript.sml
@@ -1662,18 +1662,6 @@ val tail_countable = store_thm
  >- PROVE_TAC [COUNTABLE_IMAGE_NUM]
  >> RW_TAC std_ss [EXTENSION, IN_IMAGE, GSPECIFICATION]);
 
-Theorem THREE_SETS_INTER :
-    !A B C. A INTER B INTER (C INTER B) = A INTER C INTER B
-Proof
-    RW_TAC std_ss [GSYM INTER_ASSOC]
- >> `B INTER (C INTER B) = B INTER (B INTER C)` by RW_TAC std_ss [INTER_COMM]
- >> ONCE_ASM_REWRITE_TAC []
- >> `B INTER (B INTER C) = B INTER C`
-       by RW_TAC std_ss [INTER_ASSOC, INTER_IDEMPOT]
- >> ONCE_ASM_REWRITE_TAC []
- >> FULL_SIMP_TAC std_ss [INTER_COMM]
-QED
-
 val _ = export_theory ();
 
 (* References:


### PR DESCRIPTION
Hi,

this PR added an elementary definition of "conditional probability" from HVG's `cond_probTheory` (by Liya Liu in 2012). The original work was done in HOL4 K7, based on the old real-valued `probabilityTheory`. I merged this work into HOL's current `real_probabilityTheory` with minor fixes. Then I ported all theorems to (extreal-valued) `probabilityTheory`, reproving each using extreal arithmetics.

Conditional probability [1, p.114], denoted by `p {A | B}` in textbooks, is formalized by `cond_prob p A B` in HOL:

```
   [cond_prob_def]  Definition      
      ⊢ ∀p e1 e2. cond_prob p e1 e2 = prob p (e1 ∩ e2) / prob p e2
```

(With the new definition of `extreal_div`, whenever `cond_prob p e1 e2` is involved, `prob p e2 <> 0` must hold. This is aligned with textbooks.)

With the above definiton, the Total Probability Formula  and the famous Bayes' Rule (specific and general versions) are proved:

```
   [TOTAL_PROB_SIGMA]  Theorem
      ⊢ ∀p A B s.
            prob_space p ∧ A ∈ events p ∧ FINITE s ∧
            (∀x. x ∈ s ⇒ B x ∈ events p ∧ prob p (B x) ≠ 0) ∧
            (∀a b. a ∈ s ∧ b ∈ s ∧ a ≠ b ⇒ DISJOINT (B a) (B b)) ∧
            BIGUNION (IMAGE B s) = p_space p ⇒
            prob p A = ∑ (λi. prob p (B i) * cond_prob p A (B i)) s

   [BAYES_RULE]  Theorem
      ⊢ ∀p A B.
            prob_space p ∧ A ∈ events p ∧ B ∈ events p ∧ prob p A ≠ 0 ∧
            prob p B ≠ 0 ⇒
            cond_prob p B A = cond_prob p A B * prob p B / prob p A
   
   [BAYES_RULE_GENERAL_SIGMA]  Theorem
      ⊢ ∀p A B s k.
            prob_space p ∧ A ∈ events p ∧ prob p A ≠ 0 ∧ FINITE s ∧
            (∀x. x ∈ s ⇒ B x ∈ events p ∧ prob p (B x) ≠ 0) ∧ k ∈ s ∧
            (∀a b. a ∈ s ∧ b ∈ s ∧ a ≠ b ⇒ DISJOINT (B a) (B b)) ∧
            BIGUNION (IMAGE B s) = p_space p ⇒
            cond_prob p (B k) A =
            cond_prob p A (B k) * prob p (B k) /
            ∑ (λi. prob p (B i) * cond_prob p A (B i)) s
```

Note that, there's another measure-theoretic definition of "conditional probability" in `probabilityTheory`, based on conditional expectation:

```
   [conditional_expectation_def]  Definition      
      ⊢ ∀p X s.
            conditional_expectation p X s =
            @f.
                real_random_variable f p ∧
                ∀g.
                    g ∈ s ⇒
                    expectation p (λx. f x * 𝟙 g x) =
                    expectation p (λx. X x * 𝟙 g x)
   
   [conditional_prob_def]  Definition      
      ⊢ ∀p e1 e2.
            conditional_prob p e1 e2 = conditional_expectation p (𝟙 e1) e2
```

The above two definitions were not used anywhere in the rest of `probabilityTheory`, but I think this `conditional_prob` should be equivalent with `cond_prob`, once the full theory of `conditional_expectation` comes. Then `|- conditional_prob = cond_prob` may be proved as a theorem (or not: types are different...)

P. S. This PR can be merged independently with #782. The order is not important.

Regards,

Chun Tian

[1] Feller, W.: An Introduction to Probability Theory and Its Applications, vol 1, 3rd edition. John Wiley & Sons, Inc., New York, N.Y. (2004).