### PR TITLE
Hyperlinks and sections (based on initial letters) in «REFERENCE»

### DIFF
--- a/Manual/Reference/reference.tex
+++ b/Manual/Reference/reference.tex
@@ -6,7 +6,7 @@
 %\usepackage{amsmath}
 \usepackage{alltt}
 \usepackage{../LaTeX/layout}
-\usepackage{makeidx}
+\usepackage{imakeidx}
 \usepackage{alltt}
 \usepackage{fancyvrb}
 \usepackage{graphicx}
@@ -17,12 +17,16 @@
 \input{../LaTeX/commands}
 \input{../LaTeX/ref-macros}
 
+\usepackage[hidelinks,hypertexnames=false,pdftitle={The HOL System REFERENCE}]{hyperref}
+\usepackage{breakurl} % it depends on hyperref
+
 %\includeonly{title,contents,preface,tactics,index}
 
 \verbosereftrue                           % verbose typesetting
 %\includeonly{theorems}
 %\includeonly{rules}
 
+\indexsetup{level=\chapter}
 \makeindex
 
 \begin{document}
@@ -57,8 +61,7 @@
 
    {\def\#{\char'043}                    % \tt style `#' character
     \cleardoublepage
-    \printindex}
+    \printindex
+  }
 
 \end{document}
-
-


### PR DESCRIPTION
Hi,

«The HOL REFERENCE» (PDF) was having no bookmarks nor hyperlinks but one single big chapter. I wanted to add single-letter sections into it so that I can easily navigate into the document. Also, by loading `hyperref` package all page numbers in the index is now clickable.  In addition, the "Index" itself is now a chapter shown in PDF bookmark.

(This is a rare PR where I write real SML program code instead of formal proofs.)

See attached screenshot for the typesetting results.

--Chun

<img width="1510" alt="2020-04-13 11 36 48 pm" src="https://user-images.githubusercontent.com/163421/79134528-7195a400-7de0-11ea-9b19-a7223de2643b.png">
