### PR TITLE
Small list theory fixes

### DIFF
--- a/doc/next-release.md
+++ b/doc/next-release.md
@@ -136,6 +136,15 @@ New examples:
 Incompatibilities:
 ------------------
 
+*  `listTheory` and `rich_listTheory`: Some theorems have been generalized.
+
+	For example, `EVERY_{TAKE, DROP, BUTLASTN, LASTN}` had unnecessary preconditions.
+	As a result of some theorems being generalized, some `_IMP` versions of the same
+	theorems have been dropped, as they are now special cases of the non-`_IMP` versions.
+
+	Also, `DROP_NIL` has been renamed to `DROP_EQ_NIL`, to avoid having both `DROP_nil`
+	and `DROP_NIL` around. Furthermore, `>=` in the theorem statement has been replaced with `<=`.
+
 * * * * *
 
 <div class="footer">

--- a/examples/algebra/lib/helperListScript.sml
+++ b/examples/algebra/lib/helperListScript.sml
@@ -1147,13 +1147,13 @@ val DROP_LENGTH_NIL = store_thm(
                       <> []          by induction hypothesis, n-1 < LENGTH l
 *)
 (* Proof:
-   Note !ls n. (DROP n ls = []) <=> n >= LENGTH ls    by DROP_NIL
+   Note !ls n. (DROP n ls = []) <=> LENGTH ls <= n    by DROP_EQ_NIL
      so n < LENGTH ls ==> DROP n ls <> []             by NOT_LESS_EQUAL
 *)
 val DROP_NON_NIL = store_thm(
   "DROP_NON_NIL",
   ``!n l. n < LENGTH l ==> DROP n l <> []``,
-  metis_tac[DROP_NIL, DECIDE ``x >= y <=> ~(x < y)``]);
+  metis_tac[DROP_EQ_NIL, DECIDE ``x >= y <=> ~(x < y)``]);
 
 (* Theorem: n < LENGTH ls ==> (HD (DROP n ls) = EL n ls) *)
 (* Proof:

--- a/examples/fun-op-sem/small-step/oracleSemScript.sml
+++ b/examples/fun-op-sem/small-step/oracleSemScript.sml
@@ -122,7 +122,7 @@ val small_chain_thm = Q.prove (
    `check_trace sem_s.step tr''` by metis_tac [check_trace_drop] >>
    `LAST tr' = LAST tr''` by metis_tac [last_drop] >>
    rw [] >>
-   `tr'' ≠ []` by (unabbrev_all_tac >> fs [DROP_NIL] >> decide_tac) >>
+   `tr'' ≠ []` by (unabbrev_all_tac >> fs [DROP_EQ_NIL] >> decide_tac) >>
    `(λs1 s2. sem_s.step s1 = SOME s2)^* (HD tr'') (LAST tr'')` by metis_tac [check_trace_thm] >>
    metis_tac [is_prefix_pres])
  >- (
@@ -132,7 +132,7 @@ val small_chain_thm = Q.prove (
    `check_trace sem_s.step tr''` by metis_tac [check_trace_drop] >>
    `LAST tr = LAST tr''` by metis_tac [last_drop] >>
    rw [] >>
-   `tr'' ≠ []` by (unabbrev_all_tac >> fs [DROP_NIL] >> decide_tac) >>
+   `tr'' ≠ []` by (unabbrev_all_tac >> fs [DROP_EQ_NIL] >> decide_tac) >>
    `(λs1 s2. sem_s.step s1 = SOME s2)^* (HD tr'') (LAST tr'')` by metis_tac [check_trace_thm] >>
    metis_tac [is_prefix_pres]));
 
@@ -203,7 +203,7 @@ val osmall_fbs_equiv_lem = Q.prove (
    `LENGTH tr - 1 < LENGTH tr' ∧ LENGTH tr - 1 ≤ LENGTH tr'` by (simp [] >> Cases_on `tr` >> fs []) >>
    `check_trace sem_s.step tr''` by metis_tac [check_trace_drop] >>
    `LAST tr' = LAST tr''` by metis_tac [last_drop] >>
-   `tr'' ≠ []` by (unabbrev_all_tac >> fs [DROP_NIL] >> decide_tac) >>
+   `tr'' ≠ []` by (unabbrev_all_tac >> fs [DROP_EQ_NIL] >> decide_tac) >>
    `(λs1 s2. sem_s.step s1 = SOME s2)^* (HD tr'') (LAST tr'')` by metis_tac [check_trace_thm] >>
    imp_res_tac is_prefix_pres >>
    fs [] >>

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -499,8 +499,8 @@ val EL_APPEND_EQN = store_thm(
   asm_simp_tac (srw_ss()) [EL])
 
 val MAP_TL = Q.store_thm("MAP_TL",
-  ‘!l f. ~NULL l ==> (MAP f (TL l) = TL (MAP f l))’,
-  Induct THEN REWRITE_TAC [NULL_DEF, TL, MAP]);
+  ‘!l f. MAP f (TL l) = TL (MAP f l)’,
+  Induct THEN REWRITE_TAC [TL_DEF, MAP]);
 
 val EVERY_EL = store_thm ("EVERY_EL",
  “!(l:'a list) P. EVERY P l = !n. n < LENGTH l ==> P (EL n l)”,

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -1868,10 +1868,11 @@ Proof
     [GSYM arithmeticTheory.ADD1, ADD_CLAUSES]
 QED
 
-val DROP_NIL = store_thm(
-"DROP_NIL",
-“!ls n. (DROP n ls = []) = (n >= LENGTH ls)”,
-Induct THEN SRW_TAC[] [DROP_def] THEN numLib.DECIDE_TAC)
+Theorem DROP_EQ_NIL:
+ !ls n. (DROP n ls = []) = (LENGTH ls <= n)
+Proof
+ Induct THEN SRW_TAC[] [DROP_def] THEN numLib.DECIDE_TAC
+QED
 
 val LT_SUC = Q.prove(
   ‘x < SUC y <=> (x = 0) \/ ?x0. (x = SUC x0) /\ x0 < y’,

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -502,6 +502,12 @@ val MAP_TL = Q.store_thm("MAP_TL",
   ‘!l f. MAP f (TL l) = TL (MAP f l)’,
   Induct THEN REWRITE_TAC [TL_DEF, MAP]);
 
+Theorem MEM_TL:
+ !l x. MEM x (TL l) ==> MEM x l
+Proof
+ Induct \\ simp [TL]
+QED
+
 val EVERY_EL = store_thm ("EVERY_EL",
  “!(l:'a list) P. EVERY P l = !n. n < LENGTH l ==> P (EL n l)”,
       LIST_INDUCT_TAC THEN

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -3075,6 +3075,12 @@ val LUPDATE_MAP = store_thm("LUPDATE_MAP",
  Induct_on ‘l’ THEN SRW_TAC [] [LUPDATE_def] THEN Cases_on ‘n’ THEN
  FULL_SIMP_TAC (srw_ss()) [LUPDATE_def]);
 
+Theorem LUPDATE_GENLIST:
+ !m n e f. LUPDATE e n (GENLIST f m) = GENLIST ((n =+ e) f) m
+Proof
+ BasicProvers.Induct \\ simp [GENLIST_CONS] \\ Cases \\ simp [LUPDATE_def, combinTheory.APPLY_UPDATE_THM, GENLIST_FUN_EQ]
+QED
+
 val EVERYi_def = Define‘
   (EVERYi P [] <=> T) /\
   (EVERYi P (h::t) <=> P 0 h /\ EVERYi (P o SUC) t)


### PR DESCRIPTION
The TAKE_* fixes should be uncontroversial I think. Not sure if the DROP_NIL->DROP_EQ_NIL commit should be merged. I think the name is better, and the statement no longer includes >=, but it might break old proofs.