### PR TITLE
Enhanced fcpTheory (FCP_FST, FCP_SND, FCP_CONCAT_THM, ...)

### DIFF
--- a/src/n-bit/fcpScript.sml
+++ b/src/n-bit/fcpScript.sml
@@ -31,10 +31,6 @@ val LT_REFL = prim_recTheory.LESS_REFL
 
 (* ------------------------------------------------------------------------- *)
 
-val () = Parse.set_fixity "HAS_SIZE" (Infix (NONASSOC, 450))
-
-val HAS_SIZE = Define `(s HAS_SIZE n) <=> FINITE s /\ (CARD s = n)`
-
 val CARD_IMAGE_INJ = Q.prove(
    `!(f:'a->'b) s.
        (!x y. x IN s /\ y IN s /\ (f(x) = f(y)) ==> (x = y)) /\
@@ -57,59 +53,6 @@ val HAS_SIZE_IMAGE_INJ = Q.prove(
         (!x y. x IN s /\ y IN s /\ (f(x) = f(y)) ==> (x = y)) /\
         (s HAS_SIZE n) ==> ((IMAGE f s) HAS_SIZE n)`,
    SIMP_TAC std_ss [HAS_SIZE, IMAGE_FINITE] THEN PROVE_TAC[CARD_IMAGE_INJ])
-
-val HAS_SIZE_0 = Q.prove(
-   `!(s:'a->bool) n. (s HAS_SIZE 0) = (s = {})`,
-   REPEAT GEN_TAC
-   THEN REWRITE_TAC [HAS_SIZE]
-   THEN EQ_TAC
-   THEN DISCH_TAC
-   THEN ASM_REWRITE_TAC [FINITE_RULES, CARD_CLAUSES]
-   THEN FIRST_ASSUM (MP_TAC o CONJUNCT2)
-   THEN FIRST_ASSUM (MP_TAC o CONJUNCT1)
-   THEN Q.SPEC_TAC (`s:'a->bool`,`s:'a->bool`)
-   THEN Q.SPEC_THEN `\s. (CARD s = 0) ==> (s = {})`
-                    (MATCH_MP_TAC o BETA_RULE) FINITE_INDUCT
-   THEN REWRITE_TAC [NOT_INSERT_EMPTY]
-   THEN REPEAT GEN_TAC
-   THEN STRIP_TAC
-   THEN ASM_SIMP_TAC arith_ss [CARD_INSERT]
-   )
-
-val HAS_SIZE_SUC = Q.prove(
-   `!(s:'a->bool) n.
-        (s HAS_SIZE (SUC n)) <=>
-        ~(s = {}) /\ !a. a IN s ==> ((s DELETE a) HAS_SIZE n)`,
-   REPEAT GEN_TAC
-   THEN REWRITE_TAC [HAS_SIZE]
-   THEN Q.ASM_CASES_TAC `s:'a->bool = {}`
-   THEN ASM_REWRITE_TAC [CARD_CLAUSES, FINITE_RULES, NOT_IN_EMPTY, GSYM NOT_SUC]
-   THEN REWRITE_TAC [FINITE_DELETE]
-   THEN Q.ASM_CASES_TAC `FINITE(s:'a->bool)`
-   THEN ASM_SIMP_TAC std_ss [NOT_FORALL_THM, MEMBER_NOT_EMPTY]
-   THEN EQ_TAC
-   THEN REPEAT STRIP_TAC
-   THENL [
-      MP_TAC (Q.ISPECL [`a:'a`, `s DELETE a:'a`] (CONJUNCT2 CARD_CLAUSES))
-      THEN ASM_REWRITE_TAC [FINITE_DELETE, IN_DELETE]
-      THEN Q.SUBGOAL_THEN `a INSERT (s DELETE a:'a) = s` SUBST1_TAC
-      THENL [
-         Q.UNDISCH_TAC `a:'a IN s`
-         THEN PROVE_TAC [INSERT_DELETE],
-         ASM_REWRITE_TAC [SUC_INJ]
-         THEN PROVE_TAC []
-      ],
-      FIRST_ASSUM
-         (MP_TAC o GEN_REWRITE_RULE I empty_rewrites [GSYM MEMBER_NOT_EMPTY])
-      THEN DISCH_THEN (Q.X_CHOOSE_TAC `a:'a`)
-      THEN MP_TAC (Q.ISPECL [`a:'a`, `s DELETE a:'a`] (CONJUNCT2 CARD_CLAUSES))
-      THEN ASM_REWRITE_TAC [FINITE_DELETE, IN_DELETE]
-      THEN Q.SUBGOAL_THEN `a INSERT (s DELETE a:'a) = s` SUBST1_TAC
-      THENL [
-         Q.UNDISCH_TAC `a:'a IN s` THEN PROVE_TAC[INSERT_DELETE],
-         PROVE_TAC[]
-      ]
-   ])
 
 val HAS_SIZE_INDEX = Q.prove(
    `!s n.
@@ -183,8 +126,7 @@ val dimindex_def = zDefine`
 
 val NOT_FINITE_IMP_dimindex_1 = Q.store_thm("NOT_FINITE_IMP_dimindex_1",
    `~FINITE univ(:'a) ==> (dimindex(:'a) = 1)`,
-   METIS_TAC [dimindex_def]
-   )
+   METIS_TAC [dimindex_def])
 
 val HAS_SIZE_FINITE_IMAGE = Q.prove(
    `(UNIV:'a finite_image->bool) HAS_SIZE dimindex(:'a)`,
@@ -197,8 +139,7 @@ val HAS_SIZE_FINITE_IMAGE = Q.prove(
    THEN ASM_REWRITE_TAC [HAS_SIZE, IN_UNIV, IN_SING]
    THEN SIMP_TAC arith_ss [CARD_EMPTY, CARD_SING, CARD_INSERT, FINITE_SING,
                            FINITE_INSERT, NOT_IN_EMPTY]
-   THEN PROVE_TAC[]
-   )
+   THEN PROVE_TAC[])
 
 val CARD_FINITE_IMAGE =
    PROVE [HAS_SIZE_FINITE_IMAGE, HAS_SIZE]
@@ -834,6 +775,12 @@ val FCP_CONCAT_def = Define`
            else
               a ' (i - dimindex(:'c))): 'a ** ('b + 'c)`
 
+val FCP_FST_def = Define
+   ‘FCP_FST (a :'a['b + 'c]) = (FCP(i :num). a ' ((i + dimindex (:'c)) :num)) :'a['b]’;
+
+val FCP_SND_def = Define
+   ‘FCP_SND (b :'a['b + 'c]) = (FCP(i :num). b ' i) :'a['c]’;
+
 val FCP_ZIP_def = Define`
    FCP_ZIP (a:'a ** 'b) (b:'c ** 'b) = (FCP i. (a ' i, b ' i)): ('a # 'c) ** 'b`
 
@@ -922,6 +869,29 @@ val fcp_subst_comp = Q.store_thm("fcp_subst_comp",
   srw_tac [FCP_ss] [FCP_UPDATE_def])
 
 val () = computeLib.add_persistent_funs ["FCP_EXISTS", "FCP_EVERY"]
+
+(* connections to FCP_FST and FCP_SND, added by Chun Tian *)
+Theorem FCP_CONCAT_THM :
+    !(a :'a['b]) (b :'a['c]).
+        FINITE univ(:'b) /\ FINITE univ(:'c) ==>
+       (FCP_FST (FCP_CONCAT a b) = a) /\ (FCP_SND (FCP_CONCAT a b) = b)
+Proof
+    RW_TAC std_ss [FCP_FST_def, FCP_SND_def]
+ >| [ (* goal 1 (of 2) *)
+      RW_TAC std_ss [CART_EQ, FCP_BETA] \\
+      REWRITE_TAC [FCP_CONCAT_def, index_comp] >> simp [index_sum],
+      (* goal 2 (of 2) *)
+      RW_TAC std_ss [CART_EQ, FCP_BETA] \\
+      REWRITE_TAC [FCP_CONCAT_def, index_comp] >> simp [index_sum] ]
+QED
+
+Theorem FCP_CONCAT_11 : (* added by Chun Tian *)
+    !(a :'a['b]) (b :'a['c]) c d.
+        FINITE univ(:'b) /\ FINITE univ(:'c) /\
+       (FCP_CONCAT a b = FCP_CONCAT c d) ==> (a = c) /\ (b = d)
+Proof
+    METIS_TAC [FCP_CONCAT_THM]
+QED
 
 (* ------------------------------------------------------------------------- *)
 

--- a/src/pred_set/src/more_theories/cardinalScript.sml
+++ b/src/pred_set/src/more_theories/cardinalScript.sml
@@ -18,17 +18,7 @@ fun METIS ths tm = prove(tm,METIS_TAC ths);
 val DISC_RW_KILL = DISCH_TAC THEN ONCE_ASM_REWRITE_TAC [] THEN
                    POP_ASSUM K_TAC;
 
-fun SET_TAC L =
-    POP_ASSUM_LIST(K ALL_TAC) THEN REPEAT COND_CASES_TAC THEN
-    REWRITE_TAC (append [EXTENSION, SUBSET_DEF, PSUBSET_DEF, DISJOINT_DEF,
-    SING_DEF] L) THEN
-    SIMP_TAC std_ss [NOT_IN_EMPTY, IN_UNIV, IN_UNION, IN_INTER, IN_DIFF,
-      IN_INSERT, IN_DELETE, IN_REST, IN_BIGINTER, IN_BIGUNION, IN_IMAGE,
-      GSPECIFICATION, IN_DEF, EXISTS_PROD] THEN METIS_TAC [];
-
 fun ASSERT_TAC tm = SUBGOAL_THEN tm STRIP_ASSUME_TAC;
-fun SET_RULE tm = prove(tm,SET_TAC []);
-fun ASM_SET_TAC L = REPEAT (POP_ASSUM MP_TAC) THEN SET_TAC L;
 
 val ASM_ARITH_TAC = REPEAT (POP_ASSUM MP_TAC) THEN ARITH_TAC;
 
@@ -1839,50 +1829,6 @@ val num_FINITE_AVOID = store_thm ("num_FINITE_AVOID",
 val num_INFINITE = store_thm ("num_INFINITE",
  ``INFINITE univ(:num)``,
   MESON_TAC[num_FINITE_AVOID, IN_UNIV]);
-
-(* ------------------------------------------------------------------------- *)
-(* Relational form is often more useful.                                     *)
-(* ------------------------------------------------------------------------- *)
-
-val _ = set_fixity "HAS_SIZE" (Infix(NONASSOC, 450));
-
-val HAS_SIZE = new_definition ("HAS_SIZE",
- ``s HAS_SIZE n <=> FINITE s /\ (CARD s = n)``);
-
-val HAS_SIZE_CARD = store_thm ("HAS_SIZE_CARD",
-``!s n. s HAS_SIZE n ==> (CARD s = n)``,
-  SIMP_TAC std_ss [HAS_SIZE]);
-
-Theorem HAS_SIZE_0:
-   !(s:'a->bool). s HAS_SIZE 0:num <=> (s = {})
-Proof
-  simp[HAS_SIZE, EQ_IMP_THM] THEN
-  ‘!s. FINITE s ==> (CARD s = 0 ==> s = {})’ suffices_by metis_tac[] >>
-  Induct_on ‘FINITE’ >> simp[]
-QED
-
-val HAS_SIZE_SUC = store_thm ("HAS_SIZE_SUC",
- ``!(s:'a->bool) n. s HAS_SIZE (SUC n) <=>
-   ~(s = {}) /\ !a. a IN s ==> (s DELETE a) HAS_SIZE n``,
-  REPEAT GEN_TAC THEN REWRITE_TAC[HAS_SIZE] THEN
-  ASM_CASES_TAC ``s:'a->bool = {}`` THEN
-  ASM_REWRITE_TAC[CARD_DEF, FINITE_EMPTY, FINITE_INSERT,
-  NOT_IN_EMPTY, SUC_NOT] THEN REWRITE_TAC[FINITE_DELETE] THEN
-  ASM_CASES_TAC ``FINITE(s:'a->bool)`` THEN
-  RW_TAC std_ss[NOT_FORALL_THM, MEMBER_NOT_EMPTY] THEN
-  EQ_TAC THEN REPEAT STRIP_TAC THENL
-  [ASM_SIMP_TAC std_ss [CARD_DELETE],
-  KNOW_TAC ``?x. x IN s`` THENL
-  [FULL_SIMP_TAC std_ss [MEMBER_NOT_EMPTY], ALL_TAC] THEN
-  DISCH_THEN(X_CHOOSE_TAC ``a:'a``) THEN ASSUME_TAC CARD_INSERT THEN
-  POP_ASSUM (MP_TAC o Q.SPEC `s DELETE a`) THEN
-  FULL_SIMP_TAC std_ss [FINITE_DELETE] THEN STRIP_TAC THEN
-  POP_ASSUM (MP_TAC o Q.SPEC `a`) THEN
-  FULL_SIMP_TAC std_ss [INSERT_DELETE] THEN ASM_REWRITE_TAC[IN_DELETE]]);
-
-val FINITE_HAS_SIZE = store_thm ("FINITE_HAS_SIZE",
- ``!s. FINITE s <=> s HAS_SIZE CARD s``,
-  REWRITE_TAC[HAS_SIZE]);
 
 (* ------------------------------------------------------------------------- *)
 (* This is often more useful as a rewrite.                                   *)


### PR DESCRIPTION
Hi,

`fcpTheory` (Finite Cartesian Product) is a nice way to represent n-dimensional spaces of numbers. If we have two lower dimensional vectors of type `:'a['b]` and `:'a['c]`, the function `FCP_CONCAT` concatenates them into a new fcp vector of type `:'a['b + 'c]`. This is like a `APPEND` of two shorter lists to a bigger one, but unlike lists, fcp has the ability to retrieve back the original two smaller vectors if I have the following two new functions called `FCP_FST` and `FCP_SND`:

```
val FCP_FST_def = Define
   ‘FCP_FST (a :'a['b + 'c]) = (FCP(i :num). a ' ((i + dimindex (:'c)) :num)) :'a['b]’;

val FCP_SND_def = Define
   ‘FCP_SND (b :'a['b + 'c]) = (FCP(i :num). b ' i) :'a['c]’;
```

Now I can prove the following results:

```
   [FCP_CONCAT_THM]  Theorem      
      ⊢ ∀a b.
            FINITE 𝕌(:β) ∧ FINITE 𝕌(:γ) ⇒
            FCP_FST (FCP_CONCAT a b) = a ∧ FCP_SND (FCP_CONCAT a b) = b

   [FCP_CONCAT_11]  Theorem      
      ⊢ ∀a b c d.
            FINITE 𝕌(:β) ∧ FINITE 𝕌(:γ) ∧ FCP_CONCAT a b = FCP_CONCAT c d ⇒
            a = c ∧ b = d
```

This is like `pairTheory` where `FST (a,b) = a /\ SND (a,b) = b`.  In my ongoing work (in another branch) the above additions in `fcpTheory` is the key for the constructions of n-dimensional Borel measure spaces (by product measures) and a theorem stating that any `n`-dimensional Borel measure space is the product of two smaller (`n-i` and `i`)-dimensional Borel measure spaces.

Besides, both `fcpTheory` and `cardinalTheory` have defined `HAS_SIZE` (relational version of `pred_set$CARD`). I suggest moving the shared duplicated definitions to upstream, i.e. `pred_setTheory`.

Regards,

Chun Tian