### PR TITLE
mc/graph: use `r10` for `ret_addr_input` on RISC-V

### DIFF
--- a/examples/machine-code/graph/GraphLangScript.sml
+++ b/examples/machine-code/graph/GraphLangScript.sml
@@ -2297,7 +2297,7 @@ val SKIP_TAG_IMP_CALL_RISCV = store_thm("SKIP_TAG_IMP_CALL_RISCV",
             ("mem",var_acc "mem"); ("dom",var_acc "dom");
             ("stack",var_acc "stack");
             ("dom_stack",var_acc "dom_stack");
-            ("clock",var_acc "clock"); ("ret_addr_input",var_acc "r1")]
+            ("clock",var_acc "clock"); ("ret_addr_input",var_acc "r10")]
           name (Jump exit)))``,
   fs [IMPL_INST_def,next_ok_def,check_ret_def,exec_next_def,
       check_jump_def,get_assert_def,LET_THM]

--- a/examples/machine-code/graph/graph_specsLib.sml
+++ b/examples/machine-code/graph/graph_specsLib.sml
@@ -256,8 +256,10 @@ local
     val supdate = dest_supdate tm
     val r0 = ``"r0"``
     val r1 = ``"r1"``
+    val r10 = ``"r10"``
     val r14 = ``"r14"``
     val ret_reg_name = (if !arch_name = RISCV then r1 else r14)
+    val ret_addr_reg_name = (if !arch_name = RISCV then r10 else r0)
     val ret_str = ``"ret"``
     val ret_addr_input_str = ``"ret_addr_input"``
     val (is_tail_call,ret) = let
@@ -273,8 +275,8 @@ local
     val var_acc = mk_const ("var_acc",var_acc_ty)
     fun get_assign tm =
       if aconv tm ret_addr_input_str then let
-        val var_acc_r0 = mk_comb(var_acc,r0)
-        in pairSyntax.mk_pair(ret_addr_input_str,var_acc_r0) end
+        val var_acc_ret = mk_comb(var_acc,ret_addr_reg_name)
+        in pairSyntax.mk_pair(ret_addr_input_str,var_acc_ret) end
       else let
         val tm2 = if is_tail_call then tm else
                   if aconv tm ret_str then ret_reg_name else tm


### PR DESCRIPTION
The `ret_addr_input` parameter in function signatures produced by the
machine-code-to-graph decompiler is intended to receive the address of
memory that a caller expects a callee to use for return values that
won't fit into the usual return-value registers.

In the RISC-V calling convention, the `a0` (a.k.a. `x10`) register is
used for this same purpose. This commit ensures that `ret_addr_input` is
always passed the current value of `x10` (`r10` in the decompiler).

The `ret_addr_input` parameter is used by the seL4 [graph-refine][]
toolchain to make it easier to state certain properties relating to
function calls. It is not otherwise used in the function graphs produced
by the decompiler, so this change does not affect the proof of
correctness for the decompiler.

[graph-refine]: https://github.com/sel4/graph-refine