### PR TITLE
Add compute cases for 0 for BIT_UPDATE

### DIFF
--- a/src/n-bit/wordsLib.sml
+++ b/src/n-bit/wordsLib.sml
@@ -342,8 +342,10 @@ local
 
   val bit_update_compute =
      BIT_UPDATE |> REWRITE_RULE [FUN_EQ_THM]
-                |> (fn th => CONJ (Q.SPECL [`^Na`, `F`, `^n2w n`] th)
-                                  (Q.SPECL [`^Na`, `T`, `^n2w n`] th))
+                |> (fn th => LIST_CONJ [Q.SPECL [`0`, `F`, `^n2w n`] th,
+                                        Q.SPECL [`0`, `T`, `^n2w n`] th,
+                                        Q.SPECL [`^Na`, `F`, `^n2w n`] th,
+                                        Q.SPECL [`^Na`, `T`, `^n2w n`] th])
 
   val thms =
      [numLib.SUC_RULE sum_numTheory.SUM_def, bit_update_compute,


### PR DESCRIPTION
Previously we had

```
> EVAL ``(0 :+ T) (0w:word8)``;
val it =  [] ⊢ (0 :+ T) 0w = (0 :+ T) 0w: thm
```

Now we instead have

```
> EVAL ``(0 :+ T) (0w:word8)``;
val it =  [] ⊢ (0 :+ T) 0w = 1w: thm
```