### PR TITLE
Add monadic let syntax

### DIFF
--- a/src/monad/monadsyntax.sig
+++ b/src/monad/monadsyntax.sig
@@ -19,6 +19,8 @@ sig
   val disable_monadsyntax : unit -> unit
   val temp_disable_monadsyntax : unit -> unit
 
+  val print_explicit_monadic_lets : bool -> unit
+
   type monadinfo =
        { bind : term,
          ignorebind : term option,

--- a/src/monad/monadsyntax.sml
+++ b/src/monad/monadsyntax.sml
@@ -7,8 +7,11 @@ local open optionTheory in end
 val monadseq_special = "__monad_sequence"
 val monad_emptyseq_special = "__monad_emptyseq"
 val monadassign_special = "__monad_assign"
+val monadmlet_special = "__monad_mlet"
 val monad_unitbind = "monad_unitbind"
 val monad_bind = "monad_bind"
+val mlet = "mlet"
+val LET = "LET";
 
 fun ERR f msg = mk_HOL_ERR "monadsyntax" f msg
 
@@ -43,7 +46,7 @@ struct
 end
 
 val monadDB =
-    ref (Binarymap.mkDict String.compare : (string,MonadInfo.t) Binarymap.dict)
+    ref (Binarymap.mkDict String.compare : (string,MonadInfo.t) Binarymap.dict);
 
 fun write_keyval (nm, mi) =
   let
@@ -147,13 +150,17 @@ fun clean_action a = let
   open Absyn
 in
   case a of
-    APP(loc1, APP(loc2, IDENT(loc3, s), arg1), arg2) => let
-    in
+    APP(_, APP(_, IDENT(_, s), arg1), arg2) => (
       if s = monadassign_special then
-        (SOME (to_vstruct arg1), arg2)
-      else (NONE, a)
-    end
-  | _ => (NONE, a)
+        case arg1 of
+          APP (_, IDENT (_, s), arg3) =>
+            if s = mlet then (SOME (to_vstruct arg3), true, arg2)
+            else (SOME (to_vstruct arg1), false, arg2)
+        | _ => (SOME (to_vstruct arg1), false, arg2)
+      else if s = monadmlet_special then (SOME (to_vstruct arg1), true, arg2)
+      else (NONE, false, a)
+    )
+  | _ => (NONE, false, a)
 end
 
 fun cleanseq a = let
@@ -163,11 +170,13 @@ in
     APP(loc1, APP(loc2, IDENT(loc3, s), arg1), arg2) => let
     in
       if s = monadseq_special then let
-          val (bv, arg1') = clean_action (clean_do true arg1)
+          val (bv, letm, arg1') = clean_action (clean_do true arg1)
           val arg2' = clean_actions arg2
         in
           case arg2' of
-            NONE => SOME arg1'
+            NONE => if not letm then SOME arg1'
+                    else raise mk_HOL_ERRloc "monadsyntax" "clean_seq" loc3
+                              "Trailing mlet illegal"
           | SOME a => let
             in
               case bv of
@@ -176,11 +185,17 @@ in
                                       IDENT(loc3, monad_unitbind),
                                       arg1'),
                                   a))
-              | SOME b => SOME (APP(loc1,
+              | SOME b =>
+                  if not letm then SOME (APP(loc1,
                                     APP(loc2,
                                         IDENT(loc3, monad_bind),
                                         arg1'),
                                     LAM(locn_of_absyn a, b, a)))
+                  else SOME (APP(loc1,
+                                  APP(loc2,
+                                      IDENT(loc3, LET),
+                                      LAM(locn_of_absyn a, b, a)),
+                                      arg1'))
             end
         end
       else NONE
@@ -200,6 +215,9 @@ in
         if s = monadassign_special andalso not indo then
           raise mk_HOL_ERRloc "monadsyntax" "clean_do" l
                               "Bare monad assign arrow illegal"
+        else if s = mlet andalso not indo then
+          raise mk_HOL_ERRloc "monadsyntax" "clean_do" l
+                              "Bare mlet illegal"
         else APP(l,clean_do arg1,clean_do arg2)
       | APP(l,a1,a2) => APP(l,clean_do a1, clean_do a2)
       | LAM(l,v,a) => LAM(l,v,clean_do a)
@@ -245,12 +263,15 @@ fun dest_bind G t = let
              | Option => raise UserPP_Failed
   val _ = prname = monad_unitbind orelse
           (prname = monad_bind andalso pairSyntax.is_pabs y) orelse
+          (prname = LET andalso pairSyntax.is_pabs x) orelse
            raise UserPP_Failed
 in
-  SOME (prname, x, y)
+  if prname = LET then SOME (prname, y, x) else SOME (prname, x, y)
 end handle HOL_ERR _ => NONE
          | term_pp_types.UserPP_Failed =>  NONE
 
+
+val explicit_mlets = ref false;
 
 fun print_monads (tyg, tmg) backend sysprinter ppfns (p,l,r) depth t = let
   open term_pp_types term_grammar smpp term_pp_utils
@@ -262,10 +283,10 @@ fun print_monads (tyg, tmg) backend sysprinter ppfns (p,l,r) depth t = let
   val minprint = ppstring (#2 (print_from_grammars min_grammars))
   fun syspr bp gravs t =
     sysprinter {gravs = gravs, binderp = bp, depth = depth - 1} t
-  fun pr_action (v, action) =
-      case v of
-        NONE => syspr false (Top,Top,Top) action
-      | SOME v => let
+  fun pr_action (v, letm, action) =
+      case (v, letm) of
+        (NONE, _) => syspr false (Top,Top,Top) action
+      | (SOME v, false) => let
           val new_bvars = free_vars v
         in
           ublock PP.INCONSISTENT 0
@@ -275,17 +296,36 @@ fun print_monads (tyg, tmg) backend sysprinter ppfns (p,l,r) depth t = let
              syspr false (Top,Prec(100, "monad_assign"),Top) action) >>
           addbvs new_bvars
         end
+      | (SOME v, true) => let
+          val new_bvars = free_vars v
+        in
+          if !explicit_mlets then
+            ublock PP.INCONSISTENT 0
+              (strn mlet >>
+               record_bvars new_bvars
+                  (syspr true (Top,Top,Prec(100, "monad_assign")) v) >>
+               strn " " >> strn "<-" >> brk(1,2) >>
+               syspr false (Top,Prec(100, "monad_assign"),Top) action) >>
+            addbvs new_bvars
+          else
+            ublock PP.INCONSISTENT 0
+              (record_bvars new_bvars
+                  (syspr true (Top,Top,Prec(100, "monad_assign")) v) >>
+               strn " " >> strn "<<-" >> brk(1,2) >>
+               syspr false (Top,Prec(100, "monad_assign"),Top) action) >>
+            addbvs new_bvars
+        end
   fun brk_bind binder arg1 arg2 =
-      if binder = monad_bind then let
+      if binder = monad_bind orelse binder = LET then let
               val (v,body) = (SOME ## I) (pairSyntax.dest_pabs arg2)
                              handle HOL_ERR _ => (NONE, arg2)
         in
-          ((v, arg1), body)
+          ((v, binder = LET, arg1), body)
         end
-      else ((NONE, arg1), arg2)
+      else ((NONE, false, arg1), arg2)
   fun strip acc t =
       case dest_bind tmg t of
-        NONE => List.rev ((NONE, t) :: acc)
+        NONE => List.rev ((NONE, false, t) :: acc)
       | SOME (prname, arg1, arg2) => let
           val (arg1', arg2') = brk_bind prname arg1 arg2
         in
@@ -311,8 +351,8 @@ val _ = term_grammar.userSyntaxFns.register_absynPostProcessor {
           code = transform_absyn
     }
 
-fun syntax_actions al ar aup app =
-  (al {block_info = (PP.CONSISTENT,0),
+fun syntax_actions al ar aup app = (
+   al {block_info = (PP.CONSISTENT,0),
        cons = monadseq_special,
        nilstr = monad_emptyseq_special,
        leftdelim = [TOK "do", BreakSpace(1,2)],
@@ -323,8 +363,14 @@ fun syntax_actions al ar aup app =
        paren_style = OnlyIfNecessary,
        pp_elements = [BreakSpace(1,0), TOK "<-", HardSpace 1],
        term_name = monadassign_special};
-   aup ("monadsyntax.print_monads", ``x:'a``, print_monads);
-   app ("monadsyntax.transform_absyn", transform_absyn))
+   ar {block_style = (AroundEachPhrase, (PP.INCONSISTENT, 2)),
+       fixity = Infix(NONASSOC, 100),
+       paren_style = OnlyIfNecessary,
+       pp_elements = [BreakSpace(1,0), TOK "<<-", HardSpace 1],
+       term_name = monadmlet_special};
+   aup ("monadsyntax.print_monads", mk_var("x", alpha), print_monads);
+   app ("monadsyntax.transform_absyn", transform_absyn)
+   )
 
 fun temp_add_monadsyntax () =
     syntax_actions temp_add_listform temp_add_rule temp_add_user_printer
@@ -359,7 +405,7 @@ fun gen_enable_monad fname iovl ovl s =
   let
     val {bind,ignorebind,unit,fail,choice,guard} = getMI fname s
   in
-    ovl ("monad_bind", bind) ;
+    ovl ("monad_bind", bind);
     ovl ("monad_unitbind",
          case ignorebind of NONE => mk_unitbind bind | SOME ib => ib);
     iovl ("return", unit) ;
@@ -420,6 +466,7 @@ val temp_disable_monad =
 fun gen_disable_syntax rr rup rpp =
   (rr {term_name = monad_lform_name, tok = "do"};
    rr {term_name = monadassign_special, tok = "<-"};
+   rr {term_name = monadmlet_special, tok = "<<-"};
    rup "monadsyntax.print_monads";
    rpp "monadsyntax.transform_absyn")
 
@@ -438,6 +485,8 @@ fun add_monadsyntax () = syntax_actions add_listform add_rule aup aap
 
 val enable_monadsyntax = add_monadsyntax
 val temp_enable_monadsyntax = temp_add_monadsyntax
+
+fun print_explicit_monadic_lets b = (explicit_mlets := b);
 
 val _ = TexTokenMap.temp_TeX_notation
             {hol = "<-", TeX = ("\\HOLTokenLeftmap{}", 1)}

--- a/src/monad/more_monads/selftest.sml
+++ b/src/monad/more_monads/selftest.sml
@@ -5,6 +5,9 @@ val _ = temp_remove_absyn_postprocessor "monadsyntax.transform_absyn"
 val _ = temp_remove_user_printer "monadsyntax.print_monads"
 
 val _ = set_trace "Unicode" 0
+(* interactive only:
+val _ = diemode := FailException
+*)
 
 fun udie () = die "FAILED!"
 
@@ -107,6 +110,88 @@ val _ = if same_const f ``option$OPTION_IGNORE_BIND`` andalso
            hd args ~~ ``SOME 3`` andalso
            hd (tl args) ~~ ``SOME 4``
         then OK() else udie()
+
+val _ = tprint "Testing monadsyntax parse of mlet in option monad"
+val t = ``do mlet x <- y; SOME (x + 1) od``
+val (f, args) = strip_comb t
+val _ = if same_const f boolSyntax.let_tm andalso
+           hd args ~~ ``\x. SOME (x + 1)`` andalso
+           hd (tl args) ~~ ``y : num``
+        then OK() else udie()
+
+val t = ``do y <- z; mlet x <- y; SOME (x + 1) od``
+val (f, args) = strip_comb t
+val _ = if same_const f ``option$OPTION_BIND`` andalso
+           hd args ~~ ``z : num option`` andalso
+           hd (tl args) ~~ ``\y. let x = y in SOME (x + 1)``
+        then OK() else udie()
+
+val _ = tprint "Testing monadsyntax parse of mlet arrow in option monad"
+val t = ``do x <<- y; SOME (x + 1) od``
+val (f, args) = strip_comb t
+val _ = if same_const f boolSyntax.let_tm andalso
+           hd args ~~ ``\x. SOME (x + 1)`` andalso
+           hd (tl args) ~~ ``y : num``
+        then OK() else udie()
+
+val t = ``do y <- z; x <<- y; SOME (x + 1) od``
+val (f, args) = strip_comb t
+val _ = if same_const f ``option$OPTION_BIND`` andalso
+           hd args ~~ ``z : num option`` andalso
+           hd (tl args) ~~ ``\y. let x = y in SOME (x + 1)``
+        then OK() else udie()
+
+val mlettpp_test1 =
+    ("do mlet (x:α) <- f (x:α); g x; od",
+     String.concat [
+       "let ", bx, " = ", free "f", " ", free "x", " in ",
+       free "g", " ", bx
+     ])
+
+val mlettpp_test2 =
+    ("do (x:α) <<- f (x:α); g x; od",
+     String.concat [
+       "let ", bx, " = ", free "f", " ", free "x", " in ",
+       free "g", " ", bx
+     ])
+
+val mlettpp_test3 =
+    ("do a <- b; (x:α) <<- f (x:α); g x; od",
+     String.concat [
+       "do ", bound "a", " <- ", free "b", "; ",
+       bound "x", " <<- ", free "f", " ", free "x", "; ",
+       free "g", " ", bx, " od"
+     ])
+
+val mlettpp_test4 =
+    ("do a <- b; let x = f x in g x; od",
+     String.concat [
+       "do ", bound "a", " <- ", free "b", "; ",
+       bound "x", " <<- ", free "f", " ", free "x", "; ",
+       free "g", " ", bx, " od"
+     ])
+
+val _ = app tpp' [mlettpp_test1, mlettpp_test2, mlettpp_test3, mlettpp_test4]
+
+val _ = monadsyntax.print_explicit_monadic_lets true;
+
+val mlettpp_test5 =
+    ("do a <- b; (x:α) <<- f (x:α); g x; od",
+     String.concat [
+       "do ", bound "a", " <- ", free "b", "; ",
+       "mlet ", bound "x", " <- ", free "f", " ", free "x", "; ",
+       free "g", " ", bx, " od"
+     ])
+
+val mlettpp_test6 =
+    ("do a <- b; let x = f x in g x; od",
+     String.concat [
+       "do ", bound "a", " <- ", free "b", "; ",
+       "mlet ", bound "x", " <- ", free "f", " ", free "x", "; ",
+       free "g", " ", bx, " od"
+     ])
+
+val _ = app tpp' [mlettpp_test5, mlettpp_test6];
 
 val _ = disable_monad "option"
 val _ = declare_monad ("option",


### PR DESCRIPTION
Enable parsing and printing of equivalent `mlet x <- y` and `x <<- y` syntax, which expand to regular let-bindings. Progress towards #661.

Users have the option of printing in either style using `monadsyntax.print_explicit_monad_lets : bool -> unit` (default `false`, i.e. `x <<- y` form).
Note that expansion to regular let-binding means that `do mlet x <- y; ... od` will print as `let x = y in do ... od`. Regular let-bindings in do-blocks will be printed as monadic lets where scoping permits, e.g. `do a <- b; let c = d in do g <- e; f od od` prints as `do a <- b; c <<- d; g <- e; f od`.
