### PR TITLE
Remove makeidx from holtexbasic

### DIFF
--- a/src/TeX/holtexbasic.sty
+++ b/src/TeX/holtexbasic.sty
@@ -6,7 +6,7 @@
 % -------------------------------------------------------
 
 \NeedsTeXFormat{LaTeX2e}
-\usepackage{amssymb, makeidx, underscore, fancyvrb, amsmath}
+\usepackage{amssymb, underscore, fancyvrb, amsmath}
 
 \fvset{commandchars=\\\{\},xleftmargin=1mm,framesep=1.2mm,fontsize=\small}
 


### PR DESCRIPTION
For some reason I cannot build acmart-based articles when makeidx is loaded.

(Not sure how much sense it makes that the same file also loads fancyvrb and other things, but those things do not interfere in this specific case so I did not touch them.)