### PR TITLE
Fix mem accesses incorrectly interpreted as stack accesses (#848)

### DIFF
--- a/examples/machine-code/graph/stack_analysisLib.sml
+++ b/examples/machine-code/graph/stack_analysisLib.sml
@@ -6,9 +6,16 @@ open wordsTheory set_sepTheory progTheory helperLib addressTheory combinTheory;
 open backgroundLib file_readerLib writerLib;
 open GraphLangTheory
 
+fun arch_max_return_words () = let
+  val max = (case !arch_name of
+                RISCV => 2
+              | ARM => 1
+              | M0 => 1)
+  in max end
+
 fun stack_offset_in_fst_arg sec_name = let
   val (_,ret_word_count,_) = section_io sec_name
-  in 1 < ret_word_count end
+  in arch_max_return_words () < ret_word_count end
 
 local
   val bool_arb = mk_arb(``:bool``)


### PR DESCRIPTION
Fixes Issue #848 by generalizing the test for the first argument register containing a stack offset to account for different architecture calling conventions.

The stack analysis done by the decompiler used to make the assumption that a return stack offset is passed as the value of the first register if the return structure does not fit in a machine word. This assumption is valid for ARM and M0 binaries, but resulted in incorrect stack analysis for RISC-V binaries containing functions that return structs that fit in exactly two machine words.

Signed-off-by: Mitchell Buckley <mitchell.buckley@data61.csiro.au>