### PR TITLE
mc/graph: use python3 for decompile.py

### DIFF
--- a/examples/machine-code/graph/decompile.py
+++ b/examples/machine-code/graph/decompile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 


### PR DESCRIPTION
Binaries named `python` are disappearing from Linux distros, so we
choose `python3` instead.