### PR TITLE
Add a new example: a small verified bootstrapped compiler

### DIFF
--- a/examples/bootstrap/Holmakefile
+++ b/examples/bootstrap/Holmakefile
@@ -1,0 +1,1 @@
+INCLUDES = $(HOLDIR)/examples/fun-op-sem/lprefix_lub

--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -1,0 +1,36 @@
+# A Small Verified Bootstrapped Compiler
+
+The source language is defined in files:
+ - [source_syntaxScript.sml](source_syntaxScript.sml)
+ - [source_valuesScript.sml](source_valuesScript.sml)
+ - [source_semanticsScript.sml](source_semanticsScript.sml)
+ - [source_propertiesScript.sml](source_propertiesScript.sml)
+
+The target assembly language is defined in files:
+ - [x64asm_syntaxScript.sml](x64asm_syntaxScript.sml)
+ - [x64asm_semanticsScript.sml](x64asm_semanticsScript.sml)
+ - [x64asm_propertiesScript.sml](x64asm_propertiesScript.sml)
+
+The code generator and its verification proof:
+ - [codegenScript.sml](codegenScript.sml)
+ - [codegen_proofsScript.sml](codegen_proofsScript.sml)
+
+Functions and proofs about lexing, parsing and pretty printing of source code:
+ - [parsingScript.sml](parsingScript.sml)
+ - [parsing_proofsScript.sml](parsing_proofsScript.sml)
+ - [printingScript.sml](printingScript.sml)
+
+Top-level compiler definition as shallow embedding:
+ - [compilerScript.sml](compilerScript.sml)
+
+Automation that converts shallow embeddings into deep embeddings:
+ - [automation_lemmasScript.sml](automation_lemmasScript.sml)
+ - [automationLib.sml](automationLib.sml)
+ - [automationLib.sig](automationLib.sig)
+ - [compiler_progScript.sml](compiler_progScript.sml)
+
+In-logic evaluation of the code generator applied to the deeply embedded compiler:
+ - [compiler_evalScript.sml](compiler_evalScript.sml)
+
+A file with the top-level correctness theorems:
+ - [compiler_proofsScript.sml](compiler_proofsScript.sml)

--- a/examples/bootstrap/automationLib.sig
+++ b/examples/bootstrap/automationLib.sig
@@ -1,0 +1,18 @@
+signature automationLib =
+sig
+
+    include Abbrev
+
+    val to_deep : thm -> thm
+
+    val parse_dec : term Portable.quotation -> term
+    val parse_exp : term Portable.quotation -> term
+    val define_code : term Portable.quotation -> thm
+    val get_program : term -> term
+    val update_mem : thm -> unit
+    val write_hol_string_to_file : string -> term -> unit
+    val apply_at_pat_conv : term -> conv -> conv
+    val get_comments : unit -> term
+    val attach_comment : term Portable.quotation -> unit
+
+end

--- a/examples/bootstrap/automationLib.sml
+++ b/examples/bootstrap/automationLib.sml
@@ -1,0 +1,584 @@
+structure automationLib :> automationLib =
+struct
+
+open HolKernel Parse boolLib bossLib;
+open arithmeticTheory listTheory pairTheory finite_mapTheory stringTheory;
+open source_valuesTheory source_syntaxTheory source_semanticsTheory
+     source_propertiesTheory parsingTheory printingTheory mp_then
+     automation_lemmasTheory;
+
+(* misc *)
+
+fun get_induction_for_def def = let
+  fun mk_arg_vars xs = let
+    fun aux [] = []
+      | aux (x::xs) =
+          mk_var("v" ^ (int_to_string (length xs + 1)),type_of x) :: aux xs
+    in (rev o aux o rev) xs end
+  fun f tm = let
+    val (lhs,rhs) = dest_eq tm
+    val (const,args) = strip_comb lhs
+    val vargs = mk_arg_vars args
+    val args = pairSyntax.list_mk_pair args
+    in (const,vargs,args,rhs) end
+  val cs = def |> CONJUNCTS |> map (f o concl o SPEC_ALL)
+  val cnames = map (fn (x,_,_,_) => x) cs |> op_mk_set aconv
+  val cs = map (fn c => (c, map (fn (x,y,z,q) => (y,z,q))
+                              (filter (fn (x,_,_,_) => aconv c x) cs))) cnames
+           |> map (fn (c,x) => (c,hd (map (fn (x,y,z) => x) x),
+                                map (fn (x,y,z) => (y,z)) x))
+  fun split_at P [] = fail()
+    | split_at P (x::xs) = if P x then ([],x,xs) else let
+        val (x1,y1,z1) = split_at P xs
+        in (x::x1,y1,z1) end
+  fun find_pat_match (_,args,pats) = let
+    val pat = hd pats |> fst
+    val vs = pairSyntax.list_mk_pair args
+    val ss = fst (match_term vs pat)
+    val xs = map (subst ss) args
+    in (split_at (not o is_var) xs) end
+  val xs = map find_pat_match cs
+  val ty = map (fn (_,x,_) => type_of x) xs |> hd
+  val raw_ind = TypeBase.induction_of ty
+  fun my_mk_var ty = mk_var("pat_var", ty)
+  fun list_mk_fun_type [] = hd []
+    | list_mk_fun_type [ty] = ty
+    | list_mk_fun_type (t::ts) = mk_type("fun",[t,list_mk_fun_type ts])
+  fun goal_step index [] = []
+    | goal_step index ((xs,t,ys)::rest) = let
+    val v = my_mk_var (type_of t)
+    val args = xs @ [v] @ ys
+    val P = mk_var("P" ^ (int_to_string index) ,
+              list_mk_fun_type ((map type_of args) @ [bool]))
+    val prop = list_mk_comb(P,args)
+    val goal = list_mk_forall(args,prop)
+    val step = mk_abs(v,list_mk_forall(xs @ ys,prop))
+    in (P,(goal,step)) :: goal_step (index+1) rest end
+  val res = goal_step 0 xs
+  fun ISPEC_LIST [] th = th
+    | ISPEC_LIST (x::xs) th = ISPEC_LIST xs (ISPEC x th)
+  val ind = ISPEC_LIST (map (snd o snd) res) raw_ind
+            |> CONV_RULE (DEPTH_CONV BETA_CONV)
+  val goal1 = ind |> concl |> dest_imp |> snd
+  val goal2 = list_mk_conj (map (fst o snd) res)
+  val goal = mk_imp(goal1,goal2)
+  val lemma = snd ((REPEAT STRIP_TAC THEN ASM_REWRITE_TAC []) ([],goal)) []
+  val ind = MP lemma (ind |> UNDISCH_ALL) |> DISCH_ALL |> GENL (map fst res)
+  in ind end handle HOL_ERR _ =>
+  failwith "unable to construct induction theorem from TypeBase info"
+
+fun list_dest f tm =
+  let val (x,y) = f tm in list_dest f x @ list_dest f y end
+  handle HOL_ERR _ => [tm];
+
+fun is_uppercase c = #"A" <= c andalso c <= #"Z"
+fun every p [] = true | every p (x::xs) = p x andalso every p xs;
+fun lowercase s = String.translate (fn c => implode [chr (ord c + 32)]) s
+fun fix_name s = if every is_uppercase (explode s) then lowercase s else s;
+
+fun is_rec def = let
+  val eqs = def |> SPEC_ALL |> CONJUNCTS |> map (concl o SPEC_ALL)
+  val consts = map (repeat rator o fst o dest_eq) eqs
+  val all_rhs = map (REFL o snd o dest_eq) eqs |> LIST_CONJ |> concl
+  in can (first (fn c => can (find_term (aconv c)) all_rhs)) consts end;
+
+fun guess_ind_thm def =
+  if not (is_rec def) then NONE else let
+    val c = def |> CONJUNCTS |> hd |> SPEC_ALL |> concl
+                |> dest_eq |> fst |> repeat rator |> dest_thy_const
+    in SOME (fetch "-" (#Name c ^ "_ind"))
+       handle HOL_ERR _ => SOME (fetch (#Thy c) (#Name c ^ "_ind")) end
+    handle HOL_ERR _ => SOME (get_induction_for_def def)
+
+(* build a list of defun declarations *)
+
+local
+  val defuns = ref ([]:term list)
+  val comments = ref ([]:term list)
+  val next_comment = ref “""”
+  fun print_defun defun = let
+    val str = mk_comb(“v2str”,mk_comb(“dec2v”,defun))
+              |> QCONV EVAL |> concl |> rand |> stringSyntax.fromHOLstring
+    in print ("\n\n" ^ str ^ "\n\n\n") end
+in
+  fun attach_comment q = let
+    val str = Portable.quote_to_string (fn _ => raise General.Bind) q
+    in next_comment := stringSyntax.fromMLstring (str ^ "\n") end
+  fun add_defun defun = let
+    val _ = print_defun defun
+    in (defuns := defun :: (!defuns);
+        comments := (!next_comment) :: (!comments);
+        next_comment := “""”; defun) end
+  fun get_program main = let
+    val ds = listSyntax.mk_list(rev(!defuns),“:dec”)
+    in list_mk_comb(“Program”,[ds,main]) end
+  fun get_comments () = listSyntax.mk_list(rev((!next_comment)::(!comments)),“:string”)
+end
+
+(* from types to representation functions *)
+
+val option_ty = “:α option”
+val list_ty = “:α list”
+val app_list_ty = “:α app_list”
+val pair_ty = “:α # β”
+
+val ty_invs = ref [(“:bool”,“bool”),
+                   (“:num”,“Num”),
+                   (“:char”,“char”),
+                   (“:token”,“token”),
+                   (“:test”,“test”),
+                   (“:op”,“op”),
+                   (“:exp”,“exp”),
+                   (“:dec”,“dec”),
+                   (“:prog”,“prog”),
+                   (“:word64”,“word:word64->v”),
+                   (“:word4”,“word:word4->v”),
+                   (“:reg”,“reg”),
+                   (“:cond”,“cond”),
+                   (“:inst”,“inst”),
+                   (“:v”,“deep”)];
+
+fun add_ty_inv ty tm = (ty_invs := (ty,tm)::(!ty_invs));
+
+fun ty2inv ty =
+  if can dest_vartype ty then
+    mk_var(dest_vartype ty |> explode |> tl |> implode,
+           mk_type("fun",[ty,“:v”]))
+  else if can (first (fn (x,_) => x = ty)) (!ty_invs) then
+    snd (first (fn (x,_) => x = ty) (!ty_invs))
+  else if can (match_type list_ty) ty then let
+    val a = ty2inv (listSyntax.dest_list_type ty)
+    in map_def |> ISPEC a |> SPEC_ALL |> concl |> dest_eq |> fst |> rator end
+  else if can (match_type app_list_ty) ty then let
+    val a = ty2inv (dest_type ty |> snd |> hd)
+    in app_list_def |> CONJUNCT1 |> ISPEC a |> SPEC_ALL |> concl
+                    |> dest_eq |> fst |> rator end
+  else if can (match_type option_ty) ty then let
+    val a = ty2inv (ty |> dest_type |> snd |> last)
+    in option_def |> CONJUNCT1 |> ISPEC a |> concl |> dest_eq |> fst |> rator end
+  else if can (match_type pair_ty) ty then
+    pair_def |> ISPECL (dest_type ty |> snd |> map ty2inv)
+    |> SPEC_ALL |> concl |> dest_eq |> fst |> rator
+  else fail()
+
+(* from terms to --> thms *)
+
+val finalised_mem = ref ([]: (term * thm) list)
+val in_flight_mem = ref ([]: (term * thm) list)
+val trans_thms    = ref (DB.find "auto_"
+  |> filter (fn ((thy,_),_) => thy = "automation_lemmas")
+  |> map (CONJUNCTS o fst o snd)
+  |> flatten |> (fn xs => xs @ [last_bool_if]));
+
+fun update_mem lemma =
+  (finalised_mem :=
+     map (fn (pat,th) => (pat,PURE_REWRITE_RULE [lemma] th)) (!finalised_mem));
+
+val name_eq_name_pat = “name _ = name _”;
+val goal_pat = “(b0 ⇒ (env, [x1], s0) ---> ([v1], s1))”
+val app_pat = “app (n:num) _ _ _”
+
+fun hol2deep_list hol2deep [] = trans_nil
+  | hol2deep_list hol2deep [x] = hol2deep x
+  | hol2deep_list hol2deep (x::xs) = let
+    val th1 = hol2deep (x:term)
+    val th2 = hol2deep_list hol2deep xs
+    in MATCH_MP trans_cons (CONJ th1 th2) end
+
+(* val tm = “(\a b c. a + b + c) x y z” *)
+fun dest_lam_app tm = let
+  fun dest_comb_var tm = let
+    val (x,y) = dest_comb tm
+    val _ = is_var y orelse fail()
+    in (x,y) end
+  val xs = list_dest dest_comb_var tm
+  val vs = butlast (list_dest dest_abs (hd xs))
+  val _ = not (null xs) orelse fail()
+  val ys = tl xs
+  val _ = length ys = length vs orelse fail()
+  val _ = length ys <> 0 orelse fail()
+  in zip vs ys end
+
+val name_eq_name_pat = “name n = name m”;
+fun decide_name_eq_conv tm =
+  if can (match_term name_eq_name_pat) tm then EVAL tm else NO_CONV tm
+
+fun prove_goal hol2deep gg = let
+  val ss = find_term (can dest_lam_app) gg |> dest_lam_app handle HOL_ERR _ => []
+  fun rename_conv s tm = let
+    val (v,x) = dest_abs tm
+    val (w,_) = first (fn (_,y) => aconv y v) [s]
+    in ALPHA_CONV w tm end handle HOL_ERR _ => NO_CONV tm
+  fun list_rename_conv [] = ALL_CONV
+    | list_rename_conv (s::ss) =
+        ONCE_DEPTH_CONV (rename_conv s) THENC list_rename_conv ss
+  val t2 = QCONV (DEPTH_CONV BETA_CONV THENC list_rename_conv ss) gg
+  val g2 = t2 |> concl |> rand
+  val vs = butlast (list_dest dest_forall g2)
+  val x = last (list_dest dest_forall g2) |> dest_imp |> snd
+  val new_env = x |> rator |> rand |> rator |> rand
+  val ups = find_terms combinSyntax.is_update new_env
+  fun get_substs up = let
+    val (x1,x2) = combinSyntax.dest_update up
+    val name = x1 |> rand
+    val inv_v = x2 |> rand |> rator
+    val vname = x2 |> rand |> rand
+    val (s,i) = match_term inv_v (ty2inv (type_of vname))
+    val s2 = (name |-> stringSyntax.fromMLstring (dest_var vname |> fst)) :: s
+    in s2 end
+  val s = flatten (map get_substs ups)
+  val t3 = INST s t2
+  val lemma = hol2deep (x |> rand |> rator |> rand |> rator |> rand |> rand)
+  val x = t3 |> concl |> rand |> list_dest dest_forall |> last
+  val new_env = x |> rand |> rator |> rand |> rator |> rand
+  fun LIST_UNBETA_CONV [] = ALL_CONV
+    | LIST_UNBETA_CONV (x::xs) =
+        UNBETA_CONV x THENC RATOR_CONV (LIST_UNBETA_CONV xs)
+  in
+     lemma |> INST [mk_var("env",type_of new_env)|->new_env]
+           |> CONV_RULE ((RATOR_CONV o RAND_CONV)
+               (REWRITE_CONV [combinTheory.APPLY_UPDATE_THM] THENC
+                DEPTH_CONV decide_name_eq_conv THENC
+                REWRITE_CONV [combinTheory.APPLY_UPDATE_THM,
+                              optionTheory.SOME_11,v_11] THENC
+                LIST_UNBETA_CONV (rev vs)))
+          |> GENL vs
+          |> CONV_RULE (REWR_CONV (GSYM t3))
+  end
+
+fun apply_th hol2deep target th = let
+  val pat = th |> UNDISCH_ALL |> concl |> rand |> rator |> rand |> rator |> rand
+  val (i,t) = match_term pat target
+  val _ = aconv (pat |> inst t |> subst i) target orelse fail()
+  val th1 = INST i (INST_TYPE t th)
+  val gs = th1 |> SPEC_ALL |> concl |> rator |> rand |> list_dest dest_conj
+               |> filter (fn tm => not (aconv tm T))
+  val ls = map (prove_goal hol2deep) gs
+  in (if length gs = 0 then th1
+      else (MATCH_MP th1 (LIST_CONJ ls)
+            |> CONV_RULE ((RATOR_CONV o RAND_CONV) (DEPTH_CONV BETA_CONV))))
+      |> PURE_REWRITE_RULE [boolTheory.COND_ID] end
+
+fun get_first f [] = NONE
+  | get_first f (x::xs) = SOME (f x) handle HOL_ERR _ => get_first f xs;
+
+fun add_inv tm = mk_comb(ty2inv (type_of tm), tm);
+
+fun inst_app_term hol2deep [] tm = NONE
+  | inst_app_term hol2deep ((pat,app_th)::rest) tm =
+  if not (can (match_term pat) tm) then inst_app_term hol2deep rest tm else let
+  val (i,t) = match_term pat tm
+  val lemma = app_th |> INST_TYPE t |> INST i |> PURE_REWRITE_RULE [GSYM map_def]
+  val args = lemma |> concl |> rand |> rator |> rator |> rand
+  val argl = args |> listSyntax.dest_list |> fst
+  val args' = listSyntax.mk_list(map (add_inv o rand) argl,“:v”)
+  val lemma = INST (fst (match_term args args')) lemma
+  val vs = pat |> inst t |> rand |> list_dest dest_comb |> tl
+  val th = hol2deep_list hol2deep (map (subst i) vs)
+  in SOME (MATCH_MP trans_Call (CONJ th lemma)) handle HOL_ERR _ =>
+     SOME (MATCH_MP trans_Call (CONJ th lemma |> PURE_REWRITE_RULE [GSYM map_def])) end
+
+fun genvar_rule th =
+  INST (map (fn v => v |-> genvar (type_of v)) (free_vars (concl th))) th
+
+fun add_to_mem r (pat, app_th) = (r := (pat,app_th)::(!r));
+
+val bad_input = ref T;
+fun check_res tm target th =
+  if can (find_term (aconv target)) (concl th) then th
+  else (bad_input := tm; fail())
+
+fun hol2deep tm =
+  if is_var tm then let
+    val (s,ty) = dest_var tm
+    in SPECL [stringSyntax.fromMLstring s,
+              mk_comb(ty2inv ty, tm)] trans_Var end
+  else let
+    val target = mk_comb(ty2inv (type_of tm), tm)
+    in case get_first (apply_th hol2deep target) (!trans_thms) of
+         SOME th => check_res tm target th | NONE =>
+     (case inst_app_term hol2deep (!in_flight_mem) target of
+        SOME res => check_res tm target (res |> PURE_REWRITE_RULE [GSYM map_def]) | NONE =>
+     (case inst_app_term hol2deep (!finalised_mem) target of
+        SOME res => check_res tm target (res |> PURE_REWRITE_RULE [GSYM map_def]) | NONE =>
+      let
+        val _ = print "\n\nhol2deep failed for input:\n\n"
+        val _ = print_term tm
+        val _ = print "\n\n"
+      in fail() end))
+    end
+
+fun ABBREV_CONV fname params name tm = let
+  val v = mk_var(name,type_of tm)
+  val defun = list_mk_comb(“Defun”,[fname,params,tm])
+  val _ = add_defun defun
+  in GSYM (Define ‘^v = ^tm’) end
+
+val trans_app = let
+  val vs = free_vars (concl trans_app)
+  in INST (map (fn v => v |-> genvar(type_of v)) vs) trans_app end
+
+fun apply_at_conv p c tm =
+  DEPTH_CONV (fn tm => if p tm then c tm else NO_CONV tm
+                       handle HOL_ERR _ => NO_CONV tm) tm;
+
+fun apply_at_pat_conv pat = apply_at_conv (can (match_term pat));
+
+fun process_def def = let
+  val def = def |> SPEC_ALL |> PURE_REWRITE_RULE [all_macro_defs]
+  val th = hol2deep (def |> concl |> rand)
+           |> MATCH_MP inline_let |> UNDISCH |> CONV_RULE (PATH_CONV "rlrrlr" EVAL)
+  val parts = def |> concl |> rator |> rand |> list_dest dest_comb
+  val c = hd parts
+  val vs = tl parts
+  fun v_to_str v = let
+    val s = v |> dest_var |> fst |> stringSyntax.fromMLstring
+            handle HOL_ERR _ =>
+            v |> dest_const |> fst |> stringSyntax.fromMLstring
+    in mk_comb (“name”, s) end
+  val params = listSyntax.mk_list(map v_to_str vs,“:num”)
+  val args = listSyntax.mk_list(map add_inv vs,“:v”)
+  val lemma = trans_app
+    |> SPEC (c |> dest_const |> fst |> fix_name |> stringSyntax.fromMLstring)
+    |> SPECL [params,args]
+  val new_env = lemma |> concl |> rand
+  val env_var = lemma |> concl |> rator |> rand |> dest_abs |> fst
+  val lemma1 = lemma |> SIMP_RULE std_ss [LET_THM,LENGTH]
+  val th1 = INST [env_var|->new_env] th
+  val th2 = MATCH_MP lemma1 th1
+  val c_name = c |> dest_const |> fst
+  val fname = fix_name c_name |> stringSyntax.fromMLstring
+  val th3 = th2 |> CONV_RULE (PATH_CONV "lrrrr"
+                     (ABBREV_CONV “name ^fname” params (c_name ^ "_code")))
+                |> UNDISCH
+  val th4 = th3 |> CONV_RULE (PATH_CONV "rrlrr" (REWR_CONV (GSYM def)))
+  val th5 = th4 |> CONV_RULE (PATH_CONV "lr"
+     (SIMP_CONV std_ss [make_env_def,combinTheory.APPLY_UPDATE_THM]))
+  val tms = find_terms (can (match_term name_eq_name_pat)) (concl th5)
+  val th6 = REWRITE_RULE (map EVAL tms) th5
+  val th7 = if is_imp (concl th6) then th6 else DISCH T th6
+  in th7 end
+
+fun remove_apps tm =
+  if can (match_term app_pat) tm then T else
+  if is_abs tm then let
+    val (v,b) = dest_abs tm
+    in mk_abs(v,remove_apps b) end else
+  if is_comb tm then let
+    val (x,y) = dest_comb tm
+    in mk_comb(remove_apps x, remove_apps y) end else tm
+
+fun make_format d = let
+  val pat = d |> concl |> dest_eq |> fst
+  val parts = pat |> list_dest dest_comb
+  val c = hd parts
+  val vs = tl parts
+  val vs_tm = listSyntax.mk_list(map add_inv vs,“:v”)
+  val c_str = c |> dest_const |> fst |> fix_name
+  val n = c_str |> stringSyntax.fromMLstring
+  val s = trans_nil |> concl |> rand |> rand |> rand
+  val cc = list_mk_comb(“app (name ^n)”, [vs_tm,s,pairSyntax.mk_pair(add_inv pat,s)])
+  fun mk_type [] ty = ty
+    | mk_type (t::ts) ty = t --> (mk_type ts ty)
+  val side_tm = mk_var(c_str ^ "_side", mk_type (map type_of vs) bool)
+  val s = list_mk_comb(side_tm,vs)
+  in (add_inv pat,ASSUME cc |> DISCH_ALL |> DISCH s |> REWRITE_RULE [AND_IMP_INTRO]) end
+
+fun remove_primes s = implode (filter (fn c => c <> #"'") (explode s))
+val varnames = explode "xyzstvwabcdefghijklmnopqru" |> map (implode o single)
+fun auto_name_bound_vars_conv vs tm =
+  if is_comb tm then
+    (RATOR_CONV (auto_name_bound_vars_conv vs) THENC
+     RAND_CONV (auto_name_bound_vars_conv vs)) tm
+  else if is_var tm then ALL_CONV tm
+  else if is_const tm then ALL_CONV tm
+  else let
+    val (v,body) = dest_abs tm
+    val (n,ty) = dest_var v
+    val n = remove_primes n
+    val w = hd (filter (fn s => not (mem s vs)) (n::varnames))
+    in (ALPHA_CONV (mk_var(w,ty)) THENC
+        ABS_CONV (auto_name_bound_vars_conv (w::vs))) tm end
+
+val list_case = “list_CASE (x:'a list) (nil_f:'b) cons_f”
+val pair_case = “pair_CASE x (the_case:'a -> 'b -> 'c)”
+val base_name = "variable_"
+fun make_some_names_long_conv tm = let
+  val next = ref 0
+  fun get_var ty = let
+    val n = !next
+    in (next := n + 1; mk_var(base_name ^ int_to_string n, ty)) end
+  fun pass tm = let
+    val _ = can (match_term list_case) tm orelse
+            can (match_term pair_case) tm orelse fail()
+    val (v1,body) = dest_abs (rand tm)
+    val (v2,body) = dest_abs body
+    val v1 = get_var (type_of v1)
+    val v2 = get_var (type_of v2)
+    in (RAND_CONV (ALPHA_CONV v1 THENC ABS_CONV (ALPHA_CONV v2))
+        THENC RATOR_CONV pass THENC RAND_CONV pass) tm end
+    handle HOL_ERR _ =>
+    if is_comb tm then (RATOR_CONV pass THENC RAND_CONV pass) tm else
+    if is_abs tm then (ABS_CONV pass) tm else ALL_CONV tm
+  in pass tm end
+
+fun preprocess_def def = let
+  val defs = def |> CONJUNCTS |> map SPEC_ALL
+  fun nub [] = [] | nub (x::xs) = x :: nub (filter (not o aconv x) xs)
+  fun get_c d = d |> concl |> dest_eq |> fst |> repeat rator
+  val cs = nub (map get_c defs)
+  in map (fn c => filter (fn th => aconv (get_c th) c) defs |> LIST_CONJ
+                  |> DefnBase.one_line_ify NONE |> GEN_ALL
+                  |> CONV_RULE (auto_name_bound_vars_conv [])
+                  |> CONV_RULE make_some_names_long_conv
+                  |> CONV_RULE (auto_name_bound_vars_conv []) |> SPEC_ALL) cs
+ end
+
+fun to_deep def = let
+  val ind = guess_ind_thm def
+  val defs = preprocess_def def
+  val formats = map make_format defs
+  val _ = app (add_to_mem in_flight_mem) formats
+  val thms = map process_def defs
+  val ts = map (fn th => th |> concl |> dest_imp |> fst |> remove_apps) thms
+  val ss = map (fn (tm,th) => th |> concl |> dest_imp |> fst |> dest_conj |> fst) formats
+  val vss = map (tl o list_dest dest_comb) ss
+  val ps = map (fn (vs,(t,s)) => list_mk_forall(vs,mk_imp(t,s))) (zip vss (zip ts ss))
+  val tm = list_mk_conj ps
+  val (_,_,side_def) = Hol_reln ‘^tm’
+  val cs = side_def |> CONJUNCTS |> map (repeat rator o fst o dest_eq o concl o SPEC_ALL)
+  val gs = map (fn (_,th) => th |> concl |> dest_imp |> fst
+                                |> dest_conj |> fst |> repeat rator) formats
+  val i = map2 (fn g => fn c => g |-> c) gs cs
+  val thms = map (INST i) thms
+  val ys = map (fn (vs,(c,(_,th))) =>
+             list_mk_abs(vs,mk_imp(list_mk_comb(c,vs),th |> concl |> rand)))
+             (zip vss (zip cs formats))
+  val thms =
+(*
+  val SOME ind_thm = ind
+*)
+    case ind of NONE => map (PURE_REWRITE_RULE [GSYM side_def]) thms
+    | SOME ind_thm => let
+      val name_pat = “source_values$name _”
+      val lemma = ind_thm |> SPECL ys |> CONV_RULE (DEPTH_CONV BETA_CONV)
+                          |> PURE_REWRITE_RULE [all_macro_defs]
+                          |> PURE_REWRITE_RULE [GSYM map_def]
+      val lookup_funs = LIST_CONJ thms |> hyp |> list_mk_conj
+      val goal = mk_imp(lookup_funs,concl lemma |> rand)
+      val tacs = map
+        (fn th => match_mp_tac (DISCH_ALL th |> REWRITE_RULE [AND_IMP_INTRO])) thms
+      val std_tac =
+        strip_tac
+        \\ match_mp_tac lemma
+        \\ rpt conj_tac \\ rpt gen_tac
+        \\ rpt (disch_then strip_assume_tac)
+        \\ rpt conj_tac \\ rpt gen_tac
+        \\ rpt (disch_then strip_assume_tac)
+        \\ FIRST tacs \\ fs []
+        \\ pop_assum mp_tac
+        \\ simp [Once side_def] \\ fs [name_def]
+        \\ rpt strip_tac \\ res_tac \\ fs []
+        \\ TRY (Cases_on ‘t’ \\ Cases_on ‘z’ \\ fs [] \\ NO_TAC)
+        \\ metis_tac []
+      val careful_tac =
+        strip_tac
+        \\ match_mp_tac lemma
+        \\ rpt conj_tac \\ rpt gen_tac
+        \\ rpt (disch_then strip_assume_tac)
+        \\ rpt conj_tac \\ rpt gen_tac
+        \\ rpt (disch_then strip_assume_tac)
+        \\ FIRST tacs \\ full_simp_tac std_ss []
+        \\ pop_assum mp_tac
+        \\ simp_tac std_ss [Once side_def]
+        \\ rpt (pop_assum mp_tac)
+        \\ CONV_TAC (apply_at_conv (can (match_term name_pat)) EVAL)
+        \\ rpt strip_tac
+        \\ full_simp_tac std_ss []
+        \\ rpt strip_tac
+        \\ full_simp_tac std_ss []
+        \\ rpt (pop_assum mp_tac)
+        \\ CONV_TAC (apply_at_conv (can (match_term name_pat)) EVAL)
+        \\ rpt strip_tac
+        \\ full_simp_tac std_ss []
+     (* \\ fs [] *)
+        \\ TRY (Cases_on ‘t’ \\ Cases_on ‘z’ \\ fs [] \\ NO_TAC)
+        \\ metis_tac []
+      val careful = “v2exp”
+      val thA = prove(goal,
+        if can (find_term (aconv careful)) (def |> CONJUNCTS |> hd |> SPEC_ALL |> concl |> dest_eq |> fst)
+        then careful_tac else std_tac)
+      val thms = thA |> REWRITE_RULE [GSYM AND_IMP_INTRO] |> UNDISCH_ALL |> CONJUNCTS
+      val thms = map2 (fn th => fn vs => SPECL vs th) thms vss
+      in thms end
+  val _ = (in_flight_mem := [])
+  val side_def =
+    case ind of
+      NONE => let
+        val vs = list_dest dest_forall (concl side_def) |> butlast
+        in side_def |> SPEC_ALL
+                    |> CONV_RULE (RAND_CONV (SIMP_CONV (srw_ss()) [name_def]))
+                    |> GENL vs end
+    | SOME i => let
+      val n = side_def |> SPEC_ALL |> concl |> dest_eq |> fst
+      val vs = list_dest dest_comb n
+      val t = ISPEC (list_mk_abs (tl vs, mk_eq(n,T))) i
+              |> CONV_RULE (DEPTH_CONV BETA_CONV)
+      val goal = concl t |> rand
+      val tac = match_mp_tac t \\ rw [] \\ once_rewrite_tac [side_def]
+                \\ fs [name_def] \\ CCONTR_TAC \\ fs [] \\ fs [] \\ fs [name_def]
+      val lemma = snd (tac ([],goal)) []
+      in lemma end handle HOL_ERR _ => side_def
+  val side_is_true =
+    aconv (side_def |> SPEC_ALL |> concl |> rand) T handle HOL_ERR _ => false
+  val rr = if side_is_true then PURE_REWRITE_RULE [side_def] else I
+  val results = map2 (fn (pat,_) => fn th => (pat,rr th)) formats thms
+  val _ = app (add_to_mem finalised_mem) results
+  val sides = map2 (fn th => fn vs => SPECL vs th) (CONJUNCTS side_def) vss
+  val c_name = defs |> hd |> SPEC_ALL |> concl |> dest_eq
+                    |> fst |> repeat rator |> dest_const |> fst
+  val thms = map snd results
+  val _ = print "\n"
+  val _ = print_thm (LIST_CONJ thms)
+  val _ = print "\n\n"
+  val _ = save_thm(c_name ^ "_app", LIST_CONJ thms)
+  in LIST_CONJ sides end
+
+(* functions for inputing concrete syntax directly *)
+
+local
+  fun parse_any f q = let
+    val str = Portable.quote_to_string (fn _ => raise General.Bind) q
+    val tm = stringSyntax.fromMLstring str
+    val th = EVAL ``^f (head (parse (lexer ^tm) (Num 0) []))``
+    fun get_name tm = let
+      val t = EVAL ``ascii_name ^tm`` |> concl |> rand
+      val t1 = optionSyntax.dest_some t
+      val name_tm = name_def |> CONJUNCT1 |> concl |> dest_eq |> fst |> repeat rator
+      in mk_comb(name_tm,t1) end
+    fun fix_names tm =
+      if numSyntax.is_numeral tm then
+        (get_name tm handle HOL_ERR _ => tm)
+      else if is_comb tm then
+        mk_comb(fix_names (rator tm),fix_names (rand tm))
+      else tm
+    in th |> concl |> rand |> fix_names end
+in
+  val parse_exp = parse_any ``v2exp``
+  val parse_dec = parse_any ``v2dec``
+end
+
+fun define_code q = let
+  val dec = add_defun (parse_dec q)
+  val c = dec |> rator |> rator |> rand |> rand |> stringSyntax.fromHOLstring
+  val v = mk_var(c ^ "_code", dec |> rand |> type_of)
+  in new_definition(c ^ "_code_def", mk_eq(v, dec |> rand)) end
+
+fun write_hol_string_to_file filename tm = let
+  val f = TextIO.openOut filename
+  val s = tm |> stringSyntax.fromHOLstring
+  val _ = TextIO.output (f,s)
+  val _ = TextIO.closeOut f
+  in () end
+
+end

--- a/examples/bootstrap/automation_lemmasScript.sml
+++ b/examples/bootstrap/automation_lemmasScript.sml
@@ -1,0 +1,740 @@
+
+open HolKernel Parse boolLib bossLib;
+open arithmeticTheory listTheory pairTheory finite_mapTheory stringTheory;
+open source_valuesTheory source_syntaxTheory source_semanticsTheory codegenTheory
+     source_propertiesTheory mp_then parsingTheory x64asm_syntaxTheory
+     wordsTheory wordsLib;
+
+val _ = new_theory "automation_lemmas";
+
+
+(* theorems used in proof automation *)
+
+Theorem trans_app:
+  ∀n params vs.
+    let env = make_env params vs empty_env in
+      (b ⇒ (env,[body],s) ---> ([v],s1)) ⇒
+      LENGTH params = LENGTH vs ⇒
+      lookup_fun (name n) s.funs = SOME (params,body) ⇒
+      b ⇒ app (name n) vs s (v,s1)
+Proof
+  fs [app_cases,env_and_body_def]
+QED
+
+Theorem trans_Call:
+  (b1 ⇒ (env, xs, s1) ---> (vs, s2)) ∧
+  (b2 ⇒ app fname vs s2 (v,s3)) ⇒
+  (b1 ∧ b2 ⇒ (env, [Call fname xs], s1) ---> ([v], s3))
+Proof
+  metis_tac [Eval_Call]
+QED
+
+Theorem trans_Var:
+  ∀n v. env (name n) = SOME v ⇒ (env,[Var (name n)],s) ---> ([v],s)
+Proof
+  fs [Eval_rules]
+QED
+
+Theorem trans_nil:
+  (T ⇒ (env, [], s) ---> ([], s))
+Proof
+  rw [] \\ metis_tac [Eval_rules]
+QED
+
+Theorem trans_cons:
+  (b1 ⇒ (env, [x], s1) ---> ([v], s2)) ∧
+  (b2 ⇒ (env, xs, s2) ---> (vs, s3)) ⇒
+  (b1 ∧ b2 ⇒ (env, x::xs, s1) ---> (v::vs, s3))
+Proof
+  Cases_on ‘xs’ \\ fs [] \\ rw [] \\ fs []
+  \\ imp_res_tac Eval_length \\ fs [] \\ rw []
+  \\ pop_assum mp_tac
+  THEN1 simp [Once Eval_cases]
+  \\ Cases_on ‘vs’ \\ fs []
+  \\ simp [Once Eval_cases] \\ metis_tac []
+QED
+
+Theorem auto_let:
+  (b1 ⇒ (env, [x_1], s1) ---> ([(a:'a->v) v1], s2)) ∧
+  (∀v1. b2 v1 ⇒ ((name let_n =+ SOME (a v1)) env, [y_1], s2) ---> ([b (f v1)], s3)) ⇒
+  (b1 ∧ b2 v1 ⇒
+    (env, [Let (name let_n) x_1 y_1], s1) ---> ([(b:'b->v) (LET f v1)], s3))
+Proof
+  rw [LET_THM,Eval_eq] \\ metis_tac []
+QED
+
+Theorem auto_otherwise:
+  (b1 ⇒ (env, [x_1], s) ---> ([(a:'a->v) v1], s)) ⇒
+  (b1 ⇒ (env, [If Less [Const 0; Const 1] x_1 (Const 0)], s) --->
+        ([(a:'a->v) (otherwise v1)], s))
+Proof
+  fs [Eval_eq,take_branch_def,return_def]
+QED
+
+(* bool *)
+
+Theorem auto_bool_F:
+  T ⇒ (env,[Const 0],s) ---> ([bool F],s)
+Proof
+  fs [Eval_eq]
+QED
+
+Theorem auto_bool_T:
+  T ⇒ (env,[Const 1],s) ---> ([bool T],s)
+Proof
+  fs [Eval_eq]
+QED
+
+Theorem auto_bool_not:
+  (b0 ⇒ (env,[x1],s) ---> ([bool b],s)) ⇒
+  b0 ⇒ (env,[Op Sub [Const 1; x1]],s) ---> ([bool (~b)],s)
+Proof
+  rw [Eval_eq,PULL_EXISTS] \\ fs []
+  \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+  \\ Cases_on ‘b’ \\ EVAL_TAC
+QED
+
+Theorem auto_bool_and:
+  (b0 ⇒ (env,[x1],s) ---> ([bool bA],s)) ∧
+  (b1 ⇒ (env,[x2],s) ---> ([bool bB],s)) ⇒
+  b0 ∧ b1 ⇒ (env,[Op Sub [Op Add [x1; x2]; Const 1]],s) ---> ([bool (bA ∧ bB)],s)
+Proof
+  rw [Eval_eq,PULL_EXISTS] \\ fs []
+  \\ rpt (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+  \\ Cases_on ‘bA’ \\ Cases_on ‘bB’ \\ EVAL_TAC \\ fs [AllCaseEqs()]
+QED
+
+Theorem auto_bool_iff:
+  (b0 ⇒ (env,[x1],s) ---> ([bool bA],s)) ∧
+  (b1 ⇒ (env,[x2],s) ---> ([bool bB],s)) ⇒
+  b0 ∧ b1 ⇒
+  (env,[If Equal [x1; x2] (Const 1) (Const 0)],s) ---> ([bool (bA ⇔ bB)],s)
+Proof
+  rw [Eval_eq,PULL_EXISTS] \\ fs []
+  \\ rpt (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+  \\ Cases_on ‘bA’ \\ Cases_on ‘bB’ \\ EVAL_TAC \\ fs [AllCaseEqs(),Eval_eq]
+QED
+
+Theorem last_bool_if:
+  (b0 ⇒ (env,[x_g],s) ---> ([bool b],s)) ∧
+  (b2 ⇒ (env,[x_t],s) ---> ([a t],s)) ∧
+  (b3 ⇒ (env,[x_f],s) ---> ([a f],s)) ⇒
+  b0 ∧ (if b then b2 else b3) ⇒
+  (env,[If Equal [x_g; Const 1] x_t x_f],s) ---> ([a (if b then t else f)],s)
+Proof
+  fs [Eval_eq,PULL_EXISTS,take_branch_def,AllCaseEqs(),return_def,fail_def]
+  \\ Cases_on ‘b’ \\ fs [] \\ metis_tac [EVAL “1=0:num”]
+QED
+
+(* num *)
+
+Theorem auto_num_const:
+  (T ⇒ (env, [Const 0], s) ---> ([Num 0], s)) ∧
+  (T ⇒ (env, [Const (NUMERAL n)], s) ---> ([Num (NUMERAL n)], s))
+Proof
+  fs [Eval_eq]
+QED
+
+Theorem auto_num_add:
+  (b0 ⇒ (env,[x1],s0) ---> ([Num n1],s1)) ∧
+  (b1 ⇒ (env,[x2],s1) ---> ([Num n2],s2)) ⇒
+  b0 ∧ b1 ⇒ (env,[Op Add [x1; x2]],s0) ---> ([Num (n1 + n2)],s2)
+Proof
+  fs [Eval_eq,PULL_EXISTS,eval_op_def,AllCaseEqs(),return_def,fail_def]
+  \\ metis_tac []
+QED
+
+Theorem auto_num_sub:
+  (b0 ⇒ (env,[x1],s0) ---> ([Num n1],s1)) ∧
+  (b1 ⇒ (env,[x2],s1) ---> ([Num n2],s2)) ⇒
+  b0 ∧ b1 ⇒ (env,[Op Sub [x1; x2]],s0) ---> ([Num (n1 − n2)],s2)
+Proof
+  fs [Eval_eq,PULL_EXISTS,eval_op_def,AllCaseEqs(),return_def,fail_def]
+  \\ metis_tac []
+QED
+
+Theorem auto_num_div:
+  (b0 ⇒ (env,[x1],s0) ---> ([Num n1],s1)) ∧
+  (b1 ⇒ (env,[x2],s1) ---> ([Num n2],s2)) ⇒
+  b0 ∧ b1 ∧ n2 ≠ 0 ⇒ (env,[Op Div [x1; x2]],s0) ---> ([Num (n1 DIV n2)],s2)
+Proof
+  fs [Eval_eq,PULL_EXISTS,eval_op_def,AllCaseEqs(),return_def,fail_def]
+  \\ metis_tac []
+QED
+
+Theorem auto_num_if_eq:
+  (b0 ⇒ (env,[x1],s) ---> ([Num n1],s)) ∧
+  (b1 ⇒ (env,[x2],s) ---> ([Num n2],s)) ∧
+  (b2 ⇒ (env,[y],s) ---> ([a t],s)) ∧
+  (b3 ⇒ (env,[z],s) ---> ([a f],s)) ⇒
+  b0 ∧ b1 ∧ (if n1 = n2 then b2 else b3) ⇒
+  (env,[If Equal [x1; x2] y z],s) ---> ([a (if n1 = n2 then t else f)],s)
+Proof
+  fs [Eval_eq,PULL_EXISTS,take_branch_def,AllCaseEqs(),return_def,fail_def]
+  \\ metis_tac []
+QED
+
+Theorem auto_num_if_less:
+  (b0 ⇒ (env,[x1],s) ---> ([Num n1],s)) ∧
+  (b1 ⇒ (env,[x2],s) ---> ([Num n2],s)) ∧
+  (b2 ⇒ (env,[y],s) ---> ([a t],s)) ∧
+  (b3 ⇒ (env,[z],s) ---> ([a f],s)) ⇒
+  b0 ∧ b1 ∧ (if n1 < n2 then b2 else b3) ⇒
+  (env,[If Less [x1; x2] y z],s) ---> ([a (if n1 < n2 then t else f)],s)
+Proof
+  fs [Eval_eq,PULL_EXISTS,take_branch_def,AllCaseEqs(),return_def,fail_def]
+  \\ metis_tac []
+QED
+
+(* list *)
+
+Theorem auto_list_nil:
+  T ⇒ (env,[Const 0],s) ---> ([list a []],s)
+Proof
+  fs [Eval_eq]
+QED
+
+Theorem auto_list_cons:
+  (b0 ⇒ (env,[x1],s) ---> ([a x],s)) ∧
+  (b1 ⇒ (env,[x2],s) ---> ([list a xs],s)) ⇒
+  b0 ∧ b1 ⇒
+  (env,[Op Cons [x1; x2]],s) ---> ([list a (x::xs)],s)
+Proof
+  fs [Eval_eq,eval_op_def,PULL_EXISTS,AllCaseEqs(),fail_def,return_def]
+  \\ metis_tac []
+QED
+
+Theorem auto_list_case:
+  (b0 ⇒ (env,[x0],s) ---> ([list (a:'a->v) v0],s)) ∧
+  (b1 ⇒ (env,[x1],s) ---> ([(b:'b->v) v1],s)) ∧
+  (∀y1 y2.
+     b2 y1 y2 ⇒
+     (env⦇name n2 ↦ SOME (list a y2); name n1 ↦ SOME (a y1)⦈,[x2],s) --->
+     ([b (v2 y1 y2)],s)) ⇒
+  ALL_DISTINCT ([name n1] ++ free_vars x0) ∧
+  b0 ∧ (v0 = [] ⇒ b1) /\ (∀y1 y2. v0 = y1::y2 ⇒ b2 y1 y2) ⇒
+  (env,[If Equal [x0; Const 0] x1
+         (Let (name n1) (Op Head [x0])
+            (Let (name n2) (Op Tail [x0]) x2))],s) --->
+  ([b (list_CASE v0 v1 v2)],s)
+Proof
+  Cases_on ‘v0’ \\ fs [] \\ rw [] \\ fs []
+  \\ rpt (fs [Eval_eq,PULL_EXISTS,eval_op_def,AllCaseEqs(),fail_def,
+              take_branch_def,return_def,name_def]
+          \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+QED
+
+(* option *)
+
+Theorem auto_option_none:
+  T ⇒ (env,[Const 0],s) ---> ([option a NONE],s)
+Proof
+  fs [Eval_eq]
+QED
+
+Theorem auto_option_some:
+  (b0 ⇒ (env,[x1],s) ---> ([a x],s)) ⇒
+  b0 ⇒
+  (env,[Op Cons [x1; Const 0]],s) ---> ([option a (SOME x)],s)
+Proof
+  fs [Eval_eq,eval_op_def,PULL_EXISTS,AllCaseEqs(),fail_def,return_def]
+  \\ metis_tac []
+QED
+
+Theorem auto_option_case:
+  (b0 ⇒ (env,[x0],s) ---> ([option (a:'a->v) v0],s)) ∧
+  (b1 ⇒ (env,[x1],s) ---> ([(b:'b->v) v1],s)) ∧
+  (∀y1. b2 y1 ⇒ (env⦇name n ↦ SOME (a y1)⦈,[x2],s) ---> ([b (v2 y1)],s)) ⇒
+  b0 ∧ (v0 = NONE ⇒ b1) /\ (∀y1. v0 = SOME y1 ==> b2 y1) ⇒
+  (env,[If Equal [x0; Const 0] x1
+         (Let (name n) (Op Head [x0]) x2)],s) --->
+  ([b (option_CASE v0 v1 v2)],s)
+Proof
+  Cases_on ‘v0’ \\ fs [] \\ rw [] \\ fs []
+  \\ rpt (fs [Eval_eq,PULL_EXISTS,eval_op_def,AllCaseEqs(),fail_def,
+              take_branch_def,return_def,name_def]
+          \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+QED
+
+(* pair *)
+
+Theorem auto_pair_fst:
+  (b0 ⇒ (env,[x1],s) ---> ([pair a b x],s)) ⇒
+  b0 ⇒ (env,[Op Head [x1]],s) ---> ([a (FST x)],s)
+Proof
+  Cases_on ‘x’ \\ fs [Eval_eq,eval_op_def,PULL_EXISTS,AllCaseEqs(),fail_def,return_def]
+  \\ metis_tac []
+QED
+
+Theorem auto_pair_snd:
+  (b0 ⇒ (env,[x1],s) ---> ([pair a b x],s)) ⇒
+  b0 ⇒ (env,[Op Tail [x1]],s) ---> ([b (SND x)],s)
+Proof
+  Cases_on ‘x’ \\ fs [Eval_eq,eval_op_def,PULL_EXISTS,AllCaseEqs(),fail_def,return_def]
+  \\ metis_tac []
+QED
+
+Theorem auto_pair_cons:
+  (b0 ⇒ (env,[x1],s) ---> ([a x],s)) ∧
+  (b1 ⇒ (env,[x2],s) ---> ([b y],s)) ⇒
+  b0 ∧ b1 ⇒
+  (env,[Op Cons [x1; x2]],s) ---> ([pair a b (x,y)],s)
+Proof
+  fs [Eval_eq,eval_op_def,PULL_EXISTS,AllCaseEqs(),fail_def,return_def]
+  \\ metis_tac []
+QED
+
+Theorem auto_pair_case:
+  (b0 ⇒ (env,[x0],s) ---> ([pair (a:'a->v) (b:'b->v) v0],s)) ∧
+  (∀y1 y2.
+     b1 y1 y2 ⇒
+     (env⦇name n2 ↦ SOME (b y2); name n1 ↦ SOME (a y1)⦈,[x1],s) --->
+     ([(c:'c->v) (v1 y1 y2)],s)) ⇒
+  ALL_DISTINCT ([name n1; name n2] ++ free_vars x0) ∧
+  b0 ∧ (∀y1 y2. v0 = (y1,y2) ⇒ b1 y1 y2) ⇒
+  (env,[Let (name n1) (Op Head [x0])
+         (Let (name n2) (Op Tail [x0]) x1)],s) --->
+  ([c (pair_CASE v0 v1)],s)
+Proof
+  Cases_on ‘v0’ \\ fs [] \\ rw [] \\ fs []
+  \\ rpt (fs [Eval_eq,PULL_EXISTS,eval_op_def,AllCaseEqs(),fail_def,
+              take_branch_def,return_def,name_def]
+          \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+QED
+
+(* v -- we use deep embedding to be able to support isNum *)
+
+Definition deep_def[simp]:
+  deep (Num n) = cons (bool T) (Num n) ∧
+  deep (Pair x y) = cons (bool F) (cons (deep x) (deep y))
+End
+
+Theorem auto_v_Num:
+  (b0 ⇒ (env,[x1],s) ---> ([Num n],s)) ⇒
+  b0 ⇒
+  (env,[Op Cons [Const 1; x1]],s) ---> ([deep (Num n)],s)
+Proof
+  rw [] \\ fs [Eval_eq,PULL_EXISTS,eval_op_def,return_def,AllCaseEqs(),fail_def]
+QED
+
+Theorem auto_v_Pair:
+  (b0 ⇒ (env,[x1],s) ---> ([deep x],s)) ∧
+  (b1 ⇒ (env,[x2],s) ---> ([deep y],s)) ⇒
+  b0 ∧ b1 ⇒
+  (env,[Op Cons [Const 0; Op Cons [x1; x2]]],s) ---> ([deep (Pair x y)],s)
+Proof
+  rw [] \\ fs [Eval_eq,PULL_EXISTS,eval_op_def,return_def,AllCaseEqs(),fail_def]
+  \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+QED
+
+Theorem auto_v_isNum:
+  (b0 ⇒ (env,[x1],s) ---> ([deep x],s)) ⇒
+  b0 ⇒
+  (env,[Op Head [x1]],s) ---> ([bool (isNum x)],s)
+Proof
+  Cases_on ‘x’ \\ fs [] \\ rw []
+  \\ fs [Eval_eq,PULL_EXISTS,eval_op_def,return_def,AllCaseEqs(),fail_def]
+  \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+QED
+
+Theorem auto_v_getNum:
+  (b0 ⇒ (env,[x1],s) ---> ([deep x],s)) ⇒
+  b0 ⇒
+  (env,[If Equal [Op Head [x1]; Const 0]
+          (Const 0) (Op Tail [x1])],s) ---> ([Num (getNum x)],s)
+Proof
+  Cases_on ‘x’ \\ fs [] \\ rw []
+  \\ fs [Eval_eq,PULL_EXISTS,eval_op_def,return_def,AllCaseEqs(),fail_def]
+  \\ goal_assum (first_assum o mp_then Any mp_tac)
+  \\ fs [take_branch_def,return_def]
+  \\ fs [Eval_eq,PULL_EXISTS,eval_op_def,return_def,AllCaseEqs(),fail_def]
+  \\ goal_assum (first_assum o mp_then Any mp_tac)
+QED
+
+Theorem auto_v_head[local]:
+  lookup_fun (name "h") s.funs =
+    SOME ([name "x"],
+          If Equal [Op Head [Var (name "x")]; Const 1]
+            (Var (name "x")) (Op Head [Op Tail [Var (name "x")]])) ⇒
+  (b0 ⇒ (env,[x1],s) ---> ([deep x],s)) ⇒
+  b0 ⇒
+  (env,[Call (name "h") [x1]],s) ---> ([deep (head x)],s)
+Proof
+  Cases_on ‘x’ \\ fs [] \\ rw []
+  \\ fs [Eval_eq,PULL_EXISTS,eval_op_def,return_def,AllCaseEqs(),
+         fail_def,app_cases,env_and_body_def]
+  \\ goal_assum (first_assum o mp_then Any mp_tac)
+  \\ fs [take_branch_def,return_def,combinTheory.APPLY_UPDATE_THM,
+         make_env_def,Eval_eq,PULL_EXISTS,eval_op_def,return_def,
+         AllCaseEqs(),fail_def,combinTheory.APPLY_UPDATE_THM]
+QED
+
+Theorem auto_v_tail[local]:
+  lookup_fun (name "t") s.funs =
+    SOME ([name "x"],
+          If Equal [Op Head [Var (name "x")]; Const 1]
+            (Var (name "x")) (Op Tail [Op Tail [Var (name "x")]])) ⇒
+  (b0 ⇒ (env,[x1],s) ---> ([deep x],s)) ⇒
+  b0 ⇒
+  (env,[Call (name "t") [x1]],s) ---> ([deep (tail x)],s)
+Proof
+  Cases_on ‘x’ \\ fs [] \\ rw []
+  \\ fs [Eval_eq,PULL_EXISTS,eval_op_def,return_def,AllCaseEqs(),
+         fail_def,app_cases,env_and_body_def]
+  \\ goal_assum (first_assum o mp_then Any mp_tac)
+  \\ fs [take_branch_def,return_def,combinTheory.APPLY_UPDATE_THM,
+         make_env_def,Eval_eq,PULL_EXISTS,eval_op_def,return_def,
+         AllCaseEqs(),fail_def,combinTheory.APPLY_UPDATE_THM]
+QED
+
+Theorem auto_v_head = auto_v_head |> UNDISCH;
+Theorem auto_v_tail = auto_v_tail |> UNDISCH;
+
+(* char *)
+
+Theorem auto_char_CHR:
+  (b0 ⇒ (env,[x1],s) ---> ([Num x],s)) ⇒
+  b0 ∧ x < 256 ⇒ (env,[x1],s) ---> ([char (CHR x)],s)
+Proof
+  fs [char_def]
+QED
+
+Theorem auto_char_ORD:
+  (b0 ⇒ (env,[x1],s) ---> ([char x],s)) ⇒
+  b0 ⇒ (env,[x1],s) ---> ([Num (ORD x)],s)
+Proof
+  fs [char_def]
+QED
+
+(* word *)
+
+Definition word_def:
+  word w = Num (w2n w)
+End
+
+Theorem auto_word4_n2w:
+  (b0 ⇒ (env,[x1],s) ---> ([Num x],s)) ⇒
+  b0 ∧ x < 16 ⇒ (env,[x1],s) ---> ([word ((n2w x):word4)],s)
+Proof
+  fs [word_def]
+QED
+
+Theorem auto_word64_n2w:
+  (b0 ⇒ (env,[x1],s) ---> ([Num x],s)) ⇒
+  b0 ∧ x < 2 ** 64 ⇒ (env,[x1],s) ---> ([word ((n2w x):word64)],s)
+Proof
+  fs [word_def]
+QED
+
+Theorem auto_word4_w2n:
+  (b0 ⇒ (env,[x1],s) ---> ([word (x:word4)],s)) ⇒
+  b0 ⇒ (env,[x1],s) ---> ([Num (w2n x)],s)
+Proof
+  fs [word_def]
+QED
+
+Theorem auto_word64_w2n:
+  (b0 ⇒ (env,[x1],s) ---> ([word (x:word64)],s)) ⇒
+  b0 ⇒ (env,[x1],s) ---> ([Num (w2n x)],s)
+Proof
+  fs [word_def]
+QED
+
+(* common definitions for custom datatypes *)
+
+Definition case_lets_def[simp]:
+  case_lets y [] x = x ∧
+  case_lets y (v::vs) x = Let (name v) (Op Head [y]) (case_lets (Op Tail [y]) vs x)
+End
+
+Definition case_tree_def[simp]:
+  case_tree y [] = Const 0 ∧
+  case_tree y ((n,vars,x)::xs) =
+    If Equal [Const (name n); Op Head [y]]
+      (case_lets (Op Tail [y]) vars x)
+      (case_tree (y:exp) xs)
+End
+
+Definition case_enum_def[simp]:
+  case_enum y [] = Const 0 ∧
+  case_enum y ((n,x)::xs) = If Equal [y; Const (name n)] x (case_enum (y:exp) xs)
+End
+
+(* a bit of automation for cons lemmas *)
+
+local
+  val b_tm = “b:bool”
+  val x_tm = “x:exp”
+  val v_tm = “v:v”
+in
+  val env_tm = “env:num -> v option”
+  val basic_tm = “^b_tm ⇒ (^env_tm,[^x_tm],s) ---> ([^v_tm],s)”
+  fun mk_basic_env env b x v =
+    basic_tm |> subst [env_tm|->env,v_tm|->v,b_tm|->b,x_tm|->x]
+  val mk_basic = mk_basic_env env_tm
+end
+
+fun prove_cons inv_def = let
+  fun prove_cons th = let
+    val x = th |> concl
+    val body = repeat (snd o dest_forall) x
+    val (l,r) = dest_eq body
+    val (name,is_enum) = (r |> rand |> rator |> rand |> rand, false)
+                         handle HOL_ERR _ => (r |> rand, true)
+    val const = “Const ^name”
+    val vs = if is_enum then [] else r |> rand |> rand |> listSyntax.dest_list |> fst
+    fun mk v = let
+      val vn = v |> rand |> dest_var |> fst
+      val new_x = mk_var("x_" ^ vn, “:exp”)
+      val new_b = mk_var("b_" ^ vn, “:bool”)
+      in (new_b,(new_x,mk_basic new_b new_x v)) end
+    val xs = map mk vs
+    val exps = const :: (map (fst o snd) xs @ [“Const 0”])
+    val bs = if null xs then T else list_mk_conj (map fst xs)
+    val new_x = if is_enum then const
+                else mk_comb(“parsing$conses”,listSyntax.mk_list(exps,type_of const))
+    val goal = mk_basic bs new_x l
+    val goal = if null xs then goal else
+      mk_imp(list_mk_conj (map (snd o snd) xs),goal)
+    val tac =
+      rw [Eval_eq,th,return_def,name_def,AllCaseEqs(),PULL_EXISTS,fail_def,
+          parsingTheory.conses_def,eval_op_def]
+      \\ fs [] \\ rpt (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+    val res = prove(goal,tac)
+    in res |> PURE_REWRITE_RULE [parsingTheory.conses_def] end
+  in inv_def |> CONJUNCTS |> map prove_cons |> LIST_CONJ end
+
+(* a bit of automation for case lemmas *)
+
+fun prove_case inv_def = let
+  fun right_dest f z =
+    (case f z of (x,y) => [x] @ right_dest f y) handle HOL_ERR _ => [z];
+  val inv_rows = inv_def |> CONJUNCTS
+  val ty = inv_rows |> hd |> SPEC_ALL |> concl |> dest_eq |> fst |> rand |> type_of
+  val in_inv = inv_rows |> hd |> SPEC_ALL |> concl |> dest_eq |> fst |> rator
+  val case_const = TypeBase.case_const_of ty
+  val conses = TypeBase.constructors_of ty
+  fun dest_fun_type ty =
+    case dest_type ty of ("fun",[a,b]) => (a,b) | _ => fail()
+  val tys = tl (right_dest dest_fun_type (type_of case_const))
+  val res_ty = last tys
+  val case_tys = butlast tys
+  fun mk_funs (c,ty) = mk_var("f_" ^ fst (dest_const c), ty)
+  val f_tms = map mk_funs (zip conses case_tys)
+  val v = mk_var("v0",ty)
+  val res = list_mk_comb(case_const, v :: f_tms)
+  val inv = mk_var(dest_vartype res_ty |> explode |> tl |> implode,
+               mk_type("fun",[res_ty,“:v”]))
+  val res_v = mk_comb(inv,res)
+  val b0 = mk_var("b0",“:bool”)
+  val x0 = mk_var("x0",“:exp”)
+  val v0 = mk_var("v0",ty)
+  val asm0 = mk_basic b0 x0 (mk_comb(in_inv,v0))
+(*
+  val (f,c) = hd (zip f_tms conses)
+*)
+  fun process_row (f,c) = let
+    val s = dest_const c |> fst
+    val row = first (can (find_term (aconv c)) o concl) inv_rows |> SPEC_ALL
+    val c_case = row |> concl |> rator |> rand |> rand
+    val cs = row |> concl |> rand |> rand
+    val (name,is_enum) = (cs |> rator |> rand |> rand,false) handle HOL_ERR _ => (cs,true)
+    val args = if is_enum then [] else cs |> rand |> listSyntax.dest_list |> fst
+    val vs = map rand args
+    val res = list_mk_comb(f,vs)
+    (* make the b *)
+    val bvar = mk_var("b_" ^ s,
+        wfrecUtils.list_mk_fun_type(map (type_of o rand) args @ [“:bool”]))
+    val b_tm = list_mk_comb(bvar,vs)
+    (* make env *)
+    val strs = map (fn v => mk_var(fst (dest_var v) ^ "_" ^ s,“:string”)) vs
+    val nums = map (fn t => “name ^t”) strs
+    val ups = map combinSyntax.mk_update (zip nums (map optionSyntax.mk_some args))
+    val new_env = foldl mk_comb env_tm ups
+    (* make asm *)
+    val x = mk_var(s ^ "_exp",“:exp”)
+    val asm = list_mk_forall(vs,mk_basic_env new_env b_tm x (mk_comb(inv,res)))
+    (* for code construction *)
+    val t1 = name |> rand
+    val t2 = listSyntax.mk_list(strs,“:string”)
+    val t = if is_enum then pairSyntax.mk_pair(t1,x)
+            else pairSyntax.mk_pair(t1,pairSyntax.mk_pair(t2,x))
+    (* construct pre *)
+    val ns = listSyntax.mk_list(if null nums then [] else butlast nums,“:num”)
+    val b_tm = if is_enum then b_tm else
+                 mk_conj(b_tm,“ALL_DISTINCT (^ns ++ free_vars ^x0)”)
+    val pre = list_mk_forall(vs,mk_imp(mk_eq(v0,c_case),b_tm))
+    in (asm,(t,pre)) end
+  val xs = map process_row (zip f_tms conses)
+  val asm = list_mk_conj(b0 :: map (snd o snd) xs)
+  val ys = map (fst o snd) xs
+  val x = listSyntax.mk_list(ys,type_of(hd ys))
+  val is_enum = not (can (first (can dest_fun_type o type_of)) conses)
+  val code = if is_enum then list_mk_comb(“case_enum”,[x0,x])
+             else list_mk_comb(“case_tree”,[x0,x])
+  val goal = mk_imp(list_mk_conj(asm0::map fst xs),mk_basic asm code res_v)
+  val tac =
+      Cases_on ‘v0’ \\ fs [] \\ rw [] \\ fs []
+      \\ rpt (full_simp_tac (srw_ss())
+                 [Eval_eq,PULL_EXISTS,eval_op_def,AllCaseEqs(),fail_def,
+                  take_branch_def,return_def,name_def]
+              \\ goal_assum (first_assum o mp_then Any mp_tac)
+              \\ full_simp_tac (srw_ss()) [])
+  in prove(goal,tac)
+     |> PURE_REWRITE_RULE [case_lets_def,case_tree_def,case_enum_def] end
+
+(* token *)
+
+Definition token_def[simp]:
+  token DOT = list [Name "DOT"] ∧
+  token OPEN = list [Name "OPEN"] ∧
+  token CLOSE = list [Name "CLOSE"] ∧
+  token (NUM n) = list [Name "NUM"; Num n] ∧
+  token (QUOTE n) = list [Name "QUOTE"; Num n]
+End
+
+Theorem auto_token_cons = prove_cons token_def;
+Theorem auto_token_case = prove_case token_def;
+
+(* test *)
+
+Definition test_def[simp]:
+  test source_syntax$Equal = Name "Equal" ∧
+  test source_syntax$Less = Name "Less"
+End
+
+Theorem auto_test_cons = prove_cons test_def;
+Theorem auto_test_case = prove_case test_def;
+
+(* op *)
+
+Definition op_def[simp]:
+  op Add = Name "Add" ∧
+  op Sub = Name "Sub" ∧
+  op Div = Name "Div" ∧
+  op Cons = Name "Cons" ∧
+  op Head = Name "Head" ∧
+  op Tail = Name "Tail" ∧
+  op Read = Name "Read" ∧
+  op Write = Name "Write"
+End
+
+Theorem auto_op_cons = prove_cons op_def;
+Theorem auto_op_case = prove_case op_def;
+
+(* app_list *)
+
+Definition app_list_def[simp]:
+  app_list a (List xs) = list [Name "List"; list a xs] ∧
+  app_list a (Append x y) = list [Name "Append"; app_list a x; app_list a y]
+End
+
+Theorem auto_app_list_cons = prove_cons app_list_def;
+Theorem auto_app_list_case = prove_case app_list_def;
+
+(* exp *)
+
+Definition exp_def:
+  exp (Const n) = list [Name "Const"; Num n] ∧
+  exp (Var n) = list [Name "Var"; Num n] ∧
+  exp (Op f xs) = list [Name "Op"; op f; list (MAP exp xs)] ∧
+  exp (If t xs e1 e2) = list [Name "If"; test t; list (MAP exp xs); exp e1; exp e2] ∧
+  exp (Let n e1 e2) = list [Name "Let"; Num n; exp e1; exp e2] ∧
+  exp (Call n xs) = list [Name "Call"; Num n; list (MAP exp xs)]
+Termination
+  WF_REL_TAC ‘measure exp_size’ \\ rw []
+  \\ qsuff_tac ‘∀xs a. MEM a xs ⇒ exp_size a < exp1_size xs’
+  \\ TRY (rw []  \\ res_tac \\ fs [] \\ NO_TAC)
+  \\ Induct \\ fs [exp_size_def]
+  \\ rw [] \\ fs [] \\ res_tac \\ fs []
+End
+
+Theorem exp_def[simp] = exp_def |> REWRITE_RULE [GSYM map_def]
+                                |> CONV_RULE (DEPTH_CONV ETA_CONV);
+
+Theorem auto_exp_cons = prove_cons exp_def;
+Theorem auto_exp_case = prove_case exp_def;
+
+(* dec *)
+
+Definition dec_def[simp]:
+  dec (Defun n ns x) = list [Name "Defun"; Num n; list Num ns; exp x]
+End
+
+Theorem auto_dec_cons = prove_cons dec_def;
+Theorem auto_dec_case = prove_case dec_def;
+
+(* prog *)
+
+Definition prog_def[simp]:
+  prog (Program ds x) = list [Name "Program"; list dec ds; exp x]
+End
+
+Theorem auto_prog_cons = prove_cons prog_def;
+Theorem auto_prog_case = prove_case prog_def;
+
+(* reg *)
+
+Definition reg_def[simp]:
+  reg RAX = Name "RAX" ∧
+  reg RDI = Name "RDI" ∧
+  reg RBX = Name "RBX" ∧
+  reg RBP = Name "RBP" ∧
+  reg R12 = Name "R12" ∧
+  reg R13 = Name "R13" ∧
+  reg R14 = Name "R14" ∧
+  reg R15 = Name "R15" ∧
+  reg RDX = Name "RDX"
+End
+
+Theorem auto_reg_cons = prove_cons reg_def;
+Theorem auto_reg_case = prove_case reg_def;
+
+(* cond *)
+
+Definition cond_def[simp]:
+  cond Always = list [Name "Always"] ∧
+  cond (Less r1 r2) = list [Name "Less"; reg r1; reg r2] ∧
+  cond (Equal r1 r2) = list [Name "Equal"; reg r1; reg r2]
+End
+
+Theorem auto_cond_cons = prove_cons cond_def;
+Theorem auto_cond_case = prove_case cond_def;
+
+(* inst *)
+
+Definition inst_def[simp]:
+  inst (Const r1 w64)  = list [Name "Const"; reg r1; word w64] ∧
+  inst (Mov r1 r2)     = list [Name "Mov"; reg r1; reg r2] ∧
+  inst (Add r1 r2)     = list [Name "Add"; reg r1; reg r2] ∧
+  inst (Sub r1 r2)     = list [Name "Sub"; reg r1; reg r2] ∧
+  inst (Div r1)        = list [Name "Div"; reg r1] ∧
+  inst (Jump c n)      = list [Name "Jump"; cond c; Num n] ∧
+  inst (Call n)        = list [Name "Call"; Num n] ∧
+  inst (Ret)           = list [Name "Ret"] ∧
+  inst (Pop r1)        = list [Name "Pop"; reg r1] ∧
+  inst (Push r1)       = list [Name "Push"; reg r1] ∧
+  inst (Add_RSP n)     = list [Name "Add_RSP"; Num n] ∧
+  inst (Load_RSP r n)  = list [Name "Load_RSP"; reg r; Num n] ∧
+  inst (Load r1 r2 i)  = list [Name "Load"; reg r1; reg r2; word i] ∧
+  inst (Store r1 r2 i) = list [Name "Store"; reg r1; reg r2; word i] ∧
+  inst (GetChar)       = list [Name "GetChar"] ∧
+  inst (PutChar)       = list [Name "PutChar"] ∧
+  inst (Exit)          = list [Name "Exit"] ∧
+  inst (Comment s)     = list [Name "Comment"; list char s]
+End
+
+Theorem auto_inst_cons = prove_cons inst_def;
+Theorem auto_inst_case = prove_case inst_def;
+
+(* optimizer *)
+
+Theorem inline_let: (* inline any let where the bound name doesn't fit 2**64 *)
+  (b ⇒ (env,[x],s) ---> ([v],s)) ⇒
+  LFINITE s.input ⇒
+  (b ⇒ (env,[inline_let (λn. 18446744073709551616 ≤ n) x],s) ---> ([v],s))
+Proof
+  rw [] \\ match_mp_tac (MP_CANON inline_let_thm) \\ fs []
+QED
+
+val _ = export_theory();

--- a/examples/bootstrap/codegenScript.sml
+++ b/examples/bootstrap/codegenScript.sml
@@ -1,0 +1,336 @@
+
+open HolKernel Parse boolLib bossLib;
+open arithmeticTheory listTheory pairTheory finite_mapTheory stringTheory;
+open source_valuesTheory source_syntaxTheory x64asm_syntaxTheory;
+
+val _ = new_theory "codegen";
+
+(* we return lists with explicit appends to avoid "bad append" performance *)
+
+Datatype:
+  app_list = List ('a list) | Append app_list app_list
+End
+
+Definition flatten_def:
+  flatten (List xs) acc = xs ++ acc ∧
+  flatten (Append l1 l2) acc = flatten l1 (flatten l2 acc)
+End
+
+(* initialization code *)
+
+Definition init_def:
+  init k = (*  0 *) [Const RAX 0w;
+           (*  1 *)  Const R12 16w;
+           (*  2 *)  Const R13 (n2w (2 ** 63 - 1));
+           (* jump to main function *)
+           (*  3 *)  Call k;
+           (* return to exit 0 *)
+           (*  4 *)  Const RDI 0w;
+           (*  5 *)  Exit;
+           (* alloc routine starts here: *)
+           (*  6 *)  Comment "cons";
+           (*  7 *)  Jump (Equal R14 R15) 14;
+           (*  8 *)  Store RDI R14 0w;
+           (*  9 *)  Store RAX R14 8w;
+           (* 10 *)  Mov RAX R14;
+           (* 11 *)  Add R14 R12;
+           (* 12 *)  Ret;
+           (* give up: *)
+           (* 13 *)  Comment "exit 1";
+           (* 14 *)  Push R15;
+           (* 15 *)  Const RDI 1w;
+           (* 16 *)  Exit]
+End
+
+Overload AllocLoc[inferior] = “7:num”;
+
+(* Naming conventions:
+    - prefix "c_" is used to mean "compile"
+    - argument names:
+       t - boolean indicating tail position (true if in tail position)
+       l - location where the next instruction will be placed in memory
+           (relative to first instruction of the entire program)
+       vs - a model of the stack: the ith element is SOME v if the value
+            of source variable v is at stack index i; positions containing
+            NONE do not correspond to a source-level variable; this information
+            is used by when compiling Var (in the c_var function)
+       fs - an a-list with locations for all the function locations,
+            compilation of Call (in c_exp) uses this information
+*)
+
+Definition even_len_def:
+  even_len [] = T ∧
+  even_len (x::xs) = odd_len xs ∧
+  odd_len [] = F ∧
+  odd_len (x::xs) = even_len xs
+End
+
+Definition give_up_def[simp]:
+  give_up b = if b then 14:num else 15
+End
+
+Definition c_const_def:
+  c_const l n vs = if 2**63-1 < n
+                   then (List [Jump Always (give_up (odd_len vs))], l+1)
+                   else (List [Push RAX; Const RAX (n2w n)], l+2)
+End
+
+Definition find_def:
+  find n [] k = k ∧
+  find n (NONE::vs) k = find n vs (k+1) ∧
+  find n (SOME v::vs) k = if v = (n:num) then k else find n vs (k+1)
+End
+
+Definition c_var_def:
+  c_var l n vs =
+    let k = find n vs 0 in
+      if k = 0 then (List [Push RAX], l+1) else
+        (List [Push RAX; Load_RSP RAX k], l+2)
+End
+
+Definition c_add_def:
+  c_add vs = [Pop RDI; Add RAX RDI; Jump (Less R13 RAX) (give_up (even_len vs))]
+End
+
+Definition c_sub_def:
+  c_sub l = [Pop RDI;
+             Jump (Less RAX RDI) (l+3); (* i.e. skip the next instruction *)
+             Mov RAX RDI;
+             Sub RDI RAX;
+             Mov RAX RDI]
+End
+
+Definition c_div_def:
+  c_div = [Mov RDI RAX;
+           Pop RAX;
+           Const RDX 0w;
+           Div RDI]
+End
+
+Definition c_cons_def:
+  c_cons vs = if even_len vs (* stack must be aligned at call *)
+              then [Load_RSP RDI 0; Call AllocLoc; Pop RDI]
+              else [Pop RDI; Call AllocLoc]
+End
+
+Definition c_head_def:
+  c_head = [Load RAX RAX 0w]
+End
+
+Definition c_tail_def:
+  c_tail = [Load RAX RAX 8w]
+End
+
+Definition align_def:
+  align b cs = if b then [Push RAX]++cs++[Pop RDI] else cs
+End
+
+Definition c_read_def:
+  c_read vs = align (even_len vs) [Push RAX; GetChar]
+End
+
+Definition c_write_def:
+  c_write vs = align (even_len vs) [Mov RDI RAX; PutChar; Const RAX 0w]
+End
+
+Definition c_op_def:
+  c_op Add vs l = c_add vs ∧
+  c_op Sub vs l = c_sub l ∧
+  c_op Div vs l = c_div ∧
+  c_op Cons vs l = c_cons vs ∧
+  c_op Head vs l = c_head ∧
+  c_op Tail vs l = c_tail ∧
+  c_op Read vs l = c_read vs ∧
+  c_op Write vs l = c_write vs
+End
+
+Definition c_test_def:
+  c_test (c:source_syntax$test) target =
+    let cond = (case c of Equal => Equal RDI RBX | Less => Less RDI RBX) in
+      [Mov RBX RAX; Pop RDI; Pop RAX; Jump cond target]
+End
+
+Definition c_if_def:
+  c_if t test (c1,l1) (c2,l2) (c3,l3) =
+    (Append c1 (Append (List (c_test test (l2 + if t then 0 else 1)))
+               (Append c2 (Append (List (if t then [] else [Jump Always l3])) c3))),l3)
+End
+
+Definition c_pops_def:
+  c_pops xs vs =
+    let k = LENGTH xs in
+      if k = 0 then [Push RAX] else
+      if k = 1 then [] else
+      if k = 2 then [Pop RDI] else
+      if k = 3 then [Pop RDI; Pop RDX] else
+      if k = 4 then [Pop RDI; Pop RDX; Pop RBX] else
+      if k = 5 then [Pop RDI; Pop RDX; Pop RBX; Pop RBP] else
+      otherwise [Jump Always (give_up (odd_len xs ≠ odd_len vs))]
+End
+
+Definition call_env_def:
+  call_env [] acc = acc ∧
+  call_env (x::xs) acc = call_env xs (SOME x :: acc)
+End
+
+Definition c_pushes_def:
+  c_pushes vs l =
+    let k = LENGTH vs in
+    let e = call_env vs [] in
+      if k = 0 then (List [], [NONE], l) else
+      if k = 1 then (List [],e,l) else
+      if k = 2 then (List [Push RDI],e,l + 1) else
+      if k = 3 then (List [Push RDX; Push RDI],e,l + 2) else
+      if k = 4 then (List [Push RBX; Push RDX; Push RDI],e,l + 3) else
+          otherwise (List [Push RBP; Push RBX; Push RDX; Push RDI],e,l + 4)
+End
+
+Definition c_call_def:
+  c_call t vs target xs (c,l) =
+    let ys = c_pops xs vs in
+      if t then
+        (Append c (Append (List ys)
+          (List [Add_RSP (LENGTH vs); Jump Always target])), l + LENGTH ys + 2)
+      else
+        let cs = align (even_len vs) [Call target] in
+          (Append c (Append (List ys) (List cs)), l + LENGTH ys + LENGTH cs)
+End
+
+Definition lookup_def:
+  lookup n [] = 0 ∧
+  lookup n ((x,y)::xs) = if x = (n:num) then y else lookup n xs
+End
+
+Definition make_ret_def:
+  make_ret vs (c,l) =
+    (Append c (List [Add_RSP (LENGTH vs); Ret]), l + 2)
+End
+
+Definition c_exp_def:
+  c_exp t l vs fs z =
+    (if t then
+       case z of
+       | Let n x y =>
+           (let r1 = c_exp F l vs fs x in
+            let r2 = c_exp T (SND r1) (SOME n::vs) fs y in
+              (Append (FST r1) (Append (FST r2) (List [])), SND r2))
+       | If cmp xs y z =>
+           (let r1 = c_exps l vs fs xs in
+            let r2 = c_exp T (SND r1 + 4) vs fs z in
+            let r3 = c_exp T (SND r2) vs fs y in
+              c_if T cmp r1 r2 r3)
+       | Call n xs =>
+           (c_call T vs (lookup n fs) xs (c_exps l vs fs xs))
+       | _ => make_ret vs (c_exp F l vs fs z)
+     else
+       case z of
+       | Let n x y =>
+           (let r1 = c_exp F l vs fs x in
+            let r2 = c_exp F (SND r1) (SOME n::vs) fs y in
+              (Append (FST r1) (Append (FST r2) (List [Add_RSP 1])),SND r2+1))
+       | If cmp xs y z =>
+           (let r1 = c_exps l vs fs xs in
+            let r2 = c_exp F (SND r1 + 4) vs fs z in
+            let r3 = c_exp F (SND r2 + 1) vs fs y in
+              c_if F cmp r1 r2 r3)
+       | Call n xs =>
+           (c_call F vs (lookup n fs) xs (c_exps l vs fs xs))
+       | Const n => c_const l n vs
+       | Var n => c_var l n vs
+       | Op op xs =>
+           (let r1 = c_exps l vs fs xs in
+            let insts = c_op op vs (SND r1) in
+              (Append (FST r1) (List insts), SND r1 + LENGTH insts))) ∧
+  c_exps l vs fs zs =
+    case zs of
+    | [] => (List [],l)
+    | (x::xs) => (let res1 = c_exp F l vs fs x in
+                  let res2 = c_exps (SND res1) (NONE::vs) fs xs in
+                    (Append (FST res1) (FST res2), SND res2))
+Termination
+  WF_REL_TAC ‘inv_image (measure I LEX measure I)
+    (λx. case x of INL (t,l,vs,fs,x) => (exp_size x,if t then 1 else 0)
+                 | INR (l,vs,fs,xs) => (exp1_size xs,0))’
+End
+
+Definition c_exp'_def: (* rephrasing that is better for proofs *)
+  c_exp' t l vs fs (Let n x y) =
+    (let (c1,l') = c_exp' F l vs fs x in
+     let (c2,l'') = c_exp' t l' (SOME n::vs) fs y in
+       (Append c1 (Append c2 (List (if t then [] else [Add_RSP 1]))),
+        if t then l'' else l'' + 1)) ∧
+  c_exp' t l vs fs (If test xs y z) =
+    (let (c1,l1) = c_exps' l vs fs xs in
+     let (c2,l2) = c_exp' t (l1 + 4) vs fs z in
+     let (c3,l3) = c_exp' t (l2 + if t then 0 else 1) vs fs y in
+       c_if t test (c1,l1) (c2,l2) (c3,l3)) ∧
+  c_exp' t l vs fs (Call n xs) =
+    c_call t vs (lookup n fs) xs (c_exps' l vs fs xs) ∧
+  c_exp' F l vs fs (Const n) = c_const l n vs ∧
+  c_exp' F l vs fs (Var n) = c_var l n vs ∧
+  c_exp' F l vs fs (Op op xs) =
+    (let (c,l0) = c_exps' l vs fs xs in
+     let insts = c_op op vs l0 in
+       (Append c (List insts),l0 + LENGTH insts)) ∧
+  c_exp' T l vs fs (Const v10) = make_ret vs (c_exp' F l vs fs (Const v10)) ∧
+  c_exp' T l vs fs (Var v11) = make_ret vs (c_exp' F l vs fs (Var v11)) ∧
+  c_exp' T l vs fs (Op op xs) = make_ret vs (c_exp' F l vs fs (Op op xs)) ∧
+  c_exps' l vs fs [] = (List [],l) ∧
+  c_exps' l vs fs (x::xs) =
+    (let (c1,l') = c_exp' F l vs fs x in
+     let (c2,l'') = c_exps' l' (NONE::vs) fs xs in
+      (Append c1 c2,l''))
+Termination
+  WF_REL_TAC ‘inv_image (measure I LEX measure I)
+    (λx. case x of INL (t,l,vs,fs,x) => (exp_size x,if t then 1 else 0)
+                 | INR (l,vs,fs,xs) => (exp1_size xs,0))’
+End
+
+Theorem c_exp'[simp]:
+  c_exp' = c_exp ∧ c_exps' = c_exps
+Proof
+  once_rewrite_tac [EQ_SYM_EQ]
+  \\ fs [FUN_EQ_THM] \\ ho_match_mp_tac c_exp'_ind \\ rw []
+  \\ fs [c_exp'_def] \\ rw [Once c_exp_def] \\ rpt (pairarg_tac \\ fs [])
+QED
+
+Theorem c_exp_alt = c_exp'_def |> SIMP_RULE (srw_ss()) []
+Theorem c_exp_ind_alt = c_exp'_ind |> SIMP_RULE (srw_ss()) []
+
+Definition c_defun_def:
+  c_defun l (fs:(num # num) list) (Defun n vs body) =
+    let (c0,vs0,l0) = c_pushes vs l in
+    let (c1,l1) = c_exp T l0 vs0 fs body in
+      (Append c0 c1,l1)
+End
+
+Definition name_of_def:
+  name_of (Defun n _ _) = n
+End
+
+Definition name2str_def:
+  name2str n acc =
+    if n = 0 then acc else name2str (n DIV 256) (CHR (n MOD 256) :: acc)
+End
+
+Definition c_decs_def:
+  c_decs l fs [] = (List [],[],l) ∧
+  c_decs l fs (d::ds) =
+    let fname = name_of d in
+    let comment = List [Comment (name2str fname [])] in
+    let r1 = c_defun (l+1) fs d in
+    let r2 = c_decs (SND r1) fs ds in
+      (Append comment (Append (FST r1) (FST r2)),
+       (fname,l+1)::(FST (SND r2)),
+       SND (SND r2))
+End
+
+Definition codegen_def:
+  codegen (Program funs main) =
+    let init_l = LENGTH (init 0) in
+    let (_,fs,k) = c_decs init_l [] funs in
+    let (c,fs,_) = c_decs init_l fs (funs ++ [Defun (name "main") [] main]) in
+      flatten (Append (List (init (k+1))) c) []
+End
+
+val _ = export_theory();

--- a/examples/bootstrap/codegen_proofsScript.sml
+++ b/examples/bootstrap/codegen_proofsScript.sml
@@ -1,0 +1,1889 @@
+
+open HolKernel Parse boolLib bossLib;
+open arithmeticTheory listTheory pairTheory finite_mapTheory stringTheory;
+open source_valuesTheory source_syntaxTheory x64asm_syntaxTheory mp_then
+     BasicProvers source_semanticsTheory source_propertiesTheory alignmentTheory
+     combinTheory optionTheory alistTheory wordsTheory wordsLib
+     x64asm_syntaxTheory x64asm_semanticsTheory x64asm_propertiesTheory
+     codegenTheory relationTheory lprefix_lubTheory llistTheory;
+
+val _ = new_theory "codegen_proofs";
+
+
+(* definitions of invariants and relations *)
+
+Definition code_in_def:
+  code_in n [] code = T ∧
+  code_in n (x::xs) code =
+    (lookup n code = SOME x ∧ code_in (n+1) xs code)
+End
+
+Definition init_code_in_def:
+  init_code_in instructions ⇔
+    ∃start. code_in 0 (init start) instructions
+End
+
+Definition code_rel_def:
+  code_rel fs ds instructions ⇔
+    init_code_in instructions ∧
+    ∀n params body.
+      lookup_fun n ds = SOME (params,body) ⇒
+      ∃pos. ALOOKUP fs n = SOME pos ∧
+            code_in pos (flatten (FST
+              (c_defun pos fs (Defun n params body))) []) instructions
+End
+
+Definition state_rel_def:
+  state_rel fs (s:source_semantics$state) (t:x64asm_semantics$state) ⇔
+    s.input = t.input ∧
+    s.output = t.output ∧
+    code_rel fs s.funs t.instructions ∧
+    ∃r14 r15.
+      t.regs R12 = SOME 16w ∧
+      t.regs R13 = SOME 0x7FFFFFFFFFFFFFFFw ∧
+      t.regs R14 = SOME r14 ∧
+      t.regs R15 = SOME r15 ∧
+      memory_writable r14 r15 t.memory
+End
+
+Definition has_stack_def:
+  has_stack t xs <=>
+    ∃w ws. xs = Word w :: ws ∧ t.regs RAX = SOME w ∧ t.stack = ws
+End
+
+Definition v_inv_def:
+  v_inv t (Num n) w = (n < 2 ** 63 ∧ w = n2w n) ∧
+  v_inv t (Pair x1 x2) w =
+    ∃w1 w2.
+      read_mem (w+0w) t = SOME w1 ∧ v_inv t x1 w1 ∧
+      read_mem (w+8w) t = SOME w2 ∧ v_inv t x2 w2 ∧
+      w ≠ 0w (* the address must not be the null pointer *)
+End
+
+Definition env_ok_def:
+  env_ok env vs curr t <=>
+    LENGTH vs = LENGTH curr ∧
+    ∀n v. env n = SOME v ⇒
+          find n vs 0 < LENGTH curr ∧
+          ∃w. EL (find n vs 0) curr = (Word w) ∧ v_inv t v w
+End
+
+
+(* setting up the proof goal *)
+
+val goal =
+  ``λenv e s.
+      ∀res s1 t tail' vs fs cs l1 curr rest.
+        eval env e s = (res,s1) ∧ res ≠ Err Crash ∧
+        c_exp tail' t.pc vs fs e = (cs,l1) ∧
+        state_rel fs s t ∧ env_ok env vs curr t ∧
+        has_stack t (curr ++ rest) ∧ ODD (LENGTH rest) ∧
+        code_in t.pc (flatten cs []) t.instructions ⇒
+        ∃outcome.
+          steps (State t,s.clock) outcome ∧
+          case outcome of
+          | (Halt ec output, ck) => output ≼ s1.output ∧ ec = 1w
+          | (State t1, ck) =>
+              state_rel fs s1 t1 ∧ ck = s1.clock ∧
+              ∀v. res = Res v ==>
+                  ∃w. v_inv t1 v w ∧
+                     if tail' then
+                       has_stack t1 (Word w :: rest) ∧ fetch t1 = SOME Ret
+                     else
+                       has_stack t1 (Word w :: curr ++ rest) ∧ t1.pc = l1``
+
+val goals =
+  ``λenv es s.
+      ∀res s1 t vs fs cs l1 curr rest.
+        evals env es s = (res,s1) ∧ res ≠ Err Crash ∧
+        c_exps t.pc vs fs es = (cs,l1) ∧
+        state_rel fs s t ∧ env_ok env vs curr t ∧
+        has_stack t (curr ++ rest) ∧ ODD (LENGTH rest) ∧
+        code_in t.pc (flatten cs []) t.instructions ⇒
+        ∃outcome.
+          steps (State t,s.clock) outcome ∧
+          case outcome of
+          | (Halt ec output,ck) => output ≼ s1.output ∧ ec = 1w
+          | (State t1,ck) =>
+              state_rel fs s1 t1 ∧ ck = s1.clock ∧
+              ∀vs. res = Res vs ==>
+                   ∃ws. LIST_REL (v_inv t1) vs ws ∧
+                        has_stack t1 (MAP Word (REVERSE ws) ++ curr ++ rest) ∧
+                        t1.pc = l1``
+
+local
+  val ind_thm = eval_ind |> ISPECL [goal,goals]
+    |> CONV_RULE (DEPTH_CONV BETA_CONV) |> REWRITE_RULE [];
+  val ind_goals = ind_thm |> concl |> dest_imp |> fst |> ASSUME |> CONJUNCTS |> map concl
+in
+  fun get_goal s = first (can (find_term (can (match_term (Term [QUOTE s]))))) ind_goals
+  fun compile_correct_tm () = ind_thm |> concl |> rand
+  fun the_ind_thm () = ind_thm
+  fun strip tm = tm |> ASSUME |> SIMP_RULE std_ss [PULL_FORALL] |> SPEC_ALL |> concl
+end
+
+
+(* various lemmas *)
+
+Theorem even_len_simp[simp]:
+  ∀xs. even_len xs = EVEN (LENGTH xs) ∧ odd_len xs = ODD (LENGTH xs)
+Proof
+  Induct \\ fs [even_len_def,ODD,EVEN_ODD]
+QED
+
+Theorem steps_v_inv:
+  steps (State t0,n) (State t1,m) ∧ v_inv t0 a w ⇒ v_inv t1 a w
+Proof
+  rw [] \\ pop_assum mp_tac
+  \\ qid_spec_tac ‘w’ \\ Induct_on ‘a’ \\ fs [v_inv_def]
+  \\ imp_res_tac steps_consts \\ fs [] \\ metis_tac []
+QED
+
+Theorem flatten_acc:
+  ∀p acc. flatten p acc = flatten p [] ++ acc
+Proof
+  once_rewrite_tac [EQ_SYM_EQ]
+  \\ Induct_on ‘p’ \\ simp_tac std_ss [flatten_def] \\ fs []
+  \\ last_assum (once_rewrite_tac o single o GSYM)
+  \\ first_assum (once_rewrite_tac o single o GSYM)
+  \\ fs []
+QED
+
+Theorem code_in_append[simp]:
+  ∀xs ys n code.
+    code_in n (xs ++ ys) code ⇔
+    code_in n xs code ∧ code_in (n + LENGTH xs) ys code
+Proof
+  Induct \\ fs [code_in_def,ADD1,AC CONJ_COMM CONJ_ASSOC]
+QED
+
+Theorem c_exp_length:
+  (∀t l vs fs x c l1. c_exp t l vs fs x = (c,l1) ⇒ l1 = l + LENGTH (flatten c [])) ∧
+  (∀l vs fs xs c l1. c_exps l vs fs xs = (c,l1) ⇒ l1 = l + LENGTH (flatten c []))
+Proof
+  ho_match_mp_tac c_exp_ind_alt \\ rw [] \\ fs [c_exp_alt]
+  \\ rpt (pairarg_tac \\ fs [])
+  \\ rw [] \\ fs [flatten_def]
+  \\ rw [] \\ fs [c_if_def,c_test_def]
+  \\ rw [] \\ fs [flatten_def]
+  \\ rw [] \\ fs [c_if_def,c_test_def,c_const_def,AllCaseEqs()]
+  \\ rw [] \\ fs [c_if_def,c_test_def,c_const_def,AllCaseEqs(),c_var_def,make_ret_def]
+  \\ once_rewrite_tac [flatten_acc] \\ fs [flatten_def]
+  \\ once_rewrite_tac [flatten_acc] \\ fs []
+  \\ once_rewrite_tac [flatten_acc] \\ fs []
+  \\ Cases_on ‘c_exps l vs fs xs’ \\ fs [c_call_def]
+  \\ every_case_tac
+  \\ rw [] \\ fs [c_if_def,c_test_def,c_const_def,AllCaseEqs(),c_var_def]
+  \\ once_rewrite_tac [flatten_acc] \\ fs [flatten_def]
+  \\ once_rewrite_tac [flatten_acc] \\ fs [flatten_def]
+  \\ fs [make_ret_def]
+  \\ rw [] \\ fs [c_if_def,c_test_def,c_const_def,AllCaseEqs(),c_var_def]
+  \\ once_rewrite_tac [flatten_acc] \\ fs [flatten_def]
+  \\ once_rewrite_tac [flatten_acc] \\ fs [flatten_def]
+  \\ rpt (pop_assum mp_tac)
+  \\ once_rewrite_tac [flatten_acc] \\ fs [flatten_def]
+  \\ rw [] \\ Cases_on ‘test’ \\ fs [c_test_def]
+QED
+
+Theorem find_acc:
+  ∀n vs k. find n vs k = find n vs 0 + k
+Proof
+  once_rewrite_tac [EQ_SYM_EQ]
+  \\ Induct_on ‘vs’ \\ fs [find_def] \\ rw []
+  \\ Cases_on ‘h’ \\ fs [find_def]
+  \\ last_assum (once_rewrite_tac o single o GSYM)
+  \\ decide_tac
+QED
+
+Theorem v_inv_ignore[simp]:
+  v_inv (t with stack := s) a w = v_inv t a w ∧
+  v_inv (t with pc := p) a w = v_inv t a w ∧
+  v_inv (t with regs := r) a w = v_inv t a w
+Proof
+  qid_spec_tac ‘w’ \\ Induct_on ‘a’ \\ fs [v_inv_def,read_mem_def]
+QED
+
+fun is_bool tm = type_of tm = type_of T;
+
+Theorem bool_ind:
+  ∀P. P F ∧ (P F ⇒ P T) ⇒ ∀b. P b
+Proof
+  rw [] \\ Cases_on ‘b’ \\ fs []
+QED
+
+Theorem has_stack_even:
+  has_stack t xs ⇒ EVEN (LENGTH t.stack) = ODD (LENGTH xs)
+Proof
+  fs [has_stack_def] \\ rw [] \\ fs [ODD,EVEN_ODD]
+QED
+
+Theorem memory_writable_new:
+  memory_writable x y m ∧ x ≠ y:word64 ⇒
+  can_write_mem_at m x ∧
+  can_write_mem_at m (x + 8w) ∧
+  x ≠ 0w ∧
+  ∀w1 w2. memory_writable (x+16w) y ((x+8w =+ SOME w2) ((x =+ SOME w1) m))
+Proof
+  fs [memory_writable_def] \\ strip_tac
+  \\ Cases_on ‘x’ \\ Cases_on ‘y’ \\ fs []
+  \\ fs [WORD_LS] \\ fs [aligned_w2n]
+  \\ fs [MOD_EQ_0_DIVISOR] \\ rpt var_eq_tac \\ fs []
+  \\ fs [WORD_LO,word_add_n2w] \\ rw []
+  THEN1
+   (first_x_assum match_mp_tac
+    \\ fs [WORD_LO] \\ qexists_tac ‘2 * d’ \\ fs [])
+  THEN1
+   (first_x_assum match_mp_tac
+    \\ fs [WORD_LO] \\ qexists_tac ‘2 * d + 1’ \\ fs [])
+  THEN1 (qexists_tac ‘d + 1’ \\ fs [])
+  \\ fs [PULL_EXISTS]
+  \\ fs [can_write_mem_def,APPLY_UPDATE_THM]
+  \\ Cases_on ‘a’ \\ fs []
+QED
+
+Theorem v_inv_update:
+  ∀t v w a b x y.
+    v_inv t v w ∧
+    t.memory a = SOME NONE ∧
+    t.memory b = SOME NONE ⇒
+    v_inv (t with memory := (b =+ y) ((a =+ x) t.memory)) v w
+Proof
+  Induct_on ‘v’ \\ fs [v_inv_def]
+  \\ fs [read_mem_def,APPLY_UPDATE_THM]
+  \\ rw [] \\ fs [] \\ rw [] \\ fs []
+QED
+
+Triviality blast_lemma = blastLib.BBLAST_PROVE “w ≠ w + 8w:word64”;
+
+val step_tac =
+  ho_match_mp_tac IMP_step \\ fs []
+  \\ once_rewrite_tac [step_cases] \\ fs [fetch_def,PULL_EXISTS]
+  \\ simp [take_branch_cases,APPLY_UPDATE_THM,PULL_EXISTS,set_pc_def]
+  \\ fs [write_reg_def,has_stack_def,inc_def,set_pc_def,set_stack_def,
+         EVEN,APPLY_UPDATE_THM,ODD,ODD_ADD,blast_lemma,write_mem_def,
+         EVEN_ODD,ODD,take_branch_cases,unset_reg_def];
+
+Theorem give_up:
+  code_rel fs ds t.instructions ∧
+  t.regs R15 = SOME w ∧
+  t.pc = give_up (ODD (LENGTH t.stack)) ⇒
+  steps (State t,n) (Halt 1w t.output,n)
+Proof
+  fs [code_rel_def,init_code_in_def,init_def,code_in_def] \\ rw []
+  THEN1
+   (match_mp_tac steps_trans
+    \\ ntac 3 step_tac
+    \\ ho_match_mp_tac IMP_start \\ fs []
+    \\ once_rewrite_tac [steps_cases] \\ fs [])
+  \\ match_mp_tac steps_trans
+  \\ ntac 2 step_tac
+  \\ ho_match_mp_tac IMP_start \\ fs []
+  \\ once_rewrite_tac [steps_cases] \\ fs []
+QED
+
+
+(* proving the cases *)
+
+Theorem c_exp_Const:
+  ^(get_goal "eval _ (Const _)")
+Proof
+  CONV_TAC (RESORT_FORALL_CONV
+    (fn tms => filter is_bool tms @ filter (not o is_bool) tms))
+  \\ ho_match_mp_tac bool_ind
+  \\ fs [] \\ reverse (rw [])
+  THEN1
+   (qpat_x_assum ‘c_exp T _ _ _ _ = _’ mp_tac
+    \\ simp [Once c_exp_alt]
+    \\ Cases_on ‘c_exp F t.pc vs fs (Const n)’ \\ fs []
+    \\ fs [make_ret_def]
+    \\ rw [] \\ fs [flatten_def]
+    \\ qpat_x_assum ‘code_in _ _ _’ mp_tac
+    \\ fs [flatten_def]
+    \\ once_rewrite_tac [flatten_acc] \\ fs []
+    \\ rw [] \\ first_x_assum drule \\ fs []
+    \\ rpt (disch_then drule) \\ rw []
+    \\ Cases_on ‘outcome’ \\ fs []
+    \\ reverse (Cases_on ‘q'’) \\ fs []
+    THEN1 (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+    \\ reverse (Cases_on ‘res’) \\ fs []
+    THEN1 (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+    \\ rw [] \\ rename [‘steps (State t0,s0.clock) (State t1,s1.clock)’]
+    \\ fs [has_stack_def]
+    \\ qpat_x_assum ‘_ = t1.stack’ (assume_tac o GSYM)
+    \\ qexists_tac ‘State (t1 with <| pc := t1.pc + 1; stack := rest |>), s1.clock’
+    \\ fs [code_in_def,state_rel_def,fetch_def]
+    \\ imp_res_tac c_exp_length \\ fs []
+    \\ imp_res_tac steps_inst \\ fs []
+    \\ match_mp_tac (steps_rules |> CONJUNCTS |> last)
+    \\ goal_assum (first_assum o mp_then Any mp_tac)
+    \\ match_mp_tac (steps_rules |> CONJUNCTS |> el 2)
+    \\ ‘fetch t1 = SOME (Add_RSP (LENGTH vs))’ by fs [fetch_def]
+    \\ once_rewrite_tac [step_cases] \\ fs []
+    \\ fs [set_stack_def,inc_def,state_component_equality]
+    \\ qexists_tac ‘curr’ \\ fs [env_ok_def])
+  \\ fs [eval_def] \\ rw [] \\ fs [v_inv_def,PULL_EXISTS]
+  \\ reverse (fs [c_exp_alt,c_const_def,AllCaseEqs()]) \\ rw []
+  \\ TRY
+   (qabbrev_tac ‘ss = curr ++ rest’
+    \\ fs [has_stack_def,flatten_def,code_in_def]
+    \\ ho_match_mp_tac IMP_step \\ fs []
+    \\ once_rewrite_tac [step_cases] \\ fs [fetch_def,PULL_EXISTS]
+    \\ fs [write_reg_def,inc_def,APPLY_UPDATE_THM,set_pc_def,set_stack_def]
+    \\ ho_match_mp_tac IMP_step \\ fs []
+    \\ once_rewrite_tac [step_cases] \\ fs [fetch_def,PULL_EXISTS]
+    \\ fs [write_reg_def,inc_def,APPLY_UPDATE_THM,set_pc_def,set_stack_def]
+    \\ ho_match_mp_tac IMP_start \\ fs []
+    \\ fs [state_rel_def,APPLY_UPDATE_THM] \\ NO_TAC)
+  \\ imp_res_tac has_stack_even
+  \\ pop_assum (assume_tac o GSYM)
+  \\ fs [has_stack_def,flatten_def,code_in_def]
+  \\ ho_match_mp_tac IMP_step \\ fs []
+  \\ once_rewrite_tac [step_cases] \\ fs [fetch_def,PULL_EXISTS]
+  \\ fs [write_reg_def,inc_def,APPLY_UPDATE_THM,set_pc_def,set_stack_def,
+         take_branch_cases]
+  \\ qmatch_goalsub_abbrev_tac ‘State t1’
+  \\ ‘state_rel fs s t1’ by fs [state_rel_def,Abbr‘t1’]
+  \\ fs [state_rel_def]
+  \\ drule give_up \\ fs []
+  \\ fs [Abbr‘t1’]
+  \\ fs [env_ok_def,EVEN_ODD] \\ rfs []
+  \\ disch_then (qspec_then ‘s.clock’ mp_tac)
+  \\ ‘ODD (LENGTH curr) = ODD (LENGTH t.stack)’ by
+   (Cases_on ‘curr’ \\ fs []
+    \\ Cases_on ‘rest’ \\ fs [ODD,EVEN_ODD]
+    \\ qpat_x_assum ‘_ = t.stack’ (assume_tac o GSYM) \\ fs [ODD_ADD])
+  \\ fs [] \\ strip_tac
+  \\ goal_assum (first_x_assum o mp_then Any mp_tac) \\ fs []
+QED
+
+Theorem c_exp_Var:
+  ^(get_goal "eval _ (Var _)")
+Proof
+  CONV_TAC (RESORT_FORALL_CONV
+    (fn tms => filter is_bool tms @ filter (not o is_bool) tms))
+  \\ ho_match_mp_tac bool_ind
+  \\ fs [] \\ reverse (rw [])
+  THEN1
+   (qpat_x_assum ‘c_exp T _ _ _ _ = _’ mp_tac
+    \\ simp [Once c_exp_alt]
+    \\ rename [‘Var v’] \\ rename [‘state_rel _ s t’]
+    \\ Cases_on ‘c_exp F t.pc vs fs (Var v)’ \\ fs []
+    \\ fs [make_ret_def]
+    \\ rw [] \\ fs [flatten_def]
+    \\ qpat_x_assum ‘code_in _ _ _’ mp_tac
+    \\ fs [flatten_def]
+    \\ once_rewrite_tac [flatten_acc] \\ fs []
+    \\ rw [] \\ first_x_assum drule \\ fs []
+    \\ rpt (disch_then drule) \\ rw []
+    \\ Cases_on ‘outcome’ \\ fs []
+    \\ reverse (Cases_on ‘q'’) \\ fs []
+    THEN1 (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+    \\ reverse (Cases_on ‘res’) \\ fs []
+    THEN1 (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+    \\ rw [] \\ rename [‘steps (State t0,s0.clock) (State t1,s1.clock)’]
+    \\ fs [has_stack_def]
+    \\ qpat_x_assum ‘_ = t1.stack’ (assume_tac o GSYM)
+    \\ qexists_tac ‘State (t1 with <| pc := t1.pc + 1; stack := rest |>), s1.clock’
+    \\ fs [code_in_def,state_rel_def,fetch_def]
+    \\ imp_res_tac c_exp_length \\ fs []
+    \\ imp_res_tac steps_inst \\ fs []
+    \\ match_mp_tac (steps_rules |> CONJUNCTS |> last)
+    \\ goal_assum (first_assum o mp_then Any mp_tac)
+    \\ match_mp_tac (steps_rules |> CONJUNCTS |> el 2)
+    \\ ‘fetch t1 = SOME (Add_RSP (LENGTH vs))’ by fs [fetch_def]
+    \\ once_rewrite_tac [step_cases] \\ fs []
+    \\ fs [set_stack_def,inc_def,state_component_equality]
+    \\ qexists_tac ‘curr’ \\ fs [env_ok_def])
+  \\ fs [eval_def,AllCaseEqs()] \\ rw []
+  \\ rename [‘Var v’] \\ rename [‘state_rel _ s t’]
+  \\ fs [env_ok_def]
+  \\ first_x_assum drule \\ rw []
+  \\ fs [c_exp_alt,c_var_def]
+  \\ fs [AllCaseEqs()] \\ rw []
+  \\ fs [flatten_def,code_in_def]
+  THEN1
+   (Cases_on ‘vs’ \\ fs [] \\ rw [] \\ fs [] \\ fs [find_def]
+    \\ qpat_x_assum ‘_ = 0’ mp_tac
+    \\ once_rewrite_tac [find_acc] \\ fs [AllCaseEqs()]
+    \\ rw [] \\ Cases_on ‘curr’ \\ fs []
+    \\ fs [has_stack_def] \\ rw []
+    \\ qexists_tac ‘(State (t with <| pc := t.pc+1; stack := Word w::t.stack |>), s.clock)’
+    \\ fs [] \\ fs [state_rel_def]
+    \\ match_mp_tac (steps_rules |> CONJUNCTS |> el 2)
+    \\ ‘fetch t = SOME (Push RAX)’ by fs [fetch_def]
+    \\ once_rewrite_tac [step_cases] \\ fs []
+    \\ fs [set_stack_def,inc_def,state_component_equality])
+  \\ rename [‘k < LENGTH _’]
+  \\ qexists_tac ‘(State (t with <| pc := t.pc+2;
+       regs := (RAX =+ SOME w) t.regs;
+       stack := (HD curr) :: t.stack |>), s.clock)’
+  \\ fs [state_rel_def]
+  \\ fs [has_stack_def,APPLY_UPDATE_THM]
+  \\ Cases_on ‘curr’ \\ fs [] \\ rpt var_eq_tac
+  \\ match_mp_tac (steps_rules |> CONJUNCTS |> last)
+  \\ qexists_tac ‘State (t with <| pc := t.pc+1;
+       stack := Word w' :: t.stack |>)’
+  \\ qexists_tac ‘s.clock’ \\ rw []
+  \\ match_mp_tac (steps_rules |> CONJUNCTS |> el 2)
+  \\ once_rewrite_tac [step_cases] \\ fs [fetch_def]
+  \\ fs [set_stack_def,inc_def,write_reg_def,state_component_equality]
+  \\ qexists_tac ‘w’ \\ fs []
+  \\ qpat_x_assum ‘_ = t.stack’ (assume_tac o GSYM) \\ fs []
+  \\ Cases_on ‘k’ \\ fs [rich_listTheory.EL_APPEND1]
+QED
+
+val op_init_tac =
+  rw [] \\ fs [eval_def,c_exp_alt]
+  \\ Cases_on ‘evals env xs s’ \\ fs []
+  \\ pairarg_tac \\ fs [] \\ rw []
+  \\ qpat_x_assum ‘code_in _ _ _’ mp_tac
+  \\ fs [flatten_def]
+  \\ once_rewrite_tac [flatten_acc] \\ fs [] \\ rw []
+  \\ Cases_on ‘q = Err Crash’ \\ fs []
+  \\ first_x_assum drule \\ fs []
+  \\ rpt (disch_then drule) \\ rw []
+  \\ reverse (Cases_on ‘q’) \\ fs [] \\ rw []
+  THEN1 (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+  \\ imp_res_tac eval_op_mono
+  \\ Cases_on ‘outcome’ \\ fs []
+  \\ reverse (Cases_on ‘q’) \\ fs []
+  THEN1 (goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+         \\ imp_res_tac rich_listTheory.IS_PREFIX_TRANS)
+  \\ rename [‘eval_op _ vs s0 = _’]
+  \\ first_x_assum (qspec_then ‘vs’ strip_assume_tac) \\ fs [] \\ rw []
+  \\ rename [‘steps (State t1,s1.clock) (State t2,s2.clock)’]
+  \\ ho_match_mp_tac IMP_steps \\ goal_assum (first_assum o mp_then Any mp_tac)
+  \\ imp_res_tac c_exp_length
+  \\ fs [c_op_def,c_head_def,c_tail_def,c_cons_def,c_add_def,c_sub_def,
+         c_div_def,c_read_def,c_write_def,code_in_def]
+  \\ imp_res_tac steps_inst;
+
+Theorem c_exp_Cons:
+  ~tail' ∧ f = Cons ⇒
+  ^(strip (get_goal "eval _ (Op _ _)"))
+Proof
+  op_init_tac
+  \\ fs [eval_op_def,AllCaseEqs(),fail_def,return_def]
+  \\ rw [] \\ fs [env_ok_def] \\ rw [] \\ fs [] \\ rfs []
+  \\ imp_res_tac has_stack_even
+  \\ fs [has_stack_def]
+  \\ qpat_x_assum ‘_ = t2.stack’ (assume_tac o GSYM)
+  \\ ‘init_code_in t1.instructions’ by fs [state_rel_def,code_rel_def]
+  \\ fs [init_code_in_def,code_in_def,init_def,EVEN,ODD]
+  THEN1
+   (ho_match_mp_tac IMP_step \\ fs []
+    \\ once_rewrite_tac [step_cases] \\ fs [fetch_def,PULL_EXISTS]
+    \\ fs [write_reg_def,has_stack_def,inc_def,set_pc_def,set_stack_def]
+    \\ ntac 2 step_tac
+    \\ fs [state_rel_def]
+    \\ IF_CASES_TAC \\ rw []
+    THEN1 (ntac 3 step_tac \\ ho_match_mp_tac IMP_start \\ fs [])
+    \\ drule memory_writable_new \\ fs [] \\ strip_tac
+    \\ fs [can_write_mem_def]
+    \\ ntac 6 step_tac
+    \\ ho_match_mp_tac IMP_start \\ fs [APPLY_UPDATE_THM]
+    \\ fs [v_inv_def,read_mem_def,APPLY_UPDATE_THM,blast_lemma]
+    \\ rw [] \\ match_mp_tac v_inv_update \\ fs [])
+  THEN1
+   (ho_match_mp_tac IMP_step \\ fs []
+    \\ once_rewrite_tac [step_cases] \\ fs [fetch_def,PULL_EXISTS]
+    \\ fs [write_reg_def,has_stack_def,inc_def]
+    \\ ntac 2 step_tac
+    \\ fs [state_rel_def,ODD,EVEN]
+    \\ IF_CASES_TAC \\ rw []
+    THEN1 (ntac 3 step_tac \\ ho_match_mp_tac IMP_start \\ fs [])
+    \\ drule memory_writable_new \\ fs [] \\ strip_tac
+    \\ fs [can_write_mem_def]
+    \\ ntac 5 step_tac
+    \\ ho_match_mp_tac IMP_start \\ fs [APPLY_UPDATE_THM]
+    \\ fs [v_inv_def,read_mem_def,APPLY_UPDATE_THM,blast_lemma]
+    \\ rw [] \\ match_mp_tac v_inv_update \\ fs [])
+QED
+
+Theorem c_exp_Head:
+  ~tail' ∧ f = Head ⇒
+  ^(strip (get_goal "eval _ (Op _ _)"))
+Proof
+  op_init_tac \\ step_tac
+  \\ fs [eval_op_def,AllCaseEqs(),fail_def,return_def] \\ rw []
+  \\ fs [] \\ rw [] \\ fs []
+  \\ fs [has_stack_def,wordsTheory.w2w_def,v_inv_def]
+  \\ ho_match_mp_tac IMP_start \\ fs []
+  \\ fs [write_reg_def,inc_def,state_rel_def,APPLY_UPDATE_THM]
+QED
+
+Theorem c_exp_Tail:
+  ~tail' ∧ f = Tail ⇒
+  ^(strip (get_goal "eval _ (Op _ _)"))
+Proof
+  op_init_tac \\ step_tac
+  \\ fs [eval_op_def,AllCaseEqs(),fail_def,return_def] \\ rw []
+  \\ fs [] \\ rw [] \\ fs []
+  \\ fs [has_stack_def,wordsTheory.w2w_def,v_inv_def]
+  \\ ho_match_mp_tac IMP_start \\ fs []
+  \\ fs [write_reg_def,inc_def,state_rel_def,APPLY_UPDATE_THM]
+QED
+
+Theorem c_exp_Add:
+  ~tail' ∧ f = Add ⇒
+  ^(strip (get_goal "eval _ (Op _ _)"))
+Proof
+  op_init_tac
+  \\ fs [eval_op_def,AllCaseEqs(),fail_def,return_def] \\ rw []
+  \\ fs [] \\ rw [] \\ fs [v_inv_def,GSYM PULL_FORALL] \\ rw [] \\ fs []
+  \\ imp_res_tac has_stack_even
+  \\ fs [has_stack_def]
+  \\ qpat_x_assum ‘_ = t2.stack’ (assume_tac o GSYM)
+  \\ ntac 3 step_tac
+  \\ fs [state_rel_def,word_add_n2w]
+  \\ reverse IF_CASES_TAC \\ fs []
+  THEN1 (ho_match_mp_tac IMP_start \\ fs [APPLY_UPDATE_THM]
+         \\ fs [v_inv_def,read_mem_def,FLOOKUP_UPDATE,blast_lemma])
+  \\ qmatch_goalsub_abbrev_tac ‘State t3,nn’
+  \\ ‘code_rel fs s1.funs t3.instructions’ by fs [Abbr‘t3’]
+  \\ drule give_up
+  \\ fs [Abbr‘t3’,APPLY_UPDATE_THM,ODD,EVEN_ODD,env_ok_def]
+  \\ disch_then (qspec_then ‘nn’ assume_tac)
+  \\ goal_assum (first_x_assum o mp_then Any mp_tac) \\ fs []
+QED
+
+Theorem c_exp_Sub:
+  ~tail' ∧ f = Sub ⇒
+  ^(strip (get_goal "eval _ (Op _ _)"))
+Proof
+  op_init_tac
+  \\ fs [eval_op_def,AllCaseEqs(),fail_def,return_def] \\ rw []
+  \\ fs [] \\ rw [] \\ fs [v_inv_def] \\ rw [] \\ fs []
+  \\ step_tac
+  \\ qpat_x_assum ‘_ = t2.stack’ (assume_tac o GSYM) \\ fs [set_stack_def]
+  \\ step_tac
+  \\ IF_CASES_TAC \\ fs [NOT_LESS]
+  \\ imp_res_tac (DECIDE “n ≤ m ⇒ n-m=0”) \\ asm_rewrite_tac []
+  \\ simp [GSYM PULL_FORALL,v_inv_def,set_pc_def]
+  THEN1
+   (ntac 2 step_tac
+    \\ ho_match_mp_tac IMP_start \\ fs []
+    \\ fs [write_reg_def,inc_def,state_rel_def,APPLY_UPDATE_THM]
+    \\ rename [‘n < m’] \\ ‘n ≤ m’ by fs []
+    \\ fs [LESS_EQ_EXISTS] \\ rw [] \\ fs [GSYM word_add_n2w])
+  \\ ntac 3 step_tac
+  \\ ho_match_mp_tac IMP_start \\ fs []
+  \\ fs [write_reg_def,inc_def,state_rel_def,APPLY_UPDATE_THM]
+QED
+
+Theorem c_exp_Div:
+  ~tail' ∧ f = Div ⇒
+  ^(strip (get_goal "eval _ (Op _ _)"))
+Proof
+  op_init_tac
+  \\ fs [eval_op_def,AllCaseEqs(),fail_def,return_def] \\ rw []
+  \\ fs [] \\ rw [] \\ fs [] \\ step_tac
+  \\ qpat_x_assum ‘_ = t2.stack’ (assume_tac o GSYM)
+  \\ ntac 3 step_tac
+  \\ fs [v_inv_def] \\ rw [] \\ fs []
+  \\ ho_match_mp_tac IMP_start \\ fs []
+  \\ fs [state_rel_def,v_inv_def,DIV_LT_X,APPLY_UPDATE_THM]
+QED
+
+Theorem c_exp_Read:
+  ~tail' ∧ f = Read ⇒
+  ^(strip (get_goal "eval _ (Op _ _)"))
+Proof
+  op_init_tac
+  \\ fs [eval_op_def,AllCaseEqs(),fail_def,return_def] \\ rw []
+  \\ fs [] \\ rw [] \\ fs [v_inv_def,GSYM PULL_FORALL,align_def]
+  \\ rename [‘env_ok env vs curr t1’]
+  \\ Cases_on ‘EVEN (LENGTH vs)’ \\ fs [code_in_def]
+  THEN1
+   (fs [has_stack_def]
+    \\ ntac 3 step_tac
+    \\ ‘ODD (LENGTH (curr ++ rest))’ by
+          (rewrite_tac [LENGTH_APPEND] \\ rfs [EVEN_ODD,ODD_ADD,env_ok_def])
+    \\ pop_assum mp_tac \\ asm_rewrite_tac [LENGTH,EVEN]
+    \\ simp [LENGTH,EVEN,ODD_EVEN] \\ rw []
+    \\ Cases_on ‘t2.input’ \\ fs [PULL_EXISTS,read_char_def]
+    \\ step_tac \\ ho_match_mp_tac IMP_start \\ fs []
+    \\ ‘ORD h < 256’ by fs [ORD_BOUND]
+    \\ fs [state_rel_def,v_inv_def,APPLY_UPDATE_THM,next_def])
+  THEN1
+   (fs [has_stack_def]
+    \\ ntac 2 step_tac
+    \\ ‘EVEN (LENGTH (curr ++ rest))’ by
+          (rewrite_tac [LENGTH_APPEND] \\ rfs [EVEN_ODD,ODD_ADD,env_ok_def])
+    \\ pop_assum mp_tac
+    \\ asm_rewrite_tac [LENGTH,EVEN]
+    \\ simp [LENGTH,EVEN,ODD_EVEN] \\ rw []
+    \\ Cases_on ‘t2.input’ \\ fs [PULL_EXISTS,read_char_def]
+    \\ ho_match_mp_tac IMP_start \\ fs []
+    \\ ‘ORD h < 256’ by fs [ORD_BOUND]
+    \\ fs [state_rel_def,v_inv_def,APPLY_UPDATE_THM,next_def])
+QED
+
+Theorem c_exp_Write:
+  ~tail' ∧ f = Write ⇒
+  ^(strip (get_goal "eval _ (Op _ _)"))
+Proof
+  op_init_tac
+  \\ fs [eval_op_def,AllCaseEqs(),fail_def,return_def] \\ rw []
+  \\ fs [] \\ rw [] \\ fs [v_inv_def,GSYM PULL_FORALL,align_def]
+  \\ rename [‘env_ok env vs curr t1’]
+  \\ Cases_on ‘EVEN (LENGTH vs)’ \\ fs [code_in_def]
+  THEN1
+   (ntac 3 step_tac
+    \\ CONV_TAC (RESORT_EXISTS_CONV rev) \\ rfs []
+    \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+    \\ ‘ODD (LENGTH (curr ++ rest))’ by
+          (rewrite_tac [LENGTH_APPEND] \\ rfs [EVEN_ODD,ODD_ADD,env_ok_def])
+    \\ pop_assum mp_tac
+    \\ asm_rewrite_tac [LENGTH,EVEN]
+    \\ simp [LENGTH,EVEN,ODD_EVEN] \\ rw []
+    \\ fs [unset_reg_def,put_char_def]
+    \\ ntac 2 step_tac
+    \\ ho_match_mp_tac IMP_start \\ fs []
+    \\ fs [state_rel_def,APPLY_UPDATE_THM])
+  THEN1
+   (ntac 2 step_tac
+    \\ CONV_TAC (RESORT_EXISTS_CONV rev) \\ rfs []
+    \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+    \\ ‘EVEN (LENGTH (curr ++ rest))’ by
+          (rewrite_tac [LENGTH_APPEND] \\ rfs [EVEN_ODD,ODD_ADD,env_ok_def])
+    \\ pop_assum mp_tac
+    \\ asm_rewrite_tac [LENGTH,EVEN]
+    \\ simp [LENGTH,EVEN,ODD_EVEN] \\ rw []
+    \\ fs [unset_reg_def,put_char_def]
+    \\ step_tac
+    \\ ho_match_mp_tac IMP_start \\ fs []
+    \\ fs [state_rel_def,APPLY_UPDATE_THM])
+QED
+
+Theorem c_exp_Op:
+  ^(get_goal "eval _ (Op _ _)")
+Proof
+  fs [PULL_FORALL]
+  \\ CONV_TAC (RESORT_FORALL_CONV
+       (fn tms => filter is_bool tms @ filter (not o is_bool) tms))
+  \\ ho_match_mp_tac bool_ind
+  \\ fs [] \\ reverse (rw [])
+  THEN1
+   (qpat_x_assum ‘c_exp T _ _ _ _ = _’ mp_tac
+    \\ simp [Once c_exp_alt]
+    \\ Cases_on ‘c_exp F t.pc vs fs (Op f xs)’ \\ fs []
+    \\ fs [make_ret_def]
+    \\ rw [] \\ fs [flatten_def]
+    \\ qpat_x_assum ‘code_in _ _ _’ mp_tac
+    \\ fs [flatten_def]
+    \\ once_rewrite_tac [flatten_acc] \\ fs []
+    \\ rw [] \\ first_x_assum drule \\ fs []
+    \\ rpt (disch_then drule) \\ rw []
+    \\ Cases_on ‘outcome’ \\ fs []
+    \\ reverse (Cases_on ‘q'’) \\ fs []
+    THEN1 (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+    \\ reverse (Cases_on ‘res’) \\ fs []
+    THEN1 (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+    \\ rw [] \\ rename [‘steps (State t0,s0.clock) (State t1,s1.clock)’]
+    \\ last_x_assum kall_tac
+    \\ first_x_assum (qspec_then ‘a’ mp_tac) \\ fs [] \\ strip_tac
+    \\ fs [has_stack_def]
+    \\ qpat_x_assum ‘_ = t1.stack’ (assume_tac o GSYM)
+    \\ qexists_tac ‘State (t1 with <| pc := t1.pc + 1; stack := rest |>), s1.clock’
+    \\ fs [code_in_def,state_rel_def,fetch_def]
+    \\ imp_res_tac c_exp_length \\ fs []
+    \\ imp_res_tac steps_inst \\ fs []
+    \\ match_mp_tac (steps_rules |> CONJUNCTS |> last)
+    \\ goal_assum (first_assum o mp_then Any mp_tac)
+    \\ match_mp_tac (steps_rules |> CONJUNCTS |> el 2)
+    \\ ‘fetch t1 = SOME (Add_RSP (LENGTH vs))’ by fs [fetch_def]
+    \\ once_rewrite_tac [step_cases] \\ fs []
+    \\ fs [set_stack_def,inc_def,state_component_equality]
+    \\ qexists_tac ‘curr’ \\ fs [env_ok_def])
+  \\ Cases_on ‘f’ \\ rw []
+  \\ EVERY ([c_exp_Cons, c_exp_Head, c_exp_Tail, c_exp_Add,
+             c_exp_Sub, c_exp_Div, c_exp_Read, c_exp_Write]
+       |> map (drule o SIMP_RULE std_ss [] o GEN_ALL))
+  \\ rpt (disch_then (fn th => (drule_all th \\ strip_tac) ORELSE all_tac))
+  \\ qexists_tac ‘outcome’ \\ fs []
+QED
+
+Theorem c_test_thm:
+  state_rel fs s t ∧
+  LIST_REL (v_inv t) args ws ∧
+  take_branch test args s = (Res b,s) ∧
+  has_stack t (MAP Word (REVERSE ws) ⧺ rest) ∧
+  has_stack k rest ∧
+  code_in t.pc (c_test test l4) t.instructions ⇒
+  ∃t1.
+    steps (State t,s.clock) (State t1,s.clock) ∧
+    state_rel fs s t1 ∧ has_stack t1 rest ∧
+    t1.pc = if b then l4 else t.pc + 4
+Proof
+  Cases_on ‘test’ \\ fs []
+  \\ fs [source_semanticsTheory.take_branch_def,fail_def,AllCaseEqs(),return_def]
+  \\ rw [] \\ fs [] \\ rw [] \\ fs []
+  \\ fs [v_inv_def] \\ rw []
+  \\ fs [has_stack_def]
+  \\ qpat_x_assum ‘_ = _.stack’ (assume_tac o GSYM) \\ fs []
+  \\ fs [c_test_def,code_in_def]
+  \\ ho_match_mp_tac IMP_steps_state
+  \\ ntac 4 (ho_match_mp_tac IMP_step \\ fs []
+             \\ once_rewrite_tac [step_cases] \\ fs [fetch_def]
+             \\ fs [write_reg_def,has_stack_def,inc_def,set_stack_def])
+  \\ fs [x64asm_semanticsTheory.take_branch_cases,PULL_EXISTS,
+         APPLY_UPDATE_THM,set_pc_def]
+  \\ qmatch_goalsub_abbrev_tac ‘State tt’
+  \\ qexists_tac ‘(State tt,s.clock)’ \\ fs []
+  \\ qexists_tac ‘tt’ \\ fs []
+  \\ once_rewrite_tac [steps_cases] \\ fs []
+  \\ rw [Abbr‘tt’] \\ fs [state_rel_def,APPLY_UPDATE_THM]
+QED
+
+Theorem c_exp_If:
+  ^(get_goal "eval _ (If _ _ _ _)")
+Proof
+  rw [] \\ fs [eval_def,c_exp_alt,c_if_def]
+  \\ Cases_on ‘evals env xs s’ \\ fs []
+  \\ rpt (pairarg_tac \\ fs []) \\ rw []
+  \\ qpat_x_assum ‘code_in _ _ _’ mp_tac
+  \\ fs [flatten_def]
+  \\ once_rewrite_tac [flatten_acc] \\ fs []
+  \\ once_rewrite_tac [flatten_acc] \\ fs []
+  \\ once_rewrite_tac [flatten_acc] \\ fs []
+  \\ rpt strip_tac \\ rpt var_eq_tac \\ fs [code_in_def]
+  \\ Cases_on ‘q = Err Crash’ \\ fs []
+  \\ first_x_assum drule \\ fs []
+  \\ rpt (disch_then drule) \\ rw []
+  \\ reverse (Cases_on ‘q’) \\ fs [] \\ rw []
+  THEN1 (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+  \\ rename [‘take_branch test args s5’]
+  \\ Cases_on ‘take_branch test args s5’ \\ fs []
+  \\ rename [‘_ = (taken,s6)’]
+  \\ ‘s6 = s5’ by
+    (fs [AllCaseEqs(),source_semanticsTheory.take_branch_def,fail_def,return_def] \\ rw [])
+  \\ rw []
+  \\ PairCases_on ‘outcome’ \\ fs []
+  \\ reverse (Cases_on ‘outcome0’) \\ fs []
+  THEN1 (goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+         \\ fs [AllCaseEqs()]
+         \\ rw [] \\ fs [] \\ imp_res_tac eval_mono
+         \\ imp_res_tac rich_listTheory.IS_PREFIX_TRANS \\ fs [])
+  \\ qpat_x_assum ‘_ = (res,s1)’ mp_tac
+  \\ simp [AllCaseEqs(),source_semanticsTheory.take_branch_def,fail_def,
+           return_def,PULL_EXISTS]
+  \\ reverse (rw []) \\ fs []
+  THEN1 (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+  \\ rfs [] \\ rename [‘state_rel fs s5 t5’]
+  \\ imp_res_tac c_exp_length \\ fs []
+  \\ rpt var_eq_tac \\ fs []
+  \\ ho_match_mp_tac IMP_steps \\ goal_assum (first_assum o mp_then Any mp_tac)
+  \\ pop_assum (assume_tac o GSYM)
+  \\ qmatch_asmsub_abbrev_tac ‘c_test _ l4’ \\ fs []
+  \\ ‘LENGTH (c_test test l4) = 4’ by (Cases_on ‘test’ \\ fs [c_test_def])
+  \\ fs []
+  \\ ‘t.instructions = t5.instructions’ by (imp_res_tac steps_inst \\ fs []) \\ fs []
+  \\ drule_all (c_test_thm |> Q.INST [‘rest’|->‘curr++rest’]
+                  |> SIMP_RULE (srw_ss()) [])
+  \\ strip_tac
+  \\ ho_match_mp_tac IMP_steps \\ goal_assum (first_assum o mp_then Any mp_tac)
+  \\ pop_assum (assume_tac o GSYM)
+  \\ Cases_on ‘b’ \\ fs []
+  THEN1
+   (first_x_assum drule \\ fs []
+    \\ disch_then (qspecl_then [‘curr’,‘rest’] mp_tac)
+    \\ reverse impl_tac THEN1 (metis_tac [])
+    \\ fs [] \\ imp_res_tac steps_inst \\ fs []
+    \\ fs [env_ok_def] \\ rw [] \\ res_tac \\ fs []
+    \\ imp_res_tac steps_v_inv \\ fs []
+    \\ Cases_on ‘tail'’ \\ fs [])
+  \\ qpat_x_assum ‘_ = t5.pc’ (assume_tac o GSYM) \\ fs []
+  \\ first_x_assum drule \\ fs []
+  \\ disch_then (qspecl_then [‘curr’,‘rest’] mp_tac)
+  \\ impl_tac THEN1
+   (fs [] \\ imp_res_tac steps_inst \\ fs []
+    \\ fs [env_ok_def] \\ rw [] \\ res_tac \\ fs []
+    \\ imp_res_tac steps_v_inv \\ fs [])
+  \\ strip_tac
+  \\ ho_match_mp_tac IMP_steps \\ fs []
+  \\ goal_assum (first_assum o mp_then Any mp_tac)
+  \\ PairCases_on ‘outcome’ \\ fs []
+  \\ reverse (Cases_on ‘outcome0’) \\ fs []
+  THEN1 (ho_match_mp_tac IMP_start \\ fs [])
+  \\ reverse (Cases_on ‘res’) \\ fs []
+  THEN1 (ho_match_mp_tac IMP_start \\ fs [])
+  \\ rename [‘COND taill’] \\ Cases_on ‘taill’ \\ fs []
+  THEN1 (ho_match_mp_tac IMP_start \\ fs [] \\ fs [has_stack_def])
+  \\ imp_res_tac steps_inst
+  \\ fs [has_stack_def,code_in_def]
+  \\ step_tac
+  \\ ho_match_mp_tac IMP_start \\ fs []
+  \\ fs [state_rel_def]
+QED
+
+Theorem c_exp_Let:
+  ^(get_goal "eval _ (Let _ _ _)")
+Proof
+  fs [eval_def,c_exp_alt] \\ rw []
+  \\ rpt (pairarg_tac \\ fs [])
+  \\ rpt var_eq_tac
+  \\ Cases_on ‘eval env x s’ \\ fs []
+  \\ Cases_on ‘q = Err Crash’ \\ fs []
+  \\ qpat_x_assum ‘code_in _ _ _’ mp_tac
+  \\ fs [flatten_def]
+  \\ once_rewrite_tac [flatten_acc] \\ fs []
+  \\ once_rewrite_tac [flatten_acc] \\ fs []
+  \\ strip_tac
+  \\ first_x_assum drule
+  \\ rpt (disch_then drule)
+  \\ strip_tac
+  \\ Cases_on ‘outcome’
+  \\ rename [‘steps _ (r1,r2)’]
+  \\ reverse (Cases_on ‘r1’) \\ fs []
+  THEN1
+   (goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+    \\ fs [AllCaseEqs()] \\ rw []
+    \\ imp_res_tac eval_mono
+    \\ imp_res_tac rich_listTheory.IS_PREFIX_TRANS)
+  \\ reverse (Cases_on ‘q’) \\ fs []
+  THEN1 (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [] \\ rw [])
+  \\ rename [‘eval env⦇vname ↦ SOME v⦈ y s2 = (res,s3)’] \\ rw []
+  \\ first_x_assum drule \\ fs []
+  \\ disch_then (qspecl_then [‘Word w :: curr’,‘rest’] mp_tac)
+  \\ impl_tac THEN1
+   (imp_res_tac c_exp_length \\ fs []
+    \\ imp_res_tac steps_inst \\ fs []
+    \\ rw [] \\ fs [env_ok_def] \\ rw []
+    \\ rw [] \\ fs [find_def] \\ rw []
+    \\ once_rewrite_tac [find_acc] \\ fs [ADD1]
+    \\ fs [GSYM ADD1,APPLY_UPDATE_THM]
+    \\ imp_res_tac steps_v_inv \\ fs [] \\ res_tac \\ fs [])
+  \\ strip_tac
+  \\ Cases_on ‘tail'’
+  THEN1
+   (qexists_tac ‘outcome’
+    \\ conj_tac THEN1 (Cases_on ‘outcome’ \\ imp_res_tac steps_rules \\ fs [])
+    \\ Cases_on ‘outcome’
+    \\ fs [AllCaseEqs()] \\ rw []
+    \\ Cases_on ‘q’ \\ fs []
+    \\ imp_res_tac eval_mono
+    \\ imp_res_tac rich_listTheory.IS_PREFIX_TRANS \\ fs [PULL_EXISTS]
+    \\ rw [] \\ rpt (goal_assum (first_assum o mp_then Any mp_tac)))
+  \\ fs []
+  \\ Cases_on ‘outcome’ \\ fs []
+  \\ reverse (Cases_on ‘q’) \\ fs []
+  THEN1
+   (rename [‘steps (State s8,s2.clock) (Halt Failure out,r5)’]
+    \\ qexists_tac ‘Halt Failure out,r5’ \\ fs []
+    \\ imp_res_tac steps_rules \\ fs [])
+  \\ reverse (Cases_on ‘res’) \\ fs []
+  THEN1
+   (qexists_tac ‘State s'',s3.clock’ \\ fs []
+    \\ imp_res_tac steps_rules \\ fs [])
+  \\ rename [‘steps (State t7,s2.clock) (State t8,s3.clock)’] \\ rw []
+  \\ qexists_tac ‘(State (t8 with <| pc := t8.pc+1; stack := TL t8.stack |>), s3.clock)’
+  \\ fs [] \\ rpt strip_tac
+  \\ TRY (fs [state_rel_def] \\ NO_TAC)
+  THEN1
+   (match_mp_tac (steps_rules |> CONJUNCTS |> last)
+    \\ goal_assum (first_assum o mp_then Any mp_tac)
+    \\ match_mp_tac (steps_rules |> CONJUNCTS |> last)
+    \\ goal_assum (first_assum o mp_then Any mp_tac)
+    \\ match_mp_tac (steps_rules |> CONJUNCTS |> el 2)
+    \\ fs [code_in_def]
+    \\ imp_res_tac c_exp_length \\ fs []
+    \\ imp_res_tac steps_inst \\ fs []
+    \\ ‘fetch t8 = SOME (Add_RSP 1)’ by fs [fetch_def]
+    \\ once_rewrite_tac [step_cases] \\ fs []
+    \\ fs [set_stack_def,inc_def,state_component_equality]
+    \\ qexists_tac ‘[HD t8.stack]’ \\ fs []
+    \\ fs [has_stack_def]
+    \\ qpat_x_assum ‘_ = t8.stack’ (assume_tac o GSYM) \\ fs [])
+  \\ goal_assum (first_assum o mp_then Any mp_tac)
+  \\ fs [has_stack_def] \\ rfs []
+  \\ metis_tac [TL]
+QED
+
+val Call_init_tac = rw [] \\ rpt (pop_assum mp_tac) \\ Cases_on ‘tail'’
+val [Call_tail,Call_not_tail] =
+  ([],get_goal "eval _ (Call _ _)")
+  |> Call_init_tac |> fst |> map snd
+
+Definition write_regs_def:
+  write_regs [] rs = rs ∧
+  write_regs ((x,y)::xs) rs = (x =+ SOME y) (write_regs xs rs)
+End
+
+Overload ARGS[inferior] = “[RDI;RDX;RBX;RBP]”
+
+Definition pops_regs_def:
+  pops_regs (ws:word64 list) rs =
+    if ws = [] ∨ 5 < LENGTH ws then rs else
+      write_regs (ZIP(REVERSE (TAKE ((LENGTH ws)-1) ARGS), ws)) rs
+End
+
+Theorem c_pops_thm:
+  has_stack t (MAP Word (REVERSE ws) ++ rest) ∧
+  code_in t.pc (c_pops (xs:exp list) (vs:num option list))
+    t.instructions ∧ code_rel fs ds t.instructions ∧
+  t.regs R15 = SOME r15 ∧
+  LENGTH xs = LENGTH ws ∧ (EVEN (LENGTH vs) = ODD (LENGTH rest)) ⇒
+  ∃outcome.
+    steps (State t,n) outcome ∧
+    case outcome of
+    | (Halt ec output,m) => t.output = output ∧ ec = 1w
+    | (State t1,m) => m = n ∧ LENGTH ws ≤ 5 ∧
+                      t1 = t with <| regs := pops_regs ws t.regs;
+                                     pc := t.pc + LENGTH (c_pops xs vs);
+                                     stack := rest |>
+Proof
+  fs [c_pops_def,pops_regs_def]
+  \\ Cases_on ‘xs = []’ \\ fs []
+  THEN1
+   (Cases_on ‘ws = []’ \\ fs []
+    \\ fs [has_stack_def] \\ rw [] \\ fs [code_in_def]
+    \\ step_tac
+    \\ ho_match_mp_tac IMP_start
+    \\ once_rewrite_tac [steps_cases] \\ fs [state_component_equality])
+  \\ Cases_on ‘ws = []’ \\ fs []
+  \\ IF_CASES_TAC
+  THEN1
+   (fs [LENGTH_EQ_NUM_compute] \\ rw [] \\ fs [ZIP_def,write_regs_def]
+    \\ ho_match_mp_tac IMP_start \\ fs [state_component_equality]
+    \\ fs [has_stack_def])
+  \\ Cases_on ‘xs’ \\ fs [] \\ rename [‘LENGTH xs’]
+  \\ Cases_on ‘xs’ \\ fs [] \\ rename [‘LENGTH xs’]
+  \\ Cases_on ‘xs’ \\ fs []
+  THEN1
+   (fs [LENGTH_EQ_NUM_compute] \\ rw []
+    \\ fs [ZIP_def,write_regs_def,code_in_def,has_stack_def]
+    \\ qpat_x_assum ‘_ = t.stack’ (assume_tac o GSYM)
+    \\ step_tac
+    \\ ho_match_mp_tac IMP_start
+    \\ once_rewrite_tac [steps_cases] \\ fs [state_component_equality])
+  \\ rename [‘LENGTH xs’] \\ Cases_on ‘xs’ \\ fs []
+  THEN1
+   (fs [LENGTH_EQ_NUM_compute] \\ rw []
+    \\ fs [ZIP_def,write_regs_def,code_in_def,has_stack_def]
+    \\ qpat_x_assum ‘_ = t.stack’ (assume_tac o GSYM)
+    \\ ntac 2 step_tac
+    \\ ho_match_mp_tac IMP_start
+    \\ once_rewrite_tac [steps_cases] \\ fs [state_component_equality])
+  \\ rename [‘LENGTH xs’] \\ Cases_on ‘xs’ \\ fs []
+  THEN1
+   (fs [LENGTH_EQ_NUM_compute] \\ rw []
+    \\ fs [ZIP_def,write_regs_def,code_in_def,has_stack_def]
+    \\ qpat_x_assum ‘_ = t.stack’ (assume_tac o GSYM)
+    \\ ntac 3 step_tac
+    \\ ho_match_mp_tac IMP_start
+    \\ once_rewrite_tac [steps_cases] \\ fs [state_component_equality])
+  \\ rename [‘LENGTH xs’] \\ Cases_on ‘xs’ \\ fs []
+  THEN1
+   (fs [LENGTH_EQ_NUM_compute] \\ rw []
+    \\ fs [ZIP_def,write_regs_def,code_in_def,has_stack_def]
+    \\ qpat_x_assum ‘_ = t.stack’ (assume_tac o GSYM)
+    \\ ntac 4 step_tac
+    \\ ho_match_mp_tac IMP_start
+    \\ once_rewrite_tac [steps_cases] \\ fs [state_component_equality])
+  THEN1
+   (fs [code_in_def] \\ rpt strip_tac
+    \\ step_tac
+    \\ qmatch_goalsub_abbrev_tac ‘State t1’
+    \\ ‘code_rel fs ds t1.instructions’ by fs [Abbr‘t1’]
+    \\ drule (GEN_ALL give_up)
+    \\ fs [Abbr‘t1’,has_stack_def]
+    \\ disch_then (qspec_then ‘n’ mp_tac)
+    \\ qsuff_tac ‘ODD (LENGTH t.stack) = ODD (LENGTH ws + LENGTH vs)’
+    THEN1 (strip_tac \\ fs [ODD_ADD] \\ strip_tac
+           \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+    \\ ‘ODD (LENGTH t.stack) = ~ODD (LENGTH (Word w :: t.stack))’ by fs [ODD]
+    \\ asm_rewrite_tac []
+    \\ qpat_x_assum ‘_ = _ :: t.stack’ (assume_tac o GSYM)
+    \\ asm_rewrite_tac [] \\ fs [EVEN_ODD,ODD_ADD]
+    \\ fs [ODD_EVEN] \\ fs [EVEN] \\ metis_tac [])
+QED
+
+Theorem c_pushes_thm:
+  c_pushes params pos = (c,vs1,l1) ∧
+  code_in t.pc (flatten c []) t.instructions ∧
+  t.regs = pops_regs ws regs ∧
+  t.stack = rest ∧ LENGTH params ≤ 5 ∧
+  t.regs RAX = SOME w ∧
+  (ws ≠ [] ⇒ LAST ws = w) ∧
+  LIST_REL (v_inv t) args ws ∧
+  LENGTH ws = LENGTH params ∧
+  state_rel fs r t ⇒
+  ∃new_curr t5.
+    steps (State t,n) (State t5,n) ∧
+    t5.pc = t.pc + LENGTH (flatten c []) ∧
+    l1 = pos + LENGTH (flatten c []) ∧
+    has_stack t5 (new_curr ++ rest) ∧
+    env_ok (make_env params args empty_env) vs1 new_curr t5 ∧
+    state_rel fs r t5 ∧
+    t5.instructions = t.instructions
+Proof
+  rw []
+  \\ ‘(∀n. ~MEM n ARGS ⇒ regs n = t.regs n)’ by
+   (fs [] \\ Cases \\ fs [pops_regs_def] \\ rw [] \\ fs []
+    \\ Cases_on ‘params’ \\ fs [] \\ Cases_on ‘ws’ \\ fs [] \\ rw []
+    \\ rpt (rename [‘LENGTH params = LENGTH ws’]
+            \\ Cases_on ‘params’ \\ fs [] \\ Cases_on ‘ws’ \\ fs []
+            \\ rw [ZIP_def,write_regs_def,APPLY_UPDATE_THM]))
+  \\ Cases_on ‘ws’ \\ fs []
+  THEN1
+   (rw [] \\ fs [c_pushes_def] \\ rw []
+    \\ fs [flatten_def,code_in_def,pops_regs_def,make_env_def]
+    \\ qexists_tac ‘[Word w]’ \\ fs []
+    \\ qexists_tac ‘t’ \\ fs []
+    \\ fs [has_stack_def,env_ok_def,empty_env_def])
+  \\ rw [] \\ rename [‘SUC (LENGTH ws)’]
+  \\ Cases_on ‘ws’ \\ fs []
+  THEN1
+   (rw [] \\ fs [LENGTH_EQ_NUM_compute] \\ rw []
+    \\ fs [c_pushes_def] \\ rw [] \\ fs [flatten_def]
+    \\ rename [‘make_env [k] [x]’]
+    \\ qexists_tac ‘[Word h]’
+    \\ qexists_tac ‘t’ \\ fs []
+    \\ fs [has_stack_def]
+    \\ fs [env_ok_def,make_env_def,APPLY_UPDATE_THM] \\ rw []
+    \\ EVAL_TAC \\ fs [empty_env_def])
+  \\ rw[] \\ fs [] \\ rw [] \\ rename [‘SUC (LENGTH ws)’]
+  \\ Cases_on ‘ws’ \\ fs []
+  THEN1
+   (rw [] \\ fs [LENGTH_EQ_NUM_compute] \\ rw []
+    \\ fs [c_pushes_def] \\ rw [] \\ fs [flatten_def]
+    \\ qexists_tac ‘[Word h'; Word h]’ \\ fs []
+    \\ fs [code_in_def,pops_regs_def,ZIP_def,write_regs_def]
+    \\ ho_match_mp_tac IMP_steps_alt
+    \\ step_tac
+    \\ fs [GSYM PULL_EXISTS]
+    \\ ho_match_mp_tac IMP_start \\ fs []
+    \\ qmatch_goalsub_abbrev_tac ‘State t1’
+    \\ qexists_tac ‘t1’
+    \\ fs [Abbr‘t1’,has_stack_def,APPLY_UPDATE_THM]
+    \\ fs [state_rel_def,APPLY_UPDATE_THM]
+    \\ fs [env_ok_def,make_env_def,empty_env_def,APPLY_UPDATE_THM]
+    \\ rw [] \\ EVAL_TAC \\ fs [])
+  \\ rw[] \\ fs [] \\ rw [] \\ rename [‘SUC (LENGTH ws)’]
+  \\ Cases_on ‘ws’ \\ fs []
+  THEN1
+   (rw [] \\ fs [LENGTH_EQ_NUM_compute] \\ rw []
+    \\ fs [c_pushes_def] \\ rw [] \\ fs [flatten_def]
+    \\ qexists_tac ‘[Word h''; Word h'; Word h]’ \\ fs []
+    \\ fs [code_in_def,pops_regs_def,ZIP_def,write_regs_def]
+    \\ ho_match_mp_tac IMP_steps_alt
+    \\ ntac 2 (ho_match_mp_tac IMP_step \\ fs []
+               \\ once_rewrite_tac [step_cases] \\ fs [fetch_def,PULL_EXISTS]
+               \\ fs [write_reg_def,set_stack_def,inc_def,APPLY_UPDATE_THM,EVEN]
+               \\ fs [GSYM PULL_EXISTS])
+    \\ ho_match_mp_tac IMP_start \\ fs []
+    \\ qmatch_goalsub_abbrev_tac ‘State t1’
+    \\ qexists_tac ‘t1’
+    \\ fs [Abbr‘t1’,has_stack_def,APPLY_UPDATE_THM]
+    \\ fs [state_rel_def,APPLY_UPDATE_THM]
+    \\ fs [env_ok_def,make_env_def,empty_env_def,APPLY_UPDATE_THM]
+    \\ rw [] \\ EVAL_TAC \\ fs [])
+  \\ rw[] \\ fs [] \\ rw [] \\ rename [‘SUC (LENGTH ws)’]
+  \\ Cases_on ‘ws’ \\ fs []
+  THEN1
+   (rw [] \\ fs [LENGTH_EQ_NUM_compute] \\ rw []
+    \\ fs [c_pushes_def] \\ rw [] \\ fs [flatten_def]
+    \\ qexists_tac ‘[Word h'''; Word h''; Word h'; Word h]’ \\ fs []
+    \\ fs [code_in_def,pops_regs_def,ZIP_def,write_regs_def]
+    \\ ho_match_mp_tac IMP_steps_alt
+    \\ ntac 3 (ho_match_mp_tac IMP_step \\ fs []
+               \\ once_rewrite_tac [step_cases] \\ fs [fetch_def,PULL_EXISTS]
+               \\ fs [write_reg_def,set_stack_def,inc_def,APPLY_UPDATE_THM,EVEN]
+               \\ fs [GSYM PULL_EXISTS])
+    \\ ho_match_mp_tac IMP_start \\ fs []
+    \\ qmatch_goalsub_abbrev_tac ‘State t1’
+    \\ qexists_tac ‘t1’
+    \\ fs [Abbr‘t1’,has_stack_def,APPLY_UPDATE_THM]
+    \\ fs [state_rel_def,APPLY_UPDATE_THM]
+    \\ fs [env_ok_def,make_env_def,empty_env_def,APPLY_UPDATE_THM]
+    \\ rw [] \\ EVAL_TAC \\ fs [])
+  \\ rw[] \\ fs [] \\ rw [] \\ rename [‘SUC (LENGTH ws)’]
+  \\ Cases_on ‘ws’ \\ fs []
+  THEN1
+   (rw [] \\ fs [LENGTH_EQ_NUM_compute] \\ rw []
+    \\ fs [c_pushes_def] \\ rw [] \\ fs [flatten_def]
+    \\ qexists_tac ‘[Word h''''; Word h'''; Word h''; Word h'; Word h]’ \\ fs []
+    \\ fs [code_in_def,pops_regs_def,ZIP_def,write_regs_def]
+    \\ ho_match_mp_tac IMP_steps_alt
+    \\ ntac 4 (ho_match_mp_tac IMP_step \\ fs []
+               \\ once_rewrite_tac [step_cases] \\ fs [fetch_def,PULL_EXISTS]
+               \\ fs [write_reg_def,set_stack_def,inc_def,APPLY_UPDATE_THM,EVEN]
+               \\ fs [GSYM PULL_EXISTS])
+    \\ ho_match_mp_tac IMP_start \\ fs []
+    \\ qmatch_goalsub_abbrev_tac ‘State t1’
+    \\ qexists_tac ‘t1’
+    \\ fs [Abbr‘t1’,has_stack_def,APPLY_UPDATE_THM]
+    \\ fs [state_rel_def,APPLY_UPDATE_THM]
+    \\ fs [env_ok_def,make_env_def,empty_env_def,APPLY_UPDATE_THM]
+    \\ rw [] \\ EVAL_TAC \\ fs [])
+  \\ rw [] \\ fs [LENGTH_EQ_NUM_compute] \\ rw []
+QED
+
+Theorem lookup_thm:
+  ∀fs t pos. ALOOKUP fs t = SOME pos ⇒ lookup t fs = pos
+Proof
+  Induct \\ fs [FORALL_PROD,AllCaseEqs(),lookup_def] \\ rw []
+  \\ res_tac \\ fs []
+QED
+
+Theorem pops_regs:
+  pops_regs ws regs RAX = regs RAX ∧
+  pops_regs ws regs R12 = regs R12 ∧
+  pops_regs ws regs R13 = regs R13 ∧
+  pops_regs ws regs R14 = regs R14 ∧
+  pops_regs ws regs R15 = regs R15
+Proof
+  fs [pops_regs_def] \\ IF_CASES_TAC \\ fs [] \\ Cases_on ‘ws’ \\ fs []
+  \\ rpt (rename [‘LENGTH tt’] \\ Cases_on ‘tt’  \\ fs [ZIP_def] THEN1 EVAL_TAC)
+QED
+
+Theorem c_exp_Call_tail:
+  ^Call_tail
+Proof
+  rw [] \\ fs [eval_def]
+  \\ Cases_on ‘evals env xs s’ \\ fs []
+  \\ Cases_on ‘q = Err Crash’ \\ fs []
+  \\ fs [c_exp_alt]
+  \\ Cases_on ‘c_exps t'.pc vs fs xs’ \\ fs []
+  \\ fs [c_call_def] \\ rw []
+  \\ fs [flatten_def]
+  \\ qpat_x_assum ‘code_in _ _ _’ mp_tac
+  \\ once_rewrite_tac [flatten_acc] \\ fs [code_in_def]
+  \\ strip_tac
+  \\ first_x_assum drule_all
+  \\ strip_tac
+  \\ Cases_on ‘outcome’
+  \\ rename [‘steps (State t',s.clock) (ss,n)’]
+  \\ reverse (Cases_on ‘ss’) \\ fs []
+  THEN1
+   (goal_assum (first_x_assum o mp_then Any mp_tac) \\ fs []
+    \\ fs [AllCaseEqs(),get_env_and_body_def,fail_def,return_def]
+    \\ rw [] \\ imp_res_tac eval_mono \\ fs []
+    \\ imp_res_tac rich_listTheory.IS_PREFIX_TRANS)
+  \\ reverse (Cases_on ‘q’) \\ fs []
+  THEN1 (goal_assum (first_x_assum o mp_then Any mp_tac) \\ fs [] \\ rw [])
+  \\ rw []
+  \\ Cases_on ‘get_env_and_body t a r’ \\ fs []
+  \\ reverse (Cases_on ‘q’)
+  THEN1
+   (fs [] \\ rw [] \\ goal_assum (first_x_assum o mp_then Any mp_tac)
+    \\ fs [get_env_and_body_def,AllCaseEqs(),fail_def] \\ rw [])
+  \\ fs [AllCaseEqs()] \\ rw []
+  \\ fs [AllCaseEqs(),get_env_and_body_def,fail_def] \\ rw []
+  \\ rfs []
+  \\ rename [‘steps (State t1,s.clock) (State t2,r.clock)’]
+  \\ ho_match_mp_tac IMP_steps
+  \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+  \\ rename [‘evals env xs s = (Res args,r)’]
+  \\ full_simp_tac std_ss [GSYM APPEND_ASSOC,APPEND]
+  \\ drule (GEN_ALL c_pops_thm)
+  \\ imp_res_tac steps_inst \\ fs []
+  \\ imp_res_tac c_exp_length \\ fs []
+  \\ disch_then drule
+  \\ ‘∃r15. t2.regs R15 = SOME r15’ by fs [state_rel_def] \\ fs []
+  \\ pop_assum kall_tac
+  \\ disch_then (qspecl_then [‘r.clock’,‘fs’,‘r.funs’] mp_tac)
+  \\ impl_tac
+  THEN1
+   (imp_res_tac LIST_REL_LENGTH
+    \\ imp_res_tac evals_length \\ fs []
+    \\ fs [state_rel_def,ODD_ADD,env_ok_def,EVEN_ODD])
+  \\ strip_tac
+  \\ ho_match_mp_tac IMP_steps
+  \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+  \\ Cases_on ‘outcome’ \\ fs []
+  \\ reverse (Cases_on ‘q’) \\ fs [] \\ rw []
+  THEN1
+   (ho_match_mp_tac IMP_start \\ fs []
+    \\ imp_res_tac eval_mono \\ fs [state_rel_def] \\ rfs [])
+  \\ ho_match_mp_tac IMP_step \\ fs []
+  \\ once_rewrite_tac [step_cases] \\ fs [fetch_def,PULL_EXISTS]
+  \\ fs [write_reg_def,set_stack_def,inc_def,APPLY_UPDATE_THM,EVEN]
+  \\ CONV_TAC (RESORT_EXISTS_CONV rev) \\ rfs []
+  \\ qexists_tac ‘rest’
+  \\ qexists_tac ‘curr’ \\ fs []
+  \\ ‘LENGTH vs = LENGTH curr’ by fs [env_ok_def] \\ fs []
+  \\ Cases_on ‘r.clock’ \\ fs []
+  \\ ho_match_mp_tac IMP_step'
+  \\ once_rewrite_tac [step_cases] \\ fs [fetch_def,PULL_EXISTS]
+  \\ fs [write_reg_def,set_stack_def,inc_def,APPLY_UPDATE_THM,EVEN,
+         take_branch_cases,set_pc_def]
+  \\ fs [env_and_body_def,fail_def,AllCaseEqs()] \\ rw []
+  \\ ‘code_rel fs r.funs t2.instructions’ by fs [state_rel_def]
+  \\ fs [code_rel_def]
+  \\ first_x_assum drule
+  \\ strip_tac \\ fs [name_of_def]
+  \\ imp_res_tac lookup_thm \\ fs []
+  \\ fs [c_defun_def]
+  \\ rpt (pairarg_tac \\ fs [flatten_def])
+  \\ qpat_x_assum ‘code_in _ _ _’ mp_tac
+  \\ once_rewrite_tac [flatten_acc]
+  \\ fs [code_in_def] \\ rw []
+  \\ qmatch_goalsub_abbrev_tac ‘State t3’
+  \\ drule c_pushes_thm
+  \\ ‘t1.instructions = t3.instructions’ by fs [Abbr‘t3’] \\ fs []
+  \\ ‘code_in t3.pc (flatten c0 []) t3.instructions’ by fs [Abbr‘t3’]
+  \\ disch_then drule
+  \\ ‘t3.regs = pops_regs ws t2.regs’ by fs [Abbr‘t3’]
+  \\ disch_then drule
+  \\ ‘LIST_REL (v_inv t3) args ws’ by
+    (first_x_assum (fn th => mp_tac th \\ match_mp_tac LIST_REL_mono)
+     \\ fs [Abbr‘t3’])
+  \\ disch_then (first_assum o mp_then Any mp_tac)
+  \\ ‘∃w'. t3.regs RAX = SOME w'’ by
+       rfs [has_stack_def,Abbr‘t3’,pops_regs]
+  \\ fs []
+  \\ disch_then (qspecl_then [‘r’,‘n’,‘fs’] mp_tac)
+  \\ impl_tac
+  THEN1 (imp_res_tac LIST_REL_LENGTH \\ fs []
+         \\ fs [state_rel_def,Abbr‘t3’,pops_regs]
+         \\ rfs [has_stack_def]
+         \\ Cases_on ‘ws = []’ \\ fs []
+         \\ ‘∃x l. ws = SNOC x l’ by metis_tac [SNOC_CASES] \\ fs [])
+  \\ strip_tac
+  \\ ho_match_mp_tac IMP_steps
+  \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs [Abbr‘t3’]
+  \\ qpat_x_assum ‘t5.pc = _’ (assume_tac o GSYM)  \\ fs []
+  \\ first_x_assum drule \\ fs []
+  \\ disch_then match_mp_tac \\ fs []
+  \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+  \\ fs [state_rel_def]
+QED
+
+Theorem c_exp_Call_not_tail:
+  ^Call_not_tail
+Proof
+  rw [] \\ fs [eval_def]
+  \\ Cases_on ‘evals env xs s’ \\ fs []
+  \\ Cases_on ‘q = Err Crash’ \\ fs []
+  \\ fs [c_exp_alt]
+  \\ Cases_on ‘c_exps t'.pc vs fs xs’ \\ fs []
+  \\ fs [c_call_def] \\ rw []
+  \\ fs [flatten_def]
+  \\ qpat_x_assum ‘code_in _ _ _’ mp_tac
+  \\ once_rewrite_tac [flatten_acc] \\ fs [code_in_def]
+  \\ strip_tac
+  \\ first_x_assum drule_all
+  \\ strip_tac
+  \\ Cases_on ‘outcome’
+  \\ rename [‘steps (State t',s.clock) (ss,n)’]
+  \\ reverse (Cases_on ‘ss’) \\ fs []
+  THEN1
+   (goal_assum (first_x_assum o mp_then Any mp_tac) \\ fs []
+    \\ fs [AllCaseEqs(),get_env_and_body_def,fail_def,return_def]
+    \\ rw [] \\ imp_res_tac eval_mono \\ fs []
+    \\ imp_res_tac rich_listTheory.IS_PREFIX_TRANS)
+  \\ reverse (Cases_on ‘q’) \\ fs []
+  THEN1 (goal_assum (first_x_assum o mp_then Any mp_tac) \\ fs [] \\ rw [])
+  \\ rw []
+  \\ Cases_on ‘get_env_and_body t a r’ \\ fs []
+  \\ reverse (Cases_on ‘q’)
+  THEN1
+   (fs [] \\ rw [] \\ goal_assum (first_x_assum o mp_then Any mp_tac)
+    \\ fs [get_env_and_body_def,AllCaseEqs(),fail_def] \\ rw [])
+  \\ fs [AllCaseEqs()] \\ rw []
+  \\ fs [AllCaseEqs(),get_env_and_body_def,fail_def] \\ rw []
+  \\ rfs []
+  \\ rename [‘steps (State t1,s.clock) (State t2,r.clock)’]
+  \\ ho_match_mp_tac IMP_steps
+  \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+  \\ rename [‘evals env xs s = (Res args,r)’]
+  \\ full_simp_tac std_ss [GSYM APPEND_ASSOC,APPEND]
+  \\ drule (GEN_ALL c_pops_thm)
+  \\ imp_res_tac steps_inst \\ fs []
+  \\ imp_res_tac c_exp_length \\ fs []
+  \\ disch_then drule
+  \\ ‘∃r15. t2.regs R15 = SOME r15’ by fs [state_rel_def] \\ fs []
+  \\ pop_assum kall_tac
+  \\ disch_then (qspecl_then [‘r.clock’,‘fs’,‘r.funs’] mp_tac)
+  \\ impl_tac
+  THEN1
+   (imp_res_tac LIST_REL_LENGTH
+    \\ imp_res_tac evals_length \\ fs []
+    \\ fs [state_rel_def,ODD_ADD,env_ok_def,EVEN_ODD])
+  \\ strip_tac
+  \\ ho_match_mp_tac IMP_steps
+  \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+  \\ Cases_on ‘outcome’ \\ fs []
+  \\ reverse (Cases_on ‘q’) \\ fs [] \\ rw []
+  THEN1
+   (ho_match_mp_tac IMP_start \\ fs []
+    \\ imp_res_tac eval_mono \\ fs [state_rel_def] \\ rfs [])
+  \\ reverse (Cases_on ‘EVEN (LENGTH vs)’) \\ fs [align_def,code_in_def]
+  THEN1
+   (Cases_on ‘r.clock’ \\ fs []
+    \\ ho_match_mp_tac IMP_step' \\ fs []
+    \\ once_rewrite_tac [step_cases] \\ fs [fetch_def,PULL_EXISTS]
+    \\ fs [write_reg_def,set_stack_def,inc_def,APPLY_UPDATE_THM,EVEN,set_pc_def]
+    \\ qmatch_goalsub_abbrev_tac ‘State t4’
+    \\ fs [env_and_body_def,fail_def,AllCaseEqs()] \\ rw []
+    \\ ‘code_rel fs r.funs t4.instructions’ by fs [state_rel_def,Abbr‘t4’]
+    \\ fs [code_rel_def]
+    \\ first_x_assum drule
+    \\ strip_tac \\ fs [name_of_def]
+    \\ imp_res_tac lookup_thm \\ fs []
+    \\ fs [c_defun_def]
+    \\ rpt (pairarg_tac \\ fs [flatten_def])
+    \\ qpat_x_assum ‘code_in _ _ _’ mp_tac
+    \\ once_rewrite_tac [flatten_acc]
+    \\ fs [code_in_def] \\ rw []
+    \\ drule c_pushes_thm
+    \\ ‘t1.instructions = t4.instructions’ by fs [Abbr‘t4’] \\ fs []
+    \\ ‘code_in t4.pc (flatten c0 []) t4.instructions’ by fs [Abbr‘t4’]
+    \\ disch_then drule
+    \\ ‘t4.regs = pops_regs ws t2.regs’ by fs [Abbr‘t4’]
+    \\ disch_then drule
+    \\ ‘LIST_REL (v_inv t4) args ws’ by
+      (first_x_assum (fn th => mp_tac th \\ match_mp_tac LIST_REL_mono)
+       \\ fs [Abbr‘t4’])
+    \\ disch_then (first_assum o mp_then Any mp_tac)
+    \\ ‘∃w'. t4.regs RAX = SOME w'’ by
+         rfs [has_stack_def,Abbr‘t4’,pops_regs]
+    \\ fs []
+    \\ disch_then (qspecl_then [‘r’,‘n’,‘fs’] mp_tac)
+    \\ impl_tac
+    THEN1 (imp_res_tac LIST_REL_LENGTH \\ fs []
+           \\ fs [state_rel_def,Abbr‘t4’,pops_regs]
+           \\ rfs [has_stack_def]
+           \\ Cases_on ‘ws = []’ \\ fs []
+           \\ ‘∃x l. ws = SNOC x l’ by metis_tac [SNOC_CASES] \\ fs [])
+    \\ strip_tac
+    \\ ho_match_mp_tac IMP_steps
+    \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs [Abbr‘t4’]
+    \\ qpat_x_assum ‘t5.pc = _’ (assume_tac o GSYM)  \\ fs []
+    \\ first_x_assum drule \\ fs []
+    \\ disch_then (first_assum o mp_then (Pos (el 3)) mp_tac)
+    \\ impl_tac
+    THEN1 (rfs [ODD,ODD_ADD,EVEN_ODD,env_ok_def] \\ fs [state_rel_def])
+    \\ strip_tac \\ PairCases_on‘outcome’
+    \\ reverse (Cases_on ‘outcome0’) \\ fs [] \\ rw []
+    THEN1 (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+    \\ reverse (Cases_on ‘res’) \\ fs []
+    THEN1 (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+    \\ ho_match_mp_tac IMP_steps
+    \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+    \\ step_tac
+    \\ fs [PULL_EXISTS,has_stack_def]
+    \\ qpat_x_assum ‘_ = _.stack’ (assume_tac o GSYM) \\ fs []
+    \\ ho_match_mp_tac IMP_start \\ fs []
+    \\ fs [state_rel_def])
+  THEN1
+   (Cases_on ‘r.clock’ \\ fs []
+    \\ ho_match_mp_tac IMP_step \\ fs []
+    \\ once_rewrite_tac [step_cases] \\ fs [fetch_def,PULL_EXISTS]
+    \\ fs [write_reg_def,set_stack_def,inc_def,APPLY_UPDATE_THM,
+           EVEN,set_pc_def,fetch_def,pops_regs]
+    \\ ‘∃rax. t2.regs RAX = SOME rax’ by fs [has_stack_def] \\ fs []
+    \\ pop_assum kall_tac
+    \\ ho_match_mp_tac IMP_step' \\ fs []
+    \\ once_rewrite_tac [step_cases] \\ fs [fetch_def,PULL_EXISTS]
+    \\ fs [write_reg_def,set_stack_def,inc_def,APPLY_UPDATE_THM,EVEN,set_pc_def]
+    \\ qmatch_goalsub_abbrev_tac ‘State t4’
+    \\ fs [env_and_body_def,fail_def,AllCaseEqs()] \\ rw []
+    \\ ‘code_rel fs r.funs t4.instructions’ by fs [state_rel_def,Abbr‘t4’]
+    \\ fs [code_rel_def]
+    \\ first_x_assum drule
+    \\ strip_tac \\ fs [name_of_def]
+    \\ imp_res_tac lookup_thm \\ fs []
+    \\ fs [c_defun_def]
+    \\ rpt (pairarg_tac \\ fs [flatten_def])
+    \\ qpat_x_assum ‘code_in _ _ _’ mp_tac
+    \\ once_rewrite_tac [flatten_acc]
+    \\ fs [code_in_def] \\ rw []
+    \\ drule c_pushes_thm
+    \\ ‘t1.instructions = t4.instructions’ by fs [Abbr‘t4’] \\ fs []
+    \\ ‘code_in t4.pc (flatten c0 []) t4.instructions’ by fs [Abbr‘t4’]
+    \\ disch_then drule
+    \\ ‘t4.regs = pops_regs ws t2.regs’ by fs [Abbr‘t4’]
+    \\ disch_then drule
+    \\ ‘LIST_REL (v_inv t4) args ws’ by
+      (first_x_assum (fn th => mp_tac th \\ match_mp_tac LIST_REL_mono)
+       \\ fs [Abbr‘t4’])
+    \\ disch_then (first_assum o mp_then Any mp_tac)
+    \\ ‘∃w'. t4.regs RAX = SOME w'’ by
+         rfs [has_stack_def,Abbr‘t4’,pops_regs]
+    \\ fs []
+    \\ disch_then (qspecl_then [‘r’,‘n’,‘fs’] mp_tac)
+    \\ impl_tac
+    THEN1 (imp_res_tac LIST_REL_LENGTH \\ fs []
+           \\ fs [state_rel_def,Abbr‘t4’,pops_regs]
+           \\ rfs [has_stack_def]
+           \\ Cases_on ‘ws = []’ \\ fs []
+           \\ ‘∃x l. ws = SNOC x l’ by metis_tac [SNOC_CASES] \\ fs [])
+    \\ strip_tac
+    \\ ho_match_mp_tac IMP_steps
+    \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs [Abbr‘t4’]
+    \\ qpat_x_assum ‘t5.pc = _’ (assume_tac o GSYM)  \\ fs []
+    \\ first_x_assum drule \\ fs []
+    \\ disch_then (first_assum o mp_then (Pos (el 3)) mp_tac)
+    \\ impl_tac
+    THEN1 (rfs [ODD,ODD_ADD,EVEN_ODD,env_ok_def] \\ fs [state_rel_def])
+    \\ strip_tac \\ PairCases_on‘outcome’
+    \\ reverse (Cases_on ‘outcome0’) \\ fs [] \\ rw []
+    THEN1 (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+    \\ reverse (Cases_on ‘res’) \\ fs []
+    THEN1 (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+    \\ ho_match_mp_tac IMP_steps
+    \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+    \\ step_tac
+    \\ fs [PULL_EXISTS,has_stack_def]
+    \\ qpat_x_assum ‘_ = _.stack’ (assume_tac o GSYM) \\ fs []
+    \\ imp_res_tac steps_inst \\ fs []
+    \\ step_tac
+    \\ ho_match_mp_tac IMP_start \\ fs []
+    \\ fs [state_rel_def,APPLY_UPDATE_THM])
+QED
+
+Theorem c_exp_Call:
+  ^(get_goal "eval _ (Call _ _)")
+Proof
+  Call_init_tac \\ rewrite_tac [c_exp_Call_tail,c_exp_Call_not_tail]
+QED
+
+Theorem c_exps_nil:
+  ^(get_goal "evals _ []")
+Proof
+  fs [eval_def,c_exp_alt] \\ rw []
+  \\ qexists_tac ‘State t, s.clock’ \\ fs []
+  \\ simp [Once steps_cases]
+QED
+
+Theorem c_exps_cons:
+  ^(get_goal "evals _ (_::_)")
+Proof
+  fs [eval_def,c_exp_alt] \\ rw []
+  \\ rpt (pairarg_tac \\ fs [])
+  \\ rpt var_eq_tac
+  \\ Cases_on ‘eval env x s’ \\ fs []
+  \\ Cases_on ‘q = Err Crash’ \\ fs []
+  \\ first_x_assum drule \\ fs []
+  \\ rpt (disch_then drule)
+  \\ impl_tac THEN1
+   (qpat_x_assum ‘code_in _ _ _’ mp_tac
+    \\ fs [flatten_def] \\ simp [Once flatten_acc])
+  \\ strip_tac
+  \\ Cases_on ‘outcome’
+  \\ rename [‘steps _ (r1,r2)’]
+  \\ reverse (Cases_on ‘r1’) \\ fs []
+  THEN1
+   (goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+    \\ fs [AllCaseEqs()] \\ rw []
+    \\ imp_res_tac eval_mono
+    \\ imp_res_tac rich_listTheory.IS_PREFIX_TRANS)
+  \\ reverse (Cases_on ‘q’) \\ fs []
+  THEN1 (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [] \\ rw [])
+  \\ Cases_on ‘evals env xs r’ \\ fs []
+  \\ Cases_on ‘q = Err Crash’ \\ fs [] \\ rw []
+  \\ first_x_assum drule \\ fs []
+  \\ disch_then (qspecl_then [‘Word w :: curr’,‘rest’] mp_tac)
+  \\ impl_tac THEN1
+   (qpat_x_assum ‘code_in _ _ _’ mp_tac
+    \\ fs [flatten_def] \\ simp [Once flatten_acc]
+    \\ imp_res_tac c_exp_length \\ fs []
+    \\ imp_res_tac steps_inst \\ fs [] \\ rw []
+    \\ fs [env_ok_def] \\ rw []
+    \\ first_x_assum drule
+    \\ rw [] \\ fs [find_def]
+    \\ once_rewrite_tac [find_acc] \\ fs [ADD1]
+    \\ fs [GSYM ADD1]
+    \\ imp_res_tac steps_v_inv \\ fs [])
+  \\ strip_tac
+  \\ qexists_tac ‘outcome’
+  \\ conj_tac THEN1 (Cases_on ‘outcome’ \\ imp_res_tac steps_rules \\ fs [])
+  \\ Cases_on ‘outcome’
+  \\ fs [AllCaseEqs()] \\ rw []
+  \\ Cases_on ‘q'’ \\ fs []
+  \\ imp_res_tac eval_mono
+  \\ imp_res_tac rich_listTheory.IS_PREFIX_TRANS \\ fs [PULL_EXISTS]
+  \\ full_simp_tac std_ss [GSYM APPEND_ASSOC,APPEND]
+  \\ rpt (goal_assum (first_assum o mp_then Any mp_tac))
+  \\ imp_res_tac steps_v_inv \\ fs []
+QED
+
+
+(* putting all the cases together *)
+
+Theorem c_exp_correct:
+  ^(compile_correct_tm())
+Proof
+  match_mp_tac (the_ind_thm())
+  \\ EVERY (map strip_assume_tac [c_exp_Const, c_exp_Var,
+      c_exp_Op, c_exp_If, c_exp_Let, c_exp_Call, c_exps_nil, c_exps_cons])
+  \\ asm_rewrite_tac []
+QED
+
+Theorem c_exp_Evals:
+  (env,[x],s) ---> ([v],s1) ∧
+  c_exp is_tail t.pc vs fs x = (code,l1) ∧ state_rel fs s t ∧
+  env_ok env vs curr t ∧ has_stack t (curr ⧺ rest) ∧
+  ODD (LENGTH rest) ∧ code_in t.pc (flatten code []) t.instructions ⇒
+  ∃outcome.
+    RTC step (State t) outcome ∧
+    case outcome of
+    | (Halt ec output) => output ≼ s1.output ∧ ec = 1w
+    | (State t1) =>
+        state_rel fs s1 t1 ∧
+        ∃w. v_inv t1 v w ∧
+            if is_tail then
+              has_stack t1 (Word w::rest) ∧ fetch t1 = SOME Ret
+            else
+              has_stack t1 (Word w::curr ++ rest) ∧ t1.pc = l1
+Proof
+  rw [] \\ drule Eval_imp_evals \\ strip_tac
+  \\ fs [eval_def,AllCaseEqs()]
+  \\ drule (CONJUNCT1 c_exp_correct) \\ fs []
+  \\ disch_then drule \\ fs []
+  \\ disch_then (qspecl_then [‘curr’,‘rest’] mp_tac)
+  \\ impl_tac THEN1 fs [state_rel_def]
+  \\ strip_tac
+  \\ PairCases_on ‘outcome’ \\ fs []
+  \\ qexists_tac ‘outcome0’ \\ fs []
+  \\ imp_res_tac steps_imp_RTC_step \\ fs []
+  \\ TOP_CASE_TAC \\ fs [] \\ qexists_tac ‘w’ \\ fs []
+  \\ TOP_CASE_TAC \\ fs []
+QED
+
+(* compilation of enitre program *)
+
+Triviality FST_SND:
+  FST = (λ(x,y). x) ∧ SND = (λ(x,y). y)
+Proof
+  fs [FUN_EQ_THM,FORALL_PROD]
+QED
+
+Theorem c_decs_append:
+  ∀xs ys l fs fs' l' c.
+    c_decs l fs (xs ++ ys) = (c,fs',l') ⇒
+      let (c1,fs1,l1) = c_decs l fs xs in
+      let (c2,fs2,l2) = c_decs l1 fs ys in
+        l' = l2 ∧
+        fs' = fs1 ++ fs2 ∧
+        flatten c [] = flatten (Append c1 c2) []
+Proof
+  Induct \\ fs [c_decs_def]
+  THEN1 fs [flatten_def]
+  \\ rw [] \\ fs [FST_SND] \\ fs []
+  \\ rpt (pairarg_tac \\ fs [])
+  \\ rpt var_eq_tac \\ fs []
+  \\ first_x_assum drule
+  \\ fs [] \\ strip_tac
+  \\ rpt var_eq_tac \\ fs []
+  \\ fs [flatten_def]
+QED
+
+Theorem c_exp_11:
+  (∀t l vs fs1 e fs2 c1 l1 c2 l2.
+     c_exp t l vs fs1 e = (c1,l1) ∧
+     c_exp t l vs fs2 e = (c2,l2) ⇒ l1 = l2) ∧
+  (∀l vs fs1 e fs2 c1 l1 c2 l2.
+     c_exps l vs fs1 e = (c1,l1) ∧
+     c_exps l vs fs2 e = (c2,l2) ⇒ l1 = l2)
+Proof
+  ho_match_mp_tac c_exp_ind_alt \\ rw []
+  \\ fs [c_exp_alt,c_if_def,c_call_def,make_ret_def]
+  \\ rpt (pairarg_tac \\ fs []) \\ fs [make_ret_def]
+  \\ rpt var_eq_tac \\ fs []
+  \\ res_tac \\ fs []
+  \\ rpt (pairarg_tac \\ fs []) \\ fs [make_ret_def]
+  \\ rpt var_eq_tac \\ fs []
+  \\ res_tac \\ fs []
+  \\ rpt (pairarg_tac \\ fs []) \\ fs [make_ret_def]
+  \\ rpt var_eq_tac \\ fs []
+  \\ res_tac \\ fs []
+  THEN1
+   (Cases_on ‘c_exps l vs fs1 e’ \\ Cases_on ‘c_exps l vs fs2 e’ \\ fs []
+    \\ res_tac \\ fs [] \\ fs [c_call_def,AllCaseEqs()]
+    \\ rpt var_eq_tac \\ fs []
+    \\ res_tac \\ fs [align_def] \\ rw [] \\ fs [])
+  \\ first_assum (qspec_then ‘fs1’ mp_tac) \\ fs []
+  \\ first_x_assum (qspec_then ‘fs2’ mp_tac) \\ fs []
+QED
+
+Theorem c_defun_length_11:
+  c_defun l fs1 d = (c1,l1) ∧ c_defun l fs2 d = (c2,l2) ⇒ l1 = l2
+Proof
+  Cases_on ‘d’ \\ fs [c_defun_def] \\ rw []
+  \\ rpt (pairarg_tac \\ fs []) \\ fs []
+  \\ rpt var_eq_tac \\ fs []
+  \\ imp_res_tac c_exp_11 \\ fs []
+QED
+
+Theorem c_decs_length_11:
+  ∀l fs1 fs2 ds c1 c2 fs'1 l1 fs'2 l2.
+    c_decs l fs1 ds = (c1,fs'1,l1) ∧
+    c_decs l fs2 ds = (c2,fs'2,l2) ⇒
+    l1 = l2 ∧ fs'1 = fs'2
+Proof
+  Induct_on ‘ds’ \\ fs [c_decs_def]
+  \\ rpt gen_tac \\ strip_tac
+  \\ qabbrev_tac ‘p1 = c_defun (l + 1) fs1 h’
+  \\ qabbrev_tac ‘p2 = c_defun (l + 1) fs2 h’
+  \\ qabbrev_tac ‘q1 = c_decs (SND p1) fs1 ds’
+  \\ qabbrev_tac ‘q2 = c_decs (SND p2) fs2 ds’
+  \\ PairCases_on ‘p1’ \\ PairCases_on ‘p2’ \\ fs []
+  \\ PairCases_on ‘q1’ \\ PairCases_on ‘q2’ \\ fs []
+  \\ fs [markerTheory.Abbrev_def]
+  \\ metis_tac [c_defun_length_11]
+QED
+
+Theorem c_defun_length:
+  c_defun l fs d = (c1,l1) ⇒ l1 = LENGTH (flatten c1 []) + l
+Proof
+  Cases_on ‘d’ \\ fs [c_defun_def]
+  \\ rpt (pairarg_tac \\ fs []) \\ rw []
+  \\ fs [flatten_def] \\ once_rewrite_tac [flatten_acc] \\ fs []
+  \\ imp_res_tac c_exp_length \\ fs [] \\ rw []
+  \\ fs [c_pushes_def,AllCaseEqs()]
+  \\ rw [] \\ fs [flatten_def]
+QED
+
+Theorem c_decs_length:
+  ∀ds l fs c1 fs1 l1.
+    c_decs l fs ds = (c1,fs1,l1) ⇒ l1 = LENGTH (flatten c1 []) + l
+Proof
+  Induct \\ fs [c_decs_def] \\ fs [flatten_def] \\ rw []
+  \\ Cases_on ‘c_defun (l + 1) fs h’ \\ fs []
+  \\ Cases_on ‘c_decs r fs ds’ \\ fs [] \\ PairCases_on ‘r'’ \\ fs []
+  \\ res_tac \\ fs []
+  \\ imp_res_tac c_defun_length \\ rw [] \\ fs [flatten_def]
+  \\ once_rewrite_tac [flatten_acc] \\ fs []
+QED
+
+Theorem lookup_LENGTH:
+  ∀xs h ys. lookup (LENGTH xs) (xs ⧺ h::ys) = SOME h
+Proof
+  Induct \\ fs [x64asm_semanticsTheory.lookup_def]
+QED
+
+Theorem IMP_code_in_append:
+  ∀xs ys k. k = LENGTH xs ⇒ code_in k ys (xs ++ ys)
+Proof
+  Induct_on ‘ys’ \\ fs [code_in_def,lookup_LENGTH] \\ rw []
+  \\ first_x_assum (qspec_then ‘xs ++ [h]’ mp_tac)
+  \\ fs [] \\ full_simp_tac std_ss [GSYM APPEND_ASSOC,APPEND] \\ fs []
+QED
+
+Theorem IMP_code_in_append2:
+  ∀xs ys zs k. k = LENGTH xs ⇒ code_in k ys (xs ++ ys ++ zs)
+Proof
+  Induct_on ‘ys’ \\ fs [code_in_def,lookup_LENGTH] \\ rw []
+  \\ first_x_assum (qspec_then ‘xs ++ [h]’ mp_tac)
+  \\ fs [] \\ full_simp_tac std_ss [GSYM APPEND_ASSOC,APPEND]
+  \\ fs [lookup_LENGTH]
+QED
+
+Theorem c_decs_code_in:
+  ∀ds l fs0 fs c1 k n params body xs acc.
+    c_decs l fs0 ds = (c1,fs,k) ∧
+    lookup_fun n ds = SOME (params,body) ∧
+    LENGTH xs = l ⇒
+    ∃pos.
+      ALOOKUP fs n = SOME pos ∧
+      code_in pos (flatten (FST (c_defun pos fs0 (Defun n params body))) [])
+        (xs ⧺ flatten c1 acc)
+Proof
+  Induct \\ fs [c_decs_def,lookup_fun_def] \\ rw []
+  \\ Cases_on ‘c_defun (LENGTH xs + 1) fs0 h’ \\ fs []
+  \\ Cases_on ‘c_decs r fs0 ds’ \\ fs []
+  \\ rpt var_eq_tac
+  \\ Cases_on ‘h’ \\ fs []
+  \\ fs [lookup_fun_def,name_of_def]
+  \\ rw []
+  \\ rw [] \\ imp_res_tac c_defun_length \\ fs [] \\ rw []
+  \\ fs [flatten_def]
+  \\ once_rewrite_tac [flatten_acc] \\ fs [flatten_def,code_in_def]
+  \\ once_rewrite_tac [flatten_acc] \\ fs [flatten_def,code_in_def]
+  THEN1
+   (rename [‘xs ++ x::(ys ++ zs ++ acc)’]
+    \\ ‘xs ⧺ x::(ys ⧺ zs ++ acc) = (xs ⧺ [x]) ++ ys ⧺ (zs ++ acc)’ by fs []
+    \\ asm_rewrite_tac []
+    \\ match_mp_tac IMP_code_in_append2 \\ fs [])
+  \\ qmatch_asmsub_abbrev_tac ‘c_decs pos1’ \\ rfs []
+  \\ rename [‘xs ++ x::(ys ++ _ ++ acc)’]
+  \\ ‘xs ⧺ x::(ys ⧺ flatten q' [] ⧺ acc) = (xs ⧺ x::ys) ⧺ flatten q' acc’
+         by fs [GSYM flatten_acc]
+  \\ asm_rewrite_tac []
+  \\ first_x_assum match_mp_tac \\ fs []
+  \\ unabbrev_all_tac \\ fs [ADD1]
+  \\ Cases_on ‘r'’ \\ fs []
+QED
+
+Theorem codegen_thm:
+  eval empty_env main s = (res,s1) ∧ res ≠ Err Crash ∧
+  s.funs = funs ∧
+  t.pc = 0 ∧
+  t.instructions = codegen (Program funs main) ∧
+  t.stack = [] ∧
+  t.input = s.input ∧
+  t.output = s.output ∧
+  t.regs R14 = SOME r14 ∧
+  t.regs R15 = SOME r15 ∧
+  memory_writable r14 r15 t.memory ⇒
+  ∃outcome.
+    steps (State t,s.clock) outcome ∧
+    case outcome of
+    | (State t1,ck) => t1.output = s1.output ∧ ck = s1.clock ∧ res = Err TimeOut
+    | (Halt ec output,ck) => if ec ≠ 0w then output ≼ s1.output
+                                        else output = s1.output ∧ ∃v. res = Res v
+Proof
+  rw [] \\ fs [codegen_def]
+  \\ rpt (pairarg_tac \\ fs [])
+  \\ qpat_x_assum ‘t.instructions = _’ mp_tac
+  \\ simp [flatten_def] \\ once_rewrite_tac [flatten_acc] \\ fs []
+  \\ rw [] \\ fs []
+  \\ ntac 4 (ho_match_mp_tac IMP_step \\ fs []
+             \\ once_rewrite_tac [step_cases]
+             \\ simp [fetch_def,init_def,x64asm_semanticsTheory.lookup_def]
+             \\ fs [write_reg_def,inc_def,APPLY_UPDATE_THM,
+                    set_pc_def,set_stack_def,LENGTH_EQ_NUM_compute])
+  \\ qmatch_goalsub_abbrev_tac ‘State t2’
+  \\ ‘code_in t2.pc (flatten (FST (c_defun t2.pc fs (Defun (name "main") [] main))) [])
+        t.instructions’ by
+   (drule c_decs_append \\ fs []
+    \\ rpt (pairarg_tac \\ fs []) \\ rw [] \\ fs [c_decs_def]
+    \\ imp_res_tac c_decs_length_11 \\ rpt var_eq_tac
+    \\ qmatch_goalsub_abbrev_tac ‘FST ff’
+    \\ ‘t2.pc = k + 1’ by fs [Abbr‘t2’] \\ fs []
+    \\ PairCases_on ‘ff’ \\ fs [] \\ rpt var_eq_tac
+    \\ qmatch_asmsub_abbrev_tac ‘Comment com’ \\ fs [flatten_def]
+    \\ once_rewrite_tac [flatten_acc] \\ fs [code_in_def]
+    \\ imp_res_tac c_decs_length \\ fs []
+    \\ qmatch_goalsub_abbrev_tac ‘init kk ++ flatten c1 [] ++ cc::_’
+    \\ ‘init kk ⧺ flatten c1 [] ⧺ cc::flatten ff0 [] =
+        (init kk ⧺ flatten c1 [] ⧺ [cc]) ++ flatten ff0 []’ by fs []
+    \\ pop_assum (asm_rewrite_tac o single)
+    \\ match_mp_tac IMP_code_in_append
+    \\ fs [Abbr‘kk’] \\ EVAL_TAC)
+  \\ fs [c_defun_def]
+  \\ rpt (pairarg_tac \\ fs [])
+  \\ fs [c_pushes_def] \\ rw []
+  \\ fs [flatten_def]
+  \\ drule (c_exp_correct |> CONJUNCT1) \\ fs []
+  \\ disch_then drule
+  \\ disch_then (qspecl_then [‘[Word 0w]’,‘[RetAddr 4]’] mp_tac)
+  \\ impl_tac THEN1
+   (fs [has_stack_def,Abbr‘t2’] \\ rfs [APPLY_UPDATE_THM]
+    \\ fs [env_ok_def,empty_env_def,state_rel_def,APPLY_UPDATE_THM]
+    \\ fs [code_rel_def,init_code_in_def]
+    \\ conj_tac THEN1 (qexists_tac ‘k+1’ \\ fs [] \\ EVAL_TAC)
+    \\ imp_res_tac c_decs_append \\ rfs []
+    \\ rpt (pairarg_tac \\ fs [])
+    \\ imp_res_tac c_decs_length_11 \\ rpt var_eq_tac
+    \\ pop_assum kall_tac \\ rw []
+    \\ ‘LENGTH (init (k+1)) = LENGTH (init 0)’ by EVAL_TAC
+    \\ drule_all c_decs_code_in \\ fs [flatten_def])
+  \\ strip_tac
+  \\ PairCases_on ‘outcome’ \\ reverse (Cases_on ‘outcome0’) \\ fs []
+  THEN1 (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+  \\ reverse (Cases_on ‘res’) \\ fs []
+  THEN1 (goal_assum (first_assum o mp_then Any mp_tac)
+         \\ fs [state_rel_def] \\ Cases_on ‘e’ \\ fs [])
+  \\ ho_match_mp_tac IMP_steps \\ fs []
+  \\ goal_assum (first_assum o mp_then Any mp_tac)
+  \\ fs [fetch_def,has_stack_def]
+  \\ ho_match_mp_tac IMP_step \\ fs []
+  \\ once_rewrite_tac [step_cases]
+  \\ simp [fetch_def,init_def,x64asm_semanticsTheory.lookup_def]
+  \\ fs [write_reg_def,inc_def,APPLY_UPDATE_THM,
+         set_pc_def,set_stack_def,LENGTH_EQ_NUM_compute,PULL_EXISTS]
+  \\ imp_res_tac steps_inst \\ fs [Abbr‘t2’]
+  \\ ntac 2 (ho_match_mp_tac IMP_step \\ fs []
+             \\ once_rewrite_tac [step_cases]
+             \\ simp [fetch_def,init_def,x64asm_semanticsTheory.lookup_def]
+             \\ fs [write_reg_def,inc_def,APPLY_UPDATE_THM,
+                    set_pc_def,set_stack_def,LENGTH_EQ_NUM_compute])
+  \\ ho_match_mp_tac IMP_start \\ fs []
+  \\ fs [state_rel_def]
+QED
+
+Theorem codegen_terminates:
+  (input, prog) prog_terminates output1 ∧
+  (input, codegen prog) asm_terminates output2 ⇒
+  output1 = output2
+Proof
+  Cases_on ‘prog’
+  \\ rw [prog_terminates_def,asm_terminates_def,Eval_eq_evals,init_state_ok_def]
+  \\ fs [eval_def,AllCaseEqs()]
+  \\ drule codegen_thm \\ fs []
+  \\ disch_then drule \\ fs []
+  \\ fs [init_state_def] \\ rw []
+  \\ PairCases_on ‘outcome’ \\ fs []
+  \\ Cases_on ‘outcome0’ \\ fs []
+  \\ imp_res_tac steps_imp_RTC_step \\ fs []
+  \\ imp_res_tac RTC_step_determ \\ fs []
+QED
+
+Theorem codegen_diverges:
+  prog_avoids_crash input prog ∧
+  (input, codegen prog) asm_diverges output ⇒
+  (input, prog) prog_diverges output
+Proof
+  rw [prog_avoids_crash_def,asm_diverges_def,prog_diverges_def,init_state_ok_def]
+  THEN1
+   (CCONTR_TAC \\ fs [prog_timesout_def]
+    \\ last_x_assum (qspec_then ‘k’ assume_tac)
+    \\ Cases_on ‘eval_from k t.input prog’ \\ fs []
+    \\ reverse (Cases_on ‘q’)
+    THEN1 (Cases_on ‘e’ \\ fs [] \\ rw [] \\ fs []) \\ fs []
+    \\ rw [] \\ Cases_on ‘prog’ \\ fs [eval_from_def]
+    \\ drule codegen_thm \\ fs []
+    \\ fs [init_state_def]
+    \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+    \\ CCONTR_TAC \\ fs []
+    \\ Cases_on ‘outcome’ \\ fs []
+    \\ Cases_on ‘q’ \\ fs []
+    \\ drule steps_IMP_NRC_step \\ strip_tac
+    \\ rename [‘NRC _ kk’]
+    \\ first_x_assum (qspec_then ‘kk’ mp_tac) \\ strip_tac
+    \\ imp_res_tac NRC_step_determ \\ fs [])
+  \\ match_mp_tac IMP_build_lprefix_lub_EQ
+  \\ rewrite_tac [lprefix_chain_step]
+  \\ conj_asm1_tac THEN1
+   (unabbrev_all_tac
+    \\ fs [lprefix_chain_def,prog_output_def,PULL_EXISTS]
+    \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV)
+    \\ fs [llistTheory.LPREFIX_fromList,llistTheory.from_toList]
+    \\ rpt gen_tac
+    \\ ‘k ≤ k' ∨ k' ≤ k’ by fs []
+    \\ Cases_on ‘eval_from k t.input prog’ \\ fs []
+    \\ Cases_on ‘eval_from k' t.input prog’ \\ fs []
+    \\ imp_res_tac eval_from_prefix \\ fs [])
+  \\ rw [lprefix_rel_def] \\ fs [PULL_EXISTS]
+  THEN1
+   (imp_res_tac RTC_NRC \\ rename [‘NRC _ kk’] \\ rw []
+    \\ qexists_tac ‘kk’ \\ last_x_assum (qspec_then ‘kk’ assume_tac)
+    \\ Cases_on ‘eval_from kk t.input prog’ \\ fs []
+    \\ Cases_on ‘prog’ \\ fs [eval_from_def,prog_output_def]
+    \\ drule codegen_thm \\ fs []
+    \\ disch_then drule \\ fs []
+    \\ fs [init_state_def] \\ rw []
+    \\ PairCases_on ‘outcome’ \\ fs []
+    \\ Cases_on ‘outcome0’ \\ fs []
+    THEN1
+     (imp_res_tac eval_TimeOut_clock \\ rw [] \\ fs []
+      \\ imp_res_tac asm_output_PREFIX
+      \\ rfs [LPREFIX_fromList,from_toList])
+    \\ drule steps_IMP_NRC_step \\ strip_tac
+    \\ rename [‘NRC _ kk’]
+    \\ first_x_assum (qspec_then ‘kk’ mp_tac) \\ strip_tac
+    \\ imp_res_tac NRC_step_determ \\ fs [])
+  \\ last_x_assum (qspec_then ‘k’ assume_tac)
+  \\ Cases_on ‘eval_from k t.input prog’ \\ fs [LNTH_fromList] \\ rw []
+  \\ Cases_on ‘prog’ \\ fs [eval_from_def,prog_output_def]
+  \\ drule codegen_thm \\ fs []
+  \\ disch_then drule \\ fs []
+  \\ fs [init_state_def] \\ rw []
+  \\ PairCases_on ‘outcome’ \\ fs []
+  \\ Cases_on ‘outcome0’ \\ fs []
+  THEN1
+   (rw [] \\ qexists_tac ‘s’ \\ fs []
+    \\ drule steps_IMP_NRC_step \\ strip_tac
+    \\ imp_res_tac NRC_RTC)
+  \\ drule steps_IMP_NRC_step \\ strip_tac
+  \\ rename [‘NRC _ kk’]
+  \\ first_x_assum (qspec_then ‘kk’ mp_tac) \\ strip_tac
+  \\ imp_res_tac NRC_step_determ \\ fs []
+QED
+
+val _ = export_theory();

--- a/examples/bootstrap/compilerScript.sml
+++ b/examples/bootstrap/compilerScript.sml
@@ -1,0 +1,16 @@
+(*
+  This file contains the top-level compiler definition.
+*)
+open HolKernel Parse boolLib bossLib;
+open arithmeticTheory listTheory pairTheory finite_mapTheory stringTheory;
+open source_valuesTheory source_syntaxTheory x64asm_syntaxTheory
+     parsingTheory codegenTheory wordsLib;
+
+val _ = new_theory "compiler";
+
+Definition compiler_def:
+  compiler input =
+    asm2str (codegen (parser (lexer input)))
+End
+
+val _ = export_theory();

--- a/examples/bootstrap/compiler_evalScript.sml
+++ b/examples/bootstrap/compiler_evalScript.sml
@@ -1,0 +1,29 @@
+
+open HolKernel Parse boolLib bossLib term_tactic;
+open arithmeticTheory listTheory pairTheory finite_mapTheory stringTheory;
+open wordsTheory wordsLib automationLib compilerTheory compiler_progTheory;
+
+val _ = new_theory "compiler_eval";
+
+
+Definition compiler_str_def:
+  compiler_str = prog2str compiler_prog coms
+End
+
+Definition compiler_asm_def:
+  compiler_asm = codegen compiler_prog
+End
+
+Definition compiler_asm_str_def:
+  compiler_asm_str = asm2str compiler_asm
+End
+
+Theorem compiler_str      = time EVAL “compiler_str”;
+Theorem compiler_asm      = time EVAL “compiler_asm”;
+Theorem compiler_asm_str  = time EVAL “compiler_asm_str”;
+
+val _ = write_hol_string_to_file "compiler_prog.txt" (compiler_str |> concl |> rand);
+val _ = write_hol_string_to_file "compiler_asm.s"    (compiler_asm_str |> concl |> rand);
+
+
+val _ = export_theory();

--- a/examples/bootstrap/compiler_progScript.sml
+++ b/examples/bootstrap/compiler_progScript.sml
@@ -1,0 +1,824 @@
+
+open HolKernel Parse boolLib bossLib term_tactic;
+open arithmeticTheory listTheory pairTheory finite_mapTheory stringTheory;
+open source_valuesTheory source_syntaxTheory source_semanticsTheory mp_then
+     source_propertiesTheory parsingTheory codegenTheory x64asm_syntaxTheory
+     wordsTheory wordsLib automation_lemmasTheory automationLib compilerTheory;
+
+val _ = new_theory "compiler_prog";
+
+val _ = show_assums := true;
+
+val _ = attach_comment ‘
+# This file is generated from the HOL4 theorem prover.
+
+# The code in this file implements a verified bootstrapped compiler
+# for a small Lisp-inspired language. The compiler consists of:
+#
+#  - a code generator (codegen)
+#  - a lexer and a parser
+#  - a printer that outputs GNU assmebler for Ubuntu x86-64
+#
+# Lines beginning with # are comments.
+
+
+# Definition of the codegen function’
+
+(* codegen *)
+
+val res = to_deep APPEND;
+val res = to_deep codegenTheory.flatten_def;
+val res = to_deep (init_def |> SIMP_RULE std_ss [])
+val res = to_deep even_len_def
+
+Theorem even_len_side:
+  ∀v. (even_len_side v = T) ∧ (odd_len_side v = T)
+Proof
+  Induct \\ fs [] \\ ntac 2 (once_rewrite_tac [res] \\ fs []) \\ EVAL_TAC
+QED
+
+val _ = update_mem even_len_side;
+
+val res = to_deep give_up_def
+val res = to_deep (c_const_def |> REWRITE_RULE [EVAL “2 ** 63 − 1n”])
+
+Theorem c_const_side:
+  c_const_side l n vs = T
+Proof
+  fs [] \\ once_rewrite_tac [res] \\ CCONTR_TAC \\ fs []
+QED
+
+val _ = update_mem c_const_side;
+
+val res = to_deep find_def
+val res = to_deep c_var_def
+val res = to_deep c_add_def
+val res = to_deep c_sub_def
+val res = to_deep c_div_def
+val res = to_deep c_cons_def
+val res = to_deep c_head_def
+val res = to_deep c_tail_def
+val res = to_deep align_def
+val res = to_deep c_read_def
+val res = to_deep c_write_def
+val res = to_deep c_op_def
+val res = to_deep c_test_def
+
+Theorem c_if_thm:
+  c_if t cmp x1 x2 x3 =
+    (Append (FST x1)
+      (Append (List (c_test cmp (SND x2 + if t then 0 else 1)))
+        (Append (FST x2)
+          (Append (List (if t then [] else [Jump Always (SND x3)])) (FST x3)))),
+          SND x3)
+Proof
+  PairCases_on ‘x1’ \\ PairCases_on ‘x2’ \\ PairCases_on ‘x3’ \\ fs [c_if_def]
+QED
+
+val res = to_deep c_if_thm
+val res = to_deep (LENGTH |> REWRITE_RULE [ADD1])
+val res = to_deep call_env_def
+val res = to_deep c_pushes_def
+val res = to_deep c_pops_def
+val res = to_deep c_call_def
+val res = to_deep codegenTheory.lookup_def
+val res = to_deep make_ret_def
+val res = to_deep c_exp_def
+
+Triviality FST_SND:
+  FST = (λ(x,y). x) ∧ SND = (λ(x,y). y)
+Proof
+  fs [FUN_EQ_THM,FORALL_PROD]
+QED
+
+Theorem c_exp_side:
+  (∀t l vs fs z. c_exp_side t l vs fs z = T) ∧
+  (∀l vs fs zs. c_exps_side l vs fs zs = T)
+Proof
+  ho_match_mp_tac c_exp_ind_alt \\ rw []
+  \\ once_rewrite_tac [res] \\ fs [FST_SND]
+  \\ rpt (pairarg_tac \\ fs []) \\ rw [] \\ fs [name_def]
+QED
+
+val _ = update_mem c_exp_side;
+
+Theorem c_defun_thm:
+  c_defun l fs (Defun n vs body) =
+    let r1 = c_pushes vs l in
+    let r2 = c_exp T (SND (SND r1)) (FST (SND r1)) fs body in
+      (Append (FST r1) (FST r2), SND r2)
+Proof
+  fs [c_defun_def] \\ rpt (pairarg_tac \\ fs [])
+QED
+
+val res = to_deep c_defun_thm
+val res = to_deep name_of_def
+
+Definition mul256_def:
+  mul256 n =
+    let n = n + n in
+    let n = n + n in
+    let n = n + n in
+    let n = n + n in
+    let n = n + n in
+    let n = n + n in
+    let n = n + n in
+            n + n : num
+End
+
+val res = to_deep mul256_def;
+
+Theorem mul256_thm[simp]:
+  mul256_side n ∧
+  mul256 n = 256 * n
+Proof
+  fs [mul256_def,res]
+QED
+
+Theorem name2str_thm:
+  name2str n acc =
+    if n = 0 then acc else
+      let d = n DIV 256 in
+      let m = n - mul256 d in
+        name2str d (STRING (CHR m) acc)
+Proof
+  simp [Once codegenTheory.name2str_def]
+  \\ rw [] \\ ‘0 < 256n’ by fs []
+  \\ drule DIVISION
+  \\ disch_then (qspec_then ‘n’ strip_assume_tac)
+  \\ rpt (AP_TERM_TAC ORELSE AP_THM_TAC) \\ decide_tac
+QED
+
+Definition name2str_temp:
+  name2str_temp n acc =
+    if n = 0 then acc else
+      let d = n DIV 256 in
+      let m = n - mul256 d in
+        name2str_temp d (STRING (CHR m) acc)
+End
+
+Theorem name2str_ind = name2str_temp_ind
+
+val res = to_deep name2str_thm
+
+Triviality name2str_side:
+  ∀n acc. name2str_side n acc ⇔ T
+Proof
+  completeInduct_on ‘n’ \\ fs []
+  \\ once_rewrite_tac [res]
+  \\ Cases_on ‘n = 0’ \\ fs []
+  \\ rw [] \\ ‘0 < 256n’ by fs []
+  \\ drule DIVISION
+  \\ disch_then (qspec_then ‘n’ strip_assume_tac)
+  \\ decide_tac
+QED
+
+val _ = update_mem name2str_side;
+
+val res = to_deep c_decs_def;
+
+Theorem codegen_thm:
+  codegen (Program decs main) =
+    let r1 = c_decs 17 [] decs in
+    let r2 = c_decs 17 (FST (SND r1)) (decs ++ [Defun (name "main") [] main]) in
+      flatten (Append (List (init (SND (SND r1) + 1))) (FST r2)) []
+Proof
+  fs [codegen_def,EVAL “LENGTH (init 0)”] \\ rpt (pairarg_tac \\ fs [])
+QED
+
+val res = to_deep (codegen_thm |> SIMP_RULE (srw_ss()) [name_def]);
+
+
+(* lexer *)
+
+val _ = attach_comment ‘
+
+# Definition of the lexer that reads from stdin’
+
+Definition mul10_def:
+  mul10 n =
+    let n2 = n + n in
+    let n4 = n2 + n2 in
+    let n5 = n4 + n in
+      n5 + n5 : num
+End
+
+val res = to_deep mul10_def;
+
+Theorem mul10_thm[simp]:
+  mul10_side n ∧
+  mul10 n = 10 * n
+Proof
+  fs [mul10_def,res]
+QED
+
+val read_num_code_def = define_code ‘
+  (defun read_num (acc next)
+     (if (< next '58)
+       (if (< next '48)
+         (cons acc next)
+         (read_num
+           (+ (mul10 acc) (- next '48))
+           (read)))
+       (cons acc next)))’
+
+val read_str_code_def = define_code ‘
+  (defun read_str (acc next)
+     (if (< next '123)
+       (if (< next '42)
+         (cons acc next)
+         (read_str
+           (+ (mul256 acc) next)
+           (read)))
+       (cons acc next)))’
+
+val read_any_code_def = define_code ‘
+  (defun read_any (next)
+     (if (< next '58)
+       (if (< next '48)
+         (read_str '0 next)
+         (read_num '0 next))
+       (read_str '0 next)))’
+
+Theorem read_num_thm:
+  ∀input s acc k rest.
+    read_num #"0" #"9" 10 (ORD #"0") acc input = (k, rest) ∧
+    lookup_fun (name "mul10") s.funs = SOME ([name "n"],mul10_code) ∧
+    lookup_fun (name "read_num") s.funs = SOME ([name "acc"; name "next"],read_num_code) ∧
+    s.input = fromList (TL input) ⇒
+    app (name "read_num") [Num acc; next (fromList input)] s
+      (Pair (Num k) (next (fromList rest)), s with input := fromList (TL rest))
+Proof
+  gen_tac \\ completeInduct_on ‘LENGTH input’
+  \\ rw [] \\ fs [PULL_FORALL]
+  \\ match_mp_tac (trans_app |> SIMP_RULE std_ss [LET_THM] |> MP_CANON |> GEN_ALL)
+  \\ fs [make_env_def]
+  \\ simp [read_num_code_def]
+  \\ simp [Eval_eq,PULL_EXISTS]
+  \\ fs [combinTheory.APPLY_UPDATE_THM,name_def]
+  \\ Cases_on ‘input’ \\ fs [next_def]
+  \\ fs [take_branch_def,return_def,Eval_eq,PULL_EXISTS,next_def,
+         combinTheory.APPLY_UPDATE_THM,eval_op_def,read_num_def]
+  \\ rpt BasicProvers.VAR_EQ_TAC
+  \\ fs [take_branch_def,return_def,Eval_eq,PULL_EXISTS,next_def,
+         combinTheory.APPLY_UPDATE_THM,eval_op_def,read_num_def]
+  THEN1 fs [state_component_equality]
+  \\ reverse IF_CASES_TAC
+  \\ fs [take_branch_def,return_def,Eval_eq,PULL_EXISTS,next_def,
+         combinTheory.APPLY_UPDATE_THM,eval_op_def,read_num_def]
+  THEN1 (rw [] \\ fs [state_component_equality,next_def])
+  \\ fs [take_branch_def,return_def,Eval_eq,PULL_EXISTS,next_def,
+         combinTheory.APPLY_UPDATE_THM,eval_op_def,read_num_def]
+  \\ IF_CASES_TAC
+  \\ fs [take_branch_def,return_def,Eval_eq,PULL_EXISTS,next_def,
+         combinTheory.APPLY_UPDATE_THM,eval_op_def,read_num_def]
+  THEN1 (rw [] \\ fs [state_component_equality,next_def])
+  \\ (theorem "mul10_app" |> DISCH_ALL |> Q.INST [‘n’|->‘acc’]
+         |> SIMP_RULE (srw_ss()) [] |> mp_tac)
+  \\ fs [name_def,llistTheory.LFINITE_fromList]
+  \\ strip_tac \\ goal_assum (first_assum o mp_then Any mp_tac)
+  \\ fs [] \\ Cases_on ‘t’ \\ fs [AND_IMP_INTRO]
+  \\ first_x_assum (first_assum o mp_then (Pos (el 2)) mp_tac)
+  \\ fs []
+  THEN1 (disch_then (qspec_then ‘s with input := fromList ""’ mp_tac) \\ fs [])
+  \\ disch_then (qspec_then ‘s with input := fromList t'’ mp_tac) \\ fs []
+QED
+
+Theorem read_str_thm:
+  ∀input s acc k rest.
+    read_num #"*" #"z" 256 0 acc input = (k, rest) ∧
+    lookup_fun (name "mul256") s.funs = SOME ([name "n"],mul256_code) ∧
+    lookup_fun (name "read_str") s.funs = SOME ([name "acc"; name "next"],read_str_code) ∧
+    s.input = fromList (TL input) ⇒
+    app (name "read_str") [Num acc; next (fromList input)] s
+      (Pair (Num k) (next (fromList rest)), s with input := fromList (TL rest))
+Proof
+  gen_tac \\ completeInduct_on ‘LENGTH input’
+  \\ rw [] \\ fs [PULL_FORALL]
+  \\ match_mp_tac (trans_app |> SIMP_RULE std_ss [LET_THM] |> MP_CANON |> GEN_ALL)
+  \\ fs [make_env_def]
+  \\ simp [read_str_code_def]
+  \\ simp [Eval_eq,PULL_EXISTS]
+  \\ fs [combinTheory.APPLY_UPDATE_THM,name_def]
+  \\ Cases_on ‘input’ \\ fs [next_def]
+  \\ fs [take_branch_def,return_def,Eval_eq,PULL_EXISTS,next_def,
+         combinTheory.APPLY_UPDATE_THM,eval_op_def,read_num_def]
+  \\ rpt BasicProvers.VAR_EQ_TAC
+  \\ fs [take_branch_def,return_def,Eval_eq,PULL_EXISTS,next_def,
+         combinTheory.APPLY_UPDATE_THM,eval_op_def,read_num_def]
+  THEN1 fs [state_component_equality]
+  \\ reverse IF_CASES_TAC
+  \\ fs [take_branch_def,return_def,Eval_eq,PULL_EXISTS,next_def,
+         combinTheory.APPLY_UPDATE_THM,eval_op_def,read_num_def]
+  THEN1 (rw [] \\ fs [state_component_equality,next_def])
+  \\ fs [take_branch_def,return_def,Eval_eq,PULL_EXISTS,next_def,
+         combinTheory.APPLY_UPDATE_THM,eval_op_def,read_num_def]
+  \\ IF_CASES_TAC
+  \\ fs [take_branch_def,return_def,Eval_eq,PULL_EXISTS,next_def,
+         combinTheory.APPLY_UPDATE_THM,eval_op_def,read_num_def]
+  THEN1 (rw [] \\ fs [state_component_equality,next_def])
+  \\ (theorem "mul256_app" |> DISCH_ALL |> Q.INST [‘n’|->‘acc’]
+         |> SIMP_RULE (srw_ss()) [] |> mp_tac)
+  \\ fs [name_def,llistTheory.LFINITE_fromList]
+  \\ strip_tac \\ goal_assum (first_assum o mp_then Any mp_tac)
+  \\ fs [] \\ Cases_on ‘t’ \\ fs [AND_IMP_INTRO]
+  \\ first_x_assum (first_assum o mp_then (Pos (el 2)) mp_tac)
+  \\ fs []
+  THEN1 (disch_then (qspec_then ‘s with input := fromList ""’ mp_tac) \\ fs [])
+  \\ disch_then (qspec_then ‘s with input := fromList t'’ mp_tac) \\ fs []
+QED
+
+val end_line_code_def = define_code ‘
+  (defun end_line (next)
+     (if (< next '256)
+       (if (= next '10) (read) (end_line (read)))
+       next))’
+
+Theorem end_line_thm:
+  ∀input s.
+    lookup_fun (name "end_line") s.funs = SOME ([name "next"],end_line_code) ∧
+    s.input = fromList (TL input) ⇒
+    app (name "end_line") [next (fromList input)] s
+      (next (fromList (end_line input)), s with input := fromList (TL (end_line input)))
+Proof
+  simp [] \\ gen_tac \\ completeInduct_on ‘LENGTH input’
+  \\ rpt strip_tac \\ fs [PULL_FORALL]
+  \\ match_mp_tac (trans_app |> SIMP_RULE std_ss [LET_THM] |> MP_CANON |> GEN_ALL)
+  \\ fs [make_env_def]
+  \\ simp [end_line_code_def]
+  \\ simp [Eval_eq,PULL_EXISTS]
+  \\ fs [combinTheory.APPLY_UPDATE_THM,name_def]
+  \\ Cases_on ‘input’ \\ fs [next_def]
+  \\ fs [take_branch_def,return_def,Eval_eq,PULL_EXISTS,next_def,
+         combinTheory.APPLY_UPDATE_THM,eval_op_def,read_num_def]
+  THEN1 fs [state_component_equality,lex_def,end_line_def,next_def]
+  \\ fs [ORD_BOUND]
+  \\ fs [take_branch_def,return_def,Eval_eq,PULL_EXISTS,next_def,
+         combinTheory.APPLY_UPDATE_THM,eval_op_def,read_num_def]
+  \\ fs [end_line_def]
+  \\ Cases_on ‘h’ \\ fs []
+  \\ IF_CASES_TAC \\ fs []
+  \\ simp [Eval_eq,PULL_EXISTS]
+  \\ fs [take_branch_def,return_def,Eval_eq,PULL_EXISTS,next_def,
+         combinTheory.APPLY_UPDATE_THM,eval_op_def,read_num_def]
+  \\ fs [AND_IMP_INTRO,state_component_equality]
+  THEN1 (Cases_on ‘t’ \\ fs [])
+  \\ first_x_assum (qspecl_then [‘t’,‘s with input := fromList (TL t)’] mp_tac) \\ fs []
+  \\ Cases_on ‘t’ \\ fs []
+QED
+
+val lex_code_def = define_code ‘
+  (defun lex (q next acc)
+     (if (< next '* )
+       (let (n (read))
+         (if (= next '40) (lex '0 n (cons (OPEN) acc))
+           (if (= next '41) (lex '0 n (cons (CLOSE) acc))
+             (if (= next '39) (lex '1 n acc)
+               (if (= next '35) (lex '0 (end_line n) acc)
+                 (lex '0 n acc))))))
+       (if (= next '46)
+         (lex '0 (read) (cons (DOT) acc))
+         (if (< 'z next)
+           (if (< next '256)
+             (lex '0 (read) acc) acc)
+             (let (r (read_any next))
+               (lex '0 (tail r)
+                 (if (= q '0)
+                   (cons (NUM (head r)) acc)
+                   (cons (QUOTE (head r)) acc))))))))’
+
+val lexer_code_def = define_code ‘
+  (defun lexer ()
+     (lex '0 (read) '0))’
+
+Triviality LTL_fromList_lemma[simp]:
+  (case LTL (fromList t) of NONE => fromList t | SOME t => t) = fromList (TL t)
+Proof
+  Cases_on ‘t’ \\ fs []
+QED
+
+Theorem lex_thm:
+  ∀input s acc k toks.
+    lookup_fun (name "mul10") s.funs = SOME ([name "n"],mul10_code) ∧
+    lookup_fun (name "mul256") s.funs = SOME ([name "n"],mul256_code) ∧
+    lookup_fun (name "end_line") s.funs = SOME ([name "next"],end_line_code) ∧
+    lookup_fun (name "read_num") s.funs = SOME ([name "acc"; name "next"],read_num_code) ∧
+    lookup_fun (name "read_str") s.funs = SOME ([name "acc"; name "next"],read_str_code) ∧
+    lookup_fun (name "read_any") s.funs = SOME ([name "next"],read_any_code) ∧
+    lookup_fun (name "lex") s.funs = SOME ([name "q"; name "next"; name "acc"],lex_code) ∧
+    s.input = fromList (TL input) ∧
+    lex (if k = 0 then NUM else QUOTE) input acc = toks ⇒
+    app (name "lex") [Num k; next (fromList input); list token acc] s
+      (list token toks, s with input := fromList [])
+Proof
+  simp [] \\ gen_tac \\ completeInduct_on ‘LENGTH input’
+  \\ rw [] \\ fs [PULL_FORALL]
+  \\ match_mp_tac (trans_app |> SIMP_RULE std_ss [LET_THM] |> MP_CANON |> GEN_ALL)
+  \\ fs [make_env_def]
+  \\ simp_tac std_ss [Once lex_code_def]
+  \\ simp_tac (srw_ss()) [Once Eval_eq,PULL_EXISTS]
+  \\ fs [combinTheory.APPLY_UPDATE_THM,name_def]
+  \\ Cases_on ‘input’ \\ fs [next_def]
+  \\ fs [take_branch_def,return_def,Eval_eq,PULL_EXISTS,next_def,
+         combinTheory.APPLY_UPDATE_THM,eval_op_def,read_num_def]
+  THEN1 fs [state_component_equality,lex_def]
+  \\ IF_CASES_TAC
+  \\ rpt BasicProvers.var_eq_tac
+  \\ fs [take_branch_def,return_def,Eval_eq,PULL_EXISTS,next_def,
+         combinTheory.APPLY_UPDATE_THM,eval_op_def,read_num_def]
+  THEN1
+   (IF_CASES_TAC
+    \\ fs [Eval_eq,PULL_EXISTS,combinTheory.APPLY_UPDATE_THM,eval_op_def,return_def]
+    THEN1
+     (Cases_on ‘h’ \\ fs [lex_def] \\ rw [] \\ fs [AND_IMP_INTRO]
+      \\ first_x_assum (qspecl_then [‘t’,
+           ‘s with input := fromList (TL t)’,‘OPEN::acc’,‘0’] mp_tac)
+      \\ fs [name_def])
+    \\ fs [Eval_eq,eval_op_def,return_def, take_branch_def]
+    \\ IF_CASES_TAC
+    THEN1
+     (Cases_on ‘h’ \\ fs [lex_def] \\ rw []
+      \\ fs [AND_IMP_INTRO,PULL_EXISTS,Eval_eq,combinTheory.APPLY_UPDATE_THM,
+             eval_op_def,return_def]
+      \\ first_x_assum (qspecl_then [‘t’,
+           ‘s with input := fromList (TL t)’,‘CLOSE::acc’,‘0’] mp_tac)
+      \\ fs [name_def])
+    \\ fs [Eval_eq,eval_op_def,return_def, take_branch_def,PULL_EXISTS,
+           combinTheory.APPLY_UPDATE_THM]
+    \\ IF_CASES_TAC
+    THEN1
+     (Cases_on ‘h’ \\ fs [lex_def] \\ rw []
+      \\ fs [AND_IMP_INTRO,PULL_EXISTS,Eval_eq,combinTheory.APPLY_UPDATE_THM,
+             eval_op_def,return_def]
+      \\ first_x_assum (qspecl_then [‘t’,
+           ‘s with input := fromList (TL t)’,‘acc’,‘1’] mp_tac)
+      \\ fs [name_def])
+    \\ fs [Eval_eq,eval_op_def,return_def, take_branch_def,PULL_EXISTS,
+           combinTheory.APPLY_UPDATE_THM]
+    \\ IF_CASES_TAC
+    THEN1
+     (Cases_on ‘h’ \\ fs [lex_def] \\ rw []
+      \\ fs [AND_IMP_INTRO,PULL_EXISTS,Eval_eq,combinTheory.APPLY_UPDATE_THM,
+             eval_op_def,return_def]
+      \\ qspecl_then [‘t’,‘s with input := fromList (TL t)’] mp_tac
+           (SIMP_RULE (srw_ss()) [name_def] end_line_thm)
+      \\ fs [next_def]
+      \\ strip_tac \\ goal_assum (first_assum o mp_then Any mp_tac)
+      \\ first_x_assum (qspecl_then [‘end_line t’,
+            ‘s with input := fromList (TL (end_line t))’,‘acc’,‘0’] mp_tac)
+      \\ fs [name_def]
+      \\ disch_then match_mp_tac \\ fs [end_line_length])
+    \\ fs [Eval_eq,eval_op_def,return_def, take_branch_def,PULL_EXISTS,
+           combinTheory.APPLY_UPDATE_THM]
+    \\ Cases_on ‘h’ \\ fs [lex_def] \\ rw [] \\ fs []
+    \\ first_x_assum (qspecl_then [‘t’,‘s with input := fromList (TL t)’,‘acc’,‘0’]
+                      mp_tac) \\ fs [name_def]
+    \\ fs [read_num_def])
+  \\ IF_CASES_TAC
+  THEN1
+   (Cases_on ‘h’ \\ fs [lex_def] \\ rw []
+    \\ fs [AND_IMP_INTRO,PULL_EXISTS,Eval_eq,combinTheory.APPLY_UPDATE_THM,
+           eval_op_def,return_def]
+    \\ first_x_assum (qspecl_then [‘t’,‘s with input := fromList (TL t)’,‘DOT::acc’,‘0’]
+                      mp_tac) \\ fs [name_def,next_def])
+  \\ fs [AND_IMP_INTRO,PULL_EXISTS,Eval_eq,combinTheory.APPLY_UPDATE_THM,
+         eval_op_def,return_def,take_branch_def]
+  \\ IF_CASES_TAC
+  THEN1
+   (fs [AND_IMP_INTRO,PULL_EXISTS,Eval_eq,combinTheory.APPLY_UPDATE_THM,
+        eval_op_def,return_def,take_branch_def,ORD_BOUND]
+    \\ first_x_assum (qspecl_then [‘t’,‘s with input := fromList (TL t)’,‘acc’,‘0’]
+                      mp_tac) \\ fs [name_def,lex_def]
+    \\ rw [] \\ fs [read_num_def,next_def])
+  \\ fs [AND_IMP_INTRO,PULL_EXISTS,Eval_eq,combinTheory.APPLY_UPDATE_THM,
+         eval_op_def,return_def,take_branch_def,ORD_BOUND]
+  \\ fs [lex_def]
+  \\ qpat_abbrev_tac ‘pp2 = if k = 0 then _ else _’
+  \\ qpat_abbrev_tac ‘pp = if k = 0 then _ else _’
+  \\ rw [] \\ fs []
+  \\ simp [Once app_cases,PULL_EXISTS,env_and_body_def,make_env_def]
+  \\ fs [AND_IMP_INTRO,PULL_EXISTS,Eval_eq,combinTheory.APPLY_UPDATE_THM,name_def,
+         eval_op_def,return_def,take_branch_def,read_any_code_def]
+  \\ reverse (Cases_on ‘ORD #"0" ≤ ORD h ⇒ ORD #"9" < ORD h’) \\ fs [NOT_LESS]
+  THEN1
+   (fs [AND_IMP_INTRO,PULL_EXISTS,Eval_eq,combinTheory.APPLY_UPDATE_THM,name_def,
+        eval_op_def,return_def,take_branch_def,read_any_code_def]
+    \\ pairarg_tac \\ fs []
+    \\ drule (read_num_thm |> SIMP_RULE (srw_ss()) []) \\ fs [next_def]
+    \\ disch_then (qspec_then ‘s’ mp_tac) \\ fs [name_def]
+    \\ strip_tac \\ goal_assum (first_assum o mp_then Any mp_tac)
+    \\ fs [] \\ reverse IF_CASES_TAC
+    THEN1
+     (fs [] \\ rfs [read_num_def]
+      \\ imp_res_tac read_num_length \\ fs [])
+    \\ unabbrev_all_tac \\ fs []
+    \\ Cases_on ‘k = 0’ \\ fs []
+    \\ fs [PULL_EXISTS,Eval_eq,combinTheory.APPLY_UPDATE_THM,name_def,
+           eval_op_def,return_def,take_branch_def]
+    \\ imp_res_tac read_num_length \\ fs []
+    \\ first_x_assum (qspecl_then [‘rest’,‘s with input := fromList (TL rest)’,
+         ‘if k = 0 then NUM n::acc else QUOTE n::acc’,‘0’] mp_tac)
+    \\ fs [name_def])
+  \\ fs [AND_IMP_INTRO,PULL_EXISTS,Eval_eq,combinTheory.APPLY_UPDATE_THM,
+         eval_op_def,return_def,take_branch_def,read_any_code_def,name_def]
+  \\ IF_CASES_TAC
+  \\ pairarg_tac \\ fs []
+  \\ pop_assum (mp_tac o REWRITE_RULE [read_num_def]) \\ fs []
+  \\ rw []
+  \\ fs [AND_IMP_INTRO,PULL_EXISTS,Eval_eq,combinTheory.APPLY_UPDATE_THM,
+         eval_op_def,return_def,take_branch_def,name_def]
+  \\ pairarg_tac \\ fs []
+  \\ drule (read_str_thm |> SIMP_RULE (srw_ss()) []) \\ fs [next_def,name_def]
+  \\ disch_then (qspec_then ‘s’ mp_tac) \\ fs [name_def]
+  \\ strip_tac \\ goal_assum (first_assum o mp_then Any mp_tac)
+  \\ fs [] \\ (reverse IF_CASES_TAC
+  THEN1 (fs [] \\ rfs [read_num_def] \\ imp_res_tac read_num_length \\ fs []))
+  \\ ‘rest' ≠ STRING h t’ by fs [read_num_def]
+  \\ unabbrev_all_tac \\ fs []
+  \\ Cases_on ‘k = 0’ \\ fs []
+  \\ fs [PULL_EXISTS,Eval_eq,combinTheory.APPLY_UPDATE_THM,name_def,
+         eval_op_def,return_def,take_branch_def]
+  \\ imp_res_tac read_num_length \\ fs []
+  \\ first_x_assum (qspecl_then [‘rest'’,
+       ‘s with input := fromList (TL rest')’,
+       ‘if k = 0 then NUM n' :: acc else QUOTE n'::acc’,‘0’] mp_tac)
+  \\ fs [name_def] \\ rfs []
+QED
+
+Theorem lexer_thm:
+  lookup_fun (name "mul10") s.funs = SOME ([name "n"],mul10_code) ∧
+  lookup_fun (name "mul256") s.funs = SOME ([name "n"],mul256_code) ∧
+  lookup_fun (name "end_line") s.funs = SOME ([name "next"],end_line_code) ∧
+  lookup_fun (name "read_num") s.funs = SOME ([name "acc"; name "next"],read_num_code) ∧
+  lookup_fun (name "read_str") s.funs = SOME ([name "acc"; name "next"],read_str_code) ∧
+  lookup_fun (name "read_any") s.funs = SOME ([name "next"],read_any_code) ∧
+  lookup_fun (name "lex") s.funs = SOME ([name "q"; name "next"; name "acc"],lex_code) ∧
+  lookup_fun (name "lexer") s.funs = SOME ([],lexer_code) ∧
+  s.input = fromList input ⇒
+  app (name "lexer") [] s (list token (lexer input), s with input := LNIL)
+Proof
+  rw []
+  \\ match_mp_tac (trans_app |> SIMP_RULE std_ss [LET_THM] |> MP_CANON |> GEN_ALL)
+  \\ fs [make_env_def]
+  \\ simp [lexer_code_def]
+  \\ simp [Eval_eq,PULL_EXISTS,eval_op_def,return_def]
+  \\ qspecl_then [‘input’,‘s with input := fromList (TL input)’,‘[]’,‘0’]
+       mp_tac (lex_thm |> SIMP_RULE std_ss [])
+  \\ fs [lexer_def]
+QED
+
+(* parser *)
+
+val _ = attach_comment ‘
+
+# Definition of the parser’
+
+val res = to_deep (quote_def |> SIMP_RULE (srw_ss()) [name_def]);
+val res = to_deep (parse_def |> DefnBase.one_line_ify NONE |> Q.INST [‘v’|->‘input’]);
+
+Theorem parse_side:
+  ∀v x s. parse_side v x s = T
+Proof
+  Induct \\ fs [] \\ once_rewrite_tac [res] \\ fs []
+QED
+
+val _ = update_mem parse_side;
+
+val res = to_deep v2list_def;
+val res = to_deep parsingTheory.conses_def;
+val res = to_deep (v2test_def |> SIMP_RULE (srw_ss()) [name_def]);
+
+val h_code_def = define_code ‘
+  (defun h (x) (if (= (head x) '1) x (head (tail x))))’
+
+val t_code_def = define_code ‘
+  (defun t (x) (if (= (head x) '1) x (tail (tail x))))’
+
+val res = to_deep el1_def;
+val res = to_deep el2_def;
+val res = to_deep el3_def;
+val res = to_deep vs2args_def;
+val res = to_deep is_upper_def;
+val res = to_deep pat_lets_def;
+val res = to_deep num2exp_def;
+val res = to_deep (v2exp_def |> CONV_RULE (apply_at_pat_conv “name _” EVAL));
+
+Theorem v2exp_side:
+  (∀v. v2exp_side v = T) ∧
+  (∀v. v2exps_side v = T) ∧
+  (∀v. v2lets_side v = T) ∧
+  (∀v w. v2case_side v w = T)
+Proof
+  ho_match_mp_tac v2exp_ind
+  \\ rpt strip_tac \\ simp []
+  \\ once_rewrite_tac [res]
+  \\ rpt (pop_assum mp_tac)
+  \\ rpt (qpat_abbrev_tac ‘pat = name _’
+          \\ pop_assum mp_tac
+          \\ CONV_TAC (PATH_CONV "lrr" EVAL)
+          \\ strip_tac \\ unabbrev_all_tac)
+  \\ metis_tac []
+QED
+
+val _ = update_mem v2exp_side;
+
+val res = to_deep v2dec_def;
+
+Theorem vs2prog_thm:
+  vs2prog vs =
+    case vs of
+    | [] => Program [] (Const 0)
+    | (v::vs) =>
+      case vs of
+      | [] => Program [] (v2exp v)
+      | (x::xs) => let p = vs2prog vs in
+                     case p of Program ds m => Program (v2dec v :: ds) m
+Proof
+  fs [Once (DefnBase.one_line_ify NONE vs2prog_def)]
+  \\ BasicProvers.every_case_tac \\ fs []
+QED
+
+val res = to_deep vs2prog_thm;
+val res = to_deep parser_def;
+
+(* asm2str *)
+
+val _ = attach_comment ‘
+
+# Functions for converting assembly to strings’
+
+val res = to_deep x64asm_syntaxTheory.reg_def;
+
+Theorem num_thm: (* this rephrasing avoids MOD, which is not supported *)
+  num n s =
+    if n < 10 then (CHR (48 + n))::s else
+      let d = n DIV 10 in
+      let m = n - mul10 d in
+        num d ((CHR (48 + m)) :: s)
+Proof
+  simp [Once x64asm_syntaxTheory.num_def]
+  \\ rw [] \\ ‘0 < 10n’ by fs []
+  \\ drule DIVISION
+  \\ disch_then (qspec_then ‘n’ strip_assume_tac)
+  \\ AP_TERM_TAC \\ AP_THM_TAC \\ rpt AP_TERM_TAC \\ decide_tac
+QED
+
+Definition num_temp:
+  num_temp n s =
+    if n < 10 then (CHR (48 + n))::s else
+      let d = n DIV 10 in
+      let m = n - mul10 d in
+        num_temp d ((CHR (48 + m)) :: s)
+End
+
+Theorem num_ind = num_temp_ind
+
+val res = to_deep num_thm
+
+Triviality num_side:
+  ∀n s. num_side n s ⇔ T
+Proof
+  completeInduct_on ‘n’ \\ fs []
+  \\ once_rewrite_tac [res]
+  \\ Cases_on ‘n < 10’ \\ fs []
+  \\ rw [] \\ ‘0 < 10n’ by fs []
+  \\ drule DIVISION
+  \\ disch_then (qspec_then ‘n’ strip_assume_tac)
+  \\ decide_tac
+QED
+
+val _ = update_mem num_side;
+
+val res = to_deep lab_def
+val res = to_deep x64asm_syntaxTheory.clean_def
+
+Definition mul8_def:
+  mul8 n =
+    let n = n + n in
+    let n = n + n in
+      n + n : num
+End
+
+val res = to_deep mul8_def;
+
+Theorem mul8_thm[simp]:
+  mul8_side n = T ∧
+  mul8 n = 8 * n
+Proof
+  fs [mul8_def,res]
+QED
+
+val res = to_deep (x64asm_syntaxTheory.inst_def |> REWRITE_RULE [GSYM mul8_thm])
+val res = to_deep x64asm_syntaxTheory.insts_def
+val lemma = asm2str_def |> concl |> find_term (can (match_term “FLAT _”)) |> EVAL
+val res = to_deep (asm2str_def |> SIMP_RULE std_ss [lemma])
+
+(* print *)
+
+val _ = attach_comment ‘
+
+# A function for printing a list of characters to stdout’
+
+val print_code_def = define_code ‘
+  (defun print (s)
+     (if (= s '0) '0
+       (let
+         (a (write (head s)))
+         (print (tail s)))))’
+
+Theorem print_thm:
+  ∀str s.
+    lookup_fun (name "print") s.funs = SOME ([name "s"],print_code) ⇒
+    app (name "print") [list char str] s
+      (Num 0, s with output := s.output ++ str)
+Proof
+  gen_tac \\ completeInduct_on ‘LENGTH str’
+  \\ rw [] \\ fs [PULL_FORALL]
+  \\ match_mp_tac (trans_app |> SIMP_RULE std_ss [LET_THM] |> MP_CANON |> GEN_ALL)
+  \\ fs [make_env_def]
+  \\ simp [print_code_def]
+  \\ simp [Eval_eq,PULL_EXISTS]
+  \\ fs [combinTheory.APPLY_UPDATE_THM]
+  \\ rename [‘list (MAP char t)’]
+  \\ Cases_on ‘t’ \\ fs []
+  \\ fs [list_def,take_branch_def,return_def]
+  \\ simp [Eval_eq,PULL_EXISTS]
+  THEN1 fs [state_component_equality]
+  \\ fs [combinTheory.APPLY_UPDATE_THM,eval_op_def,return_def,ORD_BOUND]
+  \\ fs [name_def,AND_IMP_INTRO,CHR_ORD]
+  \\ first_x_assum (qspecl_then [‘t'’,
+      ‘s with output := STRCAT s.output (STRING h "")’] mp_tac)
+  \\ fs [] \\ simp_tac std_ss [GSYM APPEND_ASSOC,APPEND]
+QED
+
+(* definition of whole program *)
+
+val _ = attach_comment ‘
+
+# The main expression’
+
+local
+val _ = max_print_depth := 15;
+val main_exp = parse_exp ‘(print (asm2str (codegen (parser (lexer)))))’;
+val entire_program = get_program main_exp;
+in
+
+Definition compiler_prog_def:
+  compiler_prog = ^entire_program :prog
+End
+
+Triviality compiler_prog_thm = compiler_prog_def |> CONV_RULE (RAND_CONV EVAL);
+
+Definition coms_def:
+  coms = ^(get_comments ())
+End
+
+end
+
+(* proving that it's correct *)
+
+Theorem compiler_prog_correct:
+  (input, compiler_prog) prog_terminates (compiler input)
+Proof
+  fs [prog_terminates_def,compiler_prog_thm,compiler_def]
+  \\ qpat_abbrev_tac ‘pat = Defun _ _ _ :: _’
+  \\ simp [Eval_eq,PULL_EXISTS]
+  \\ qspecl_then [‘init_state (fromList input) pat’,‘input’]
+       mp_tac (GEN_ALL lexer_thm)
+  \\ impl_tac THEN1
+    (rewrite_tac [read_num_code_def,read_str_code_def,read_any_code_def,
+                  lex_code_def,lexer_code_def,end_line_code_def]
+     \\ rpt strip_tac \\ unabbrev_all_tac \\ EVAL_TAC)
+  \\ simp [name_def] \\ strip_tac
+  \\ goal_assum (first_x_assum o mp_then Any mp_tac)
+  \\ ‘init_state (fromList input) pat with input := LNIL = init_state LNIL pat’ by
+      simp [init_state_def]
+  \\ simp [] \\ pop_assum kall_tac
+  \\ ‘∀input. (init_state input pat).input = input’ by (EVAL_TAC \\ fs [])
+  \\ simp [] \\ pop_assum kall_tac
+  \\ mp_tac (fetch "-" "parser_app" |> DISCH_ALL |> REWRITE_RULE [AND_IMP_INTRO]
+      |> Q.INST [‘tokens’|->‘lexer input’,‘s’|->‘init_state LNIL pat’])
+  \\ impl_tac THEN1 (unabbrev_all_tac \\ EVAL_TAC \\ fs [llistTheory.LFINITE_THM])
+  \\ simp [name_def] \\ strip_tac
+  \\ goal_assum (first_x_assum o mp_then Any mp_tac)
+  \\ mp_tac (fetch "-" "codegen_app" |> DISCH_ALL |> REWRITE_RULE [AND_IMP_INTRO]
+      |> Q.INST [‘v’|->‘parser (lexer input)’,‘s’|->‘init_state LNIL pat’])
+  \\ impl_tac THEN1 (unabbrev_all_tac \\ EVAL_TAC \\ fs [llistTheory.LFINITE_THM])
+  \\ simp [name_def] \\ strip_tac
+  \\ goal_assum (first_x_assum o mp_then Any mp_tac)
+  \\ mp_tac (fetch "-" "asm2str_app" |> DISCH_ALL |> REWRITE_RULE [AND_IMP_INTRO]
+      |> Q.INST [‘xs’|->‘codegen (parser (lexer input))’,‘s’|->‘init_state LNIL pat’])
+  \\ impl_tac THEN1 (unabbrev_all_tac \\ EVAL_TAC \\ fs [llistTheory.LFINITE_THM])
+  \\ simp [name_def] \\ strip_tac
+  \\ goal_assum (first_x_assum o mp_then Any mp_tac)
+  \\ mp_tac (print_thm |> DISCH_ALL |> REWRITE_RULE [AND_IMP_INTRO] |> SPEC_ALL
+      |> Q.INST [‘str’|->‘asm2str (codegen (parser (lexer input)))’,
+                 ‘s’|->‘init_state LNIL pat’])
+  \\ impl_tac THEN1 (unabbrev_all_tac \\ EVAL_TAC
+                     \\ fs [llistTheory.LFINITE_THM,print_code_def,name_def])
+  \\ simp [name_def] \\ strip_tac
+  \\ goal_assum (first_x_assum o mp_then Any mp_tac)
+  \\ simp [init_state_def]
+QED
+
+val _ = export_theory();

--- a/examples/bootstrap/compiler_proofsScript.sml
+++ b/examples/bootstrap/compiler_proofsScript.sml
@@ -1,0 +1,34 @@
+(*
+  Proves that the compiler in assembly form implements the compiler function.
+*)
+open HolKernel Parse boolLib bossLib;
+open arithmeticTheory listTheory pairTheory finite_mapTheory stringTheory;
+open source_valuesTheory source_syntaxTheory x64asm_syntaxTheory
+     parsingTheory codegenTheory wordsLib compiler_evalTheory
+     codegen_proofsTheory compiler_progTheory parsing_proofsTheory;
+
+val _ = new_theory "compiler_proofs";
+
+Theorem compiler_asm_correct:
+  ∀input output.
+    (input, compiler_asm) asm_terminates output ⇒
+    output = compiler input
+Proof
+  metis_tac [compiler_asm_def,codegen_terminates,compiler_prog_correct]
+QED
+
+Theorem compiler_compiler_str:
+  compiler compiler_str = compiler_asm_str
+Proof
+  fs [compiler_str_def,compilerTheory.compiler_def,
+      parser_lexer_prog2str,compiler_asm_str_def,compiler_asm_def]
+QED
+
+Theorem compiler_asm_bootstrap:
+  (compiler_str, compiler_asm) asm_terminates output ⇒
+  output = compiler_asm_str
+Proof
+  metis_tac [compiler_asm_correct,compiler_compiler_str]
+QED
+
+val _ = export_theory();

--- a/examples/bootstrap/parsingScript.sml
+++ b/examples/bootstrap/parsingScript.sml
@@ -1,0 +1,209 @@
+
+open HolKernel Parse boolLib bossLib term_tactic;
+open arithmeticTheory listTheory pairTheory finite_mapTheory stringTheory;
+open source_valuesTheory source_syntaxTheory;
+
+val _ = new_theory "parsing";
+
+
+(* lexing *)
+
+Datatype:
+  token = OPEN | CLOSE | DOT | NUM num | QUOTE num
+End
+
+Definition read_num_def:
+  read_num l h f x acc [] = (acc,[]) ∧
+  read_num l h f x acc (c::cs) =
+    if ORD l ≤ ORD c ∧ ORD c ≤ ORD h then
+      read_num l h f x (f * acc + (ORD c - x)) cs
+    else (acc,c::cs)
+End
+
+Theorem read_num_length:
+  ∀l h xs n ys f acc x.
+    read_num l h f x acc xs = (n,ys) ⇒
+    LENGTH ys ≤ LENGTH xs ∧ (xs ≠ ys ⇒ LENGTH ys < LENGTH xs)
+Proof
+  Induct_on ‘xs’ \\ rw [read_num_def]
+  \\ TRY pairarg_tac \\ fs [] \\ rw [] \\ res_tac \\ fs []
+QED
+
+Definition end_line_def:
+  end_line [] = [] ∧
+  end_line (c::cs) = if c = #"\n" then cs else end_line cs
+End
+
+Theorem end_line_length:
+  ∀cs. STRLEN (end_line cs) < SUC (STRLEN cs)
+Proof
+  Induct \\ rw [end_line_def]
+QED
+
+Definition lex_def:
+  lex q [] acc = acc ∧
+  lex q (c::cs) acc =
+      if MEM c " \t\n" then lex NUM cs acc else
+      if c = #"#" then lex NUM (end_line cs) acc else
+      if c = #"." then lex NUM cs (DOT::acc) else
+      if c = #"(" then lex NUM cs (OPEN::acc) else
+      if c = #")" then lex NUM cs (CLOSE::acc) else
+      if c = #"'" then lex QUOTE cs acc else
+        let (n,rest) = read_num #"0" #"9" 10 (ORD #"0") 0 (c::cs) in
+          if rest ≠ c::cs then lex NUM rest (q n::acc) else
+            let (n,rest) = read_num #"*" #"z" 256 0 0 (c::cs) in
+              if rest ≠ c::cs then lex NUM rest (q n::acc) else
+                lex NUM cs acc
+Termination
+  WF_REL_TAC ‘measure (LENGTH o FST o SND)’ \\ rw []
+  \\ imp_res_tac (GSYM read_num_length) \\ fs [end_line_length]
+End
+
+Definition lexer_def:
+  lexer input = lex NUM input []
+End
+
+
+(* parsing *)
+
+Definition quote_def:
+  quote n = list [Num (name "'"); Num n]
+End
+
+Definition parse_def:
+  parse [] x s = x ∧
+  parse (CLOSE :: rest) x s = parse rest (Num 0) (x::s) ∧
+  parse (OPEN :: rest) x s =
+    (case s of [] => parse rest x s
+     | (y::ys) => parse rest (Pair x y) ys) ∧
+  parse (NUM n :: rest) x s = parse rest (Pair (Num n) x) s ∧
+  parse (QUOTE n :: rest) x s = parse rest (Pair (quote n) x) s ∧
+  parse (DOT :: rest) x s = parse rest (head x) s
+End
+
+
+(* converting from v to prog *)
+
+Definition v2test_def:
+  v2test v = if getNum v = name "<" then Less else Equal
+End
+
+Definition v2list_def:
+  v2list v = if isNum v then [] else head v :: v2list (tail v)
+Termination
+  WF_REL_TAC ‘measure v_size’
+  \\ rpt conj_tac \\ rw [name_def]
+  \\ rpt (goal_term (fn tm => tmCases_on (hd (free_vars (rator tm))) [] \\ fs []))
+End
+
+Definition conses_def:
+  conses [] = Op Cons [] ∧
+  conses [x] = Op Cons [x] ∧
+  conses [x;y] = Op Cons [x;y] ∧
+  conses (x::xs) = Op Cons [x; conses xs]
+End
+
+Definition pat_lets_def:
+  pat_lets x v rhs =
+    if isNum v then rhs else
+      let var = getNum (head v) in
+        Let var (Op Head [x])
+          (pat_lets (Op Tail [x]) (tail v) rhs)
+Termination
+  WF_REL_TAC ‘measure (λ(x,v,rhs). v_size v)’ \\ rw []
+  \\ rpt (goal_term (fn tm => tmCases_on (find_term is_var (rator tm)) [] \\ fs []))
+End
+
+Definition num2exp_def:
+  num2exp n = if is_upper n then Const n else Var n
+End
+
+fun apply_at_conv p c tm =
+  DEPTH_CONV (fn tm => if p tm then c tm else NO_CONV tm
+                       handle HOL_ERR _ => NO_CONV tm) tm;
+
+fun apply_at_pat_conv pat = apply_at_conv (can (match_term pat));
+
+Definition v2exp_def:
+  v2exp v =
+    (if isNum v then num2exp (getNum v) else
+       let n = getNum (head v) in
+         if n = name "'" then Const (getNum (el1 v)) else
+         if n = name "+" then Op Add (v2exps (tail v)) else
+         if n = name "-" then Op Sub (v2exps (tail v)) else
+         if n = name "div" then Op Div (v2exps (tail v)) else
+         if n = name "cons" then conses (v2exps (tail v)) else
+         if n = name "cons*" then Op Cons (v2exps (tail v)) else
+         if n = name "list" then conses (v2exps (tail v) ++ [Const 0]) else
+         if n = name "head" then Op Head (v2exps (tail v)) else
+         if n = name "tail" then Op Tail (v2exps (tail v)) else
+         if n = name "read" then Op Read (v2exps (tail v)) else
+         if n = name "case" then v2case (v2exp (el1 v)) (tail (tail v)) else
+         if n = name "write" then Op Write (v2exps (tail v)) else
+         if n = name "if" then
+           If (v2test (head (el1 v)))
+             (v2exps (tail (el1 v))) (v2exp (el2 v)) (v2exp (el3 v)) else
+         if n = name "let" then v2lets (tail v) else
+         if n = name "var" then Var (getNum (head (tail v))) else
+         if n = name "call" then
+           Call (getNum (el1 v)) (v2exps (tail (tail v)))
+         else otherwise (if is_upper n then
+           conses (Const n :: (v2exps (tail v) ++ [Const 0]))
+         else Call (getNum (el0 v)) (v2exps (tail v)))) ∧
+  v2exps v =
+    (if isNil v then [] else v2exp (head v) :: v2exps (tail v)) ∧
+  v2lets v =
+    (if isNum v then Const 0 else
+       Let (getNum (el0 (el0 v))) (v2exp (el1 (el0 v)))
+         if isNum (tail (tail v)) then v2exp (el1 v) else v2lets (tail v)) ∧
+  v2case x v =
+    (if isNum v then Const 0 else
+       let row = el0 v in
+       let pat = head row in
+       let rhs = el1 row in
+         if isNum pat then
+           if getNum pat = name "_" then
+             If Less [Const 0; Const 1] (v2exp rhs) (v2case x (tail v))
+           else
+             If Equal [x; Const (getNum pat)] (v2exp rhs) (v2case x (tail v))
+         else
+           If Equal [Const (getNum (head pat)); Op Head [x]]
+             (pat_lets (Op Tail [x]) (tail pat) (v2exp rhs)) (v2case x (tail v)))
+Termination
+  WF_REL_TAC ‘measure (λx. case x of INL v => v_size v
+                                   | INR (INL v) => v_size v
+                                   | INR (INR (INL v)) => v_size v
+                                   | INR (INR (INR (x, v))) => v_size v)’
+  \\ CONV_TAC (apply_at_pat_conv “name _” EVAL)
+  \\ rpt strip_tac
+  \\ Cases_on ‘v’ \\ full_simp_tac std_ss [isNum_def,head_def,tail_def,v_size_def]
+  \\ rpt (pop_assum kall_tac) \\ fs []
+  \\ rpt (goal_term (fn tm => tmCases_on (find_term is_var (rator tm)) [] \\ fs []))
+End
+
+Definition vs2args_def:
+  vs2args [] = [] ∧
+  vs2args (v::vs) = getNum (el1 v) :: vs2args vs
+End
+
+Definition v2dec_def:
+  v2dec v = Defun (getNum (el1 v))
+                  (vs2args (v2list (el2 v)))
+                  (v2exp (el3 v))
+End
+
+Definition vs2prog_def:
+  vs2prog [] = Program [] (Const 0) ∧
+  vs2prog [v] = Program [] (v2exp v) ∧
+  vs2prog (v::vs) =
+    case vs2prog vs of Program ds m => Program (v2dec v :: ds) m
+End
+
+(* entire parser *)
+
+Definition parser_def:
+  parser tokens =
+    vs2prog (v2list (parse tokens (Num 0) []))
+End
+
+val _ = export_theory();

--- a/examples/bootstrap/parsing_proofsScript.sml
+++ b/examples/bootstrap/parsing_proofsScript.sml
@@ -1,0 +1,782 @@
+
+open HolKernel Parse boolLib bossLib;
+open arithmeticTheory listTheory pairTheory finite_mapTheory stringTheory;
+open source_valuesTheory printingTheory parsingTheory;
+
+val _ = new_theory "parsing_proofs";
+
+Definition dest_quote_def:
+  dest_quote v =
+    case v of
+    | (Pair x (Pair (Num n) (Num 0))) =>
+        (if x = Num (name "'") then SOME (QUOTE n) else NONE)
+    | _ => NONE
+End
+
+Definition v2toks_def:
+  v2toks v =
+    case v of Num n => [NUM n] | _ =>
+    case dest_quote v of SOME s => [s] | NONE =>
+      let (l,e) = dest_list v in
+        [OPEN] ++
+          (if e = Num 0 then FLAT (MAP v2toks l) else
+             FLAT (MAP v2toks l) ++ [DOT] ++ (v2toks e)) ++
+        [CLOSE]
+Termination
+  WF_REL_TAC ‘measure v_size’ \\ rw []
+  \\ imp_res_tac dest_list_size \\ fs [v_size_def,isNum_def]
+End
+
+Definition pretty2toks_def:
+  pretty2toks (Str s) = lexer s ∧
+  pretty2toks (Append p _ q) = pretty2toks q ++ pretty2toks p ∧
+  pretty2toks (Parenthesis p) = [CLOSE] ++ pretty2toks p ++ [OPEN] ∧
+  pretty2toks (Size _ p) = pretty2toks p
+End
+
+Theorem flatten_acc:
+  ∀indent p acc. flatten indent p acc = flatten indent p [] ++ acc
+Proof
+  Induct_on ‘p’ \\ simp_tac std_ss [flatten_def]
+  \\ rpt (pop_assum (once_rewrite_tac o single)) \\ fs []
+QED
+
+Theorem lex_acc:
+  ∀p xs acc. lex p xs acc = lex p xs [] ++ acc
+Proof
+  qsuff_tac ‘∀p xs (a:token list) acc. lex p xs [] ++ acc = lex p xs acc’
+  THEN1 metis_tac []
+  \\ ho_match_mp_tac lex_ind \\ rw []
+  \\ once_rewrite_tac [lex_def]
+  \\ simp_tac (srw_ss()) []
+  \\ rpt IF_CASES_TAC
+  \\ rw [] \\ fs [] \\ rw []
+  \\ rpt (pairarg_tac \\ fs []) \\ rw []
+  \\ rpt (pop_assum mp_tac)
+  \\ metis_tac [APPEND,APPEND_ASSOC]
+QED
+
+Theorem read_num_suffix:
+  ∀a b c d xs y ys n1 n2 acc rest1 rest2.
+    read_num a b c d acc (xs ++ y::ys) = (n1,rest1) ∧
+    read_num a b c d acc xs  = (n2,rest2) ∧
+    ~(ORD a ≤ ORD y ∧ ORD y ≤ ORD b) ⇒
+    n1 = n2 ∧ rest1 = rest2 ++ y::ys
+Proof
+  Induct_on ‘xs’ \\ fs [read_num_def] THEN1 rw []
+  \\ rpt gen_tac \\ rpt (pairarg_tac \\ fs [])
+  \\ IF_CASES_TAC \\ fs [] \\ rw [] \\ fs[]
+  \\ first_x_assum drule \\ fs []
+QED
+
+Theorem read_num_EVERY_IMP:
+  ∀s x1 x2 y1 y2 y3 n rest.
+    read_num x1 x2 y1 y2 y3 s = (n,rest) ∧ EVERY p s ⇒ EVERY p rest
+Proof
+  Induct \\ fs [read_num_def] \\ rw [] \\ res_tac \\ fs []
+QED
+
+Theorem lex_APPEND_split:
+  ∀c.
+    ORD c < ORD #"*" ⇒
+    ∀xs ys acc p.
+      EVERY (\x. x ≠ CHR 35) xs ⇒
+      lex p (STRCAT xs (STRING c ys)) acc = lex NUM (c::ys) (lex p xs acc)
+Proof
+  gen_tac \\ strip_tac \\ gen_tac \\ completeInduct_on ‘LENGTH xs’
+  \\ rw [] \\ fs [PULL_FORALL]
+  \\ Cases_on ‘xs’
+  THEN1 (fs [lex_def] \\ rw [] \\ fs [read_num_def])
+  \\ fs []
+  \\ CONV_TAC (RATOR_CONV (SIMP_CONV std_ss [lex_def]))
+  \\ CONV_TAC (PATH_CONV "rr" (SIMP_CONV std_ss [lex_def]))
+  \\ rw [] \\ fs []
+  \\ pairarg_tac \\ fs []
+  \\ once_rewrite_tac [EQ_SYM_EQ]
+  \\ pairarg_tac \\ fs []
+  \\ qabbrev_tac ‘ss = h::t’
+  \\ ‘STRING h (STRCAT (STRCAT t [c]) ys) = ss ++ c::ys’ by fs []
+  \\ qpat_x_assum ‘_ = (n,rest)’ mp_tac
+  \\ asm_rewrite_tac [] \\ strip_tac
+  \\ drule read_num_suffix \\ fs []
+  \\ strip_tac \\ IF_CASES_TAC \\ fs []
+  THEN1
+   (‘LENGTH rest' < LENGTH (h::t)’ by
+      (imp_res_tac read_num_length \\ rfs [] \\ rw [] \\ fs [])
+    \\ fs [AND_IMP_INTRO]
+    \\ first_x_assum drule
+    \\ imp_res_tac read_num_EVERY_IMP \\ rw [])
+  \\ pairarg_tac \\ fs []
+  \\ pairarg_tac \\ fs [] \\ pop_assum mp_tac
+  \\ rewrite_tac [GSYM APPEND_ASSOC,APPEND] \\ strip_tac
+  \\ drule read_num_suffix \\ fs []
+  \\ strip_tac \\ fs []
+  \\ IF_CASES_TAC \\ fs []
+  \\ ‘LENGTH rest'' < LENGTH (h::t)’ by
+      (imp_res_tac read_num_length \\ rfs [] \\ rw [] \\ fs [])
+  \\ fs [] \\ first_x_assum drule
+  \\ imp_res_tac read_num_EVERY_IMP \\ rw []
+QED
+
+Theorem lex_indent:
+  ∀t. EVERY (λc. c = #" " ∨ c = #"\n") t ⇒
+      lex NUM (t ++ s) acc = lex NUM s acc
+Proof
+  Induct \\ fs [] \\ rw [] \\ fs [] \\ fs [lex_def]
+QED
+
+Definition no_hash_def[simp]:
+  no_hash (Str s) = EVERY (λx. x ≠ #"#") s ∧
+  no_hash (Append p1 b p2) = (no_hash p1 ∧ no_hash p2) ∧
+  no_hash (Parenthesis p) = no_hash p ∧
+  no_hash (Size _ p) = no_hash p
+End
+
+Theorem no_hash_flatten:
+  ∀x s1 s2.
+    EVERY (λx. x ≠ #"#") s1 ∧ EVERY (λx. x ≠ #"#") s2 ⇒
+    EVERY (λx. x ≠ #"#") (flatten s1 x s2) = no_hash x
+Proof
+  Induct_on ‘x’ \\ fs [flatten_def] \\ rw []
+  \\ once_rewrite_tac [flatten_acc] \\ fs []
+QED
+
+Theorem lex_flatten:
+  ∀p indent.
+    EVERY (λc. MEM c " \n") indent ∧ indent ≠ [] ∧ no_hash p ⇒
+    lex NUM (flatten indent p []) [] = pretty2toks p
+Proof
+  Induct
+  THEN1
+   (rw [flatten_def,pretty2toks_def,lex_def]
+    \\ once_rewrite_tac [lex_acc] \\ fs []
+    \\ qmatch_goalsub_abbrev_tac ‘flatten ss’
+    \\ first_x_assum (qspec_then ‘ss’ mp_tac)
+    \\ fs [Abbr‘ss’] \\ rw []
+    \\ once_rewrite_tac [flatten_acc] \\ fs []
+    \\ ‘ORD #")" < ORD #"*"’ by EVAL_TAC
+    \\ drule lex_APPEND_split
+    \\ ‘EVERY (λx. x ≠ #"#") (flatten (STRCAT indent "   ") p "")’ by
+     (‘EVERY (λx. x ≠ #"#") "" ∧
+       EVERY (λx. x ≠ #"#") (STRCAT indent "   ")’ by
+        (fs [] \\ fs [EVERY_MEM] \\ strip_tac \\ res_tac \\ fs [])
+      \\ imp_res_tac no_hash_flatten)
+    \\ disch_then drule \\ fs []
+    \\ disch_then (qspecl_then [‘[]’,‘[]’] mp_tac)
+    \\ fs [] \\ rw [] \\ EVAL_TAC)
+  THEN1 fs [flatten_def,pretty2toks_def,lexer_def]
+  \\ fs [pretty2toks_def,flatten_def]
+  \\ rpt strip_tac
+  \\ qmatch_goalsub_abbrev_tac ‘white_space ++ _’
+  \\ ‘EVERY (λc. c = #" " ∨ c = #"\n") white_space ∧ white_space ≠ []’
+        by (fs [Abbr‘white_space’] \\ rw [])
+  \\ ‘white_space = HD white_space :: TL white_space’ by
+        (Cases_on ‘white_space’ \\ fs [])
+  \\ pop_assum (fn th => once_rewrite_tac [th] \\ assume_tac (GSYM th))
+  \\ full_simp_tac std_ss [GSYM APPEND_ASSOC,APPEND]
+  \\ ‘ORD (HD white_space) < ORD #"*"’ by
+        (Cases_on ‘white_space’ \\ fs [])
+  \\ drule lex_APPEND_split
+  \\ once_rewrite_tac [flatten_acc]
+  \\ qmatch_goalsub_abbrev_tac ‘lex _ (pat ++ _)’
+  \\ ‘EVERY (λx. x ≠ #"#") pat’ by
+   (fs [Abbr‘pat’]
+    \\ ‘EVERY (λx. x ≠ #"#") "" ∧ EVERY (λx. x ≠ #"#") indent’ by
+          (fs [] \\ fs [EVERY_MEM] \\ strip_tac \\ res_tac \\ fs [])
+    \\ imp_res_tac no_hash_flatten)
+  \\ disch_then drule \\ fs [Abbr‘pat’]
+  \\ once_rewrite_tac [flatten_acc] \\ fs []
+  \\ disch_then (qspecl_then [‘(TL white_space) ++ (flatten indent p' "")’] mp_tac)
+  \\ fs [] \\ asm_simp_tac std_ss [] \\ fs []
+  \\ simp_tac std_ss [GSYM APPEND |> CONJUNCT2]
+  \\ asm_rewrite_tac []
+  \\ once_rewrite_tac [lex_acc]
+  \\ fs [lex_indent]
+QED
+
+Theorem pretty2toks_annotate:
+  ∀p. pretty2toks (annotate p) = pretty2toks p
+Proof
+  Induct \\ fs [annotate_def,pretty2toks_def]
+QED
+
+Theorem pretty2toks_smart_remove_all:
+  ∀p. pretty2toks (remove_all p) = pretty2toks p
+Proof
+  Induct \\ fs [remove_all_def,pretty2toks_def]
+QED
+
+Theorem pretty2toks_smart_remove:
+  ∀p n i. pretty2toks (smart_remove i n p) = pretty2toks p
+Proof
+  Induct \\ fs [smart_remove_def,pretty2toks_def]
+  \\ rw [pretty2toks_smart_remove_all,pretty2toks_def]
+QED
+
+Theorem read_num_append:
+  ∀xs acc ys.
+    read_num c1 c2 x y acc (xs ++ ys) =
+      let (k,t) = read_num c1 c2 x y acc xs in
+        if t = [] then read_num c1 c2 x y k ys else (k,t ++ ys)
+Proof
+  Induct \\ fs [read_num_def] \\ rw []
+QED
+
+Theorem read_num_num2str:
+  ∀n acc.
+    read_num #"0" #"9" 10 48 acc (num2str n) = (acc * 10 ** LENGTH (num2str n) + n,[])
+Proof
+  ho_match_mp_tac num2str_ind
+  \\ gen_tac \\ strip_tac
+  \\ once_rewrite_tac [num2str_def] \\ fs []
+  \\ IF_CASES_TAC \\ fs []
+  THEN1 fs [read_num_def]
+  \\ fs [read_num_append]
+  \\ fs [read_num_def]
+  \\ ‘n MOD 10 < 10’ by fs [MOD_LESS]
+  \\ ‘n MOD 10 + 48 < 256’ by simp []
+  \\ simp [ORD_CHR] \\ rw []
+  \\ once_rewrite_tac [EQ_SYM_EQ]
+  \\ fs [GSYM ADD1,EXP]
+  \\ ‘0 < 10n’ by fs []
+  \\ drule DIVISION
+  \\ disch_then (fn th => CONV_TAC (RATOR_CONV (ONCE_REWRITE_CONV [th])))
+  \\ fs []
+  \\ once_rewrite_tac [ADD_COMM]
+  \\ once_rewrite_tac [MULT_COMM]
+  \\ simp [ADD_DIV_ADD_DIV]
+QED
+
+Theorem read_num_num2ascii:
+  ∀n x acc.
+    num2ascii n = SOME x ⇒
+    read_num #"*" #"z" 256 0 acc x = (acc * 256 ** LENGTH x + n,[])
+Proof
+  ho_match_mp_tac num2ascii_ind
+  \\ gen_tac \\ strip_tac
+  \\ once_rewrite_tac [num2ascii_def] \\ fs []
+  \\ IF_CASES_TAC \\ fs [AllCaseEqs(),PULL_EXISTS]
+  THEN1 fs [read_num_def]
+  \\ rw [] \\ fs []
+  \\ fs [read_num_append]
+  \\ fs [read_num_def]
+  \\ fs [GSYM ADD1,EXP]
+  \\ once_rewrite_tac [EQ_SYM_EQ]
+  \\ ‘0 < 256n’ by fs []
+  \\ drule DIVISION
+  \\ disch_then (fn th => CONV_TAC (RATOR_CONV (ONCE_REWRITE_CONV [th])))
+  \\ fs []
+  \\ once_rewrite_tac [ADD_COMM]
+  \\ once_rewrite_tac [MULT_COMM]
+  \\ simp [ADD_DIV_ADD_DIV]
+QED
+
+Theorem num2str_not_nil:
+  num2str n ≠ []
+Proof
+  once_rewrite_tac [num2str_def] \\ rw [] \\ fs []
+QED
+
+Theorem num2str_cons_IMP:
+  ∀n h t.
+    num2str n = STRING h t ⇒
+    ORD #"0" ≤ ORD h ∧ ORD h ≤ ORD #"9"
+Proof
+  ho_match_mp_tac num2str_ind \\ rw []
+  \\ pop_assum mp_tac
+  \\ once_rewrite_tac [num2str_def] \\ rw [] \\ fs []
+  \\ Cases_on ‘num2str (n DIV 10)’ \\ fs []
+  \\ rw [] \\ fs [num2str_not_nil]
+QED
+
+Theorem num2ascii_SOME_IMP:
+  ∀n x.
+    num2ascii n = SOME x ⇒
+    ∃c cs. x = c::cs ∧ (ORD #"*" ≤ ORD c ∧ ORD c ≤ ORD #"z" ∧ ORD c ≠ ORD #".")
+Proof
+  ho_match_mp_tac num2ascii_ind \\ rw []
+  \\ pop_assum mp_tac
+  \\ once_rewrite_tac [num2ascii_def]
+  \\ rw [] \\ fs [AllCaseEqs()] \\ rw []
+  \\ res_tac \\ fs []
+QED
+
+Theorem lex_name2str:
+  lex p (name2str n) [] = [p n]
+Proof
+  fs [name2str_def]
+  \\ BasicProvers.CASE_TAC
+  THEN1
+   (pop_assum kall_tac
+    \\ Cases_on ‘num2str n’
+    \\ fs [lex_def,num2str_not_nil]
+    \\ imp_res_tac num2str_cons_IMP
+    \\ rw [] \\ fs [lex_def]
+    \\ last_assum (assume_tac o GSYM) \\ fs []
+    \\ rewrite_tac [read_num_num2str] \\ fs [num2str_not_nil,lex_def])
+  \\ fs [ascii_name_def,AllCaseEqs()]
+  \\ imp_res_tac num2ascii_SOME_IMP
+  \\ fs [lex_def]
+  \\ rw [] \\ fs []
+  \\ fs [read_num_def]
+  \\ drule read_num_num2ascii \\ fs [read_num_def]
+  \\ disch_then (qspec_then ‘0’ mp_tac) \\ fs [lex_def]
+QED
+
+Definition any_list_def:
+  any_list [] e = e ∧
+  any_list (x::xs) e = Pair x (any_list xs e)
+End
+
+Theorem dest_list_IMP:
+  ∀v l e. dest_list v = (l,e) ⇒ v = any_list l e ∧ isNum e
+Proof
+  Induct_on ‘l’ \\ fs []
+  \\ Cases_on ‘v’ \\ fs [dest_list_def,any_list_def]
+  \\ rw [] \\ pairarg_tac \\ fs [] \\ rw [] \\ res_tac
+QED
+
+Theorem any_list_eq_list[simp]:
+  ∀xs. any_list xs (Num 0) = list xs
+Proof
+  Induct \\ fs [any_list_def,list_def]
+QED
+
+Theorem pretty2toks_v2pretty:
+  ∀h. pretty2toks (v2pretty h) = REVERSE (v2toks h)
+Proof
+  gen_tac \\ completeInduct_on ‘v_size h’
+  \\ rw [] \\ fs [PULL_FORALL]
+  \\ once_rewrite_tac [v2pretty_def]
+  \\ reverse (Cases_on ‘h’) \\ simp []
+  THEN1 simp [pretty2toks_def,Once v2toks_def,lex_name2str,lexer_def]
+  \\ simp [Once v2toks_def]
+  \\ ‘~isNum (Pair v v0)’ by fs []
+  \\ rename [‘v_size vv’]
+  \\ reverse BasicProvers.CASE_TAC
+  THEN1
+   (fs [dest_quote_def,printingTheory.dest_quote_def,AllCaseEqs()]
+    \\ rw [pretty2toks_def,lex_def,lexer_def,lex_name2str])
+  \\ reverse BasicProvers.CASE_TAC
+  THEN1 (fs [dest_quote_def,printingTheory.dest_quote_def,AllCaseEqs()] \\ rw [])
+  \\ pairarg_tac \\ fs [pretty2toks_def] \\ rw []
+  \\ imp_res_tac dest_list_IMP \\ fs []
+  \\ rpt (qpat_x_assum ‘_ = NONE’ kall_tac)
+  THEN1
+   (rw [] \\ Induct_on ‘l’ \\ fs []
+    \\ fs [list_def,dest_list_def] \\ rw []
+    \\ pairarg_tac \\ fs [] \\ rw []
+    \\ Cases_on ‘l = []’ \\ rw [] \\ fs [newlines_def]
+    \\ Cases_on ‘l’ \\ fs [newlines_def,list_def]
+    \\ fs [pretty2toks_def])
+  \\ rw [] \\ Induct_on ‘l’ \\ fs [] THEN1 fs [any_list_def]
+  \\ fs [any_list_def,dest_list_def] \\ rw []
+  \\ pairarg_tac \\ fs [] \\ rw []
+  \\ Cases_on ‘l = []’ \\ rw [] \\ fs [newlines_def]
+  THEN1 (fs [pretty2toks_def,any_list_def] \\ EVAL_TAC)
+  \\ Cases_on ‘l’ \\ fs [newlines_def,any_list_def]
+  \\ fs [pretty2toks_def]
+QED
+
+Theorem dropWhile_cons_imp:
+  ∀s c h t.
+    dropWhile (λx. x ≠ c) s = h::t ⇒
+    ∃prefix. s = prefix ++ c :: t ∧ h = c ∧ EVERY (λx. x ≠ c) prefix
+Proof
+  Induct \\ fs [] \\ rw [] \\ res_tac \\ fs []
+QED
+
+Theorem end_line_prefix:
+  ∀prefix xs.
+    EVERY (λx. x ≠ #"\n") prefix ⇒
+    end_line (STRCAT prefix (STRING #"\n" xs)) = xs
+Proof
+  Induct \\ fs [end_line_def]
+QED
+
+Theorem lex_is_comment:
+  ∀c rest. is_comment c ⇒ lex NUM (c ++ rest) [] = lex NUM rest []
+Proof
+  ho_match_mp_tac is_comment_ind \\ rw []
+  \\ fs [is_comment_def]
+  \\ reverse (Cases_on ‘c = #"#"’) \\ fs []
+  \\ simp [Once lex_def]
+  \\ rename [‘dropWhile (λx. x ≠ #"\n") s’]
+  \\ Cases_on ‘dropWhile (λx. x ≠ #"\n") s’ \\ fs []
+  \\ rw [] \\ imp_res_tac dropWhile_cons_imp \\ rw []
+  \\ rewrite_tac [GSYM APPEND_ASSOC,APPEND]
+  \\ drule end_line_prefix \\ strip_tac \\ asm_rewrite_tac []
+QED
+
+Theorem num2ascii_no_hash:
+  ∀n x. num2ascii n = SOME x ⇒ EVERY (λx. x ≠ #"#") x
+Proof
+  ho_match_mp_tac num2ascii_ind \\ rw [] \\ fs []
+  \\ pop_assum mp_tac \\ rw [Once num2ascii_def] \\ fs [AllCaseEqs()]
+  \\ res_tac \\ fs [] \\ rw []
+QED
+
+Theorem no_hash_name2str:
+  EVERY (λx. x ≠ #"#") (name2str n)
+Proof
+  fs [name2str_def]
+  \\ Cases_on ‘ascii_name n’ \\ fs []
+  THEN1
+   (pop_assum kall_tac \\ qid_spec_tac ‘n’
+    \\ ho_match_mp_tac num2str_ind
+    \\ rw [] \\ simp [Once num2str_def] \\ rw []
+    \\ ‘n MOD 10 < 10’ by fs []
+    \\ ‘(n MOD 10) + 48 < 256 ∧ 35 < 256’ by decide_tac
+    \\ imp_res_tac CHR_11 \\ fs [])
+  \\ fs [ascii_name_def,AllCaseEqs()]
+  \\ imp_res_tac num2ascii_no_hash \\ fs []
+QED
+
+Theorem no_hash_smart_remove_annotate_v2pretty[simp]:
+  no_hash (smart_remove m n (annotate (v2pretty h)))
+Proof
+  ‘∀p. no_hash (annotate p) = no_hash p’ by
+    (Induct_on ‘p’ \\ rw [annotate_def,no_hash_def])
+  \\ ‘∀p. no_hash (remove_all p) = no_hash p’ by
+       (Induct_on ‘p’ \\ rw [remove_all_def,no_hash_def])
+  \\ ‘∀m n p. no_hash (smart_remove m n p) = no_hash p’ by
+       (Induct_on ‘p’ \\ rw [smart_remove_def,no_hash_def])
+  \\ fs [] \\ qid_spec_tac ‘h’
+  \\ ho_match_mp_tac v2pretty_ind
+  \\ rw [] \\ once_rewrite_tac [v2pretty_def]
+  \\ rpt (BasicProvers.TOP_CASE_TAC \\ fs [])
+  \\ rpt (pairarg_tac \\ fs []) \\ rw [no_hash_def]
+  THEN1
+   (pop_assum mp_tac \\ rpt (pop_assum kall_tac)
+    \\ Induct_on ‘l’ \\ fs [newlines_def,no_hash_def]
+    \\ rw [] \\ last_x_assum mp_tac
+    \\ impl_tac THEN1 fs []
+    \\ Cases_on ‘l’ \\ fs [newlines_def])
+  \\ fs []
+  THEN1
+   (qpat_x_assum ‘∀h._’ mp_tac \\ rpt (pop_assum kall_tac)
+    \\ Induct_on ‘l’ \\ fs [newlines_def,no_hash_def]
+    \\ rw [] \\ last_x_assum mp_tac
+    \\ impl_tac THEN1 fs []
+    \\ Cases_on ‘l’ \\ fs [newlines_def])
+  \\ fs [printingTheory.dest_quote_def,AllCaseEqs()]
+  \\ rw [no_hash_name2str]
+QED
+
+Theorem lexer_vs2str:
+  ∀vs coms. lexer (vs2str vs coms) = REVERSE (FLAT (MAP v2toks vs))
+Proof
+  Induct THEN1 (EVAL_TAC \\ fs [])
+  \\ fs [vs2str_def,lexer_def] \\ gen_tac
+  \\ ‘EVERY (λx. x ≠ #"#") (v2str h)’ by fs [v2str_def,no_hash_flatten]
+  \\ drule (lex_APPEND_split |> Q.SPEC ‘#"\n"’
+            |> CONV_RULE (PATH_CONV "lr" EVAL) |> REWRITE_RULE [])
+  \\ rewrite_tac [GSYM APPEND_ASSOC,APPEND] \\ fs [] \\ rw []
+  \\ Cases_on ‘coms’ \\ fs []
+  \\ TRY IF_CASES_TAC \\ fs []
+  \\ TRY (drule lex_is_comment)
+  \\ rpt strip_tac
+  \\ asm_rewrite_tac [GSYM APPEND_ASSOC]
+  \\ simp [Once lex_def]
+  \\ simp [Once lex_def]
+  \\ once_rewrite_tac [lex_acc]
+  \\ fs [] \\ simp [v2str_def]
+  \\ fs [lex_flatten,pretty2toks_annotate,pretty2toks_smart_remove]
+  \\ fs [pretty2toks_v2pretty]
+QED
+
+Theorem v_size_any_list:
+  ∀l e.
+    v_size (any_list l e) = SUM (MAP v_size l) + LENGTH l + v_size e
+Proof
+  Induct \\ fs [any_list_def]
+QED
+
+Theorem parse_v2toks:
+   ∀vs ys xs ts e.
+     isNum e ⇒
+     parse (REVERSE (FLAT (MAP v2toks vs)) ++ ts) (any_list ys e) xs =
+     parse ts (any_list (vs ++ ys) e) xs
+Proof
+  gen_tac \\ completeInduct_on ‘SUM (MAP v_size vs) + LENGTH vs’
+  \\ rpt strip_tac \\ rw [] \\ fs [PULL_FORALL]
+  \\ Cases_on ‘vs = []’ THEN1 rw []
+  \\ ‘∃x l. vs = SNOC x l’ by metis_tac [SNOC_CASES]
+  \\ fs [REVERSE_APPEND]
+  \\ Cases_on ‘l ≠ []’ THEN1
+   (first_assum
+       (qspecl_then [‘[x]’,‘ys’,‘xs’,‘REVERSE (FLAT (MAP v2toks l)) ⧺ ts’,‘e’] mp_tac)
+    \\ impl_tac THEN1 (Cases_on ‘l’ \\ fs [SUM_APPEND])
+    \\ fs [] \\ strip_tac \\ fs [] \\ pop_assum kall_tac
+    \\ first_assum (qspecl_then [‘l’,‘x::ys’,‘xs’,‘ts’,‘e’] mp_tac)
+    \\ impl_tac THEN1 fs [SUM_APPEND]
+    \\ fs [] \\ rewrite_tac [GSYM APPEND_ASSOC,APPEND])
+  \\ once_rewrite_tac [v2toks_def]
+  \\ reverse (Cases_on ‘x’) \\ simp []
+  THEN1 (fs [parse_def,any_list_def])
+  \\ rename [‘dest_quote (Pair v1 v2)’]
+  \\ ‘~isNum (Pair v1 v2)’ by fs []
+  \\ rename [‘~isNum v’]
+  \\ reverse (Cases_on ‘dest_quote v’) \\ fs []
+  THEN1
+   (rw [] \\ fs [dest_quote_def,AllCaseEqs()] \\ rw[] \\ fs []
+    \\ fs [parse_def,any_list_def,quote_def,list_def])
+  \\ pairarg_tac \\ fs []
+  \\ Cases_on ‘e' = Num 0’ \\ fs []
+  THEN1
+   (fs [REVERSE_APPEND,parse_def]
+    \\ rewrite_tac [GSYM APPEND_ASSOC,APPEND]
+    \\ CONV_TAC (DEPTH_CONV ETA_CONV) \\ rw []
+    \\ first_assum (qspecl_then [‘l'’,‘[]’,‘any_list ys e::xs’,‘OPEN::ts’,‘Num 0’] mp_tac)
+    \\ impl_tac THEN1
+     (rw [] \\ imp_res_tac dest_list_IMP
+      \\ full_simp_tac std_ss [v_size_any_list] \\ fs [])
+    \\ strip_tac \\ fs [list_def]
+    \\ fs [parse_def,any_list_def]
+    \\ imp_res_tac dest_list_IMP \\ fs [])
+  \\ fs [REVERSE_APPEND,parse_def]
+  \\ rewrite_tac [GSYM APPEND_ASSOC,APPEND]
+  \\ CONV_TAC (DEPTH_CONV ETA_CONV)
+  \\ qpat_abbrev_tac ‘ts1 = DOT::_’
+  \\ first_assum (qspecl_then [‘[e']’,‘[]’,‘any_list ys e::xs’,‘ts1’,‘Num 0’] mp_tac)
+  \\ impl_tac THEN1
+   (rw [] \\ imp_res_tac dest_list_IMP \\ rw [] \\ fs [v_size_any_list]
+    \\ Cases_on ‘l'’ \\ fs [any_list_def]
+    \\ Cases_on ‘e'’ \\ fs [dest_list_def]
+    \\ pairarg_tac \\ fs [])
+  \\ fs [list_def] \\ strip_tac \\ fs []
+  \\ qunabbrev_tac ‘ts1’ \\ fs [parse_def]
+  \\ rewrite_tac [GSYM APPEND_ASSOC,APPEND] \\ rw []
+  \\ first_assum (qspecl_then [‘l'’,‘[]’,‘any_list ys e::xs’,‘OPEN::ts’,‘e'’] mp_tac)
+  \\ impl_tac
+  THEN1 (rw [] \\ imp_res_tac dest_list_IMP \\ rw [] \\ fs [v_size_any_list])
+  \\ fs [any_list_def,parse_def]
+  \\ imp_res_tac dest_list_IMP \\ fs []
+QED
+
+Theorem parse_lexer_vs2str:
+  ∀vs coms ys xs. (parse (lexer (vs2str vs coms)) (Num 0) []) = list vs
+Proof
+  fs [lexer_vs2str] \\ rw []
+  \\ assume_tac (parse_v2toks |> Q.SPECL [‘vs’,‘[]’,‘[]’,‘[]’,‘Num 0’])
+  \\ fs [parse_def,any_list_def,list_def]
+QED
+
+
+(* proof: converting a prog to v and then back is the identity *)
+
+Theorem list_v2list:
+  ∀xs. v2list (list xs) = xs
+Proof
+  Induct \\ fs [list_def] \\ once_rewrite_tac [v2list_def] \\ fs []
+QED
+
+Theorem v2exps_list_exp2v:
+  ∀es.
+    (∀x. MEM x es ⇒ v2exp (exp2v x) = x) ⇒
+    v2exps (list (MAP exp2v es)) = es
+Proof
+  Induct THEN1 EVAL_TAC \\ fs [list_def] \\ rw []
+  \\ once_rewrite_tac [v2exp_def] \\ fs []
+QED
+
+Theorem dest_cons_chain_IMP_conses:
+  ∀y x. dest_cons_chain y = SOME x ⇒ conses x = y
+Proof
+  ho_match_mp_tac dest_cons_chain_ind
+  \\ rw [] \\ fs [dest_cons_chain_def,AllCaseEqs()]
+  \\ rw [] \\ fs [conses_def]
+  \\ Cases_on ‘xs’ \\ fs [conses_def]
+  \\ rw [] \\ fs [dest_cons_chain_def]
+  \\ Cases_on ‘t’ \\ fs [dest_cons_chain_def,conses_def]
+QED
+
+Theorem dest_case_enum_IMP:
+  ∀z x' rows.
+    dest_case_enum z x' = SOME rows ∧
+    (∀x z. MEM (x,z) rows ⇒ v2exp (exp2v z) = z) ⇒
+    v2case z (enum2v (MAP (λ(x,e). (x,exp2v e)) rows)) = x'
+Proof
+  ho_match_mp_tac dest_case_enum_ind
+  \\ fs [dest_case_enum_def,row2v_def] \\ rw []
+  THEN1 EVAL_TAC
+  \\ fs [AllCaseEqs()] \\ rw [] \\ rfs []
+  \\ fs [enum2v_def] \\ simp [Once v2exp_def] \\ fs []
+  \\ first_x_assum match_mp_tac
+  \\ fs [] \\ rw [] \\ res_tac \\ fs []
+QED
+
+Theorem dest_case_lets_IMP:
+  ∀y x vars rhs.
+    dest_case_lets y x = (vars,rhs) ⇒
+    pat_lets y (list (MAP Num vars)) rhs = x
+Proof
+  ho_match_mp_tac dest_case_lets_ind
+  \\ rw [] \\ fs [dest_case_lets_def,AllCaseEqs()]
+  \\ rw [] \\ fs []
+  \\ TRY (once_rewrite_tac [pat_lets_def] \\ fs [] \\ NO_TAC)
+  \\ pairarg_tac \\ fs [] \\ rw []
+  \\ simp [Once pat_lets_def] \\ fs []
+QED
+
+Theorem dest_case_tree_IMP:
+  ∀z x' rows.
+    dest_case_tree z x' = SOME rows ∧
+    (∀x y z. MEM (x,y,z) rows ⇒ v2exp (exp2v z) = z) ⇒
+    v2case z (row2v (MAP (λ(x,vs,e). (x,vs,exp2v e)) rows)) = x'
+Proof
+  ho_match_mp_tac dest_case_tree_ind
+  \\ fs [dest_case_tree_def,row2v_def] \\ rw []
+  THEN1 EVAL_TAC
+  \\ fs [AllCaseEqs()]
+  \\ pairarg_tac \\ fs [] \\ rw []
+  \\ fs [row2v_def]
+  \\ simp [Once v2exp_def] \\ fs []
+  \\ imp_res_tac dest_case_lets_IMP \\ fs []
+  \\ first_x_assum match_mp_tac
+  \\ fs [] \\ rw [] \\ res_tac \\ fs []
+QED
+
+Theorem v2exp_exp2v:
+  (∀x. v2exp (exp2v x) = x) ∧
+  (∀x. is_Let x ⇒ v2lets (lets2v x) = x)
+Proof
+  ho_match_mp_tac exp2v_ind \\ rw []
+  THEN1 (rw [exp2v_def]
+         \\ once_rewrite_tac [v2exp_def]
+         \\ rewrite_tac [isNum_def,head_def,getNum_def,tail_def,LET_THM]
+         \\ simp [name_def,is_upper_def]
+         \\ fs [isNum_def] \\ fs [num2exp_def])
+  THEN1 (rw [exp2v_def]
+         \\ once_rewrite_tac [v2exp_def]
+         \\ simp [name_def,is_upper_def]
+         \\ fs [isNum_def] \\ fs [num2exp_def])
+  THEN1 (* Op *)
+   (reverse (Cases_on ‘dest_cons_chain (Op op es)’) \\ fs []
+    THEN1
+     (Cases_on ‘op’ \\ fs [dest_cons_chain_def,exp2v_def]
+      \\ reverse IF_CASES_TAC THEN1
+       (fs [] \\ drule v2exps_list_exp2v \\ strip_tac
+        \\ CONV_TAC (DEPTH_CONV ETA_CONV) \\ fs [op2str_def,name_def]
+        \\ once_rewrite_tac [v2exp_def] \\ fs [name_def]
+        \\ imp_res_tac dest_cons_chain_IMP_conses \\ fs [])
+      \\ Cases_on ‘up_const x’ \\ fs []
+      THEN1
+       (fs [] \\ drule v2exps_list_exp2v \\ strip_tac
+        \\ once_rewrite_tac [v2exp_def] \\ fs [name_def]
+        \\ CONV_TAC (DEPTH_CONV ETA_CONV) \\ fs [op2str_def,name_def]
+        \\ imp_res_tac dest_cons_chain_IMP_conses \\ fs []
+        \\ ‘∃x1 x2. x = SNOC x1 x2’ by
+          (Cases_on ‘x’ \\ fs [] \\ metis_tac [SNOC_CASES,NOT_NIL_CONS,SNOC_APPEND])
+        \\ full_simp_tac std_ss [FRONT_SNOC,LAST_SNOC]
+        \\ rfs [SNOC_APPEND])
+      \\ CONV_TAC (DEPTH_CONV ETA_CONV) \\ fs [op2str_def,name_def]
+      \\ once_rewrite_tac [v2exp_def]
+      \\ rewrite_tac [head_def,getNum_def,isNum_def,LET_THM,tail_def]
+      \\ asm_simp_tac std_ss []
+      \\ fs [DefnBase.one_line_ify NONE up_const_def,AllCaseEqs()]
+      \\ CCONTR_TAC \\ fs []
+      \\ TRY (qpat_x_assum ‘is_upper _’ mp_tac \\ rw []
+              \\ rename [‘is_upper (name _)’] \\ EVAL_TAC)
+      \\ pop_assum mp_tac
+      \\ imp_res_tac dest_cons_chain_IMP_conses \\ fs []
+      \\ fs [] \\ pop_assum (rewrite_tac o single o GSYM)
+      \\ (Cases_on ‘v0 = []’ \\ fs [] THEN1 (rw [] \\ fs [EVAL “is_upper 0”]))
+      \\ drule v2exps_list_exp2v \\ strip_tac \\ fs []
+      \\ ‘∃x1 x2. v0 = SNOC x1 x2’ by
+        (Cases_on ‘v0’ \\ fs [] \\ metis_tac [SNOC_CASES,NOT_NIL_CONS,SNOC_APPEND])
+      \\ full_simp_tac std_ss [FRONT_SNOC,LAST_SNOC,LAST_DEF]
+      \\ rfs [SNOC_APPEND])
+    \\ Cases_on ‘op’ \\ fs []
+    \\ drule v2exps_list_exp2v \\ strip_tac
+    \\ fs [exp2v_def,list_def]
+    \\ once_rewrite_tac [v2exp_def] \\ fs [op2str_def]
+    \\ fs [name_def] \\ CONV_TAC (DEPTH_CONV ETA_CONV) \\ fs [])
+  THEN1 (* If *)
+   (reverse (Cases_on ‘dest_case_enum (HD xs) (If t xs x x')’)
+    THEN1
+     (fs [exp2v_def]
+      \\ once_rewrite_tac [v2exp_def] \\ fs [list_def,name_def]
+      \\ pop_assum mp_tac
+      \\ simp [Once (DefnBase.one_line_ify NONE dest_case_enum_def), AllCaseEqs()]
+      \\ strip_tac \\ rw []
+      \\ qabbrev_tac ‘z = HD xs’ \\ rw []
+      \\ fs [enum2v_def] \\ simp [Once v2exp_def]
+      \\ imp_res_tac dest_case_enum_IMP
+      \\ pop_assum match_mp_tac \\ rw [] \\ res_tac)
+    \\ Cases_on ‘dest_case_tree (get_Op_Head (EL 1 xs)) (If t xs x x')’
+    THEN1
+     (fs [exp2v_def] \\ drule v2exps_list_exp2v \\ strip_tac
+      \\ once_rewrite_tac [v2exp_def] \\ fs [list_def,name_def]
+      \\ CONV_TAC (DEPTH_CONV ETA_CONV) \\ fs []
+      \\ Cases_on ‘t’ \\ EVAL_TAC)
+    \\ fs [exp2v_def]
+    \\ once_rewrite_tac [v2exp_def] \\ fs [list_def,name_def]
+    \\ pop_assum mp_tac
+    \\ simp [Once (DefnBase.one_line_ify NONE dest_case_tree_def), AllCaseEqs()]
+    \\ strip_tac \\ rw []
+    \\ qabbrev_tac ‘z = get_Op_Head (EL 1 xs)’ \\ rw []
+    \\ pairarg_tac \\ fs [] \\ rw []
+    \\ fs [row2v_def] \\ simp [Once v2exp_def]
+    \\ imp_res_tac dest_case_lets_IMP \\ fs []
+    \\ imp_res_tac dest_case_tree_IMP \\ fs []
+    \\ pop_assum match_mp_tac  \\ rw [] \\ res_tac)
+  THEN1
+   (fs [exp2v_def,list_def]
+    \\ once_rewrite_tac [v2exp_def] \\ fs [list_def,name_def])
+  THEN1
+   (Cases_on ‘MEM n (MAP name protected_names)’ \\ fs [exp2v_def]
+    THEN1
+     (drule v2exps_list_exp2v \\ strip_tac
+      \\ once_rewrite_tac [v2exp_def |> SIMP_RULE (srw_ss()) [name_def]]
+      \\ simp [AllCaseEqs(),list_def,name_def]
+      \\ CONV_TAC (DEPTH_CONV ETA_CONV) \\ fs [])
+    \\ Cases_on ‘is_upper n’ \\ fs [exp2v_def]
+    \\ drule v2exps_list_exp2v \\ strip_tac
+    THEN1
+     (once_rewrite_tac [v2exp_def |> SIMP_RULE (srw_ss()) [name_def]]
+      \\ simp [AllCaseEqs(),list_def,name_def]
+      \\ CONV_TAC (DEPTH_CONV ETA_CONV) \\ fs [])
+    \\ qpat_x_assum ‘~MEM _ _’ (fn th => assume_tac (CONV_RULE EVAL th))
+    \\ pop_assum mp_tac \\ rewrite_tac [DE_MORGAN_THM]
+    \\ once_rewrite_tac [v2exp_def |> SIMP_RULE (srw_ss()) [name_def]]
+    \\ rewrite_tac [list_def] \\ simp_tac (srw_ss()) [LET_THM]
+    \\ CONV_TAC (DEPTH_CONV ETA_CONV) \\ asm_rewrite_tac [])
+  \\ fs [exp2v_def]
+  \\ once_rewrite_tac [v2exp_def |> SIMP_RULE (srw_ss()) [name_def]]
+  \\ fs [] \\ rename [‘is_Let y’]
+  \\ Cases_on ‘is_Let y’ \\ fs []
+  \\ rw [] \\ qsuff_tac ‘F’ \\ fs []
+  \\ pop_assum mp_tac \\ fs []
+  \\ Cases_on ‘y’ \\ fs [is_Let_def,exp2v_def]
+  \\ fs [] \\ rename [‘is_Let y’]
+  \\ Cases_on ‘is_Let y’ \\ fs []
+  \\ Cases_on ‘y’ \\ fs [is_Let_def,exp2v_def]
+QED
+
+Theorem v2dec_dec2v:
+  ∀x. v2dec (dec2v x) = x
+Proof
+  Cases \\ fs [dec2v_def,list_def,v2dec_def,list_v2list,v2exp_exp2v]
+  \\ Induct_on ‘l’ \\ fs [vs2args_def,exp2v_def]
+QED
+
+Theorem vs2prog_prog2vs:
+  ∀x. vs2prog (prog2vs x) = x
+Proof
+  Cases \\ Induct_on ‘l’
+  \\ fs [prog2vs_def,vs2prog_def,v2exp_exp2v]
+  \\ Cases_on ‘prog2vs (Program l e)’
+  \\ fs [prog2vs_def,vs2prog_def,v2dec_dec2v]
+  \\ Cases_on ‘l’ \\ fs [prog2vs_def]
+QED
+
+(* putting everything together *)
+
+Theorem parser_lexer_prog2str:
+  ∀p coms. parser (lexer (prog2str p coms)) = p
+Proof
+  fs [parser_def,prog2str_def,parse_lexer_vs2str,list_v2list,vs2prog_prog2vs]
+QED
+
+val _ = export_theory();

--- a/examples/bootstrap/printingScript.sml
+++ b/examples/bootstrap/printingScript.sml
@@ -1,0 +1,424 @@
+
+open HolKernel Parse boolLib bossLib;
+open arithmeticTheory listTheory pairTheory finite_mapTheory stringTheory;
+open source_valuesTheory source_syntaxTheory mp_then;
+
+val _ = new_theory "printing";
+
+
+(* pretty printing v *)
+
+Definition num2str_def:
+  num2str n = if n < 10 then [CHR (48 + n)] else
+                num2str (n DIV 10) ++ [CHR (48 + (n MOD 10))]
+End
+
+Definition num2ascii_def:
+  num2ascii n =
+    if n = 0 then NONE else
+      let k = n MOD 256 in
+        if (ORD #"*" ≤ k ∧ k ≤ ORD #"z" ∧ k ≠ ORD #".") then
+          if n < 256 then SOME [CHR k] else
+            case num2ascii (n DIV 256) of
+            | NONE => NONE
+            | SOME s => SOME (s ++ [CHR k])
+        else NONE
+End
+
+Definition ascii_name_def:
+  ascii_name n =
+    case num2ascii n of
+    | NONE => NONE
+    | SOME s => let k = ORD (HD s) in
+                  if ORD #"0" ≤ k ∧ k ≤ ORD #"9" then NONE else SOME s
+End
+
+Definition name2str_def:
+  name2str n =
+    case ascii_name n of NONE => num2str n | SOME s => s
+End
+
+Definition dest_quote_def:
+  dest_quote v =
+    case v of
+    | (Pair x (Pair (Num n) (Num 0))) =>
+        (if x = Num (name "'") then SOME ("'" ++ name2str n) else NONE)
+    | _ => NONE
+End
+
+Definition dest_list_def:
+  dest_list (Num n) = ([],Num n) ∧
+  dest_list (Pair x y) = let (l,e) = dest_list y in (x::l,e)
+End
+
+Theorem dest_list_size:
+  ∀v e l.
+    (l,e) = dest_list v ⇒
+    v_size e ≤ v_size v ∧
+    (~isNum v ⇒ v_size e < v_size v) ∧
+    ∀x. MEM x l ⇒ v_size x < v_size v
+Proof
+  Induct_on ‘v’ \\ fs [dest_list_def,isNum_def]
+  \\ pairarg_tac \\ fs [] \\ rw [] \\ res_tac \\ fs [v_size_def]
+QED
+
+Datatype:
+  pretty = Parenthesis pretty
+         | Str string | Append pretty bool pretty | Size num pretty
+End
+
+Definition newlines_def:
+  newlines [] = Str "" ∧
+  newlines [x] = x ∧
+  newlines (x::xs) = Append x T (newlines xs)
+End
+
+Definition v2pretty_def:
+  v2pretty v =
+    case v of Num n => Str (name2str n) | _ =>
+    case dest_quote v of SOME s => Str s | NONE =>
+      let (l,e) = dest_list v in
+        Parenthesis
+          (if e = Num 0 then newlines (MAP v2pretty l) else
+             Append (newlines (MAP v2pretty l)) T
+               (Append (Str " . ") T (v2pretty e)))
+Termination
+  WF_REL_TAC ‘measure v_size’ \\ rw []
+  \\ imp_res_tac dest_list_size \\ fs [v_size_def,isNum_def]
+End
+
+Definition get_size_def:
+  get_size (Size n x) = n ∧
+  get_size (Append x _ y) = get_size x + get_size y + 1 ∧
+  get_size (Parenthesis x) = get_size x + 2 ∧
+  get_size _ = 0
+End
+
+Definition get_next_size_def:
+  get_next_size (Size n x) = n ∧
+  get_next_size (Append x _ y) = get_next_size x ∧
+  get_next_size (Parenthesis x) = get_next_size x + 2 ∧
+  get_next_size _ = 0
+End
+
+Definition annotate_def:
+  annotate (Str s) = Size (LENGTH s) (Str s) ∧
+  annotate (Parenthesis b) =
+    (let b = annotate b in
+       Size (get_size b + 2) (Parenthesis b)) ∧
+  annotate (Append b1 n b2) =
+    (let b1 = annotate b1 in
+     let b2 = annotate b2 in
+       (* Size (get_size b1 + get_size b2 + 1) *) (Append b1 n b2)) ∧
+  annotate (Size n b) = annotate b
+End
+
+Definition remove_all_def:
+  remove_all (Parenthesis v) = Parenthesis (remove_all v) ∧
+  remove_all (Str v1) = Str v1 ∧
+  remove_all (Append v2 _ v3) = Append (remove_all v2) F (remove_all v3) ∧
+  remove_all (Size v4 v5) = remove_all v5
+End
+
+Definition smart_remove_def:
+  smart_remove i k (Size n b) =
+    (if k + n < 70 then remove_all b else smart_remove i k b) ∧
+  smart_remove i k (Parenthesis v) = Parenthesis (smart_remove (i+1) (k+1) v) ∧
+  smart_remove i k (Str v1) = Str v1 ∧
+  smart_remove i k (Append v2 b v3) =
+    let n2 = get_size v2 in
+    let n3 = get_next_size v3 in
+      if k + n2 + n3 < 50 then
+        Append (smart_remove i k v2) F (smart_remove i (k+n2) v3)
+      else
+        Append (smart_remove i k v2) T (smart_remove i i v3)
+End
+
+Definition flatten_def:
+  flatten indent (Size n p) s = flatten indent p s ∧
+  flatten indent (Parenthesis p) s = "(" ++ flatten (indent ++ "   ") p (")" ++ s) ∧
+  flatten indent (Str t) s = t ++ s ∧
+  flatten indent (Append p1 b p2) s =
+    flatten indent p1 ((if b then indent else " ") ++ flatten indent p2 s)
+End
+
+Definition v2str_def:
+  v2str v = flatten "\n" (smart_remove 0 0 (annotate (v2pretty v))) ""
+End
+
+Definition is_comment_def:
+  is_comment [] = T ∧
+  is_comment (c::cs) =
+    if c = CHR 35 then
+      (case dropWhile (λx. x ≠ CHR 10) cs of
+       | [] => F
+       | (c::cs) => is_comment cs)
+    else if c = CHR 10 then is_comment cs else F
+Termination
+  WF_REL_TAC ‘measure LENGTH’ \\ rw []
+  \\ rename [‘dropWhile f xs’]
+  \\ qspecl_then [‘f’,‘xs’] mp_tac LENGTH_dropWhile_LESS_EQ
+  \\ fs []
+End
+
+Definition vs2str_def:
+  vs2str [] coms = "\n" ∧
+  vs2str (x::xs) coms =
+    ((case coms of [] => [] | (c::cs) => if is_comment c then c else []) ++
+    ("\n" ++ (v2str x ++ ("\n" ++ vs2str xs (case coms of [] => [] | c::cs => cs)))))
+End
+
+
+(* converting prog to v *)
+
+Definition op2str_def:
+  op2str Add = "+" ∧
+  op2str Sub = "-" ∧
+  op2str Div = "div" ∧
+  op2str Cons = "cons*" ∧
+  op2str Head = "head" ∧
+  op2str Tail = "tail" ∧
+  op2str Read = "read" ∧
+  op2str Write = "write"
+End
+
+Definition test2str_def:
+  test2str Less = "<" ∧
+  test2str Equal = "="
+End
+
+Definition protected_names_def:
+  protected_names =
+    (* does not need to include "defun" *)
+    ["'"; "if"; "let"; "call"; "+"; "-"; "div"; "<"; "="; "cons"; "cons*";
+     "head"; "tail"; "read"; "write"; "list"; "case"; "var"]
+End
+
+Definition dest_cons_chain_def:
+  dest_cons_chain (Op Cons [x; y]) =
+    (case dest_cons_chain y of
+     | NONE => SOME [x; y]
+     | SOME xs => SOME (x :: xs)) ∧
+  dest_cons_chain _ = NONE
+End
+
+Theorem dest_cons_chain_size:
+  ∀x vs. dest_cons_chain x = SOME vs ⇒ exp1_size vs + op_size Cons + 1 ≤ exp_size x
+Proof
+  completeInduct_on ‘exp_size x’ \\ rw [] \\ fs [PULL_FORALL]
+  \\ qpat_x_assum ‘dest_cons_chain _ = SOME _’ mp_tac
+  \\ once_rewrite_tac [DefnBase.one_line_ify NONE dest_cons_chain_def]
+  \\ fs [AllCaseEqs()] \\ rw []
+  THEN1 (rw [] \\ fs [] \\ fs [exp_size_def])
+  \\ first_assum (first_assum o mp_then Any mp_tac)
+  \\ strip_tac \\ fs [exp_size_def]
+QED
+
+Definition up_const_def:
+  up_const (Const n::_) = (if is_upper n then SOME n else NONE) ∧
+  up_const _ = NONE
+End
+
+Definition is_Let_def[simp]:
+  is_Let (Let _ _ _) = T ∧
+  is_Let _ = F
+End
+
+Theorem exp_size_non_zero:
+  exp_size y ≠ 0
+Proof
+  Cases_on ‘y’ \\ fs [exp_size_def]
+QED
+
+Triviality FRONT_exp1_size:
+  ¬NULL v ⇒ exp1_size (FRONT v) ≤ exp1_size v
+Proof
+  Cases_on ‘v = []’ \\ fs []
+  \\ qspec_then ‘v’ mp_tac SNOC_CASES \\ asm_rewrite_tac []
+  \\ strip_tac \\ full_simp_tac std_ss [FRONT_SNOC]
+  \\ rw [] \\ fs [SNOC_APPEND]
+  \\ Induct_on ‘l’ \\ fs [exp_size_def]
+QED
+
+Definition dest_case_lets_def:
+  dest_case_lets z (Let v x y) =
+    (if x ≠ Op Head [z] then ([], Let v x y) else
+       let (vs,t) = dest_case_lets (Op Tail [z]) y in
+         (v::vs,t)) ∧
+  dest_case_lets z r = ([],r)
+End
+
+Definition dest_case_tree_def:
+  dest_case_tree y (Const n) = (if n = 0 then SOME [] else NONE) ∧
+  dest_case_tree y (If Equal [Const k; x] t1 t2) =
+    (if x ≠ Op Head [y] then NONE else
+       case dest_case_tree y t2 of
+       | NONE => NONE
+       | SOME rows =>
+          let (vars,rhs) = dest_case_lets (Op Tail [y]) t1 in
+            SOME ((k,vars,rhs)::rows)) ∧
+  dest_case_tree y _ = NONE
+End
+
+Definition row2v_def:
+  row2v [] = Num 0 ∧
+  row2v ((k,vars,v)::rest) = cons (list [list (Num k :: MAP Num vars); v]) (row2v rest)
+End
+
+Definition get_Op_Head_def:
+  get_Op_Head (Op Head [x]) = x ∧
+  get_Op_Head _ = Const 0
+End
+
+Definition dest_case_enum_def:
+  dest_case_enum y (Const n) = (if n = 0 then SOME [] else NONE) ∧
+  dest_case_enum y (If Equal [x; Const k] t1 t2) =
+    (if x ≠ y then NONE else
+     if k = name "_" then NONE else
+       case dest_case_enum y t2 of
+       | NONE => NONE
+       | SOME rows => SOME ((SOME k,t1)::rows)) ∧
+  dest_case_enum y (If Less [Const n; Const m] t1 t2) =
+    (if n ≠ 0 ∨ m ≠ 1 then NONE else
+       case dest_case_enum y t2 of
+       | NONE => NONE
+       | SOME rows => SOME ((NONE,t1)::rows)) ∧
+  dest_case_enum y _ = NONE
+End
+
+Definition enum2v_def:
+  enum2v [] = Num 0 ∧
+  enum2v ((NONE,v)::rest) = cons (list [Name "_"; v]) (enum2v rest) ∧
+  enum2v ((SOME k,v)::rest) =  cons (list [Num k; v]) (enum2v rest)
+End
+
+Theorem dest_case_enum_exp_size:
+  ∀z a t xs y rows.
+    dest_case_enum a (If t xs y z) = SOME rows ⇒
+    (MEM (x,e) rows ⇒ exp_size e < exp_size y + exp_size z)
+Proof
+  gen_tac \\ completeInduct_on ‘exp_size z’
+  \\ gen_tac \\ strip_tac \\ fs [PULL_FORALL]
+  \\ simp [Once (DefnBase.one_line_ify NONE dest_case_enum_def), AllCaseEqs()]
+  \\ fs [PULL_EXISTS]
+  \\ rpt gen_tac \\ strip_tac
+  \\ rpt BasicProvers.var_eq_tac
+  \\ rw [] \\ fs [exp_size_def]
+  \\ TRY (Cases_on ‘z’ \\ fs [exp_size_def] \\ NO_TAC)
+  \\ Cases_on ‘z’ \\ fs [dest_case_enum_def]
+  \\ rw [] \\ fs [exp_size_def]
+  \\ rename [‘If _ _ _ e4’]
+  \\ first_x_assum (qspec_then ‘e4’ mp_tac)
+  \\ fs [exp_size_def]
+  \\ disch_then drule \\ fs []
+QED
+
+Theorem dest_case_lets_exp_size:
+  ∀x y vars e. dest_case_lets x y = (vars,e) ⇒ exp_size e ≤ exp_size y
+Proof
+  ho_match_mp_tac dest_case_lets_ind
+  \\ fs [dest_case_lets_def]
+  \\ rw [] \\ pairarg_tac \\ fs [] \\ rw []
+  \\ fs [exp_size_def]
+QED
+
+Theorem dest_case_tree_exp_size:
+  ∀z a t xs y rows.
+    dest_case_tree a (If t xs y z) = SOME rows ⇒
+    (MEM (x,vs,e) rows ⇒ exp_size e < exp_size y + exp_size z) ∧
+    exp_size a < exp1_size xs
+Proof
+  gen_tac \\ completeInduct_on ‘exp_size z’
+  \\ gen_tac \\ strip_tac \\ fs [PULL_FORALL]
+  \\ simp [Once (DefnBase.one_line_ify NONE dest_case_tree_def), AllCaseEqs()]
+  \\ fs [PULL_EXISTS]
+  \\ rpt gen_tac \\ strip_tac
+  \\ pairarg_tac \\ fs []
+  \\ rpt BasicProvers.var_eq_tac
+  \\ rw [] \\ fs [exp_size_def]
+  THEN1
+   (‘exp_size z ≠ 0’ by (Cases_on ‘z’ \\ fs [exp_size_def])
+    \\ imp_res_tac dest_case_lets_exp_size \\ fs [])
+  \\ Cases_on ‘z’ \\ fs [dest_case_tree_def]
+  \\ rw [] \\ fs []
+  \\ rename [‘If _ _ _ e4’]
+  \\ first_x_assum (qspec_then ‘e4’ mp_tac)
+  \\ fs [exp_size_def]
+  \\ disch_then drule \\ fs []
+QED
+
+Definition exp2v_def:
+  exp2v (Var v) =
+    (if is_upper v then list [Num (name "var"); Num v] else Num v) ∧
+  exp2v (Const n) =
+    (if is_upper n then Num n else list [Num (name "'"); Num n]) ∧
+  exp2v (Op op es) =
+    (case dest_cons_chain (Op op es) of
+     | SOME es =>
+         if ~NULL es ∧ LAST es = Const 0 then
+           (case up_const es of
+            | NONE => list ([Name "list"] ++ MAP exp2v (FRONT es))
+            | SOME k => list (Num k :: MAP exp2v (FRONT (TL es))))
+         else list ([Name "cons"] ++ MAP exp2v es)
+     | NONE => list ([Name (op2str op)] ++ MAP exp2v es)) ∧
+  exp2v (If t xs y z) =
+    (case dest_case_enum (HD xs) (If t xs y z) of
+     | SOME rows => cons (Name "case") (cons (exp2v (HD xs))
+                      (enum2v (MAP (λ(x,e). (x,exp2v e)) rows)))
+     | NONE =>
+       case dest_case_tree (get_Op_Head (EL 1 xs)) (If t xs y z) of
+       | SOME rows => cons (Name "case") (cons (exp2v (get_Op_Head (EL 1 xs)))
+                        (row2v (MAP (λ(x,vs,e). (x,vs,exp2v e)) rows)))
+       | NONE =>
+          list [Num (name "if");
+                list (Num (name (test2str t)) :: MAP exp2v xs); exp2v y; exp2v z]) ∧
+  exp2v (Let v x y) =
+    (cons (Name "let") (lets2v (Let v x y))) ∧
+  exp2v (Call n es) =
+    (if MEM n (MAP name protected_names) ∨ is_upper n then
+       list ([Num (name "call"); Num n] ++ MAP exp2v es)
+     else list ([Num n] ++ MAP exp2v es)) ∧
+  lets2v (Let v x y) = (cons (list [Num v; exp2v x])
+                             (if is_Let y then lets2v y else list [exp2v y])) ∧
+  lets2v _ = Num 0
+Termination
+  WF_REL_TAC ‘measure (λx. case x of INL v => exp_size v + 1
+                                   | INR v => exp_size v)’ \\ rw []
+  \\ imp_res_tac dest_cons_chain_size
+  \\ fs [exp_size_def]
+  \\ ‘∀es a. MEM a es ⇒ exp_size a ≤ exp1_size es’
+       by (Induct \\ rw [] \\ res_tac \\ fs [exp_size_def])
+  \\ TRY (rw [] \\ res_tac \\ fs [] \\ NO_TAC)
+  \\ res_tac \\ fs []
+  \\ imp_res_tac dest_case_enum_exp_size \\ fs [exp_size_def]
+  \\ imp_res_tac dest_case_tree_exp_size \\ fs [exp_size_def]
+  \\ TRY (Cases_on ‘op’) \\ fs [dest_cons_chain_def]
+  \\ ‘exp_size x ≠ 0 ∧ exp_size y ≠ 0’ by fs [exp_size_non_zero] \\ fs []
+  \\ imp_res_tac FRONT_exp1_size \\ fs []
+  THEN1 (Cases_on ‘xs’ \\ fs [dest_case_enum_def,exp_size_def])
+  \\ Cases_on ‘v’ \\ fs []
+  \\ Cases_on ‘NULL t’
+  \\ imp_res_tac FRONT_exp1_size \\ fs [exp_size_def]
+  \\ Cases_on ‘t’ \\ fs []
+  \\ fs [DefnBase.one_line_ify NONE up_const_def, AllCaseEqs()]
+  \\ rw [] \\ fs [EVAL “is_upper 0”]
+End
+
+Definition dec2v_def:
+  dec2v (Defun n params body) =
+    list [Num (name "defun"); Num n; list (MAP Num params); exp2v body]
+End
+
+Definition prog2vs_def:
+  prog2vs (Program [] main) = [exp2v main] ∧
+  prog2vs (Program (d::ds) main) = dec2v d :: prog2vs (Program ds main)
+End
+
+
+(* entire pretty printer *)
+
+Definition prog2str_def:
+  prog2str p = vs2str (prog2vs p)
+End
+
+val _ = export_theory();

--- a/examples/bootstrap/source_propertiesScript.sml
+++ b/examples/bootstrap/source_propertiesScript.sml
@@ -1,0 +1,640 @@
+
+open HolKernel Parse boolLib bossLib;
+open arithmeticTheory listTheory pairTheory finite_mapTheory stringTheory llistTheory;
+open source_valuesTheory source_syntaxTheory source_semanticsTheory mp_then;
+
+val _ = new_theory "source_properties";
+
+
+(* In this file we prove that the big-step relational semantics (--->)
+   is equal to a special case of the big-step functional semantics (evals).
+
+  (env, xs, s) ---> (vs, s')
+  =
+  ∃ck. evals env xs (s with clock := ck) = (Res vs, s') ∧
+       s.clock = s'.clock
+
+   This is theorem Eval_eq_evals.
+
+   This file also proves theorems that are used in proof automation. *)
+
+
+Theorem evals_set_clock:
+  (∀env x s r s'.
+     eval env x s = (Res r,s') ⇒
+     ∀ck. ∃ck0. eval env x (s with clock := ck0) = (Res r,s' with clock := ck)) ∧
+  (∀env xs s r s'.
+     evals env xs s = (Res r,s') ⇒
+     ∀ck. ∃ck0. evals env xs (s with clock := ck0) = (Res r,s' with clock := ck))
+Proof
+  ho_match_mp_tac eval_ind \\ rw []
+  THEN1 fs [eval_def,state_component_equality]
+  THEN1 fs [eval_def,state_component_equality,AllCaseEqs()]
+  THEN1
+   (fs [eval_def,state_component_equality,AllCaseEqs()]
+    \\ rw [] \\ fs [PULL_EXISTS]
+    \\ first_x_assum (qspec_then ‘ck’ mp_tac) \\ strip_tac
+    \\ qexists_tac ‘ck0’ \\ fs []
+    \\ fs [eval_op_def,AllCaseEqs(),return_def,fail_def] \\ fs [])
+  THEN1
+   (fs [eval_def,state_component_equality,AllCaseEqs()]
+    \\ rw [] \\ fs [PULL_EXISTS]
+    \\ last_x_assum (qspec_then ‘ck’ mp_tac) \\ strip_tac
+    \\ last_x_assum (qspec_then ‘ck0’ mp_tac) \\ strip_tac
+    \\ qexists_tac ‘ck0'’ \\ fs [])
+  THEN1
+   (fs [eval_def,state_component_equality,AllCaseEqs()]
+    \\ rw [] \\ fs [PULL_EXISTS]
+    \\ last_x_assum (qspec_then ‘ck’ mp_tac) \\ strip_tac
+    \\ last_x_assum (qspec_then ‘ck0’ mp_tac) \\ strip_tac
+    \\ qexists_tac ‘ck0'’ \\ fs []
+    \\ fs [take_branch_def,AllCaseEqs(),fail_def,return_def]
+    \\ rw [] \\ fs [])
+  THEN1
+   (fs [eval_def,state_component_equality,AllCaseEqs()]
+    \\ rw [] \\ fs [PULL_EXISTS]
+    \\ last_x_assum (qspec_then ‘ck’ mp_tac) \\ strip_tac
+    \\ last_x_assum (qspec_then ‘ck0+1’ mp_tac) \\ strip_tac
+    \\ qexists_tac ‘ck0'’ \\ fs []
+    \\ fs [get_env_and_body_def,env_and_body_def,AllCaseEqs(),fail_def,return_def]
+    \\ rw [] \\ fs [])
+  THEN1 fs [eval_def,state_component_equality,AllCaseEqs()]
+  THEN1
+   (fs [eval_def,state_component_equality,AllCaseEqs()]
+    \\ rw [] \\ fs [PULL_EXISTS]
+    \\ last_x_assum (qspec_then ‘ck’ mp_tac) \\ strip_tac
+    \\ last_x_assum (qspec_then ‘ck0’ mp_tac) \\ strip_tac
+    \\ qexists_tac ‘ck0'’ \\ fs [])
+QED
+
+Theorem eval_set_clock = CONJUNCT1 evals_set_clock;
+Theorem evals_set_clock = CONJUNCT2 evals_set_clock;
+
+
+Theorem Eval_imp_evals:
+  ∀env xs s vs s'.
+    (env, xs, s) ---> (vs, s') ⇒
+      ∃ck. evals env xs (s with clock := ck) = (Res vs, s') ∧ s.clock = s'.clock
+Proof
+  ho_match_mp_tac (Eval_ind
+    |> Q.SPEC ‘λ(env,xs,s) (vs,s'). P env xs s vs s'’
+    |> SIMP_RULE (srw_ss()) [FORALL_PROD] |> GEN_ALL)
+  \\ rw [] \\ fs [eval_def,state_component_equality]
+  THEN1 (fs [eval_def,AllCaseEqs()]
+    \\ drule eval_set_clock
+    \\ disch_then (qspec_then ‘ck'’ mp_tac)
+    \\ strip_tac \\ fs []
+    \\ qexists_tac ‘ck0’ \\ fs [])
+  THEN1 (fs [eval_def,AllCaseEqs(),eval_op_def,fail_def,return_def] \\ rw []
+    \\ qexists_tac ‘ck’ \\ fs [])
+  THEN1
+   (fs [eval_def,AllCaseEqs()]
+    \\ last_x_assum assume_tac
+    \\ drule eval_set_clock
+    \\ disch_then (qspec_then ‘ck'’ mp_tac)
+    \\ strip_tac \\ fs []
+    \\ qexists_tac ‘ck0’ \\ fs [])
+  \\ fs [eval_def,AllCaseEqs()]
+  \\ drule evals_set_clock
+  \\ TRY
+    (disch_then (qspec_then ‘ck'’ mp_tac)
+     \\ strip_tac \\ fs []
+     \\ qexists_tac ‘ck0’ \\ fs []
+     \\ fs [take_branch_def,AllCaseEqs(),return_def,fail_def] \\ NO_TAC)
+  \\ disch_then (qspec_then ‘ck'+1’ mp_tac)
+  \\ strip_tac \\ fs []
+  \\ qexists_tac ‘ck0’ \\ fs []
+  \\ fs [AllCaseEqs(),return_def,fail_def,get_env_and_body_def,env_and_body_def]
+QED
+
+Theorem evals_imp_Eval:
+  ∀ck env xs s vs s'.
+    evals env xs s = (Res vs, s') ⇒
+    (env, xs, s with clock := ck) ---> (vs, s' with clock := ck)
+Proof
+  gen_tac \\ ho_match_mp_tac evals_ind \\ rw []
+  THEN1
+   (once_rewrite_tac [Eval_cases] \\ fs []
+    \\ fs [eval_def] \\ rw [] \\ fs [state_component_equality])
+  THEN1
+   (once_rewrite_tac [Eval_cases] \\ fs []
+    \\ fs [eval_def] \\ rw [] \\ fs [state_component_equality]
+    \\ fs [AllCaseEqs()] \\ rw [] \\ fs [])
+  THEN1
+   (once_rewrite_tac [Eval_cases] \\ fs []
+    \\ fs [eval_def,AllCaseEqs()] \\ rw [] \\ fs []
+    \\ goal_assum (first_assum o mp_then.mp_then mp_then.Any mp_tac)
+    \\ fs [eval_op_def,AllCaseEqs(),return_def,fail_def] \\ fs [])
+  THEN1
+   (once_rewrite_tac [Eval_cases] \\ fs []
+    \\ fs [eval_def,AllCaseEqs()] \\ rw [] \\ fs []
+    \\ goal_assum (first_assum o mp_then.mp_then mp_then.Any mp_tac) \\ fs [])
+  THEN1
+   (once_rewrite_tac [Eval_cases] \\ fs []
+    \\ fs [eval_def,AllCaseEqs()] \\ rw [] \\ fs []
+    \\ fs [take_branch_def,AllCaseEqs(),return_def,fail_def] \\ rw [] \\ fs []
+    \\ goal_assum (first_assum o mp_then.mp_then (mp_then.Pos (el 1)) mp_tac) \\ fs [])
+  THEN1
+   (once_rewrite_tac [Eval_cases] \\ fs []
+    \\ fs [eval_def,AllCaseEqs(),get_env_and_body_def,fail_def] \\ rw [] \\ fs []
+    \\ fs [env_and_body_def,AllCaseEqs(),return_def,fail_def] \\ rw [] \\ fs []
+    \\ goal_assum (first_assum o mp_then.mp_then (mp_then.Pos (el 1)) mp_tac) \\ fs [])
+  \\ fs [eval_def,AllCaseEqs()] \\ rw [] \\ fs [PULL_EXISTS]
+  THEN1 (once_rewrite_tac [Eval_cases] \\ fs [] \\ metis_tac [])
+  \\ Cases_on ‘xs’ \\ fs [eval_def]
+  \\ once_rewrite_tac [Eval_cases] \\ fs [] \\ metis_tac []
+QED
+
+Theorem Eval_eq_evals:
+  (env, xs, s1) ---> (vs, s2)
+  =
+  ∃ck. evals env xs (s1 with clock := ck) = (Res vs, s2) ∧
+       s1.clock = s2.clock
+Proof
+  eq_tac THEN1 metis_tac [Eval_imp_evals]
+  \\ rw [] \\ drule evals_imp_Eval \\ fs []
+  \\ qsuff_tac ‘s1 with clock := s2.clock = s1 ∧ s2 with clock := s1.clock = s2’
+  THEN1 metis_tac [] \\ fs [state_component_equality]
+QED
+
+
+(* Prove a more useful version of Eval_cases called Eval_eq *)
+
+val thms =
+  map (fn tm => Q.SPEC tm Eval_cases |> SIMP_RULE (srw_ss()) [])
+  [‘(env,[],s)’,
+   ‘(env,x::y::xs,s1)’,
+   ‘(env,[Const v],s)’,
+   ‘(env,[Var n],s)’,
+   ‘(env,[Op f xs],s1)’,
+   ‘(env,[Let n x y],s1)’,
+   ‘(env,[If test xs y z],s1)’,
+   ‘(env,[Call fname xs],s1)’]
+
+Triviality Call_eq:
+  (env,[Call fname xs],s1) ---> a1 ⇔
+  ∃vs s2 v s3.
+    (env,xs,s1) ---> (vs,s2) ∧
+    app fname vs s2 (v,s3) ∧ a1 = ([v],s3)
+Proof
+  fs thms \\ fs [app_cases,PULL_EXISTS] \\ metis_tac []
+QED
+
+Theorem Eval_eq = LIST_CONJ (butlast thms @ [Call_eq] |> map GEN_ALL);
+
+
+(* later states *)
+
+Definition later_def:
+  s1 ≤ s2 ⇔
+    s1.output ≼ s2.output ∧
+    LSUFFIX s1.input s2.input ∧
+    s2.clock = s1.clock ∧
+    s1.funs = s2.funs
+End
+
+Theorem later_refl:
+  ∀s. s ≤ (s:state)
+Proof
+  rewrite_tac [later_def] \\ fs []
+QED
+
+Theorem later_antisym:
+  ∀s1 s2. s1 ≤ s2 ∧ s2 ≤ s1 ∧ LFINITE s1.input ⇒ s1 = s2
+Proof
+  once_rewrite_tac [state_component_equality]
+  \\ rewrite_tac [later_def,rich_listTheory.IS_SUFFIX_compute] \\ rpt strip_tac
+  \\ imp_res_tac rich_listTheory.IS_PREFIX_ANTISYM
+  \\ imp_res_tac LSUFFIX_ANTISYM
+  \\ metis_tac [listTheory.REVERSE_11]
+QED
+
+Theorem later_trans:
+  ∀s1 s2 s3. s1 ≤ s2 ∧ s2 ≤ s3 ⇒ s1 ≤ s3
+Proof
+  rewrite_tac [later_def] \\ rw []
+  \\ imp_res_tac llistTheory.LPREFIX_TRANS
+  \\ metis_tac [rich_listTheory.IS_PREFIX_TRANS,LSUFFIX_TRANS]
+QED
+
+Theorem eval_op_later:
+  eval_op f vs s = (res,t) ⇒ s ≤ t
+Proof
+  fs [eval_op_def,AllCaseEqs(),fail_def,return_def] \\ rw []
+  \\ fs [later_refl] \\ fs [later_def]
+  \\ Cases_on ‘s.input’ \\ fs [] \\ Cases_on ‘t’ \\ fs [LSUFFIX]
+QED
+
+Theorem Eval_later:
+  (env,xs,s) ---> (vs,t) ⇒ s ≤ t
+Proof
+  qsuff_tac ‘∀s1 s2. s1 ---> s2 ==> SND (SND s1) ≤ SND s2’
+  THEN1 (fs [FORALL_PROD] \\ metis_tac [])
+  \\ ho_match_mp_tac Eval_strongind \\ rw [later_refl]
+  \\ imp_res_tac eval_op_later
+  \\ imp_res_tac later_trans \\ fs []
+QED
+
+
+(* Free variables *)
+
+Definition free_vars_def[simp]:
+  free_vars (Var x) = [x] ∧
+  free_vars (Const _) = [] ∧
+  free_vars (Op _ xs) = FLAT (MAP free_vars xs) ∧
+  free_vars (If _ xs  y z) = FLAT (MAP free_vars xs) ++ free_vars y ++ free_vars z ∧
+  free_vars (Let n x y) = free_vars x ++ FILTER (\k. k ≠ n) (free_vars y) ∧
+  free_vars (Call _ xs) = FLAT (MAP free_vars xs)
+Termination
+  WF_REL_TAC ‘measure exp_size’ \\ rw []
+  \\ qsuff_tac ‘!xs a. MEM a xs ==> exp_size a <= exp1_size xs’
+  \\ TRY (rw [] \\ res_tac \\ fs [] \\ NO_TAC)
+  \\ Induct \\ fs [] \\ rw [] \\ fs [exp_size_def]
+  \\ res_tac \\ fs []
+End
+
+Theorem delete_env_update:
+  (env,xs,s) ---> (vs,t) /\ ~MEM n (FLAT (MAP free_vars xs)) ==>
+  (env⦇n ↦ x⦈,xs,s) ---> (vs,t)
+Proof
+  qsuff_tac ‘∀s1 s2. s1 ---> s2 ==>
+               ∀env xs s vs t.
+                 s1 = (env,xs,s) /\ s2 = (vs,t) /\ s1 ---> s2 /\
+                 ~MEM n (FLAT (MAP free_vars xs)) ==>
+                 (env⦇n ↦ x⦈,xs,s) ---> (vs,t)’
+  THEN1 fs [PULL_FORALL]
+  \\ ho_match_mp_tac Eval_strongind \\ rw []
+  \\ rpt (pop_assum mp_tac)
+  \\ CONV_TAC (DEPTH_CONV ETA_CONV)
+  \\ rw [] \\ fs [MEM_FILTER]
+  \\ once_rewrite_tac [Eval_cases] \\ fs [combinTheory.APPLY_UPDATE_THM]
+  \\ TRY (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [] \\ NO_TAC)
+  \\ goal_assum (first_assum o mp_then (Pos (el 1)) mp_tac) \\ fs []
+  \\ Cases_on ‘n = n'’ \\ fs []
+  \\ metis_tac [combinTheory.UPDATE_COMMUTES]
+QED
+
+Theorem remove_env_update[simp]:
+  ¬MEM n (free_vars x0) ⇒
+  ((env⦇n ↦ SOME v⦈,[x0],s) ---> res <=> (env,[x0],s) ---> res)
+Proof
+  rw [] \\ eq_tac \\ rw [] \\ PairCases_on ‘res’
+  THEN1
+   (drule delete_env_update
+    \\ disch_then (qspecl_then [‘env n’,‘n’] mp_tac) \\ fs []
+    \\ qsuff_tac ‘env⦇n ↦ env n⦈ = env’ \\ simp_tac bool_ss [] \\ fs [])
+  \\ match_mp_tac delete_env_update \\ fs []
+QED
+
+
+(* Substitution *)
+
+fun get_induction_for_def def = let
+  fun mk_arg_vars xs = let
+    fun aux [] = []
+      | aux (x::xs) =
+          mk_var("v" ^ (int_to_string (length xs + 1)),type_of x) :: aux xs
+    in (rev o aux o rev) xs end
+  fun f tm = let
+    val (lhs,rhs) = dest_eq tm
+    val (const,args) = strip_comb lhs
+    val vargs = mk_arg_vars args
+    val args = pairSyntax.list_mk_pair args
+    in (const,vargs,args,rhs) end
+  val cs = def |> CONJUNCTS |> map (f o concl o SPEC_ALL)
+  val cnames = map (fn (x,_,_,_) => x) cs |> op_mk_set aconv
+  val cs = map (fn c => (c, map (fn (x,y,z,q) => (y,z,q))
+                              (filter (fn (x,_,_,_) => aconv c x) cs))) cnames
+           |> map (fn (c,x) => (c,hd (map (fn (x,y,z) => x) x),
+                                map (fn (x,y,z) => (y,z)) x))
+  fun split_at P [] = fail()
+    | split_at P (x::xs) = if P x then ([],x,xs) else let
+        val (x1,y1,z1) = split_at P xs
+        in (x::x1,y1,z1) end
+  fun find_pat_match (_,args,pats) = let
+    val pat = hd pats |> fst
+    val vs = pairSyntax.list_mk_pair args
+    val ss = fst (match_term vs pat)
+    val xs = map (subst ss) args
+    in (split_at (not o is_var) xs) end
+  val xs = map find_pat_match cs
+  val ty = map (fn (_,x,_) => type_of x) xs |> hd
+  val raw_ind = TypeBase.induction_of ty
+  fun my_mk_var ty = mk_var("pat_var", ty)
+  fun list_mk_fun_type [] = hd []
+    | list_mk_fun_type [ty] = ty
+    | list_mk_fun_type (t::ts) = mk_type("fun",[t,list_mk_fun_type ts])
+  fun goal_step index [] = []
+    | goal_step index ((xs,t,ys)::rest) = let
+    val v = my_mk_var (type_of t)
+    val args = xs @ [v] @ ys
+    val P = mk_var("P" ^ (int_to_string index) ,
+              list_mk_fun_type ((map type_of args) @ [bool]))
+    val prop = list_mk_comb(P,args)
+    val goal = list_mk_forall(args,prop)
+    val step = mk_abs(v,list_mk_forall(xs @ ys,prop))
+    in (P,(goal,step)) :: goal_step (index+1) rest end
+  val res = goal_step 0 xs
+  fun ISPEC_LIST [] th = th
+    | ISPEC_LIST (x::xs) th = ISPEC_LIST xs (ISPEC x th)
+  val ind = ISPEC_LIST (map (snd o snd) res) raw_ind
+            |> CONV_RULE (DEPTH_CONV BETA_CONV)
+  val goal1 = ind |> concl |> dest_imp |> snd
+  val goal2 = list_mk_conj (map (fst o snd) res)
+  val goal = mk_imp(goal1,goal2)
+  val lemma = snd ((REPEAT STRIP_TAC THEN ASM_REWRITE_TAC []) ([],goal)) []
+  val ind = MP lemma (ind |> UNDISCH_ALL) |> DISCH_ALL |> GENL (map fst res)
+  in ind end handle HOL_ERR _ =>
+  failwith "unable to construct induction theorem from TypeBase info"
+
+Definition subst_def:
+  subst v x (Var w) = SOME (if v = w then x else Var w) ∧
+  subst v x (Const n) = SOME (Const n) ∧
+  subst v x (Call d ys) = OPTION_MAP (Call d) (substs v x ys) ∧
+  subst v x (Op f ys) = OPTION_MAP (Op f) (substs v x ys) ∧
+  subst v x (If cmp xs y z) =
+    (case (substs v x xs, subst v x y, subst v x z) of
+     | (SOME xs, SOME y, SOME z) => SOME (If cmp xs y z)
+     | _ => NONE) ∧
+  subst v x (Let n y z) =
+    (case subst v x y of
+     | NONE => NONE
+     | SOME t =>
+         if n = v then SOME (Let n t z) else
+         if MEM n (free_vars x) then NONE else
+           OPTION_MAP (Let n t) (subst v x z)) ∧
+  substs v x [] = SOME [] ∧
+  substs v x (y::ys) =
+    (case subst v x y of
+     | NONE => NONE
+     | SOME t =>
+       case substs v x ys of
+       | NONE => NONE
+       | SOME ts => SOME (t::ts))
+End
+
+Theorem Eval_cons:
+  LFINITE s.input ⇒
+  (env,t::ts,s) ---> (vs,s) =
+  ∃v vs'. vs = v::vs' ∧ (env,[t],s) ---> ([v],s) ∧ (env,ts,s) ---> (vs',s)
+Proof
+  Cases_on ‘ts’ \\ fs [Eval_eq,PULL_EXISTS]
+  \\ Cases_on ‘t’ \\ fs [Eval_eq,PULL_EXISTS]
+  \\ Cases_on ‘vs’ \\ fs [app_cases]
+  \\ metis_tac [later_antisym,later_trans,Eval_later,eval_op_later]
+QED
+
+val later_tac =
+  imp_res_tac Eval_later \\ imp_res_tac eval_op_later
+  \\ imp_res_tac later_antisym \\ rpt BasicProvers.var_eq_tac \\ fs [];
+
+Theorem subst_thm:
+  LFINITE s.input ⇒
+  (∀v x y z env xv yv.
+    subst v x y = SOME z ∧
+    (env,[x],s) ---> ([xv],s) ∧
+    (env⦇v ↦ SOME xv⦈,[y],s) ---> ([yv],s) ⇒
+    (env,[z],s) ---> ([yv],s)) ∧
+  (∀v x ys zs env xv yvs.
+    substs v x ys = SOME zs ∧
+    (env,[x],s) ---> ([xv],s) ∧
+    (env⦇v ↦ SOME xv⦈,ys,s) ---> (yvs,s) ⇒
+    (env,zs,s) ---> (yvs,s))
+Proof
+  strip_tac
+  \\ ho_match_mp_tac (get_induction_for_def subst_def)
+  \\ rpt strip_tac
+  THEN1 (fs [subst_def,AllCaseEqs()] \\ rw [] \\ fs [])
+  THEN1 (fs [subst_def,AllCaseEqs()] \\ rw [] \\
+         fs [Eval_eq,combinTheory.APPLY_UPDATE_THM,AllCaseEqs()] \\ rw [])
+  THEN1
+   (fs [subst_def,AllCaseEqs(),Eval_eq] \\ rw [] \\ fs []
+    \\ first_x_assum drule
+    \\ later_tac
+    \\ rpt (disch_then drule) \\ rw []
+    \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+  THEN1
+   (fs [subst_def,AllCaseEqs()] \\ rw []
+    \\ rpt (first_x_assum drule)
+    \\ rpt (disch_then drule \\ strip_tac)
+    \\ fs [Eval_eq] \\ later_tac
+    \\ last_x_assum drule \\ strip_tac
+    \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+    \\ Cases_on ‘b’ \\ fs [] \\ metis_tac [])
+  THEN1
+   (fs [subst_def,AllCaseEqs()] \\ rw []
+    THEN1
+     (rpt (first_x_assum drule)
+      \\ rpt (disch_then drule \\ strip_tac)
+      \\ fs [Eval_eq] \\ later_tac
+      \\ last_x_assum drule \\ strip_tac
+      \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+    \\ fs [Eval_eq]
+    \\ last_x_assum drule
+    \\ rpt (disch_then drule)
+    \\ later_tac \\ fs []
+    \\ rpt (disch_then drule)
+    \\ rw []
+    \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+    \\ last_x_assum drule
+    \\ disch_then (qspec_then ‘env⦇n ↦ SOME v1⦈’ mp_tac)
+    \\ fs [] \\ disch_then drule
+    \\ disch_then match_mp_tac
+    \\ metis_tac [combinTheory.UPDATE_COMMUTES])
+  THEN1
+   (fs [subst_def,Eval_eq,AllCaseEqs(),app_cases] \\ rw [PULL_EXISTS]
+    \\ rpt (goal_assum (first_assum o mp_then (Pos last) mp_tac) \\ fs [])
+    \\ res_tac \\ later_tac)
+  \\ ntac 2 (fs [subst_def,Eval_eq,AllCaseEqs()] \\ rw [])
+  \\ pop_assum mp_tac
+  \\ drule Eval_cons
+  \\ disch_then (once_rewrite_tac o single)
+  \\ rpt strip_tac
+  \\ asm_rewrite_tac [CONS_11]
+  \\ metis_tac []
+QED
+
+
+(* Inlining of Let-expressions*)
+
+Definition inline_let_def:
+  inline_let p (Var v) = Var v ∧
+  inline_let p (Const n) = Const n ∧
+  inline_let p (Call d ys) = Call d (inline_lets p ys) ∧
+  inline_let p (Op f ys) = Op f (inline_lets p ys) ∧
+  inline_let p (If cmp xs y z) =
+    If cmp (inline_lets p xs) (inline_let p y) (inline_let p z) ∧
+  inline_let p (Let n y z) =
+    (let y = inline_let p y in
+     let z = inline_let p z in
+       if p n then
+         case subst n y z of
+         | NONE => Let n y z
+         | SOME res => res
+       else Let n y z) ∧
+  inline_lets p [] = [] ∧
+  inline_lets p (y::ys) = inline_let p y :: inline_lets p ys
+End
+
+Theorem inline_let_thm:
+  LFINITE s.input ⇒
+  (env,[x],s) ---> ([v],s) ⇒
+  ∀filter. (env,[inline_let filter x],s) ---> ([v],s)
+Proof
+  strip_tac \\ simp [PULL_FORALL] \\ gen_tac
+  \\ qsuff_tac
+    ‘∀x y.
+       x ---> y ⇒ ∀env xs vs. x = (env,xs,s) ∧ y = (vs,s) ⇒
+                              (env,inline_lets filter xs,s) ---> (vs,s)’
+  THEN1 (rw [] \\ res_tac \\ fs [inline_let_def])
+  \\ ho_match_mp_tac Eval_strongind
+  \\ rw [] \\ fs [inline_let_def] \\ fs [Eval_eq]
+  \\ later_tac \\ fs [inline_let_def]
+  \\ TRY (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+  \\ fs [app_cases] \\ rw []
+  \\ BasicProvers.every_case_tac \\ fs []
+  \\ fs [Eval_eq]
+  \\ TRY (goal_assum (first_assum o mp_then Any mp_tac) \\ fs [])
+  \\ last_x_assum assume_tac
+  \\ metis_tac [subst_thm]
+QED
+
+
+(* Misc *)
+
+Theorem eval_op_mono:
+  ∀f vs s res t. eval_op f vs s = (res,t) ⇒ s.output ≼ t.output
+Proof
+  fs [eval_op_def,AllCaseEqs(),fail_def,return_def] \\ rw [] \\ fs []
+QED
+
+Theorem eval_mono:
+  (∀env x s r t. eval env x s = (r,t) ⇒ s.output ≼ t.output) ∧
+  (∀env xs s r t. evals env xs s = (r,t) ⇒ s.output ≼ t.output)
+Proof
+  ho_match_mp_tac eval_ind \\ rw []
+  \\ fs [eval_def,AllCaseEqs()] \\ rw []
+  \\ res_tac \\ imp_res_tac eval_op_mono \\ fs []
+  \\ imp_res_tac rich_listTheory.IS_PREFIX_TRANS \\ rfs []
+  \\ fs [source_semanticsTheory.take_branch_def,fail_def,return_def,AllCaseEqs()]
+  \\ fs [get_env_and_body_def,fail_def,return_def,AllCaseEqs()] \\ rw []
+QED
+
+Theorem evals_length:
+  ∀xs env s args s1.
+    evals env xs s = (Res args,s1) ⇒ LENGTH args = LENGTH xs
+Proof
+  Induct \\ fs [eval_def,AllCaseEqs()] \\ rw [] \\ res_tac \\ fs []
+QED
+
+Theorem Eval_length:
+  ∀env xs s1 vs s2.
+    (env,xs,s1) ---> (vs,s2) ⇒ LENGTH xs = LENGTH vs
+Proof
+  ho_match_mp_tac (Eval_ind
+    |> Q.SPEC ‘λ(env,xs,s) (vs,s'). P env xs s vs s'’
+    |> SIMP_RULE (srw_ss()) [FORALL_PROD] |> GEN_ALL) \\ fs []
+QED
+
+Theorem Eval_two:
+  (env,[x1; x2],s1) ---> (vs,s2) =
+  ∃v1 v2 s'.
+    (env,[x1],s1) ---> ([v1],s') ∧
+    (env,[x2],s') ---> ([v2],s2) ∧ vs = [v1;v2]
+Proof
+  eq_tac \\ rw [] THEN1
+   (pop_assum mp_tac
+    \\ simp [Once Eval_cases] \\ rw [] \\ fs [] \\ imp_res_tac Eval_length
+    \\ fs [] \\ Cases_on ‘vs'’ \\ fs [] \\ rw [] \\ metis_tac [])
+  \\ simp [Once Eval_cases] \\ rw [] \\ fs [] \\ metis_tac []
+QED
+
+Theorem eval_from_prefix:  (* required for divergence proof *)
+  eval_from k1 input prog = (res1,t1) ∧
+  eval_from k2 input prog = (res2,t2) ∧
+  k1 ≤ k2 ⇒
+  t1.output ≼ t2.output
+Proof
+  qsuff_tac
+  ‘(∀env x s res1 t1 k.
+      eval env x s = (res1,t1) ∧ k <= s.clock ⇒
+      ∃res2 t2. eval env x (s with clock := k) = (res2,t2) ∧
+                t2.output ≼ t1.output ∧
+                (∀e. res1 = Err e ⇒ ∃e. res2 = Err e) ∧
+                ∀x. res2 = Res x ⇒ res1 = Res x ∧
+                    ∃k1. t2 = t1 with clock := k1 ∧ k1 ≤ t1.clock) ∧
+   (∀env xs s res1 t1 k.
+      evals env xs s = (res1,t1) ∧ k <= s.clock ⇒
+      ∃res2 t2. evals env xs (s with clock := k) = (res2,t2) ∧
+                t2.output ≼ t1.output ∧
+                (∀e. res1 = Err e ⇒ ∃e. res2 = Err e) ∧
+                ∀x. res2 = Res x ⇒ res1 = Res x ∧
+                    ∃k1. t2 = t1 with clock := k1 ∧ k1 ≤ t1.clock)’
+  THEN1
+   (Cases_on ‘prog’ \\ fs [eval_from_def] \\ rw []
+    \\ res_tac \\ fs [] \\ ntac 2 (first_x_assum mp_tac)
+    \\ disch_then drule \\ fs [])
+  \\ ho_match_mp_tac eval_ind \\ rw []
+  THEN1 (fs [eval_def] \\ rw [] \\ fs [state_component_equality])
+  THEN1 (fs [eval_def,AllCaseEqs()] \\ rw [] \\ fs [state_component_equality])
+  THEN1
+   (fs [eval_def,AllCaseEqs()] \\ rw []
+    \\ res_tac \\ fs [] \\ rw []
+    \\ reverse (Cases_on ‘res2’) \\ fs []
+    \\ rw [] \\ fs []
+    \\ imp_res_tac eval_op_mono \\ fs []
+    \\ imp_res_tac rich_listTheory.IS_PREFIX_TRANS \\ rw []
+    \\ last_x_assum drule \\ fs []
+    \\ fs [state_component_equality]
+    \\ fs [eval_op_def,AllCaseEqs(),fail_def,return_def]
+    \\ rw [] \\ fs [])
+  THEN1
+   (fs [eval_def,AllCaseEqs()] \\ rw []
+    \\ res_tac \\ fs [] \\ rw []
+    \\ reverse (Cases_on ‘res2’) \\ fs []
+    \\ imp_res_tac eval_mono \\ fs []
+    \\ imp_res_tac rich_listTheory.IS_PREFIX_TRANS \\ rw [])
+  THEN1
+   (reverse (fs [eval_def,AllCaseEqs()]) \\ rw [] \\ fs []
+    THEN1 (res_tac \\ fs [] \\ rw [])
+    \\ first_x_assum drule \\ rw [] \\ fs []
+    \\ reverse (Cases_on ‘res2’) \\ fs []
+    \\ fs [take_branch_def,AllCaseEqs(),fail_def,return_def]
+    \\ rw [] \\ fs []
+    \\ imp_res_tac eval_mono \\ fs []
+    \\ imp_res_tac rich_listTheory.IS_PREFIX_TRANS \\ rw [])
+  THEN1
+   (reverse (fs [eval_def,AllCaseEqs()]) \\ rw [] \\ fs []
+    THEN1 (res_tac \\ fs [] \\ rw [])
+    \\ first_x_assum drule \\ rw [] \\ fs []
+    \\ reverse (Cases_on ‘res2’) \\ fs []
+    \\ fs [get_env_and_body_def,AllCaseEqs(),fail_def,return_def]
+    \\ rw [] \\ fs [env_and_body_def]
+    \\ imp_res_tac eval_mono \\ fs []
+    \\ imp_res_tac rich_listTheory.IS_PREFIX_TRANS \\ rw []
+    \\ Cases_on ‘k1 = 0’ \\ fs [])
+  THEN1 (fs [eval_def] \\ rw [] \\ fs [state_component_equality])
+  \\ reverse (fs [eval_def,AllCaseEqs()]) \\ rw [] \\ fs []
+  THEN1 (res_tac \\ fs [] \\ rw [])
+  \\ first_x_assum drule \\ rw [] \\ fs []
+  \\ reverse (Cases_on ‘res2’) \\ fs []
+  \\ imp_res_tac eval_mono \\ fs []
+  \\ imp_res_tac rich_listTheory.IS_PREFIX_TRANS \\ rw []
+  \\ first_x_assum drule \\ rw [] \\ fs []
+  \\ reverse (Cases_on ‘res2’) \\ fs []
+  \\ imp_res_tac eval_mono \\ fs []
+  \\ imp_res_tac rich_listTheory.IS_PREFIX_TRANS \\ rw []
+  \\ fs [state_component_equality]
+QED
+
+Theorem eval_TimeOut_clock:
+  (∀env x s t. eval env x s = (Err TimeOut,t) ⇒ t.clock = 0) ∧
+  (∀env xs s t. evals env xs s = (Err TimeOut,t) ⇒ t.clock = 0)
+Proof
+  ho_match_mp_tac eval_ind \\ rw []
+  \\ fs [eval_def,AllCaseEqs(),eval_op_def,return_def,fail_def,
+         take_branch_def,get_env_and_body_def]
+  \\ rw [] \\ fs []
+QED
+
+val _ = export_theory();

--- a/examples/bootstrap/source_semanticsScript.sml
+++ b/examples/bootstrap/source_semanticsScript.sml
@@ -1,0 +1,342 @@
+
+open HolKernel Parse boolLib bossLib;
+open arithmeticTheory listTheory llistTheory pairTheory finite_mapTheory;
+open source_valuesTheory source_syntaxTheory stringTheory lprefix_lubTheory;
+
+val _ = new_theory "source_semantics";
+
+
+(* types *)
+
+Datatype:
+  state = <| funs : dec list        (* all defined functions                         *)
+           ; clock : num            (* clock for divergence preservation             *)
+           ; input : char llist     (* content of stdin, a potentially infinite list *)
+           ; output : char list |>  (* content of stdout, always a finite list       *)
+End
+
+Datatype:
+  err = TimeOut | Crash
+End
+
+Datatype:
+  result = Res 'a | Err err
+End
+
+
+(* helper functions for primitive operations etc. *)
+
+Definition return_def:
+  return v s = (Res v, s:state)
+End
+
+Definition fail_def:
+  fail s = (Err Crash, s:state)
+End
+
+Definition next_def:
+  next s =
+    case LHD s of
+    | NONE => Num (2 ** 32 - 1) (* EOF *)
+    | SOME c => Num (ORD c)
+End
+
+(* evaluation of primitive operations *)
+Definition eval_op_def:
+  eval_op f vs s =
+    case (f,vs) of
+    | (Add, [Num n1; Num n2]) => return (Num (n1 + n2)) s
+    | (Sub, [Num n1; Num n2]) => return (Num (n1 - n2)) s
+    | (Div, [Num n1; Num n2]) => if n2 = 0 then fail s else return (Num (n1 DIV n2)) s
+    | (Cons, [x; y]) => return (Pair x y) s
+    | (Head, [Pair x y]) => return x s
+    | (Tail, [Pair x y]) => return y s
+    | (Read, []) => return (next s.input)
+       (s with input := case LTL s.input of NONE => s.input | SOME t => t)
+    | (Write, [Num n]) =>
+       (if n < 256 then return (Num 0) (s with output := s.output ++ [CHR n])
+        else fail s)
+    | _ => fail s
+End
+
+Definition take_branch_def:
+  take_branch test vs s =
+    case (test,vs) of
+    | (Equal, [Pair x y; Num 0]) => return F s
+    | (Equal, [Num m; Num n]) => return (m = n) s
+    | (Less,  [Num m; Num n]) => return (m < n) s
+    | _ => fail s
+End
+
+Definition empty_env_def:
+  empty_env = (λx. NONE) :num -> v option
+End
+
+Definition make_env_def:
+  make_env [] [] acc = acc ∧
+  make_env (x::xs) (y::ys) acc = make_env xs ys ((x =+ SOME y) acc)
+End
+
+Definition lookup_fun_def:
+  lookup_fun n [] = NONE ∧
+  lookup_fun n (Defun k ps body :: rest) =
+    if k = n then SOME (ps,body) else lookup_fun n rest
+End
+
+Definition env_and_body_def:
+  env_and_body n args s =
+    case lookup_fun n s.funs of
+    | NONE => NONE
+    | SOME (params, body) =>
+      if LENGTH params ≠ LENGTH args then NONE
+      else SOME (make_env params args empty_env, body)
+End
+
+(* initially the output is empty *)
+Definition init_state_def:
+  init_state inp funs =
+    <| input := inp; output := ""; funs := funs |>
+End
+
+
+(* definition 1: a big-step relational semantics *)
+
+val _ = set_fixity "--->" (Infixl 489); (* the symbol we will use for the relation *)
+
+Inductive Eval:
+  (∀env v s.
+    (env, [Const v], s) ---> ([Num v], s))
+  ∧
+  (∀env n v s.
+    env n = SOME v ⇒
+    (env, [Var n], s) ---> ([v], s))
+  ∧
+  (∀env s.
+    (env, [], s) ---> ([], s))
+  ∧
+  (∀env x v y xs vs s1 s2 s3.
+    (env, [x], s1) ---> ([v], s2) ∧
+    (env, y::xs, s2) ---> (vs, s3) ⇒
+    (env, x::y::xs, s1) ---> (v::vs, s3))
+  ∧
+  (∀env xs vs s1 s2 s3 f v.
+    (env, xs, s1) ---> (vs, s2) ∧
+    eval_op f vs s2 = (Res v, s3) ⇒
+    (env, [Op f xs], s1) ---> ([v], s3))
+  ∧
+  (∀env x s1 v1 s2 n s3 v2.
+    (env, [x], s1) ---> ([v1], s2) ∧
+    ((n =+ SOME v1)env, [y], s2) ---> ([v2], s3) ⇒
+    (env, [Let n x y], s1) ---> ([v2], s3))
+  ∧
+  (∀env xs s1 vs s2 test b y z v s3.
+    (env, xs, s1) ---> (vs, s2) ∧
+    take_branch test vs s2 = (Res b, s2) ∧
+    (env, [if b then y else z], s2) ---> ([v], s3) ⇒
+    (env, [If test xs y z], s1) ---> ([v], s3))
+  ∧
+  (∀env xs s1 vs s2 fname v new_env body s3.
+    (env, xs, s1) ---> (vs, s2) ∧
+    env_and_body fname vs s2 = SOME (new_env, body) ∧
+    (new_env, [body], s2) ---> ([v], s3) ⇒
+    (env, [Call fname xs], s1) ---> ([v], s3))
+End
+
+Inductive app:
+  ∀fname vs s1 v s2 new_env body.
+    env_and_body fname vs s1 = SOME (new_env, body) ∧
+    (new_env, [body], s1) ---> ([v], s2) ⇒
+    app fname vs s1 (v,s2)
+End
+
+Theorem Eval_Call:
+  ∀env xs s1 vs s2 fname v s3.
+    (env, xs, s1) ---> (vs, s2) ∧
+    app fname vs s2 (v,s3) ⇒
+    (env, [Call fname xs], s1) ---> ([v], s3)
+Proof
+  rw [] \\ once_rewrite_tac [Eval_cases] \\ fs []
+  \\ goal_assum (first_assum o mp_then.mp_then mp_then.Any mp_tac)
+  \\ fs [app_cases]
+QED
+
+val _ = set_fixity "prog_terminates" (Infixl 480);
+
+Definition prog_terminates_def:
+  (input, Program funs main) prog_terminates output =
+    ∃s r. (empty_env, [main], init_state input funs) ---> (r, s) ∧
+          output = s.output
+End
+
+Overload prog_terminates =
+  “λ(input:string,p) output. (fromList input,p) prog_terminates output”;
+
+
+(* definition 2: a functional big-step semantics *)
+
+Definition get_env_and_body_def:
+  get_env_and_body fname args s =
+    case env_and_body fname args s of
+    | NONE => fail s
+    | SOME (env, body) =>
+      if s.clock = 0 then (Err TimeOut, s)
+      else (Res (env, body), s with clock := s.clock - 1)
+End
+
+Definition fix_def: (* helps prove termination of the definition of eval *)
+  fix s x =
+    if (SND x).clock ≤ s.clock then x
+    else (FST x, SND x with clock := s.clock)
+End
+
+(* evaluation of expressions and expression lists *)
+Definition eval_def:
+  eval (env:num -> v option) (Const n) s = (Res (Num n), s) ∧
+  eval env (Var t) s =
+    (case env t of
+     | NONE => (Err Crash, s)
+     | SOME v => (Res v, s)) ∧
+  eval env (Op f xs) s =
+    (case evals env xs s of
+     | (Err e, s) => (Err e, s)
+     | (Res vs, s1) => eval_op f vs s1) ∧
+  eval env (Let t x y) s =
+    (case fix s (eval env x s) of
+     | (Err e, s1) => (Err e, s1)
+     | (Res v, s1) => eval ((t =+ SOME v) env) y s1) ∧
+  eval env (If test xs y z) s =
+    (case fix s (evals env xs s) of
+     | (Err e, s1) => (Err e, s1)
+     | (Res vs, s1) =>
+       case take_branch test vs s1 of
+       | (Res b, s1) => eval env (if b then y else z) s1
+       | (Err e, s1) => (Err e, s1)) ∧
+  eval env (Call t xs) s =
+    (case fix s (evals env xs s) of
+     | (Err e, s1) => (Err e, s1)
+     | (Res vs, s1) =>
+       case get_env_and_body t vs s1 of
+       | (Err e,s2) => (Err e, s2)
+       | (Res (new_env, body), s2) => eval new_env body s2) ∧
+  evals env [] s = (Res [], s) ∧
+  evals env (x::xs) s =
+    (case fix s (eval env x s) of
+     | (Err v, s1) => (Err v, s1)
+     | (Res v, s1) =>
+       case evals env xs s1 of
+       | (Err v, s2) => (Err v, s2)
+       | (Res vs, s2) => (Res (v::vs), s2))
+Termination
+  WF_REL_TAC ‘inv_image (measure I LEX measure I)
+                (λx. case x of INL (env,x,s) => (s.clock,exp_size x)
+                             | INR (env,xs,s) => (s.clock,exp1_size xs))’
+  \\ rw [] \\ fs [fix_def,CaseEq"bool"] \\ rw [] \\ fs []
+  \\ fs [take_branch_def,AllCaseEqs(),return_def,fail_def,get_env_and_body_def]
+  \\ rw [] \\ fs []
+End
+
+Theorem eval_clock:
+  (∀env x s res s'. eval env x s = (res,s') ⇒ s'.clock ≤ s.clock) ∧
+  (∀env xs s res s'. evals env xs s = (res,s') ⇒ s'.clock ≤ s.clock)
+Proof
+  ho_match_mp_tac eval_ind \\ rw [eval_def]
+  \\ fs [AllCaseEqs(),get_env_and_body_def,eval_op_def,fix_def,return_def,fail_def]
+  \\ rw [] \\ fs []
+  \\ fs [AllCaseEqs(),take_branch_def,return_def,fail_def]
+  \\ rw [] \\ fs []
+QED
+
+Triviality fix_eval:
+  fix s (eval env x s) = eval env x s ∧
+  fix s (evals env xs s) = evals env xs s
+Proof
+  Cases_on ‘eval env x s’ \\ Cases_on ‘evals env xs s’ \\ fs []
+  \\ imp_res_tac eval_clock \\ fs [fix_def]
+QED
+
+Theorem eval_def  = REWRITE_RULE [fix_eval] eval_def;
+Theorem eval_ind  = REWRITE_RULE [fix_eval] eval_ind;
+Theorem evals_ind = REWRITE_RULE [fix_eval] eval_ind
+  |> Q.SPECL [‘λenv x s. P env [x] s’,‘P’]
+  |> CONV_RULE (DEPTH_CONV BETA_CONV)
+  |> UNDISCH |> CONJUNCT2 |> DISCH_ALL |> GEN_ALL;
+
+(* monadic formulation of eval_def *)
+
+Type M = ``:state -> 'a result # state``
+
+Definition bind_def:
+  bind f g s =
+    case f s of
+    | (Res res, s1) => g res s1
+    | (Err e, s1) => (Err e, s1)
+End
+
+Overload monad_unitbind[local] = ``bind``
+Overload monad_bind[local] = ``bind``
+Overload return[local] = ``return``
+
+val _ = monadsyntax.add_monadsyntax()
+
+Theorem eval_thm:
+  eval env (Const n) =
+    return (Num n) ∧
+  eval env (Var vname) =
+    (case env vname of
+     | NONE => fail
+     | SOME v => return v) ∧
+  eval env (Op f xs) =
+    do vs <- evals env xs;
+       eval_op f vs od ∧
+  eval env (Let vname x y) =
+    do v <- eval env x;
+       eval ((vname =+ SOME v)env) y od ∧
+  eval env (If test xs y z) =
+    do vs <- evals env xs;
+       b <- take_branch test vs;
+       eval env (if b then y else z) od ∧
+  eval env (Call fname xs) =
+    do vs <- evals env xs;
+       (new_env,body) <- get_env_and_body fname vs;
+       eval new_env body od ∧
+  evals env [] =
+    return [] ∧
+  evals env (x::xs) =
+    do v <- eval env x;
+       vs <- evals env xs;
+       return (v::vs) od
+Proof
+  fs [FUN_EQ_THM,eval_def,bind_def,return_def,fail_def,take_branch_def]
+  \\ rw [] \\ BasicProvers.every_case_tac \\ fs [fail_def,return_def,fail_def]
+QED
+
+Definition eval_from_def:
+  eval_from k input (Program funs main) =
+    eval empty_env main (init_state input funs with clock := k)
+End
+
+Definition prog_avoids_crash_def:
+  prog_avoids_crash input prog =
+    ∀k res s. eval_from k input prog = (res, s) ⇒ res ≠ Err Crash
+End
+
+Definition prog_timesout_def:
+  prog_timesout k input prog =
+    ∃s. eval_from k input prog = (Err TimeOut, s)
+End
+
+Definition prog_output_def:
+  prog_output k input prog =
+    let (res,s) = eval_from k input prog in
+      fromList s.output
+End
+
+val _ = set_fixity "prog_diverges" (Infixl 480);
+
+Definition prog_diverges_def:
+  (input, prog) prog_diverges output ⇔
+    (∀k. prog_timesout k input prog) ∧
+    output = build_lprefix_lub { prog_output k input prog | k IN UNIV }
+End
+
+val _ = export_theory();

--- a/examples/bootstrap/source_syntaxScript.sml
+++ b/examples/bootstrap/source_syntaxScript.sml
@@ -1,0 +1,39 @@
+
+open HolKernel Parse boolLib bossLib;
+open arithmeticTheory listTheory pairTheory finite_mapTheory stringTheory;
+open source_valuesTheory;
+
+val _ = new_theory "source_syntax";
+
+
+(* abstract syntax *)
+
+Type name = “:num”
+
+Datatype:
+  op = Add | Sub | Div | Cons | Head | Tail | Read | Write
+End
+
+Datatype:
+  test = Less | Equal
+End
+
+Datatype:
+  exp = Const num                   (* constant number            *)
+      | Var name                    (* local variable             *)
+      | Op op (exp list)            (* primitive operations       *)
+      | If test (exp list) exp exp  (* if test .. then .. else .. *)
+      | Let name exp exp            (* let name = .. in ..        *)
+      | Call name (exp list)        (* call a function            *)
+End
+
+Datatype:
+  dec = Defun name (name list) exp   (* func name, formal params, body *)
+End
+
+Datatype:                         (* a complete program is a list of   *)
+  prog = Program (dec list) exp   (* function declarations followed by *)
+End                               (* an expression to evaluate         *)
+
+
+val _ = export_theory();

--- a/examples/bootstrap/source_valuesScript.sml
+++ b/examples/bootstrap/source_valuesScript.sml
@@ -1,0 +1,133 @@
+
+open HolKernel Parse boolLib bossLib term_tactic;
+open arithmeticTheory listTheory stringTheory;
+
+val _ = new_theory "source_values";
+
+(* Values in the source semantics are binary trees where the
+   leaves are natural numbers (num) *)
+Datatype:
+  v = Pair v v | Num num
+End
+
+(* Since strings are not in the representation, we have a function that
+   coverts strings into numbers. Note that parsing and pretty printing
+   is set up so that printing reproduces these strings when possible. *)
+Definition name_def:
+  name [] = 0 ∧
+  name (c::cs) = ORD c * 256 ** (LENGTH cs) + name cs
+End
+
+Overload Name = “λn. Num (name n)”
+
+(* Lists are terminated with Num 0 *)
+Definition list_def[simp]:
+  list [] = Num 0 ∧
+  list (x::xs) = Pair x (list xs)
+End
+
+(* various convenience functions below, most are automatic rewrites [simp] *)
+
+Definition less_def[simp]:
+  less (Num n) (Num m) <=> n < m
+End
+
+Definition plus_def[simp]:
+  plus (Num n) (Num m) = Num (n + m)
+End
+
+Definition minus_def[simp]:
+  minus (Num n) (Num m) = Num (n - m)
+End
+
+Definition div_def[simp]:
+  div (Num n) (Num m) = Num (n DIV m)
+End
+
+Definition head_def[simp]:
+  head (Pair x y) = x ∧
+  head v = v
+End
+
+Definition tail_def[simp]:
+  tail (Pair x y) = y ∧
+  tail v = v
+End
+
+Definition cons_def[simp]:
+  cons x y = Pair x y
+End
+
+Definition bool_def[simp]:
+  bool T = Num 1 ∧
+  bool F = Num 0
+End
+
+Definition map_def[simp]:
+  map f xs = list (MAP f xs)
+End
+
+Overload "list" = “map”;
+
+Definition pair_def[simp]:
+  pair f g (x,y) = Pair (f x) (g y)
+End
+
+Definition option_def[simp]:
+  option f NONE = list [] ∧
+  option f (SOME x) = list [f x]
+End
+
+Definition char_def[simp]:
+  char c = Num (ORD c)
+End
+
+Definition isNum_def[simp]:
+  isNum (Num n) = T ∧ isNum _ = F
+End
+
+Definition getNum_def[simp]:
+  getNum (Num n) = n ∧
+  getNum _ = 0
+End
+
+Definition el1_def[simp]:
+  el1 v = head (tail v)
+End
+
+Definition el2_def[simp]:
+  el2 v = el1 (tail v)
+End
+
+Definition el3_def[simp]:
+  el3 v = el2 (tail v)
+End
+
+Overload isNil[inferior] = “isNum”;
+Overload el0[inferior] = “head”;
+
+Theorem isNum_bool[simp]:
+  isNum (bool b)
+Proof
+  Cases_on ‘b’ \\ EVAL_TAC
+QED
+
+Theorem v_size_def[simp] = fetch "-" "v_size_def";
+
+Theorem all_macro_defs = LIST_CONJ [list_def, cons_def, bool_def,
+   map_def, pair_def, option_def];
+
+Definition is_upper_def:
+  (* checks whether string (represented as num) starts with uppercase letter *)
+  is_upper n =
+    if n < 256:num then
+      if n < 65 (* ord A = 65 *) then F else
+      if n < 91 (* ord Z = 90 *) then T else F
+    else is_upper (n DIV 256)
+End
+
+Definition otherwise_def[simp]:
+  otherwise x = x
+End
+
+val _ = export_theory();

--- a/examples/bootstrap/x64asm_propertiesScript.sml
+++ b/examples/bootstrap/x64asm_propertiesScript.sml
@@ -1,0 +1,226 @@
+
+open HolKernel Parse boolLib bossLib BasicProvers;
+open wordsTheory wordsLib arithmeticTheory listTheory pairTheory mp_then
+     combinTheory x64asm_syntaxTheory x64asm_semanticsTheory relationTheory;
+
+val _ = new_theory "x64asm_properties";
+
+Inductive steps:
+  (∀s (n:num).
+    steps (s,n) (s,n))
+  ∧
+  (∀s1 s2 n.
+    step s1 s2 ⇒ steps (s1,n) (s2,n))
+  ∧
+  (∀s1 s2 n.
+    step s1 s2 ⇒ steps (s1,n+1) (s2,n))
+  ∧
+  (∀s1 n1 s2 n2 s3 n3.
+    steps (s1,n1) (s2,n2) ∧
+    steps (s2,n2) (s3,n3) ⇒ steps (s1,n1) (s3,n3))
+End
+
+Theorem step_consts:
+  step (State t0) (State t1) ⇒
+  t1.instructions = t0.instructions ∧
+  ∀w x. read_mem w t0 = SOME x ⇒ read_mem w t1 = SOME x
+Proof
+  fs [step_cases] \\ rw [] \\ fs []
+  \\ EVAL_TAC \\ fs []
+  \\ fs [write_mem_def,AllCaseEqs(),read_mem_def] \\ rw []
+  \\ fs [APPLY_UPDATE_THM]
+  \\ rw [] \\ fs []
+QED
+
+Theorem steps_consts:
+  ∀x y.
+    steps x y ⇒
+    (∀t1 m. y = (State t1,m) ⇒ ∃t0 n. x = (State t0,n)) ∧
+    ∀t0 n t1 m.
+      x = (State t0,n) ∧ y = (State t1,m) ⇒
+      t1.instructions = t0.instructions ∧
+      ∀w x. read_mem w t0 = SOME x ⇒ read_mem w t1 = SOME x
+Proof
+  ho_match_mp_tac steps_strongind \\ rw []
+  \\ imp_res_tac step_consts \\ fs [] \\ rw [] \\ fs []
+  \\ pop_assum mp_tac \\ fs [step_cases] \\ rw [] \\ fs []
+QED
+
+Theorem steps_inst:
+  steps (State t0,n) (State t1,m) ⇒ t1.instructions = t0.instructions
+Proof
+  rw [] \\ imp_res_tac steps_consts \\ fs []
+QED
+
+Theorem steps_trans:
+  ∀x y z. steps x y ∧ steps y z ⇒ steps x z
+Proof
+  fs [FORALL_PROD] \\ metis_tac [steps_rules]
+QED
+
+Theorem steps_refl[simp]:
+  ∀x. steps x x
+Proof
+  once_rewrite_tac [steps_cases] \\ fs [FORALL_PROD]
+QED
+
+Theorem IMP_steps_state:
+  (∃mid. steps (start,n) mid ∧ ∃s. steps mid (State s,n) ∧ P s) ⇒
+  ∃s. steps (start,n) (State s,n) ∧ P s
+Proof
+  rw [] \\ metis_tac [steps_trans]
+QED
+
+Theorem IMP_steps_alt:
+  (∃y. steps x y ∧ ∃t1. steps y (State t1,n) ∧ P t1) ⇒
+  ∃t1. steps x (State t1,n) ∧ P t1
+Proof
+  metis_tac [steps_trans]
+QED
+
+Theorem IMP_steps:
+  (∃mid outcome. steps start mid ∧ steps mid outcome ∧ P outcome) ⇒
+  ∃outcome. steps start outcome ∧ P outcome
+Proof
+  rw [] \\ qexists_tac ‘outcome’ \\ fs []
+  \\ PairCases_on ‘start’ \\ PairCases_on ‘mid’ \\ PairCases_on ‘outcome’
+  \\ match_mp_tac (steps_rules |> CONJUNCTS |> last)
+  \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+QED
+
+Theorem IMP_step:
+  (∃mid outcome. step (FST start) (mid) ∧ steps (mid,SND start) outcome ∧ P outcome) ⇒
+  ∃outcome. steps start outcome ∧ P outcome
+Proof
+  rw [] \\ qexists_tac ‘outcome’ \\ fs []
+  \\ PairCases_on ‘start’ \\ PairCases_on ‘outcome’
+  \\ match_mp_tac (steps_rules |> CONJUNCTS |> last)
+  \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs []
+  \\ match_mp_tac (steps_rules |> CONJUNCTS |> el 2) \\ fs []
+QED
+
+Theorem IMP_step':
+  (∃mid outcome. step s mid ∧ steps (mid,n) outcome ∧ P outcome) ⇒
+  ∃outcome. steps (s,SUC n) outcome ∧ P outcome
+Proof
+  rw [] \\ qexists_tac ‘outcome’ \\ fs []
+  \\ PairCases_on ‘outcome’
+  \\ match_mp_tac (steps_rules |> CONJUNCTS |> last)
+  \\ goal_assum (first_assum o mp_then Any mp_tac) \\ fs [ADD1]
+  \\ match_mp_tac (steps_rules |> CONJUNCTS |> el 3) \\ fs []
+QED
+
+Theorem IMP_start:
+  P start ⇒
+  ∃outcome. steps start outcome ∧ P outcome
+Proof
+  rw [] \\ qexists_tac ‘start’ \\ fs [] \\ PairCases_on ‘start’
+  \\ match_mp_tac (steps_rules |> CONJUNCTS |> el 1 |> DISCH T) \\ fs []
+QED
+
+Theorem steps_imp_RTC_step:
+  ∀s t. steps s t ⇒ step⃰ (FST s) (FST t)
+Proof
+  ho_match_mp_tac steps_ind \\ fs []
+  \\ metis_tac [RTC_TRANSITIVE,transitive_def]
+QED
+
+Theorem step_determ:
+  step x y ∧ step x z ==> y = z
+Proof
+  once_rewrite_tac [step_cases] \\ rw [] \\ fs [] \\ rw [] \\ fs []
+  \\ ntac 2 (fs [take_branch_cases] \\ fs [] \\ rw [] \\ fs [])
+  \\ rfs [APPEND_11_LENGTH]
+QED
+
+Theorem not_step_Halt[simp]:
+  ~step (Halt e1 o1) u
+Proof
+  once_rewrite_tac [step_cases] \\ fs []
+QED
+
+Theorem RTC_step_determ:
+  ∀x e1 o1 e2 o2.
+    step⃰ x (Halt e1 o1) ∧ step⃰ x (Halt e2 o2) ⇒ e2 = e1 ∧ o2 = o1
+Proof
+  qsuff_tac ‘∀x y. step⃰ x y ⇒
+    ∀e1 o1 e2 o2.
+       y = (Halt e1 o1) ∧ step⃰ x (Halt e2 o2) ⇒ e2 = e1 ∧ o2 = o1’
+  THEN1 metis_tac []
+  \\ ho_match_mp_tac RTC_INDUCT
+  \\ rpt strip_tac \\ rpt var_eq_tac \\ fs []
+  \\ pop_assum mp_tac
+  \\ once_rewrite_tac [RTC_CASES1] \\ fs []
+  \\ rw [] \\ fs [] \\ imp_res_tac step_determ \\ rw [] \\ res_tac
+QED
+
+Theorem steps_IMP_NRC_step:
+  ∀s k res r. steps (s,k) (res,r) ⇒ ∃k. NRC step k s res
+Proof
+  ho_match_mp_tac (steps_ind |> SIMP_RULE std_ss [FORALL_PROD]
+    |> Q.SPEC ‘λ(x,y) (t,r). P x y t r’ |> SIMP_RULE std_ss [] |> GEN_ALL) \\ rw []
+  THEN1 (qexists_tac ‘0’ \\ fs [])
+  THEN1 (qexists_tac ‘SUC 0’ \\ fs [])
+  THEN1 (qexists_tac ‘SUC 0’ \\ fs [])
+  \\ metis_tac [NRC_ADD_I]
+QED
+
+Theorem NRC_step_determ:
+  ∀k s res1 res2. NRC step k s res1 ∧ NRC step k s res2 ⇒ res1 = res2
+Proof
+  Induct \\ fs [NRC] \\ rw []
+  \\ imp_res_tac step_determ \\ rw [] \\ res_tac
+QED
+
+Triviality steps_NRC:
+  ∀x y. steps x y ⇒ ∃k. NRC step ((SND x - SND y) + k) (FST x) (FST y) ∧ SND y ≤ SND x
+Proof
+  ho_match_mp_tac steps_ind \\ rw [] \\ fs []
+  THEN1 (qexists_tac ‘0’ \\ fs [])
+  THEN1 (qexists_tac ‘SUC 0’ \\ fs [])
+  THEN1 (qexists_tac ‘0’ \\ fs [])
+  \\ qexists_tac ‘k+k'’
+  \\ ‘k + k' + n1 − n3 = (k + n1 − n2) + (k' + n2 − n3)’ by fs []
+  \\ metis_tac [NRC_ADD_I]
+QED
+
+Theorem step_mono:
+  step (State t1) (State t2) ⇒ t1.output ≼ t2.output
+Proof
+  rw [step_cases] \\ fs [write_reg_def,inc_def,set_pc_def,set_stack_def,write_mem_def,
+    AllCaseEqs(),unset_reg_def,put_char_def] \\ rw [] \\ fs []
+QED
+
+Theorem NRC_step_mono:
+  ∀n t1 t2. NRC step n (State t1) (State t2) ⇒ t1.output ≼ t2.output
+Proof
+  Induct \\ fs [NRC_SUC_RECURSE_LEFT] \\ rw []
+  \\ Cases_on ‘z’ \\ fs [] \\ res_tac
+  \\ imp_res_tac step_mono
+  \\ imp_res_tac rich_listTheory.IS_PREFIX_TRANS
+QED
+
+Theorem asm_output_PREFIX:
+  NRC step k (State t) (State t1) ∧
+  steps (State t,k) (State t2,0) ⇒
+  t1.output ≼ t2.output
+Proof
+  rw [] \\ drule steps_NRC \\ fs [] \\ rw []
+  \\ imp_res_tac NRC_ADD_E
+  \\ imp_res_tac NRC_step_determ \\ rw []
+  \\ imp_res_tac NRC_step_mono
+QED
+
+Theorem lprefix_chain_step:
+  lprefix_chain {fromList t'.output | step⃰ (State t) (State t')}
+Proof
+  fs [lprefix_lubTheory.lprefix_chain_def] \\ rw []
+  \\ fs [llistTheory.LPREFIX_fromList,llistTheory.from_toList]
+  \\ imp_res_tac RTC_NRC
+  \\ ‘n ≤ n' ∨ n' ≤ n’ by fs []
+  \\ fs [LESS_EQ_EXISTS] \\ rw []
+  \\ metis_tac [NRC_ADD_E,NRC_step_determ,NRC_step_mono,
+                rich_listTheory.IS_PREFIX_TRANS]
+QED
+
+val _ = export_theory();

--- a/examples/bootstrap/x64asm_semanticsScript.sml
+++ b/examples/bootstrap/x64asm_semanticsScript.sml
@@ -1,0 +1,251 @@
+
+open HolKernel Parse boolLib bossLib;
+open wordsTheory wordsLib arithmeticTheory listTheory llistTheory pairTheory
+     finite_mapTheory x64asm_syntaxTheory alignmentTheory lprefix_lubTheory;
+
+val _ = new_theory "x64asm_semantics";
+
+
+(* semantics *)
+
+Datatype:
+  word_or_ret = Word word64 | RetAddr num
+End
+
+Datatype:
+  state =
+    <| instructions : inst list
+     ; pc : num
+     ; regs : reg -> word64 option
+     ; stack : word_or_ret list
+     ; memory : word64 -> word64 option option
+     ; input  : char llist  (* input can be an infinite stream     *)
+     ; output : char list   (* at each point output must be finite *)
+     |>
+End
+
+Definition lookup_def:
+  lookup n [] = NONE ∧
+  lookup n (x::xs) = if n = 0 then SOME x else lookup (n-1) xs
+End
+
+Definition fetch_def:
+  fetch s = lookup s.pc s.instructions
+End
+
+Definition inc_def:
+  inc s = s with pc := s.pc + 1
+End
+
+Definition write_reg_def:
+  write_reg r w s = s with regs := s.regs⦇r ↦ SOME w⦈
+End
+
+Definition unset_reg_def:
+  unset_regs [] s = s ∧
+  unset_regs (r::rs) s = unset_regs rs (s with regs := s.regs⦇r ↦ NONE⦈)
+End
+
+Definition put_char_def:
+  put_char c s = s with output := s.output ++ [c]
+End
+
+Definition read_mem_def:
+  read_mem a s =
+    case s.memory a of
+    | NONE => NONE
+    | SOME opt => opt
+End
+
+Definition write_mem_def:
+  write_mem a w s =
+    case s.memory a of
+    | SOME NONE => SOME (s with memory := ((a =+ SOME (SOME w)) s.memory))
+    | _ => NONE
+End
+
+Definition set_stack_def:
+  set_stack xs s = (s with stack := xs)
+End
+
+Definition set_pc_def:
+  set_pc n s = (s with pc := n)
+End
+
+Datatype:
+  s_or_h = State state | Halt word64 string
+End
+
+Inductive take_branch:
+  (∀s.
+    take_branch Always s T)
+  ∧
+  (∀s r1 r2 w1 w2.
+    s.regs r1 = SOME w1 ∧
+    s.regs r2 = SOME w2 ⇒
+    take_branch (Less r1 r2) s (w2n w1 < w2n w2))
+  ∧
+  (∀s r1 r2 w1 w2.
+    s.regs r1 = SOME w1 ∧
+    s.regs r2 = SOME w2 ⇒
+    take_branch (Equal r1 r2) s (w1 = w2))
+End
+
+Overload EOF_CONST = “0xFFFFFFFFw : word64”
+
+Definition read_char_def:
+  read_char input =
+    case input of
+    | LNIL => (EOF_CONST, input)
+    | LCONS c cs => (n2w (ORD c), cs)
+End
+
+Inductive step:
+  (∀s r w.
+    fetch s = SOME (Const r w) ⇒
+    step (State s) (State (write_reg r w (inc s))))
+  ∧
+  (∀s r1 r2 w.
+    fetch s = SOME (Mov r1 r2) ∧
+    s.regs r2 = SOME w ⇒
+    step (State s) (State (write_reg r1 w (inc s))))
+  ∧
+  (∀s r1 r2 w1 w2.
+    fetch s = SOME (Add r1 r2) ∧
+    s.regs r1 = SOME w1 ∧
+    s.regs r2 = SOME w2 ⇒
+    step (State s) (State (write_reg r1 (w1 + w2) (inc s))))
+  ∧
+  (∀s r1 r2 w1 w2.
+    fetch s = SOME (Sub r1 r2) ∧
+    s.regs r1 = SOME w1 ∧
+    s.regs r2 = SOME w2 ⇒
+    step (State s) (State (write_reg r1 (w1 - w2) (inc s))))
+  ∧
+  (∀s r w1 w2.
+    fetch s = SOME (Div r) ∧ w2 ≠ 0w ∧
+    s.regs RDX = SOME 0w ∧
+    s.regs RAX = SOME w1 ∧
+    s.regs r = SOME w2 ⇒
+    step (State s) (State (write_reg RAX (n2w (w2n w1 DIV w2n w2))
+                            (write_reg RDX (n2w (w2n w1 MOD w2n w2))
+                              (inc s)))))
+  ∧
+  (∀s cond n yes.
+    fetch s = SOME (Jump cond n) ∧
+    take_branch cond s yes ⇒
+    step (State s) (State (set_pc (if yes then n else (s.pc + 1)) s)))
+  ∧
+  (∀s n.
+    fetch s = SOME (Call n) ⇒
+    step (State s) (State (set_pc n
+                      (set_stack (RetAddr (s.pc+1) :: s.stack) s))))
+  ∧
+  (∀s n rest.
+    fetch s = SOME Ret ∧
+    s.stack = RetAddr n :: rest ⇒
+    step (State s) (State (set_pc n (set_stack rest s))))
+  ∧
+  (∀s r w rest.
+    fetch s = SOME (Pop r) ∧
+    s.stack = Word w :: rest ⇒
+    step (State s) (State (set_stack rest (write_reg r w (inc s)))))
+  ∧
+  (∀s r w.
+    fetch s = SOME (Push r) ∧
+    s.regs r = SOME w ⇒
+    step (State s) (State (set_stack (Word w :: s.stack) (inc s))))
+  ∧
+  (∀s r w offset.
+    fetch s = SOME (Load_RSP r offset) ∧
+    offset < LENGTH s.stack ∧
+    EL offset s.stack = Word w ⇒
+    step (State s) (State (write_reg r w (inc s))))
+  ∧
+  (∀s xs ys.
+    fetch s = SOME (Add_RSP (LENGTH xs)) ∧
+    s.stack = xs ++ ys ⇒
+    step (State s) (State (set_stack ys (inc s))))
+  ∧
+  (∀s src ra imm wa w s'.
+    fetch s = SOME (Store src ra imm) ∧
+    s.regs ra = SOME wa ∧
+    s.regs src = SOME w ∧
+    write_mem (wa + w2w imm) w s = SOME s' ⇒
+    step (State s) (State (inc s')))
+  ∧
+  (∀s dst ra imm wa w.
+    fetch s = SOME (Load dst ra imm) ∧
+    s.regs ra = SOME wa ∧
+    read_mem (wa + w2w imm) s = SOME w ⇒
+    step (State s) (State (write_reg dst w (inc s))))
+  ∧
+  (∀s c.
+    fetch s = SOME GetChar ∧
+    read_char s.input = (c, rest) ∧
+    EVEN (LENGTH s.stack) ⇒
+    step (State s)
+         (State (write_reg RET_REG c
+                   (unset_regs [ARG_REG; RDX]
+                      (inc (s with input := rest))))))
+  ∧
+  (∀s n.
+    fetch s = SOME PutChar ∧
+    s.regs ARG_REG = SOME (n2w n) ∧ n < 256 ∧
+    EVEN (LENGTH s.stack) ⇒
+    step (State s)
+         (State (unset_regs [RET_REG; ARG_REG; RDX]
+                   (inc (put_char (CHR n) s)))))
+  ∧
+  (∀s exit_code.
+    fetch s = SOME Exit ∧
+    s.regs ARG_REG = SOME exit_code ∧
+    EVEN (LENGTH s.stack) ⇒
+    step (State s) (Halt exit_code s.output))
+End
+
+Definition can_write_mem_def:
+  can_write_mem_at m a <=> m a = SOME NONE
+End
+
+Definition memory_writable_def:
+  memory_writable r14 r15 m <=>
+    r14 <=+ r15 ∧ aligned 4 r14 ∧ aligned 4 r15 ∧ r14 ≠ 0w ∧
+    ∀a. r14 <=+ a ∧ a <+ r15 ∧ aligned 3 a ⇒
+        can_write_mem_at m a
+End
+
+Definition init_state_ok_def:
+  init_state_ok t input asm =
+    ∃r14 r15.
+      t.pc = 0 ∧ t.instructions = asm ∧
+      t.input = input ∧ t.output = [] ∧
+      t.stack = [] ∧
+      t.regs R14 = SOME r14 ∧
+      t.regs R15 = SOME r15 ∧
+      memory_writable r14 r15 t.memory
+End
+
+val _ = set_fixity "asm_terminates" (Infixl 480);
+
+Definition asm_terminates_def:
+  (input, asm) asm_terminates output =
+    ∃t. init_state_ok t input asm ∧
+        step⃰ (State t) (Halt 0w output)  (* reflexive transitive closure of step *)
+End
+
+Overload asm_terminates =
+  “λ(input:string,p) output. (fromList input,p) asm_terminates output”;
+
+val _ = set_fixity "asm_diverges" (Infixl 480);
+
+Definition asm_diverges_def:
+  (input, asm) asm_diverges output =
+    ∃t. init_state_ok t input asm ∧
+      (* repeated application of step never halts or gets stuck: *)
+      (∀k. ∃t'. NRC step k (State t) (State t')) ∧
+      (* the output is the least upper bound of all reachable output *)
+      output = build_lprefix_lub { fromList t'.output | step⃰ (State t) (State t') }
+End
+
+val _ = export_theory();

--- a/examples/bootstrap/x64asm_syntaxScript.sml
+++ b/examples/bootstrap/x64asm_syntaxScript.sml
@@ -1,0 +1,138 @@
+
+open HolKernel Parse boolLib bossLib;
+open wordsTheory wordsLib arithmeticTheory listTheory stringTheory finite_mapTheory;
+
+val _ = new_theory "x64asm_syntax";
+
+
+(* syntax *)
+
+Datatype:
+  reg = RAX (* ret val *)
+      | RDI (* arg to call *)
+      | RBX | RBP | R12 | R13 | R14 | R15 (* callee saved *)
+      | RDX (* caller saved, i.e. gets clobbered by external calls *)
+End
+
+Overload ARG_REG[inferior] = “RDI”
+Overload RET_REG[inferior] = “RAX”
+
+Datatype:
+  cond = Always | Less reg reg | Equal reg reg
+End
+
+Datatype:
+  inst =
+     (* arithmetic *)
+   | Const reg word64
+   | Mov reg reg
+   | Add reg reg
+   | Sub reg reg
+   | Div reg
+     (* jumps *)
+   | Jump cond num
+   | Call num
+     (* stack *)
+   | Ret
+   | Pop reg
+   | Push reg
+   | Add_RSP num
+   | Load_RSP reg num
+     (* memory *)
+   | Load reg reg word4
+   | Store reg reg word4
+     (* I/O *)
+   | GetChar
+   | PutChar
+   | Exit
+     (* comment (has no semantics) *)
+   | Comment string
+End
+
+Type asm[pp] = “:inst list”;
+
+
+(* converting to string form *)
+
+val reg_tm = (rand o concl o REWRITE_CONV [APPEND])
+ “reg RAX s = "%rax" ++ s ∧
+  reg RDI s = "%rdi" ++ s ∧
+  reg RDX s = "%rdx" ++ s ∧
+  reg RBP s = "%rbp" ++ s ∧
+  reg RBX s = "%rbx" ++ s ∧
+  reg R12 s = "%r12" ++ s ∧
+  reg R13 s = "%r13" ++ s ∧
+  reg R14 s = "%r14" ++ s ∧
+  reg R15 s = "%r15" ++ s”
+
+Definition reg_def:
+  ^reg_tm
+End
+
+Definition num_def:
+  num n s = if n < 10 then CHR (48 + n) :: s else
+                num (n DIV 10) (CHR (48 + (n MOD 10)) :: s)
+End
+
+Definition lab_def:
+  lab n s = #"L" :: num n s
+End
+
+Definition clean_def:
+  clean [] acc = acc ∧
+  clean (c::cs) acc = if ORD c < 43 then clean cs acc else c :: clean cs acc
+End
+
+val inst_tm = (rand o concl o REWRITE_CONV [APPEND])
+ “inst (Const r imm) s = "movq $" ++ num (w2n imm) (", " ++ reg r s) ∧
+  inst (Mov dst src) s = "movq " ++ reg src (", " ++ reg dst s) ∧
+  inst (Add dst src) s = "addq " ++ reg src (", " ++ reg dst s) ∧
+  inst (Sub dst src) s = "subq " ++ reg src (", " ++ reg dst s) ∧
+  inst (Div r) s = "divq " ++ reg r s ∧
+  inst (Jump Always n) s = "jmp " ++ lab n s ∧
+  inst (Jump (Equal r1 r2) n) s =
+    "cmpq " ++ reg r2 (", " ++ reg r1 (" ; je " ++ lab n s)) ∧
+  inst (Jump (Less r1 r2) n) s =
+    "cmpq " ++ reg r2 (", " ++ reg r1 (" ; jb " ++ lab n s)) ∧
+  inst (Call n) s = "call " ++ lab n s ∧
+  inst Ret s = "ret" ++ s ∧
+  inst (Pop r) s = "popq " ++ reg r s ∧
+  inst (Push r) s = "pushq " ++ reg r s ∧
+  inst (Load_RSP r n) s = "movq " ++ num (8 * n) ("(%rsp), " ++ reg r s) ∧
+  inst (Add_RSP n) s = "addq $" ++ num (8 * n) (", %rsp" ++ s) ∧
+  inst (Store src a w) s =
+    "movq " ++ reg src (", " ++ num (w2n w) ("(" ++ reg a (")" ++ s))) ∧
+  inst (Load dst a w) s =
+    "movq " ++ num (w2n w) ("(" ++ reg a ("), " ++ reg dst s)) ∧
+  inst GetChar s = "movq stdin(%rip), %rdi ; call _IO_getc@PLT" ++ s ∧
+  inst PutChar s = "movq stdout(%rip), %rsi ; call _IO_putc@PLT" ++ s ∧
+  inst Exit s = "call exit@PLT" ++ s ∧
+  inst (Comment c) s = "\n\n\t/* " ++ clean c (" */" ++ s)”
+
+Definition inst_def:
+  ^inst_tm
+End
+
+Definition insts_def:
+  insts n [] = [] ∧
+  insts n (x::xs) = lab n (#":" :: #"\t" :: inst x (#"\n" :: insts (n+1) xs))
+End
+
+Definition asm2str_def:
+  asm2str xs = FLAT
+    ["\t.bss\n";
+     "\t.p2align 3          /* 8-byte align        */\n";
+     "heapS:\n";
+     "\t.space 8*1024*1024  /* bytes of heap space */\n";
+     "\t.p2align 3          /* 8-byte align        */\n";
+     "heapE:\n\n";
+     "\t.text\n";
+     "\t.globl main\n";
+     "main:\n";
+     "\tsubq $8, %rsp        /* 16-byte align %rsp */\n";
+     "\tmovabs $heapS, %r14  /* r14 := heap start  */\n";
+     "\tmovabs $heapE, %r15  /* r15 := heap end    */\n\n"]
+    ++ insts 0 xs
+End
+
+val _ = export_theory();

--- a/tools/sequences/final-examples
+++ b/tools/sequences/final-examples
@@ -29,6 +29,7 @@
 !!examples/Crypto/TWOFISH
 
 !!!examples/l3-machine-code/cheri/step
+[poly]!!!examples/bootstrap
 [poly]!!!examples/theorem-prover
 [poly]!!!examples/machine-code
 

--- a/tools/sequences/final-examples
+++ b/tools/sequences/final-examples
@@ -29,7 +29,7 @@
 !!examples/Crypto/TWOFISH
 
 !!!examples/l3-machine-code/cheri/step
-[poly]!!!examples/bootstrap
+[poly](stdknl)!!!examples/bootstrap
 [poly]!!!examples/theorem-prover
 [poly]!!!examples/machine-code
 


### PR DESCRIPTION
This commit contains a development of a "minimal" verified
bootstrapped compiler that targets x86-64 assembly code.

I have added this to the build-sequence as one of the final
examples. The tactic proofs build under both the standard and the
experimental kernels. However, the bootstrap evaluation (in
compiler_evalScript.sml) seems to get stuck on the experimental
kernel. (Is it possible to exclude an example from the build
sequence if HOL is built using the experimental kernel?)