### PR TITLE
Make pretty-printing of goalTrees a little nicer

### DIFF
--- a/src/proofman/goalTree.sml
+++ b/src/proofman/goalTree.sml
@@ -100,17 +100,16 @@ fun pp_gtree gt =
        | pp (vGoal g) = pp_goal g
        | pp (vThen(vt1,vt2)) =
              block CONSISTENT 1 (
-               pp vt1 >> add_string " THEN" >> add_break (1,0) >>
+               pp vt1 >> add_string " \\\\" >> add_break (1,0) >>
                pp vt2
              )
        | pp (vThenl(vt,tlist)) =
              block CONSISTENT 1 (
-               pp vt >> add_string " THENL" >> add_break (1,0) >>
-               add_string "[" >>
+               pp vt >> add_break (1,0) >>
                block CONSISTENT 0 (
-                 pr_list pp (add_string"," >> add_break(1,0)) tlist
-               ) >>
-               add_string "]"
+                 pr_list (fn s => add_string ">- (" >> add_break(1,0) >> pp s) (add_string")" >> add_break(1,0)) tlist
+               )
+  >> add_string ")"
              )
  in pp gt
  end;

--- a/src/proofman/goalTree.sml
+++ b/src/proofman/goalTree.sml
@@ -109,7 +109,7 @@ fun pp_gtree gt =
                block CONSISTENT 0 (
                  pr_list (fn s => add_string ">- (" >> add_break(1,0) >> pp s) (add_string")" >> add_break(1,0)) tlist
                )
-  >> add_string ")"
+             >> add_string ")"
              )
  in pp gt
  end;


### PR DESCRIPTION
This pull request replaces the occurences of `THEN` and `THENL` in `src/proofman/goalTree.sml` with `>>` and `>-` respectively.