### PR TITLE
Name inductive cases

### DIFF
--- a/src/boss/bossLib.sig
+++ b/src/boss/bossLib.sig
@@ -155,6 +155,9 @@ sig
   val REABBREV_TAC     : tactic
   val WITHOUT_ABBREVS  : tactic -> tactic
 
+  (* name cases of an induction theorem *)
+  val name_ind_cases : term list -> thm -> thm
+
   (* more simplification variants *)
   val fsrw_tac : simpLib.ssfrag list -> thm list -> tactic
   val simp : thm list -> tactic

--- a/src/boss/bossLib.sml
+++ b/src/boss/bossLib.sml
@@ -179,6 +179,9 @@ val WITHOUT_ABBREVS = markerLib.WITHOUT_ABBREVS
 
 local
 fun add_Case_conv x = REWR_CONV (ISPEC x markerTheory.add_Case)
+
+fun mk_tuple [] = oneSyntax.one_tm
+  | mk_tuple xs = pairSyntax.list_mk_pair vs
 in
 
 (*---------------------------------------------------------------------------*)
@@ -203,7 +206,7 @@ fun name_ind_cases nm_tms thm = let
           handle HOL_ERR _ => raise ERR "name_ind_cases" "unexpected concl head"
         val nm = if n < length nm_tms then [List.nth (nm_tms, n)] else []
         val vs = nm @ filter (not o is_var) xs
-      in add_Case_conv (pairSyntax.list_mk_pair vs) tm end
+      in add_Case_conv (mk_tuple vs) tm end
   in CONV_RULE (RATOR_CONV (RAND_CONV concl_conv)) spec_thm
     |> GENL vs
   end

--- a/src/boss/bossLib.sml
+++ b/src/boss/bossLib.sml
@@ -181,7 +181,7 @@ local
 fun add_Case_conv x = REWR_CONV (ISPEC x markerTheory.add_Case)
 
 fun mk_tuple [] = oneSyntax.one_tm
-  | mk_tuple xs = pairSyntax.list_mk_pair vs
+  | mk_tuple xs = pairSyntax.list_mk_pair xs
 in
 
 (*---------------------------------------------------------------------------*)
@@ -202,9 +202,9 @@ fun name_ind_cases nm_tms thm = let
       then EVERY_CONJ_CONV concl_conv tm
       else let
         val (f, xs) = strip_comb tm
-        val n = index (term_eq f) vs
-          handle HOL_ERR _ => raise ERR "name_ind_cases" "unexpected concl head"
-        val nm = if n < length nm_tms then [List.nth (nm_tms, n)] else []
+        val nm = case total (index (term_eq f)) vs of
+            NONE => []
+          | SOME n => if n < length nm_tms then [List.nth (nm_tms, n)] else []
         val vs = nm @ filter (not o is_var) xs
       in add_Case_conv (mk_tuple vs) tm end
   in CONV_RULE (RATOR_CONV (RAND_CONV concl_conv)) spec_thm

--- a/src/marker/markerScript.sml
+++ b/src/marker/markerScript.sml
@@ -143,5 +143,19 @@ val usingThm_def = new_definition("usingThm_def", “usingThm (b:bool) = b”);
 val _ = remove_ovl_mapping  "using" {Name = "using", Thy = "marker"}
 val _ = remove_ovl_mapping  "usingThm" {Name = "usingThm", Thy = "marker"}
 
+(*---------------------------------------------------------------------------*)
+(* Case                                                                      *)
+(*                                                                           *)
+(* For marking the current case in case divisions and inductive proofs       *)
+(*---------------------------------------------------------------------------*)
+
+val Case_def = new_definition(
+  "Case_def",
+  ``Case X = T``);
+
+val add_Case = store_thm (
+  "add_Case",
+  ``!X. P <=> (Case X ==> P)``,
+  REWRITE_TAC [Case_def]);
 
 val _ = export_theory();

--- a/src/marker/markerScript.sml
+++ b/src/marker/markerScript.sml
@@ -158,4 +158,12 @@ val add_Case = store_thm (
   ``!X. P <=> (Case X ==> P)``,
   REWRITE_TAC [Case_def]);
 
+val elim_Case = store_thm (
+  "elim_Case",
+  ``(Case X /\ Y) = Y /\
+    (Y /\ Case X) = Y /\
+    (Case X ==> Y) = Y``,
+  REWRITE_TAC [Case_def]
+  );
+
 val _ = export_theory();

--- a/src/marker/markerSyntax.sig
+++ b/src/marker/markerSyntax.sig
@@ -34,4 +34,7 @@ sig
   val is_using : term -> bool
   val DEST_USING : thm -> thm
 
+  val Case_tm : term
+  val dest_Case : term -> term
+
 end

--- a/src/marker/markerSyntax.sml
+++ b/src/marker/markerSyntax.sml
@@ -10,6 +10,7 @@ val AC_tm       = prim_mk_const{Name="AC",       Thy="marker"};
 val Cong_tm     = prim_mk_const{Name="Cong",     Thy="marker"};
 val abbrev_tm   = prim_mk_const{Name="Abbrev",   Thy="marker"};
 val label_tm    = prim_mk_const{Name=":-",       Thy="marker"};
+val Case_tm     = prim_mk_const{Name="Case",     Thy="marker"};
 
 (*---------------------------------------------------------------------------*)
 (* Abbrev (n = M) can appear as a hypothesis in a goal.                      *)
@@ -172,5 +173,13 @@ fun DEST_USING th =
         EQ_MP (SPEC x usingThm_def) th
       else raise ERR "DEST_USING" "Not a using theorem"
     end
+
+fun dest_Case t = if is_comb t then let
+    val (f, x) = dest_comb t
+  in if same_const Case_tm f
+    then x
+    else raise ERR "dest_Case" "not case tm"
+  end
+  else raise ERR "dest_Case" "not comb"
 
 end (* struct *)


### PR DESCRIPTION
Adds a markerTheory constant for doing "which case is this" annotations. This is something
of a pattern in CakeML for proofs with many cases.

The most useful bit is a gadget that modifies induction theorems so that the this-case
annotation will be present in each goal.