### PR TITLE
Fixes of algebra and fermat examples under experimental kernel

### DIFF
--- a/examples/algebra/polynomial/polyFieldModuloScript.sml
+++ b/examples/algebra/polynomial/polyFieldModuloScript.sml
@@ -4952,10 +4952,12 @@ Proof
   `Ring r /\ #1 <> #0` by rw[] >>
   qabbrev_tac `f = \c:num. X - |c|` >>
   rw_tac std_ss[INJ_DEF, IN_PPOW, IN_DIFF, IN_SING] >| [
+    rename1 ‘s <> natural n’ >>
     `s SUBSET (IMAGE SUC (count n))` by rw[GSYM IN_POW] >>
     `FINITE (IMAGE f s)` by metis_tac[IMAGE_FINITE, SUBSET_FINITE, FINITE_COUNT] >>
     `(IMAGE f s) SUBSET (PolyRing r).carrier` by rw[poly_X_sub_c_image_poly_subset, Abbr`f`] >>
     rw[poly_prod_set_property],
+    rename1 ‘s IN POW (natural n)’ >>
     `!s t. FINITE s /\ MAX_SET s < char r /\ FINITE t /\ MAX_SET t < char r /\
              (PPROD (IMAGE f s) = PPROD (IMAGE f t)) ==> s SUBSET t` by
   (rw_tac std_ss[SUBSET_DEF, Abbr`f`] >>

--- a/examples/fermat/little/Holmakefile
+++ b/examples/fermat/little/Holmakefile
@@ -1,5 +1,5 @@
 # prefix to HOL examples
-LOC_PREFIX = ../../../../HOL/examples
+LOC_PREFIX = $(HOLDIR)/examples
 
 PRE_INCLUDES = $(LOC_PREFIX)/algebra/ring
 

--- a/examples/fermat/twosq/Holmakefile
+++ b/examples/fermat/twosq/Holmakefile
@@ -1,5 +1,5 @@
 # prefix to HOL examples
-LOC_PREFIX = ../../../../HOL/examples
+LOC_PREFIX = $(HOLDIR)/examples
 
 PRE_INCLUDES = $(LOC_PREFIX)/algebra/ring
 

--- a/examples/fermat/twosq/twoSquaresScript.sml
+++ b/examples/fermat/twosq/twoSquaresScript.sml
@@ -1160,6 +1160,7 @@ Proof
   rw[fixed_points_def, mills_def, Zadd_element, EXTENSION] >>
   simp[EQ_IMP_THM] >>
   rpt strip_tac >| [
+    rename1 ‘x = (x',y,z)’ >>
     `~square p` by metis_tac[prime_non_square] >>
     `p MOD 4 <> 0` by decide_tac >>
     `zagier x = x` by metis_tac[FUNPOW_1, DECIDE``1 < 2``] >>


### PR DESCRIPTION
Hi,

this PR fixes the broken proof (under `--expk` build option) of two theory files from the `algebra` and `fermat` examples, in the obvious way (using `rename1` to forcely change the variable names back). 

Besides, the two `Holmakefile` of the `fermat` example (wrongly) assumes the toplevel HOL directory is just "HOL", which is not true in my machine. Using the variable `$(HOLDIR)` is the correct way.

Chun


