### PR TITLE
Add tactical for multiple goal selection, and vim support for existing single goal selection

### DIFF
--- a/help/Docfiles/Tactical.SELECT_LT.doc
+++ b/help/Docfiles/Tactical.SELECT_LT.doc
@@ -1,0 +1,34 @@
+\DOC
+
+\TYPE {SELECT_LT : tactic -> list_tactic}
+
+\SYNOPSIS
+Applies a tactic to the all the goals in the goal-list for which the
+tactic succeeds.
+
+\KEYWORDS
+
+\DESCRIBE
+Given a list of goals {gl}, an application of {SELECT_LT tac} to {gl}
+will try to apply {tac} to each goal in {gl} in turn. If no goal lets
+{tac} succeed, the goal state remains unchanged. Otherwise, the goals
+for which {tac} succeeds will generate (possibly empty) list(s) of
+new sub-goals. These new sub-goals are pushed onto the front of the
+rest of {gl}.
+
+\FAILURE
+The application of {SELECT_LT} to a tactic never fails. The resulting
+list-tactic also never fails.
+
+\EXAMPLE
+{
+> SELECT_LT CONJ_TAC [([], “r ∧ s”), ([], “p ⇒ q”), ([“a ∨ b”], “p ∧ q”)]
+val it =
+  ([([], “r”), ([], “s”), ([“a ∨ b”], “p”), ([“a ∨ b”], “q”), ([], “p ⇒ q”)], fn):
+  goal list * list_validation
+}
+
+\SEEALSO
+Tactical.FIRST_LT, Tactical.THEN_LT, Tactical.HEADGOAL.
+
+\ENDDOC

--- a/src/1/Tactical.sig
+++ b/src/1/Tactical.sig
@@ -66,6 +66,7 @@ sig
   val EVERY_LT       : list_tactic list -> list_tactic
   val FIRST          : tactic list -> tactic
   val FIRST_LT       : tactic -> list_tactic
+  val SELECT_LT      : tactic -> list_tactic
   val MAP_EVERY      : ('a -> tactic) -> 'a list -> tactic
   val map_every      : ('a -> tactic) -> 'a list -> tactic
   val MAP_FIRST      : ('a -> tactic) -> 'a list -> tactic

--- a/src/boss/bossLib.sig
+++ b/src/boss/bossLib.sig
@@ -146,6 +146,7 @@ sig
   val sg             : term quotation -> tactic
   val subgoal        : term quotation -> tactic
   val >~             : ('a,'b)gentactic*term quotation list -> ('a,'b)gentactic
+  val >>~            : ('a,'b)gentactic*term quotation list -> ('a,'b)gentactic
   val cheat          : tactic
   val kall_tac       : 'a -> tactic
 

--- a/src/boss/bossLib.sml
+++ b/src/boss/bossLib.sml
@@ -166,6 +166,7 @@ val op suffices_by    = BasicProvers.suffices_by
 val sg                = BasicProvers.sg
 val subgoal           = BasicProvers.subgoal
 val op >~             = Q.>~
+val op >>~            = Q.>>~
 
 val CASE_TAC          = BasicProvers.CASE_TAC;
 

--- a/src/q/Q.sig
+++ b/src/q/Q.sig
@@ -72,6 +72,10 @@ sig
   val SELECT_GOAL_LT         : tmquote list -> list_tactic
   val >~                     : ('a,'b)gentactic * tmquote list ->
                                ('a,'b)gentactic
+  val SELECT_GOALS_LT        : tmquote list -> list_tactic
+  val SELECT_GOALS_LT_THEN   : tmquote list -> tactic -> list_tactic
+  val >>~                    : ('a,'b)gentactic * tmquote list ->
+                               ('a,'b)gentactic
   val kRENAME_TAC            : tmquote list -> tactic -> tactic
   val coreRENAME_TAC         : tmquote list -> tactic -> tactic
 

--- a/src/q/Q.sml
+++ b/src/q/Q.sml
@@ -595,4 +595,10 @@ fun SELECT_GOAL_LT pats = FIRST_LT (RENAME_TAC pats)
 
 fun (tac >~ pats) = tac THEN_LT SELECT_GOAL_LT pats
 
+fun SELECT_GOALS_LT pats = SELECT_LT (RENAME_TAC pats)
+
+fun SELECT_GOALS_LT_THEN pats tac = SELECT_LT (RENAME_TAC pats THEN tac)
+
+fun (tac >>~ pats) = tac THEN_LT SELECT_GOALS_LT pats
+
 end (* Q *)

--- a/src/thm/Overlay.sml
+++ b/src/thm/Overlay.sml
@@ -15,7 +15,7 @@ infix 8 via by suffices_by
 infix 9 using
 
 (* infixes for THEN shorthands *)
-infix >> >- >| \\ >>> >>- ?? >~
+infix >> >- >| \\ >>> >>- ?? >~ >>~
 
 infix ~~ !~ Un Isct -- IN -*
 

--- a/tools/vim/README
+++ b/tools/vim/README
@@ -63,6 +63,7 @@ hG          Send region to g after quoting it, to start a new proof.
 he          Send region (should be a tactic) to e, to expand a tactic.
 hS          Send region (should be a quotation) as a new subgoal.
 hF          Send region (should be a quotation) to be proved sufficient then proved.
+hP          Send region (should be a list of quotations) to select and rename a goal to match the given patterns.
 
 If a visual mode command above is given in normal mode, the region will be the
 line containing the cursor.
@@ -102,7 +103,7 @@ hg strips commas from the end of the region.
 hS strips everything including and after the first "by" in the region, if any.
 hF strips everything including and after the first "suffices_by" in the region, if any.
 
-he strips these tokens from the ends of the region
+he and hP strip these tokens from the ends of the region
   start: ) ] [
   end:   ( [
   both:  , THEN THENL THEN1 << >> ++ \\ by

--- a/tools/vim/hol.src
+++ b/tools/vim/hol.src
@@ -111,7 +111,7 @@ endf
 let s:stripStart     = ')\|\]\|\['
 let s:stripEnd       = '(\|\['
 let s:stripBothWords = 'THEN[1L]\?\|by'
-let s:stripBoth      = ',\|<<\|>>\|++\|\\\\\|>-\|>|'
+let s:stripBoth      = ',\|<<\|>>\|++\|\\\\\|>-\|>|\|>\~'
 let s:delim          = '\_[[:space:]()]'
 
 fu! HOLExpand()
@@ -192,6 +192,18 @@ fu! HOLSelect(l,r)
   call search(a:r,"ce")
 endf
 
+fu! HOLPattern()
+  silent keepjumps normal pgg0
+  while search('\%^\_s*\%(\%('.s:stripBoth.'\|'.s:stripStart.'\)\|\%('.s:stripBothWords.'\)\)\ze'.s:delim,'cWe')
+    silent keepjumps normal vgg0"_d
+  endw
+  while search('\%(\%('.s:stripBoth.'\|'.s:stripEnd.'\)\|'.s:delim.'\zs\%('.s:stripBothWords.'\)\)\_s*\%$','cW')
+    silent keepjumps normal vG$"_dgg0
+  endw
+  keepjumps normal iproofManagerLib.expand_list(Q.SELECT_GOAL_LT(
+  keepjumps normal G$a))
+endf
+
 if !(exists("maplocalleader"))
   let maplocalleader = "\\"
 endif
@@ -204,6 +216,7 @@ vn <silent> <LocalLeader>G :call YankThenHOLCall(function("HOLUQGoal"),[])<CR>
 vn <silent> <LocalLeader>e :call YankThenHOLCall(function("HOLExpand"),[])<CR>
 vn <silent> <LocalLeader>S :call YankThenHOLCall(function("HOLSubgoal"),[])<CR>
 vn <silent> <LocalLeader>F :call YankThenHOLCall(function("HOLSuffices"),[])<CR>
+vn <silent> <LocalLeader>P :call YankThenHOLCall(function("HOLPattern"),[])<CR>
 nm <silent><expr> <LocalLeader>l "V".maplocalleader."l"
 nm <silent><expr> <LocalLeader>L "V".maplocalleader."L"
 nm <silent><expr> <LocalLeader>s "V".maplocalleader."s"
@@ -213,6 +226,7 @@ nm <silent><expr> <LocalLeader>G "V".maplocalleader."G"
 nm <silent><expr> <LocalLeader>e "V".maplocalleader."e"
 nm <silent><expr> <LocalLeader>S "V".maplocalleader."S"
 nm <silent><expr> <LocalLeader>F "V".maplocalleader."F"
+nm <silent><expr> <LocalLeader>P "V".maplocalleader."P"
 nn <silent> <LocalLeader>R :<C-U>call HOLRotate()<CR>
 nn <silent> <LocalLeader>b :<C-U>call HOLRepeat("proofManagerLib.backup();")<CR>
 nn <silent> <LocalLeader>B :<C-U>call HOLRepeat("proofManagerLib.restore();")<CR>


### PR DESCRIPTION
**Summary of changes:**
- Add `SELECT_LT` list-tactical. This is similar to the existing `FIRST_LT`, but it will apply the tactic to *all* succeeding goals (rather than the first) and reorder them.
- Add `SELECT_GOALS_LT` (and corresponding `>>~` combinator). This is similar to the existing `SELECT_GOAL_LT`, but can select multiple goals and cannot fail.
- Add `SELECT_GOALS_LT_THEN`. This allows the user to supply an additional tactic, the success of which is an extra criterion for goal selection. In the final goal state, this tactic will have already been applied to the selected goals.
- Add basic vim support for existing single goal selection (`SELECT_GOAL_LT`) via the `hP` key binding.

I have not yet added Emacs/vim support for the new feature, pending discussion about how best to integrate this.
