### PR TITLE
Alternative definitions of 2-dimensional Borel sets (+ other fixes)

### DIFF
--- a/src/pred_set/src/more_theories/cardinalScript.sml
+++ b/src/pred_set/src/more_theories/cardinalScript.sml
@@ -2991,13 +2991,17 @@ val COUNTABLE_CASES = store_thm ("COUNTABLE_CASES",
  >> ONCE_REWRITE_TAC[COUNTABLE_ALT_cardleq, FINITE_CARD_LT]
  >> METIS_TAC [CARD_LE_LT]);
 
-val CARD_LE_COUNTABLE = store_thm ("CARD_LE_COUNTABLE",
- ``!s:'a->bool t:'a->bool. COUNTABLE t /\ s <=_c t ==> COUNTABLE s``,
-  REWRITE_TAC[COUNTABLE, ge_c] THEN REPEAT STRIP_TAC THEN
-  KNOW_TAC ``?(t :'a -> bool).
-      (s :'a -> bool) <=_c t /\ t <=_c univ((:num) :num itself)`` THENL
-  [EXISTS_TAC ``t:'a->bool`` THEN ASM_REWRITE_TAC[],
-   METIS_TAC [CARD_LE_TRANS]]);
+(* changed ‘t:'a->bool’ to ‘t:'b->bool’ *)
+Theorem CARD_LE_COUNTABLE :
+    !s:'a->bool t:'b->bool. COUNTABLE t /\ s <=_c t ==> COUNTABLE s
+Proof
+    REWRITE_TAC [COUNTABLE, ge_c]
+ >> rpt STRIP_TAC
+ >> KNOW_TAC ``?(t :'b -> bool).
+      (s :'a -> bool) <=_c t /\ t <=_c univ((:num) :num itself)``
+ >- (EXISTS_TAC ``t:'b->bool`` >> ASM_REWRITE_TAC[])
+ >> METIS_TAC [CARD_LE_TRANS]
+QED
 
 val CARD_EQ_COUNTABLE = store_thm ("CARD_EQ_COUNTABLE",
  ``!s:'a->bool t:'a->bool. COUNTABLE t /\ s =_c t ==> COUNTABLE s``,

--- a/src/probability/borelScript.sml
+++ b/src/probability/borelScript.sml
@@ -2714,6 +2714,17 @@ Proof
  >> ASM_SET_TAC [space_def]
 QED
 
+Theorem IN_MEASURABLE_BOREL_EQ' :
+    !a f g. (!x. x IN space a ==> (f x = g x)) /\
+            g IN measurable a Borel ==> f IN measurable a Borel
+Proof
+    rw [IN_MEASURABLE_BOREL, IN_FUNSET]
+ >> POP_ASSUM (MP_TAC o Q.SPEC `c`)
+ >> Suff ‘{x | g x < Normal c} INTER space a =
+          {x | f x < Normal c} INTER space a’ >- rw []
+ >> ASM_SET_TAC []
+QED
+
 (*****************************************************)
 
 val BOREL_MEASURABLE_SETS_RO_r = prove (
@@ -3218,30 +3229,48 @@ val BOREL_MEASURABLE_SETS_SING_r = prove (
      by RW_TAC std_ss [IN_FUNSET, BOREL_MEASURABLE_SETS_CO]
  >> METIS_TAC []);
 
-val BOREL_MEASURABLE_SETS_SING = store_thm (* was: BOREL_MEASURABLE_SING *)
-  ("BOREL_MEASURABLE_SETS_SING", ``!c. {c} IN subsets Borel``,
+Theorem BOREL_MEASURABLE_SETS_SING : (* was: BOREL_MEASURABLE_SING *)
+    !c. {c} IN subsets Borel
+Proof
     GEN_TAC >> Cases_on `c`
  >- REWRITE_TAC [BOREL_MEASURABLE_SETS_NEGINF']
  >- REWRITE_TAC [BOREL_MEASURABLE_SETS_POSINF']
- >> REWRITE_TAC [BOREL_MEASURABLE_SETS_SING_r]);
+ >> REWRITE_TAC [BOREL_MEASURABLE_SETS_SING_r]
+QED
 
-val BOREL_MEASURABLE_SETS_SING' = store_thm (* new *)
-  ("BOREL_MEASURABLE_SETS_SING'", ``!c. {x | x = c} IN subsets Borel``,
+Theorem BOREL_MEASURABLE_SETS_FINITE :
+    !s. FINITE s ==> s IN subsets Borel
+Proof
+    HO_MATCH_MP_TAC FINITE_INDUCT
+ >> rpt STRIP_TAC
+ >- (MATCH_MP_TAC SIGMA_ALGEBRA_EMPTY \\
+     REWRITE_TAC [SIGMA_ALGEBRA_BOREL])
+ >> ‘e INSERT s = {e} UNION s’ by SET_TAC []
+ >> POP_ORW
+ >> MATCH_MP_TAC SIGMA_ALGEBRA_UNION
+ >> rw [BOREL_MEASURABLE_SETS_SING, SIGMA_ALGEBRA_BOREL]
+QED
+
+Theorem BOREL_MEASURABLE_SETS_SING' :
+    !c. {x | x = c} IN subsets Borel
+Proof
     GEN_TAC
  >> `{x | x = c} = {c}` by RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_SING]
- >> POP_ORW >> Cases_on `c`
- >- REWRITE_TAC [BOREL_MEASURABLE_SETS_NEGINF']
- >- REWRITE_TAC [BOREL_MEASURABLE_SETS_POSINF']
- >> REWRITE_TAC [BOREL_MEASURABLE_SETS_SING_r]);
+ >> POP_ORW
+ >> REWRITE_TAC [BOREL_MEASURABLE_SETS_SING]
+QED
 
-val BOREL_MEASURABLE_SETS_NOT_SING = store_thm
-  ("BOREL_MEASURABLE_SETS_NOT_SING", ``!c. {x | x <> c} IN subsets Borel``,
+Theorem BOREL_MEASURABLE_SETS_NOT_SING :
+    !c. {x | x <> c} IN subsets Borel
+Proof
     RW_TAC std_ss []
  >> `{x | x <> c} = (space Borel) DIFF ({c})`
-      by RW_TAC std_ss [SPACE_BOREL, EXTENSION, IN_DIFF, IN_SING, GSPECIFICATION, IN_UNIV]
+      by RW_TAC std_ss [SPACE_BOREL, EXTENSION, IN_DIFF, IN_SING, GSPECIFICATION,
+                        IN_UNIV]
  >> POP_ORW
  >> METIS_TAC [SIGMA_ALGEBRA_BOREL, BOREL_MEASURABLE_SETS_SING,
-               sigma_algebra_def, algebra_def]);
+               sigma_algebra_def, algebra_def]
+QED
 
 (* For backwards compatibilities *)
 val BOREL_MEASURABLE_SETS1 = save_thm
@@ -3295,20 +3324,21 @@ val BOREL_MEASURABLE_SETS = store_thm
 (*        Borel measurable functions           *)
 (* ******************************************* *)
 
-val IN_MEASURABLE_BOREL_CONST = store_thm
-  ("IN_MEASURABLE_BOREL_CONST",
-  ``!a k f. sigma_algebra a /\ (!x. x IN space a ==> (f x = k)) ==> f IN measurable a Borel``,
- (* proof *)
-    RW_TAC std_ss [IN_MEASURABLE_BOREL,IN_FUNSET, IN_UNIV]
+Theorem IN_MEASURABLE_BOREL_CONST :
+    !a k f. sigma_algebra a /\ (!x. x IN space a ==> (f x = k)) ==>
+            f IN measurable a Borel
+Proof
+    RW_TAC std_ss [IN_MEASURABLE_BOREL, IN_FUNSET, IN_UNIV]
  >> Cases_on `Normal c <= k`
  >- (`{x | f x < Normal c} INTER space a = {}`
-         by  (RW_TAC std_ss [EXTENSION,GSPECIFICATION,NOT_IN_EMPTY,IN_INTER]
+         by  (RW_TAC std_ss [EXTENSION, GSPECIFICATION, NOT_IN_EMPTY, IN_INTER]
               >> METIS_TAC [extreal_lt_def])
-      >> METIS_TAC [sigma_algebra_def,algebra_def])
+      >> METIS_TAC [sigma_algebra_def, algebra_def])
  >> `{x | f x < Normal c} INTER space a = space a`
-      by (RW_TAC std_ss [EXTENSION,GSPECIFICATION,IN_INTER]
+      by (RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER]
           >> METIS_TAC [extreal_lt_def])
- >> METIS_TAC [sigma_algebra_def,algebra_def,INTER_IDEMPOT,DIFF_EMPTY]);
+ >> METIS_TAC [sigma_algebra_def, algebra_def, INTER_IDEMPOT,DIFF_EMPTY]
+QED
 
 Theorem IN_MEASURABLE_BOREL_CONST' :
     !a k. sigma_algebra a ==> (\x. k) IN measurable a Borel
@@ -4484,78 +4514,6 @@ QED
 (* ------------------------------------------------------------------------- *)
 (*  Construction of Borel measure space by CARATHEODORY_SEMIRING             *)
 (* ------------------------------------------------------------------------- *)
-
-(* cf. integrationTheory.INTERVAL_UPPERBOUND for open/closed intervals *)
-Theorem right_open_interval_upperbound :
-    !a b. a < b ==> interval_upperbound (right_open_interval a b) = b
-Proof
-    RW_TAC std_ss [interval_upperbound]
- >- (fs [EXTENSION, GSPECIFICATION, in_right_open_interval] \\
-     METIS_TAC [REAL_LE_REFL])
- >> RW_TAC std_ss [right_open_interval, GSPECIFICATION,
-                   GSYM REAL_LE_ANTISYM]
- >- (MATCH_MP_TAC REAL_IMP_SUP_LE >> rw []
-     >- (Q.EXISTS_TAC `a` >> rw [REAL_LE_REFL]) \\
-     MATCH_MP_TAC REAL_LT_IMP_LE >> art [])
- >> MATCH_MP_TAC REAL_LE_EPSILON
- >> rpt STRIP_TAC
- >> Q.ABBREV_TAC `y = sup {x | a <= x /\ x < b}`
- >> `b <= y + e <=> b - e <= y` by REAL_ARITH_TAC >> POP_ORW
- >> Q.UNABBREV_TAC `y`
- >> MATCH_MP_TAC REAL_IMP_LE_SUP >> rw []
- >- (Q.EXISTS_TAC `a` >> rw [REAL_LE_REFL])
- >- (Q.EXISTS_TAC `b` >> rw [] \\
-     MATCH_MP_TAC REAL_LT_IMP_LE >> art [])
- >> Cases_on `a <= b - e`
- >- (Q.EXISTS_TAC `b - e` >> rw [REAL_LE_TRANS] \\
-     Q.PAT_X_ASSUM `0 < e` MP_TAC >> REAL_ARITH_TAC)
- >> Q.EXISTS_TAC `a` >> rw [REAL_LE_REFL]
- >> MATCH_MP_TAC REAL_LT_IMP_LE >> fs [real_lte]
-QED
-
-Theorem right_open_interval_lowerbound :
-    !a b. a < b ==> interval_lowerbound (right_open_interval a b) = a
-Proof
-    RW_TAC std_ss [interval_lowerbound]
- >- (fs [EXTENSION, GSPECIFICATION, in_right_open_interval] \\
-     METIS_TAC [REAL_LE_REFL])
- >> RW_TAC std_ss [right_open_interval, GSPECIFICATION]
- >> MATCH_MP_TAC REAL_INF_MIN >> rw []
-QED
-
-Theorem right_open_interval_two_bounds :
-    !a b. interval_lowerbound (right_open_interval a b) <=
-          interval_upperbound (right_open_interval a b)
-Proof
-    rpt GEN_TAC
- >> Cases_on `a < b`
- >- (rw [right_open_interval_upperbound, right_open_interval_lowerbound] \\
-     IMP_RES_TAC REAL_LT_IMP_LE)
- >> fs [GSYM right_open_interval_empty]
- >> rw [interval_lowerbound, interval_upperbound, le_refl]
-QED
-
-Theorem right_open_interval_between_bounds :
-    !x a b. x IN right_open_interval a b <=>
-            interval_lowerbound (right_open_interval a b) <= x /\
-            x < interval_upperbound (right_open_interval a b)
-Proof
-    rpt GEN_TAC
- >> reverse (Cases_on `a < b`)
- >- (FULL_SIMP_TAC std_ss [GSYM right_open_interval_empty] \\
-     rw [NOT_IN_EMPTY, INTERVAL_BOUNDS_EMPTY] \\
-     REAL_ARITH_TAC)
- >> rw [in_right_open_interval]
- >> EQ_TAC >> rpt STRIP_TAC (* 4 subgoals *)
- >| [ (* goal 1 (of 4) *)
-      fs [right_open_interval_lowerbound],
-      (* goal 2 (of 4) *)
-      fs [right_open_interval_upperbound],
-      (* goal 3 (of 4) *)
-      rfs [right_open_interval_lowerbound, right_open_interval_upperbound],
-      (* goal 4 (of 4) *)
-      rfs [right_open_interval_lowerbound, right_open_interval_upperbound] ]
-QED
 
 (* The content (length) of [a, b), cf. integrationTheory.content *)
 local
@@ -6658,7 +6616,8 @@ QED
 val lebesgueI_borel = borel_imp_lebesgue_sets;
 
 (* TODO: prove this theorem with PSUBSET, i.e. the existence of non-Borel
-   Lebesgue-measurable sets. Currently it's useless. *)
+   Lebesgue-measurable sets.
+ *)
 Theorem lborel_subset_lebesgue :
     (measurable_sets lborel) SUBSET (measurable_sets lebesgue)
 Proof
@@ -6680,7 +6639,7 @@ QED
 
 val borel_measurable_lebesgueI = borel_imp_lebesgue_measurable;
 
-Theorem negligible_in_sets_lebesgue : (* was: lebesgueI_negligible *)
+Theorem negligible_in_lebesgue : (* was: lebesgueI_negligible *)
     !s. negligible s ==> s IN measurable_sets lebesgue
 Proof
     RW_TAC std_ss [negligible]
@@ -6688,9 +6647,9 @@ Proof
  >> METIS_TAC [integrable_on, line, GSYM interval]
 QED
 
-val lebesgueI_negligible = negligible_in_sets_lebesgue;
+val lebesgueI_negligible = negligible_in_lebesgue;
 
-Theorem lebesgue_negligible : (* was: lmeasure_eq_0 *)
+Theorem lebesgue_of_negligible : (* was: lmeasure_eq_0 *)
     !s. negligible s ==> (measure lebesgue s = 0)
 Proof
     RW_TAC std_ss [measure_lebesgue]
@@ -6705,7 +6664,7 @@ Proof
  >> SIMP_TAC std_ss [sup_sing]
 QED
 
-val lmeasure_eq_0 = lebesgue_negligible;
+val lmeasure_eq_0 = lebesgue_of_negligible;
 
 Theorem lebesgue_measure_iff_LIMSEQ : (* was: lmeasure_iff_LIMSEQ *)
     !A m. A IN measurable_sets lebesgue /\ 0 <= m ==>
@@ -6778,7 +6737,7 @@ Theorem lebesgue_sing =
 Theorem lebesgue_empty :
     measure lebesgue {} = 0
 Proof
-    MATCH_MP_TAC lebesgue_negligible
+    MATCH_MP_TAC lebesgue_of_negligible
  >> REWRITE_TAC [NEGLIGIBLE_EMPTY]
 QED
 
@@ -9417,6 +9376,104 @@ Proof
        IN_MEASURABLE_BOREL_SUB_tactics_5n ])
 QED
 
+(* ------------------------------------------------------------------------- *)
+(*  Two-dimensional Borel sigma-algebra (extreal version), author: Chun Tian *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem IN_MEASURABLE_BOREL_BOREL_I :
+    (\x. x) IN measurable Borel Borel
+Proof
+    ‘(\x :extreal. x) = I’ by METIS_TAC [I_THM]
+ >> POP_ORW
+ >> MATCH_MP_TAC MEASURABLE_I
+ >> REWRITE_TAC [SIGMA_ALGEBRA_BOREL]
+QED
+
+Theorem IN_MEASURABLE_BOREL_BOREL_ABS :
+    abs IN measurable Borel Borel
+Proof
+    MATCH_MP_TAC IN_MEASURABLE_BOREL_ABS
+ >> Q.EXISTS_TAC ‘\x. x’
+ >> rw [SIGMA_ALGEBRA_BOREL, IN_MEASURABLE_BOREL_BOREL_I, SPACE_BOREL]
+QED
+
+Theorem SIGMA_ALGEBRA_BOREL_2D :
+    sigma_algebra (Borel CROSS Borel)
+Proof
+    MATCH_MP_TAC SIGMA_ALGEBRA_PROD_SIGMA
+ >> rw [SPACE_BOREL, subset_class_def]
+QED
+
+Theorem SPACE_BOREL_2D :
+    space (Borel CROSS Borel) = UNIV
+Proof
+    REWRITE_TAC [SPACE_PROD_SIGMA, SPACE_BOREL, CROSS_UNIV]
+QED
+
+Theorem IN_MEASURABLE_BOREL_2D_VECTOR :
+    !a X Y. sigma_algebra a /\
+            X IN measurable a Borel /\ Y IN measurable a Borel ==>
+            (\x. (X x,Y x)) IN measurable a (Borel CROSS Borel)
+Proof
+    rpt STRIP_TAC
+ >> Q.ABBREV_TAC ‘g = \x. (X x,Y x)’
+ >> simp [IN_MEASURABLE, IN_FUNSET, SPACE_PROD_SIGMA, SPACE_BOREL]
+ >> STRONG_CONJ_TAC >- REWRITE_TAC [SIGMA_ALGEBRA_BOREL_2D]
+ >> DISCH_TAC
+ (* stage work *)
+ >> Suff ‘IMAGE (\s. PREIMAGE g s INTER space a)
+                (subsets (Borel CROSS Borel)) SUBSET subsets a’
+ >- (rw [IN_IMAGE, SUBSET_DEF] \\
+     FIRST_X_ASSUM MATCH_MP_TAC \\
+     Q.EXISTS_TAC ‘s’ >> art [])
+ >> Know ‘IMAGE (\s. PREIMAGE g s INTER space a)
+                (prod_sets (subsets Borel) (subsets Borel)) SUBSET subsets a’
+ >- (Q.UNABBREV_TAC ‘g’ \\
+     rw [IN_IMAGE, SUBSET_DEF, IN_PROD_SETS] \\
+     simp [PREIMAGE_CROSS, o_DEF, ETA_AX] \\
+    ‘PREIMAGE X t INTER PREIMAGE Y u INTER space a =
+       (PREIMAGE X t INTER space a) INTER (PREIMAGE Y u INTER space a)’
+      by SET_TAC [] >> POP_ORW \\
+     MATCH_MP_TAC SIGMA_ALGEBRA_INTER \\
+     fs [IN_MEASURABLE])
+ >> DISCH_TAC
+ (* applying SIGMA_SUBSET *)
+ >> Know ‘subsets (sigma (space a)
+                         (IMAGE (\s. PREIMAGE g s INTER space a)
+                                (prod_sets (subsets Borel) (subsets Borel)))) SUBSET
+          subsets a’
+ >- (MATCH_MP_TAC SIGMA_SUBSET >> rw [])
+ >> POP_ASSUM K_TAC
+ >> DISCH_TAC
+ (* stage work *)
+ >> Suff ‘IMAGE (\s. PREIMAGE g s INTER space a) (subsets (Borel CROSS Borel)) =
+          subsets (sigma (space a)
+                         (IMAGE (\s. PREIMAGE g s INTER space a)
+                                (prod_sets (subsets Borel) (subsets Borel))))’
+ >- (Rewr' >> art [])
+ >> REWRITE_TAC [prod_sigma_def]
+ (* applying PREIMAGE_SIGMA *)
+ >> MATCH_MP_TAC PREIMAGE_SIGMA
+ >> rw [IN_FUNSET, IN_CROSS, SPACE_BOREL, subset_class_def]
+ >> MATCH_MP_TAC SUBSET_CROSS
+ >> REWRITE_TAC [SUBSET_UNIV]
+QED
+
+Theorem IN_MEASURABLE_BOREL_2D_FUNCTION :
+    !a X Y f. sigma_algebra a /\
+              X IN measurable a Borel /\ Y IN measurable a Borel /\
+              f IN measurable (Borel CROSS Borel) Borel ==>
+              (\x. f (X x,Y x)) IN measurable a Borel
+Proof
+    rpt STRIP_TAC
+ >> Q.ABBREV_TAC ‘g = \x. (X x,Y x)’
+ >> ‘(\x. f (X x,Y x)) = f o g’ by rw [Abbr ‘g’, o_DEF] >> POP_ORW
+ >> MATCH_MP_TAC MEASURABLE_COMP
+ >> Q.EXISTS_TAC ‘Borel CROSS Borel’ >> art []
+ >> Q.UNABBREV_TAC ‘g’
+ >> MATCH_MP_TAC IN_MEASURABLE_BOREL_2D_VECTOR >> art []
+QED
+
 val _ = export_theory ();
 
 (* References:
@@ -9430,7 +9487,7 @@ val _ = export_theory ();
   [4] Hurd, J.: Formal verification of probabilistic algorithms. (2001).
   [5] Wikipedia: https://en.wikipedia.org/wiki/Henri_Lebesgue
   [6] Chung, K.L.: A Course in Probability Theory, Third Edition. Academic Press (2001).
-  [7] https://en.wikipedia.org/wiki/%C3%89mile_Borel
+  [7] Emile Borel: https://en.wikipedia.org/wiki/%C3%89mile_Borel
   [8] Hardy, G.H., Littlewood, J.E.: A Course of Pure Mathematics, Tenth Edition.
       Cambridge University Press, London (1967).
  *)

--- a/src/probability/extrealScript.sml
+++ b/src/probability/extrealScript.sml
@@ -2537,47 +2537,6 @@ Proof
  >> RW_TAC arith_ss []
 QED
 
-(* an extended version of EXP_LE_X, needed by Borel_Cantelli_lemma2 (direct proof):
-val EXP_LE_X_FULL = store_thm
-  ("EXP_LE_X_FULL", ``!x :real. &1 + x <= exp x``,
-    GEN_TAC
- >> Cases_on `0 <= x` (* existing case *)
- >- (MATCH_MP_TAC EXP_LE_X >> art [])
- >> fs [GSYM real_lt]
- >> Cases_on `x <= -1` (* easy case *)
- >- (MATCH_MP_TAC REAL_LE_TRANS >> Q.EXISTS_TAC `0` >> REWRITE_TAC [EXP_POS_LE] \\
-    `0r = 1 + -1` by RW_TAC real_ss [] >> POP_ORW >> art [REAL_LE_LADD])
- >> fs [GSYM real_lt]
- >> ONCE_REWRITE_TAC [GSYM REAL_SUB_LE]
- >> Q.ABBREV_TAC `f = \x :real. exp x - (1 + x)`
- >> `exp x - (1 + x) = f x` by METIS_TAC [] >> POP_ORW
- >> Q.ABBREV_TAC `g = \x :real. exp x - 1`
- >> Know `!x. (f diffl (g x)) x` (* diffl *)
- >- (GEN_TAC >> Q.UNABBREV_TAC `f` \\
-     Q.UNABBREV_TAC `g` >> BETA_TAC \\
-     MATCH_MP_TAC (REWRITE_RULE [REAL_ADD_LID] (DIFF_CONV ``\x :real. exp x - (1 + x)``)) \\
-     REWRITE_TAC [ETA_AX, DIFF_EXP]) >> DISCH_TAC
- >> Know `!x :real. x <= 0 ==> g x <= 0`
- >- (Q.UNABBREV_TAC `g` >> RW_TAC std_ss [] \\
-     REWRITE_TAC [REAL_LE_SUB_RADD, REAL_ADD_LID] \\
-    `1 :real = exp 0` by REWRITE_TAC [EXP_0] >> POP_ORW \\
-     art [EXP_MONO_LE]) >> DISCH_TAC
- >> Know `f 0 = 0`
- >- (Q.UNABBREV_TAC `f` >> BETA_TAC \\
-     RW_TAC real_ss [EXP_0, REAL_ADD_RID]) >> DISCH_TAC
- >>
-    cheat);
-
-val exp_le_x = store_thm
-  ("exp_le_x", ``!x :extreal. &1 + x <= exp x``,
-    cheat);
-
-val exp_le_x_neg = store_thm
-  ("exp_le_x_neg", ``!x :extreal. &1 - x <= exp (-x)``,
-    cheat);
-
- *)
-
 (***************************)
 (*         Various         *)
 (***************************)

--- a/src/probability/integrationScript.sml
+++ b/src/probability/integrationScript.sml
@@ -255,6 +255,19 @@ Proof
  >> ASM_MESON_TAC[REAL_LE_REFL]
 QED
 
+Theorem OPEN_INTERVAL_UPPERBOUND :
+    !a b:real. a < b ==> interval_upperbound(interval(a,b)) = b
+Proof
+    RW_TAC std_ss [interval_upperbound]
+ >- METIS_TAC [INTERVAL_EQ_EMPTY, GSYM real_lte]
+ >> MATCH_MP_TAC REAL_SUP_UNIQUE
+ >> rw [GSPECIFICATION, IN_INTERVAL]
+ >- (MATCH_MP_TAC REAL_LT_IMP_LE >> art [])
+ >> MP_TAC (Q.SPECL [‘max a b'’, ‘b’] REAL_MEAN)
+ >> rw [REAL_MAX_LT]
+ >> Q.EXISTS_TAC ‘z’ >> art []
+QED
+
 Theorem INTERVAL_LOWERBOUND :
     !a b:real. a <= b ==> (interval_lowerbound(interval[a,b]) = a)
 Proof
@@ -264,6 +277,19 @@ Proof
  >> MATCH_MP_TAC REAL_INF_UNIQUE
  >> SIMP_TAC std_ss [GSPECIFICATION, IN_INTERVAL]
  >> ASM_MESON_TAC [REAL_LE_REFL]
+QED
+
+Theorem OPEN_INTERVAL_LOWERBOUND :
+    !a b:real. a < b ==> interval_lowerbound(interval(a,b)) = a
+Proof
+    RW_TAC std_ss [interval_lowerbound]
+ >- METIS_TAC [INTERVAL_EQ_EMPTY, GSYM real_lte]
+ >> MATCH_MP_TAC REAL_INF_UNIQUE
+ >> rw [GSPECIFICATION, IN_INTERVAL]
+ >- (MATCH_MP_TAC REAL_LT_IMP_LE >> art [])
+ >> MP_TAC (Q.SPECL [‘a’, ‘min b b'’] REAL_MEAN)
+ >> rw [REAL_LT_MIN]
+ >> Q.EXISTS_TAC ‘z’ >> art []
 QED
 
 Theorem INTERVAL_LOWERBOUND_NONEMPTY :

--- a/src/probability/martingaleScript.sml
+++ b/src/probability/martingaleScript.sml
@@ -467,7 +467,7 @@ Proof
  >> rw []
 QED
 
-Theorem integral_cong_measure :
+Theorem integral_cong_measure_base[local] :
     !sp sts u v f.
         measure_space (sp,sts,u) /\ measure_space (sp,sts,v) /\
        (!s. s IN sts ==> (u s = v s)) ==>
@@ -484,11 +484,20 @@ Proof
  >> rw [FN_PLUS_POS, FN_MINUS_POS]
 QED
 
+Theorem integral_cong_measure :
+    !sp sts u v f.
+        measure_space (sp,sts,u) /\ measure_space (sp,sts,v) /\
+       (!s. s IN sts ==> (u s = v s)) ==>
+       (integral (sp,sts,u) f = integral (sp,sts,v) f)
+Proof
+    PROVE_TAC [integral_cong_measure_base]
+QED
+
 Theorem integral_cong_measure' :
     !m1 m2 f. measure_space m1 /\ measure_space m2 /\
              (m_space m1 = m_space m2) /\ (measurable_sets m1 = measurable_sets m2) /\
              (!s. s IN measurable_sets m1 ==> (measure m1 s = measure m2 s)) ==>
-             (integral m1 f = integral m2 f) /\ (integrable m1 f <=> integrable m2 f)
+             (integral m1 f = integral m2 f)
 Proof
     rpt GEN_TAC >> STRIP_TAC
  >> MP_TAC (Q.SPECL [‘m_space m1’, ‘measurable_sets m1’, ‘measure m1’, ‘measure m2’, ‘f’]
@@ -496,211 +505,30 @@ Proof
  >> rw []
 QED
 
+Theorem integrable_cong_measure :
+    !sp sts u v f.
+        measure_space (sp,sts,u) /\ measure_space (sp,sts,v) /\
+       (!s. s IN sts ==> (u s = v s)) ==>
+       (integrable (sp,sts,u) f <=> integrable (sp,sts,v) f)
+Proof
+    PROVE_TAC [integral_cong_measure_base]
+QED
+
+Theorem integrable_cong_measure' :
+    !m1 m2 f. measure_space m1 /\ measure_space m2 /\
+             (m_space m1 = m_space m2) /\ (measurable_sets m1 = measurable_sets m2) /\
+             (!s. s IN measurable_sets m1 ==> (measure m1 s = measure m2 s)) ==>
+             (integrable m1 f <=> integrable m2 f)
+Proof
+    rpt GEN_TAC >> STRIP_TAC
+ >> MP_TAC (Q.SPECL [‘m_space m1’, ‘measurable_sets m1’, ‘measure m1’, ‘measure m2’, ‘f’]
+                    integrable_cong_measure)
+ >> rw []
+QED
+
 (* ------------------------------------------------------------------------- *)
 (*  Product measures and Fubini's theorem (Chapter 14 of [1])                *)
 (* ------------------------------------------------------------------------- *)
-
-(* Lemma 14.1 of [1, p.137] (not used anywhere) *)
-Theorem SEMIRING_PROD_SETS :
-    !a b. semiring a /\ semiring b ==>
-          semiring ((space a CROSS space b),prod_sets (subsets a) (subsets b))
-Proof
-    rpt STRIP_TAC
- >> RW_TAC std_ss [semiring_def, space_def, subsets_def]
- (* subset_class *)
- >- (RW_TAC std_ss [subset_class_def, IN_PROD_SETS, GSPECIFICATION] \\
-     RW_TAC std_ss [SUBSET_DEF, IN_CROSS] >| (* 2 subgoals, same ending *)
-     [ Suff ‘t SUBSET space a’ >- rw [SUBSET_DEF],
-       Suff ‘u SUBSET space b’ >- rw [SUBSET_DEF] ] \\
-     PROVE_TAC [subset_class_def, semiring_def])
- (* EMPTY *)
- >- (RW_TAC std_ss [IN_CROSS, IN_PROD_SETS, GSPECIFICATION, Once EXTENSION,
-                    NOT_IN_EMPTY] \\
-     qexistsl_tac [‘{}’, ‘{}’] >> fs [semiring_def])
- (* INTER *)
- >- (fs [IN_PROD_SETS] \\
-     rename1 ‘s = t1 CROSS u1’ \\
-     rename1 ‘t = t2 CROSS u2’ \\
-     qexistsl_tac [`t1 INTER t2`, `u1 INTER u2`] \\
-     reverse CONJ_TAC >- METIS_TAC [SEMIRING_INTER] \\
-     RW_TAC std_ss [Once EXTENSION, IN_CROSS, IN_INTER] >> PROVE_TAC [])
- (* DIFF (hard) *)
- >> fs [prod_sets_def]
- >> rename1 `s = A CROSS B`
- >> rename1 `t = A' CROSS B'`
- >> REWRITE_TAC [DIFF_INTER_COMPL]
- >> Know `COMPL (A' CROSS B') =
-          (COMPL A' CROSS B') UNION (A' CROSS COMPL B') UNION (COMPL A' CROSS COMPL B')`
- >- (RW_TAC std_ss [Once EXTENSION, IN_CROSS, IN_COMPL, IN_UNION] \\
-     PROVE_TAC []) >> Rewr'
- >> REWRITE_TAC [UNION_OVER_INTER]
- >> REWRITE_TAC [INTER_CROSS, GSYM DIFF_INTER_COMPL]
- >> `?c1. c1 SUBSET subsets a /\ FINITE c1 /\ disjoint c1 /\
-          (A DIFF A' = BIGUNION c1)` by METIS_TAC [semiring_def] >> art []
- >> `?c2. c2 SUBSET subsets b /\ FINITE c2 /\ disjoint c2 /\
-          (B DIFF B' = BIGUNION c2)` by METIS_TAC [semiring_def] >> art []
- (* applying finite_disjoint_decomposition *)
- >> Know `FINITE c1 /\ disjoint c1` >- art []
- >> DISCH_THEN (MP_TAC o (MATCH_MP finite_disjoint_decomposition))
- >> DISCH_THEN (qx_choosel_then [`f1`, `n1`] STRIP_ASSUME_TAC)
- >> Know `FINITE c2 /\ disjoint c2` >- art []
- >> DISCH_THEN (MP_TAC o (MATCH_MP finite_disjoint_decomposition))
- >> DISCH_THEN (qx_choosel_then [`f2`, `n2`] STRIP_ASSUME_TAC)
- >> ASM_REWRITE_TAC [] (* rewrite c1 and c2 in the goal *)
- >> Know `BIGUNION (IMAGE f1 (count n1)) CROSS (B INTER B') =
-          BIGUNION (IMAGE (\n. f1 n CROSS (B INTER B')) (count n1))`
- >- (RW_TAC std_ss [Once EXTENSION, IN_BIGUNION_IMAGE, IN_CROSS,
-                    IN_COUNT] >> PROVE_TAC []) >> Rewr'
- >> Know `(A INTER A') CROSS BIGUNION (IMAGE f2 (count n2)) =
-          BIGUNION (IMAGE (\n. (A INTER A') CROSS f2 n) (count n2))`
- >- (RW_TAC std_ss [Once EXTENSION, IN_BIGUNION_IMAGE, IN_CROSS,
-                    IN_COUNT] >> PROVE_TAC []) >> Rewr'
- >> Know `BIGUNION (IMAGE f1 (count n1)) CROSS
-          BIGUNION (IMAGE f2 (count n2)) =
-          BIGUNION (IMAGE (\(i,j). f1 i CROSS f2 j) (count n1 CROSS count n2))`
- >- (RW_TAC std_ss [Once EXTENSION, IN_BIGUNION_IMAGE, IN_CROSS, IN_COUNT] \\
-     EQ_TAC >> rpt STRIP_TAC >| (* 3 subgoals *)
-     [ (* goal 1 (of 3) *)
-       rename1 `y < n1` >> rename1 `z < n2` \\
-       Q.EXISTS_TAC `(y,z)` >> fs [],
-       (* goal 2 (of 3) *)
-       rename1 `FST z < n1` \\
-       Q.EXISTS_TAC `FST z` >> art [] \\
-       Cases_on `z` >> fs [],
-       (* goal 3 (of 3) *)
-       rename1 `SND z < n2` \\
-       Q.EXISTS_TAC `SND z` >> art [] \\
-       Cases_on `z` >> fs [] ]) >> Rewr'
- >> Q.EXISTS_TAC `(IMAGE (\n. f1 n CROSS (B INTER B')) (count n1)) UNION
-                  (IMAGE (\n. (A INTER A') CROSS f2 n) (count n2)) UNION
-                  (IMAGE (\(i,j). f1 i CROSS f2 j) (count n1 CROSS count n2))`
- >> rw [BIGUNION_UNION] (* 4 subgoals, first 3 are easy *)
- >- (RW_TAC std_ss [SUBSET_DEF, IN_IMAGE, GSPECIFICATION] \\
-     Q.EXISTS_TAC `(f1 n,B INTER B')` >> rw []
-     >- fs [SUBSET_DEF, IN_IMAGE, IN_COUNT] \\
-     fs [semiring_def])
- >- (RW_TAC std_ss [SUBSET_DEF, IN_IMAGE, GSPECIFICATION] \\
-     Q.EXISTS_TAC `(A INTER A',f2 n)` >> rw []
-     >- fs [semiring_def] \\
-     fs [SUBSET_DEF, IN_IMAGE, IN_COUNT])
- >- (RW_TAC std_ss [SUBSET_DEF, IN_IMAGE, GSPECIFICATION] \\
-     rename1 `y IN count n1 CROSS count n2` \\
-     Cases_on `y` >> fs [IN_CROSS, IN_COUNT] \\
-     Q.EXISTS_TAC `(f1 q,f2 r)` >> fs [SUBSET_DEF, IN_IMAGE, IN_COUNT] \\
-     CONJ_TAC >| (* 2 subgoals *)
-     [ (* goal 1 (of 2) *)
-       FIRST_X_ASSUM MATCH_MP_TAC >> Q.EXISTS_TAC `q` >> art [],
-       (* goal 2 (of 2) *)
-       FIRST_X_ASSUM MATCH_MP_TAC >> Q.EXISTS_TAC `r` >> art [] ])
- >> RW_TAC std_ss [disjoint_def, IN_IMAGE, IN_COUNT, IN_CROSS, IN_UNION]
- (* 9 (3 * 3) subgoals *)
- >| [ (* goal 1 (of 9) *)
-      MATCH_MP_TAC DISJOINT_CROSS_L \\
-      FIRST_X_ASSUM MATCH_MP_TAC >> art [] >> METIS_TAC [],
-      (* goal 2 (of 9) *)
-      RW_TAC std_ss [DISJOINT_ALT, IN_CROSS] >> ASM_SET_TAC [],
-      (* goal 3 (of 9) *)
-      Cases_on `x` >> fs [] \\
-      RW_TAC std_ss [DISJOINT_ALT, IN_CROSS] \\
-      DISJ2_TAC \\
-      Know `SND x NOTIN (B DIFF B')` >- ASM_SET_TAC [] \\
-      Q.PAT_X_ASSUM `B DIFF B' = BIGUNION (IMAGE f2 (count n2))`
-        (ONCE_REWRITE_TAC o wrap) \\
-      rw [IN_BIGUNION_IMAGE, IN_COUNT] >> METIS_TAC [],
-      (* goal 4 (of 9) *)
-      RW_TAC std_ss [DISJOINT_ALT, IN_CROSS] >> ASM_SET_TAC [],
-      (* goal 5 (of 9) *)
-      MATCH_MP_TAC DISJOINT_CROSS_R \\
-      FIRST_X_ASSUM MATCH_MP_TAC >> art [] >> METIS_TAC [],
-      (* goal 6 (of 9) *)
-      Cases_on `x` >> fs [] \\
-      RW_TAC std_ss [DISJOINT_ALT, IN_CROSS] \\
-      DISJ1_TAC \\
-      Know `FST x NOTIN (A DIFF A')` >- ASM_SET_TAC [] \\
-      Q.PAT_X_ASSUM `A DIFF A' = BIGUNION (IMAGE f1 (count n1))`
-        (ONCE_REWRITE_TAC o wrap) \\
-      rw [IN_BIGUNION_IMAGE, IN_COUNT] >> METIS_TAC [],
-      (* goal 7 (of 9) *)
-      Cases_on `x` >> fs [] \\
-      RW_TAC std_ss [DISJOINT_ALT, IN_CROSS] \\
-      DISJ2_TAC \\
-      Suff `SND x IN B DIFF B'` >- ASM_SET_TAC [] \\
-      Q.PAT_X_ASSUM `B DIFF B' = BIGUNION (IMAGE f2 (count n2))`
-        (ONCE_REWRITE_TAC o wrap) \\
-      rw [IN_BIGUNION_IMAGE, IN_COUNT] \\
-      Q.EXISTS_TAC `r` >> art [],
-      (* goal 8 (of 9) *)
-      Cases_on `x` >> fs [] \\
-      RW_TAC std_ss [DISJOINT_ALT, IN_CROSS] \\
-      DISJ1_TAC \\
-      Suff `FST x IN A DIFF A'` >- ASM_SET_TAC [] \\
-      Q.PAT_X_ASSUM `A DIFF A' = BIGUNION (IMAGE f1 (count n1))`
-        (ONCE_REWRITE_TAC o wrap) \\
-      rw [IN_BIGUNION_IMAGE, IN_COUNT] \\
-      Q.EXISTS_TAC `q` >> art [],
-      (* goal 9 (of 9) *)
-      Cases_on `x` >> Cases_on `x'` >> fs [] \\
-      RW_TAC std_ss [DISJOINT_ALT, IN_CROSS] \\
-      reverse (Cases_on `q = q'`)
-      >- (DISJ1_TAC >> ASM_SET_TAC []) \\
-      reverse (Cases_on `r = r'`)
-      >- (DISJ2_TAC >> ASM_SET_TAC []) \\
-      METIS_TAC [] ]
-QED
-
-(* a sigma_algebra is also a semiring *)
-Theorem SEMIRING_PROD_SETS' :
-    !a b. sigma_algebra a /\ sigma_algebra b ==>
-          semiring ((space a CROSS space b),prod_sets (subsets a) (subsets b))
-Proof
-    rpt STRIP_TAC
- >> MATCH_MP_TAC SEMIRING_PROD_SETS
- >> CONJ_TAC
- >> MATCH_MP_TAC ALGEBRA_IMP_SEMIRING
- >> MATCH_MP_TAC SIGMA_ALGEBRA_ALGEBRA >> art []
-QED
-
-(* Definition 14.2 of [1, p.137] *)
-val prod_sigma_def = Define
-   ‘prod_sigma a b =
-      sigma (space a CROSS space b) (prod_sets (subsets a) (subsets b))’;
-
-val _ = overload_on ("CROSS", “prod_sigma”);
-
-(* prod_sigma is indeed a sigma-algebra *)
-Theorem SIGMA_ALGEBRA_PROD_SIGMA :
-    !a b. subset_class (space a) (subsets a) /\
-          subset_class (space b) (subsets b) ==> sigma_algebra (prod_sigma a b)
-Proof
-    RW_TAC std_ss [prod_sigma_def]
- >> MATCH_MP_TAC SIGMA_ALGEBRA_SIGMA
- >> RW_TAC std_ss [subset_class_def, IN_PROD_SETS, GSPECIFICATION, IN_CROSS]
- >> fs [subset_class_def]
- >> RW_TAC std_ss [SUBSET_DEF, IN_CROSS]
- >> METIS_TAC [SUBSET_DEF]
-QED
-
-(* |- !X Y A B.
-          subset_class X A /\ subset_class Y B ==>
-          sigma_algebra ((X,A) CROSS (Y,B))
- *)
-Theorem SIGMA_ALGEBRA_PROD_SIGMA' =
-   Q.GENL [‘X’, ‘Y’, ‘A’, ‘B’]
-          (REWRITE_RULE [space_def, subsets_def]
-                        (Q.SPECL [‘(X,A)’, ‘(Y,B)’] SIGMA_ALGEBRA_PROD_SIGMA));
-
-Theorem SPACE_PROD_SIGMA :
-    !a b. space (prod_sigma a b) = space a CROSS space b
-Proof
-    rw [SPACE_SIGMA, prod_sigma_def]
-QED
-
-Theorem SIGMA_ALGEBRA_BOREL_2D :
-    sigma_algebra (Borel CROSS Borel)
-Proof
-    MATCH_MP_TAC SIGMA_ALGEBRA_PROD_SIGMA
- >> rw [SPACE_BOREL, subset_class_def]
-QED
 
 (* FCP version of ‘prod_sigma’ *)
 val fcp_sigma_def = Define
@@ -4628,6 +4456,19 @@ Proof
  >> Rewr'
  >> METIS_TAC []
 QED
+
+(* More compact forms of FUBINI and FUBINI' *)
+Theorem Fubini = FUBINI
+ |> (Q.SPECL [‘m_space m1’, ‘m_space m2’, ‘measurable_sets m1’, ‘measurable_sets m2’,
+              ‘measure m1’, ‘measure m2’])
+ |> (REWRITE_RULE [MEASURE_SPACE_REDUCE])
+ |> (Q.GENL [‘m1’, ‘m2’]);
+
+Theorem Fubini' = FUBINI'
+ |> (Q.SPECL [‘m_space m1’, ‘m_space m2’, ‘measurable_sets m1’, ‘measurable_sets m2’,
+              ‘measure m1’, ‘measure m2’])
+ |> (REWRITE_RULE [MEASURE_SPACE_REDUCE])
+ |> (Q.GENL [‘m1’, ‘m2’]);
 
 (* This theorem only needs TONELLI *)
 Theorem IN_MEASURABLE_BOREL_FROM_PROD_SIGMA :

--- a/src/probability/probabilityScript.sml
+++ b/src/probability/probabilityScript.sml
@@ -2417,6 +2417,8 @@ Definition indep_families_def :
     indep_families p q r = !s t. s IN q /\ t IN r ==> indep p s t
 End
 
+val _ = overload_on("indep_sets", “indep_families”);
+
 (* 5. extension of `indep_families`: pairwise independent sets/collections of events *)
 Definition pairwise_indep_sets :
     pairwise_indep_sets p A (J :'index set) =
@@ -2424,8 +2426,9 @@ Definition pairwise_indep_sets :
 End
 
 Theorem pairwise_indep_sets_def :
-    !p A J. pairwise_indep_sets p A J <=>
-            !i j. i IN J /\ j IN J /\ i <> j ==> indep_families p (A i) (A j)
+    !p A (J :'index set).
+       pairwise_indep_sets p A J <=>
+       !i j. i IN J /\ j IN J /\ i <> j ==> indep_families p (A i) (A j)
 Proof
     RW_TAC std_ss [pairwise_indep_sets, pairwise]
 QED
@@ -2444,6 +2447,8 @@ Definition indep_rv_def :
             indep p ((PREIMAGE X a) INTER p_space p)
                     ((PREIMAGE Y b) INTER p_space p)
 End
+
+val _ = overload_on("indep_vars", “indep_rv”);
 
 (* 8. extension of `indep_rv`: pairwise independent random variables *)
 Definition pairwise_indep_vars :
@@ -2497,12 +2502,6 @@ val INDEP_SYM_EQ = store_thm
 val INDEP_FAMILIES_SYM = store_thm
   ("INDEP_FAMILIES_SYM", ``!p q r. indep_families p q r ==> indep_families p r q``,
     RW_TAC std_ss [indep_families_def]
- >> MATCH_MP_TAC INDEP_SYM
- >> FIRST_X_ASSUM MATCH_MP_TAC >> art []);
-
-val INDEP_RV_SYM = store_thm
-  ("INDEP_RV_SYM", ``!p X Y s t. indep_rv p X Y s t ==> indep_rv p Y X t s``,
-    RW_TAC std_ss [indep_rv_def]
  >> MATCH_MP_TAC INDEP_SYM
  >> FIRST_X_ASSUM MATCH_MP_TAC >> art []);
 
@@ -3057,8 +3056,7 @@ val _ = overload_on ("tail_algebra", ``tail_algebra_of_rv``);
   `sigma_functions` (martingaleTheory).
  *)
 Theorem Kolmogorov_0_1_Law :
-    !p E. prob_space p /\
-          (!n. (E n) IN events p) /\ indep_events p E UNIV ==>
+    !p E. prob_space p /\ (!n. (E n) IN events p) /\ indep_events p E UNIV ==>
           !e. e IN subsets (tail_algebra p E) ==> (prob p e = 0) \/ (prob p e = 1)
 Proof
     RW_TAC std_ss [tail_algebra_def, subsets_def, IN_BIGINTER_IMAGE, IN_UNIV]
@@ -3275,9 +3273,11 @@ val covariance_def = Define
    `covariance p X Y =
       expectation p (\x. (X x - expectation p X) * (Y x - expectation p Y))`;
 
-val covariance_self = store_thm
-  ("covariance_self", ``!p X. covariance p X X = variance p X``,
-    RW_TAC std_ss [variance_alt, covariance_def, pow_2]);
+Theorem covariance_self :
+    !p X. covariance p X X = variance p X
+Proof
+    RW_TAC std_ss [variance_alt, covariance_def, pow_2]
+QED
 
 (* i.e. `covariance p X Y` is zero if X and Y are uncorelated *)
 Theorem uncorrelated_thm :
@@ -7702,10 +7702,11 @@ Proof
 QED
 
 (* r.v.'s having indentical distributions have the same integrability *)
-Theorem identical_distribution_integrable :
-    !p X. prob_space p /\ (!n. random_variable (X n) p Borel) /\
-          identical_distribution p X Borel UNIV /\ integrable p (X 0) ==>
-          !(n :num). integrable p (X n)
+Theorem identical_distribution_integrable_general :
+    !p X (J :'index set). prob_space p /\
+         (!n. n IN J ==> random_variable (X n) p Borel) /\
+          identical_distribution p X Borel UNIV /\
+         (?i. i IN J /\ integrable p (X i)) ==> !n. n IN J ==> integrable p (X n)
 Proof
     RW_TAC std_ss [identical_distribution_def, IN_UNIV]
  >> ‘X n IN Borel_measurable (m_space p,measurable_sets p)’
@@ -7715,25 +7716,41 @@ Proof
      MATCH_MP_TAC SIGMA_ALGEBRA_INTER >> rw [SIGMA_ALGEBRA_BOREL] \\
      MATCH_MP_TAC SIGMA_ALGEBRA_SPACE >> rw [SIGMA_ALGEBRA_BOREL])
  >> DISCH_TAC
- >> MP_TAC (Q.SPECL [‘p’, ‘X (0 :num)’, ‘\x. x’] expectation_distribution)
+ >> MP_TAC (Q.SPECL [‘p’, ‘X (i :'index)’, ‘\x. x’] expectation_distribution)
  >> RW_TAC std_ss [o_DEF]
- >> MP_TAC (Q.SPECL [‘p’, ‘X (n :num)’, ‘\x. x’] expectation_distribution)
+ >> MP_TAC (Q.SPECL [‘p’, ‘X (n :'index)’, ‘\x. x’] expectation_distribution)
  >> RW_TAC std_ss [o_DEF]
- >> Suff ‘integrable (space Borel,subsets Borel,distribution p (X 0)) (\x. x) <=>
+ >> Suff ‘integrable (space Borel,subsets Borel,distribution p (X i)) (\x. x) <=>
           integrable (space Borel,subsets Borel,distribution p (X n)) (\x. x)’
  >- METIS_TAC []
  (* applying integral_cong_measure *)
- >> ‘prob_space (space Borel,subsets Borel,distribution p (X 0)) /\
+ >> ‘prob_space (space Borel,subsets Borel,distribution p (X i)) /\
      prob_space (space Borel,subsets Borel,distribution p (X n))’
        by METIS_TAC [distribution_prob_space]
- >> METIS_TAC [integral_cong_measure, prob_space_def]
+ >> MATCH_MP_TAC integrable_cong_measure
+ >> fs [prob_space_def]
+QED
+
+Theorem identical_distribution_integrable :
+    !p X. prob_space p /\ (!n. random_variable (X n) p Borel) /\
+          identical_distribution p X Borel UNIV /\ integrable p (X 0) ==>
+          !(n :num). integrable p (X n)
+Proof
+    rpt STRIP_TAC
+ >> MP_TAC (Q.SPECL [‘p’, ‘X’, ‘UNIV’]
+                    (INST_TYPE [“:'index” |-> “:num”]
+                               identical_distribution_integrable_general))
+ >> RW_TAC std_ss [IN_UNIV]
+ >> POP_ASSUM MATCH_MP_TAC
+ >> Q.EXISTS_TAC ‘0’ >> art []
 QED
 
 (* r.v.'s having indentical distributions have the same expectation *)
-Theorem identical_distribution_expectation :
-    !p X. prob_space p /\ (!n. random_variable (X n) p Borel) /\
+Theorem identical_distribution_expectation_general :
+    !p X (J :'index set). prob_space p /\ J <> {} /\
+         (!n. n IN J ==> random_variable (X n) p Borel) /\
           identical_distribution p X Borel UNIV ==>
-          !(n :num). expectation p (X n) = expectation p (X 0)
+          ?e. !n. n IN J ==> expectation p (X n) = e
 Proof
     RW_TAC std_ss [identical_distribution_def, IN_UNIV]
  >> Know ‘(\x. x) IN measurable Borel Borel’
@@ -7741,19 +7758,65 @@ Proof
      MATCH_MP_TAC SIGMA_ALGEBRA_INTER >> rw [SIGMA_ALGEBRA_BOREL] \\
      MATCH_MP_TAC SIGMA_ALGEBRA_SPACE >> rw [SIGMA_ALGEBRA_BOREL])
  >> DISCH_TAC
- >> MP_TAC (Q.SPECL [‘p’, ‘X (0 :num)’, ‘\x. x’] expectation_distribution)
+ >> Q.ABBREV_TAC ‘i = CHOICE J’
+ >> ‘i IN J’ by METIS_TAC [CHOICE_DEF]
+ >> MP_TAC (Q.SPECL [‘p’, ‘X (i :'index)’, ‘\x. x’] expectation_distribution)
  >> RW_TAC std_ss [o_DEF]
- >> MP_TAC (Q.SPECL [‘p’, ‘X (n :num)’, ‘\x. x’] expectation_distribution)
+ >> Q.EXISTS_TAC ‘expectation p (X i)’
+ >> rpt STRIP_TAC
+ >> MP_TAC (Q.SPECL [‘p’, ‘X (n :'index)’, ‘\x. x’] expectation_distribution)
  >> RW_TAC std_ss [o_DEF]
  >> ‘!n. X n = (\x. X n x)’ by METIS_TAC [ETA_THM] >> POP_ORW
- >> Suff ‘integral (space Borel,subsets Borel,distribution p (X 0)) (\x. x) =
+ >> Suff ‘integral (space Borel,subsets Borel,distribution p (X i)) (\x. x) =
           integral (space Borel,subsets Borel,distribution p (X n)) (\x. x)’
  >- rw []
  (* applying integral_cong_measure *)
- >> ‘prob_space (space Borel,subsets Borel,distribution p (X 0)) /\
+ >> ‘prob_space (space Borel,subsets Borel,distribution p (X i)) /\
      prob_space (space Borel,subsets Borel,distribution p (X n))’
        by METIS_TAC [distribution_prob_space]
- >> METIS_TAC [integral_cong_measure, prob_space_def, expectation_def]
+ >> MATCH_MP_TAC integral_cong_measure
+ >> fs [prob_space_def]
+QED
+
+Theorem identical_distribution_expectation :
+    !p X. prob_space p /\ (!n. random_variable (X n) p Borel) /\
+          identical_distribution p X Borel UNIV ==>
+          !(n :num). expectation p (X n) = expectation p (X 0)
+Proof
+    rpt STRIP_TAC
+ >> MP_TAC (Q.SPECL [‘p’, ‘X’, ‘UNIV’]
+                    (INST_TYPE [“:'index” |-> “:num”]
+                               identical_distribution_expectation_general))
+ >> RW_TAC std_ss [IN_UNIV, UNIV_NOT_EMPTY] >> art []
+QED
+
+(* Theorem 3.1.4 [2, p.37] *)
+Theorem random_variable_compose :
+    !p X f. prob_space p /\ random_variable X p Borel /\
+            f IN measurable Borel Borel ==> random_variable (f o X) p Borel
+Proof
+    RW_TAC std_ss [random_variable_def]
+ >> MATCH_MP_TAC MEASURABLE_COMP
+ >> Q.EXISTS_TAC `Borel` >> art []
+QED
+
+(* Theorem 3.1.5 [2, p.38] (fundamental theorem of random vectors) *)
+Theorem random_variable_functional :
+    !p X Y f. prob_space p /\ random_variable X p Borel /\ random_variable Y p Borel /\
+              f IN measurable (Borel CROSS Borel) Borel ==>
+              random_variable (\x. f (X x,Y x)) p Borel
+Proof
+    RW_TAC std_ss [random_variable_def, prob_space_def, p_space_def, events_def]
+ >> MATCH_MP_TAC IN_MEASURABLE_BOREL_2D_FUNCTION
+ >> fs [measure_space_def]
+QED
+
+Theorem indep_vars_comm : (* was: INDEP_RV_SYM *)
+    !p X Y s t. indep_rv p X Y s t ==> indep_rv p Y X t s
+Proof
+    RW_TAC std_ss [indep_rv_def]
+ >> MATCH_MP_TAC INDEP_SYM
+ >> FIRST_X_ASSUM MATCH_MP_TAC >> art []
 QED
 
 (* ========================================================================= *)

--- a/src/probability/real_borelScript.sml
+++ b/src/probability/real_borelScript.sml
@@ -22,10 +22,12 @@
 open HolKernel Parse boolLib bossLib;
 
 open metisLib arithmeticTheory pred_setTheory pred_setLib numTheory numLib
-     listTheory combinTheory pairTheory realTheory realLib jrhUtils realSimps
-     simpLib seqTheory real_sigmaTheory transcTheory limTheory RealArith;
+     listTheory combinTheory pairTheory realTheory realLib jrhUtils RealArith
+     seqTheory real_sigmaTheory transcTheory cardinalTheory;
 
-open hurdUtils util_probTheory sigma_algebraTheory real_topologyTheory;
+open metricTheory topologyTheory real_topologyTheory integrationTheory;
+
+open hurdUtils util_probTheory sigma_algebraTheory;
 
 (* ------------------------------------------------------------------------- *)
 (* Start a new theory called "borel" (renamed to "real_borel")               *)
@@ -2203,6 +2205,78 @@ Proof
  >> Q.EXISTS_TAC `(q,r)` >> rw []
 QED
 
+(* cf. integrationTheory.INTERVAL_UPPERBOUND for open/closed intervals *)
+Theorem right_open_interval_upperbound :
+    !a b. a < b ==> interval_upperbound (right_open_interval a b) = b
+Proof
+    RW_TAC std_ss [interval_upperbound]
+ >- (fs [EXTENSION, GSPECIFICATION, in_right_open_interval] \\
+     METIS_TAC [REAL_LE_REFL])
+ >> RW_TAC std_ss [right_open_interval, GSPECIFICATION,
+                   GSYM REAL_LE_ANTISYM]
+ >- (MATCH_MP_TAC REAL_IMP_SUP_LE >> rw []
+     >- (Q.EXISTS_TAC `a` >> rw [REAL_LE_REFL]) \\
+     MATCH_MP_TAC REAL_LT_IMP_LE >> art [])
+ >> MATCH_MP_TAC REAL_LE_EPSILON
+ >> rpt STRIP_TAC
+ >> Q.ABBREV_TAC `y = sup {x | a <= x /\ x < b}`
+ >> `b <= y + e <=> b - e <= y` by REAL_ARITH_TAC >> POP_ORW
+ >> Q.UNABBREV_TAC `y`
+ >> MATCH_MP_TAC REAL_IMP_LE_SUP >> rw []
+ >- (Q.EXISTS_TAC `a` >> rw [REAL_LE_REFL])
+ >- (Q.EXISTS_TAC `b` >> rw [] \\
+     MATCH_MP_TAC REAL_LT_IMP_LE >> art [])
+ >> Cases_on `a <= b - e`
+ >- (Q.EXISTS_TAC `b - e` >> rw [REAL_LE_TRANS] \\
+     Q.PAT_X_ASSUM `0 < e` MP_TAC >> REAL_ARITH_TAC)
+ >> Q.EXISTS_TAC `a` >> rw [REAL_LE_REFL]
+ >> MATCH_MP_TAC REAL_LT_IMP_LE >> fs [real_lte]
+QED
+
+Theorem right_open_interval_lowerbound :
+    !a b. a < b ==> interval_lowerbound (right_open_interval a b) = a
+Proof
+    RW_TAC std_ss [interval_lowerbound]
+ >- (fs [EXTENSION, GSPECIFICATION, in_right_open_interval] \\
+     METIS_TAC [REAL_LE_REFL])
+ >> RW_TAC std_ss [right_open_interval, GSPECIFICATION]
+ >> MATCH_MP_TAC REAL_INF_MIN >> rw []
+QED
+
+Theorem right_open_interval_two_bounds :
+    !a b. interval_lowerbound (right_open_interval a b) <=
+          interval_upperbound (right_open_interval a b)
+Proof
+    rpt GEN_TAC
+ >> Cases_on `a < b`
+ >- (rw [right_open_interval_upperbound, right_open_interval_lowerbound] \\
+     IMP_RES_TAC REAL_LT_IMP_LE)
+ >> fs [GSYM right_open_interval_empty]
+ >> rw [interval_lowerbound, interval_upperbound]
+QED
+
+Theorem right_open_interval_between_bounds :
+    !x a b. x IN right_open_interval a b <=>
+            interval_lowerbound (right_open_interval a b) <= x /\
+            x < interval_upperbound (right_open_interval a b)
+Proof
+    rpt GEN_TAC
+ >> reverse (Cases_on `a < b`)
+ >- (FULL_SIMP_TAC std_ss [GSYM right_open_interval_empty] \\
+     rw [NOT_IN_EMPTY, INTERVAL_BOUNDS_EMPTY] \\
+     REAL_ARITH_TAC)
+ >> rw [in_right_open_interval]
+ >> EQ_TAC >> rpt STRIP_TAC (* 4 subgoals *)
+ >| [ (* goal 1 (of 4) *)
+      fs [right_open_interval_lowerbound],
+      (* goal 2 (of 4) *)
+      fs [right_open_interval_upperbound],
+      (* goal 3 (of 4) *)
+      rfs [right_open_interval_lowerbound, right_open_interval_upperbound],
+      (* goal 4 (of 4) *)
+      rfs [right_open_interval_lowerbound, right_open_interval_upperbound] ]
+QED
+
 (* ------------------------------------------------------------------------- *)
 (* Standard Cubes                                                            *)
 (* ------------------------------------------------------------------------- *)
@@ -2271,4 +2345,825 @@ Proof
     GEN_TAC THEN MATCH_MP_TAC LINE_MONO THEN ARITH_TAC
 QED
 
+(* ------------------------------------------------------------------------- *)
+(*  Two-dimensional Borel sigma-algebra (real version), author: Chun Tian    *)
+(* ------------------------------------------------------------------------- *)
+
+val mr2_tm = “(\((x1,x2),(y1,y2)). sqrt ((x1 - y1) pow 2 + (x2 - y2) pow 2) :real)”;
+
+Theorem MR2_lemma1[local] :
+    !x1 x2 z1 z2. ^mr2_tm ((x1,x2),(z1,z2)) = ^mr2_tm ((x1-z1,x2-z2),(0,0))
+Proof
+    rw []
+QED
+
+Theorem MR2_lemma2[local] :
+    !x1 x2 y1 y2. ^mr2_tm ((x1+y1,x2+y2),(0,0)) <=
+                  ^mr2_tm ((x1,x2),(0,0)) + ^mr2_tm ((y1,y2),(0,0))
+Proof
+    rw []
+ >> CCONTR_TAC >> fs [real_lte]
+ >> Know ‘(sqrt (x1 pow 2 + x2 pow 2) + sqrt (y1 pow 2 + y2 pow 2)) pow 2 <
+          (sqrt ((x1 + y1) pow 2 + (x2 + y2) pow 2)) pow 2’
+ >- (MATCH_MP_TAC REAL_POW_LT2 >> rw [] \\
+     MATCH_MP_TAC REAL_LE_ADD \\
+     CONJ_TAC \\ (* 2 subgoals, same tactics *)
+     MATCH_MP_TAC SQRT_POS_LE >> MATCH_MP_TAC REAL_LE_ADD >> rw [REAL_LE_POW2])
+ >> KILL_TAC
+ >> REWRITE_TAC [GSYM real_lte]
+ >> Know ‘sqrt ((x1 + y1) pow 2 + (x2 + y2) pow 2) pow 2 =
+          (x1 + y1) pow 2 + (x2 + y2) pow 2’
+ >- (MATCH_MP_TAC SQRT_POW_2 \\
+     MATCH_MP_TAC REAL_LE_ADD >> rw [REAL_LE_POW2])
+ >> Rewr'
+ >> GEN_REWRITE_TAC (RAND_CONV o ONCE_DEPTH_CONV) empty_rewrites [ADD_POW_2]
+ >> Know ‘sqrt (x1 pow 2 + x2 pow 2) pow 2 = x1 pow 2 + x2 pow 2’
+ >- (MATCH_MP_TAC SQRT_POW_2 \\
+     MATCH_MP_TAC REAL_LE_ADD >> rw [REAL_LE_POW2])
+ >> Rewr'
+ >> Know ‘sqrt (y1 pow 2 + y2 pow 2) pow 2 = y1 pow 2 + y2 pow 2’
+ >- (MATCH_MP_TAC SQRT_POW_2 \\
+     MATCH_MP_TAC REAL_LE_ADD >> rw [REAL_LE_POW2])
+ >> Rewr'
+ >> rw [ADD_POW_2]
+ >> Suff ‘x1 * y1 + x2 * y2 <= sqrt (x1 pow 2 + x2 pow 2) * sqrt (y1 pow 2 + y2 pow 2)’
+ >- REAL_ARITH_TAC
+ >> Know ‘sqrt (x1 pow 2 + x2 pow 2) * sqrt (y1 pow 2 + y2 pow 2) =
+          sqrt ((x1 pow 2 + x2 pow 2) * (y1 pow 2 + y2 pow 2))’
+ >- (MATCH_MP_TAC EQ_SYM \\
+     MATCH_MP_TAC SQRT_MUL \\
+     CONJ_TAC \\ (* 2 subgoals, same tactics *)
+     MATCH_MP_TAC REAL_LE_ADD >> rw [REAL_LE_POW2])
+ >> Rewr'
+ >> CCONTR_TAC >> fs [real_lte]
+ >> Know ‘(sqrt ((x1 pow 2 + x2 pow 2) * (y1 pow 2 + y2 pow 2))) pow 2 <
+          (x1 * y1 + x2 * y2) pow 2’
+ >- (MATCH_MP_TAC REAL_POW_LT2 >> rw [] \\
+     MATCH_MP_TAC SQRT_POS_LE \\
+     MATCH_MP_TAC REAL_LE_MUL \\
+     CONJ_TAC >> MATCH_MP_TAC REAL_LE_ADD >> rw [REAL_LE_POW2])
+ >> KILL_TAC
+ >> REWRITE_TAC [GSYM real_lte]
+ >> Know ‘sqrt ((x1 pow 2 + x2 pow 2) * (y1 pow 2 + y2 pow 2)) pow 2 =
+          (x1 pow 2 + x2 pow 2) * (y1 pow 2 + y2 pow 2)’
+ >- (MATCH_MP_TAC SQRT_POW_2 \\
+     MATCH_MP_TAC REAL_LE_MUL \\
+     CONJ_TAC >> MATCH_MP_TAC REAL_LE_ADD >> rw [REAL_LE_POW2])
+ >> Rewr'
+ >> rw [ADD_POW_2, POW_MUL, REAL_ADD_LDISTRIB, REAL_ADD_RDISTRIB]
+ >> Suff ‘2 * (x1 * x2 * y1 * y2) <= x1 pow 2 * y2 pow 2 + x2 pow 2 * y1 pow 2’
+ >- REAL_ARITH_TAC
+ >> Know ‘0 <= (x1 * y2 - x2 * y1) pow 2’ >- rw [REAL_LE_POW2]
+ >> ONCE_REWRITE_TAC [POW_2]
+ >> REAL_ARITH_TAC
+QED
+
+Theorem MR2_lemma3[local] :
+    !x1 x2 y1 y2. ^mr2_tm ((x1,x2),(y1,y2)) = ^mr2_tm ((y1,y2),(x1,x2))
+Proof
+    rw []
+ >> Know ‘(x1 - y1) pow 2 = (y1 - x1) pow 2’
+ >- (REWRITE_TAC [POW_2] >> REAL_ARITH_TAC)
+ >> Rewr'
+ >> Know ‘(x2 - y2) pow 2 = (y2 - x2) pow 2’
+ >- (REWRITE_TAC [POW_2] >> REAL_ARITH_TAC)
+ >> Rewr
+QED
+
+Theorem ISMET_R2 :
+    ismet ^mr2_tm
+Proof
+    Q.ABBREV_TAC ‘d = ^mr2_tm’
+ >> rw [ismet] (* 2 subgoals *)
+ >- (Q.UNABBREV_TAC ‘d’ \\
+     Cases_on ‘x’ >> Cases_on ‘y’ >> simp [] \\
+     reverse EQ_TAC >- rw [SQRT_0] \\
+     STRIP_TAC >> rename1 ‘x1 = x2 /\ y1 = y2’ \\
+     CCONTR_TAC >> fs [] >| (* 2 subgoals *)
+     [ (* goal 1 (of 2) *)
+       Suff ‘0 < (x1 - x2) pow 2 + (y1 - y2) pow 2’
+       >- (METIS_TAC [SQRT_POS_LT, REAL_LT_IMP_NE]) \\
+       Q.PAT_X_ASSUM ‘sqrt _ = 0’ K_TAC \\
+      ‘x1 - x2 <> 0’ by PROVE_TAC [REAL_SUB_0] \\
+      ‘0 < (x1 - x2) pow 2’ by METIS_TAC [ZERO_LT_POW] \\
+      ‘0 <= (y1 - y2) pow 2’ by PROVE_TAC [REAL_LE_POW2] \\
+       REAL_ASM_ARITH_TAC,
+       (* goal 2 (of 2) *)
+       Suff ‘0 < (x1 - x2) pow 2 + (y1 - y2) pow 2’
+       >- (METIS_TAC [SQRT_POS_LT, REAL_LT_IMP_NE]) \\
+       Q.PAT_X_ASSUM ‘sqrt _ = 0’ K_TAC \\
+      ‘y1 - y2 <> 0’ by PROVE_TAC [REAL_SUB_0] \\
+      ‘0 < (y1 - y2) pow 2’ by METIS_TAC [ZERO_LT_POW] \\
+      ‘0 <= (x1 - x2) pow 2’ by PROVE_TAC [REAL_LE_POW2] \\
+       REAL_ASM_ARITH_TAC ])
+ >> Cases_on ‘x’ (* (q,r) *)
+ >> Cases_on ‘y’ (* (q',r') *)
+ >> Cases_on ‘z’ (* (q'',r'') *)
+ >> rename1 ‘d ((x1,x2),(z1,z2)) <= d ((y1,y2),(x1,x2)) + d ((y1,y2),(z1,z2))’
+ >> Know ‘d ((x1,x2),z1,z2) = d ((x1-z1,x2-z2),(0,0))’
+ >- METIS_TAC [MR2_lemma1]
+ >> Rewr'
+ >> ‘x1 - z1 = x1 - y1 + (y1 - z1)’ by REAL_ARITH_TAC >> POP_ORW
+ >> ‘x2 - z2 = x2 - y2 + (y2 - z2)’ by REAL_ARITH_TAC >> POP_ORW
+ >> Know ‘d ((y1,y2),(x1,x2)) = d ((x1,x2),(y1,y2))’
+ >- METIS_TAC [MR2_lemma3]
+ >> Rewr'
+ >> Know ‘d ((x1 - y1 + (y1 - z1),x2 - y2 + (y2 - z2)),(0,0)) <=
+          d ((x1 - y1,x2 - y2),(0,0)) + d ((y1 - z1,y2 - z2),(0,0))’
+ >- METIS_TAC [MR2_lemma2]
+ >> Suff ‘d ((x1 - y1,x2 - y2),0,0) + d ((y1 - z1,y2 - z2),0,0) =
+          d ((x1,x2),y1,y2) + d ((y1,y2),z1,z2)’ >- rw []
+ >> METIS_TAC [MR2_lemma1]
+QED
+
+Definition mr2 :
+    mr2 = metric ^mr2_tm
+End
+
+Theorem MR2_DEF :
+    !x1 x2 y1 y2. (dist mr2) ((x1,x2),(y1,y2)) =
+                  sqrt ((x1 - y1) pow 2 + (x2 - y2) pow 2)
+Proof
+    rw [mr2, REWRITE_RULE [metric_tybij] ISMET_R2]
+QED
+
+(* Theorem 3.8 [1,p.19]: borel_2d can be also generated by open rectangles
+   having rational endpoints.
+
+   see open_UNION_rational_box for one-dimension case.
+ *)
+Theorem borel_2d_lemma1[local] :
+    !U. open_in (mtop mr2) U ==>
+        U = BIGUNION {J | ?a b c d. a IN q_set /\ b IN q_set /\ c IN q_set /\ d IN q_set /\
+                                    J = OPEN_interval (a,b) CROSS OPEN_interval (c,d) /\
+                                    J SUBSET U}
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC SUBSET_ANTISYM
+ >> reverse CONJ_TAC
+ >- (rw [SUBSET_DEF, IN_BIGUNION] \\
+     POP_ASSUM MATCH_MP_TAC >> art [])
+ (* now the hard part, fix ‘x IN U’ *)
+ >> rw [Once SUBSET_DEF]
+ >> fs [MTOP_OPEN]
+ >> Q.PAT_X_ASSUM ‘!x. U x ==> _’ (MP_TAC o (Q.SPEC ‘x’))
+ >> POP_ASSUM (MP_TAC o (REWRITE_RULE [IN_APP]))
+ >> RW_TAC std_ss []
+ >> Cases_on ‘x’ >> rename1 ‘U (x1,x2)’
+ >> MP_TAC (Q.SPECL [‘x2’, ‘e / 2’] rational_boxes)
+ >> MP_TAC (Q.SPECL [‘x1’, ‘e / 2’] rational_boxes)
+ >> Know ‘0 < e / 2’
+ >- (MATCH_MP_TAC REAL_LT_DIV >> rw [])
+ >> RW_TAC std_ss []
+ >> rename1 ‘x2 IN box c d’
+ >> fs [box_alt, ball, dist]
+ >> Q.EXISTS_TAC ‘OPEN_interval (a,b) CROSS OPEN_interval (c,d)’
+ >> rw [IN_CROSS]
+ >> qexistsl_tac [‘a’, ‘b’, ‘c’, ‘d’]
+ >> rw [SUBSET_DEF, IN_CROSS]
+ >> REWRITE_TAC [IN_APP]
+ >> FIRST_X_ASSUM MATCH_MP_TAC
+ >> Cases_on ‘x’ >> fs []
+ (* stage work *)
+ >> MATCH_MP_TAC REAL_LET_TRANS
+ >> Q.EXISTS_TAC ‘dist mr2 ((x1,x2),(q,x2)) + dist mr2 ((q,x2),(q,r))’
+ >> REWRITE_TAC [METRIC_TRIANGLE]
+ >> rw [MR2_DEF]
+ >> Know ‘(x1 - q) pow 2 = (abs (x1 - q)) pow 2’
+ >- (rw [POW_ABS, ABS_POW2]) >> Rewr'
+ >> Know ‘(x2 - r) pow 2 = (abs (x2 - r)) pow 2’
+ >- (rw [POW_ABS, ABS_POW2]) >> Rewr'
+ >> Know ‘sqrt (abs (x1 - q) pow 2) = abs (x1 - q)’
+ >- (MATCH_MP_TAC POW_2_SQRT \\
+     REWRITE_TAC [ABS_POS]) >> Rewr'
+ >> Know ‘sqrt (abs (x2 - r) pow 2) = abs (x2 - r)’
+ >- (MATCH_MP_TAC POW_2_SQRT \\
+     REWRITE_TAC [ABS_POS]) >> Rewr'
+ >> ‘e = e / 2 + e / 2’ by REWRITE_TAC [REAL_HALF_DOUBLE] >> POP_ORW
+ >> MATCH_MP_TAC REAL_LT_ADD2
+ >> CONJ_TAC (* 2 subgoals *)
+ >| [ (* goal 1 (of 2) *)
+      Q.PAT_X_ASSUM ‘interval (a,b) SUBSET _’ MP_TAC \\
+      Q.PAT_X_ASSUM ‘q IN interval (a,b)’ MP_TAC,
+      (* goal 2 (of 2) *)
+      Q.PAT_X_ASSUM ‘interval (c,d) SUBSET _’ MP_TAC \\
+      Q.PAT_X_ASSUM ‘r IN interval (c,d)’ MP_TAC ]
+ >> rw [SUBSET_DEF, IN_INTERVAL]
+QED
+
+Theorem IMAGE_FST_CROSS_INTERVAL :
+    !a b c d. c < d ==> IMAGE FST (interval (a,b) CROSS interval (c,d)) = interval (a,b)
+Proof
+    rw [Once EXTENSION, IN_INTERVAL]
+ >> EQ_TAC >> rw [] >> art []
+ >> MP_TAC (Q.SPECL [‘c’, ‘d’] REAL_MEAN)
+ >> RW_TAC std_ss []
+ >> Q.EXISTS_TAC ‘(x,z)’
+ >> RW_TAC std_ss []
+QED
+
+Theorem IMAGE_SND_CROSS_INTERVAL :
+    !a b c d. a < b ==> IMAGE SND (interval (a,b) CROSS interval (c,d)) = interval (c,d)
+Proof
+    rw [Once EXTENSION, IN_INTERVAL]
+ >> EQ_TAC >> rw [] >> art []
+ >> MP_TAC (Q.SPECL [‘a’, ‘b’] REAL_MEAN)
+ >> RW_TAC std_ss []
+ >> Q.EXISTS_TAC ‘(z,x)’
+ >> RW_TAC std_ss []
+QED
+
+(* This proof needs advanced results from cardinalTheory *)
+Theorem borel_2d_lemma2[local] :
+    !U. COUNTABLE {J | ?a b c d. a IN q_set /\ b IN q_set /\ c IN q_set /\ d IN q_set /\
+                                 J = OPEN_interval (a,b) CROSS OPEN_interval (c,d) /\
+                                 J SUBSET U}
+Proof
+    GEN_TAC
+ >> MATCH_MP_TAC (INST_TYPE [“:'b” |-> “:real # real # real # real”]
+                            CARD_LE_COUNTABLE)
+ >> Q.EXISTS_TAC ‘q_set CROSS (q_set CROSS (q_set CROSS q_set))’
+ >> CONJ_TAC >- PROVE_TAC [COUNTABLE_CROSS, QSET_COUNTABLE]
+ >> rw [cardleq_def]
+ >> Q.EXISTS_TAC ‘\s. if s = {} then (0,0,0,0)
+                      else (interval_lowerbound (IMAGE FST s),
+                            interval_upperbound (IMAGE FST s),
+                            interval_lowerbound (IMAGE SND s),
+                            interval_upperbound (IMAGE SND s))’
+ >> rw [INJ_DEF] (* 5 subgoals *)
+ >| [ (* goal 1 (of 5) *)
+      reverse (Cases_on ‘a < b’)
+      >- (fs [GSYM real_lte, INTERVAL_EQ_EMPTY] \\
+          rw [real_of_num, NUM_IN_QSET]) \\
+      reverse (Cases_on ‘c < d’)
+      >- (fs [GSYM real_lte, INTERVAL_EQ_EMPTY] \\
+          rw [real_of_num, NUM_IN_QSET]) \\
+     ‘interval (a,b) <> {} /\ interval (c,d) <> {}’
+        by PROVE_TAC [GSYM real_lte, INTERVAL_EQ_EMPTY] \\
+      Know ‘interval (a,b) CROSS interval (c,d) <> {}’
+      >- (CCONTR_TAC >> rfs [CROSS_EMPTY_EQN]) \\
+      RW_TAC std_ss [] \\
+      Know ‘IMAGE FST (interval (a,b) CROSS interval (c,d)) = interval (a,b)’
+      >- (MATCH_MP_TAC IMAGE_FST_CROSS_INTERVAL >> art []) >> Rewr' \\
+      Suff ‘interval_lowerbound (interval (a,b)) = a’ >- rw [] \\
+      MATCH_MP_TAC OPEN_INTERVAL_LOWERBOUND >> art [],
+      (* goal 2 (of 5) *)
+      reverse (Cases_on ‘a < b’)
+      >- (fs [GSYM real_lte, INTERVAL_EQ_EMPTY] \\
+          rw [real_of_num, NUM_IN_QSET]) \\
+      reverse (Cases_on ‘c < d’)
+      >- (fs [GSYM real_lte, INTERVAL_EQ_EMPTY] \\
+          rw [real_of_num, NUM_IN_QSET]) \\
+     ‘interval (a,b) <> {} /\ interval (c,d) <> {}’
+        by PROVE_TAC [GSYM real_lte, INTERVAL_EQ_EMPTY] \\
+      Know ‘interval (a,b) CROSS interval (c,d) <> {}’
+      >- (CCONTR_TAC >> rfs [CROSS_EMPTY_EQN]) \\
+      RW_TAC std_ss [] \\
+      Know ‘IMAGE FST (interval (a,b) CROSS interval (c,d)) = interval (a,b)’
+      >- (MATCH_MP_TAC IMAGE_FST_CROSS_INTERVAL >> art []) >> Rewr' \\
+      Suff ‘interval_upperbound (interval (a,b)) = b’ >- rw [] \\
+      MATCH_MP_TAC OPEN_INTERVAL_UPPERBOUND >> art [],
+      (* goal 3 (of 5) *)
+      reverse (Cases_on ‘a < b’)
+      >- (fs [GSYM real_lte, INTERVAL_EQ_EMPTY] \\
+          rw [real_of_num, NUM_IN_QSET]) \\
+      reverse (Cases_on ‘c < d’)
+      >- (fs [GSYM real_lte, INTERVAL_EQ_EMPTY] \\
+          rw [real_of_num, NUM_IN_QSET]) \\
+     ‘interval (a,b) <> {} /\ interval (c,d) <> {}’
+        by PROVE_TAC [GSYM real_lte, INTERVAL_EQ_EMPTY] \\
+      Know ‘interval (a,b) CROSS interval (c,d) <> {}’
+      >- (CCONTR_TAC >> rfs [CROSS_EMPTY_EQN]) \\
+      RW_TAC std_ss [] \\
+      Know ‘IMAGE SND (interval (a,b) CROSS interval (c,d)) = interval (c,d)’
+      >- (MATCH_MP_TAC IMAGE_SND_CROSS_INTERVAL >> art []) >> Rewr' \\
+      Suff ‘interval_lowerbound (interval (c,d)) = c’ >- rw [] \\
+      MATCH_MP_TAC OPEN_INTERVAL_LOWERBOUND >> art [],
+      (* goal 4 (of 5) *)
+      reverse (Cases_on ‘a < b’)
+      >- (fs [GSYM real_lte, INTERVAL_EQ_EMPTY] \\
+          rw [real_of_num, NUM_IN_QSET]) \\
+      reverse (Cases_on ‘c < d’)
+      >- (fs [GSYM real_lte, INTERVAL_EQ_EMPTY] \\
+          rw [real_of_num, NUM_IN_QSET]) \\
+     ‘interval (a,b) <> {} /\ interval (c,d) <> {}’
+        by PROVE_TAC [GSYM real_lte, INTERVAL_EQ_EMPTY] \\
+      Know ‘interval (a,b) CROSS interval (c,d) <> {}’
+      >- (CCONTR_TAC >> rfs [CROSS_EMPTY_EQN]) \\
+      RW_TAC std_ss [] \\
+      Know ‘IMAGE SND (interval (a,b) CROSS interval (c,d)) = interval (c,d)’
+      >- (MATCH_MP_TAC IMAGE_SND_CROSS_INTERVAL >> art []) >> Rewr' \\
+      Suff ‘interval_upperbound (interval (c,d)) = d’ >- rw [] \\
+      MATCH_MP_TAC OPEN_INTERVAL_UPPERBOUND >> art [],
+      (* goal 5 (of 5) *)
+      reverse (Cases_on ‘a < b’)
+      >- (fs [GSYM real_lte, INTERVAL_EQ_EMPTY] \\
+          reverse (Cases_on ‘a' < b'’)
+          >- (fs [GSYM real_lte, INTERVAL_EQ_EMPTY]) \\
+          reverse (Cases_on ‘c' < d'’)
+          >- (fs [GSYM real_lte, INTERVAL_EQ_EMPTY]) \\
+         ‘interval (a',b') <> {} /\ interval (c',d') <> {}’
+            by PROVE_TAC [GSYM real_lte, INTERVAL_EQ_EMPTY] \\
+          Know ‘interval (a',b') CROSS interval (c',d') <> {}’
+          >- (CCONTR_TAC >> rfs [CROSS_EMPTY_EQN]) \\
+          DISCH_THEN (fs o wrap) \\
+          Know ‘IMAGE FST (interval (a',b') CROSS interval (c',d')) = interval (a',b')’
+          >- (MATCH_MP_TAC IMAGE_FST_CROSS_INTERVAL >> art []) \\
+          DISCH_THEN (fs o wrap) \\
+          Know ‘IMAGE SND (interval (a',b') CROSS interval (c',d')) = interval (c',d')’
+          >- (MATCH_MP_TAC IMAGE_SND_CROSS_INTERVAL >> art []) \\
+          DISCH_THEN (fs o wrap) \\
+          Know ‘interval_lowerbound (interval (a',b')) = a'’
+          >- (MATCH_MP_TAC OPEN_INTERVAL_LOWERBOUND >> art []) \\
+          DISCH_THEN (fs o wrap) \\
+          Know ‘interval_upperbound (interval (a',b')) = b'’
+          >- (MATCH_MP_TAC OPEN_INTERVAL_UPPERBOUND >> art []) \\
+          DISCH_THEN (fs o wrap) \\
+          rfs [REAL_LT_REFL]) \\
+      reverse (Cases_on ‘c < d’)
+      >- (fs [GSYM real_lte] \\
+         ‘interval (c,d) = {}’ by PROVE_TAC [INTERVAL_EQ_EMPTY] >> fs [] \\
+          reverse (Cases_on ‘a' < b'’)
+          >- (fs [GSYM real_lte, INTERVAL_EQ_EMPTY]) \\
+          reverse (Cases_on ‘c' < d'’)
+          >- (fs [GSYM real_lte, INTERVAL_EQ_EMPTY]) \\
+         ‘interval (a',b') <> {} /\ interval (c',d') <> {}’
+            by PROVE_TAC [GSYM real_lte, INTERVAL_EQ_EMPTY] \\
+          Know ‘interval (a',b') CROSS interval (c',d') <> {}’
+          >- (CCONTR_TAC >> rfs [CROSS_EMPTY_EQN]) \\
+          DISCH_THEN (fs o wrap) \\
+          Know ‘IMAGE FST (interval (a',b') CROSS interval (c',d')) = interval (a',b')’
+          >- (MATCH_MP_TAC IMAGE_FST_CROSS_INTERVAL >> art []) \\
+          DISCH_THEN (fs o wrap) \\
+          Know ‘IMAGE SND (interval (a',b') CROSS interval (c',d')) = interval (c',d')’
+          >- (MATCH_MP_TAC IMAGE_SND_CROSS_INTERVAL >> art []) \\
+          DISCH_THEN (fs o wrap) \\
+          Know ‘interval_lowerbound (interval (a',b')) = a'’
+          >- (MATCH_MP_TAC OPEN_INTERVAL_LOWERBOUND >> art []) \\
+          DISCH_THEN (fs o wrap) \\
+          Know ‘interval_upperbound (interval (a',b')) = b'’
+          >- (MATCH_MP_TAC OPEN_INTERVAL_UPPERBOUND >> art []) \\
+          DISCH_THEN (fs o wrap) \\
+          rfs [REAL_LT_REFL]) \\
+     ‘interval (a,b) <> {} /\ interval (c,d) <> {}’
+        by PROVE_TAC [GSYM real_lte, INTERVAL_EQ_EMPTY] \\
+      Know ‘interval (a,b) CROSS interval (c,d) <> {}’
+      >- (CCONTR_TAC >> rfs [CROSS_EMPTY_EQN]) \\
+      DISCH_THEN (fs o wrap) \\
+      reverse (Cases_on ‘a' < b'’)
+      >- (fs [GSYM real_lte] \\
+         ‘interval (a',b') = {}’ by PROVE_TAC [INTERVAL_EQ_EMPTY] >> fs [] \\
+          Know ‘IMAGE FST (interval (a,b) CROSS interval (c,d)) = interval (a,b)’
+          >- (MATCH_MP_TAC IMAGE_FST_CROSS_INTERVAL >> art []) \\
+          DISCH_THEN (fs o wrap) \\
+          Know ‘IMAGE SND (interval (a,b) CROSS interval (c,d)) = interval (c,d)’
+          >- (MATCH_MP_TAC IMAGE_SND_CROSS_INTERVAL >> art []) \\
+          DISCH_THEN (fs o wrap) \\
+          Know ‘interval_lowerbound (interval (a,b)) = a’
+          >- (MATCH_MP_TAC OPEN_INTERVAL_LOWERBOUND >> art []) \\
+          DISCH_THEN (fs o wrap) \\
+          Know ‘interval_upperbound (interval (a,b)) = b’
+          >- (MATCH_MP_TAC OPEN_INTERVAL_UPPERBOUND >> art []) \\
+          DISCH_THEN (fs o wrap) \\
+          rfs [REAL_LT_REFL]) \\
+      reverse (Cases_on ‘c' < d'’)
+      >- (fs [GSYM real_lte] \\
+         ‘interval (c',d') = {}’ by PROVE_TAC [INTERVAL_EQ_EMPTY] >> fs [] \\
+          Know ‘IMAGE FST (interval (a,b) CROSS interval (c,d)) = interval (a,b)’
+          >- (MATCH_MP_TAC IMAGE_FST_CROSS_INTERVAL >> art []) \\
+          DISCH_THEN (fs o wrap) \\
+          Know ‘IMAGE SND (interval (a,b) CROSS interval (c,d)) = interval (c,d)’
+          >- (MATCH_MP_TAC IMAGE_SND_CROSS_INTERVAL >> art []) \\
+          DISCH_THEN (fs o wrap) \\
+          Know ‘interval_lowerbound (interval (a,b)) = a’
+          >- (MATCH_MP_TAC OPEN_INTERVAL_LOWERBOUND >> art []) \\
+          DISCH_THEN (fs o wrap) \\
+          Know ‘interval_upperbound (interval (a,b)) = b’
+          >- (MATCH_MP_TAC OPEN_INTERVAL_UPPERBOUND >> art []) \\
+          DISCH_THEN (fs o wrap) \\
+          rfs [REAL_LT_REFL]) \\
+     ‘interval (a',b') <> {} /\ interval (c',d') <> {}’
+        by PROVE_TAC [GSYM real_lte, INTERVAL_EQ_EMPTY] \\
+      Know ‘interval (a',b') CROSS interval (c',d') <> {}’
+      >- (CCONTR_TAC >> rfs [CROSS_EMPTY_EQN]) \\
+      DISCH_THEN (fs o wrap) \\
+      Know ‘IMAGE FST (interval (a,b) CROSS interval (c,d)) = interval (a,b)’
+      >- (MATCH_MP_TAC IMAGE_FST_CROSS_INTERVAL >> art []) \\
+      DISCH_THEN (fs o wrap) \\
+      Know ‘IMAGE SND (interval (a,b) CROSS interval (c,d)) = interval (c,d)’
+      >- (MATCH_MP_TAC IMAGE_SND_CROSS_INTERVAL >> art []) \\
+      DISCH_THEN (fs o wrap) \\
+      Know ‘IMAGE FST (interval (a',b') CROSS interval (c',d')) = interval (a',b')’
+      >- (MATCH_MP_TAC IMAGE_FST_CROSS_INTERVAL >> art []) \\
+      DISCH_THEN (fs o wrap) \\
+      Know ‘IMAGE SND (interval (a',b') CROSS interval (c',d')) = interval (c',d')’
+      >- (MATCH_MP_TAC IMAGE_SND_CROSS_INTERVAL >> art []) \\
+      DISCH_THEN (fs o wrap) \\
+      Know ‘interval_lowerbound (interval (a,b)) = a’
+      >- (MATCH_MP_TAC OPEN_INTERVAL_LOWERBOUND >> art []) \\
+      DISCH_THEN (fs o wrap) \\
+      Know ‘interval_upperbound (interval (a,b)) = b’
+      >- (MATCH_MP_TAC OPEN_INTERVAL_UPPERBOUND >> art []) \\
+      DISCH_THEN (fs o wrap) \\
+      Know ‘interval_lowerbound (interval (a',b')) = a'’
+      >- (MATCH_MP_TAC OPEN_INTERVAL_LOWERBOUND >> art []) \\
+      DISCH_THEN (fs o wrap) \\
+      Know ‘interval_upperbound (interval (a',b')) = b'’
+      >- (MATCH_MP_TAC OPEN_INTERVAL_UPPERBOUND >> art []) \\
+      DISCH_THEN (fs o wrap) \\
+      Know ‘interval_lowerbound (interval (c,d)) = c’
+      >- (MATCH_MP_TAC OPEN_INTERVAL_LOWERBOUND >> art []) \\
+      DISCH_THEN (fs o wrap) \\
+      Know ‘interval_upperbound (interval (c,d)) = d’
+      >- (MATCH_MP_TAC OPEN_INTERVAL_UPPERBOUND >> art []) \\
+      DISCH_THEN (fs o wrap) \\
+      Know ‘interval_lowerbound (interval (c',d')) = c'’
+      >- (MATCH_MP_TAC OPEN_INTERVAL_LOWERBOUND >> art []) \\
+      DISCH_THEN (fs o wrap) \\
+      Know ‘interval_upperbound (interval (c',d')) = d'’
+      >- (MATCH_MP_TAC OPEN_INTERVAL_UPPERBOUND >> art []) \\
+      DISCH_THEN (fs o wrap) ]
+QED
+
+Theorem POW_2_SUB[local] :
+    !x y. (x - y) pow 2 = (y - x) pow 2
+Proof
+    rpt GEN_TAC
+ >> ‘(x - y) pow 2 = (abs (x - y)) pow 2’ by PROVE_TAC [REAL_POW2_ABS] >> POP_ORW
+ >> ‘(y - x) pow 2 = (abs (y - x)) pow 2’ by PROVE_TAC [REAL_POW2_ABS] >> POP_ORW
+ >> REWRITE_TAC [Once ABS_SUB]
+QED
+
+Theorem box_open_in_mr2 :
+    !a b c d. open_in (mtop mr2) (interval (a,b) CROSS interval (c,d))
+Proof
+    rw [MTOP_OPEN]
+ >> Cases_on ‘x’ >> fs []
+ (* open_in (mtop mr2) (interval (a,b) CROSS interval (c,d)) *)
+ >> reverse (Cases_on ‘a < b’)
+ >- (‘interval (a,b) = {}’ by METIS_TAC [real_lte, INTERVAL_EQ_EMPTY] \\
+     FULL_SIMP_TAC std_ss [NOT_IN_EMPTY])
+ >> reverse (Cases_on ‘c < d’)
+ >- (‘interval (c,d) = {}’ by METIS_TAC [real_lte, INTERVAL_EQ_EMPTY] \\
+     FULL_SIMP_TAC std_ss [NOT_IN_EMPTY])
+ (* stage work *)
+ >> Q.ABBREV_TAC ‘dx = min (q - a) (b - q)’
+ >> Q.ABBREV_TAC ‘dy = min (r - c) (d - r)’
+ >> Q.EXISTS_TAC ‘min dx dy’
+ >> STRONG_CONJ_TAC
+ >- (rw [Abbr ‘dx’, Abbr ‘dy’, REAL_LT_MIN, REAL_SUB_LT] \\
+     fs [IN_INTERVAL])
+ >> DISCH_TAC
+ >> GEN_TAC
+ >> Cases_on ‘y’
+ >> rw [REAL_LT_MIN, IN_INTERVAL] (* 4 subgoals *)
+ >> rename1 ‘dist mr2 ((x0,y0),(x1,y1)) < dx’
+ >| [ (* goal 1 (of 4) *)
+      CCONTR_TAC >> fs [GSYM real_lte] \\
+      Know ‘dist mr2 ((x0,y0),(x1,y0)) <= dist mr2 ((x0,y0),(x1,y1))’
+      >- (rw [MR2_DEF] \\
+          MATCH_MP_TAC SQRT_MONO_LE >> rw [REAL_LE_POW2]) >> DISCH_TAC \\
+      Know ‘dist mr2 ((x0,y0),(x1,y0)) < dx’
+      >- (MATCH_MP_TAC REAL_LET_TRANS \\
+          Q.EXISTS_TAC ‘dist mr2 ((x0,y0),(x1,y1))’ >> art []) \\
+      rw [Abbr ‘dx’, REAL_LT_MIN, MR2_DEF] \\
+      DISJ1_TAC >> rw [GSYM real_lte] \\
+      Cases_on ‘0 <= x0 - x1’
+      >- (Know ‘sqrt ((x0 - x1) pow 2) = x0 - x1’
+          >- (MATCH_MP_TAC POW_2_SQRT >> art []) >> Rewr' \\
+          Q.PAT_X_ASSUM ‘x1 <= a’ MP_TAC \\
+          REAL_ARITH_TAC) \\
+      POP_ASSUM (STRIP_ASSUME_TAC o (REWRITE_RULE [real_lte])) \\
+      Know ‘x0 < 0 + x1’
+      >- (rw [GSYM REAL_LT_SUB_RADD]) >> rw [] \\
+      Know ‘x0 < a’
+      >- (MATCH_MP_TAC REAL_LTE_TRANS \\
+          Q.EXISTS_TAC ‘x1’ >> art []) >> DISCH_TAC \\
+      Q.PAT_X_ASSUM ‘x0 IN interval (a,b)’
+        (STRIP_ASSUME_TAC o (REWRITE_RULE [IN_INTERVAL])) \\
+      PROVE_TAC [REAL_LT_ANTISYM],
+      (* goal 2 (of 4) *)
+      CCONTR_TAC >> fs [GSYM real_lte] \\
+      Know ‘dist mr2 ((x0,y0),(x1,y0)) <= dist mr2 ((x0,y0),(x1,y1))’
+      >- (rw [MR2_DEF] \\
+          MATCH_MP_TAC SQRT_MONO_LE >> rw [REAL_LE_POW2]) >> DISCH_TAC \\
+      Know ‘dist mr2 ((x0,y0),(x1,y0)) < dx’
+      >- (MATCH_MP_TAC REAL_LET_TRANS \\
+          Q.EXISTS_TAC ‘dist mr2 ((x0,y0),(x1,y1))’ >> art []) \\
+      rw [Abbr ‘dx’, REAL_LT_MIN, MR2_DEF] \\
+      DISJ2_TAC >> rw [GSYM real_lte] \\
+      ONCE_REWRITE_TAC [POW_2_SUB] \\
+      Cases_on ‘0 <= x1 - x0’
+      >- (Know ‘sqrt ((x1 - x0) pow 2) = x1 - x0’
+          >- (MATCH_MP_TAC POW_2_SQRT >> art []) >> Rewr' \\
+          ASM_REWRITE_TAC [REAL_LE_SUB_CANCEL2]) \\
+      POP_ASSUM (STRIP_ASSUME_TAC o (REWRITE_RULE [real_lte])) \\
+      Know ‘x1 < 0 + x0’
+      >- (rw [GSYM REAL_LT_SUB_RADD]) >> rw [] \\
+      Know ‘b < x0’
+      >- (MATCH_MP_TAC REAL_LET_TRANS \\
+          Q.EXISTS_TAC ‘x1’ >> art []) >> DISCH_TAC \\
+      Q.PAT_X_ASSUM ‘x0 IN interval (a,b)’
+        (STRIP_ASSUME_TAC o (REWRITE_RULE [IN_INTERVAL])) \\
+      PROVE_TAC [REAL_LT_ANTISYM],
+      (* goal 3 (of 4) *)
+      CCONTR_TAC >> fs [GSYM real_lte] \\
+      Know ‘dist mr2 ((x0,y0),(x0,y1)) <= dist mr2 ((x0,y0),(x1,y1))’
+      >- (rw [MR2_DEF] \\
+          MATCH_MP_TAC SQRT_MONO_LE >> rw [REAL_LE_POW2]) >> DISCH_TAC \\
+      Know ‘dist mr2 ((x0,y0),(x0,y1)) < dy’
+      >- (MATCH_MP_TAC REAL_LET_TRANS \\
+          Q.EXISTS_TAC ‘dist mr2 ((x0,y0),(x1,y1))’ >> art []) \\
+      rw [Abbr ‘dy’, REAL_LT_MIN, MR2_DEF] \\
+      DISJ1_TAC >> rw [GSYM real_lte] \\
+      Cases_on ‘0 <= y0 - y1’
+      >- (Know ‘sqrt ((y0 - y1) pow 2) = y0 - y1’
+          >- (MATCH_MP_TAC POW_2_SQRT >> art []) >> Rewr' \\
+          Q.PAT_X_ASSUM ‘y1 <= c’ MP_TAC \\
+          REAL_ARITH_TAC) \\
+      POP_ASSUM (STRIP_ASSUME_TAC o (REWRITE_RULE [real_lte])) \\
+      Know ‘y0 < 0 + y1’
+      >- (rw [GSYM REAL_LT_SUB_RADD]) >> rw [] \\
+      Know ‘y0 < c’
+      >- (MATCH_MP_TAC REAL_LTE_TRANS \\
+          Q.EXISTS_TAC ‘y1’ >> art []) >> DISCH_TAC \\
+      Q.PAT_X_ASSUM ‘y0 IN interval (c,d)’
+        (STRIP_ASSUME_TAC o (REWRITE_RULE [IN_INTERVAL])) \\
+      PROVE_TAC [REAL_LT_ANTISYM],
+      (* goal 4 (of 4) *)
+      CCONTR_TAC >> fs [GSYM real_lte] \\
+      Know ‘dist mr2 ((x0,y0),(x0,y1)) <= dist mr2 ((x0,y0),(x1,y1))’
+      >- (rw [MR2_DEF] \\
+          MATCH_MP_TAC SQRT_MONO_LE >> rw [REAL_LE_POW2]) >> DISCH_TAC \\
+      Know ‘dist mr2 ((x0,y0),(x0,y1)) < dy’
+      >- (MATCH_MP_TAC REAL_LET_TRANS \\
+          Q.EXISTS_TAC ‘dist mr2 ((x0,y0),(x1,y1))’ >> art []) \\
+      rw [Abbr ‘dy’, REAL_LT_MIN, MR2_DEF] \\
+      DISJ2_TAC >> rw [GSYM real_lte] \\
+      ONCE_REWRITE_TAC [POW_2_SUB] \\
+      Cases_on ‘0 <= y1 - y0’
+      >- (Know ‘sqrt ((y1 - y0) pow 2) = y1 - y0’
+          >- (MATCH_MP_TAC POW_2_SQRT >> art []) >> Rewr' \\
+          ASM_REWRITE_TAC [REAL_LE_SUB_CANCEL2]) \\
+      POP_ASSUM (STRIP_ASSUME_TAC o (REWRITE_RULE [real_lte])) \\
+      Know ‘y1 < 0 + y0’
+      >- (rw [GSYM REAL_LT_SUB_RADD]) >> rw [] \\
+      Know ‘d < y0’
+      >- (MATCH_MP_TAC REAL_LET_TRANS \\
+          Q.EXISTS_TAC ‘y1’ >> art []) >> DISCH_TAC \\
+      Q.PAT_X_ASSUM ‘y0 IN interval (c,d)’
+        (STRIP_ASSUME_TAC o (REWRITE_RULE [IN_INTERVAL])) \\
+      PROVE_TAC [REAL_LT_ANTISYM] ]
+QED
+
+Theorem borel_2d_lemma3[local] :
+    sigma UNIV {s | open_in (mtop mr2) s} =
+    sigma UNIV {J | ?a b c d. a IN q_set /\ b IN q_set /\ c IN q_set /\ d IN q_set /\
+                              J = OPEN_interval (a,b) CROSS OPEN_interval (c,d)}
+Proof
+    Q.ABBREV_TAC ‘S1 = sigma UNIV {s | open_in (mtop mr2) s}’
+ >> Q.ABBREV_TAC
+     ‘S3 = sigma UNIV {J | ?a b c d. a IN q_set /\ b IN q_set /\ c IN q_set /\ d IN q_set /\
+                                     J = OPEN_interval (a,b) CROSS OPEN_interval (c,d)}’
+ >> Suff ‘subsets S1 = subsets S3’ >- METIS_TAC [SIGMA_CONG]
+ >> MATCH_MP_TAC SUBSET_ANTISYM
+ >> reverse CONJ_TAC
+ >- (qunabbrevl_tac [‘S1’, ‘S3’] \\
+     MATCH_MP_TAC SIGMA_MONOTONE \\
+     rw [Once SUBSET_DEF] \\
+     REWRITE_TAC [box_open_in_mr2])
+ (* subsets S1 SUBSET subsets S3 *)
+ >> Q.UNABBREV_TAC ‘S1’
+ >> ‘univ(:real # real) = space S3’ by METIS_TAC [SPACE_SIGMA] >> POP_ORW
+ >> MATCH_MP_TAC SIGMA_SUBSET
+ >> Know ‘sigma_algebra S3’
+ >- (Q.UNABBREV_TAC ‘S3’ \\
+     MATCH_MP_TAC SIGMA_ALGEBRA_SIGMA >> rw [subset_class_def])
+ >> rw [SUBSET_DEF]
+ >> POP_ASSUM (ONCE_REWRITE_TAC o wrap o (MATCH_MP borel_2d_lemma1))
+ >> MATCH_MP_TAC SIGMA_ALGEBRA_COUNTABLE_UNION >> art [borel_2d_lemma2]
+ >> MATCH_MP_TAC SUBSET_TRANS
+ >> Q.EXISTS_TAC ‘{J | ?a b c d. a IN q_set /\ b IN q_set /\ c IN q_set /\ d IN q_set /\
+                                 J = OPEN_interval (a,b) CROSS OPEN_interval (c,d)}’
+ >> reverse CONJ_TAC >- rw [Abbr ‘S3’, SIGMA_SUBSET_SUBSETS]
+ >> rw [SUBSET_DEF]
+ >> qexistsl_tac [‘a’, ‘b’, ‘c’, ‘d’] >> rw []
+QED
+
+(* now rationals are all removed *)
+Theorem borel_2d_lemma4[local] :
+    sigma UNIV {s | open_in (mtop mr2) s} =
+    sigma UNIV {J | ?a b c d. J = OPEN_interval (a,b) CROSS OPEN_interval (c,d)}
+Proof
+    Q.ABBREV_TAC ‘S1 = sigma UNIV {s | open_in (mtop mr2) s}’
+ >> Q.ABBREV_TAC
+     ‘S2 = sigma UNIV {J | ?a b c d. J = OPEN_interval (a,b) CROSS OPEN_interval (c,d)}’
+ >> Q.ABBREV_TAC
+     ‘S3 = sigma UNIV {J | ?a b c d. a IN q_set /\ b IN q_set /\ c IN q_set /\ d IN q_set /\
+                                     J = OPEN_interval (a,b) CROSS OPEN_interval (c,d)}’
+ >> Suff ‘subsets S1 = subsets S2’ >- METIS_TAC [SIGMA_CONG]
+ >> MATCH_MP_TAC SUBSET_ANTISYM
+ >> reverse CONJ_TAC
+ >- (qunabbrevl_tac [‘S1’, ‘S2’] \\
+     MATCH_MP_TAC SIGMA_MONOTONE \\
+     rw [Once SUBSET_DEF] \\
+     REWRITE_TAC [box_open_in_mr2])
+ >> MATCH_MP_TAC SUBSET_TRANS
+ >> Q.EXISTS_TAC ‘subsets S3’
+ >> reverse CONJ_TAC
+ >- (qunabbrevl_tac [‘S2’, ‘S3’] \\
+     MATCH_MP_TAC SIGMA_MONOTONE \\
+     rw [Once SUBSET_DEF] \\
+     qexistsl_tac [‘a’, ‘b’, ‘c’, ‘d’] >> REWRITE_TAC [])
+ >> ‘S1 = S3’ by METIS_TAC [borel_2d_lemma3] >> POP_ORW
+ >> qunabbrevl_tac [‘S2’, ‘S3’]
+ >> MATCH_MP_TAC SIGMA_MONOTONE
+ >> rw [Once SUBSET_DEF]
+ >> qexistsl_tac [‘a’, ‘b’, ‘c’, ‘d’] >> REWRITE_TAC []
+QED
+
+Theorem sigma_algebra_borel_2d :
+    sigma_algebra (borel CROSS borel)
+Proof
+    MATCH_MP_TAC SIGMA_ALGEBRA_PROD_SIGMA
+ >> rw [subset_class_def, space_borel]
+QED
+
+(* 2D borel sets can be also generated by open sets in MR2 *)
+Theorem borel_2d :
+    borel CROSS borel = sigma UNIV {s | open_in (mtop mr2) s}
+Proof
+    Suff ‘subsets (borel CROSS borel) =
+          subsets (sigma UNIV {s | open_in (mtop mr2) s})’
+ >- (rw [prod_sigma_def, SPACE_SIGMA, GSYM CROSS_UNIV, space_borel] \\
+     MATCH_MP_TAC SIGMA_CONG >> art [])
+ >> MATCH_MP_TAC SUBSET_ANTISYM
+ >> reverse CONJ_TAC
+ >- (rw [borel_2d_lemma4] \\
+     Know ‘univ(:real # real) = space (borel CROSS borel)’
+     >- (rw [SPACE_PROD_SIGMA, CROSS_UNIV, space_borel]) >> Rewr' \\
+     MATCH_MP_TAC SIGMA_SUBSET \\
+     REWRITE_TAC [sigma_algebra_borel_2d, prod_sigma_def] \\
+     MATCH_MP_TAC SUBSET_TRANS \\
+     Q.EXISTS_TAC ‘prod_sets (subsets borel) (subsets borel)’ \\
+     REWRITE_TAC [SIGMA_SUBSET_SUBSETS] \\
+     rw [SUBSET_DEF, IN_PROD_SETS] \\
+     qexistsl_tac [‘interval (a,b)’, ‘interval (c,d)’] \\
+     rw [OPEN_interval, borel_measurable_sets_gr_less])
+ (* applying prod_sigma_alt *)
+ >> Know ‘borel CROSS borel =
+          sigma (space borel CROSS space borel) (binary borel borel) (binary FST SND) {0; 1}’
+ >- (MATCH_MP_TAC prod_sigma_alt \\
+     REWRITE_TAC [sigma_algebra_borel])
+ >> Rewr'
+ >> rw [sigma_functions_def, binary_def, space_borel, GSYM CROSS_UNIV]
+ >> Q.ABBREV_TAC ‘B = sigma univ(:real # real) {s | open_in (mtop mr2) s}’
+ >> ‘univ(:real # real) = space B’ by PROVE_TAC [SPACE_SIGMA] >> POP_ORW
+ >> MATCH_MP_TAC SIGMA_SUBSET
+ >> Q.UNABBREV_TAC ‘B’
+ >> CONJ_TAC
+ >- (MATCH_MP_TAC SIGMA_ALGEBRA_SIGMA \\
+     rw [subset_class_def])
+ >> rw [SUBSET_DEF] >> rename1 ‘s IN subsets borel’
+ >| [ (* goal 1 (of 2) *)
+      Suff ‘IMAGE (\s. PREIMAGE FST s) (subsets borel) SUBSET
+            subsets (sigma univ(:real # real) {s | open_in (mtop mr2) s})’
+      >- (rw [SUBSET_DEF] >> POP_ASSUM MATCH_MP_TAC \\
+          Q.EXISTS_TAC ‘s’ >> art []) \\
+      KILL_TAC \\
+      REWRITE_TAC [borel_eq_gr_less] \\
+      Q.ABBREV_TAC ‘sts = IMAGE (\(a,b). {x | a < x /\ x < b}) univ(:real # real)’ \\
+      Q.ABBREV_TAC ‘Z = univ(:real # real)’ \\
+      Know ‘IMAGE (\s. PREIMAGE FST s INTER Z) (subsets (sigma UNIV sts)) =
+            subsets (sigma Z (IMAGE (\s. PREIMAGE FST s INTER Z) sts))’
+      >- (MATCH_MP_TAC PREIMAGE_SIGMA >> rw [subset_class_def, IN_FUNSET]) \\
+      simp [Abbr ‘Z’] >> Rewr' \\
+      Q.ABBREV_TAC ‘B = sigma univ(:real # real) {s | open_in (mtop mr2) s}’ \\
+     ‘univ(:real # real) = space B’ by PROVE_TAC [SPACE_SIGMA] >> POP_ORW \\
+      MATCH_MP_TAC SIGMA_SUBSET \\
+      Q.UNABBREV_TAC ‘B’ \\
+      CONJ_TAC >- (MATCH_MP_TAC SIGMA_ALGEBRA_SIGMA >> rw [subset_class_def]) \\
+      MATCH_MP_TAC SUBSET_TRANS \\
+      Q.EXISTS_TAC ‘{s | open_in (mtop mr2) s}’ >> rw [SIGMA_SUBSET_SUBSETS] \\
+      simp [Abbr ‘sts’, SUBSET_DEF] \\
+      Q.X_GEN_TAC ‘y’ >> rw [] \\
+      Cases_on ‘x’ >> simp [] \\
+      Know ‘PREIMAGE FST {x | q < x /\ x < r} = {x | q < x /\ x < r} CROSS univ(:real)’
+      >- (rw [Once EXTENSION, IN_PREIMAGE, IN_CROSS]) >> Rewr' \\
+      rw [MTOP_OPEN] \\
+      Cases_on ‘x’ >> rename1 ‘q < FST (x,y)’ >> fs [] \\
+      Q.ABBREV_TAC ‘dx = min (x - q) (r - x)’ \\
+      Q.EXISTS_TAC ‘dx’ \\
+      CONJ_TAC >- (rw [Abbr ‘dx’, REAL_LT_MIN, REAL_SUB_LT]) \\
+      Q.X_GEN_TAC ‘z’ >> Cases_on ‘z’ >> simp [] \\
+      DISCH_TAC >> rename1 ‘dist mr2 ((x0,y0),(x1,y1)) < dx’ \\
+      Know ‘dist mr2 ((x0,y0),(x1,y0)) <= dist mr2 ((x0,y0),(x1,y1))’
+      >- (rw [MR2_DEF] \\
+          MATCH_MP_TAC SQRT_MONO_LE >> rw [REAL_LE_POW2]) >> DISCH_TAC \\
+      Know ‘dist mr2 ((x0,y0),(x1,y0)) < dx’
+      >- (MATCH_MP_TAC REAL_LET_TRANS \\
+          Q.EXISTS_TAC ‘dist mr2 ((x0,y0),(x1,y1))’ >> art []) \\
+      rw [Abbr ‘dx’, REAL_LT_MIN, MR2_DEF] >| (* 2 subgoals *)
+      [ (* goal 1.1 (of 2) *)
+        Cases_on ‘0 <= x0 - x1’
+        >- (Know ‘sqrt ((x0 - x1) pow 2) = x0 - x1’
+            >- (MATCH_MP_TAC POW_2_SQRT >> art []) >> DISCH_THEN (fs o wrap) \\
+            Q.PAT_X_ASSUM ‘x0 - x1 < x0 - q’ MP_TAC \\
+            REAL_ARITH_TAC) \\
+        POP_ASSUM (STRIP_ASSUME_TAC o (REWRITE_RULE [real_lte])) \\
+        Know ‘x0 < 0 + x1’
+        >- (rw [GSYM REAL_LT_SUB_RADD]) >> rw [] \\
+        MATCH_MP_TAC REAL_LT_TRANS \\
+        Q.EXISTS_TAC ‘x0’ >> art [],
+        (* goal 1.2 (of 2) *)
+       ‘sqrt ((x1 - x0) pow 2) < r - x0’ by PROVE_TAC [POW_2_SUB] \\
+        Cases_on ‘0 <= x1 - x0’
+        >- (Know ‘sqrt ((x1 - x0) pow 2) = x1 - x0’
+            >- (MATCH_MP_TAC POW_2_SQRT >> art []) >> DISCH_THEN (fs o wrap) \\
+            Q.PAT_X_ASSUM ‘x1 - x0 < r - x0’ MP_TAC \\
+            REAL_ARITH_TAC) \\
+        POP_ASSUM (STRIP_ASSUME_TAC o (REWRITE_RULE [real_lte])) \\
+        Know ‘x1 < 0 + x0’
+        >- (rw [GSYM REAL_LT_SUB_RADD]) >> rw [] \\
+        MATCH_MP_TAC REAL_LT_TRANS \\
+        Q.EXISTS_TAC ‘x0’ >> art [] ],
+      (* goal 2 (of 2) *)
+      Suff ‘IMAGE (\s. PREIMAGE SND s) (subsets borel) SUBSET
+            subsets (sigma univ(:real # real) {s | open_in (mtop mr2) s})’
+      >- (rw [SUBSET_DEF] >> POP_ASSUM MATCH_MP_TAC \\
+          Q.EXISTS_TAC ‘s’ >> art []) \\
+      KILL_TAC \\
+      REWRITE_TAC [borel_eq_gr_less] \\
+      Q.ABBREV_TAC ‘sts = IMAGE (\(a,b). {x | a < x /\ x < b}) univ(:real # real)’ \\
+      Q.ABBREV_TAC ‘Z = univ(:real # real)’ \\
+      Know ‘IMAGE (\s. PREIMAGE SND s INTER Z) (subsets (sigma UNIV sts)) =
+            subsets (sigma Z (IMAGE (\s. PREIMAGE SND s INTER Z) sts))’
+      >- (MATCH_MP_TAC PREIMAGE_SIGMA >> rw [subset_class_def, IN_FUNSET]) \\
+      simp [Abbr ‘Z’] >> Rewr' \\
+      Q.ABBREV_TAC ‘B = sigma univ(:real # real) {s | open_in (mtop mr2) s}’ \\
+     ‘univ(:real # real) = space B’ by PROVE_TAC [SPACE_SIGMA] >> POP_ORW \\
+      MATCH_MP_TAC SIGMA_SUBSET \\
+      Q.UNABBREV_TAC ‘B’ \\
+      CONJ_TAC >- (MATCH_MP_TAC SIGMA_ALGEBRA_SIGMA >> rw [subset_class_def]) \\
+      MATCH_MP_TAC SUBSET_TRANS \\
+      Q.EXISTS_TAC ‘{s | open_in (mtop mr2) s}’ >> rw [SIGMA_SUBSET_SUBSETS] \\
+      simp [Abbr ‘sts’, SUBSET_DEF] \\
+      Q.X_GEN_TAC ‘y’ >> rw [] \\
+      Cases_on ‘x’ >> simp [] \\
+      Know ‘PREIMAGE SND {x | q < x /\ x < r} = univ(:real) CROSS {x | q < x /\ x < r}’
+      >- (rw [Once EXTENSION, IN_PREIMAGE, IN_CROSS]) >> Rewr' \\
+      rw [MTOP_OPEN] \\
+      Cases_on ‘x’ >> rename1 ‘q < SND (x,y)’ >> fs [] \\
+      Q.ABBREV_TAC ‘dy = min (y - q) (r - y)’ \\
+      Q.EXISTS_TAC ‘dy’ \\
+      CONJ_TAC >- (rw [Abbr ‘dy’, REAL_LT_MIN, REAL_SUB_LT]) \\
+      Q.X_GEN_TAC ‘z’ >> Cases_on ‘z’ >> simp [] \\
+      DISCH_TAC >> rename1 ‘dist mr2 ((x0,y0),(x1,y1)) < dy’ \\
+      Know ‘dist mr2 ((x0,y0),(x0,y1)) <= dist mr2 ((x0,y0),(x1,y1))’
+      >- (rw [MR2_DEF] \\
+          MATCH_MP_TAC SQRT_MONO_LE >> rw [REAL_LE_POW2]) >> DISCH_TAC \\
+      Know ‘dist mr2 ((x0,y0),(x0,y1)) < dy’
+      >- (MATCH_MP_TAC REAL_LET_TRANS \\
+          Q.EXISTS_TAC ‘dist mr2 ((x0,y0),(x1,y1))’ >> art []) \\
+      rw [Abbr ‘dy’, REAL_LT_MIN, MR2_DEF] >| (* 2 subgoals *)
+      [ (* goal 2.1 (of 2) *)
+        Cases_on ‘0 <= y0 - y1’
+        >- (Know ‘sqrt ((y0 - y1) pow 2) = y0 - y1’
+            >- (MATCH_MP_TAC POW_2_SQRT >> art []) >> DISCH_THEN (fs o wrap) \\
+            Q.PAT_X_ASSUM ‘y0 - y1 < y0 - q’ MP_TAC \\
+            REAL_ARITH_TAC) \\
+        POP_ASSUM (STRIP_ASSUME_TAC o (REWRITE_RULE [real_lte])) \\
+        Know ‘y0 < 0 + y1’
+        >- (rw [GSYM REAL_LT_SUB_RADD]) >> rw [] \\
+        MATCH_MP_TAC REAL_LT_TRANS \\
+        Q.EXISTS_TAC ‘y0’ >> art [],
+        (* goal 2.2 (of 2) *)
+       ‘sqrt ((y1 - y0) pow 2) < r - y0’ by PROVE_TAC [POW_2_SUB] \\
+        Cases_on ‘0 <= y1 - y0’
+        >- (Know ‘sqrt ((y1 - y0) pow 2) = y1 - y0’
+            >- (MATCH_MP_TAC POW_2_SQRT >> art []) >> DISCH_THEN (fs o wrap) \\
+            Q.PAT_X_ASSUM ‘y1 - y0 < r - y0’ MP_TAC \\
+            REAL_ARITH_TAC) \\
+        POP_ASSUM (STRIP_ASSUME_TAC o (REWRITE_RULE [real_lte])) \\
+        Know ‘y1 < 0 + y0’
+        >- (rw [GSYM REAL_LT_SUB_RADD]) >> rw [] \\
+        MATCH_MP_TAC REAL_LT_TRANS \\
+        Q.EXISTS_TAC ‘y0’ >> art [] ] ]
+QED
+
+Theorem borel_2d_alt_box :
+    borel CROSS borel = sigma UNIV {(box a b) CROSS (box c d) | T}
+Proof
+    REWRITE_TAC [borel_2d, borel_2d_lemma4]
+ >> Suff ‘{J | (?a b c d. J = interval (a,b) CROSS interval (c,d))} =
+          {box a b CROSS box c d | T}’ >- Rewr
+ >> rw [Once EXTENSION, box_alt]
+QED
+
 val _ = export_theory ();
+
+(* References:
+
+  [1] Schilling, R.L.: Measures, Integrals and Martingales (Second Edition).
+      Cambridge University Press (2017).
+ *)

--- a/src/probability/real_borelScript.sml
+++ b/src/probability/real_borelScript.sml
@@ -3010,10 +3010,10 @@ Proof
      rw [SUBSET_DEF, IN_PROD_SETS] \\
      qexistsl_tac [‘interval (a,b)’, ‘interval (c,d)’] \\
      rw [OPEN_interval, borel_measurable_sets_gr_less])
- (* applying prod_sigma_alt *)
+ (* applying prod_sigma_alt_sigma_functions *)
  >> Know ‘borel CROSS borel =
           sigma (space borel CROSS space borel) (binary borel borel) (binary FST SND) {0; 1}’
- >- (MATCH_MP_TAC prod_sigma_alt \\
+ >- (MATCH_MP_TAC prod_sigma_alt_sigma_functions \\
      REWRITE_TAC [sigma_algebra_borel])
  >> Rewr'
  >> rw [sigma_functions_def, binary_def, space_borel, GSYM CROSS_UNIV]

--- a/src/probability/sigma_algebraScript.sml
+++ b/src/probability/sigma_algebraScript.sml
@@ -3103,7 +3103,7 @@ Proof
 QED
 
 (* Theorem 14.17 (i): alternative definition of product sigma-algebra [7, p.149] *)
-Theorem prod_sigma_alt :
+Theorem prod_sigma_alt_sigma_functions :
     !A B. sigma_algebra A /\ sigma_algebra B ==>
           prod_sigma A B =
           sigma_functions (space A CROSS space B)


### PR DESCRIPTION
Hi,

this PR continues the previous work in #774 and #822. From product measures, two-dimensional Borel sets (real-valued) can be easily stated as `borel × borel`, where `CROSS` is overloaded on `prod_sigma` with the following definition (previously in `martingaleTheory`, now moved to `sigma_algebraTheory`):

```
   [prod_sigma_def]  Definition      
      ⊢ ∀a b.
          a × b =
          sigma (space a × space b) (prod_sets (subsets a) (subsets b))
```

But this definition is not convenient when trying to show a two-variable function (of the type `:real # real -> real`) is Borel-measurable. To resolve this issue, I first followed `src/real/metricTheory` and defined the standard 2D Euclidean metric space (in `real_borelTheory`. It cannot be moved to `metricTheory` because of the use of `sqrt` defined in `transcTheory`)

```
   [mr2]  Definition      
      ⊢ mr2 = metric (λ((x1,x2),y1,y2). sqrt ((x1 − y1)² + (x2 − y2)²))

   [MR2_DEF]  Theorem      
      ⊢ ∀x1 x2 y1 y2.
          dist mr2 ((x1,x2),y1,y2) = sqrt ((x1 − y1)² + (x2 − y2)²)
```

Then, following a very hard path with many intermediate lemmas, I have proved that 2D Borel sets (`borel × borel`) can be generated by all 2D open sets (w.r.t. `mr2`) and also all open rectangles:

```
   [borel_2d]  Theorem      
      ⊢ borel × borel = sigma 𝕌(:real # real) {s | open_in (mtop mr2) s}
   
   [borel_2d_alt_box]  Theorem      
      ⊢ borel × borel = sigma 𝕌(:real # real) {box a b × box c d | T}
```

These two results can be **later** used in `probabilityTheory` to show that a pair of independent random variables X and Y satisfies E[XY] = E[X] E[Y], where E denotes the mathematical expectation (and thus forms a path towards the Law of Large Numbers for I.I.D. random variables).

I moved some theorems (all related to sigma algebras and prod sigma algebras) from `martingaleTheory` to upward `sigma_algebraTheory`, mostly because the latter file is relatively small.

Beside the above main results, in case HOL is preparing a new release, I also did some minor fixes and other small improvements in HOL core theories, but mostly in `src/probability`.   The only important change outside of the probability folder is the following handy theorem in `cardinalTheory` that I needed in proving the above `borel_2d` theorem:

```
   [CARD_LE_COUNTABLE]  Theorem      
      ⊢ ∀s t. COUNTABLE t ∧ s ≼ t ⇒ COUNTABLE s
```

Previously the types of both `s` and `t` are `:'a -> bool`. But I have two sets of different types. It turns out that the same proof still work when I changed `t:'a->bool` to `t:'b->bool`. Now this theorem is more useful and nothing is broken.

Regards,

Chun Tian