### PR TITLE
Add higher-order case splits

### DIFF
--- a/src/1/Prim_rec.sig
+++ b/src/1/Prim_rec.sig
@@ -45,9 +45,16 @@ sig
    val case_cong_thm               : thm -> thm -> thm
    val prove_constructors_distinct : thm -> thm option list
    val prove_constructors_one_one  : thm -> thm option list
+
+   (*-------------------------------------------------------------------------
+      Prove various equalities on case distinction terms.
+    -------------------------------------------------------------------------*)
+
    val prove_case_rand_thm         : {case_def : thm, nchotomy : thm} -> thm
    val prove_case_elim_thm         : {case_def : thm, nchotomy : thm} -> thm
    val prove_case_eq_thm           : {case_def : thm, nchotomy : thm} -> thm
+   val prove_case_ho_elim_thm      : {case_def : thm, nchotomy : thm} -> thm
+   val prove_case_ho_imp_thm       : {case_def : thm, nchotomy : thm} -> thm
 
    (* A utility function *)
    val EXISTS_EQUATION             : term -> thm -> thm

--- a/src/1/Prim_rec.sml
+++ b/src/1/Prim_rec.sml
@@ -2013,14 +2013,11 @@ end
 fun prove_case_ho_elim_thm ty_def = let
     val thm1 = prove_case_rand_thm ty_def
     val elim_thm = prove_case_elim_thm ty_def
-    val f = concl thm1 |> lhs |> rator
-    val (nm, f_ty) = dest_var f
-    val (x_ty, _) = dom_rng f_ty
-    val f2 = mk_var (nm, x_ty --> bool)
-  in GEN f thm1 |> ISPEC f2 |> GEN f2
-    |> REWRITE_RULE [elim_thm]
-    |> CONV_RULE (DEPTH_CONV BETA_CONV)
-  end
+    fun get_f thm = concl thm |> lhs |> rator
+    val (_, eq_ty) = dom_rng (type_of (get_f thm1))
+    val thm2 = INST_TYPE [eq_ty |-> bool] thm1
+      |> CONV_RULE (RAND_CONV (REWR_CONV elim_thm))
+  in GEN (get_f thm2) thm2 |> BETA_RULE end
 
 (* the forall/implies variant of the case subdivision,
         more useful for conclusions and forward reasoning
@@ -2036,16 +2033,15 @@ fun prove_case_ho_imp_thm ty_def = let
     val (x_ty, _) = dom_rng f_ty
     val x = mk_var ("x", x_ty)
     val f2 = mk_abs (x, mk_neg (mk_comb (f, x)))
-    val rews = [SPEC (mk_neg (mk_var ("P", bool))) DISJ_EQ_IMP, DE_MORGAN_THM,
-        NOT_EXISTS_THM, NOT_CLAUSES]
-  in ISPEC f2 thm1 |> AP_TERM negation
-      |> CONV_RULE (DEPTH_CONV BETA_CONV)
-      |> CONV_RULE (BINOP_CONV (REWRITE_CONV [DE_MORGAN_THM]))
-      |> CONV_RULE (REDEPTH_CONV (HO_REWR_CONV NOT_EXISTS_THM))
-      |> REWRITE_RULE [DE_MORGAN_THM, DISJ_EQ_IMP, NOT_CLAUSES]
+    val rews1 = [CONV_RULE (DEPTH_CONV ETA_CONV) NOT_EXISTS_THM]
+        @ BODY_CONJUNCTS DE_MORGAN_THM
+  in
+    SPEC f2 thm1 |> AP_TERM negation
+      |> CONV_RULE (REDEPTH_CONV (FIRST_CONV
+        (BETA_CONV :: map REWR_CONV rews1)))
+      |> REWRITE_RULE [DISJ_EQ_IMP, NOT_CLAUSES]
+      |> GEN f
   end
-
-
 
 
 

--- a/src/1/TypeBase.sig
+++ b/src/1/TypeBase.sig
@@ -66,11 +66,11 @@ sig
    val AllCaseEqs         : unit -> thm
 
    (* f (case x of ...) <=> (case x of ..) *)
-   val case_rand_thm      : hol_type -> thm
+   val case_rand_of       : hol_type -> thm
    (* f (case x of ...) <=> disjunction of possibilities *)
-   val case_prop_disj_thm : hol_type -> thm
+   val case_pred_disj_of  : hol_type -> thm
    (* f (case x of ...) <=> conjunction of implications *)
-   val case_prop_imp_thm  : hol_type -> thm
+   val case_pred_imp_of   : hol_type -> thm
 
    val update_induction   : thm -> unit
    val update_axiom       : thm -> unit

--- a/src/1/TypeBase.sig
+++ b/src/1/TypeBase.sig
@@ -65,6 +65,11 @@ sig
    val CaseEqs            : string list -> thm
    val AllCaseEqs         : unit -> thm
 
+   (* f (case x of ...) <=> disjunction of possibilities *)
+   val case_prop_disj_thm : hol_type -> thm
+   (* f (case x of ...) <=> conjunction of implications *)
+   val case_prop_imp_thm  : hol_type -> thm
+
    val update_induction   : thm -> unit
    val update_axiom       : thm -> unit
 end

--- a/src/1/TypeBase.sig
+++ b/src/1/TypeBase.sig
@@ -65,6 +65,8 @@ sig
    val CaseEqs            : string list -> thm
    val AllCaseEqs         : unit -> thm
 
+   (* f (case x of ...) <=> (case x of ..) *)
+   val case_rand_thm      : hol_type -> thm
    (* f (case x of ...) <=> disjunction of possibilities *)
    val case_prop_disj_thm : hol_type -> thm
    (* f (case x of ...) <=> conjunction of implications *)

--- a/src/1/TypeBase.sml
+++ b/src/1/TypeBase.sml
@@ -227,13 +227,13 @@ fun AllCaseEqs() =
 
 fun type_info_of ty = {case_def = case_def_of ty, nchotomy = nchotomy_of ty}
 
-fun case_rand_thm ty = let
+fun case_rand_of ty = let
     val thm = Prim_rec.prove_case_rand_thm (type_info_of ty)
     val f = concl thm |> boolSyntax.lhs |> rator
   in GEN f thm end
 
-val case_prop_disj_thm = Prim_rec.prove_case_ho_elim_thm o type_info_of
-val case_prop_imp_thm = Prim_rec.prove_case_ho_imp_thm o type_info_of
+val case_pred_disj_of = Prim_rec.prove_case_ho_elim_thm o type_info_of
+val case_pred_imp_of = Prim_rec.prove_case_ho_imp_thm o type_info_of
 
 (* ---------------------------------------------------------------------- *
  * Install case transformation function for parser                        *

--- a/src/1/TypeBase.sml
+++ b/src/1/TypeBase.sml
@@ -225,6 +225,11 @@ fun AllCaseEqs() =
     TypeBasePure.fold foldthis boolTheory.TRUTH (theTypeBase())
   end
 
+fun case_prop_disj_thm ty = Prim_rec.prove_case_ho_elim_thm
+    {case_def = case_def_of ty, nchotomy = nchotomy_of ty}
+fun case_prop_imp_thm ty = Prim_rec.prove_case_ho_imp_thm
+    {case_def = case_def_of ty, nchotomy = nchotomy_of ty}
+
 (* ---------------------------------------------------------------------- *
  * Install case transformation function for parser                        *
  * ---------------------------------------------------------------------- *)

--- a/src/1/TypeBase.sml
+++ b/src/1/TypeBase.sml
@@ -225,10 +225,15 @@ fun AllCaseEqs() =
     TypeBasePure.fold foldthis boolTheory.TRUTH (theTypeBase())
   end
 
-fun case_prop_disj_thm ty = Prim_rec.prove_case_ho_elim_thm
-    {case_def = case_def_of ty, nchotomy = nchotomy_of ty}
-fun case_prop_imp_thm ty = Prim_rec.prove_case_ho_imp_thm
-    {case_def = case_def_of ty, nchotomy = nchotomy_of ty}
+fun type_info_of ty = {case_def = case_def_of ty, nchotomy = nchotomy_of ty}
+
+fun case_rand_thm ty = let
+    val thm = Prim_rec.prove_case_rand_thm (type_info_of ty)
+    val f = concl thm |> boolSyntax.lhs |> rator
+  in GEN f thm end
+
+val case_prop_disj_thm = Prim_rec.prove_case_ho_elim_thm o type_info_of
+val case_prop_imp_thm = Prim_rec.prove_case_ho_imp_thm o type_info_of
 
 (* ---------------------------------------------------------------------- *
  * Install case transformation function for parser                        *


### PR DESCRIPTION
The higher-order elim rule combines the case_elim and case_rand
theorems already available from Prim_rec. The implication form
uses negation to flip the quantifiers, from a disjunction of
existentially-quantified possibilities to a conjunction of
universally-qualified implications.