### PR TITLE
cleanup disj_norm workarounds in probability scripts

### DIFF
--- a/src/probability/borelScript.sml
+++ b/src/probability/borelScript.sml
@@ -36,11 +36,7 @@ open hurdUtils util_probTheory extrealTheory sigma_algebraTheory
 
 val _ = new_theory "borel";
 
-val std_ss = std_ss -* ["lift_disj_eq", "lift_imp_disj"]
-val real_ss = real_ss -* ["lift_disj_eq", "lift_imp_disj"]
-val _ = temp_delsimps ["lift_disj_eq", "lift_imp_disj"]
-
-val ASM_ARITH_TAC = REPEAT (POP_ASSUM MP_TAC) >> ARITH_TAC; (* numLib *)
+val ASM_ARITH_TAC = rpt (POP_ASSUM MP_TAC) >> ARITH_TAC; (* numLib *)
 val DISC_RW_KILL = DISCH_TAC >> ONCE_ASM_REWRITE_TAC [] >> POP_ASSUM K_TAC;
 fun METIS ths tm = prove(tm, METIS_TAC ths);
 
@@ -4730,7 +4726,8 @@ Proof
      qunabbrevl_tac [`empties`, `filtered`] \\
      RW_TAC std_ss [Once EXTENSION, MEM_FILTER, MEM_COUNT_LIST,
                     IN_DIFF, IN_COUNT] \\
-     EQ_TAC >> RW_TAC std_ss []) >> Rewr'
+     EQ_TAC >> RW_TAC std_ss [] \\
+     PROVE_TAC []) >> Rewr'
  (* Part II: sort the list by lowerbounds *)
  >> Q.ABBREV_TAC `R = \s t. interval_lowerbound s <= interval_lowerbound t`
  >> Know `transitive R /\ total R`
@@ -6042,7 +6039,7 @@ Proof
  >- (qx_genl_tac [‘m’, ‘n’] >> DISCH_TAC \\
      fs [DISJOINT_ALT, Abbr ‘rf’] \\
      rw [real_set_def] >> rename1 ‘y IN f m’ \\
-     STRONG_DISJ_TAC >> rename1 ‘real y = real z’ \\
+     rename1 ‘real z = real y’ \\
      Cases_on ‘z = PosInf’ >- rw [] >> DISJ2_TAC \\
      Cases_on ‘z = NegInf’ >- rw [] >> DISJ2_TAC \\
     ‘?a. y = Normal a’ by METIS_TAC [extreal_cases] \\

--- a/src/probability/martingaleScript.sml
+++ b/src/probability/martingaleScript.sml
@@ -16,10 +16,6 @@ open hurdUtils util_probTheory extrealTheory sigma_algebraTheory
 
 val _ = new_theory "martingale";
 
-val std_ss = std_ss -* ["lift_disj_eq", "lift_imp_disj"]
-val real_ss = real_ss -* ["lift_disj_eq", "lift_imp_disj"]
-val _ = temp_delsimps ["lift_disj_eq", "lift_imp_disj"]
-
 val _ = hide "S";
 
 (* "The theory of martingales as we know it now goes back to
@@ -1528,17 +1524,14 @@ Proof
                qexistsl_tac [‘\y. pos_fn_integral (X,A,u) (\x. indicator_fn (E n) (cons x y))’,
                              ‘\y. pos_fn_integral (X,A,u)
                                     (\x. indicator_fn (d INTER E n) (cons x y))’] \\
-               rw [] >| (* 3 subgoals *)
-               [ (* goal 1 (of 3) *)
+               rw [] >| (* 2 subgoals *)
+               [ (* goal 1 (of 2) *)
                 ‘E n = E n INTER E n’ by PROVE_TAC [INTER_IDEMPOT] >> POP_ORW \\
                  Q.PAT_X_ASSUM ‘!n. E n IN D n’ (MP_TAC o (Q.SPEC ‘n’)) \\
                  RW_TAC std_ss [Abbr ‘D’, GSPECIFICATION],
-                 (* goal 2 (of 3) *)
+                 (* goal 2 (of 2) *)
                  Q.PAT_X_ASSUM ‘d IN D n’ MP_TAC \\
-                 RW_TAC std_ss [Abbr ‘D’, GSPECIFICATION],
-                 (* goal 3 (of 3) *)
-                 DISJ1_TAC >> MATCH_MP_TAC pos_not_neginf \\
-                 MATCH_MP_TAC pos_fn_integral_pos >> rw [INDICATOR_FN_POS] ]) \\
+                 RW_TAC std_ss [Abbr ‘D’, GSPECIFICATION] ]) \\
            Q.X_GEN_TAC ‘y’ >> STRIP_TAC >> BETA_TAC \\
            HO_MATCH_MP_TAC pos_fn_integral_sub \\
            simp [INDICATOR_FN_POS, INDICATOR_FN_NOT_INFTY] \\
@@ -1559,17 +1552,14 @@ Proof
                qexistsl_tac [‘\x. pos_fn_integral (Y,B,v) (\y. indicator_fn (E n) (cons x y))’,
                              ‘\x. pos_fn_integral (Y,B,v)
                                     (\y. indicator_fn (d INTER E n) (cons x y))’] \\
-               rw [] >| (* 3 subgoals *)
-               [ (* goal 1 (of 3) *)
+               rw [] >| (* 2 subgoals *)
+               [ (* goal 1 (of 2) *)
                 ‘E n = E n INTER E n’ by PROVE_TAC [INTER_IDEMPOT] >> POP_ORW \\
                  Q.PAT_X_ASSUM ‘!n. E n IN D n’ (MP_TAC o (Q.SPEC ‘n’)) \\
                  RW_TAC std_ss [Abbr ‘D’, GSPECIFICATION],
-                 (* goal 2 (of 3) *)
+                 (* goal 2 (of 2) *)
                  Q.PAT_X_ASSUM ‘d IN D n’ MP_TAC \\
-                 RW_TAC std_ss [Abbr ‘D’, GSPECIFICATION],
-                 (* goal 3 (of 3) *)
-                 DISJ1_TAC >> MATCH_MP_TAC pos_not_neginf \\
-                 MATCH_MP_TAC pos_fn_integral_pos >> rw [INDICATOR_FN_POS] ]) \\
+                 RW_TAC std_ss [Abbr ‘D’, GSPECIFICATION] ]) \\
            Q.X_GEN_TAC ‘x’ >> STRIP_TAC >> BETA_TAC \\
            HO_MATCH_MP_TAC pos_fn_integral_sub \\
            simp [INDICATOR_FN_POS, INDICATOR_FN_NOT_INFTY] \\
@@ -4185,11 +4175,15 @@ Proof
      Q.EXISTS_TAC ‘{y | y IN Y /\ pos_fn_integral (X,A,u) (\x. (fn_plus f) (x,y)) = PosInf} UNION
                    {y | y IN Y /\ pos_fn_integral (X,A,u) (\x. (fn_minus f) (x,y)) = PosInf}’ \\
      CONJ_TAC >- (PROVE_TAC [NULL_SET_UNION, GSYM IN_NULL_SET]) \\
-     Q.X_GEN_TAC ‘y’ >> rw []
-     >- (‘!x. (fn_plus f) (x,y) - (fn_minus f) (x,y) = f (x,y)’
-            by METIS_TAC [FN_DECOMP] >> POP_ORW \\
-         simp [Once IN_MEASURABLE_BOREL_PLUS_MINUS]) \\
-     art []) >> DISCH_TAC
+     Q.X_GEN_TAC ‘y’ >> rw [] >| (* 3 subgoals *)
+     [ (* goal 1 (of 3) *)
+      ‘!x. (fn_plus f) (x,y) - (fn_minus f) (x,y) = f (x,y)’
+          by METIS_TAC [FN_DECOMP] >> POP_ORW \\
+       simp [Once IN_MEASURABLE_BOREL_PLUS_MINUS],
+       (* goal 2 (of 3) *)
+       CCONTR_TAC >> FULL_SIMP_TAC std_ss [],
+       (* goal 3 (of 3) *)
+       CCONTR_TAC >> FULL_SIMP_TAC std_ss [] ]) >> DISCH_TAC
  (* goal: AE x::(X,A,u). integrable (Y,B,v) (\y. f (x,y)) *)
  >> STRONG_CONJ_TAC
  >- (rw [Once FN_DECOMP, integrable_def] \\
@@ -4210,11 +4204,15 @@ Proof
      Q.EXISTS_TAC ‘{x | x IN X /\ pos_fn_integral (Y,B,v) (\y. (fn_plus f) (x,y)) = PosInf} UNION
                    {x | x IN X /\ pos_fn_integral (Y,B,v) (\y. (fn_minus f) (x,y)) = PosInf}’ \\
      CONJ_TAC >- (PROVE_TAC [NULL_SET_UNION, GSYM IN_NULL_SET]) \\
-     Q.X_GEN_TAC ‘x’ >> rw []
-     >- (‘!y. (fn_plus f) (x,y) - (fn_minus f) (x,y) = f (x,y)’
-            by METIS_TAC [FN_DECOMP] >> POP_ORW \\
-         simp [Once IN_MEASURABLE_BOREL_PLUS_MINUS]) \\
-     art []) >> DISCH_TAC
+     Q.X_GEN_TAC ‘x’ >> rw [] >| (* 3 subgoals *)
+     [ (* goal 1 (of 3) *)
+      ‘!y. (fn_plus f) (x,y) - (fn_minus f) (x,y) = f (x,y)’
+          by METIS_TAC [FN_DECOMP] >> POP_ORW \\
+       simp [Once IN_MEASURABLE_BOREL_PLUS_MINUS],
+       (* goal 2 (of 3) *)
+       CCONTR_TAC >> FULL_SIMP_TAC std_ss [],
+       (* goal 3 (of 3) *)
+       CCONTR_TAC >> FULL_SIMP_TAC std_ss [] ]) >> DISCH_TAC
  (* goal: integrable (X,A,u) (\x. integral (Y,B,v) (\y. f (x,y))) *)
  >> STRONG_CONJ_TAC
  >- (rw [integrable_def] >| (* 3 subgoals *)

--- a/src/probability/real_measureScript.sml
+++ b/src/probability/real_measureScript.sml
@@ -15,8 +15,6 @@ open hurdUtils util_probTheory sigma_algebraTheory real_borelTheory;
 
 val _ = new_theory "real_measure";
 
-val std_ss' = std_ss ++ boolSimps.ETA_ss;
-
 (* ------------------------------------------------------------------------- *)
 (* Basic measure theory definitions.                                         *)
 (* ------------------------------------------------------------------------- *)
@@ -1599,44 +1597,50 @@ val MEASURE_SPACE_REDUCE = store_thm
    >> Cases
    >> RW_TAC std_ss [m_space_def, measurable_sets_def, measure_def]);
 
-val MONOTONE_CONVERGENCE = store_thm
-  ("MONOTONE_CONVERGENCE",
-   ``!m s f.
+Theorem MONOTONE_CONVERGENCE :
+    !m s f.
        measure_space m /\ f IN (UNIV -> measurable_sets m) /\
        (!n. f n SUBSET f (SUC n)) /\
        (s = BIGUNION (IMAGE f UNIV)) ==>
-       measure m o f --> measure m s``,
-   RW_TAC std_ss [measure_space_def, IN_FUNSET, IN_UNIV]
-   >> (MP_TAC o
+       measure m o f --> measure m s
+Proof
+    RW_TAC std_ss [measure_space_def, IN_FUNSET, IN_UNIV]
+ >> (MP_TAC o
        INST_TYPE [beta |-> ``:num``] o
        Q.SPECL [`m`, `BIGUNION (IMAGE f UNIV)`, `\x. num_CASE x {} f`])
       MEASURE_COUNTABLE_INCREASING
-   >> Cond
-   >- (RW_TAC std_ss [IN_FUNSET, IN_UNIV, num_case_def, measure_space_def] >|
-       [Cases_on `x` >|
-        [RW_TAC std_ss [num_case_def]
-         >> PROVE_TAC [SIGMA_ALGEBRA_ALGEBRA, ALGEBRA_EMPTY, subsets_def],
-         RW_TAC std_ss [num_case_def]],
-        Cases_on `n`
-        >> RW_TAC std_ss [num_case_def, EMPTY_SUBSET],
-        RW_TAC std_ss [EXTENSION,GSPECIFICATION]
-        >> RW_TAC std_ss [IN_BIGUNION_IMAGE, IN_UNIV]
-        >> EQ_TAC >|
-        [RW_TAC std_ss []
-         >> Q.EXISTS_TAC `SUC x'`
-         >> RW_TAC std_ss [num_case_def],
-         RW_TAC std_ss []
-         >> POP_ASSUM MP_TAC
-         >> Cases_on `x'` >- RW_TAC std_ss [NOT_IN_EMPTY, num_case_def]
-         >> RW_TAC std_ss [num_case_def]
-         >> PROVE_TAC []]])
-   >> RW_TAC std_ss []
-   >> Know `measure m o f = (\n. (measure m o (\x. num_CASE x {} f)) (SUC n))`
-   >- (RW_TAC std_ss [FUN_EQ_THM]
-       >> RW_TAC std_ss [num_case_def, o_THM])
-   >> Rewr
-   >> Ho_Rewrite.REWRITE_TAC [GSYM SEQ_SUC]
-   >> RW_TAC std_ss' []);
+ >> Cond
+ >- (RW_TAC std_ss [IN_FUNSET, IN_UNIV, num_case_def, measure_space_def] >|
+     [ (* goal 1 *)
+       Cases_on `x` >|
+       [ RW_TAC std_ss [num_case_def] \\
+         PROVE_TAC [SIGMA_ALGEBRA_ALGEBRA, ALGEBRA_EMPTY, subsets_def],
+         RW_TAC std_ss [num_case_def] ],
+       (* goal 2 *)
+       Cases_on `n` \\
+       RW_TAC std_ss [num_case_def, EMPTY_SUBSET],
+       (* goal 3 *)
+       RW_TAC std_ss [EXTENSION, GSPECIFICATION] \\
+       RW_TAC std_ss [IN_BIGUNION_IMAGE, IN_UNIV] \\
+       EQ_TAC >| (* 2 subgoals *)
+       [ (* goal 1 (of 2) *)
+         RW_TAC std_ss [] \\
+         Q.EXISTS_TAC `SUC x'` \\
+         RW_TAC std_ss [num_case_def],
+         (* goal 2 (of 2) *)
+         RW_TAC std_ss [] \\
+         POP_ASSUM MP_TAC \\
+         Cases_on `x'` >- RW_TAC std_ss [NOT_IN_EMPTY, num_case_def] \\
+         RW_TAC std_ss [num_case_def] \\
+         PROVE_TAC [] ] ])
+ >> RW_TAC std_ss []
+ >> Know `measure m o f = (\n. (measure m o (\x. num_CASE x {} f)) (SUC n))`
+ >- (RW_TAC std_ss [FUN_EQ_THM] \\
+     RW_TAC std_ss [num_case_def, o_THM])
+ >> Rewr
+ >> Ho_Rewrite.REWRITE_TAC [GSYM SEQ_SUC]
+ >> RW_TAC (std_ss ++ boolSimps.ETA_ss) []
+QED
 
 val MEASURABLE_SETS_SUBSET_SPACE = store_thm
   ("MEASURABLE_SETS_SUBSET_SPACE",

--- a/src/probability/real_topologyScript.sml
+++ b/src/probability/real_topologyScript.sml
@@ -24,14 +24,13 @@ open numTheory numLib unwindLib tautLib Arith prim_recTheory RealArith
      sumTheory InductiveDefinition ind_typeTheory listTheory mesonLib
      seqTheory limTheory transcTheory realLib topologyTheory metricTheory;
 
-val _ = new_theory "real_topology";
-val std_ss = std_ss -* ["lift_disj_eq", "lift_imp_disj"]
-val real_ss = real_ss -* ["lift_disj_eq", "lift_imp_disj"]
-val _ = temp_delsimps ["lift_disj_eq", "lift_imp_disj"]
-
 open wellorderTheory cardinalTheory iterateTheory productTheory hurdUtils;
 
 val _ = new_theory "real_topology";
+
+val std_ss = std_ss -* ["lift_disj_eq", "lift_imp_disj"]
+val real_ss = real_ss -* ["lift_disj_eq", "lift_imp_disj"]
+val _ = temp_delsimps ["lift_disj_eq", "lift_imp_disj"]
 
 fun MESON ths tm = prove(tm,MESON_TAC ths);
 fun METIS ths tm = prove(tm,METIS_TAC ths);


### PR DESCRIPTION
Hi,

this PR removed the following lines in probability related scripts and fixed the broken proofs, so that all theorems are proven under default definitions of `std_ss` and `real_ss`:

```
val std_ss = std_ss -* ["lift_disj_eq", "lift_imp_disj"]
val real_ss = real_ss -* ["lift_disj_eq", "lift_imp_disj"]
val _ = temp_delsimps ["lift_disj_eq", "lift_imp_disj"]
```

Overall speaking, the new proofs became slightly smaller with the new default simp sets.

--Chun
