### PR TITLE
Fixed MiniSAT source code for C++11 (invalid suffix on literal)

### DIFF
--- a/src/HolSat/sat_solvers/minisat/Main.C
+++ b/src/HolSat/sat_solvers/minisat/Main.C
@@ -72,11 +72,11 @@ void printStats(SolverStats& stats, double& cpu_time, int64& mem_used)
 {
     cpu_time = cpuTime();
     mem_used = memUsed();
-    reportf("restarts              : %"I64_fmt"\n", stats.starts);
-    reportf("conflicts             : %-12"I64_fmt"   (%.0f /sec)\n", stats.conflicts   , stats.conflicts   /cpu_time);
-    reportf("decisions             : %-12"I64_fmt"   (%.0f /sec)\n", stats.decisions   , stats.decisions   /cpu_time);
-    reportf("propagations          : %-12"I64_fmt"   (%.0f /sec)\n", stats.propagations, stats.propagations/cpu_time);
-    reportf("conflict literals     : %-12"I64_fmt"   (%4.2f %% deleted)\n", stats.tot_literals, (stats.max_literals - stats.tot_literals)*100 / (double)stats.max_literals);
+    reportf("restarts              : %" I64_fmt "\n", stats.starts);
+    reportf("conflicts             : %-12" I64_fmt "   (%.0f /sec)\n", stats.conflicts   , stats.conflicts   /cpu_time);
+    reportf("decisions             : %-12" I64_fmt "   (%.0f /sec)\n", stats.decisions   , stats.decisions   /cpu_time);
+    reportf("propagations          : %-12" I64_fmt "   (%.0f /sec)\n", stats.propagations, stats.propagations/cpu_time);
+    reportf("conflict literals     : %-12" I64_fmt "   (%4.2f %% deleted)\n", stats.tot_literals, (stats.max_literals - stats.tot_literals)*100 / (double)stats.max_literals);
     if (mem_used != 0) reportf("Memory used           : %.2f MB\n", mem_used / 1048576.0);
     reportf("CPU time              : %g s\n", cpu_time);
 }

--- a/src/HolSat/sat_solvers/minisat/Solver.C
+++ b/src/HolSat/sat_solvers/minisat/Solver.C
@@ -832,7 +832,7 @@ bool Solver::solve(const vec<Lit>& assumps)
         if (var(conflict[i]) >= 100){
             Lit p = conflict[i];
             Var x = var(p);
-            printf("confl[%d] = "L_LIT"\n", i, L_lit(p));
+            printf("confl[%d] = " L_LIT "\n", i, L_lit(p));
             printf("level     = %d\n", level[x]);
             printf("reason    = %p\n", reason[x]);
             printf("unit_id   = %d\n", unit_id[x]);


### PR DESCRIPTION
Hi,

this is a very small and safe patch to MiniSAT source code. It seems that C++11 standard requires a space between literal and identifier [-Wreserved-user-defined-literal] and FreeBSD's default LLVM-based C++ compiler cannot compile MiniSAT's source code unless we fix the source code (or add some special compiling options).
```
binghe@freebsd:~/ML/HOL/src/HolSat/sat_solvers/minisat $ gmake
Making dependencies ...
Main.C:75:40: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
    reportf("restarts              : %"I64_fmt"\n", stats.starts);
                                       ^
                                        
Main.C:76:43: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
    reportf("conflicts             : %-12"I64_fmt"   (%.0f /sec)\n", stats.conflicts   , stats.conflicts   /cpu_time);
                                          ^
                                           
Main.C:77:43: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
    reportf("decisions             : %-12"I64_fmt"   (%.0f /sec)\n", stats.decisions   , stats.decisions   /cpu_time);
                                          ^
                                           
Main.C:78:43: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
    reportf("propagations          : %-12"I64_fmt"   (%.0f /sec)\n", stats.propagations, stats.propagations/cpu_time);
                                          ^
                                           
Main.C:79:43: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
    reportf("conflict literals     : %-12"I64_fmt"   (%4.2f %% deleted)\n", stats.tot_literals, (stats.max_literals - stats.tot_lite...
                                          ^
                                           
5 errors generated.
Solver.C:835:34: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
            printf("confl[%d] = "L_LIT"\n", i, L_lit(p));
                                 ^
                                  
1 error generated.
Makefile:88: depend.mak: No such file or directory
gmake: *** [Makefile:81: depend.mak] Error 1
```

However, this is still not enough to fix all MiniSAT-related issues on FreeBSD (see #899): the way `src/HolSat/sat_solvers/minisat/Makefile` is doing (by generating `depend.mak` on the fly and then immediately include it) seems a unique feature of GNU make, while on FreeBSD the BSD-version `make` command cannot support:
```
make: "/usr/home/binghe/ML/HOL/src/HolSat/sat_solvers/minisat/Makefile" line 88: Could not find depend.mak
make: Fatal errors encountered -- cannot continue
make: stopped in /usr/home/binghe/ML/HOL/src/HolSat/sat_solvers/minisat
```

But this is a very minor issue: BSD user just need to install `gmake` manually and execute `gmake` (instead of `make`) in that directory and then MiniSAT can be built without other issues:

(A common solution found in many open source software is  to introduce a `MAKE` environment variable and give user the choice to use `gmake` (or something else) whenever the building process needs to call `make`.)

Regards,

Chun Tian