### PR TITLE
Fix sporadically occuring bug in lassie related to sempre

### DIFF
--- a/examples/lassie/sempre/src/edu/stanford/nlp/sempre/Master.java
+++ b/examples/lassie/sempre/src/edu/stanford/nlp/sempre/Master.java
@@ -44,7 +44,7 @@ public class Master {
     public String newGrammarPath;
   }
   public static Options opts = new Options();
-  
+
   public class Response {
     // Example that was parsed, if any.
     public Example ex;
@@ -137,7 +137,7 @@ public class Master {
     Server server = new Server(this);
     server.run();;
   }
-  
+
   public void runInteractivePrompt() {
     Session session = getSession("stdin");
 
@@ -145,7 +145,7 @@ public class Master {
       printHelp();
     try {
       ConsoleReader reader = new ConsoleReader();
-      reader.setPrompt("> ");
+      reader.setPrompt("#SEMPRE# ");
       String line;
       while ((line = reader.readLine()) != null) {
         int indent = LogInfo.getIndLevel();
@@ -255,7 +255,7 @@ public class Master {
     Map<String, Integer> choices = new LinkedHashMap<>();
     deriv.incrementAllChoices(1, choices);
     FeatureVector.logChoices("Pred", choices);
-    
+
     // Print denotation
     LogInfo.begin_track("Top formula");
     LogInfo.logs("%s", deriv.formula);
@@ -264,10 +264,10 @@ public class Master {
 	LogInfo.begin_track("Top value");
 	deriv.value.log();
 	LogInfo.end_track();
-    } 
+    }
   }
-  
-    
+
+
   private void handleCommand(Session session, String line, Response response) {
     LispTree tree = LispTree.proto.parseFromString(line);
     tree = builder.grammar.applyMacros(tree);

--- a/examples/lassie/src/LassieLib.sml
+++ b/examples/lassie/src/LassieLib.sml
@@ -191,7 +191,6 @@ struct
                 else
                 let
                   val theString = strAcc ^ " " ^ (removeTrailing (! LASSIESEP) str);
-                  val _ = (print ("Turned :"^ strAcc ^ " " ^ str); print "\n Into: "; print theString; print "\n");
                   val t = sempre theString;
                 in
                   case #result t of

--- a/examples/lassie/src/LassieLib.sml
+++ b/examples/lassie/src/LassieLib.sml
@@ -59,7 +59,7 @@ struct
       val s = TextIO.input(instream);
       val _ = if !logging then print s else ()
     in
-      if String.isSuffix "\n> " s orelse s = "> " then s
+      if String.isSuffix "#SEMPRE# " s orelse s = "#SEMPRE# " then s
       (* else if s = "" then raise LassieException "Reached EOS? Empty string was read."  *)
       else s ^ (waitSempre instream)
     end;
@@ -191,6 +191,7 @@ struct
                 else
                 let
                   val theString = strAcc ^ " " ^ (removeTrailing (! LASSIESEP) str);
+                  val _ = (print ("Turned :"^ strAcc ^ " " ^ str); print "\n Into: "; print theString; print "\n");
                   val t = sempre theString;
                 in
                   case #result t of
@@ -210,7 +211,9 @@ struct
                 end
                 (* The Lassie separator was a HOL4 level token *)
                 handle LassieException diag =>
-                  (strAcc ^ " " ^ str, goalpos, gl, vld))
+                  if (diag = "Could not extract formula")
+                  then (strAcc ^ " " ^ str, goalpos, gl, vld)
+                  else raise LassieException diag)
              ("", All, gls1, vld1) theStrings)
     in
       if (str = "") then (gls, vld)


### PR DESCRIPTION
SEMPRE sporadically adds line-breaks to the information it prints on stdout.
Due to the way how SEMPRE and Lassie communicate, this meant that there was a slight chance for terms like `x <= y <=> ...` to be understood as the SEMPRE prompt instead of being a part of the full response. This lead to inconsistencies between SEMPRE's and Lassie's internal states.
This PR fixes this randomly occuring bug by making the SEMPRE prompt syntactically different from HOL4 symbols.