### PR TITLE
Recovered old definition of real_random_variable_def

### DIFF
--- a/src/probability/borelScript.sml
+++ b/src/probability/borelScript.sml
@@ -2738,6 +2738,21 @@ Proof
  >> ASM_SET_TAC []
 QED
 
+Theorem IN_MEASURABLE_BOREL_CONG :
+    !m f g. (!x. x IN m_space m ==> (f x = g x)) ==>
+            (f IN measurable (m_space m,measurable_sets m) Borel <=>
+             g IN measurable (m_space m,measurable_sets m) Borel)
+Proof
+    rpt STRIP_TAC
+ >> EQ_TAC >> STRIP_TAC
+ >| [ (* goal 1 (of 2) *)
+      MATCH_MP_TAC IN_MEASURABLE_BOREL_EQ \\
+      Q.EXISTS_TAC ‘f’ >> rw [],
+      (* goal 2 (of 2) *)
+      MATCH_MP_TAC IN_MEASURABLE_BOREL_EQ \\
+      Q.EXISTS_TAC ‘g’ >> rw [] ]
+QED
+
 (*****************************************************)
 
 val BOREL_MEASURABLE_SETS_RO_r = prove (

--- a/src/probability/lebesgueScript.sml
+++ b/src/probability/lebesgueScript.sml
@@ -2176,6 +2176,20 @@ Proof
  >> METIS_TAC [pos_fn_integral_pos_simple_fn, pos_simple_fn_integral_indicator]
 QED
 
+Theorem pos_fn_integral_const :
+    !m c. measure_space m /\ measure m (m_space m) < PosInf /\ 0 <= c ==>
+         (pos_fn_integral m (\x. Normal c) = Normal c * measure m (m_space m))
+Proof
+    rpt STRIP_TAC
+ >> Know ‘pos_fn_integral m (\x. Normal c)  =
+          pos_fn_integral m (\x. (\x. Normal c) x * indicator_fn (m_space m) x)’
+ >- (MATCH_MP_TAC pos_fn_integral_mspace \\
+     rw [extreal_of_num_def, extreal_le_eq])
+ >> BETA_TAC >> Rewr'
+ >> MATCH_MP_TAC pos_fn_integral_cmul_indicator
+ >> simp [MEASURE_SPACE_MSPACE_MEASURABLE]
+QED
+
 Theorem pos_fn_integral_sum_cmul_indicator :
     !m s a x. measure_space m /\ FINITE s /\ (!i:num. i IN s ==> 0 <= x i) /\
              (!i:num. i IN s ==> a i IN measurable_sets m) ==>
@@ -5068,6 +5082,18 @@ val integrable_eq = store_thm (* new *)
           MATCH_MP_TAC pos_fn_integral_mspace >> art [] \\
           REWRITE_TAC [FN_MINUS_POS]) >> Rewr \\
       ASM_REWRITE_TAC [] ]);
+
+Theorem integrable_cong :
+    !m f g. measure_space m /\ (!x. x IN m_space m ==> (f x = g x)) ==>
+           (integrable m f <=> integrable m g)
+Proof
+    rpt STRIP_TAC
+ >> EQ_TAC >> STRIP_TAC
+ >| [ (* goal 1 (of 2) *)
+      MATCH_MP_TAC integrable_eq >> Q.EXISTS_TAC ‘f’ >> art [],
+      (* goal 2 (of 2) *)
+      MATCH_MP_TAC integrable_eq >> Q.EXISTS_TAC ‘g’ >> rw [] ]
+QED
 
 (* added ‘x IN m_space m’ *)
 Theorem integrable_pos :

--- a/src/probability/util_probScript.sml
+++ b/src/probability/util_probScript.sml
@@ -1378,6 +1378,19 @@ Proof
   SIMP_TAC std_ss [BINARY_RANGE] THEN SET_TAC []
 QED
 
+Theorem FINITE_TWO :
+    !s t. FINITE {s; t}
+Proof
+    PROVE_TAC [FINITE_INSERT, FINITE_SING]
+QED
+
+Theorem SUBSET_TWO :
+    !N s t. N SUBSET {s; t} /\ N <> {} ==> N = {s} \/ N = {t} \/ N = {s; t}
+Proof
+    rpt GEN_TAC
+ >> SET_TAC []
+QED
+
 (* ------------------------------------------------------------------------- *)
 (*  Some lemmas needed by CARATHEODORY in measureTheory (author: Chun Tian)  *)
 (* ------------------------------------------------------------------------- *)


### PR DESCRIPTION
Hi,

the purpose of this PR is to fix (by recovering the old, correct) definition of `real_random_variable_def` (in `probabilityTheory`):
```
   [real_random_variable_def]  Definition      
      ⊢ ∀X p.
          real_random_variable X p ⇔
          random_variable X p Borel ∧
          ∀x. x ∈ p_space p ⇒ X x ≠ −∞ ∧ X x ≠ +∞
```
In the above definition, the part `x ∈ p_space p` was wrongly removed in my previous PRs (between k13 and k14). As the result many existing proofs are over-simplified, as without it the random variable (measurable function) `X` must be a total function.

Once random variables are not total, many term rewritings in related proofs do not work any more. Instead, many "congruence" lemmas are now newly added and used, e.g.:
```
   [converge_AE_cong]  Theorem      
      ⊢ ∀p X Y Z m.
          (∀n x. m ≤ n ∧ x ∈ p_space p ⇒ X n x = Y n x) ⇒
          ((X --> Z) (almost_everywhere p) ⇔
           (Y --> Z) (almost_everywhere p))

   [expectation_cong]  Theorem      
      ⊢ ∀p f g.
          prob_space p ∧ (∀x. x ∈ p_space p ⇒ f x = g x) ⇒
          expectation p f = expectation p g

   [variance_cong]  Theorem      
      ⊢ ∀p f g.
          prob_space p ∧ (∀x. x ∈ p_space p ⇒ f x = g x) ⇒
          variance p f = variance p g
```

Some other congruence-like theorems about independent random variables are also added, e.g. 
```
   [indep_vars_cong]  Theorem      
      ⊢ ∀p X B J f.
          indep_vars p X B J ∧
          (∀n. n ∈ J ⇒ random_variable (X n) p (B n)) ∧
          (∀n. n ∈ J ⇒ f n ∈ measurable (B n) (B n)) ⇒
          indep_vars p (λn. f n ∘ X n) B J
```

Chun Tian