### PR TITLE
Replaced 'throw(..)' (removed in C++17) with 'noexcept(false)' in minisat.

### DIFF
--- a/src/HolSat/sat_solvers/minisat/File.C
+++ b/src/HolSat/sat_solvers/minisat/File.C
@@ -118,8 +118,11 @@ void putUInt(File& out, uint64 val)
 }
 
 
-uint64 getUInt(File& in)
-    noexcept(false)
+#if __cplusplus >= 201703L
+uint64 getUInt (File& in) noexcept(false)
+#else
+uint64 getUInt (File& in) throw(Exception_EOF)
+#endif
 {
     uint byte0, byte1, byte2, byte3, byte4, byte5, byte6, byte7;
     byte0 = in.getChar();

--- a/src/HolSat/sat_solvers/minisat/File.C
+++ b/src/HolSat/sat_solvers/minisat/File.C
@@ -119,7 +119,7 @@ void putUInt(File& out, uint64 val)
 
 
 uint64 getUInt(File& in)
-    throw(Exception_EOF)
+    noexcept(false)
 {
     uint byte0, byte1, byte2, byte3, byte4, byte5, byte6, byte7;
     byte0 = in.getChar();

--- a/src/HolSat/sat_solvers/minisat/File.h
+++ b/src/HolSat/sat_solvers/minisat/File.h
@@ -131,7 +131,7 @@ public:
 
 
 void                 putUInt (File& out, uint64 val);
-uint64               getUInt (File& in) throw(Exception_EOF);
+uint64               getUInt (File& in) noexcept(false);
 static inline uint64 encode64(int64  val)           { return (val >= 0) ? (uint64)val << 1 : (((uint64)(~val) << 1) | 1); }
 static inline int64  decode64(uint64 val)           { return ((val & 1) == 0) ? (int64)(val >> 1) : ~(int64)(val >> 1); }
 static inline void   putInt  (File& out, int64 val) { putUInt(out, encode64(val)); }

--- a/src/HolSat/sat_solvers/minisat/File.h
+++ b/src/HolSat/sat_solvers/minisat/File.h
@@ -15,6 +15,9 @@
 #endif
 
 
+
+
+
 //=================================================================================================
 // A buffered file abstraction with only 'putChar()' and 'getChar()'.
 
@@ -131,7 +134,11 @@ public:
 
 
 void                 putUInt (File& out, uint64 val);
+#if __cplusplus >= 201703L
 uint64               getUInt (File& in) noexcept(false);
+#else
+uint64               getUInt (File& in) throw(Exception_EOF);
+#endif
 static inline uint64 encode64(int64  val)           { return (val >= 0) ? (uint64)val << 1 : (((uint64)(~val) << 1) | 1); }
 static inline int64  decode64(uint64 val)           { return ((val & 1) == 0) ? (int64)(val >> 1) : ~(int64)(val >> 1); }
 static inline void   putInt  (File& out, int64 val) { putUInt(out, encode64(val)); }


### PR DESCRIPTION
I replaced 'throw(Exception_EOF)' with 'noexcept(false)' in minisat. Dynamic exception specification (i.e., throw(..)) was removed from C++17, the replacement is 'noexcept(false)' according to [Removing Deprecated Exception Specifications from C++17](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0003r0.html).

This commit ensures that minisat can be compiled by g++ version 11 and later. 

