### PR TITLE
Redefine REAL_SUM_IMAGE based on iterateTheory (now moved to src/real)

### DIFF
--- a/examples/diningcryptos/basic_leakage_examplesScript.sml
+++ b/examples/diningcryptos/basic_leakage_examplesScript.sml
@@ -1,24 +1,22 @@
-open HolKernel Parse boolLib bossLib metisLib arithmeticTheory pred_setTheory
-     pred_setLib stringLib
-     listTheory state_transformerTheory
+open HolKernel Parse boolLib bossLib;
+
+open metisLib arithmeticTheory pred_setTheory
+     pred_setLib stringLib listTheory state_transformerTheory
      extra_numTheory combinTheory
      pairTheory realTheory realLib jrhUtils
-     realSimps numTheory
-     simpLib seqTheory subtypeTheory
+     realSimps numTheory simpLib seqTheory subtypeTheory
      transcTheory limTheory stringTheory rich_listTheory stringSimps listSimps
-     informationTheory leakageTheory
-     leakageLib wordsTheory wordsLib;
+     informationTheory leakageTheory leakageLib wordsTheory wordsLib;
 
 open extra_boolTheory extra_pred_setTheory extra_realTheory extra_listTheory
      extra_stringTheory extra_stringLib;
 
 open real_sigmaTheory;
+
 open hurdUtils util_probTheory real_measureTheory real_lebesgueTheory
      real_probabilityTheory;
 
 val _ = new_theory "basic_leakage_examples";
-
-val REVERSE = Tactical.REVERSE;
 
 val safe_set_ss = (simpLib.++ (bool_ss, PRED_SET_ss));
 
@@ -161,11 +159,11 @@ Definition M1:
          (\s':string. if (s' = "out") then (H s "high") + (L s "low") else 0))
 End
 
-val example1_conv = SIMP_CONV arith_ss [high, low, random, lem1,lem2,lem3];
+val example1_conv = SIMP_CONV arith_ss [high, low, random, lem1, lem2, lem3];
 
 Theorem leakage_example1:
-  leakage (unif_prog_space (high (SUC (SUC (SUC 0))))
-           (low (SUC (SUC (SUC 0)))) random) M1 = 2
+    leakage (unif_prog_space (high (SUC (SUC (SUC 0))))
+                             (low (SUC (SUC (SUC 0)))) random) M1 = 2
 Proof
   CONV_TAC (LAND_CONV
             (LEAKAGE_COMPUTE_CONV (“high (SUC (SUC (SUC 0)))”,

--- a/examples/diningcryptos/informationScript.sml
+++ b/examples/diningcryptos/informationScript.sml
@@ -4,7 +4,7 @@
 
 open HolKernel Parse boolLib bossLib metisLib arithmeticTheory pred_setTheory
      listTheory state_transformerTheory combinTheory
-     pairTheory realTheory realLib jrhUtils
+     pairTheory realTheory realLib jrhUtils iterateTheory
      realSimps numTheory simpLib seqTheory subtypeTheory
      transcTheory limTheory stringTheory rich_listTheory stringSimps listSimps;
 
@@ -20,6 +20,9 @@ open hurdUtils util_probTheory sigma_algebraTheory real_measureTheory
 (* ------------------------------------------------------------------------- *)
 
 val _ = new_theory "information";
+
+Overload indicator_fn[local] = “indicator”
+Theorem indicator_fn_def[local] = indicator
 
 (* ************************************************************************* *)
 (* Basic Definitions                                                         *)

--- a/src/probability/Holmakefile
+++ b/src/probability/Holmakefile
@@ -4,7 +4,7 @@ ifdef POLY
 HOLHEAP = heap
 OBJNAMES = realTheory realLib real_sigmaTheory seqTheory transcTheory \
 	RealArith sortingTheory pred_setLib numpairTheory res_quanTools \
-	logrootTheory
+	logrootTheory iterateTheory listTheory rich_listTheory
 
 OBJS = $(patsubst %,$(dprot $(SIGOBJ)/%.uo),$(OBJNAMES))
 
@@ -23,8 +23,11 @@ ifeq ($(KERNELID),otknl)
 
 ARTFILES = $(patsubst %Script.sml,%.ot.art,$(wildcard *Script.sml))
 
-# this takes a lot of time, disabled by default
-# all: $(ARTFILES) hol4-analysis-unint.art hol4-probability-unint.art
+# This takes a lot of time, disabled by default
+extra: $(ARTFILES) hol4-analysis-unint.art hol4-probability-unint.art
+
+# This requires more than 32GB memory! ("-j 1" is recommended)
+heavy: hol4-analysis.art hol4-probability.art
 
 hol4-analysis-unint.art: hol4-analysis-unint.thy $(ARTFILES)
 	opentheory info --article -o $@ $<

--- a/src/probability/README.md
+++ b/src/probability/README.md
@@ -4,6 +4,8 @@ This directory contains HOL4's Measure, Lebesgue Integration and Probability the
 
 ## Preliminaries
 
+     hurdUtils.{sml|sig}          * Some useful tools originally defined by Joe Hurd
+     util_probScript.sml          * Utility lemmas needed by other scripts
      extrealScript.sml            * The theory of extended reals
      real_topologyScript.sml      * Elementary Topology in Euclidean Space (from HOL Light)
      derivativeScript.sml         * Univariate Derivative Theory in R^1 (from HOL Light)
@@ -12,6 +14,7 @@ This directory contains HOL4's Measure, Lebesgue Integration and Probability the
 ## Measure, Integral and Probability Theory defined on extended reals
 
      sigma_algebraScript.sml      * Sigma-algebra and other systems of sets
+     real_borelScript.sml         * Borel-measurable sets generated from reals
      measureScript.sml            * Measure Theory defined on extended reals
      borelScript.sml              * Borel sets and Borel measurable functions
      lebesgueScript.sml           * Lebesgue integration theory
@@ -20,13 +23,6 @@ This directory contains HOL4's Measure, Lebesgue Integration and Probability the
 
 ## Measure, Integral and Probability Theory defined on reals
 
-     real_borelScript.sml         * Borel-measurable sets generated from reals
      real_measureScript.sml       * Measure Theory defined on reals
      real_lebesgueScript.sml      * Lebesgue integrals based on reals
      real_probabilityScript.sml   * Probability Theory based on reals
-
-## Utilities
-
-     hurdUtils.{sml|sig}          * Some useful tools originally defined by Joe Hurd
-     util_probScript.sml          * Utility lemmas needed by other scripts
-     iterateScript.sml            * Generic iterated operations and special cases over N and R (from HOL Light)

--- a/src/probability/hol4-analysis-unint.thy
+++ b/src/probability/hol4-analysis-unint.thy
@@ -4,13 +4,9 @@ description: HOL real analysis (before re-interpretation)
 author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
 license: MIT
 main {
-  import: iterate
   import: real-topology
   import: derivative
   import: integration
-}
-iterate {
-  article: "iterate.ot.art"
 }
 real-topology {
   import: iterate

--- a/src/probability/integrationScript.sml
+++ b/src/probability/integrationScript.sml
@@ -44,6 +44,7 @@ val ASM_REAL_ARITH_TAC = REAL_ASM_ARITH_TAC; (* RealArith *)
 val IMP_CONJ           = CONJ_EQ_IMP;        (* cardinalTheory *)
 val FINITE_SUBSET      = SUBSET_FINITE_I;    (* pred_setTheory *)
 val LE_0               = ZERO_LESS_EQ;       (* arithmeticTheory *)
+val SUM_LE             = SUM_MONO_LE;        (* iterateTheory *)
 
 (* This overrides realTheory.SUM_LE *)
 val SUM_LE = iterateTheory.SUM_LE;

--- a/src/probability/integrationScript.sml
+++ b/src/probability/integrationScript.sml
@@ -46,9 +46,6 @@ val FINITE_SUBSET      = SUBSET_FINITE_I;    (* pred_setTheory *)
 val LE_0               = ZERO_LESS_EQ;       (* arithmeticTheory *)
 val SUM_LE             = SUM_MONO_LE;        (* iterateTheory *)
 
-(* This overrides realTheory.SUM_LE *)
-val SUM_LE = iterateTheory.SUM_LE;
-
 (* --------------------------------------------------------------------- *)
 (* STRONG_DISJ2_TAC : tactic                                             *)
 (*                                                                       *)

--- a/src/probability/real_topologyScript.sml
+++ b/src/probability/real_topologyScript.sml
@@ -48,9 +48,6 @@ val FINITE_SUBSET      = SUBSET_FINITE_I;    (* pred_setTheory *)
 val LE_0               = ZERO_LESS_EQ;       (* arithmeticTheory *)
 val SUM_LE             = SUM_MONO_LE;        (* iterateTheory *)
 
-(* This overrides realTheory.SUM_LE *)
-val SUM_LE = iterateTheory.SUM_LE;
-
 (* ------------------------------------------------------------------------- *)
 (* Pairwise property over sets and lists.                                    *)
 (* ------------------------------------------------------------------------- *)

--- a/src/probability/real_topologyScript.sml
+++ b/src/probability/real_topologyScript.sml
@@ -39,14 +39,14 @@ val DISC_RW_KILL = DISCH_TAC THEN ONCE_ASM_REWRITE_TAC [] THEN
                    POP_ASSUM K_TAC;
 
 fun ASSERT_TAC tm = SUBGOAL_THEN tm STRIP_ASSUME_TAC;
-
 val ASM_ARITH_TAC = REPEAT (POP_ASSUM MP_TAC) THEN ARITH_TAC;
-val ASM_REAL_ARITH_TAC = REAL_ASM_ARITH_TAC;
 
 (* Minimal hol-light compatibility layer *)
-val IMP_CONJ      = CONJ_EQ_IMP;     (* cardinalTheory *)
-val FINITE_SUBSET = SUBSET_FINITE_I; (* pred_setTheory *)
-val LE_0          = ZERO_LESS_EQ;    (* arithmeticTheory *)
+val ASM_REAL_ARITH_TAC = REAL_ASM_ARITH_TAC; (* RealArith *)
+val IMP_CONJ           = CONJ_EQ_IMP;        (* cardinalTheory *)
+val FINITE_SUBSET      = SUBSET_FINITE_I;    (* pred_setTheory *)
+val LE_0               = ZERO_LESS_EQ;       (* arithmeticTheory *)
+val SUM_LE             = SUM_MONO_LE;        (* iterateTheory *)
 
 (* This overrides realTheory.SUM_LE *)
 val SUM_LE = iterateTheory.SUM_LE;

--- a/src/real/hol4-real-unint.thy
+++ b/src/real/hol4-real-unint.thy
@@ -1,5 +1,5 @@
 name: hol-real-unint
-version: 1.0
+version: 1.1
 description: HOL real theories (before re-interpretation)
 author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
 license: MIT
@@ -15,6 +15,7 @@ main {
   import: metric
   import: lim
   import: nets
+  import: iterate
 }
 real {
   article: "real.ot.art"
@@ -25,8 +26,11 @@ intreal {
 }
 transc {
   import: real
-  import: powser
+  import: metric
+  import: nets
+  import: seq
   import: lim
+  import: powser
   article: "transc.ot.art"
 }
 powser {
@@ -47,9 +51,15 @@ poly {
   import: lim
   article: "poly.ot.art"
 }
+iterate {
+  import: real
+  article: "iterate.ot.art"
+}
 real-sigma {
   import: real
   import: seq
+  import: iterate
+  import: transc
   article: "real_sigma.ot.art"
 }
 seq {

--- a/src/real/iterateScript.sml
+++ b/src/real/iterateScript.sml
@@ -501,20 +501,23 @@ val FINREC_FUN_LEMMA = store_thm ("FINREC_FUN_LEMMA",
   MATCH_MP_TAC SELECT_UNIQUE THEN ASM_MESON_TAC[],
   DISCH_THEN(SUBST1_TAC o SYM) THEN CONV_TAC SELECT_CONV THEN ASM_MESON_TAC[]]);
 
-val FINREC_FUN = store_thm ("FINREC_FUN",
- ``!(f:'a->'b->'b) b.
+Theorem FINREC_FUN :
+    !(f:'a->'b->'b) b.
         (!x y s. ~(x = y) ==> (f x (f y s) = f y (f x s)))
         ==> ?g. (g {} = b) /\
                 !s x. FINITE s /\ x IN s
-                      ==> (g s = f x (g (s DELETE x)))``,
+                      ==> (g s = f x (g (s DELETE x)))
+Proof
   REPEAT STRIP_TAC THEN IMP_RES_THEN MP_TAC FINREC_UNIQUE_LEMMA THEN
-  REPEAT STRIP_TAC THEN KNOW_TAC ``!n1 n2 s a1 a2. FINREC f b s a1 n1 /\
-  FINREC f b s a2 n2 ==> (a1 = a2) /\ (n1 = n2)`` THENL [METIS_TAC [],
+  REPEAT STRIP_TAC THEN
+  KNOW_TAC ``!n1 n2 s a1 a2. FINREC f b s a1 n1 /\
+                             FINREC f b s a2 n2 ==> (a1 = a2) /\ (n1 = n2)``
+  THEN1 METIS_TAC [] THEN
   DISCH_THEN (MP_TAC o CONJ (SPECL [``f:'a->'b->'b``, ``b:'b``] FINREC_EXISTS_LEMMA)) THEN
   DISCH_THEN(MP_TAC o MATCH_MP FINREC_FUN_LEMMA) THEN
   DISCH_THEN(X_CHOOSE_TAC ``g:('a->bool)->'b``) THEN
   EXISTS_TAC ``g:('a->bool)->'b`` THEN CONJ_TAC THENL
-   [SUBGOAL_THEN ``FINITE(EMPTY:'a->bool)``
+  [ SUBGOAL_THEN ``FINITE(EMPTY:'a->bool)``
     (ANTE_RES_THEN (fn th => GEN_REWR_TAC I [GSYM th])) THENL
      [REWRITE_TAC[FINITE_EMPTY],
       EXISTS_TAC ``0:num`` THEN REWRITE_TAC[FINREC]],
@@ -524,18 +527,20 @@ val FINREC_FUN = store_thm ("FINREC_FUN",
     FIRST_ASSUM(MP_TAC o SPEC ``(g:('a->bool)->'b) s``) THEN
     REWRITE_TAC[] THEN REWRITE_TAC[GSYM LEFT_FORALL_IMP_THM] THEN
     INDUCT_TAC THENL
-     [ASM_REWRITE_TAC[FINREC] THEN DISCH_TAC THEN UNDISCH_TAC ``x:'a IN s`` THEN
+    [ ASM_REWRITE_TAC[FINREC] THEN DISCH_TAC THEN UNDISCH_TAC ``x:'a IN s`` THEN
       ASM_REWRITE_TAC[NOT_IN_EMPTY],
       IMP_RES_THEN ASSUME_TAC FINREC_SUC_LEMMA THEN
       DISCH_THEN(ANTE_RES_THEN (MP_TAC o SPEC ``x:'a``)) THEN
       ASM_REWRITE_TAC[] THEN
       DISCH_THEN(X_CHOOSE_THEN ``w:'b`` (CONJUNCTS_THEN ASSUME_TAC)) THEN
       SUBGOAL_THEN ``(g (s DELETE x:'a) = w:'b)`` SUBST1_TAC THENL
-       [SUBGOAL_THEN ``FINITE(s DELETE x:'a)`` MP_TAC THENL
-         [FULL_SIMP_TAC std_ss [FINITE_DELETE],
+      [ SUBGOAL_THEN ``FINITE(s DELETE x:'a)`` MP_TAC THENL
+        [ FULL_SIMP_TAC std_ss [FINITE_DELETE],
           DISCH_THEN(ANTE_RES_THEN (MP_TAC o GSYM)) THEN
           DISCH_THEN(fn th => REWRITE_TAC[th]) THEN
-          METIS_TAC []], ASM_REWRITE_TAC[]]]]]);
+          METIS_TAC [] ],
+        ASM_REWRITE_TAC [] ] ] ]
+QED
 
 val SET_RECURSION_LEMMA = store_thm ("SET_RECURSION_LEMMA",
  ``!(f:'a->'b->'b) b.
@@ -2804,18 +2809,23 @@ QED
 
 val SUM_LE = SUM_MONO_LE;
 
-val SUM_LT = store_thm ("SUM_LT",
- ``!f g s:'a->bool.
+(* renamed: name conflicts with seqTheory.SUM_LT *)
+Theorem SUM_MONO_LT : (* was: SUM_LT *)
+    !f g s:'a->bool.
         FINITE(s) /\ (!x. x IN s ==> f(x) <= g(x)) /\
         (?x. x IN s /\ f(x) < g(x))
-         ==> sum s f < sum s g``,
+         ==> sum s f < sum s g
+Proof
   REPEAT GEN_TAC THEN
   REPEAT(DISCH_THEN(CONJUNCTS_THEN2 ASSUME_TAC MP_TAC)) THEN
   DISCH_THEN(X_CHOOSE_THEN ``a:'a`` STRIP_ASSUME_TAC) THEN
   SUBGOAL_THEN ``s = (a:'a) INSERT (s DELETE a)`` SUBST1_TAC THENL
    [UNDISCH_TAC ``a:'a IN s`` THEN SIMP_TAC std_ss [INSERT_DELETE], ALL_TAC]
   THEN ASM_SIMP_TAC std_ss [SUM_CLAUSES, FINITE_DELETE, IN_DELETE] THEN
-  ASM_SIMP_TAC std_ss [REAL_LTE_ADD2, SUM_LE, IN_DELETE, FINITE_DELETE]);
+  ASM_SIMP_TAC std_ss [REAL_LTE_ADD2, SUM_LE, IN_DELETE, FINITE_DELETE]
+QED
+
+val SUM_LT = SUM_MONO_LT;
 
 val SUM_LT_ALL = store_thm ("SUM_LT_ALL",
  ``!f g s. FINITE s /\ ~(s = {}) /\ (!x. x IN s ==> f(x) < g(x))

--- a/src/real/real_sigmaScript.sml
+++ b/src/real/real_sigmaScript.sml
@@ -4,8 +4,10 @@
 
 open HolKernel Parse boolLib bossLib;
 
-open arithmeticTheory combinTheory transcTheory
-     pred_setTheory realTheory realLib res_quanTools pairTheory seqTheory;
+open arithmeticTheory combinTheory res_quanTools pairTheory pred_setTheory
+     realTheory realLib seqTheory transcTheory;
+
+open iterateTheory;
 
 val _ = new_theory "real_sigma";
 
@@ -14,7 +16,7 @@ val KILL_TAC = POP_ASSUM_LIST K_TAC;
 val Know = Q_TAC KNOW_TAC;
 val Suff = Q_TAC SUFF_TAC;
 val POP_ORW = POP_ASSUM (fn thm => ONCE_REWRITE_TAC [thm]);
-
+val art = ASM_REWRITE_TAC;
 
 (* ----------------------------------------------------------------------
     REAL_SUM_IMAGE
@@ -26,126 +28,90 @@ val POP_ORW = POP_ASSUM (fn thm => ONCE_REWRITE_TAC [thm]);
     Where f's range is the real numbers and P is finite.
    ---------------------------------------------------------------------- *)
 
-val REAL_SUM_IMAGE_DEF = new_definition(
-  "REAL_SUM_IMAGE_DEF",
-  ``REAL_SUM_IMAGE f s = ITSET (\e acc. f e + acc) s (0:real)``);
+(* The old definition (only used by REAL_SUM_IMAGE_THM):
 
-val REAL_SUM_IMAGE_THM = store_thm(
-  "REAL_SUM_IMAGE_THM",
-  ``!f. (REAL_SUM_IMAGE f {} = 0) /\
+Definition REAL_SUM_IMAGE_DEF :
+    REAL_SUM_IMAGE f s = ITSET (\e acc. f e + acc) s (0:real)
+End
+
+   The new definition (based iterateTheory):
+ *)
+Definition REAL_SUM_IMAGE_DEF :
+    REAL_SUM_IMAGE f s = iterate$Sum s f
+End
+
+Overload SIGMA = “REAL_SUM_IMAGE”
+
+Theorem REAL_SUM_IMAGE_THM :
+    !f. (REAL_SUM_IMAGE f {} = 0) /\
         (!e s. FINITE s ==>
                (REAL_SUM_IMAGE f (e INSERT s) =
-                f e + REAL_SUM_IMAGE f (s DELETE e)))``,
-  REPEAT STRIP_TAC
-  >- SIMP_TAC (srw_ss()) [ITSET_THM, REAL_SUM_IMAGE_DEF]
-  >> SIMP_TAC (srw_ss()) [REAL_SUM_IMAGE_DEF]
-  >> Q.ABBREV_TAC `g = \e acc. f e + acc`
-  >> Suff `ITSET g (e INSERT s) 0 =
-                    g e (ITSET g (s DELETE e) 0)`
-  >- (Q.UNABBREV_TAC `g` >> SRW_TAC [] [])
-  >> MATCH_MP_TAC COMMUTING_ITSET_RECURSES
-  >> Q.UNABBREV_TAC `g`
-  >> RW_TAC real_ss []
-  >> REAL_ARITH_TAC);
+                f e + REAL_SUM_IMAGE f (s DELETE e)))
+Proof
+    Q.X_GEN_TAC ‘f’
+ >> ASSUME_TAC MONOIDAL_REAL_ADD
+ >> rw [REAL_SUM_IMAGE_DEF, iterateTheory.sum_def, GSYM NEUTRAL_REAL_ADD]
+ >- rw [ITERATE_CLAUSES]
+ >> reverse (Cases_on ‘e IN s’)
+ >- (‘s DELETE e = s’ by METIS_TAC [DELETE_NON_ELEMENT] >> POP_ORW \\
+     rw [ITERATE_CLAUSES])
+ >> ‘e INSERT s = e INSERT (s DELETE e)’ by SET_TAC [] >> POP_ORW
+ >> rw [ITERATE_CLAUSES]
+QED
 
-val REAL_SUM_IMAGE_SING = store_thm(
-  "REAL_SUM_IMAGE_SING",
-  ``!f e. REAL_SUM_IMAGE f {e} = f e``,
-  SRW_TAC [][REAL_SUM_IMAGE_THM]);
+(* it translates a sum theorem into a SIGMA theorem *)
+fun translate th = REWRITE_RULE [GSYM REAL_SUM_IMAGE_DEF] th;
 
-val REAL_SUM_IMAGE_POS = store_thm
-  ("REAL_SUM_IMAGE_POS",
-   ``!f s. FINITE s /\
-           (!x. x IN s ==> 0 <= f x) ==>
-                0 <= REAL_SUM_IMAGE f s``,
-   REPEAT STRIP_TAC
-   >> POP_ASSUM MP_TAC >> Q.SPEC_TAC (`f`, `f`)
-   >> POP_ASSUM MP_TAC >> Q.SPEC_TAC (`s`, `s`)
-   >> Q.ABBREV_TAC `Q = (\s. !f. (!x. x IN s ==> 0 <= f x) ==> 0 <= REAL_SUM_IMAGE f s)`
-   >> Suff `!s. FINITE s ==> Q s` >- (Q.UNABBREV_TAC `Q` >> RW_TAC std_ss [])
-   >> MATCH_MP_TAC FINITE_INDUCT
-   >> Q.UNABBREV_TAC `Q`
-   >> RW_TAC real_ss [REAL_SUM_IMAGE_THM]
-   >> MATCH_MP_TAC REAL_LE_ADD
-   >> CONJ_TAC >- FULL_SIMP_TAC real_ss [IN_INSERT]
-   >> FULL_SIMP_TAC std_ss [DELETE_NON_ELEMENT]
-   >> Q.PAT_ASSUM `!f. (!x. x IN s ==> 0 <= f x) ==> 0 <= REAL_SUM_IMAGE f s` MATCH_MP_TAC
-   >> REPEAT STRIP_TAC >> Q.PAT_ASSUM `!x. b` MATCH_MP_TAC
-   >> RW_TAC std_ss [IN_INSERT]);
+(* |- !f x. REAL_SUM_IMAGE f {x} = f x *)
+Theorem REAL_SUM_IMAGE_SING = translate SUM_SING
 
-val REAL_SUM_IMAGE_SPOS = store_thm
-  ("REAL_SUM_IMAGE_SPOS",
-   ``!s. FINITE s /\ (~(s = {})) ==>
-           !f. (!x. x IN s ==> 0 < f x) ==>
-                0 < REAL_SUM_IMAGE f s``,
-   Suff `!s. FINITE s ==>
-                (\s. (~(s = {})) ==>
-           !f. (!x. x IN s ==> 0 < f x) ==>
-                0 < REAL_SUM_IMAGE f s) s`
-   >- RW_TAC std_ss []
-   >> MATCH_MP_TAC FINITE_INDUCT
-   >> RW_TAC real_ss [REAL_SUM_IMAGE_THM, DELETE_NON_ELEMENT, IN_INSERT, DISJ_IMP_THM,
-                      FORALL_AND_THM]
-   >> Cases_on `s = {}`
-   >- RW_TAC real_ss [REAL_SUM_IMAGE_THM]
-   >> MATCH_MP_TAC REAL_LT_ADD
-   >> ASM_SIMP_TAC real_ss []);
+Theorem REAL_SUM_IMAGE_POS :
+    !f s. FINITE s /\ (!x. x IN s ==> 0 <= f x) ==>
+          0 <= REAL_SUM_IMAGE f s
+Proof
+    rw [REAL_SUM_IMAGE_DEF, SUM_POS_LE]
+QED
 
-val REAL_SUM_IMAGE_NONZERO_lem = prove
-  (``!P. FINITE P ==>
-        (\P. !f. (!x.x IN P ==> 0 <= f x) /\ (?x. x IN P /\ ~(f x = 0)) ==>
-                ((~(REAL_SUM_IMAGE f P = 0)) = (~(P = {})))) P``,
-   (MATCH_MP_TAC FINITE_INDUCT
-    >> RW_TAC std_ss [REAL_SUM_IMAGE_THM, NOT_INSERT_EMPTY, IN_INSERT]
-    >> FULL_SIMP_TAC std_ss [DELETE_NON_ELEMENT])
-   >- (ONCE_REWRITE_TAC [GSYM REAL_LE_ANTISYM]
-       >> `0 <= f e + REAL_SUM_IMAGE f s`
-                by (MATCH_MP_TAC REAL_LE_ADD
-                    >> RW_TAC std_ss []
-                    >> MATCH_MP_TAC REAL_SUM_IMAGE_POS
-                    >> METIS_TAC [])
-       >> ASM_REWRITE_TAC []
-       >> RW_TAC std_ss [GSYM real_lt]
-       >> MATCH_MP_TAC REAL_LTE_TRANS
-       >> Q.EXISTS_TAC `f e + 0`
-       >> CONJ_TAC
-       >- (RW_TAC real_ss [] >> POP_ASSUM (K ALL_TAC)
-           >> POP_ASSUM MP_TAC >> POP_ASSUM (MP_TAC o Q.SPECL [`e`])
-           >> SIMP_TAC std_ss []
-           >> REAL_ARITH_TAC)
-       >> MATCH_MP_TAC REAL_LE_ADD2
-       >> RW_TAC real_ss []
-       >> MATCH_MP_TAC REAL_SUM_IMAGE_POS
-       >> METIS_TAC [])
-   >> Cases_on `f e = 0`
-   >- (RW_TAC real_ss [] >> METIS_TAC [NOT_IN_EMPTY])
-   >> ONCE_REWRITE_TAC [GSYM REAL_LE_ANTISYM]
-   >> `0 <= f e + REAL_SUM_IMAGE f s`
-                by (MATCH_MP_TAC REAL_LE_ADD
-                    >> RW_TAC std_ss []
-                    >> MATCH_MP_TAC REAL_SUM_IMAGE_POS
-                    >> METIS_TAC [])
-   >> ASM_REWRITE_TAC []
-   >> RW_TAC std_ss [GSYM real_lt]
-   >> MATCH_MP_TAC REAL_LTE_TRANS
-   >> Q.EXISTS_TAC `f e + 0`
-   >> CONJ_TAC
-   >- (RW_TAC real_ss [] >> POP_ASSUM (K ALL_TAC)
-       >> POP_ASSUM MP_TAC >> POP_ASSUM (K ALL_TAC)
-       >> POP_ASSUM (K ALL_TAC) >> POP_ASSUM (MP_TAC o Q.SPECL [`e`])
-           >> SIMP_TAC std_ss []
-           >> REAL_ARITH_TAC)
-   >> MATCH_MP_TAC REAL_LE_ADD2
-   >> RW_TAC real_ss []
-   >> MATCH_MP_TAC REAL_SUM_IMAGE_POS
-   >> METIS_TAC []);
+(* NEW, without ‘FINITE s’ *)
+Theorem REAL_SUM_IMAGE_POS' :
+    !f s. (!x. x IN s ==> 0 <= f x) ==> 0 <= REAL_SUM_IMAGE f s
+Proof
+    rw [REAL_SUM_IMAGE_DEF, SUM_POS_LE]
+QED
 
-val REAL_SUM_IMAGE_NONZERO = store_thm
-  ("REAL_SUM_IMAGE_NONZERO",
-   ``!P. FINITE P ==>
-        !f. (!x.x IN P ==> 0 <= f x) /\ (?x. x IN P /\ ~(f x = 0)) ==>
-                ((~(REAL_SUM_IMAGE f P = 0)) = (~(P = {})))``,
-   METIS_TAC [REAL_SUM_IMAGE_NONZERO_lem]);
+Theorem REAL_SUM_IMAGE_SPOS :
+    !s. FINITE s /\ (~(s = {})) ==>
+        !f. (!x. x IN s ==> 0 < f x) ==>
+            0 < REAL_SUM_IMAGE f s
+Proof
+    rw [REAL_SUM_IMAGE_DEF]
+ >> MATCH_MP_TAC SUM_POS_LT >> art []
+ >> CONJ_TAC >- METIS_TAC [REAL_LT_IMP_LE]
+ >> fs [GSYM MEMBER_NOT_EMPTY]
+ >> Q.EXISTS_TAC ‘x’ >> rw []
+QED
+
+(* ‘?x. x IN P’ already indicates ‘P <> {}’, thus the actual conclusion is just
+   ‘SIGMA f P <> 0’ *)
+Theorem REAL_SUM_IMAGE_NONZERO :
+    !P. FINITE P ==>
+        !f. (!x. x IN P ==> 0 <= f x) /\ (?x. x IN P /\ ~(f x = 0)) ==>
+            ((~(REAL_SUM_IMAGE f P = 0)) <=> (~(P = {})))
+Proof
+    rw [REAL_SUM_IMAGE_DEF]
+ >> ‘P <> {}’ by METIS_TAC [MEMBER_NOT_EMPTY]
+ >> rw []
+ >> Suff ‘0 < sum P f’ >- METIS_TAC [REAL_LT_IMP_NE]
+ >> ‘0 < f x’ by METIS_TAC [REAL_LE_LT]
+ >> MATCH_MP_TAC SUM_POS_LT >> rw []
+ >> Q.EXISTS_TAC ‘x’ >> art []
+QED
+
+(* |- !f s.
+        FINITE s /\ (!x. x IN s ==> 0 <= f x) /\ (?x. x IN s /\ 0 < f x) ==>
+        0 < SIGMA f s
+ *)
+Theorem REAL_SUM_IMAGE_POS_LT = translate SUM_POS_LT
 
 val REAL_SUM_IMAGE_IF_ELIM_lem = prove
   (``!s. FINITE s ==>
@@ -218,13 +184,12 @@ val REAL_SUM_IMAGE_FINITE_CONST2 = store_thm (* from "examples/diningcryptos" *)
    >> POP_ASSUM MATCH_MP_TAC
    >> Q.EXISTS_TAC `x'` >> RW_TAC std_ss [IN_INSERT]);
 
-val REAL_SUM_IMAGE_FINITE_CONST3 = store_thm
-  ("REAL_SUM_IMAGE_FINITE_CONST3",
-   ``!P. FINITE P ==>
-        !c. (REAL_SUM_IMAGE (\x. c) P = (&(CARD P)) * c)``,
-   REPEAT STRIP_TAC
-   >> (MATCH_MP_TAC o UNDISCH o Q.SPEC `P`) REAL_SUM_IMAGE_FINITE_CONST2
-   >> RW_TAC std_ss []);
+Theorem REAL_SUM_IMAGE_FINITE_CONST3 :
+    !P. FINITE P ==>
+        !c. (REAL_SUM_IMAGE (\x. c) P = (&(CARD P)) * c)
+Proof
+    rw [REAL_SUM_IMAGE_DEF, SUM_CONST]
+QED
 
 val REAL_SUM_IMAGE_IN_IF_lem = prove
   (``!P. FINITE P ==>
@@ -248,84 +213,50 @@ val REAL_SUM_IMAGE_IN_IF = store_thm
         !f. REAL_SUM_IMAGE f P = REAL_SUM_IMAGE (\x. if x IN P then f x else 0) P``,
    METIS_TAC [REAL_SUM_IMAGE_IN_IF_lem]);
 
-val REAL_SUM_IMAGE_CMUL_lem = prove
-  (``!f c P. FINITE P ==>
-        (\P. REAL_SUM_IMAGE (\x. c * f x) P = c * (REAL_SUM_IMAGE f P)) P``,
-   STRIP_TAC >> STRIP_TAC >> MATCH_MP_TAC FINITE_INDUCT
-   >> RW_TAC real_ss [REAL_SUM_IMAGE_THM, REAL_ADD_LDISTRIB, DELETE_NON_ELEMENT]);
+Theorem REAL_SUM_IMAGE_CMUL :
+    !P. FINITE P ==>
+        !f c. (REAL_SUM_IMAGE (\x. c * f x) P = c * (REAL_SUM_IMAGE f P))
+Proof
+    rw [REAL_SUM_IMAGE_DEF, SUM_LMUL]
+QED
 
-val REAL_SUM_IMAGE_CMUL = store_thm
-  ("REAL_SUM_IMAGE_CMUL",
-   ``!P. FINITE P ==>
-        !f c. (REAL_SUM_IMAGE (\x. c * f x) P = c * (REAL_SUM_IMAGE f P))``,
-   METIS_TAC [REAL_SUM_IMAGE_CMUL_lem]);
+Theorem REAL_SUM_IMAGE_RMUL = translate SUM_RMUL
 
-val REAL_SUM_IMAGE_NEG = store_thm
-  ("REAL_SUM_IMAGE_NEG",
-   ``!P. FINITE P ==>
-        !f. (REAL_SUM_IMAGE (\x. ~ f x) P = ~ (REAL_SUM_IMAGE f P))``,
-   REPEAT STRIP_TAC
-   >> (ASSUME_TAC o Q.SPECL [`f`, `~1`] o UNDISCH o Q.SPEC `P`) REAL_SUM_IMAGE_CMUL
-   >> FULL_SIMP_TAC real_ss []);
+Theorem REAL_SUM_IMAGE_NEG :
+    !P. FINITE P ==>
+        !f. (REAL_SUM_IMAGE (\x. ~ f x) P = ~ (REAL_SUM_IMAGE f P))
+Proof
+    rw [REAL_SUM_IMAGE_DEF, SUM_NEG]
+QED
 
-val REAL_SUM_IMAGE_IMAGE = store_thm
-  ("REAL_SUM_IMAGE_IMAGE",
-   ``!P. FINITE P ==>
-         !f'. INJ f' P (IMAGE f' P) ==>
-              !f. REAL_SUM_IMAGE f (IMAGE f' P) = REAL_SUM_IMAGE (f o f') P``,
-   Induct_on `FINITE`
-   >> SRW_TAC [][REAL_SUM_IMAGE_THM]
-   >> `IMAGE f' P DELETE f' e = IMAGE f' P`
-   by (SRW_TAC [][EXTENSION]
-       >> EQ_TAC >- (METIS_TAC[])
-       >> POP_ASSUM MP_TAC
-       >> ASM_SIMP_TAC (srw_ss()) [INJ_DEF]
-       >> METIS_TAC[])
-   >> `P DELETE e = P` by METIS_TAC [DELETE_NON_ELEMENT]
-   >> SRW_TAC [][]
-   >> FIRST_X_ASSUM MATCH_MP_TAC
-   >> Q.PAT_ASSUM `INJ f' SS1 SS2` MP_TAC
-   >> CONV_TAC (BINOP_CONV (SIMP_CONV (srw_ss()) [INJ_DEF]))
-   >> METIS_TAC[]);
+Theorem REAL_SUM_IMAGE_IMAGE :
+    !P. FINITE P ==>
+        !f'. INJ f' P (IMAGE f' P) ==>
+             !f. REAL_SUM_IMAGE f (IMAGE f' P) = REAL_SUM_IMAGE (f o f') P
+Proof
+    rw [REAL_SUM_IMAGE_DEF, INJ_DEF]
+ >> MATCH_MP_TAC SUM_IMAGE >> rw []
+QED
 
-val REAL_SUM_IMAGE_DISJOINT_UNION_lem = prove
-  (``!P.
-        FINITE P ==>
-        (\P. !P'. FINITE P' ==>
-                (\P'. DISJOINT P P' ==>
-                        (!f. REAL_SUM_IMAGE f (P UNION P') =
-                             REAL_SUM_IMAGE f P +
-                             REAL_SUM_IMAGE f P')) P') P``,
-   MATCH_MP_TAC FINITE_INDUCT
-   >> CONJ_TAC
-   >- (RW_TAC real_ss [DISJOINT_EMPTY, UNION_EMPTY, REAL_SUM_IMAGE_THM])
-   >> REPEAT STRIP_TAC
-   >> CONV_TAC (BETA_CONV) >> MATCH_MP_TAC FINITE_INDUCT
-   >> CONJ_TAC
-   >- (RW_TAC real_ss [DISJOINT_EMPTY, UNION_EMPTY, REAL_SUM_IMAGE_THM])
-   >> FULL_SIMP_TAC std_ss [DISJOINT_INSERT]
-   >> ONCE_REWRITE_TAC [DISJOINT_SYM]
-   >> RW_TAC std_ss [INSERT_UNION, DISJOINT_INSERT, IN_INSERT]
-   >> FULL_SIMP_TAC std_ss [DISJOINT_SYM]
-   >> ONCE_REWRITE_TAC [UNION_COMM] >> RW_TAC std_ss [INSERT_UNION]
-   >> ONCE_REWRITE_TAC [UNION_COMM] >> ONCE_REWRITE_TAC [INSERT_COMM]
-   >> `FINITE (e INSERT s UNION s')` by RW_TAC std_ss [FINITE_INSERT, FINITE_UNION]
-   >> Q.ABBREV_TAC `Q = e INSERT s UNION s'`
-   >> RW_TAC std_ss [REAL_SUM_IMAGE_THM]
-   >> Q.UNABBREV_TAC `Q`
-   >> `~ (e' IN (e INSERT s UNION s'))`
-        by RW_TAC std_ss [IN_INSERT, IN_UNION]
-   >> FULL_SIMP_TAC std_ss [DELETE_NON_ELEMENT]
-   >> RW_TAC std_ss [REAL_SUM_IMAGE_THM]
-   >> REAL_ARITH_TAC);
+(* NEW, without ‘FINITE P’ *)
+Theorem REAL_SUM_IMAGE_IMAGE' :
+    !P f'. INJ f' P (IMAGE f' P) ==>
+           !f. REAL_SUM_IMAGE f (IMAGE f' P) = REAL_SUM_IMAGE (f o f') P
+Proof
+    rw [REAL_SUM_IMAGE_DEF, INJ_DEF]
+ >> MATCH_MP_TAC SUM_IMAGE >> rw []
+QED
 
-val REAL_SUM_IMAGE_DISJOINT_UNION = store_thm
-  ("REAL_SUM_IMAGE_DISJOINT_UNION",
-   ``!P P'. FINITE P /\ FINITE P' /\ DISJOINT P P' ==>
+Theorem REAL_SUM_IMAGE_DISJOINT_UNION :
+    !P P'. FINITE P /\ FINITE P' /\ DISJOINT P P' ==>
                 (!f. REAL_SUM_IMAGE f (P UNION P') =
                      REAL_SUM_IMAGE f P +
-                     REAL_SUM_IMAGE f P')``,
-   METIS_TAC [REAL_SUM_IMAGE_DISJOINT_UNION_lem]);
+                     REAL_SUM_IMAGE f P')
+Proof
+    rw [REAL_SUM_IMAGE_DEF]
+ >> MATCH_MP_TAC SUM_UNION
+ >> rw [GSYM DISJOINT_DEF, FINITE_UNION]
+QED
 
 val REAL_SUM_IMAGE_EQ_CARD_lem = prove
    (``!P. FINITE P ==>
@@ -427,18 +358,16 @@ val REAL_SUM_IMAGE_COUNT = store_thm
                             DECIDE ``!(x:num) (y:num). x < y ==> ~(x = y)``]
    >> RW_TAC std_ss [REAL_ADD_SYM]);
 
-val REAL_SUM_IMAGE_MONO = store_thm
-  ("REAL_SUM_IMAGE_MONO",
-   ``!P. FINITE P ==>
-           !f f'. (!x. x IN P ==> f x <= f' x) ==>
-                REAL_SUM_IMAGE f P <= REAL_SUM_IMAGE f' P``,
-   Suff `!P. FINITE P ==>
-                (\P. !f f'. (!x. x IN P ==> f x <= f' x) ==>
-                REAL_SUM_IMAGE f P <= REAL_SUM_IMAGE f' P) P`
-   >- PROVE_TAC []
-   >> MATCH_MP_TAC FINITE_INDUCT
-   >> RW_TAC real_ss [REAL_SUM_IMAGE_THM,DELETE_NON_ELEMENT, IN_INSERT,
-                      DISJ_IMP_THM, FORALL_AND_THM, REAL_LE_ADD2]);
+Theorem REAL_SUM_IMAGE_MONO :
+    !P. FINITE P ==>
+        !f f'. (!x. x IN P ==> f x <= f' x) ==>
+               REAL_SUM_IMAGE f P <= REAL_SUM_IMAGE f' P
+Proof
+    rw [REAL_SUM_IMAGE_DEF]
+ >> MATCH_MP_TAC SUM_MONO_LE >> rw []
+QED
+
+Theorem REAL_SUM_IMAGE_MONO_LT = translate SUM_LT
 
 val REAL_SUM_IMAGE_POS_MEM_LE = store_thm
   ("REAL_SUM_IMAGE_POS_MEM_LE",
@@ -512,19 +441,13 @@ val REAL_SUM_IMAGE_CONST_EQ_1_EQ_INV_CARD = store_thm
    >> REPEAT (POP_ASSUM (K ALL_TAC))
    >> METIS_TAC [REAL_NZ_IMP_LT, GSYM REAL_EQ_RDIV_EQ, REAL_INV_1OVER, SUC_NOT]);
 
-val REAL_SUM_IMAGE_ADD = store_thm
-  ("REAL_SUM_IMAGE_ADD",
-   ``!s. FINITE s ==> !f f'.
+Theorem REAL_SUM_IMAGE_ADD :
+    !s. FINITE s ==> !f f'.
                 (REAL_SUM_IMAGE (\x. f x + f' x) s =
-                 REAL_SUM_IMAGE f s + REAL_SUM_IMAGE f' s)``,
-   Suff `!s. FINITE s ==>
-        (\s. !f f'.
-                (REAL_SUM_IMAGE (\x. f x + f' x) s =
-                 REAL_SUM_IMAGE f s + REAL_SUM_IMAGE f' s)) s`
-   >- RW_TAC std_ss []
-   >> MATCH_MP_TAC FINITE_INDUCT
-   >> RW_TAC real_ss [REAL_SUM_IMAGE_THM, DELETE_NON_ELEMENT]
-   >> REAL_ARITH_TAC);
+                 REAL_SUM_IMAGE f s + REAL_SUM_IMAGE f' s)
+Proof
+    rw [REAL_SUM_IMAGE_DEF, SUM_ADD]
+QED
 
 val REAL_SUM_IMAGE_REAL_SUM_IMAGE = store_thm
   ("REAL_SUM_IMAGE_REAL_SUM_IMAGE",
@@ -560,12 +483,20 @@ val REAL_SUM_IMAGE_REAL_SUM_IMAGE = store_thm
         INST_TYPE [``:'b``|->``:'c``]) REAL_SUM_IMAGE_IMAGE
    >> RW_TAC std_ss [INJ_DEF, IN_IMAGE, o_DEF] >> METIS_TAC []);
 
-val REAL_SUM_IMAGE_0 = store_thm
-  ("REAL_SUM_IMAGE_0",
-   ``!s. FINITE s ==> (REAL_SUM_IMAGE (\x. 0) s = 0)``,
-   REPEAT STRIP_TAC
-   >> (MP_TAC o Q.SPECL [`(\x. 0)`,`0`] o UNDISCH o Q.SPEC `s`) REAL_SUM_IMAGE_FINITE_CONST
-   >> RW_TAC real_ss []);
+Theorem REAL_SUM_IMAGE_0 :
+    !s. FINITE s ==> (REAL_SUM_IMAGE (\x. 0) s = 0)
+Proof
+    rw [REAL_SUM_IMAGE_DEF, SUM_0]
+QED
+
+(* NEW, without ‘FINITE s’ *)
+Theorem REAL_SUM_IMAGE_0' :
+    !s. REAL_SUM_IMAGE (\x. 0) s = 0
+Proof
+    rw [REAL_SUM_IMAGE_DEF, SUM_0]
+QED
+
+Theorem REAL_SUM_IMAGE_EQ_0 = translate SUM_EQ_0
 
 val SEQ_REAL_SUM_IMAGE = store_thm
   ("SEQ_REAL_SUM_IMAGE",
@@ -632,12 +563,20 @@ val REAL_SUM_IMAGE_POW = store_thm
   >> RW_TAC std_ss [REAL_SUM_IMAGE_CMUL]
   >> RW_TAC std_ss [Once REAL_MUL_COMM,REAL_SUM_IMAGE_CMUL,POW_2]);
 
-val REAL_SUM_IMAGE_EQ = store_thm
- ("REAL_SUM_IMAGE_EQ", ``!s (f:'a->real) f'. FINITE s /\ (!x. x IN s ==> (f x = f' x))
-                         ==> (REAL_SUM_IMAGE f s = REAL_SUM_IMAGE f' s)``,
-  RW_TAC std_ss []
-  >> ONCE_REWRITE_TAC [(UNDISCH o Q.SPEC `s`) REAL_SUM_IMAGE_IN_IF]
-  >> RW_TAC std_ss []);
+Theorem REAL_SUM_IMAGE_EQ :
+    !s (f:'a->real) f'. FINITE s /\ (!x. x IN s ==> (f x = f' x))
+                    ==> (REAL_SUM_IMAGE f s = REAL_SUM_IMAGE f' s)
+Proof
+    rw [REAL_SUM_IMAGE_DEF, SUM_EQ]
+QED
+
+(* NEW, without ‘FINITE s’ *)
+Theorem REAL_SUM_IMAGE_EQ' :
+    !s (f:'a->real) f'. (!x. x IN s ==> (f x = f' x))
+                    ==> (REAL_SUM_IMAGE f s = REAL_SUM_IMAGE f' s)
+Proof
+    rw [REAL_SUM_IMAGE_DEF, SUM_EQ]
+QED
 
 val REAL_SUM_IMAGE_IN_IF_ALT = store_thm
   ("REAL_SUM_IMAGE_IN_IF_ALT",``!s f z:real.
@@ -646,14 +585,13 @@ val REAL_SUM_IMAGE_IN_IF_ALT = store_thm
   >> MATCH_MP_TAC REAL_SUM_IMAGE_EQ
   >> RW_TAC std_ss []);
 
-val REAL_SUM_IMAGE_SUB = store_thm
- ("REAL_SUM_IMAGE_SUB", ``!s (f:'a -> real) f'. FINITE s ==>
+Theorem REAL_SUM_IMAGE_SUB :
+    !s (f:'a -> real) f'. FINITE s ==>
                  (REAL_SUM_IMAGE (\x. f x - f' x) s =
-                  REAL_SUM_IMAGE f s - REAL_SUM_IMAGE f' s)``,
-  RW_TAC std_ss [Once real_sub,REAL_SUM_IMAGE_ADD,Once REAL_NEG_MINUS1]
-  >> RW_TAC std_ss [Once real_sub,REAL_SUM_IMAGE_ADD,Once
-                    REAL_NEG_MINUS1,REAL_SUM_IMAGE_CMUL]
-  >> RW_TAC std_ss [GSYM REAL_NEG_MINUS1,real_sub]);
+                  REAL_SUM_IMAGE f s - REAL_SUM_IMAGE f' s)
+Proof
+    rw [REAL_SUM_IMAGE_DEF, SUM_SUB]
+QED
 
 val REAL_SUM_IMAGE_MONO_SET = store_thm
  ("REAL_SUM_IMAGE_MONO_SET", ``!(f:'a -> real) s t.
@@ -691,21 +629,25 @@ val REAL_SUM_IMAGE_CROSS_SYM = store_thm
   >> RW_TAC std_ss []);
 
 Theorem REAL_SUM_IMAGE_ABS_TRIANGLE :
-   !f s. FINITE s ==> abs (REAL_SUM_IMAGE f s) <= REAL_SUM_IMAGE (abs o f) s
+    !f s. FINITE s ==> abs (REAL_SUM_IMAGE f s) <= REAL_SUM_IMAGE (abs o f) s
 Proof
-    Q.X_GEN_TAC ‘f’
- >> HO_MATCH_MP_TAC FINITE_INDUCT
- >> CONJ_TAC >- REWRITE_TAC [REAL_SUM_IMAGE_THM, ABS_0, REAL_LE_REFL]
- >> rpt STRIP_TAC
- >> ASM_SIMP_TAC std_ss [REAL_SUM_IMAGE_THM]
- >> MATCH_MP_TAC REAL_LE_TRANS
- >> Q.EXISTS_TAC ‘abs (f e) + abs (REAL_SUM_IMAGE f (s DELETE e))’
- >> REWRITE_TAC [ABS_TRIANGLE]
- >> MATCH_MP_TAC REAL_LE_LADD_IMP
- >> FULL_SIMP_TAC std_ss [DELETE_NON_ELEMENT]
+    rw [REAL_SUM_IMAGE_DEF, SUM_ABS, o_DEF]
 QED
 
-val _ = overload_on ("SIGMA", ``REAL_SUM_IMAGE ``);
+Theorem REAL_SUM_IMAGE_DELETE = translate SUM_DELETE
+Theorem REAL_SUM_IMAGE_SWAP = translate SUM_SWAP
+Theorem REAL_SUM_IMAGE_BOUND = translate SUM_BOUND
+Theorem REAL_SUM_IMAGE_IMAGE_LE = translate SUM_IMAGE_LE
+
+Theorem REAL_SUM_IMAGE_PERMUTES :
+    !f p s:'a->bool. p PERMUTES s ==> REAL_SUM_IMAGE f s = REAL_SUM_IMAGE (f o p) s
+Proof
+    rw [BIJ_ALT, REAL_SUM_IMAGE_DEF, IN_FUNSET]
+ >> MATCH_MP_TAC SUM_BIJECTION >> rw []
+ >> Q.PAT_X_ASSUM ‘!y. y IN s ==> ?!x. P’ (MP_TAC o Q.SPEC ‘y’)
+ >> RW_TAC bool_ss [EXISTS_UNIQUE_DEF] (* why it takes so long time? *)
+ >> Q.EXISTS_TAC ‘x’ >> art []
+QED
 
 (* ------------------------------------------------------------------------- *)
 (* ---- jensen's inequality (from "miller" example)             ------------ *)
@@ -732,19 +674,20 @@ val jensen_convex_SIGMA = store_thm
         >> Know `!s. FINITE s ==>
                 (\s. !g. (SIGMA g s = 0) /\ (!x. x IN s ==> 0 <= g x /\ g x <= 1) ==>
                             (!x. x IN s ==> (g x = 0))) s`
-        >- (MATCH_MP_TAC FINITE_INDUCT
-            >> RW_TAC real_ss [REAL_SUM_IMAGE_THM, DELETE_NON_ELEMENT, IN_INSERT, DISJ_IMP_THM,
-                               FORALL_AND_THM, NOT_IN_EMPTY] (* 2 sub-goals *)
-            >- (Know `!(x:real) y. 0 <= x /\ 0 <= y /\ (x + y = 0) ==> ((x = 0) /\ (y = 0))`
-                >- REAL_ARITH_TAC
-                >> PROVE_TAC [REAL_SUM_IMAGE_POS])
-            >>
-            ( Know `!(x:real) y. 0 <= x /\ 0 <= y /\ (x + y = 0) ==> ((x = 0) /\ (y = 0))`
+        >- (MATCH_MP_TAC FINITE_INDUCT \\
+            RW_TAC real_ss [REAL_SUM_IMAGE_THM, DELETE_NON_ELEMENT, IN_INSERT, DISJ_IMP_THM,
+                            FORALL_AND_THM, NOT_IN_EMPTY] >| (* 2 sub-goals *)
+            [ (* goal 1 (of 2) *)
+              Know `!(x:real) y. 0 <= x /\ 0 <= y /\ (x + y = 0) ==> ((x = 0) /\ (y = 0))`
+              >- REAL_ARITH_TAC
+              >> PROVE_TAC [REAL_SUM_IMAGE_POS],
+              (* goal 2 (of 2) *)
+              Know `!(x:real) y. 0 <= x /\ 0 <= y /\ (x + y = 0) ==> ((x = 0) /\ (y = 0))`
               >- REAL_ARITH_TAC
               >> Q.PAT_X_ASSUM `!g. (SIGMA g s' = 0) /\ (!x. x IN s' ==> 0 <= g x /\ g x <= 1) ==>
                                 !x. x IN s' ==> (g x = 0)`
                 (MP_TAC o Q.SPEC `g'`)
-              >> PROVE_TAC [REAL_SUM_IMAGE_POS] ))
+              >> PROVE_TAC [REAL_SUM_IMAGE_POS] ])
         >> Know `!x:real. (1 + x = 1) = (x = 0)` >- REAL_ARITH_TAC
         >> STRIP_TAC >> FULL_SIMP_TAC real_ss []
         >> POP_ASSUM (K ALL_TAC)


### PR DESCRIPTION
Hi,

In `iterateTheory` ("src/probability", ported from HOL Light) there's the definition `sum` of the values of real functions over a (finite) set:
```
   [sum_def]  Definition      
      ⊢ sum = iterate $+
```
while in HOL's own `real_sigmaTheory` ("src/real") there's a similar concept `REAL_SUM_IMAGE` (or `SIGMA`) widely used by user code and other HOL core theories:
```
   [REAL_SUM_IMAGE_DEF]  Definition      
      ⊢ ∀f s. SIGMA f s = ITSET (λe acc. f e + acc) s 0
```
They only differ at the order of arguments: `sum s f = SIGMA f s`, but `iterateTheory` is more advanced (to be explained below) with more useful lemmas. The main purpose of this PR is to re-define `REAL_SUM_IMAGE` by `sum` so that:

1.  many existing `SIGMA` theorems now have trivial proofs based on their `sum` version;
2. new `SIGMA` theorems can be easily migrated from their `sum` versions.

```
   [REAL_SUM_IMAGE_DEF]  Definition (NEW)      
      ⊢ ∀f s. SIGMA f s = sum s f
```

As the result, the size of `real_sigmaTheory` is reduced with more `SIGMA` theorems provided. And we take this chance to move `iterateTheory` from "src/probability" to "src/real" (so that `real_sigmaTheory` can depend on it).   (Note that it seems possible to further define `SIGMA` as an overloading of `\f s. sum s f`, but when I tries this, some proofs are broken, then I gave up.)

It turns out that `iterateTheory` is more advanced: now some `SIGMA` theorems can be proved without finiteness assumptions on the involved sets! For example, the following "primed" versions are now added:
```
   [REAL_SUM_IMAGE_0']  Theorem      
      ⊢ ∀s. SIGMA (λx. 0) s = 0

   [REAL_SUM_IMAGE_EQ']  Theorem      
      ⊢ ∀s f f'. (∀x. x ∈ s ⇒ f x = f' x) ⇒ SIGMA f s = SIGMA f' s

   [REAL_SUM_IMAGE_IMAGE']  Theorem      
      ⊢ ∀P f'.
          INJ f' P (IMAGE f' P) ⇒
          ∀f. SIGMA f (IMAGE f' P) = SIGMA (f ∘ f') P

   [REAL_SUM_IMAGE_POS']  Theorem      
      ⊢ ∀f s. (∀x. x ∈ s ⇒ 0 ≤ f x) ⇒ 0 ≤ SIGMA f s
```
These theorems are impossible to prove if `SIGMA` were defined by `ITSET` based on induction of finite sets. But they are all mathematically true, even the involved set is infinite or even uncountable!  (I didn't dig into `iterateTheory` to see how this can be achieved).  On the other hand, it's also true that not every `SIGMA` theorem can drop their finiteness assumptions. For example, the following theorem on addition
```
   [REAL_SUM_IMAGE_ADD]  Theorem      
      ⊢ ∀s. FINITE s ⇒
            ∀f f'. SIGMA (λx. f x + f' x) s = SIGMA f s + SIGMA f' s
```
doesn't hold for the sum of infinite series (even countable), if I remember correctly from the textbook.   Any way, by dropping some finiteness antecedents from the existing theorems may lead to shorter proofs while the proof is still mathematically precise (the present case is totally different with division-by-zero of reals).

I did a small "editor-of-choice" selection of `sum` lemmas and translated them into `SIGMA` lemmas (using a simple ML function `translated` I defined in "real_sigmaScript.sml"). The most impressive one is the following lemma about permutation (self bijection):
```
   [REAL_SUM_IMAGE_PERMUTES]  Theorem      
      ⊢ ∀f p s. p PERMUTES s ⇒ SIGMA f s = SIGMA (f ∘ p) s
```
It's amazing that this theorem universally holds for whatever sets, even uncountably large (as long as the `SIGMA` result is specified).

Recall that the finite product of extreals (`extreal$EXTREAL_PROD_IMAGE`) was changed to based on also `iterateTheory`. I took this chance to re-prove some of its lemmas using advanced lemmas from `iterateTheory` and slightly shorten the size of "extrealScript.sml".  This is basically why in this PR more theorems are added but more lines are deleted than added.

Currently there are still many useful lemmas about real numbers that could be moved to `realTheory` for easier finding by end users. But many of these lemmas need `real_ss`, which is not available in `realTheory`.  I think for now it's better to leave them as is, since `realTheory` is already very big.

Regards,

Chun Tian
