### PR TITLE
Some alternative definitions of (sub-,super-)martingales

### DIFF
--- a/src/probability/lebesgueScript.sml
+++ b/src/probability/lebesgueScript.sml
@@ -10274,49 +10274,6 @@ Proof
   CONJ_TAC THENL [METIS_TAC [], ALL_TAC] THEN ASM_SET_TAC [DISJOINT_DEF]
 QED
 
-Theorem ext_suminf_cmult_indicator :
-    !A f x i. disjoint_family A /\ x IN A i /\ (!i. 0 <= f i) ==>
-              (suminf (\n. f n * indicator_fn (A n) x) = f i)
-Proof
-  RW_TAC std_ss [disjoint_family, disjoint_family_on, IN_UNIV] THEN
-  Suff `!n. f n * indicator_fn (A n) x = if n = i then f n else 0` THENL
-  [DISCH_TAC,
-   RW_TAC std_ss [indicator_fn_def, mul_rone, mul_rzero] THEN
-   ASM_SET_TAC []] THEN
-  Suff `f i = SIGMA (\i. f i * indicator_fn (A i) x) (count (SUC i))` THENL
-  [DISCH_THEN (fn th => ONCE_REWRITE_TAC [th]) THEN MATCH_MP_TAC ext_suminf_sum THEN
-   RW_TAC std_ss [le_refl] THEN POP_ASSUM MP_TAC THEN ASM_SIMP_TAC arith_ss [ADD1],
-   ASM_SIMP_TAC std_ss []] THEN
-  `count (SUC i) <> {}` by (SIMP_TAC std_ss [GSYM MEMBER_NOT_EMPTY] THEN
-     Q.EXISTS_TAC `i` THEN SIMP_TAC arith_ss [GSPECIFICATION, count_def]) THEN
-  Suff `count (SUC i) = count i UNION {i}` THENL
-  [RW_TAC std_ss [],
-   SIMP_TAC arith_ss [count_def, EXTENSION, IN_UNION, GSPECIFICATION, IN_SING]] THEN
-  Suff `SIGMA (\i'. if i' = i then f i else 0) (count i UNION {i}) =
-                  SIGMA (\i'. if i' = i then f i else 0) (count i) +
-                  SIGMA (\i'. if i' = i then f i else 0) ({i})` THENL
-  [RW_TAC std_ss [],
-   ABBREV_TAC ``g = (\i'. if i' = i then (f:num->extreal) i else 0)`` THEN
-   Suff `(!x. x IN (count i UNION {i}) ==> g x <> NegInf) \/
-                   (!x. x IN (count i UNION {i}) ==> g x <> PosInf)` THENL
-   [Q.SPEC_TAC (`g`,`g`) THEN MATCH_MP_TAC EXTREAL_SUM_IMAGE_DISJOINT_UNION THEN
-    SIMP_TAC std_ss [FINITE_COUNT, FINITE_SING, DISJOINT_DEF] THEN
-    SIMP_TAC std_ss [EXTENSION, IN_INTER, IN_SING, NOT_IN_EMPTY, count_def] THEN
-    SIMP_TAC arith_ss [GSPECIFICATION],
-    DISJ1_TAC] THEN
-   EXPAND_TAC "g" THEN POP_ASSUM K_TAC THEN RW_TAC std_ss [lt_infty] THENL
-   [ALL_TAC, METIS_TAC [lt_infty, num_not_infty]] THEN
-   MATCH_MP_TAC lte_trans THEN Q.EXISTS_TAC `0` THEN ASM_REWRITE_TAC [] THEN
-   METIS_TAC [lt_infty, num_not_infty]] THEN
-  SIMP_TAC std_ss [EXTREAL_SUM_IMAGE_SING] THEN
-  Suff `SIGMA (\i'. if i' = i then f i else 0) (count i) = 0` THENL
-  [SIMP_TAC std_ss [add_lzero],
-   MATCH_MP_TAC EXTREAL_SUM_IMAGE_0] THEN
-  RW_TAC std_ss [FINITE_COUNT] THEN POP_ASSUM MP_TAC THEN
-  ONCE_REWRITE_TAC [MONO_NOT_EQ] THEN RW_TAC std_ss [] THEN
-  SIMP_TAC arith_ss [count_def, GSPECIFICATION]
-QED
-
 Theorem finite_integrable_function_exists : (* was: Ex_finite_integrable_function *)
     !m. measure_space m /\ sigma_finite m ==>
         ?h. h IN measurable (m_space m, measurable_sets m) Borel /\

--- a/src/probability/martingaleScript.sml
+++ b/src/probability/martingaleScript.sml
@@ -21,16 +21,16 @@ val _ = hide "S";
 
 fun METIS ths tm = prove(tm, METIS_TAC ths);
 
-(* "The theory of martingales as we know it now goes back to
-    Doob and most of the material of this and the following chapter can be found in
-    his seminal monograph [2] from 1953.
+(* "The theory of martingales as we know it now goes back to Doob and most of
+    the material of this and the following chapter can be found in his seminal
+    monograph [2] from 1953.
 
     We want to understand martingales as an analysis tool which will be useful
     for the study of L^p- and almost everywhere convergence and, in particular,
     for the further development of measure and integration theory. Our presentation
     differs somewhat from the standard way to introduce martingales - conditional
-    expectations will be defined later in Chapter 22 - but the results and their
-    proofs are pretty much the usual ones."
+    expectations will be defined later in [1, Chapter 22] - but the results and
+    their proofs are pretty much the usual ones."
 
   -- Rene L. Schilling, "Measures, Integrals and Martingales" [1]
 
@@ -42,7 +42,7 @@ fun METIS ths tm = prove(tm, METIS_TAC ths);
   -- J. L. Doob, "What is a Martingale?" [3] *)
 
 (* ------------------------------------------------------------------------- *)
-(*  Martingale definitions ([1, Chapter 17])                                 *)
+(*  Martingale definitions ([1, Chapter 23])                                 *)
 (* ------------------------------------------------------------------------- *)
 
 Definition sub_sigma_algebra_def :
@@ -97,7 +97,7 @@ End
 (*   Convergence theorems and their applications [1, Chapter 9 & 12]         *)
 (* ------------------------------------------------------------------------- *)
 
-(* Another convergence theorem, named after P. Fatou, usually called Fatou's lemma,
+(* Another convergence theorem, usually called Fatou's lemma,
    named after Pierre Fatou (1878-1929), a French mathematician and astronomer.
 
    This is mainly to prove the validity of the definition of `ext_liminf`. The value
@@ -1129,74 +1129,6 @@ Proof
  >> qexistsl_tac [‘a'’, ‘b'’] >> art []
  >> METIS_TAC [SUBSET_DEF]
 QED
-
-(* "exhausting" sequence in a system of sets *)
-Definition exhausting_sequence_def :
-    exhausting_sequence (a :'a algebra) (f :num -> 'a -> bool) =
-      (f IN (UNIV -> subsets a) /\ (!n. f n SUBSET f (SUC n)) /\
-       BIGUNION (IMAGE f UNIV) = space a)
-End
-
-Theorem exhausting_sequence_alt :
-   !a f. exhausting_sequence a f <=>
-         f IN (univ(:num) -> subsets a) /\ (!m n. m <= n ==> f m SUBSET f n) /\
-         BIGUNION (IMAGE f univ(:num)) = space a
-Proof
-    RW_TAC std_ss [exhausting_sequence_def]
- >> reverse EQ_TAC >- RW_TAC std_ss []
- >> STRIP_TAC >> art []
- >> GEN_TAC >> Induct_on ‘n’ >- RW_TAC arith_ss [SUBSET_REFL]
- >> DISCH_TAC
- >> ‘(m = SUC n) \/ m <= n’ by RW_TAC arith_ss [] >- rw [SUBSET_REFL]
- >> MATCH_MP_TAC SUBSET_TRANS
- >> Q.EXISTS_TAC ‘f n’ >> art []
- >> FIRST_X_ASSUM MATCH_MP_TAC >> art []
-QED
-
-Definition has_exhausting_sequence :
-    has_exhausting_sequence a = ?f. exhausting_sequence a f
-End
-
-(* This was part of sigma_finite_def, but no requirement on the measure of each
-   (f n). The definition is useful because ‘space a IN subsets a’ does not hold
-   in general for semiring.
- *)
-Theorem has_exhausting_sequence_def =
-    REWRITE_RULE [exhausting_sequence_def] has_exhausting_sequence;
-
-Theorem has_exhausting_sequence_alt =
-    REWRITE_RULE [exhausting_sequence_alt] has_exhausting_sequence;
-
-(* connection with ‘sigma_finite’ *)
-Theorem sigma_finite_has_exhausting_sequence :
-    !sp sts u. sigma_finite (sp,sts,u) ==> has_exhausting_sequence (sp,sts)
-Proof
-    RW_TAC std_ss [sigma_finite_def, has_exhausting_sequence_def,
-                   m_space_def, measurable_sets_def, space_def, subsets_def]
- >> Q.EXISTS_TAC ‘f’ >> rw []
-QED
-
-(* alternative definition of ‘sigma_finite’ *)
-Theorem sigma_finite_alt_exhausting_sequence :
-    !m. sigma_finite m <=>
-        ?f. exhausting_sequence (m_space m,measurable_sets m) f /\
-            !n. measure m (f n) < PosInf
-Proof
-    RW_TAC std_ss [sigma_finite_def, exhausting_sequence_def,
-                   space_def, subsets_def]
- >> EQ_TAC >> RW_TAC std_ss []
- >> Q.EXISTS_TAC ‘f’ >> art []
-QED
-
-(* |- !m. sigma_finite m <=>
-          ?f. (f IN (univ(:num) -> measurable_sets m) /\
-               (!m n. m <= n ==> f m SUBSET f n) /\
-               BIGUNION (IMAGE f univ(:num)) = m_space m) /\
-              !n. measure m (f n) < PosInf
- *)
-Theorem sigma_finite_alt =
-    REWRITE_RULE [exhausting_sequence_alt, subsets_def, space_def]
-                 sigma_finite_alt_exhausting_sequence;
 
 Theorem exhausting_sequence_general_cross :
     !(cons :'a -> 'b -> 'c) X Y A B f g.
@@ -5049,7 +4981,7 @@ Proof
 QED
 
 (* ------------------------------------------------------------------------- *)
-(*  Filtration and basic version of martingales (Chapter 17 of [1])          *)
+(*  Filtration and basic version of martingales (Chapter 23 of [1])          *)
 (* ------------------------------------------------------------------------- *)
 
 (* ‘sub_sigma_algebra’ is a partial-order between sigma-algebra *)
@@ -5115,25 +5047,29 @@ val FILTRATION = store_thm
  >- (DISCH_TAC >> IMP_RES_TAC FILTRATION_SUBSETS >> fs [filtration_def])
  >> RW_TAC std_ss [filtration_def]);
 
-val filtered_measure_space_alt = store_thm
-  ("filtered_measure_space_alt",
-  ``!m a. filtered_measure_space m a <=>
-          measure_space m /\ filtration (m_space m,measurable_sets m) a``,
+Theorem filtered_measure_space_alt :
+    !m a. filtered_measure_space m a <=>
+          measure_space m /\ filtration (m_space m,measurable_sets m) a
+Proof
     rpt GEN_TAC
  >> Cases_on `m` >> Cases_on `r`
- >> REWRITE_TAC [filtered_measure_space_def, m_space_def, measurable_sets_def]);
+ >> REWRITE_TAC [filtered_measure_space_def, m_space_def, measurable_sets_def]
+QED
 
-val sigma_finite_filtered_measure_space_alt = store_thm
-  ("sigma_finite_filtered_measure_space_alt",
-  ``!m a. sigma_finite_filtered_measure_space m a <=>
-          filtered_measure_space m a /\ sigma_finite (m_space m,subsets (a 0),measure m)``,
+Theorem sigma_finite_filtered_measure_space :
+    !m a. sigma_finite_filtered_measure_space m a <=>
+          measure_space m /\ filtration (m_space m,measurable_sets m) a /\
+          sigma_finite (m_space m,subsets (a 0),measure m)
+Proof
     rpt GEN_TAC
- >> Cases_on `m` >> Cases_on `r`
- >> REWRITE_TAC [sigma_finite_filtered_measure_space_def, m_space_def, measure_def]);
+ >> Cases_on ‘m’ >> Cases_on ‘r’ >> rename1 ‘measure_space (sp,sts,m)’
+ >> rw [sigma_finite_filtered_measure_space_def,
+        filtered_measure_space_def, GSYM CONJ_ASSOC]
+QED
 
 (* all sub measure spaces of a sigma-finite fms are also sigma-finite *)
-Theorem SIGMA_FINITE_FILTERED_MEASURE_SPACE_I :
-    !sp sts a m. sigma_finite_filtered_measure_space (sp,sts,m) a ==>
+Theorem SIGMA_FINITE_FILTERED_MEASURE_SPACE[local] :
+    !sp sts m a. sigma_finite_filtered_measure_space (sp,sts,m) a ==>
                  !n. sigma_finite (sp,subsets (a n),m)
 Proof
     RW_TAC std_ss [sigma_finite_filtered_measure_space_def,
@@ -5153,15 +5089,27 @@ Proof
  >> METIS_TAC [SUBSET_DEF]
 QED
 
-Theorem sigma_finite_filtered_measure_space_alt :
-    !sp sts a m. sigma_finite_filtered_measure_space (sp,sts,m) a <=>
-                 filtered_measure_space (sp,sts,m) a /\
-                 !n. sigma_finite (sp,subsets (a n),m)
+(* |- !m a.
+        sigma_finite_filtered_measure_space m a ==>
+        !n. sigma_finite (m_space m,subsets (a n),measure m)
+ *)
+Theorem SIGMA_FINITE_FILTERED_MEASURE_SPACE_I =
+        SIGMA_FINITE_FILTERED_MEASURE_SPACE
+    |> (Q.SPECL [‘m_space m’, ‘measurable_sets m’, ‘measure m’])
+    |> (Q.GEN ‘m’)
+    |> (REWRITE_RULE [MEASURE_SPACE_REDUCE])
+
+Theorem sigma_finite_filtered_measure_space_alt_all :
+    !m a. sigma_finite_filtered_measure_space m a <=>
+          measure_space m /\ filtration (m_space m,measurable_sets m) a /\
+          !n. sigma_finite (m_space m,subsets (a n),measure m)
 Proof
-    rpt GEN_TAC >> EQ_TAC
- >- (DISCH_TAC >> IMP_RES_TAC SIGMA_FINITE_FILTERED_MEASURE_SPACE_I \\
-     fs [sigma_finite_filtered_measure_space_def])
- >> RW_TAC std_ss [sigma_finite_filtered_measure_space_def]
+    rpt GEN_TAC
+ >> reverse EQ_TAC
+ >- RW_TAC std_ss [sigma_finite_filtered_measure_space]
+ >> DISCH_TAC
+ >> IMP_RES_TAC SIGMA_FINITE_FILTERED_MEASURE_SPACE_I
+ >> fs [sigma_finite_filtered_measure_space]
 QED
 
 (* the smallest sigma-algebra generated by all (a n) *)
@@ -5200,25 +5148,414 @@ val INFTY_SIGMA_ALGEBRA_MAXIMAL = store_thm
      Q.EXISTS_TAC `n` >> art [])
  >> REWRITE_TAC [SIGMA_SUBSET_SUBSETS]);
 
-(* u is a martingale if, and only if, it is both a sub- and a supermartingale *)
-val MARTINGALE_BOTH_SUB_SUPER = store_thm
-  ("MARTINGALE_BOTH_SUB_SUPER",
-  ``!m a u. martingale m a u <=> sub_martingale m a u /\ super_martingale m a u``,
+(* ------------------------------------------------------------------------- *)
+(*  Martingale alternative definitions and properties (Chapter 23 of [1])    *)
+(* ------------------------------------------------------------------------- *)
+
+(* ‘u’ is a martingale if, and only if, it is both a sub- and a super-martingale
+
+   This is Example 23.3 (i) [1, p.277]
+ *)
+Theorem MARTINGALE_EQ_SUB_SUPER :
+    !m a u. martingale m a u <=> sub_martingale m a u /\ super_martingale m a u
+Proof
     RW_TAC std_ss [martingale_def, sub_martingale_def, super_martingale_def]
  >> EQ_TAC >> RW_TAC std_ss [le_refl]
- >> ASM_SIMP_TAC std_ss [GSYM le_antisym]);
+ >> ASM_SIMP_TAC std_ss [GSYM le_antisym]
+QED
+
+(* simple alternative definitions: ‘n < SUC n’ is replaced by ‘i <= j’ *)
+val martingale_shared_tactics_1 =
+    reverse EQ_TAC >- RW_TAC arith_ss []
+ >> RW_TAC arith_ss [sigma_finite_filtered_measure_space]
+ >> Q.PAT_X_ASSUM ‘i <= j’ MP_TAC
+ >> Induct_on ‘j - i’
+ >- (RW_TAC arith_ss [] \\
+    ‘j = i’ by RW_TAC arith_ss [] >> RW_TAC arith_ss [le_refl])
+ >> RW_TAC arith_ss []
+ >> ‘v = PRE j - i’ by RW_TAC arith_ss []
+ >> ‘i < j /\ i <= PRE j’ by RW_TAC arith_ss []
+ >> ‘SUC (PRE j) = j’ by RW_TAC arith_ss []
+ >> ‘s IN subsets (a (PRE j))’ by METIS_TAC [FILTRATION_MONO, SUBSET_DEF]
+ >> Q.PAT_X_ASSUM ‘!n s. s IN subsets (a n) ==> P’
+     (MP_TAC o (Q.SPECL [‘PRE j’, ‘s’]))
+ >> RW_TAC arith_ss [];
+
+val martingale_shared_tactics_2 =
+    MATCH_MP_TAC le_trans
+ >> Q.EXISTS_TAC ‘integral m (\x. u (PRE j) x * indicator_fn s x)’
+ >> POP_ASSUM (REWRITE_TAC o wrap)
+ >> FIRST_X_ASSUM irule
+ >> RW_TAC arith_ss [];
+
+Theorem martingale_alt :
+   !m a u.
+      martingale m a u <=>
+      sigma_finite_filtered_measure_space m a /\ (!n. integrable m (u n)) /\
+      !i j s. i <= j /\ s IN subsets (a i) ==>
+             (integral m (\x. u i x * indicator_fn s x) =
+              integral m (\x. u j x * indicator_fn s x))
+Proof
+    RW_TAC std_ss [martingale_def]
+ >> martingale_shared_tactics_1
+QED
+
+Theorem super_martingale_alt :
+   !m a u.
+      super_martingale m a u <=>
+      sigma_finite_filtered_measure_space m a /\ (!n. integrable m (u n)) /\
+      !i j s. i <= j /\ s IN subsets (a i) ==>
+             (integral m (\x. u j x * indicator_fn s x) <=
+              integral m (\x. u i x * indicator_fn s x))
+Proof
+    RW_TAC std_ss [super_martingale_def]
+ >> martingale_shared_tactics_1
+ >> martingale_shared_tactics_2
+QED
+
+Theorem sub_martingale_alt :
+   !m a u.
+      sub_martingale m a u <=>
+      sigma_finite_filtered_measure_space m a /\ (!n. integrable m (u n)) /\
+      !i j s. i <= j /\ s IN subsets (a i) ==>
+             (integral m (\x. u i x * indicator_fn s x) <=
+              integral m (\x. u j x * indicator_fn s x))
+Proof
+    RW_TAC std_ss [sub_martingale_def]
+ >> martingale_shared_tactics_1
+ >> martingale_shared_tactics_2
+QED
+
+(* Remark 23.2 [1, p.276]: we can replace the sigma-algebra (a n) with any
+   INTER-stable generator (g n) of (a n) containing an exhausive sequence.
+
+   NOTE: in typical applications, it's expected to have (g n) such that
+  ‘!i j. i <= j ==> g i SUBSET g j’ and thus the exhausting sequence of (g 0)
+   is also the exhausting sequence of all (g n).
+ *)
+
+val martingale_alt_generator_shared_tactics_1 =
+    qx_genl_tac [‘m’, ‘a’, ‘u’, ‘G’]
+ >> RW_TAC std_ss [sigma_finite_filtered_measure_space, filtered_measure_space_alt,
+                   martingale_alt, sub_martingale_alt, super_martingale_alt]
+ >> EQ_TAC (* easy part first *)
+ >- (RW_TAC std_ss [] \\
+     FIRST_X_ASSUM MATCH_MP_TAC >> rw [] \\
+     Suff ‘(G i) SUBSET subsets (sigma (m_space m) (G i))’ >- METIS_TAC [SUBSET_DEF] \\
+     REWRITE_TAC [SIGMA_SUBSET_SUBSETS])
+ >> rw [sigma_finite_alt_exhausting_sequence, exhausting_sequence_def, IN_FUNSET]
+ >- (fs [has_exhausting_sequence_def, IN_FUNSET, IN_UNIV] \\
+     Q.PAT_X_ASSUM ‘!n. ?f. P’ (MP_TAC o (Q.SPEC ‘0’)) \\
+     RW_TAC std_ss [] \\
+     Q.EXISTS_TAC ‘f’ >> rw []
+     >- (Suff ‘(G 0) SUBSET subsets (sigma (m_space m) (G 0))’
+         >- METIS_TAC [SUBSET_DEF] \\
+         REWRITE_TAC [SIGMA_SUBSET_SUBSETS]) \\
+     FIRST_X_ASSUM MATCH_MP_TAC \\
+     Q.EXISTS_TAC ‘0’ >> art [])
+ (* stage work *)
+ >> FULL_SIMP_TAC std_ss [integral_def]
+ >> Know ‘!n. subsets (a n) SUBSET (measurable_sets m)’
+ >- (fs [filtration_def, sub_sigma_algebra_def])
+ >> DISCH_TAC
+ >> ‘!n s. s IN G n ==> s IN measurable_sets m’
+      by METIS_TAC [SIGMA_SUBSET_SUBSETS, SUBSET_DEF]
+ >> Know ‘!n s. (\x. u n x * indicator_fn s x)^+ =
+                (\x. fn_plus (u n) x * indicator_fn s x)’
+ >- (rpt GEN_TAC >> ONCE_REWRITE_TAC [mul_comm] \\
+     MATCH_MP_TAC FN_PLUS_FMUL >> rw [INDICATOR_FN_POS])
+ >> DISCH_THEN (FULL_SIMP_TAC std_ss o wrap)
+ >> Know ‘!n s. (\x. u n x * indicator_fn s x)^- =
+                (\x. fn_minus (u n) x * indicator_fn s x)’
+ >- (rpt GEN_TAC >> ONCE_REWRITE_TAC [mul_comm] \\
+     MATCH_MP_TAC FN_MINUS_FMUL >> rw [INDICATOR_FN_POS])
+ >> DISCH_THEN (FULL_SIMP_TAC std_ss o wrap)
+ (* simplifications by abbreviations *)
+ >> Q.ABBREV_TAC ‘A = \n s. pos_fn_integral m (\x. (u n)^+ x * indicator_fn s x)’
+ >> Q.ABBREV_TAC ‘B = \n s. pos_fn_integral m (\x. (u n)^- x * indicator_fn s x)’
+ >> FULL_SIMP_TAC std_ss []
+ >> Know ‘!n s. 0 <= A n s /\ 0 <= B n s’
+ >- (rw [Abbr ‘A’, Abbr ‘B’] \\
+     MATCH_MP_TAC pos_fn_integral_pos >> rw [] \\
+     MATCH_MP_TAC le_mul \\
+     rw [FN_PLUS_POS, FN_MINUS_POS, INDICATOR_FN_POS])
+ >> DISCH_TAC
+ >> Know ‘!n s. A n s < PosInf /\ B n s < PosInf’
+ >- (rw [Abbr ‘A’, Abbr ‘B’] >| (* 2 subgoals *)
+     [ (* goal 1 (of 2) *)
+       MATCH_MP_TAC let_trans \\
+       Q.EXISTS_TAC ‘pos_fn_integral m (fn_plus (u n))’ \\
+       reverse CONJ_TAC >- (REWRITE_TAC [GSYM lt_infty] \\
+                            METIS_TAC [integrable_def]) \\
+       MATCH_MP_TAC pos_fn_integral_mono >> rw []
+       >- (MATCH_MP_TAC le_mul >> rw [FN_PLUS_POS, INDICATOR_FN_POS]) \\
+       GEN_REWRITE_TAC (RAND_CONV o ONCE_DEPTH_CONV) empty_rewrites [GSYM mul_rone] \\
+       MATCH_MP_TAC le_lmul_imp >> rw [FN_PLUS_POS, INDICATOR_FN_LE_1],
+       (* goal 2 (of 2) *)
+       MATCH_MP_TAC let_trans \\
+       Q.EXISTS_TAC ‘pos_fn_integral m (fn_minus (u n))’ \\
+       reverse CONJ_TAC >- (REWRITE_TAC [GSYM lt_infty] \\
+                            METIS_TAC [integrable_def]) \\
+       MATCH_MP_TAC pos_fn_integral_mono >> rw []
+       >- (MATCH_MP_TAC le_mul >> rw [FN_MINUS_POS, INDICATOR_FN_POS]) \\
+       GEN_REWRITE_TAC (RAND_CONV o ONCE_DEPTH_CONV) empty_rewrites [GSYM mul_rone] \\
+       MATCH_MP_TAC le_lmul_imp >> rw [FN_MINUS_POS, INDICATOR_FN_LE_1] ])
+ >> DISCH_TAC;
+ (* end of martingale_alt_generator_shared_tactics_1 *)
+
+val martingale_alt_generator_shared_tactics_2 =
+    Q.ABBREV_TAC ‘f = \i j x. fn_plus (u i) x + fn_minus (u j) x’
+ >> Know ‘!i j s. s IN measurable_sets m ==> A i s + B j s = (f i j * m) s’
+ >- (qx_genl_tac [‘k’, ‘n’, ‘t’] \\
+     RW_TAC std_ss [Abbr ‘f’, Abbr ‘A’, Abbr ‘B’, density_measure_def] \\
+     Know ‘pos_fn_integral m (\x. (u k)^+ x * indicator_fn t x) +
+           pos_fn_integral m (\x. (u n)^- x * indicator_fn t x) =
+           pos_fn_integral m (\x. (u k)^+ x * indicator_fn t x +
+                                  (u n)^- x * indicator_fn t x)’
+     >- (ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
+         HO_MATCH_MP_TAC pos_fn_integral_add >> rw [] >| (* 4 subgoals *)
+         [ (* goal 1 (of 4) *)
+           MATCH_MP_TAC le_mul >> rw [FN_PLUS_POS, INDICATOR_FN_POS],
+           (* goal 2 (of 4) *)
+           MATCH_MP_TAC le_mul >> rw [FN_MINUS_POS, INDICATOR_FN_POS],
+           (* goal 3 (of 4) *)
+           MATCH_MP_TAC IN_MEASURABLE_BOREL_MUL_INDICATOR >> rw []
+           >- (FULL_SIMP_TAC std_ss [measure_space_def]) \\
+           MATCH_MP_TAC IN_MEASURABLE_BOREL_FN_PLUS \\
+           FULL_SIMP_TAC std_ss [integrable_def],
+           (* goal 4 (of 4) *)
+           MATCH_MP_TAC IN_MEASURABLE_BOREL_MUL_INDICATOR >> rw []
+           >- (FULL_SIMP_TAC std_ss [measure_space_def]) \\
+           MATCH_MP_TAC IN_MEASURABLE_BOREL_FN_MINUS \\
+           FULL_SIMP_TAC std_ss [integrable_def] ]) >> Rewr' \\
+     MATCH_MP_TAC pos_fn_integral_cong >> rw [] >| (* 3 subgoals *)
+     [ (* goal 1 (of 3) *)
+       MATCH_MP_TAC le_add >> CONJ_TAC >> MATCH_MP_TAC le_mul \\
+       rw [FN_PLUS_POS, FN_MINUS_POS, INDICATOR_FN_POS],
+       (* goal 2 (of 3) *)
+       MATCH_MP_TAC le_mul >> rw [INDICATOR_FN_POS] \\
+       MATCH_MP_TAC le_add >> rw [FN_PLUS_POS, FN_MINUS_POS],
+       (* goal 3 (of 3) *)
+       rw [indicator_fn_def] ])
+ >> DISCH_TAC
+ >> ‘s IN measurable_sets m’ by METIS_TAC [SIGMA_SUBSET_SUBSETS, SUBSET_DEF];
+ (* end of martingale_alt_generator_shared_tactics_2 *)
+
+val martingale_alt_generator_shared_tactics_3 =
+    Know ‘!i j. measure_space (m_space m,measurable_sets m,f i j * m)’
+ >- (qx_genl_tac [‘M’, ‘N’] \\
+     MATCH_MP_TAC (REWRITE_RULE [density_def] measure_space_density) \\
+     RW_TAC std_ss [Abbr ‘f’] >| (* 2 subgoals *)
+     [ (* goal 1 (of 2) *)
+       MATCH_MP_TAC IN_MEASURABLE_BOREL_ADD' \\
+       qexistsl_tac [‘fn_plus (u M)’, ‘fn_minus (u N)’] >> simp [] \\
+       CONJ_TAC >- FULL_SIMP_TAC std_ss [measure_space_def] \\
+       FULL_SIMP_TAC std_ss [integrable_def] \\
+       PROVE_TAC [IN_MEASURABLE_BOREL_FN_PLUS, IN_MEASURABLE_BOREL_FN_MINUS],
+       (* goal 2 (of 2) *)
+       MATCH_MP_TAC le_add >> rw [FN_PLUS_POS, FN_MINUS_POS] ])
+ >> DISCH_TAC;
+(* end of martingale_alt_generator_shared_tactics_3 *)
+
+val martingale_alt_generator_shared_tactics_4 =
+    Suff ‘!i j n. measure_space (m_space m,subsets (sigma (m_space m) (G n)),f i j * m)’
+ >- Rewr
+ >> Q.PAT_X_ASSUM ‘i <= j’ K_TAC
+ >> Q.PAT_X_ASSUM ‘s IN subsets (sigma (m_space m) (G i))’ K_TAC
+ >> Q.PAT_X_ASSUM ‘s IN measurable_sets m’ K_TAC
+ >> rpt GEN_TAC
+ >> MATCH_MP_TAC MEASURE_SPACE_RESTRICTION
+ >> Q.EXISTS_TAC ‘measurable_sets m’ >> art []
+ >> CONJ_TAC >- PROVE_TAC [] (* sigma (G n) SUBSET measurable_sets m *)
+ >> ‘(m_space m,subsets (sigma (m_space m) (G n))) = sigma (m_space m) (G n)’
+       by METIS_TAC [SPACE, SPACE_SIGMA]
+ >> POP_ORW
+ >> MATCH_MP_TAC SIGMA_ALGEBRA_SIGMA >> art [];
+ (* end of martingale_alt_generator_shared_tactics_4 *)
+
+Theorem martingale_alt_generator :
+   !m a u g. (!n. a n = sigma (m_space m) (g n)) /\
+             (!n. has_exhausting_sequence (m_space m,g n)) /\
+             (!n s. s IN (g n) ==> measure m s < PosInf) /\
+             (!n s t. s IN (g n) /\ t IN (g n) ==> s INTER t IN (g n)) ==>
+     (martingale m a u <=>
+      filtered_measure_space m a /\ (!n. integrable m (u n)) /\
+      !i j s. i <= j /\ s IN (g i) ==>
+             (integral m (\x. u i x * indicator_fn s x) =
+              integral m (\x. u j x * indicator_fn s x)))
+Proof
+    martingale_alt_generator_shared_tactics_1
+ (* stage work on transforming the goal into equivalence of two measures *)
+ >> Know ‘!i j s. (A i s - B i s = A j s - B j s <=>
+                   A i s + B j s = A j s + B i s)’
+ >- (qx_genl_tac [‘M’, ‘N’, ‘t’] \\
+    ‘A M t <> NegInf /\ A N t <> NegInf /\ B M t <> NegInf /\ B N t <> NegInf’
+       by METIS_TAC [pos_not_neginf] \\
+    ‘A M t <> PosInf /\ A N t <> PosInf /\ B M t <> PosInf /\ B N t <> PosInf’
+       by METIS_TAC [lt_infty] \\
+    ‘?r1. A M t = Normal r1’ by METIS_TAC [extreal_cases] >> POP_ORW \\
+    ‘?r2. A N t = Normal r2’ by METIS_TAC [extreal_cases] >> POP_ORW \\
+    ‘?r3. B M t = Normal r3’ by METIS_TAC [extreal_cases] >> POP_ORW \\
+    ‘?r4. B N t = Normal r4’ by METIS_TAC [extreal_cases] >> POP_ORW \\
+     rw [extreal_add_def, extreal_sub_def, extreal_le_eq] >> REAL_ARITH_TAC)
+ >> DISCH_THEN (FULL_SIMP_TAC pure_ss o wrap)
+ (* applying density_measure_def *)
+ >> martingale_alt_generator_shared_tactics_2
+ (* final modification of the goal *)
+ >> ‘A i s + B j s = A j s + B i s <=> (f i j * m) s = (f j i * m) s’
+      by METIS_TAC [] >> POP_ORW
+ (* final modification of the major assumption *)
+ >> Know ‘!i j s. i <= j /\ s IN G i ==> (f i j * m) s = (f j i * m) s’
+ >- (qx_genl_tac [‘k’, ‘n’, ‘t’] >> rpt STRIP_TAC \\
+    ‘t IN measurable_sets m’ by PROVE_TAC [] \\
+     METIS_TAC [])
+ >> DISCH_TAC
+ >> Q.PAT_X_ASSUM ‘!i j s. i <= j /\ s IN G i ==> A i s + B j s = A j s + B i s’ K_TAC
+ (* applying measure_space_density, density_def *)
+ >> martingale_alt_generator_shared_tactics_3
+ (* applying UNIQUENESS_OF_MEASURE *)
+ >> irule UNIQUENESS_OF_MEASURE
+ >> qexistsl_tac [‘m_space m’, ‘G i’] >> simp []
+ >> CONJ_TAC (* f i j * m = f j i * m *)
+ >- (rpt STRIP_TAC >> FIRST_X_ASSUM MATCH_MP_TAC >> art [])
+ >> Know ‘!n. subset_class (m_space m) (G n)’
+ >- (rw [subset_class_def] \\
+    ‘x IN measurable_sets m’ by METIS_TAC [SUBSET_DEF] \\
+     FULL_SIMP_TAC std_ss [measure_space_def, sigma_algebra_def, algebra_def,
+                           subset_class_def, space_def, subsets_def])
+ >> DISCH_TAC
+ (* easy goals first *)
+ >> ASM_REWRITE_TAC [CONJ_ASSOC]
+ >> reverse CONJ_TAC (* sigma_finite of G *)
+ >- (Q.PAT_X_ASSUM ‘!n. has_exhausting_sequence (m_space m,G n)’ (MP_TAC o (Q.SPEC ‘i’)) \\
+     rw [sigma_finite_def, has_exhausting_sequence_def, IN_FUNSET] \\
+     rename1 ‘!x. g x IN G i’ >> Q.EXISTS_TAC ‘g’ >> rw [] \\
+    ‘g n IN measurable_sets m’ by METIS_TAC [SUBSET_DEF] \\
+    ‘(f i j * m) (g n) = A i (g n) + B j (g n)’ by METIS_TAC [] >> POP_ORW \\
+     METIS_TAC [add_not_infty, lt_infty])
+ (* final: applying MEASURE_SPACE_RESTRICTION *)
+ >> martingale_alt_generator_shared_tactics_4
+QED
+
+val martingale_alt_generator_shared_tactics_5 =
+    Know ‘!i j s. (A i s - B i s <= A j s - B j s <=>
+                   A i s + B j s <= A j s + B i s)’
+ >- (qx_genl_tac [‘M’, ‘N’, ‘t’] \\
+    ‘A M t <> NegInf /\ A N t <> NegInf /\ B M t <> NegInf /\ B N t <> NegInf’
+       by METIS_TAC [pos_not_neginf] \\
+    ‘A M t <> PosInf /\ A N t <> PosInf /\ B M t <> PosInf /\ B N t <> PosInf’
+       by METIS_TAC [lt_infty] \\
+    ‘?r1. A M t = Normal r1’ by METIS_TAC [extreal_cases] >> POP_ORW \\
+    ‘?r2. A N t = Normal r2’ by METIS_TAC [extreal_cases] >> POP_ORW \\
+    ‘?r3. B M t = Normal r3’ by METIS_TAC [extreal_cases] >> POP_ORW \\
+    ‘?r4. B N t = Normal r4’ by METIS_TAC [extreal_cases] >> POP_ORW \\
+     rw [extreal_add_def, extreal_sub_def, extreal_le_eq] >> REAL_ARITH_TAC)
+ >> DISCH_THEN (FULL_SIMP_TAC pure_ss o wrap);
+ (* end of martingale_alt_generator_shared_tactics_5 *)
+
+(* For sub- and super-martingales, we need, in addition, that (g n) is a semi-ring.
+
+   This theorem (and the next one) relies on measureTheory.SEMIRING_SIGMA_MONOTONE
+ *)
+Theorem sub_martingale_alt_generator :
+   !m a u g. (!n. a n = sigma (m_space m) (g n)) /\
+             (!n. has_exhausting_sequence (m_space m,g n)) /\
+             (!n s. s IN (g n) ==> measure m s < PosInf) /\
+             (!n. semiring (m_space m,g n)) ==>
+     (sub_martingale m a u <=>
+      filtered_measure_space m a /\ (!n. integrable m (u n)) /\
+      !i j s. i <= j /\ s IN (g i) ==>
+             (integral m (\x. u i x * indicator_fn s x) <=
+              integral m (\x. u j x * indicator_fn s x)))
+Proof
+    martingale_alt_generator_shared_tactics_1
+ (* stage work on transforming the goal into equivalence of two measures *)
+ >> martingale_alt_generator_shared_tactics_5
+ (* applying density_measure_def *)
+ >> martingale_alt_generator_shared_tactics_2
+ (* final modification of the goal *)
+ >> ‘A i s + B j s <= A j s + B i s <=> (f i j * m) s <= (f j i * m) s’
+      by METIS_TAC [] >> POP_ORW
+ (* final modification of the major assumption *)
+ >> Know ‘!i j s. i <= j /\ s IN G i ==> (f i j * m) s <= (f j i * m) s’
+ >- (qx_genl_tac [‘M’, ‘N’, ‘t’] >> rpt STRIP_TAC \\
+    ‘t IN measurable_sets m’ by PROVE_TAC [] \\
+     METIS_TAC [])
+ >> DISCH_TAC
+ >> Q.PAT_X_ASSUM ‘!i j s. i <= j /\ s IN G i ==> A i s + B j s <= _’ K_TAC
+ (* applying measure_space_density, density_def *)
+ >> martingale_alt_generator_shared_tactics_3
+ (* applying SEMIRING_SIGMA_MONOTONE *)
+ >> irule SEMIRING_SIGMA_MONOTONE
+ >> qexistsl_tac [‘m_space m’, ‘G i’] >> simp []
+ >> CONJ_TAC (* (f j i * m) s < PosInf *)
+ >- (Q.X_GEN_TAC ‘t’ >> DISCH_TAC \\
+    ‘t IN measurable_sets m’ by METIS_TAC [SUBSET_DEF] \\
+    ‘(f j i * m) t = A j t + B i t’ by METIS_TAC [] >> POP_ORW \\
+     METIS_TAC [add_not_infty, lt_infty])
+ (* applying MEASURE_SPACE_RESTRICTION *)
+ >> martingale_alt_generator_shared_tactics_4
+ (* subset_class *)
+ >> Q.PAT_X_ASSUM ‘!n. semiring (m_space m,G n)’ (MP_TAC o (Q.SPEC ‘n’))
+ >> rw [semiring_def]
+QED
+
+Theorem super_martingale_alt_generator :
+   !m a u g. (!n. a n = sigma (m_space m) (g n)) /\
+             (!n. has_exhausting_sequence (m_space m,g n)) /\
+             (!n s. s IN (g n) ==> measure m s < PosInf) /\
+             (!n. semiring (m_space m,g n)) ==>
+     (super_martingale m a u <=>
+      filtered_measure_space m a /\ (!n. integrable m (u n)) /\
+      !i j s. i <= j /\ s IN (g i) ==>
+             (integral m (\x. u j x * indicator_fn s x) <=
+              integral m (\x. u i x * indicator_fn s x)))
+Proof
+    martingale_alt_generator_shared_tactics_1
+ (* stage work on transforming the goal into equivalence of two measures *)
+ >> martingale_alt_generator_shared_tactics_5
+ (* applying density_measure_def *)
+ >> martingale_alt_generator_shared_tactics_2
+ (* final modification of the goal *)
+ >> ‘A j s + B i s <= A i s + B j s <=> (f j i * m) s <= (f i j * m) s’
+      by METIS_TAC [] >> POP_ORW
+ (* final modification of the major assumption *)
+ >> Know ‘!i j s. i <= j /\ s IN G i ==> (f j i * m) s <= (f i j * m) s’
+ >- (qx_genl_tac [‘M’, ‘N’, ‘t’] >> rpt STRIP_TAC \\
+    ‘t IN measurable_sets m’ by PROVE_TAC [] \\
+     METIS_TAC [])
+ >> DISCH_TAC
+ >> Q.PAT_X_ASSUM ‘!i j s. i <= j /\ s IN G i ==> A j s + B i s <= _’ K_TAC
+ (* applying measure_space_density, density_def *)
+ >> martingale_alt_generator_shared_tactics_3
+ (* applying SEMIRING_SIGMA_MONOTONE *)
+ >> irule SEMIRING_SIGMA_MONOTONE
+ >> qexistsl_tac [‘m_space m’, ‘G i’] >> simp []
+ >> CONJ_TAC (* (f i j * m) s < PosInf *)
+ >- (Q.X_GEN_TAC ‘t’ >> DISCH_TAC \\
+    ‘t IN measurable_sets m’ by METIS_TAC [SUBSET_DEF] \\
+    ‘(f i j * m) t = A i t + B j t’ by METIS_TAC [] >> POP_ORW \\
+     METIS_TAC [add_not_infty, lt_infty])
+ (* applying MEASURE_SPACE_RESTRICTION *)
+ >> martingale_alt_generator_shared_tactics_4
+ (* subset_class *)
+ >> Q.PAT_X_ASSUM ‘!n. semiring (m_space m,G n)’ (MP_TAC o (Q.SPEC ‘n’))
+ >> rw [semiring_def]
+QED
 
 (* ------------------------------------------------------------------------- *)
-(*  General version of martingales with poset indexes (Chapter 19 of [1])    *)
+(*  General version of martingales with poset indexes (Chapter 25 of [1])    *)
 (* ------------------------------------------------------------------------- *)
 
-val POSET_NUM_LE = store_thm
-  ("POSET_NUM_LE", ``poset (univ(:num),$<=)``,
+Theorem POSET_NUM_LE :
+    poset (univ(:num),$<=)
+Proof
     RW_TAC std_ss [poset_def]
  >- (Q.EXISTS_TAC `0` >> REWRITE_TAC [GSYM IN_APP, IN_UNIV])
  >- (MATCH_MP_TAC LESS_EQUAL_ANTISYM >> art [])
  >> MATCH_MP_TAC LESS_EQ_TRANS
- >> Q.EXISTS_TAC `y` >> art []);
+ >> Q.EXISTS_TAC `y` >> art []
+QED
 
 (* below J is an index set, R is a partial order on J *)
 Definition general_filtration_def :
@@ -5229,7 +5566,7 @@ End
 
 val _ = overload_on ("filtration", “general_filtration”);
 
-Theorem filtration_alt :
+Theorem filtration_alt_general : (* was: filtration_alt *)
     !A a. filtration A a = general_filtration (univ(:num),$<=) A a
 Proof
     RW_TAC std_ss [filtration_def, general_filtration_def, POSET_NUM_LE, IN_UNIV]
@@ -5242,12 +5579,13 @@ End
 
 val _ = overload_on ("filtered_measure_space", “general_filtered_measure_space”);
 
-Theorem general_filtered_measure_space_alt :
+(* was: general_filtered_measure_space_alt *)
+Theorem filtered_measure_space_alt_general :
     !sp sts m a. filtered_measure_space (sp,sts,m) a <=>
                  general_filtered_measure_space (univ(:num),$<=) (sp,sts,m) a
 Proof
     RW_TAC std_ss [filtered_measure_space_def, general_filtered_measure_space_def,
-                   filtration_alt, POSET_NUM_LE, IN_UNIV]
+                   filtration_alt_general, POSET_NUM_LE, IN_UNIV]
 QED
 
 Definition sigma_finite_general_filtered_measure_space_def :
@@ -5259,16 +5597,20 @@ End
 val _ = overload_on ("sigma_finite_filtered_measure_space",
                      “sigma_finite_general_filtered_measure_space”);
 
-Theorem sigma_finite_filtered_measure_space_alt :
+(* was: sigma_finite_filtered_measure_space_alt *)
+Theorem sigma_finite_filtered_measure_space_alt_general :
     !sp sts m a. sigma_finite_filtered_measure_space (sp,sts,m) a <=>
                  sigma_finite_general_filtered_measure_space (univ(:num),$<=) (sp,sts,m) a
 Proof
-    RW_TAC std_ss [sigma_finite_filtered_measure_space_alt,
-                   sigma_finite_general_filtered_measure_space_def,
-                   general_filtered_measure_space_alt, IN_UNIV]
+    rw [sigma_finite_filtered_measure_space_alt_all, GSYM CONJ_ASSOC,
+        sigma_finite_general_filtered_measure_space_def,
+        GSYM filtered_measure_space_alt_general, filtered_measure_space_def]
 QED
 
-(* `general_martingale m a u (univ(:num),$<=) = martingale m a u` *)
+(* `general_martingale m a u (univ(:num),$<=) = martingale m a u`
+
+   This is Definition 25.3 [1, p.301].
+ *)
 Definition general_martingale_def :
    general_martingale (J,R) m a u =
      (sigma_finite_general_filtered_measure_space (J,R) m a /\

--- a/src/probability/measureScript.sml
+++ b/src/probability/measureScript.sml
@@ -1660,16 +1660,75 @@ val measure_split = store_thm
 (*  Uniqueness of Measure - Dynkin system [3]                                *)
 (* ------------------------------------------------------------------------- *)
 
-(* `sigma-finite` is a property of measure space but sigma algebra *)
-val sigma_finite_def = Define
-   `sigma_finite m =
-    ?f :num -> 'a set.
-     f IN (UNIV -> measurable_sets m) /\
-     (!n. f n SUBSET f (SUC n)) /\
-     (BIGUNION (IMAGE f UNIV) = m_space m) /\
-     (!n. measure m (f n) < PosInf)`;
+(* an "exhausting" sequence in a system of sets, moved from martingaleTheory *)
+Definition exhausting_sequence_def :
+    exhausting_sequence (a :'a algebra) (f :num -> 'a -> bool) =
+      (f IN (UNIV -> subsets a) /\ (!n. f n SUBSET f (SUC n)) /\
+       BIGUNION (IMAGE f UNIV) = space a)
+End
 
-(* this definition is sometimes useful for not repeating ‘m’ *)
+Theorem exhausting_sequence_alt :
+   !a f. exhausting_sequence a f <=>
+         f IN (univ(:num) -> subsets a) /\ (!m n. m <= n ==> f m SUBSET f n) /\
+         BIGUNION (IMAGE f univ(:num)) = space a
+Proof
+    RW_TAC std_ss [exhausting_sequence_def]
+ >> reverse EQ_TAC >- RW_TAC std_ss []
+ >> STRIP_TAC >> art []
+ >> GEN_TAC >> Induct_on ‘n’ >- RW_TAC arith_ss [SUBSET_REFL]
+ >> DISCH_TAC
+ >> ‘(m = SUC n) \/ m <= n’ by RW_TAC arith_ss [] >- rw [SUBSET_REFL]
+ >> MATCH_MP_TAC SUBSET_TRANS
+ >> Q.EXISTS_TAC ‘f n’ >> art []
+ >> FIRST_X_ASSUM MATCH_MP_TAC >> art []
+QED
+
+Definition has_exhausting_sequence :
+    has_exhausting_sequence a = ?f. exhausting_sequence a f
+End
+
+(* This was part of sigma_finite_def, but no requirement on the measure of each
+   (f n). The definition is useful because ‘space a IN subsets a’ does not hold
+   in general for semiring.
+
+   |- !a. has_exhausting_sequence a <=>
+          ?f. f IN (univ(:num) -> subsets a) /\ (!n. f n SUBSET f (SUC n)) /\
+              BIGUNION (IMAGE f univ(:num)) = space a
+ *)
+Theorem has_exhausting_sequence_def =
+    REWRITE_RULE [exhausting_sequence_def] has_exhausting_sequence
+
+(* |- !a. has_exhausting_sequence a <=>
+          ?f. f IN (univ(:num) -> subsets a) /\
+              (!m n. m <= n ==> f m SUBSET f n) /\
+              BIGUNION (IMAGE f univ(:num)) = space a
+ *)
+Theorem has_exhausting_sequence_alt =
+    REWRITE_RULE [exhausting_sequence_alt] has_exhausting_sequence
+
+(* `sigma-finite` is a property of measure space but sigma algebra.
+
+   The new definition based on ‘exhausting_sequence’ (was in martingaleTheory):
+ *)
+Definition sigma_finite :
+    sigma_finite m = ?f. exhausting_sequence (m_space m,measurable_sets m) f /\
+                         !n. measure m (f n) < PosInf
+End
+
+(* The old definition now becomes an equivalent theorem: *)
+Theorem sigma_finite_def :
+    !m. sigma_finite m <=>
+        ?f :num -> 'a set.
+           f IN (UNIV -> measurable_sets m) /\
+           (!n. f n SUBSET f (SUC n)) /\
+           (BIGUNION (IMAGE f UNIV) = m_space m) /\
+           (!n. measure m (f n) < PosInf)
+Proof
+    rw [sigma_finite, exhausting_sequence_def]
+ >> METIS_TAC []
+QED
+
+(* This definition is sometimes useful for not repeating ‘m’ *)
 Definition sigma_finite_measure_space_def :
     sigma_finite_measure_space m = (measure_space m /\ sigma_finite m)
 End
@@ -1678,6 +1737,37 @@ End
    e.g. algebra, ring, semiring, ... because by itself `m` is not meaningful. *)
 val premeasure_def = Define `
     premeasure m <=> positive m /\ countably_additive m`;
+
+(* connection with ‘sigma_finite’ *)
+Theorem sigma_finite_has_exhausting_sequence :
+    !sp sts u. sigma_finite (sp,sts,u) ==> has_exhausting_sequence (sp,sts)
+Proof
+    RW_TAC std_ss [sigma_finite_def, has_exhausting_sequence_def,
+                   m_space_def, measurable_sets_def, space_def, subsets_def]
+ >> Q.EXISTS_TAC ‘f’ >> rw []
+QED
+
+(* alternative definition of ‘sigma_finite’ *)
+Theorem sigma_finite_alt_exhausting_sequence :
+    !m. sigma_finite m <=>
+        ?f. exhausting_sequence (m_space m,measurable_sets m) f /\
+            !n. measure m (f n) < PosInf
+Proof
+    RW_TAC std_ss [sigma_finite_def, exhausting_sequence_def,
+                   space_def, subsets_def]
+ >> EQ_TAC >> RW_TAC std_ss []
+ >> Q.EXISTS_TAC ‘f’ >> art []
+QED
+
+(* |- !m. sigma_finite m <=>
+          ?f. (f IN (univ(:num) -> measurable_sets m) /\
+               (!m n. m <= n ==> f m SUBSET f n) /\
+               BIGUNION (IMAGE f univ(:num)) = m_space m) /\
+              !n. measure m (f n) < PosInf
+ *)
+Theorem sigma_finite_alt =
+    REWRITE_RULE [exhausting_sequence_alt, subsets_def, space_def]
+                 sigma_finite_alt_exhausting_sequence;
 
 (*****************************************************************************)
 (*            Premeasure properties of various systems of sets               *)
@@ -4414,7 +4504,8 @@ Proof
  >> fs [algebra_def, space_def, subsets_def]
 QED
 
-(* The "algebra" version (weakest) of Caratheodory theorem *)
+(* The "algebra" version (weakest) of Caratheodory theorem
+   cf. real_measureTheory.CARATHEODORY *)
 Theorem CARATHEODORY :
     !m0. algebra (m_space m0, measurable_sets m0) /\
          positive m0 /\ countably_additive m0 ==>
@@ -4426,6 +4517,163 @@ Proof
  >> MATCH_MP_TAC CARATHEODORY_SEMIRING
  >> IMP_RES_TAC ALGEBRA_IMP_SEMIRING >> art [premeasure_def]
  >> fs [algebra_def, space_def, subsets_def]
+QED
+
+Theorem measure_space_add :
+    !sp sts u v. measure_space (sp,sts,u) /\ measure_space (sp,sts,v) ==>
+                 measure_space (sp,sts,\s. u s + v s)
+Proof
+    rw [measure_space_def]
+ >- (fs [positive_def] >> rpt STRIP_TAC \\
+     MATCH_MP_TAC le_add >> rw [])
+ >> fs [countably_additive_def, IN_FUNSET]
+ >> rw [o_DEF]
+ (* applying ext_suminf_add *)
+ >> ONCE_REWRITE_TAC [EQ_SYM_EQ]
+ >> Know ‘suminf (\n. (\x. u (f x)) n + (\x. v (f x)) n) =
+          suminf (\x. u (f x)) + suminf (\x. v (f x))’
+ >- (MATCH_MP_TAC ext_suminf_add >> fs [positive_def])
+ >> rw []
+QED
+
+(* Lemma 16.6 [1, p.167] (cf. UNIQUENESS_OF_MEASURE, where ‘<=’ becomes ‘=’)
+
+   This theorem is used by sub|super_martingale_alt_generator (martingaleTheory).
+   It's also a nice application of CARATHEODORY_SEMIRING + UNIQUENESS_OF_MEASURE.
+ *)
+Theorem SEMIRING_SIGMA_MONOTONE :
+    !sp sts u v. semiring (sp,sts) /\ has_exhausting_sequence (sp,sts) /\
+                 measure_space (sp,subsets (sigma sp sts),u) /\
+                 measure_space (sp,subsets (sigma sp sts),v) /\
+                (!s. s IN sts ==> u s <= v s /\ v s < PosInf) ==>
+                (!s. s IN subsets (sigma sp sts) ==> (u s <= v s))
+Proof
+    rpt STRIP_TAC
+ >> Know ‘!s. s IN sts ==> u s < PosInf’
+ >- (Q.X_GEN_TAC ‘t’ >> STRIP_TAC \\
+     MATCH_MP_TAC let_trans >> Q.EXISTS_TAC ‘v t’ >> rw [])
+ >> DISCH_TAC
+ >> Know ‘!s. s IN sts ==> 0 <= u s’
+ >- (Know ‘positive (sp,subsets (sigma sp sts),u)’
+     >- PROVE_TAC [measure_space_def] \\
+     simp [positive_def] >> STRIP_TAC \\
+     Q.X_GEN_TAC ‘t’ >> STRIP_TAC \\
+     FIRST_X_ASSUM MATCH_MP_TAC \\
+     Suff ‘sts SUBSET subsets (sigma sp sts)’ >- METIS_TAC [SUBSET_DEF] \\
+     REWRITE_TAC [SIGMA_SUBSET_SUBSETS])
+ >> DISCH_TAC
+ >> Know ‘!s. s IN sts ==> 0 <= v s’
+ >- (Know ‘positive (sp,subsets (sigma sp sts),v)’
+     >- PROVE_TAC [measure_space_def] \\
+     simp [positive_def] >> STRIP_TAC \\
+     Q.X_GEN_TAC ‘t’ >> STRIP_TAC \\
+     FIRST_X_ASSUM MATCH_MP_TAC \\
+     Suff ‘sts SUBSET subsets (sigma sp sts)’ >- METIS_TAC [SUBSET_DEF] \\
+     REWRITE_TAC [SIGMA_SUBSET_SUBSETS])
+ >> DISCH_TAC
+ >> Q.ABBREV_TAC ‘r = \s. v s - u s’
+ (* preparing for CARATHEODORY_SEMIRING *)
+ >> Know ‘premeasure (sp,sts,r)’
+ >- (REWRITE_TAC [premeasure_def] \\
+     STRONG_CONJ_TAC (* positive *)
+     >- (simp [positive_def, Abbr ‘r’] \\
+        ‘positive (sp,subsets (sigma sp sts),u) /\
+         positive (sp,subsets (sigma sp sts),v)’ by PROVE_TAC [measure_space_def] \\
+         fs [positive_def, sub_rzero] \\
+         Q.X_GEN_TAC ‘t’ >> STRIP_TAC \\
+         Suff ‘0 <= v t - u t <=> u t <= v t’ >- (Rewr' >> PROVE_TAC []) \\
+         ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
+         MATCH_MP_TAC sub_zero_le \\
+         reverse CONJ_TAC >- (REWRITE_TAC [lt_infty] \\
+                              FIRST_X_ASSUM MATCH_MP_TAC >> art []) \\
+         MATCH_MP_TAC pos_not_neginf \\
+         FIRST_X_ASSUM MATCH_MP_TAC \\
+         Suff ‘sts SUBSET subsets (sigma sp sts)’ >- METIS_TAC [SUBSET_DEF] \\
+         REWRITE_TAC [SIGMA_SUBSET_SUBSETS]) >> DISCH_TAC \\
+     rw [countably_additive_def, Abbr ‘r’, o_DEF, IN_FUNSET] \\
+  (* applying ext_suminf_sub *)
+     Know ‘suminf (\x. (v o f) x - (u o f) x) = suminf (v o f) - suminf (u o f)’
+     >- (MATCH_MP_TAC ext_suminf_sub >> rw [o_DEF] \\
+         Know ‘suminf (measure (sp,subsets (sigma sp sts),v) o f) =
+               measure (sp,subsets (sigma sp sts),v) (BIGUNION (IMAGE f UNIV))’
+         >- (MATCH_MP_TAC COUNTABLY_ADDITIVE >> simp [IN_FUNSET] \\
+             CONJ_TAC >- FULL_SIMP_TAC std_ss [measure_space_def] \\
+             Suff ‘sts SUBSET subsets (sigma sp sts)’ >- METIS_TAC [SUBSET_DEF] \\
+             REWRITE_TAC [SIGMA_SUBSET_SUBSETS]) \\
+         rw [o_DEF, lt_infty]) \\
+     rw [o_DEF] \\
+     Know ‘suminf (measure (sp,subsets (sigma sp sts),v) o f) =
+           measure (sp,subsets (sigma sp sts),v) (BIGUNION (IMAGE f UNIV))’
+     >- (MATCH_MP_TAC COUNTABLY_ADDITIVE >> simp [IN_FUNSET] \\
+         CONJ_TAC >- FULL_SIMP_TAC std_ss [measure_space_def] \\
+         Suff ‘sts SUBSET subsets (sigma sp sts)’ >- METIS_TAC [SUBSET_DEF] \\
+         REWRITE_TAC [SIGMA_SUBSET_SUBSETS]) \\
+     Know ‘suminf (measure (sp,subsets (sigma sp sts),u) o f) =
+           measure (sp,subsets (sigma sp sts),u) (BIGUNION (IMAGE f UNIV))’
+     >- (MATCH_MP_TAC COUNTABLY_ADDITIVE >> simp [IN_FUNSET] \\
+         CONJ_TAC >- FULL_SIMP_TAC std_ss [measure_space_def] \\
+         Suff ‘sts SUBSET subsets (sigma sp sts)’ >- METIS_TAC [SUBSET_DEF] \\
+         REWRITE_TAC [SIGMA_SUBSET_SUBSETS]) \\
+     rw [o_DEF])
+ >> DISCH_TAC
+ (* applying CARATHEODORY_SEMIRING, this asserts ‘measure_space m’ *)
+ >> MP_TAC (Q.SPEC ‘(sp,sts,r)’ CARATHEODORY_SEMIRING) >> rw []
+ (* stage work *)
+ >> Know ‘!s. s IN sts ==> v s = r s + u s’
+ >- (Q.X_GEN_TAC ‘t’ >> rw [Abbr ‘r’, Once EQ_SYM_EQ] \\
+     MATCH_MP_TAC sub_add \\
+     reverse CONJ_TAC >- rw [lt_infty] \\
+     MATCH_MP_TAC pos_not_neginf >> rw [])
+ >> DISCH_TAC
+ >> Q.ABBREV_TAC ‘v' = \s. r s + u s’
+ >> Know ‘premeasure (sp,sts,v')’
+ >- (REWRITE_TAC [premeasure_def] \\
+     STRONG_CONJ_TAC (* positive *)
+     >- (simp [positive_def, Abbr ‘v'’] \\
+        ‘positive (sp,subsets (sigma sp sts),u)’ by PROVE_TAC [measure_space_def] \\
+        ‘positive (sp,sts,r)’ by PROVE_TAC [premeasure_def] \\
+         fs [positive_def, sub_rzero]) >> DISCH_TAC \\
+     rw [countably_additive_def, Abbr ‘v'’, o_DEF, IN_FUNSET] \\
+  (* applying ext_suminf_sub *)
+     Know ‘suminf (\x. (r o f) x + (u o f) x) = suminf (r o f) + suminf (u o f)’
+     >- (MATCH_MP_TAC ext_suminf_add >> rw [o_DEF] \\
+        ‘positive (sp,sts,r)’ by PROVE_TAC [premeasure_def] \\
+         fs [positive_def]) \\
+     rw [o_DEF] \\
+     Know ‘suminf (measure (sp,sts,r) o f) =
+           measure (sp,sts,r) (BIGUNION (IMAGE f UNIV))’
+     >- (MATCH_MP_TAC COUNTABLY_ADDITIVE >> simp [IN_FUNSET] \\
+         FULL_SIMP_TAC std_ss [premeasure_def]) \\
+     Know ‘suminf (measure (sp,subsets (sigma sp sts),u) o f) =
+           measure (sp,subsets (sigma sp sts),u) (BIGUNION (IMAGE f UNIV))’
+     >- (MATCH_MP_TAC COUNTABLY_ADDITIVE >> simp [IN_FUNSET] \\
+         CONJ_TAC >- FULL_SIMP_TAC std_ss [measure_space_def] \\
+         Suff ‘sts SUBSET subsets (sigma sp sts)’ >- METIS_TAC [SUBSET_DEF] \\
+         REWRITE_TAC [SIGMA_SUBSET_SUBSETS]) \\
+     rw [o_DEF])
+ >> DISCH_TAC
+ (* applying CARATHEODORY_SEMIRING, this asserts ‘measure_space m'’ *)
+ >> MP_TAC (Q.SPEC ‘(sp,sts,v')’ CARATHEODORY_SEMIRING) >> rw []
+ (* preparing for UNIQUENESS_OF_MEASURE *)
+ >> Q.ABBREV_TAC ‘v'' = \s. measure m s + u s’
+ (* applying UNIQUENESS_OF_MEASURE *)
+ >> Know ‘!s. s IN subsets (sigma sp sts) ==> v s = v'' s’
+ >- (‘!s. s IN sts ==> v s = v'' s’ by METIS_TAC [] \\
+     MATCH_MP_TAC UNIQUENESS_OF_MEASURE >> simp [sigma_finite] \\
+     fs [semiring_def, has_exhausting_sequence] \\
+     CONJ_TAC >- (Q.EXISTS_TAC ‘f’ >> art [] \\
+                  fs [exhausting_sequence_def, IN_FUNSET]) \\
+     Q.UNABBREV_TAC ‘v''’ \\
+     MATCH_MP_TAC measure_space_add >> art [] \\
+    ‘subsets (sigma sp sts) = measurable_sets m’ by METIS_TAC [subsets_def] \\
+     POP_ORW \\
+    ‘sp = m_space m’ by METIS_TAC [SPACE_SIGMA, space_def] >> POP_ORW \\
+     rw [MEASURE_SPACE_REDUCE])
+ >> rw [Abbr ‘v''’]
+ >> MATCH_MP_TAC le_addl_imp
+ >> ‘s IN measurable_sets m’ by METIS_TAC [subsets_def]
+ >> Suff ‘positive m’ >- rw [positive_def]
+ >> PROVE_TAC [MEASURE_SPACE_POSITIVE]
 QED
 
 (* ------------------------------------------------------------------------- *)

--- a/src/probability/real_borelScript.sml
+++ b/src/probability/real_borelScript.sml
@@ -3280,9 +3280,8 @@ Proof
      Suff ‘cy = R * (1 / 2 * inv X + 1 / 2 * inv (R / Y))’
      >- (Rewr' >> art []) \\
      Q.UNABBREV_TAC ‘cy’ \\
-     REWRITE_TAC [real_div, REAL_INV_MUL', REAL_INV_INV, REAL_ADD_LDISTRIB,
-                  REAL_MUL_LID] \\
-     rw [Once REAL_ADD_COMM])
+     REWRITE_TAC [real_div, REAL_ADD_LDISTRIB, REAL_MUL_LID] \\
+     rw [REAL_INV_MUL, REAL_INV_INV, Once REAL_ADD_COMM])
  >> DISCH_TAC
  (* now estimate e *)
  >> Q.EXISTS_TAC ‘min (A / 2) (B / 2)’


### PR DESCRIPTION
Hi, (this is my 100th PR sent to HOL project.)

`martingaleTheory` was added (between `lebesgueTheory` and `probabilityTheory`) to hold some extra theorems of the oversized `lebesgueTheory` and the theory of product measures.  I was planning to re-prove Radon-Nikodym theorem using martingales but later this theorem was successfully recovered from the work of HVG concordia people. This left the possible confusion that, inside `martingaleTheory`, there's no much stuff about martingales, except for their basic definitions:
```
   [martingale_def]  Definition      
      ⊢ ∀m a u.
          martingale m a u ⇔
          sigma_finite_filtered_measure_space m a ∧
          (∀n. integrable m (u n)) ∧
          ∀n s.
            s ∈ subsets (a n) ⇒
            ∫ m (λx. u (SUC n) x * 𝟙 s x) = ∫ m (λx. u n x * 𝟙 s x)
```
(replacing the part `∫ (SUC n) = ∫ n` with `∫ (SUC n) <= ∫ n` (or `∫ (SUC n) >= ∫ n`) we got the definition of super- (or sub-)martingales).

In this PR I added some alternative definitions of (sub-,super-)martingales as an initial effort of enriching this theory.  The first step is to extend the part `SUC n` with arbitrary integer bigger than `n` (by induction):
```
   [martingale_alt]  Theorem      
      ⊢ ∀m a u.
          martingale m a u ⇔
          sigma_finite_filtered_measure_space m a ∧
          (∀n. integrable m (u n)) ∧
          ∀i j s.
            i ≤ j ∧ s ∈ subsets (a i) ⇒
            ∫ m (λx. u i x * 𝟙 s x) = ∫ m (λx. u j x * 𝟙 s x)
```
For sub- and super-martingales, the alternative definitions are similar. Furthermore, the requirements of `s ∈ subsets (a i)` (each `a i` must be a sigma-algebra) can be weakened by only the generators of each sigma-algebras. This result is non-trivial and invaluable when showing `martingale m a u` is the goal:
```
   [martingale_alt_generator]  Theorem      
      ⊢ ∀m a u g.
          (∀n. a n = sigma (m_space m) (g n)) ∧
          (∀n. has_exhausting_sequence (m_space m,g n)) ∧
          (∀n s. s ∈ g n ⇒ measure m s < +∞) ∧
          (∀n s t. s ∈ g n ∧ t ∈ g n ⇒ s ∩ t ∈ g n) ⇒
          (martingale m a u ⇔
           filtered_measure_space m a ∧ (∀n. integrable m (u n)) ∧
           ∀i j s.
             i ≤ j ∧ s ∈ g i ⇒
             ∫ m (λx. u i x * 𝟙 s x) = ∫ m (λx. u j x * 𝟙 s x))
```

Again, for sub- and super-martingales, the alternative definitions are similar, e.g.:
```
   [sub_martingale_alt_generator]  Theorem      
      ⊢ ∀m a u g.
          (∀n. a n = sigma (m_space m) (g n)) ∧
          (∀n. has_exhausting_sequence (m_space m,g n)) ∧
          (∀n s. s ∈ g n ⇒ measure m s < +∞) ∧
          (∀n. semiring (m_space m,g n)) ⇒
          (sub_martingale m a u ⇔
           filtered_measure_space m a ∧ (∀n. integrable m (u n)) ∧
           ∀i j s.
             i ≤ j ∧ s ∈ g i ⇒
             ∫ m (λx. u i x * 𝟙 s x) ≤ ∫ m (λx. u j x * 𝟙 s x))
```
But the theorems for sub- and super-martingales additionally require a deep monotone property of semiring (of sets) on generators, which is of interests by itself. This theorem is also a nice application of Caratheodory's extension theorem (and uniqueness of measures):
```
   [SEMIRING_SIGMA_MONOTONE]  Theorem (measureTheory)      
      ⊢ ∀sp sts u v.
          semiring (sp,sts) ∧ has_exhausting_sequence (sp,sts) ∧
          measure_space (sp,subsets (sigma sp sts),u) ∧
          measure_space (sp,subsets (sigma sp sts),v) ∧
          (∀s. s ∈ sts ⇒ u s ≤ v s ∧ v s < +∞) ⇒
          ∀s. s ∈ subsets (sigma sp sts) ⇒ u s ≤ v s
```

The theory of martingales currently does not exist in any other theorem prover. I hope this work could make HOL4 a little more special on probability formalizations. There are still countless more work that could be done in the future. (For instance, the "traditional" way of defining martingales is to use _conditional expectations_, but currently in HOL we have nothing but the bare definitions for conditional expectations, see `probabilityTheory.conditional_expectation_def`.)

P. S. I additionally removed the only use of `REAL_INV_MUL'` in probability-related scripts, and moved one theorem out of `lebesgueTheory` for a little better balance of script sizes.

Regards,

Chun Tian