### PR TITLE
Add theory-qualification to the TRUTH theorem in QuoteFilter

### DIFF
--- a/tools/Holmake/QuoteFilter
+++ b/tools/Holmake/QuoteFilter
@@ -198,7 +198,7 @@ fun magic_bind (arg as QFS{induction_thm,...}) =
     Systeml.bindstr ("val " ^ !induction_thm ^
                      " = DB.fetch \"-\" \"" ^
                      !induction_thm ^
-                     "\" handle HOL_ERR _ => TRUTH;") ^ ";"
+                     "\" handle HOL_ERR _ => boolTheory.TRUTH;") ^ ";"
 
 type lexresult = int*string
 

--- a/tools/Holmake/tests/quote-filter/expected-mosml
+++ b/tools/Holmake/tests/quote-filter/expected-mosml
@@ -25,8 +25,8 @@ val (even_rules,even_ind,even_cases) = (fn q => fn _ => IndDefLib.xHol_reln "eve
 \(!n. even n ==> odd (n + 1)) /\\\n\
 \\n\
 \  (!m. odd m ==> even (m + 1))"
-] NONE; val even_strongind = DB.fetch "-" "even_strongind" handle HOL_ERR _ => TRUTH;;val even_0 = boolLib.save_thm("even_0[simp]", Drule.cj 1 even_rules);val even_suc = boolLib.save_thm("even_suc", Drule.cj 3 even_rules);
+] NONE; val even_strongind = DB.fetch "-" "even_strongind" handle HOL_ERR _ => boolTheory.TRUTH;;val even_0 = boolLib.save_thm("even_0[simp]", Drule.cj 1 even_rules);val even_suc = boolLib.save_thm("even_suc", Drule.cj 3 even_rules);
 
 val foo = TotalDefn.qDefine "foo" [QUOTE " (*#loc 30 16*)\n\
 \  foo x = if x < 2 then 1 else x * foo (x - 1)"
-] NONE; val foo_ind = DB.fetch "-" "foo_ind" handle HOL_ERR _ => TRUTH;;
+] NONE; val foo_ind = DB.fetch "-" "foo_ind" handle HOL_ERR _ => boolTheory.TRUTH;;

--- a/tools/Holmake/tests/quote-filter/expected-poly
+++ b/tools/Holmake/tests/quote-filter/expected-poly
@@ -25,8 +25,8 @@ val (even_rules,even_ind,even_cases) = (fn q => fn _ => IndDefLib.xHol_reln "eve
 \(!n. even n ==> odd (n + 1)) /\\\n\
 \\n\
 \  (!m. odd m ==> even (m + 1))"
-] NONE; val _ = CompilerSpecific.quietbind "val even_strongind = DB.fetch \"-\" \"even_strongind\" handle HOL_ERR _ => TRUTH;";val even_0 = boolLib.save_thm("even_0[simp]", Drule.cj 1 even_rules);val even_suc = boolLib.save_thm("even_suc", Drule.cj 3 even_rules);
+] NONE; val _ = CompilerSpecific.quietbind "val even_strongind = DB.fetch \"-\" \"even_strongind\" handle HOL_ERR _ => boolTheory.TRUTH;";val even_0 = boolLib.save_thm("even_0[simp]", Drule.cj 1 even_rules);val even_suc = boolLib.save_thm("even_suc", Drule.cj 3 even_rules);
 
 val foo = TotalDefn.qDefine "foo" [QUOTE " (*#loc 30 16*)\n\
 \  foo x = if x < 2 then 1 else x * foo (x - 1)"
-] NONE; val _ = CompilerSpecific.quietbind "val foo_ind = DB.fetch \"-\" \"foo_ind\" handle HOL_ERR _ => TRUTH;";
+] NONE; val _ = CompilerSpecific.quietbind "val foo_ind = DB.fetch \"-\" \"foo_ind\" handle HOL_ERR _ => boolTheory.TRUTH;";


### PR DESCRIPTION
Prior to this addition, `Holmake` would fail with a non-informative error message ("Static Errors") on theories containing Definition-syntax but not having `TRUTH` in scope. The same script would run without error in an interactive session. Below is an example when Holmake will fail, but an interactive session succeed.

Here is the script:
```sml
(* fooScript.sml *)
open HolKernel;

val _ = new_theory "foo";

Definition foo_def:
  foo = ()
End

val _ = export_theory ();
```
And here is the failure:
```
oskar@macintosh: ~/tmp Holmake
fooTheory                                                                 real:    0s  user:    0sFAIL<1>
 <<HOL message: Created theory "foo">>
 Saved definition __ "foo_def"
 error in quse /Users/oskar/tmp/fooScript.sml : Fail "Static Errors"
 error in load /Users/oskar/tmp/fooScript : Fail "Static Errors"
 Uncaught exception: Fail "Static Errors"
```
And here is the same script in an interactive session:
```
oskar@macintosh: ~/tmp hol

---------------------------------------------------------------------
       HOL-4 [Kananaskis 14 (stdknl, built Wed Mar 24 14:14:03 2021)]

       For introductory HOL help, type: help "hol";
       To exit type <Control>-D
---------------------------------------------------------------------
[Use-ing configuration file /Users/oskar/.hol-config.sml]
> Vim input /tmp/vimhol0Script.sml
HOLLoadSendQuiet HolKernel completed
Vim input /tmp/vimhol0Script.sml
<<HOL message: Created theory "foo">>
Definition has been stored under "foo_def"
val foo_def =  [] ⊢ foo = (): thm
Exporting theory "foo" ... done.
Theory "foo" took 0.09913s to build
```