### PR TITLE
Add support for passing variable defs to Holmake as arguments

### DIFF
--- a/tools/Holmake/Holmake.sml
+++ b/tools/Holmake/Holmake.sml
@@ -66,16 +66,22 @@ end
 (*** parse command line *)
 fun apply_updates fs v = List.foldl (fn (f,v) => #update f (warn,v)) v fs
 
-fun getcline args = let
-  open GetOpt
-in
-  getOpt {argOrder = Permute,
-          options = HM_Cline.option_descriptions,
-          errFn = die}
-         args
-end
+fun getcline args =
+  let
+    open GetOpt
+    val (opts, rest) = getOpt {argOrder = Permute,
+                               options = HM_Cline.option_descriptions,
+                               errFn = die}
+                              args
+    fun is_varassign str =
+      List.length (String.tokens (fn x => x = #"=") str) = 2
+    val (vars, targets) = List.partition is_varassign rest
+  in
+    (opts, vars, targets)
+  end
 
-val (master_cline_options, targets) = getcline (CommandLine.arguments())
+val (master_cline_options, cline_vars, targets) =
+  getcline (CommandLine.arguments())
 
 val master_cline_nohmf =
     HM_Cline.default_options |> apply_updates master_cline_options
@@ -99,17 +105,27 @@ type tgt_ruledb = (dep, {hmftext: string, dependencies:dep list,
                     Binarymap.dict
 val empty_trdb : tgt_ruledb = Binarymap.mkDict hm_target.compare
 
+(* Extend the base environment with vars passed at commandline. *)
+fun extend_with_cline_vars env =
+  List.foldl (fn (vstr, env) =>
+                case String.tokens (fn x => x = #"=") vstr of
+                  [vname, contents] => env_extend (vname, [LIT contents]) env
+                | _ => die ("Malformed variable assignment " ^
+                            "passed at commandline: " ^ vstr))
+             env
+             cline_vars
 
 local
   open hm_target
-  val base = read_holpathdb()
+  val base = extend_with_cline_vars (read_holpathdb())
   val hmcache = ref (Binarymap.mkDict String.compare)
   val default = (base,empty_trdb,NONE)
   fun get_hmf0 d =
       if OS.FileSys.access("Holmakefile", [OS.FileSys.A_READ]) then
         let
           val (env, rdb, tgt0) =
-              ReadHMF.read "Holmakefile" (read_holpathdb())
+              ReadHMF.read "Holmakefile"
+                           (extend_with_cline_vars (read_holpathdb()))
               handle Fail s =>
                      (warn ("Bad Holmakefile in " ^ d ^ ": " ^ s);
                       (base,Binarymap.mkDict String.compare,NONE))
@@ -159,7 +175,7 @@ val (cline_hmakefile, cline_nohmf) =
 fun get_hmf_cline_updates hmenv =
   let
     val hmf_cline = envlist hmenv "CLINE_OPTIONS"
-    val (hmf_options, hmf_rest) = getcline hmf_cline
+    val (hmf_options, _, hmf_rest) = getcline hmf_cline
     val _ = if null hmf_rest then ()
             else
               warn ("Unused c/line options in makefile: "^
@@ -178,9 +194,9 @@ val starting_holmakefile =
         | x => x
 
 val (start_hmenv, start_rules, start_tgt) = get_hmf()
+
 val start_envlist = envlist start_hmenv
 val start_options = start_envlist "OPTIONS"
-
 
 fun chattiness_level switches =
   case (#debug switches, #verbose switches, #quiet switches) of
@@ -504,6 +520,8 @@ in
   diag "startup" (fn _ => "Additional includes = [" ^
                           String.concatWith ", "
                                             cline_additional_includes ^ "]");
+  diag "startup" (fn _ => "Additional Holmake variables = [" ^
+                          String.concatWith "," cline_vars ^ "]");
   diag "startup" (fn _ => HM_BaseEnv.debug_info option_value)
 end
 

--- a/tools/Holmake/Holmake.sml
+++ b/tools/Holmake/Holmake.sml
@@ -74,7 +74,11 @@ fun getcline args =
                                errFn = die}
                               args
     fun is_varassign str =
-      List.length (String.tokens (fn x => x = #"=") str) = 2
+      let
+        val fs = String.fields (fn x => x = #"=") str
+      in
+        List.length fs = 2 andalso List.all (fn s => String.size s > 0) fs
+      end
     val (vars, targets) = List.partition is_varassign rest
   in
     (opts, vars, targets)
@@ -108,7 +112,7 @@ val empty_trdb : tgt_ruledb = Binarymap.mkDict hm_target.compare
 (* Extend the base environment with vars passed at commandline. *)
 fun extend_with_cline_vars env =
   List.foldl (fn (vstr, env) =>
-                case String.tokens (fn x => x = #"=") vstr of
+                case String.fields (fn x => x = #"=") vstr of
                   [vname, contents] => env_extend (vname, [LIT contents]) env
                 | _ => die ("Malformed variable assignment " ^
                             "passed at commandline: " ^ vstr))

--- a/tools/Holmake/tests/clinevars/Holmakefile
+++ b/tools/Holmake/tests/clinevars/Holmakefile
@@ -1,0 +1,2 @@
+selftest.exe: selftest.uo
+	$(HOLMOSMLC) -o $@ $<

--- a/tools/Holmake/tests/clinevars/selftest.sml
+++ b/tools/Holmake/tests/clinevars/selftest.sml
@@ -1,0 +1,41 @@
+open testutils
+
+
+val _ = tprint "Testing Holmake VAR=value command-line variable assignments:";
+fun do_holmake args =
+  OS.Process.system
+    ("cd test && " ^ Systeml.HOLDIR ^ "/bin/Holmake " ^ args);
+
+val _ = tprint "1. Good: successful assignment";
+val res = do_holmake
+  "-r INBETWEEN=YES RECURSIVE=also_YES.321 TEST1=SET";
+val _ = if OS.Process.isSuccess res then OK() else die ""; (* check output *)
+
+val _ = tprint "2. Good: specific target";
+val res = do_holmake "ARULE=IGNORE A_RULE A_RULE=IGNORE";
+val _ = if OS.Process.isSuccess res then OK() else die ""; (* check output *)
+
+val _ = tprint "3. Bad: Holmake foo=";
+val res = do_holmake "foo= A_RULE";
+val _ = if OS.Process.isSuccess res then die"" else OK();
+
+val _ = tprint "4. Bad: Holmake =foo";
+val res = do_holmake "=foo A_RULE";
+val _ = if OS.Process.isSuccess res then die"" else OK();
+
+val _ = tprint "5. Bad: Holmake = foo";
+val res = do_holmake "= foo A_RULE";
+val _ = if OS.Process.isSuccess res then die"" else OK();
+
+val _ = tprint "6. Bad: Holmake foo=bar=";
+val res = do_holmake "foo=bar= A_RULE";
+val _ = if OS.Process.isSuccess res then die"" else OK();
+
+val _ = tprint "7. Bad: Holmake =bar=foo=";
+val res = do_holmake "=bar=foo= A_RULE";
+val _ = if OS.Process.isSuccess res then die"" else OK();
+
+val _ = tprint "8. Bad: Holmake bar==foo";
+val res = do_holmake "bar==foo A_RULE";
+val _ = if OS.Process.isSuccess res then die"" else OK();
+

--- a/tools/Holmake/tests/clinevars/test/Holmakefile
+++ b/tools/Holmake/tests/clinevars/test/Holmakefile
@@ -1,0 +1,13 @@
+INCLUDES=rec1
+.PHONY: all test test1 A_RULE
+
+all: test test1
+
+test: # called with TEST1=SET
+	[ "$(TEST1)" = "SET" ]
+
+test1:
+	[ "$(INBETWEEN)" = "YES" ]
+
+A_RULE: # A rule
+	echo Hello!

--- a/tools/Holmake/tests/clinevars/test/rec1/Holmakefile
+++ b/tools/Holmake/tests/clinevars/test/rec1/Holmakefile
@@ -1,0 +1,6 @@
+.PHONY: all test
+
+all: test
+
+test:
+	[ "$(RECURSIVE)" = "also_YES.321" ]

--- a/tools/sequences/kernel
+++ b/tools/sequences/kernel
@@ -27,6 +27,7 @@ src/1
 src/proofman
 [poly]bin/hol.bare
 !src/proofman/tests
+!tools/Holmake/tests/clinevars
 !tools/Holmake/tests/holpathdb/proj2
 !tools/Holmake/tests/holpathdb/proj2/proj2A
 !tools/Holmake/tests/depchain1/dir3


### PR DESCRIPTION
Adds support for `VAR=value` style command-line arguments to Holmake. If it works, then this PR should close #100.

Here is a summary of the change: When Holmake is done parsing command-line options, the remaining arguments are separated into those that match `<ANYTHING>=<ANYTHING>` and those that do not. The latter are treated as before, while the former are inserted into the base environment _after_ the holpathdb is read, and _before_ the Holmakefile is read, each time Holmake reads a Holmakefile (this is the intent, at least).

