### PR TITLE
Fix for broken selftest (tacticToe and smlParallel)

### DIFF
--- a/src/AI/sml_inspection/selftest.sml
+++ b/src/AI/sml_inspection/selftest.sml
@@ -2,11 +2,10 @@ open HolKernel boolLib
 local open smlExecute smlInfix smlLexer smlOpen smlParser smlPrettify
   smlRedirect smlTimeout smlParallel in end
 
-(* local open smlParallel in
-  val l1 = List.tabulate (100,I);
-  val _ = parmap_queue_extern 2 idspec () l1;
+local open smlParallel in
+  val l1 = List.tabulate (10,I);
+  val _ = parmap_queue_extern 2 examplespec () l1;
 end
-*)
 
 local open aiLib smlTimeout in
   fun f () = 5;

--- a/src/AI/sml_inspection/smlParallel.sml
+++ b/src/AI/sml_inspection/smlParallel.sml
@@ -423,7 +423,7 @@ fun parmap_queue_extern ncore es param argl =
 
 val examplespec : (unit,int,int) extspec =
   {
-  self_dir = HOLDIR ^ "/src/AI/sml_inspection",
+  self_dir = "$(HOLDIR)/src/AI/sml_inspection",
   self = "smlParallel.examplespec",
   parallel_dir = default_parallel_dir,
   reflect_globals = "()",

--- a/src/tactictoe/selftest/Holmakefile
+++ b/src/tactictoe/selftest/Holmakefile
@@ -1,0 +1,7 @@
+all: $(DEFAULT_TARGETS) selftest.exe
+.PHONY: all
+
+selftest.exe: selftest.uo
+	$(HOLMOSMLC) -o $@ $<
+
+EXTRA_CLEANS = selftest.exe

--- a/src/tactictoe/selftest/selftest.sml
+++ b/src/tactictoe/selftest/selftest.sml
@@ -1,0 +1,7 @@
+open HolKernel boolLib tacticToe tttEval;
+
+val _ = tttUnfold.ttt_record_thy "ConseqConv";
+
+open metisTools ConseqConvTheory;
+
+val _ = ttt ([],T);

--- a/src/tactictoe/src/selftest.sml
+++ b/src/tactictoe/src/selftest.sml
@@ -1,8 +1,1 @@
 open HolKernel boolLib tacticToe tttEval;
-(*
-val _ = tttUnfold.ttt_record_thy "ConseqConv";
-
-open metisTools ConseqConvTheory;
-
-val _ = ttt ([],T);
-*)

--- a/tools/sequences/core-theories
+++ b/tools/sequences/core-theories
@@ -24,13 +24,6 @@ src/num/arith/src
 src/num
 src/num/termination
 
-[poly]src/AI
-[poly]src/AI/sml_inspection
-[poly]src/AI/proof_search
-[poly]src/AI/machine_learning
-[poly]src/tactictoe/src
-[poly]src/holyhammer
-
 # A Poly/ML heap, numheap, is deposited in src/num/termination to
 # speed up the last few theories (sets, extra numbers, and lists) before
 # bossLib
@@ -54,3 +47,12 @@ src/boss
 [poly]bin/hol
 !tools/Holmake/tests/Iflag
 !examples/developers/ThmSetData
+
+[poly]src/AI
+[poly]src/AI/sml_inspection
+[poly]src/AI/proof_search
+[poly]src/AI/machine_learning
+[poly]src/tactictoe/src
+#selftest in another directory as it relies on files being uploaded to sigobj
+[poly]src/tactictoe/selftest
+[poly]src/holyhammer

--- a/tools/sequences/core-theories
+++ b/tools/sequences/core-theories
@@ -53,6 +53,6 @@ src/boss
 [poly]src/AI/proof_search
 [poly]src/AI/machine_learning
 [poly]src/tactictoe/src
-#selftest in another directory as it relies on files being uploaded to sigobj
+# next line relies on previous files being uploaded to sigobj
 [poly]src/tactictoe/selftest
 [poly]src/holyhammer


### PR DESCRIPTION
1) I needed to used ($HOLDIR) instead of unfolding HOLDIR  (i.e /home/thibault/HOL) in the INCLUDES of the Holmakefile generated by the smlParallel selftest, I am not sure why.

2) Moving the files in the sequences worked but I had to additionnaly create a different directory for TacticToe selftest as it relied on TacticToe files being uploaded to sigobj.

3) I got this error aftewards. I am not sure if I am causing it.
tyabb_output                                                             real:    0s  user:    0sFAIL<7F>
 /bin/sh: 1: ./tymunge.exe: not found
utymunge.exe                                                                                     M-KILLED
munge248.exe                                                                                     M-KILLED
munge.exe                                                                                        M-KILLED
*** FATAL: Build failed in directory /home/thibault/HOL-1/src/TeX/theory_tests (exited with code 1)

