### PR TITLE
hol config

### DIFF
--- a/Manual/Tools/Holmakefile
+++ b/Manual/Tools/Holmakefile
@@ -6,7 +6,7 @@ EXTRA_CLEANS = polyscripter testoutput1
 all: polyscripter testoutput1
 
 polyscripter: polyscripter.sml $(dprot $(HOLDIR)/bin/hol.state)
-	$(protect $(HOLDIR)/bin/buildheap) Arbrat $< -o $@ --exe main
+	env HOL_CONFIG='' $(protect $(HOLDIR)/bin/buildheap) Arbrat $< -o $@ --exe main
 
 testoutput1: testinput1 polyscripter umap expected1 $(dprot ../../tools/cmp/cmp.exe) $(HOLDIR)/examples/misc/root2Theory.uo
 	./polyscripter umap < $< > $@

--- a/doc/next-release.md
+++ b/doc/next-release.md
@@ -20,6 +20,10 @@ Contents
 New features:
 -------------
 
+- A `HOL_CONFIG` environment variable is considered to allow for a custom `hol-config` configuration at a non-standard location or potentially ignoring any present hol-config.
+  If the variable is set, any other hol-config file will be ignored. If the value of `HOL_CONFIG` is a readable file, it will be used.
+
+
 Bugs fixed:
 -----------
 

--- a/tools/check-intconfig.sml
+++ b/tools/check-intconfig.sml
@@ -1,27 +1,32 @@
-case
-  Lib.get_first Process.getEnv ["HOME",
-                                (* windows things *)
-                                "HOMEPATH", "APPDATA"]
-of
-  NONE => ()
-| SOME d => let
-    fun checkfor s = let
-      val f = Path.concat(d,s)
+let
+  fun checkfor f =
+    if FileSys.access (f, [FileSys.A_READ]) then SOME f else NONE
+  fun loadConfig f = let
+      val oldq = HOL_Interactive.amquiet()
     in
-      if FileSys.access (f, [FileSys.A_READ]) then SOME f else NONE
+      print ("[Use-ing configuration file "^f^"]\n");
+      oldq orelse HOL_Interactive.toggle_quietdec();
+      use f;
+      ignore (oldq orelse HOL_Interactive.toggle_quietdec())
     end
-  in
-    case Lib.get_first checkfor ["hol-config.sml", "hol-config.ML",
-                                 ".hol-config", ".hol-config.sml",
-                                 ".hol-config.ML"]
-    of
-      NONE => ()
-    | SOME f => let
-        val oldq = HOL_Interactive.amquiet()
-      in
-        print ("[Use-ing configuration file "^f^"]\n");
-        oldq orelse HOL_Interactive.toggle_quietdec();
-        use f;
-        ignore (oldq orelse HOL_Interactive.toggle_quietdec())
-      end
-  end;
+in
+  (* check if custom configuration is declared *)
+  case Process.getEnv "HOL_CONFIG" of
+    NONE =>
+      (case
+        Lib.get_first Process.getEnv ["HOME",
+                                      (* windows things *)
+                                      "HOMEPATH", "APPDATA"]
+      of
+        SOME dir =>
+          Option.app loadConfig
+            (Lib.get_first (fn s => checkfor (Path.concat(dir,s)))
+              ["hol-config.sml", "hol-config.ML",
+                ".hol-config", ".hol-config.sml",
+                ".hol-config.ML"])
+        | NONE => ())
+    | SOME the_custom_config =>
+      case checkfor the_custom_config of
+        NONE => print ("[Ignoring configuration from HOL_CONFIG:"^ the_custom_config ^" (unreadable or empty)]\n")
+        | SOME f => loadConfig f
+end;

--- a/tools/vim/vimhol.sh
+++ b/tools/vim/vimhol.sh
@@ -68,8 +68,7 @@ WD="$(echo "$@" | xargs dirname 2>/dev/null \
 VIMHOL_FIFO="$(mktemp -u -p "${XDG_RUNTIME_DIR:-/tmp}" "hol-XXXXXXXXXX")"
 test -p "$VIMHOL_FIFO" || mkfifo "$VIMHOL_FIFO"
 
-# For $HOLDIR/bin/hol, reset $HOME to $HOLDIR/tools/vim
-# so it uses $HOLDIR/tools/vim/hol-config.sml
+# For $HOLDIR/bin/hol, set $HOL_CONFIG to use $HOLDIR/tools/vim/hol-config.sml
 # Early tmux versions neither support hooks (to delete VIMHOL_FIFO) nor the -c
 # flag (to set the cwd).
 tmux \
@@ -77,7 +76,7 @@ tmux \
     -s "$(basename "$VIMHOL_FIFO")" \
     "env VIMHOL_FIFO='$VIMHOL_FIFO' ${EDITOR:-vim} -c 'source $VIMOPT' \
         -c 'bufdo doautocmd BufRead' $*" \; \
-  split-window -h "cd '$WD'; env HOME='$HOLDIR/tools/vim/' VIMHOL_FIFO='$VIMHOL_FIFO' $RLWRAP $HOLDIR/bin/hol" \; \
+  split-window -h "cd '$WD'; env HOL_CONFIG='$HOLDIR/tools/vim/hol-config.sml' VIMHOL_FIFO='$VIMHOL_FIFO' $RLWRAP $HOLDIR/bin/hol" \; \
   select-pane -t :.- \; \
   bind-key C-q confirm-before -p "kill-session #S? (y/n)" \
     "run-shell 'rm -f $VIMHOL_FIFO'; kill-session" \; \


### PR DESCRIPTION
Adds support for a `HOL_CONFIG` environment variable to allow for a custom `hol-config` configuration at a non-standard location or potentially ignoring any present hol config. If the variable is set, any other hol-config file will be ignored. If the value of `HOL_CONFIG` is a readable file, it will be used.
These changes are motivated by #851 and avoid resetting `$HOME` within the vimhol script.