### PR TITLE
Add `unionWith` function to `balanced_mapTheory`

### DIFF
--- a/examples/balanced_bst/balanced_mapScript.sml
+++ b/examples/balanced_bst/balanced_mapScript.sml
@@ -599,6 +599,23 @@ val union_def = Define `
 (union cmp t1 Tip = t1) ∧
 (union cmp t1 t2 = hedgeUnion cmp NONE NONE t1 t2)`;
 
+Definition hedgeUnionWithKey_def:
+  (hedgeUnionWithKey _ _ _ _ t1 Tip = t1) ∧
+  (hedgeUnionWithKey cmp _ blo bhi Tip (Bin _ kx x l r) =
+    link kx x (filterGt cmp blo l) (filterLt cmp bhi r)) ∧
+  (hedgeUnionWithKey cmp f blo bhi (Bin _ kx x l r) t2 =
+    let newx = (case lookup cmp kx t2 of NONE => x | SOME y => f kx x y) in
+    link kx newx
+      (hedgeUnionWithKey cmp f blo (SOME kx) l (trim cmp blo (SOME kx) t2))
+      (hedgeUnionWithKey cmp f (SOME kx) bhi r (trim cmp (SOME kx) bhi t2)))
+End
+
+Definition unionWith_def:
+  (unionWith _ _ Tip t2 = t2) ∧
+  (unionWith _ _ t1 Tip = t1) ∧
+  (unionWith cmp f t1 t2 = hedgeUnionWithKey cmp (λk x y. f x y) NONE NONE t1 t2)
+End
+
 val foldrWithKey_def = Define `
 (foldrWithKey f z' Tip = z') ∧
 (foldrWithKey f z' (Bin _ kx x l r) =
@@ -1961,6 +1978,15 @@ Proof
  metis_tac [cmp_thms]
 QED
 
+Triviality restrict_domain_FMERGE_WITH_KEY:
+  restrict_domain cmp lo hi (FMERGE_WITH_KEY f m1 m2) =
+    FMERGE_WITH_KEY f (restrict_domain cmp lo hi m1) (restrict_domain cmp lo hi m2)
+Proof
+  rw[restrict_domain_def, fmap_eq_flookup,
+     FLOOKUP_DRESTRICT, FLOOKUP_FMERGE_WITH_KEY] >>
+  IF_CASES_TAC >> gvs[]
+QED
+
 Definition bounded_root_def:
   bounded_root cmp lk hk t ⇔
     !s k v l r. t = Bin s k v l r ⇒ k ∈ restrict_set cmp lk hk
@@ -2564,6 +2590,163 @@ val lookup_union = Q.store_thm("lookup_union",
                                       NONE => lookup cmp k t2
                                     | SOME v => SOME v`,
   rw[lookup_thm,union_thm,FLOOKUP_FUNION]);
+
+Triviality hedgeUnionWithKey_thm:
+  ∀cmp f blo bhi t1 t2.
+    good_cmp cmp ∧
+    invariant cmp t1 ∧
+    invariant cmp t2 ∧
+    bounded_all cmp blo bhi t1 ∧
+    bounded_root cmp blo bhi t2 ∧
+    (∀k1 k2 x y. cmp k1 k2 = Equal ⇒ f k1 x y = f k2 x y)
+  ⇒ invariant cmp (hedgeUnionWithKey cmp f blo bhi t1 t2) ∧
+    to_fmap cmp (hedgeUnionWithKey cmp f blo bhi t1 t2) =
+      restrict_domain cmp blo bhi
+        (FMERGE_WITH_KEY (λks x y. f (CHOICE ks) x y) (to_fmap cmp t1) (to_fmap cmp t2))
+Proof
+  recInduct hedgeUnionWithKey_ind >> simp[hedgeUnionWithKey_def] >>
+  rpt conj_tac >> rpt gen_tac >> strip_tac
+  >- rw[to_fmap_def, FUNION_FEMPTY_2, bounded_restrict_id]
+  >- (
+    inv_mp_tac link_thm >> simp[GSYM CONJ_ASSOC] >>
+    inv_mp_tac filterGt_thm >> simp[] >> gvs[invariant_eq] >> strip_tac >>
+    inv_mp_tac filterLt_thm >> simp[] >> strip_tac >> rpt conj_tac
+    >- gvs[key_ordered_to_fmap, restrict_domain_def]
+    >- gvs[key_ordered_to_fmap, restrict_domain_def] >>
+    `restrict_domain cmp blo bhi FEMPTY = FEMPTY` by rw [restrict_domain_def] >>
+    simp[to_fmap_def, restrict_domain_union, restrict_domain_update] >> strip_tac >>
+    fmrw[restrict_domain_def, fmap_eq_flookup] >>
+    Cases_on `blo` >> Cases_on `bhi` >>
+    gvs[restrict_set_def, option_cmp_def, option_cmp2_def, bounded_root_def] >>
+    rw[FLOOKUP_DEF] >>
+    gvs[key_ordered_to_fmap] >> res_tac >> imp_res_tac to_fmap_key_set >>
+    metis_tac[cmp_thms, key_set_cmp_thm]
+    ) >>
+  simp[bounded_all_def] >> strip_tac >>
+  inv_mp_tac link_thm >> gvs[] >>
+  `invariant cmp l` by metis_tac[invariant_def] >>
+  `invariant cmp r` by metis_tac[invariant_def] >> gvs[] >>
+  qpat_abbrev_tac `tree = Bin _ _ _ _ _` >>
+  last_x_assum mp_tac >> impl_tac >> simp[]
+  >- (
+    inv_mp_tac trim_thm >> simp[] >> strip_tac >>
+    irule bounded_all_shrink1 >> simp[PULL_EXISTS] >> goal_assum drule >>
+    gvs[invariant_def]
+    ) >>
+  last_x_assum mp_tac >> impl_tac >> simp[]
+  >- (
+    inv_mp_tac trim_thm >> simp[] >> strip_tac >>
+    irule bounded_all_shrink2 >> simp[PULL_EXISTS] >> goal_assum drule >>
+    gvs[invariant_def]
+    ) >>
+  ntac 2 strip_tac >> simp[] >> conj_tac
+  >- (
+    gvs[key_ordered_to_fmap, restrict_domain_def, FMERGE_WITH_KEY_DEF] >>
+    simp[PULL_EXISTS, restrict_set_def, option_cmp2_def, DISJ_EQ_IMP] >>
+    rw[key_set_cmp_def, key_set_def] >> metis_tac[good_cmp_def]
+    ) >>
+  strip_tac >>
+  drule lookup_thm >> disch_then $ qspecl_then [`kx`,`tree`] assume_tac >> gvs[] >>
+  simp[to_fmap_def, restrict_domain_FMERGE_WITH_KEY,
+       restrict_domain_union, restrict_domain_update] >>
+  drule trim_thm >>
+  disch_then $ qspecl_then [`tree`,`blo`,`SOME kx`] assume_tac >> gvs[] >>
+  drule trim_thm >>
+  disch_then $ qspecl_then [`tree`,`SOME kx`,`bhi`] assume_tac >> gvs[] >>
+  ntac 15 $ pop_assum kall_tac >> gvs[invariant_eq] >>
+  `restrict_domain cmp blo bhi (to_fmap cmp l) =
+   restrict_domain cmp blo (SOME kx) (to_fmap cmp l)` by (
+    fmrw[restrict_domain_def, fmap_eq_flookup] >>
+    gvs[key_ordered_to_fmap, restrict_set_def, option_cmp2_def] >>
+    every_case_tac >> gvs[] >>
+    rw[FLOOKUP_DEF] >> CCONTR_TAC >> gvs[] >> res_tac
+    >- (
+      imp_res_tac key_set_cmp_thm >>
+      first_x_assum $ qspec_then `x'` assume_tac >> gvs[] >>
+      metis_tac[good_cmp_def]
+      )
+    >- (
+      first_x_assum $ qspec_then `x'` assume_tac >>
+      Cases_on `bhi` >> gvs[option_cmp2_def] >>
+      metis_tac[good_cmp_def]
+      )
+    ) >>
+  `restrict_domain cmp blo bhi (to_fmap cmp r) =
+   restrict_domain cmp (SOME kx) bhi (to_fmap cmp r)` by (
+    fmrw[restrict_domain_def, fmap_eq_flookup] >>
+    gvs[key_ordered_to_fmap, restrict_set_def] >>
+    every_case_tac >> gvs[] >>
+    rw[FLOOKUP_DEF] >> CCONTR_TAC >> gvs[] >> res_tac
+    >- (
+      imp_res_tac key_set_cmp_thm >>
+      first_x_assum $ qspec_then `x'` assume_tac >> gvs[]
+      )
+    >- (
+      first_x_assum $ qspec_then `x'` assume_tac >>
+      Cases_on `blo` >> gvs[option_cmp_def] >>
+      metis_tac[good_cmp_def]
+      )
+    ) >>
+  simp[] >>
+  ntac 2 $ pop_assum kall_tac >>
+  simp[FMERGE_WITH_KEY_FUPDATE] >>
+  qmatch_goalsub_abbrev_tac `_ |+ (_, a) = _ |+ (_, b)` >>
+  `a = b` by (
+    fmrw[Abbr `a`, Abbr `b`, restrict_domain_def] >>
+    CASE_TAC >> rw[] >> first_x_assum irule >>
+    DEEP_INTRO_TAC CHOICE_INTRO >> simp[key_set_def] >>
+    metis_tac[good_cmp_def]) >>
+  pop_assum SUBST_ALL_TAC >> ntac 2 $ pop_assum kall_tac >>
+  simp[FUPD11_SAME_UPDATE, GSYM fmap_domsub] >>
+  rw[fmap_eq_flookup, DOMSUB_FLOOKUP_THM] >> IF_CASES_TAC >> gvs[] >>
+  drule $ GSYM restrict_domain_combine >>
+  disch_then $ drule_at Any >>
+  disch_then $ qspecl_then [`tree`,`x`] assume_tac >> gvs[] >>
+  qmatch_asmsub_abbrev_tac `FLOOKUP (a ⊌ b)` >>
+  `∀k. FLOOKUP a k = NONE ∨ FLOOKUP b k = NONE` by (
+    rw[] >> Cases_on `FLOOKUP a k` >> Cases_on `FLOOKUP b k` >> gvs[] >>
+    gvs[Abbr `a`, Abbr `b`, FLOOKUP_DEF] >>
+    gvs[restrict_domain_def, restrict_set_def, option_cmp2_def] >>
+    gvs[key_set_eq] >> imp_res_tac good_cmp_thm >> res_tac >> gvs[]) >>
+  fmrw[FLOOKUP_FMERGE_WITH_KEY, Abbr `a`, Abbr `b`] >>
+  qpat_x_assum `FLOOKUP _ _ = _` kall_tac >>
+  first_x_assum $ qspec_then `x` assume_tac >> every_case_tac >> gvs[] >>
+  gvs[restrict_domain_def, FLOOKUP_DRESTRICT, restrict_set_def,
+      option_cmp2_def, key_set_eq] >>
+  imp_res_tac good_cmp_thm >> res_tac >> gvs[]
+QED
+
+Theorem unionWith_thm:
+  ∀cmp f blo bhi t1 t2.
+    good_cmp cmp ∧
+    invariant cmp t1 ∧
+    invariant cmp t2
+  ⇒ invariant cmp (unionWith cmp f t1 t2) ∧
+    to_fmap cmp (unionWith cmp f t1 t2) =
+      FMERGE_WITH_KEY (λks x y. f x y) (to_fmap cmp t1) (to_fmap cmp t2)
+Proof
+  Cases_on `t1` >> Cases_on `t2` >> simp[unionWith_def, to_fmap_def] >>
+  ntac 2 gen_tac >> strip_tac >>
+  inv_mp_tac hedgeUnionWithKey_thm >> simp[] >>
+  rw[bounded_all_NONE, bounded_root_def, restrict_set_def, option_cmp_def,
+     restrict_domain_def, option_cmp2_def, to_fmap_def] >>
+  rw[fmap_eq_flookup, FLOOKUP_FMERGE_WITH_KEY, FLOOKUP_DRESTRICT] >> gvs[] >>
+  IF_CASES_TAC >> gvs[] >> simp[FLOOKUP_UPDATE, FLOOKUP_DEF] >>
+  every_case_tac >> gvs[] >> imp_res_tac to_fmap_key_set >> gvs[]
+QED
+
+Theorem lookup_unionWith:
+  good_cmp cmp ∧ invariant cmp t1 ∧ invariant cmp t2 ⇒
+  lookup cmp k (unionWith cmp f t1 t2) =
+    case lookup cmp k t1 of
+    | NONE => lookup cmp k t2
+    | SOME v1 =>
+      case lookup cmp k t2 of
+      | NONE => SOME v1
+      | SOME v2 => SOME $ f v1 v2
+Proof
+  rw[lookup_thm, unionWith_thm, FLOOKUP_FMERGE_WITH_KEY]
+QED
 
 val EXT2 = Q.prove (
 `!s1 s2. s1 = s2 ⇔ (!k v. (k,v) ∈ s1 ⇔ (k,v) ∈ s2)`,

--- a/examples/balanced_bst/balanced_mapScript.sml
+++ b/examples/balanced_bst/balanced_mapScript.sml
@@ -2717,7 +2717,7 @@ Proof
 QED
 
 Theorem unionWith_thm:
-  ∀cmp f blo bhi t1 t2.
+  ∀cmp f t1 t2.
     good_cmp cmp ∧
     invariant cmp t1 ∧
     invariant cmp t2

--- a/src/finite_maps/finite_mapScript.sml
+++ b/src/finite_maps/finite_mapScript.sml
@@ -2515,23 +2515,9 @@ Q.MATCH_ASSUM_RENAME_TAC `R a (SND b)` THEN
 Cases_on `b` THEN FULL_SIMP_TAC(srw_ss())[] THEN
 SRW_TAC[][fmap_rel_FUPDATE_same])
 
-val fmap_rel_FEMPTY = store_thm(
-"fmap_rel_FEMPTY",
-``fmap_rel R FEMPTY FEMPTY``,
-SRW_TAC[][fmap_rel_def])
-val _ = export_rewrites["fmap_rel_FEMPTY"]
-
-val fmap_rel_FEMPTY2 = store_thm(
-  "fmap_rel_FEMPTY2",
-  ``(fmap_rel R FEMPTY f <=> (f = FEMPTY)) /\
-    (fmap_rel R f FEMPTY <=> (f = FEMPTY))``,
-  SRW_TAC [][fmap_rel_def, FDOM_EQ_EMPTY, EQ_IMP_THM] THEN
-  METIS_TAC [FDOM_EQ_EMPTY]);
-val _ = export_rewrites ["fmap_rel_FEMPTY2"]
-
-Theorem fmap_rel_FEMPTY3[simp]:
-  (fmap_rel (R : 'a -> 'b -> bool) FEMPTY (f1 : 'c |-> 'b) <=> f1 = FEMPTY) ∧
-  (fmap_rel R (f2 : 'c |-> 'a) FEMPTY <=> f2 = FEMPTY)
+Theorem fmap_rel_FEMPTY[simp]:
+  (fmap_rel (R : 'a -> 'b -> bool) FEMPTY (f2 : 'c |-> 'b) <=> f2 = FEMPTY) ∧
+  (fmap_rel R (f1 : 'c |-> 'a) FEMPTY <=> f1 = FEMPTY)
 Proof
   rw[fmap_rel_def] >> simp[FDOM_EQ_EMPTY] >> eq_tac >> rw[]
 QED
@@ -2588,7 +2574,7 @@ Proof
   every_case_tac >> gvs[]
 QED
 
-Theorem fmap_rel_ind:
+Theorem fmap_rel_ind[rule_induction]:
   !R FR.
     FR FEMPTY FEMPTY /\
     (!k v1 v2 f1 f2.

--- a/src/finite_maps/finite_mapScript.sml
+++ b/src/finite_maps/finite_mapScript.sml
@@ -1179,7 +1179,7 @@ Proof
   every_case_tac >> gvs[]
 QED
 
-Theorem FMERGE_WITH_KEY_EQ_EMPTY:
+Theorem FMERGE_WITH_KEY_EQ_EMPTY[simp]:
   (FMERGE_WITH_KEY f m1 m2 = FEMPTY) <=> (m1 = FEMPTY) /\ (m2 = FEMPTY)
 Proof
   rw[fmap_eq_flookup, FLOOKUP_FMERGE_WITH_KEY] >>
@@ -2518,7 +2518,7 @@ val fmap_rel_FEMPTY2 = store_thm(
   METIS_TAC [FDOM_EQ_EMPTY]);
 val _ = export_rewrites ["fmap_rel_FEMPTY2"]
 
-Theorem fmap_rel_FEMPTY3:
+Theorem fmap_rel_FEMPTY3[simp]:
   (fmap_rel (R : 'a -> 'b -> bool) FEMPTY (f1 : 'c |-> 'b) <=> f1 = FEMPTY) ∧
   (fmap_rel R (f2 : 'c |-> 'a) FEMPTY <=> f2 = FEMPTY)
 Proof
@@ -3184,13 +3184,13 @@ Proof
   EVERY_CASE_TAC >> gvs[]
 QED
 
-Theorem FDIFF_FEMPTY:
+Theorem FDIFF_FEMPTY[simp]:
   FDIFF FEMPTY s = FEMPTY
 Proof
   rw[fmap_eq_flookup, FLOOKUP_FDIFF]
 QED
 
-Theorem FDIFF_EMPTY:
+Theorem FDIFF_EMPTY[simp]:
   !f. FDIFF f {} = f
 Proof
   rw[fmap_eq_flookup, FLOOKUP_FDIFF]

--- a/src/finite_maps/finite_mapScript.sml
+++ b/src/finite_maps/finite_mapScript.sml
@@ -1031,6 +1031,163 @@ val FLOOKUP_DRESTRICT = store_thm("FLOOKUP_DRESTRICT",
   ``!fm s k. FLOOKUP (DRESTRICT fm s) k = if k IN s then FLOOKUP fm k else NONE``,
   SRW_TAC[][FLOOKUP_DEF,DRESTRICT_DEF] THEN FULL_SIMP_TAC std_ss []);
 
+Theorem FLOOKUP_FMERGE:
+  FLOOKUP (FMERGE f m1 m2) k =
+    case (FLOOKUP m1 k, FLOOKUP m2 k) of
+    | (SOME v1, SOME v2) => SOME $ f v1 v2
+    | (f1, f2) => OPTION_CHOICE f1 f2
+Proof
+  rw[FLOOKUP_DEF, FMERGE_DEF] >> gvs[]
+QED
+
+Theorem FLOOKUP_FMERGE = FLOOKUP_FMERGE |> SIMP_RULE (srw_ss()) [];
+
+
+(*---------------------------------------------------------------------------
+     Merge with key
+ ---------------------------------------------------------------------------*)
+
+Theorem FMERGE_WITH_KEY_EXISTS[local]:
+  !f m1 m2. ?u.
+    FDOM u = FDOM m1 UNION FDOM m2 /\
+    !x. u ' x =
+      if x IN FDOM m1 /\ x IN FDOM m2 then f x (m1 ' x) (m2 ' x)
+      else if x IN FDOM m1 then m1 ' x else m2 ' x
+Proof
+  gen_tac >> ho_match_mp_tac fmap_SIMPLE_INDUCT >> rw[]
+  >- (qexists_tac `m2` >> simp[]) >>
+  first_x_assum $ qspec_then `m2` assume_tac >> gvs[] >>
+  Cases_on `x IN FDOM m2` >> gvs[]
+  >- (
+    qexists_tac `u |+ (x, f x y (m2 ' x))` >>
+    gvs[INSERT_UNION_EQ, FAPPLY_FUPDATE_THM] >> rw[] >> gvs[]
+    )
+  >- (
+    qexists_tac `u |+ (x, y)` >>
+    gvs[INSERT_UNION_EQ, FAPPLY_FUPDATE_THM] >> rw[] >> gvs[]
+    )
+QED
+
+val FMERGE_WITH_KEY_DEF = new_specification
+  ("FMERGE_WITH_KEY_DEF", ["FMERGE_WITH_KEY"],
+   CONV_RULE (ONCE_DEPTH_CONV SKOLEM_CONV) FMERGE_WITH_KEY_EXISTS);
+
+Theorem FLOOKUP_FMERGE_WITH_KEY[local]:
+  FLOOKUP (FMERGE_WITH_KEY f m1 m2) k =
+    case (FLOOKUP m1 k, FLOOKUP m2 k) of
+    | (SOME v1, SOME v2) => SOME $ f k v1 v2
+    | (f1, f2) => OPTION_CHOICE f1 f2
+Proof
+  rw[FLOOKUP_DEF, FMERGE_WITH_KEY_DEF] >> gvs[]
+QED
+
+Theorem FLOOKUP_FMERGE_WITH_KEY =
+  FLOOKUP_FMERGE_WITH_KEY |> SIMP_RULE (srw_ss()) [];
+
+Theorem FMERGE_WITH_KEY_FEMPTY[simp]:
+  FMERGE_WITH_KEY f FEMPTY m2 = m2 /\
+  FMERGE_WITH_KEY f m1 FEMPTY = m1
+Proof
+  rw[fmap_eq_flookup, FLOOKUP_FMERGE_WITH_KEY] >> CASE_TAC >> simp[]
+QED
+
+Theorem FLOOKUP_FMERGE_WITH_KEY_COMM:
+  COMM (FMERGE_WITH_KEY f) = !k. COMM (f k)
+Proof
+  rw[combinTheory.COMM_DEF, fmap_eq_flookup, FLOOKUP_FMERGE_WITH_KEY] >>
+  eq_tac >> rw[]
+  >- (
+    pop_assum $ qspecl_then [`FEMPTY |+ (k,x)`,`FEMPTY |+ (k,y)`,`k`] mp_tac >>
+    simp[FLOOKUP_UPDATE]
+    ) >>
+  rename1 `FLOOKUP _ k` >> Cases_on `FLOOKUP x k` >> Cases_on `FLOOKUP y k`
+  >- simp[] >- simp[] >- simp[] >>
+  qmatch_asmsub_abbrev_tac `FLOOKUP x _ = SOME a` >>
+  qmatch_asmsub_abbrev_tac `FLOOKUP y _ = SOME b` >>
+  last_x_assum $ qspecl_then [`k`,`a`,`b`] assume_tac >> simp[] >> gvs[]
+QED
+
+Theorem FLOOKUP_FMERGE_WITH_KEY_ASSOC:
+  ASSOC (FMERGE_WITH_KEY f) = !k. ASSOC (f k)
+Proof
+  rw[combinTheory.ASSOC_DEF, fmap_eq_flookup, FLOOKUP_FMERGE_WITH_KEY] >>
+  eq_tac >> rw[]
+  >- (
+    pop_assum $ qspecl_then
+      [`FEMPTY |+ (k,x)`,`FEMPTY |+ (k,y)`,`FEMPTY |+ (k,z)`,`k`] mp_tac >>
+    simp[FLOOKUP_UPDATE]
+    ) >>
+  rename1 `FLOOKUP _ k` >>
+  Cases_on `FLOOKUP x k` >> Cases_on `FLOOKUP y k` >> Cases_on `FLOOKUP z k`
+  >- simp[] >- simp[] >- simp[] >- simp[] >- simp[] >- simp[] >- simp[] >>
+  qmatch_asmsub_abbrev_tac `FLOOKUP x _ = SOME a` >>
+  qmatch_asmsub_abbrev_tac `FLOOKUP y _ = SOME b` >>
+  qmatch_asmsub_abbrev_tac `FLOOKUP z _ = SOME c` >>
+  last_x_assum $ qspecl_then [`k`,`a`,`b`,`c`] assume_tac >> simp[] >> gvs[]
+QED
+
+Theorem FMERGE_WITH_KEY_FUPDATE:
+  FMERGE_WITH_KEY f (m1 |+ (k,v1)) m2 =
+    (FMERGE_WITH_KEY f m1 m2) |+
+      (k, case FLOOKUP m2 k of NONE => v1 | SOME v2 => f k v1 v2)
+Proof
+  rw[fmap_eq_flookup, FLOOKUP_FMERGE_WITH_KEY, FLOOKUP_UPDATE] >>
+  IF_CASES_TAC >> gvs[] >> CASE_TAC >> gvs[]
+QED
+
+Theorem FMERGE_WITH_KEY_FUNION:
+  FMERGE_WITH_KEY f (FUNION m1 m2) m3 =
+  FUNION
+    (FMERGE_WITH_KEY f m1 (DRESTRICT m3 (FDOM m1)))
+    (FMERGE_WITH_KEY f m2 m3)
+Proof
+  rw[fmap_eq_flookup, FLOOKUP_FMERGE_WITH_KEY, FLOOKUP_FUNION, FLOOKUP_DRESTRICT] >>
+  every_case_tac >> gvs[FLOOKUP_DEF]
+QED
+
+Theorem FMERGE_WITH_KEY_FMERGE:
+  FMERGE f = FMERGE_WITH_KEY (\k v1 v2. f v1 v2)
+Proof
+  rw[FUN_EQ_THM, fmap_eq_flookup, FLOOKUP_FMERGE, FLOOKUP_FMERGE_WITH_KEY]
+QED
+
+Theorem FUNION_FMERGE_WITH_KEY:
+  !m1 m2 f. DISJOINT (FDOM m1) (FDOM m2) ==>
+    FMERGE_WITH_KEY f m1 m2 = FUNION m1 m2
+Proof
+  rw[fmap_eq_flookup, FLOOKUP_FMERGE_WITH_KEY, FLOOKUP_FUNION] >>
+  CASE_TAC >> simp[] >> CASE_TAC >> simp[] >> gvs[FLOOKUP_DEF, DISJOINT_ALT]
+QED
+
+Theorem FMERGE_WITH_KEY_NO_CHANGE:
+  (FMERGE_WITH_KEY f m1 m2 = m1 <=>
+    !x. x IN FDOM m2 ==> x IN FDOM m1 /\ (f x (m1 ' x) (m2 ' x) = m1 ' x)) /\
+  (FMERGE_WITH_KEY f m1 m2 = m2 <=>
+    !x. x IN FDOM m1 ==> x IN FDOM m2 /\ (f x (m1 ' x) (m2 ' x) = m2 ' x))
+Proof
+  rw[fmap_eq_flookup, FLOOKUP_FMERGE_WITH_KEY] >> eq_tac >> rw[] >>
+  gvs[FLOOKUP_DEF] >>
+  last_x_assum $ qspec_then `x` assume_tac >> gvs[] >>
+  every_case_tac >> gvs[]
+QED
+
+Theorem FMERGE_WITH_KEY_DRESTRICT:
+  DRESTRICT (FMERGE_WITH_KEY f m1 m2) vs =
+  FMERGE_WITH_KEY f (DRESTRICT m1 vs) (DRESTRICT m2 vs)
+Proof
+  rw[fmap_eq_flookup, FLOOKUP_DRESTRICT, FLOOKUP_FMERGE_WITH_KEY] >>
+  every_case_tac >> gvs[]
+QED
+
+Theorem FMERGE_WITH_KEY_EQ_EMPTY:
+  (FMERGE_WITH_KEY f m1 m2 = FEMPTY) <=> (m1 = FEMPTY) /\ (m2 = FEMPTY)
+Proof
+  rw[fmap_eq_flookup, FLOOKUP_FMERGE_WITH_KEY] >>
+  eq_tac >> rw[] >>
+  pop_assum $ qspec_then `x` assume_tac >> every_case_tac >> gvs[]
+QED
+
+
 (*---------------------------------------------------------------------------
        Universal quantifier on finite maps
  ---------------------------------------------------------------------------*)
@@ -1992,6 +2149,28 @@ SIMP_TAC std_ss [GSYM fmap_EQ_THM, FMAP_MAP2_THM,
                  COND_RAND, COND_RATOR,
                  DISJ_IMP_THM]);
 
+Theorem FLOOKUP_FMAP_MAP2:
+  !f m k. FLOOKUP (FMAP_MAP2 f m) k = OPTION_MAP (\v. f (k,v)) (FLOOKUP m k)
+Proof
+  rw[FLOOKUP_DEF, FMAP_MAP2_def, FUN_FMAP_DEF]
+QED
+
+Theorem DOMSUB_FMAP_MAP2:
+  !f m s. (FMAP_MAP2 f m) \\ s = FMAP_MAP2 f (m \\ s)
+Proof
+  rw[fmap_eq_flookup, DOMSUB_FLOOKUP_THM, FLOOKUP_FMAP_MAP2] >>
+  IF_CASES_TAC >> simp[]
+QED
+
+Theorem FMAP_MAP2_FUPDATE_LIST:
+  !l m f.
+    FMAP_MAP2 f (m |++ l) = FMAP_MAP2 f m |++ MAP (\(k,v). (k, f (k,v))) l
+Proof
+  Induct >> rw[FUPDATE_LIST_THM] >>
+  PairCases_on `h` >> simp[FMAP_MAP2_FUPDATE]
+QED
+
+
 (*---------------------------------------------------------------------------*)
 (* Some general stuff                                                        *)
 (* added 17 March 2009 by Thomas Tuerk                                       *)
@@ -2338,6 +2517,13 @@ val fmap_rel_FEMPTY2 = store_thm(
   SRW_TAC [][fmap_rel_def, FDOM_EQ_EMPTY, EQ_IMP_THM] THEN
   METIS_TAC [FDOM_EQ_EMPTY]);
 val _ = export_rewrites ["fmap_rel_FEMPTY2"]
+
+Theorem fmap_rel_FEMPTY3:
+  (fmap_rel (R : 'a -> 'b -> bool) FEMPTY (f1 : 'c |-> 'b) <=> f1 = FEMPTY) ∧
+  (fmap_rel R (f2 : 'c |-> 'a) FEMPTY <=> f2 = FEMPTY)
+Proof
+  rw[fmap_rel_def] >> simp[FDOM_EQ_EMPTY] >> eq_tac >> rw[]
+QED
 
 val fmap_rel_refl = store_thm(
 "fmap_rel_refl",
@@ -2942,6 +3128,91 @@ Proof
     (EXISTS_NOT_IN_FDOM_LEMMA |> SIMP_RULE std_ss [whileTheory.LEAST_EXISTS])>>
    fs[]
 QED
+
+Theorem FLOOKUP_FDIFF:
+  FLOOKUP (FDIFF fm s) k = if k IN s then NONE else FLOOKUP fm k
+Proof
+  rw[FDIFF_def, FLOOKUP_DRESTRICT] >> gvs[]
+QED
+
+Theorem FDIFF_FDIFF:
+  !fm s1 s2. FDIFF (FDIFF fm s1) s2 = FDIFF fm (s1 ∪ s2)
+Proof
+  rw[FDIFF_def, DRESTRICT_DRESTRICT, fmap_eq_flookup, FLOOKUP_DRESTRICT]
+QED
+
+Theorem FLOOKUP_FDIFF:
+  FLOOKUP (FDIFF fm s) k = if k IN s then NONE else FLOOKUP fm k
+Proof
+  rw[FDIFF_def, FLOOKUP_DRESTRICT] >> gvs[]
+QED
+
+Theorem FDIFF_FUNION:
+  !fm1 fm2 s. FDIFF (FUNION fm1 fm2) s = FUNION (FDIFF fm1 s) (FDIFF fm2 s)
+Proof
+  rw[FDIFF_def, DRESTRICTED_FUNION] >>
+  rw[fmap_eq_flookup] >>
+  rw[FLOOKUP_DRESTRICT, FLOOKUP_FUNION] >> fs[] >>
+  rw[FLOOKUP_DEF]
+QED
+
+Theorem FDIFF_FDOMSUB:
+  FDIFF (f \\ x) p = FDIFF f p \\ x
+Proof
+  rw[fmap_eq_flookup,FDIFF_def,FLOOKUP_DRESTRICT,DOMSUB_FLOOKUP_THM] >> rw[]
+QED
+
+Theorem FDIFF_FDOMSUB_INSERT:
+  FDIFF (f \\ x) p = FDIFF f (x INSERT p)
+Proof
+  rw[fmap_eq_flookup,FDIFF_def,FLOOKUP_DRESTRICT,DOMSUB_FLOOKUP_THM] >>
+  rw[] >> gvs[]
+QED
+
+Theorem FDIFF_BOUND:
+  FDIFF f p = FDIFF f (p INTER FDOM f)
+Proof
+  rw[FDIFF_def,fmap_eq_flookup,FLOOKUP_DRESTRICT] >>
+  rw[] >> gvs[flookup_thm]
+QED
+
+Theorem FDIFF_FUPDATE:
+  FDIFF (fm |+ (k,v)) s =
+  if k IN s then FDIFF fm s else (FDIFF fm s) |+ (k,v)
+Proof
+  rw[fmap_eq_flookup, FLOOKUP_FDIFF, FLOOKUP_UPDATE] >>
+  EVERY_CASE_TAC >> gvs[]
+QED
+
+Theorem FDIFF_FEMPTY:
+  FDIFF FEMPTY s = FEMPTY
+Proof
+  rw[fmap_eq_flookup, FLOOKUP_FDIFF]
+QED
+
+Theorem FDIFF_EMPTY:
+  !f. FDIFF f {} = f
+Proof
+  rw[fmap_eq_flookup, FLOOKUP_FDIFF]
+QED
+
+Theorem FDIFF_FMAP_MAP2:
+  !f m s. FDIFF (FMAP_MAP2 f m) s = FMAP_MAP2 f (FDIFF m s)
+Proof
+  rw[fmap_eq_flookup, FLOOKUP_FDIFF, FLOOKUP_FMAP_MAP2] >> rw[]
+QED
+
+Theorem FMERGE_WITH_KEY_FUNION_ALT:
+  FMERGE_WITH_KEY f (FUNION m1 m2) m3 =
+    FUNION
+      (FMERGE_WITH_KEY f m1 (DRESTRICT m3 (FDOM m1)))
+      (FMERGE_WITH_KEY f m2 (FDIFF m3 (FDOM m1)))
+Proof
+  rw[fmap_eq_flookup, FLOOKUP_FMERGE_WITH_KEY,
+     FLOOKUP_FUNION, FLOOKUP_DRESTRICT, FLOOKUP_FDIFF] >>
+  every_case_tac >> gvs[FLOOKUP_DEF]
+QED
+
 
 (* ----------------------------------------------------------------------
     fixpoint calculations over finite maps

--- a/src/finite_maps/finite_mapScript.sml
+++ b/src/finite_maps/finite_mapScript.sml
@@ -3180,12 +3180,6 @@ Proof
   rw[FDIFF_def, DRESTRICT_DRESTRICT, fmap_eq_flookup, FLOOKUP_DRESTRICT]
 QED
 
-Theorem FLOOKUP_FDIFF:
-  FLOOKUP (FDIFF fm s) k = if k IN s then NONE else FLOOKUP fm k
-Proof
-  rw[FDIFF_def, FLOOKUP_DRESTRICT] >> gvs[]
-QED
-
 Theorem FDIFF_FUNION:
   !fm1 fm2 s. FDIFF (FUNION fm1 fm2) s = FUNION (FDIFF fm1 s) (FDIFF fm2 s)
 Proof


### PR DESCRIPTION
As in Haskell's `Data.Map`, `unionWith` takes the union of two balanced maps, but uses its function parameter to combine values for keys present in both maps.

Theorems are stated in terms of a new constant in `finite_mapTheory`, `FMERGE_WITH_KEY` - this is like the existing `FMERGE`, but its function parameter processes the key as well as the values in the case where a key is present in both maps.

Some other theorems are also added to `finite_mapTheory` - these are mostly ported from https://github.com/cakeml/pure.