### PR TITLE
Fixed Moscow ML builds adding more dependencies

### DIFF
--- a/src/probability/Holmakefile
+++ b/src/probability/Holmakefile
@@ -1,4 +1,5 @@
-INCLUDES = ../real ../sort ../res_quan/src
+INCLUDES = ../real ../sort ../res_quan/src ../n-bit ../pred_set/src/more_theories \
+	../topology ../quotient/src
 EXTRA_CLEANS = heap
 
 ifdef POLY

--- a/src/rational/Holmakefile
+++ b/src/rational/Holmakefile
@@ -1,4 +1,4 @@
-INCLUDES = ../ring/src ../integer
+INCLUDES = ../ring/src ../integer ../res_quan/src ../quotient/src ../sort
 
 all: $(DEFAULT_TARGETS) selftest.exe
 .PHONY: all

--- a/src/real/Holmakefile
+++ b/src/real/Holmakefile
@@ -1,5 +1,5 @@
 INCLUDES = ../integer ../hol88 ../topology ../pred_set/src/more_theories \
-           ../res_quan/src
+           ../res_quan/src ../quotient/src
 
 THYFILES = $(patsubst %Script.sml,%Theory.uo,$(wildcard *.sml))
 TARGETS = $(patsubst %.sml,%.uo,$(THYFILES))

--- a/src/update/Holmakefile
+++ b/src/update/Holmakefile
@@ -1,1 +1,1 @@
-INCLUDES = ../sort
+INCLUDES = ../sort ../n-bit


### PR DESCRIPTION
Following 0a73682, this trivial PR finally brings HOL4's Moscow ML builds back.