### PR TITLE
Rename examples/fermat/twosq/iterateTheory

### DIFF
--- a/examples/fermat/twosq/README.md
+++ b/examples/fermat/twosq/README.md
@@ -8,7 +8,7 @@ These theories support the formalisation of an algorithm for Fermat's Two Square
 * __involute__, basic properties of involution.
 * __involuteFix__, pairs and fixes of involution.
 * __involuteAction__, involution and group action.
-* __iterate__, iteration of a function, with period of iteration.
+* __iteration__, iteration of a function, with period of iteration.
 * __iterateCompose__, iteration of involution composition.
 * __iterateCompute__, iteration period computation, recursion and while-loop.
 

--- a/examples/fermat/twosq/files.txt
+++ b/examples/fermat/twosq/files.txt
@@ -24,18 +24,18 @@
 1 involute
 0 helperTwosq
 
-0 iterate        -- iteration period of FUNPOW.
+0 iteration      -- iteration period of FUNPOW.
 
 1 iterateCompute -- iteration period computation, recursion and while-loop.
 0 listRange
-0 iterate
+0 iteration
 0 helperTwosq
 
 3 iterateCompose -- iteration of involution composition.
 1 iterateCompute
 2 involuteFix
 1 involute
-0 iterate
+0 iteration
 0 helperTwosq
 
 4 twoSquares     -- existence, uniqueness and algorithm (clean version for paper).
@@ -44,6 +44,6 @@
 1 windmill
 3 iterateCompose
 1 iterateCompute
-0 iterate
+0 iteration
 0 groupAction
 0 helperTwosq

--- a/examples/fermat/twosq/iterateComposeScript.sml
+++ b/examples/fermat/twosq/iterateComposeScript.sml
@@ -29,7 +29,7 @@ open involuteTheory; (* for involute_bij *)
 open involuteFixTheory;
 
 (* val _ = load "iterateComputeTheory"; *)
-open iterateTheory;
+open iterationTheory;
 open iterateComputeTheory; (* for iterate_while_thm *)
 
 

--- a/examples/fermat/twosq/iterateComputeScript.sml
+++ b/examples/fermat/twosq/iterateComputeScript.sml
@@ -14,7 +14,7 @@ val _ = new_theory "iterateCompute";
 
 
 (* open dependent theories *)
-val _ = load("iterateTheory");
+val _ = load("iterationTheory");
 open helperFunctionTheory;
 open helperSetTheory;
 open helperNumTheory;
@@ -23,7 +23,7 @@ open helperNumTheory;
 open arithmeticTheory pred_setTheory;
 open dividesTheory; (* for divides_def *)
 
-open iterateTheory;
+open iterationTheory;
 open listTheory;
 open listRangeTheory;
 open helperListTheory; (* for listRangeINC_SNOC *)

--- a/examples/fermat/twosq/iterationScript.sml
+++ b/examples/fermat/twosq/iterationScript.sml
@@ -8,7 +8,7 @@
 open HolKernel boolLib bossLib Parse;
 
 (* declare new theory at start *)
-val _ = new_theory "iterate";
+val _ = new_theory "iteration";
 
 (* ------------------------------------------------------------------------- *)
 

--- a/examples/fermat/twosq/twoSquaresScript.sml
+++ b/examples/fermat/twosq/twoSquaresScript.sml
@@ -31,7 +31,7 @@ open involuteTheory; (* for involute_bij *)
 open involuteFixTheory;
 
 (* val _ = load "iterateComposeTheory"; *)
-open iterateTheory;
+open iterationTheory;
 open iterateComposeTheory;
 
 (* val _ = load "iterateComputeTheory"; *)


### PR DESCRIPTION
To avoid clash with src/real/iterateTheory