### PR TITLE
Minor completion of Lebesgue integration (+integral_neginf, etc.)

### DIFF
--- a/src/probability/extrealScript.sml
+++ b/src/probability/extrealScript.sml
@@ -5433,6 +5433,23 @@ Proof
     REWRITE_TAC [IN_APP, lt_inf_epsilon]
 QED
 
+Theorem inf_num :
+    inf (\x. ?n :num. x = -&n) = NegInf
+Proof
+    rw [GSYM le_infty, inf_le]
+ >> CCONTR_TAC
+ >> fs [GSYM extreal_lt_def, GSYM lt_infty]
+ >> STRIP_ASSUME_TAC (MATCH_MP (Q.SPEC ‘y’ SIMP_EXTREAL_ARCH_NEG)
+                               (ASSUME “y <> NegInf”))
+ >> Know ‘-&SUC n < y’
+ >- (MATCH_MP_TAC lte_trans \\
+     Q.EXISTS_TAC ‘-&n’ >> rw [extreal_of_num_def, extreal_ainv_def, extreal_lt_eq])
+ >> DISCH_TAC
+ >> Suff ‘y <= -&SUC n’ >- METIS_TAC [let_antisym]
+ >> FIRST_X_ASSUM MATCH_MP_TAC
+ >> Q.EXISTS_TAC ‘SUC n’ >> rw []
+QED
+
 Theorem sup_comm : (* was: SUP_commute *)
     !f. sup {sup {f i j | j IN univ(:num)} | i IN univ(:num)} =
         sup {sup {f i j | i IN univ(:num)} | j IN univ(:num)}
@@ -7052,20 +7069,23 @@ val max_le2_imp = store_thm
     RW_TAC std_ss [max_le]
  >> RW_TAC std_ss [le_max]);
 
-val max_refl = store_thm
-  ("max_refl", ``!x. max x x = x``,
-    RW_TAC std_ss [extreal_max_def, le_refl]);
+Theorem max_refl[simp] :
+    !x. max x x = x
+Proof
+    RW_TAC std_ss [extreal_max_def, le_refl]
+QED
 
 val max_comm = store_thm
   ("max_comm", ``!x y. max x y = max y x``,
     RW_TAC std_ss [extreal_max_def]
  >> PROVE_TAC [le_antisym, le_total]);
 
-val max_infty = store_thm
-  ("max_infty",
-  ``!x. (max x PosInf = PosInf) /\ (max PosInf x = PosInf) /\
-        (max NegInf x = x) /\ (max x NegInf = x)``,
-    RW_TAC std_ss [extreal_max_def, le_infty]);
+Theorem max_infty[simp] :
+    !x. (max x PosInf = PosInf) /\ (max PosInf x = PosInf) /\
+        (max NegInf x = x) /\ (max x NegInf = x)
+Proof
+    RW_TAC std_ss [extreal_max_def, le_infty]
+QED
 
 val max_reduce = store_thm
   ("max_reduce", ``!x y :extreal. x <= y \/ x < y ==> (max x y = y) /\ (max y x = y)``,

--- a/src/probability/measureScript.sml
+++ b/src/probability/measureScript.sml
@@ -130,6 +130,16 @@ val measure_preserving_def = Define
       s IN measurable_sets m2 ==>
            (measure m1 ((PREIMAGE f s) INTER (m_space m1)) = measure m2 s)}`;
 
+(* This substitutes HVG's ‘measure_of’ methodology: instead of writing things like
+   ‘measure_of m1 = measure_of m2’ now we write ‘measure_space_eq m1 m2’ instead.
+ *)
+Definition measure_space_eq_def :
+    measure_space_eq m1 m2 =
+      (m_space m1 = m_space m2 /\
+       measurable_sets m1 = measurable_sets m2 /\
+       (!s. s IN measurable_sets m1 ==> (measure m1 s = measure m2 s)))
+End
+
 (* ------------------------------------------------------------------------- *)
 (*  Basic measure theory theorems                                            *)
 (* ------------------------------------------------------------------------- *)
@@ -699,6 +709,27 @@ Proof
       (* goal 3 (of 3) *)
       rw [countably_additive_def, IN_FUNSET, IN_UNIV, o_DEF] \\
       fs [measure_space_def, countably_additive_def, IN_FUNSET, IN_UNIV, o_DEF] ]
+QED
+
+Theorem measure_space_eq' :
+    !m1 m2. measure_space m1 /\ measure_space_eq m1 m2 ==> measure_space m2
+Proof
+    RW_TAC std_ss [measure_space_eq_def]
+ >> MATCH_MP_TAC measure_space_eq
+ >> Q.EXISTS_TAC ‘m1’ >> rw []
+QED
+
+Theorem measure_space_eq_comm :
+    !m1 m2. measure_space_eq m1 m2 ==> measure_space_eq m2 m1
+Proof
+    RW_TAC std_ss [measure_space_eq_def]
+QED
+
+Theorem measure_space_eq_trans :
+    !m1 m2 m3. measure_space_eq m1 m2 /\ measure_space_eq m2 m3 ==>
+               measure_space_eq m1 m3
+Proof
+    RW_TAC std_ss [measure_space_eq_def]
 QED
 
 val MEASURE_SPACE_INTER = store_thm

--- a/src/probability/real_topologyScript.sml
+++ b/src/probability/real_topologyScript.sml
@@ -28,9 +28,7 @@ open wellorderTheory cardinalTheory iterateTheory hurdUtils;
 
 val _ = new_theory "real_topology";
 
-val std_ss = std_ss -* ["lift_disj_eq", "lift_imp_disj"]
-val real_ss = real_ss -* ["lift_disj_eq", "lift_imp_disj"]
-val _ = temp_delsimps ["lift_disj_eq", "lift_imp_disj"]
+val std_ss' = std_ss -* ["lift_disj_eq", "lift_imp_disj"];
 
 fun MESON ths tm = prove(tm,MESON_TAC ths);
 fun METIS ths tm = prove(tm,METIS_TAC ths);
@@ -1841,14 +1839,15 @@ val DEPENDENT_EXPLICIT = store_thm ("DEPENDENT_EXPLICIT",
      ASM_SIMP_TAC real_ss [REAL_MUL_RINV], DISCH_TAC THEN ASM_REWRITE_TAC []] THEN
     ASM_SET_TAC []]);
 
-val INDEPENDENT_INJECTIVE_IMAGE_GEN = store_thm ("INDEPENDENT_INJECTIVE_IMAGE_GEN",
- ``!f:real->real s. independent s /\ linear f /\
+Theorem INDEPENDENT_INJECTIVE_IMAGE_GEN :
+   !(f:real->real) s. independent s /\ linear f /\
      (!x y. x IN span s /\ y IN span s /\ (f(x) = f(y)) ==> (x = y))
-    ==> independent (IMAGE f s)``,
+    ==> independent (IMAGE f s)
+Proof
   REPEAT GEN_TAC THEN
   DISCH_THEN(CONJUNCTS_THEN2 MP_TAC STRIP_ASSUME_TAC) THEN
   ONCE_REWRITE_TAC[MONO_NOT_EQ] THEN
-  SIMP_TAC std_ss [independent, DEPENDENT_EXPLICIT] THEN
+  SIMP_TAC std_ss' [independent, DEPENDENT_EXPLICIT] THEN
   REWRITE_TAC[CONJ_ASSOC, FINITE_SUBSET_IMAGE] THEN DISCH_TAC THEN
   KNOW_TAC ``(?s':real->bool u:real->real. (FINITE s' /\ s' SUBSET s) /\
       (?v. v IN IMAGE f s' /\ ~(u v = &0)) /\
@@ -1870,7 +1869,8 @@ val INDEPENDENT_INJECTIVE_IMAGE_GEN = store_thm ("INDEPENDENT_INJECTIVE_IMAGE_GE
     FIRST_X_ASSUM(SUBST1_TAC o SYM) THEN CONV_TAC SYM_CONV THEN
     W(MP_TAC o PART_MATCH (lhs o rand) SUM_IMAGE o lhand o snd) THEN
     ASM_SIMP_TAC std_ss [o_DEF] THEN ASM_SIMP_TAC std_ss [LINEAR_CMUL] THEN
-    DISCH_THEN MATCH_MP_TAC THEN ASM_MESON_TAC[SPAN_SUPERSET, SUBSET_DEF]]);
+    DISCH_THEN MATCH_MP_TAC THEN ASM_MESON_TAC[SPAN_SUPERSET, SUBSET_DEF]]
+QED
 
 val INDEPENDENT_INJECTIVE_IMAGE = store_thm ("INDEPENDENT_INJECTIVE_IMAGE",
  ``!f:real->real s. independent s /\ linear f /\
@@ -3171,13 +3171,14 @@ val CONNECTED_OPEN_SET = store_thm ("CONNECTED_OPEN_SET",
      [``s INTER u:real->bool``, ``s INTER v:real->bool``] THEN
     ASM_SIMP_TAC std_ss [OPEN_INTER] THEN REPEAT (POP_ASSUM MP_TAC) THEN SET_TAC[]]);
 
-val CONNECTED_IFF_CONNECTABLE_POINTS = store_thm ("CONNECTED_IFF_CONNECTABLE_POINTS",
- ``!s:real->bool.
+Theorem CONNECTED_IFF_CONNECTABLE_POINTS :
+   !(s:real->bool).
         connected s <=>
         !a b. a IN s /\ b IN s
-              ==> ?t. connected t /\ t SUBSET s /\ a IN t /\ b IN t``,
+              ==> ?t. connected t /\ t SUBSET s /\ a IN t /\ b IN t
+Proof
   GEN_TAC THEN EQ_TAC THENL [MESON_TAC[SUBSET_REFL], DISCH_TAC] THEN
-  SIMP_TAC std_ss [connected, NOT_EXISTS_THM] THEN
+  SIMP_TAC std_ss' [connected, NOT_EXISTS_THM] THEN
   MAP_EVERY X_GEN_TAC [``e1:real->bool``, ``e2:real->bool``] THEN
   REWRITE_TAC [METIS [DE_MORGAN_THM]
                     ``~a \/ ~b \/ ~c \/ (d <> e) \/ (f = g) \/ (h = i) <=>
@@ -3193,7 +3194,8 @@ val CONNECTED_IFF_CONNECTABLE_POINTS = store_thm ("CONNECTED_IFF_CONNECTABLE_POI
   DISCH_THEN(CHOOSE_THEN(CONJUNCTS_THEN2 MP_TAC ASSUME_TAC)) THEN
   REWRITE_TAC[] THEN
   MAP_EVERY EXISTS_TAC [``e1:real->bool``, ``e2:real->bool``] THEN
-  ASM_SET_TAC[]);
+  ASM_SET_TAC[]
+QED
 
 val CONNECTED_EMPTY = store_thm ("CONNECTED_EMPTY",
  ``connected {}``,
@@ -3244,13 +3246,15 @@ val CONNECTED_REAL_LEMMA = store_thm ("CONNECTED_REAL_LEMMA",
                   REAL_ARITH ``&0 < e /\ x <= b ==> x - e <= b:real``,
       REAL_ARITH ``&0 < e /\ e < d ==> x - e < x /\ abs((x - e) - x) < d:real``]]);
 
-val CONNECTED_SEGMENT = store_thm ("CONNECTED_SEGMENT",
- ``(!a b:real. connected(segment[a,b])) /\
-   (!a b:real. connected(segment(a,b)))``,
+Theorem CONNECTED_SEGMENT :
+   (!a b:real. connected(segment[a,b])) /\
+   (!a b:real. connected(segment(a,b)))
+Proof
   CONJ_TAC THEN REPEAT GEN_TAC THENL
- [ASM_CASES_TAC ``b:real = a`` THEN
+ [ (* goal 1 (of 2): connected(segment[a,b]) *)
+  ASM_CASES_TAC ``b:real = a`` THEN
   ASM_SIMP_TAC std_ss [SEGMENT_REFL, CONNECTED_EMPTY, CONNECTED_SING] THEN
-  ASM_SIMP_TAC std_ss [connected, OPEN_SEGMENT_ALT, CONJUNCT1 segment,
+  ASM_SIMP_TAC std_ss' [connected, OPEN_SEGMENT_ALT, CONJUNCT1 segment,
                NOT_EXISTS_THM] THEN
   REWRITE_TAC [METIS [DE_MORGAN_THM]
    ``~a \/ ~b \/ ~c \/ (d <> e) \/ (f = g) \/ (h = i) <=>
@@ -3333,10 +3337,12 @@ val CONNECTED_SEGMENT = store_thm ("CONNECTED_SEGMENT",
        -((y' - x') * (a - b))``],
     RULE_ASSUM_TAC(SIMP_RULE std_ss [EXTENSION, IN_INTER, GSPECIFICATION,
                                 SUBSET_DEF, IN_UNION, NOT_IN_EMPTY]) THEN
-    METIS_TAC[REAL_LE_TRANS, REAL_LET_TRANS, REAL_LTE_TRANS]], ALL_TAC] THEN
+    METIS_TAC[REAL_LE_TRANS, REAL_LET_TRANS, REAL_LTE_TRANS]],
+
+  (* goal 2 (of 2): connected(segment(a,b)) *)
   ASM_CASES_TAC ``b:real = a`` THEN
   ASM_SIMP_TAC std_ss [SEGMENT_REFL, CONNECTED_EMPTY, CONNECTED_SING] THEN
-  ASM_SIMP_TAC std_ss [connected, OPEN_SEGMENT_ALT, CONJUNCT1 segment,
+  ASM_SIMP_TAC std_ss' [connected, OPEN_SEGMENT_ALT, CONJUNCT1 segment,
                NOT_EXISTS_THM] THEN
   REWRITE_TAC [METIS [DE_MORGAN_THM]
    ``~a \/ ~b \/ ~c \/ (d <> e) \/ (f = g) \/ (h = i) <=>
@@ -3416,7 +3422,8 @@ val CONNECTED_SEGMENT = store_thm ("CONNECTED_SEGMENT",
        -((y' - x') * (a - b))``],
     RULE_ASSUM_TAC(SIMP_RULE std_ss [EXTENSION, IN_INTER, GSPECIFICATION,
                                 SUBSET_DEF, IN_UNION, NOT_IN_EMPTY]) THEN
-    METIS_TAC[REAL_LE_TRANS, REAL_LET_TRANS, REAL_LTE_TRANS]]);
+    METIS_TAC[REAL_LE_TRANS, REAL_LET_TRANS, REAL_LTE_TRANS]] ]
+QED
 
 val CONNECTED_UNIV = store_thm ("CONNECTED_UNIV",
  ``connected univ(:real)``,
@@ -3726,9 +3733,25 @@ val CONNECTED_EQUIVALENCE_RELATION = store_thm ("CONNECTED_EQUIVALENCE_RELATION"
 
 val _ = set_fixity "limit_point_of" (Infix(NONASSOC, 450));
 
-val limit_point_of = new_definition ("limit_point_of",
- ``x limit_point_of s <=>
-        !t. x IN t /\ open t ==> ?y. ~(y = x) /\ y IN s /\ y IN t``);
+(* ‘limpt’ is defined in topologyTheory *)
+Definition limit_point_of_def :
+    x limit_point_of s <=> limpt(euclidean) x s
+End
+
+Theorem limit_point_of :
+    !x s. x limit_point_of s <=>
+          !t. x IN t /\ Open t ==> ?y. ~(y = x) /\ y IN s /\ y IN t
+Proof
+    rw [limit_point_of_def, limpt, neigh, TOPSPACE_EUCLIDEAN, GSYM OPEN_IN, IN_APP]
+ >> EQ_TAC >> rw []
+ >- (Q.PAT_X_ASSUM ‘!N. _ ==> ?y. x <> y /\ s y /\ N y’ (MP_TAC o (Q.SPEC ‘t’)) \\
+     Know ‘?P. Open P /\ P SUBSET t /\ P x’
+     >- (Q.EXISTS_TAC ‘t’ >> rw []) >> rw [] \\
+     Q.EXISTS_TAC ‘y’ >> rw [])
+ >> Q.PAT_X_ASSUM ‘!t. t x /\ Open t ==> _’ (MP_TAC o (Q.SPEC ‘P’))
+ >> rw []
+ >> Q.EXISTS_TAC ‘y’ >> fs [SUBSET_DEF, IN_APP]
+QED
 
 val LIMPT_SUBSET = store_thm ("LIMPT_SUBSET",
  ``!x s t. x limit_point_of s /\ s SUBSET t ==> x limit_point_of t``,
@@ -9888,18 +9911,19 @@ val QUOTIENT_MAP_RESTRICT = store_thm ("QUOTIENT_MAP_RESTRICT",
    MATCH_MP_TAC CONTINUOUS_CLOSED_IN_PREIMAGE_GEN ORELSE ASM_SIMP_TAC std_ss []) THEN
   ASM_SET_TAC[]);
 
-val CONNECTED_MONOTONE_QUOTIENT_PREIMAGE = store_thm ("CONNECTED_MONOTONE_QUOTIENT_PREIMAGE",
- ``!f:real->real s t.
+Theorem CONNECTED_MONOTONE_QUOTIENT_PREIMAGE :
+   !f:real->real s t.
     f continuous_on s /\ (IMAGE f s = t) /\
    (!u. u SUBSET t
    ==> (open_in (subtopology euclidean s) {x | x IN s /\ f x IN u} <=>
         open_in (subtopology euclidean t) u)) /\
        (!y. y IN t ==> connected {x | x IN s /\ (f x = y)}) /\
-        connected t ==> connected s``,
+        connected t ==> connected s
+Proof
   REPEAT STRIP_TAC THEN SIMP_TAC std_ss [connected, NOT_EXISTS_THM] THEN
   MAP_EVERY X_GEN_TAC [``u:real->bool``, ``v:real->bool``] THEN CCONTR_TAC THEN
   FULL_SIMP_TAC std_ss [] THEN UNDISCH_TAC ``connected(t:real->bool)`` THEN
-  SIMP_TAC std_ss [CONNECTED_OPEN_IN] THEN
+  SIMP_TAC std_ss' [CONNECTED_OPEN_IN] THEN
   MAP_EVERY EXISTS_TAC
   [``IMAGE (f:real->real) (s INTER u)``,
    ``IMAGE (f:real->real) (s INTER v)``] THEN
@@ -9925,7 +9949,8 @@ val CONNECTED_MONOTONE_QUOTIENT_PREIMAGE = store_thm ("CONNECTED_MONOTONE_QUOTIE
   MATCH_MP_TAC(MESON[]
    ``({x | x IN s /\ f x IN IMAGE f u} = u) /\ open_in top u
        ==> open_in top {x | x IN s /\ f x IN IMAGE f u}``) THEN
-  ASM_SIMP_TAC std_ss [OPEN_IN_OPEN_INTER] THEN ASM_SET_TAC[]);
+  ASM_SIMP_TAC std_ss [OPEN_IN_OPEN_INTER] THEN ASM_SET_TAC[]
+QED
 
 val CONNECTED_MONOTONE_QUOTIENT_PREIMAGE_GEN = store_thm ("CONNECTED_MONOTONE_QUOTIENT_PREIMAGE_GEN",
  ``!f:real->real s t c.
@@ -13594,14 +13619,15 @@ val SEPARATE_POINT_CLOSED = store_thm ("SEPARATE_POINT_CLOSED",
   STRIP_TAC THEN EXISTS_TAC ``dist(a:real,b)`` THEN
   METIS_TAC[DIST_POS_LT]);
 
-val SEPARATE_COMPACT_CLOSED = store_thm ("SEPARATE_COMPACT_CLOSED",
- ``!s t:real->bool.
+Theorem SEPARATE_COMPACT_CLOSED :
+   !s t:real->bool.
         compact s /\ closed t /\ (s INTER t = {})
-        ==> ?d. &0 < d /\ !x y. x IN s /\ y IN t ==> d <= dist(x,y)``,
+        ==> ?d. &0 < d /\ !x y. x IN s /\ y IN t ==> d <= dist(x,y)
+Proof
   REPEAT STRIP_TAC THEN
   MP_TAC(ISPECL [``{x - y:real | x IN s /\ y IN t}``, ``0:real``]
                 SEPARATE_POINT_CLOSED) THEN
-  ASM_SIMP_TAC std_ss [COMPACT_CLOSED_DIFFERENCES, GSPECIFICATION, EXISTS_PROD] THEN
+  ASM_SIMP_TAC std_ss' [COMPACT_CLOSED_DIFFERENCES, GSPECIFICATION, EXISTS_PROD] THEN
   REWRITE_TAC[REAL_ARITH ``(0 = x - y) <=> (x = y:real)``] THEN
   KNOW_TAC ``(!(p_1 :real) (p_2 :real).
     p_1 <> p_2 \/ p_1 NOTIN (s :real -> bool) \/
@@ -13610,7 +13636,8 @@ val SEPARATE_COMPACT_CLOSED = store_thm ("SEPARATE_COMPACT_CLOSED",
   DISCH_THEN (X_CHOOSE_TAC ``d:real``) THEN EXISTS_TAC ``d:real`` THEN
   POP_ASSUM MP_TAC THEN SIMP_TAC std_ss [LEFT_IMP_EXISTS_THM] THEN
   REWRITE_TAC [dist] THEN
-  METIS_TAC[REAL_ARITH ``abs(0 - (x - y)) = abs(x - y:real)``]);
+  METIS_TAC[REAL_ARITH ``abs(0 - (x - y)) = abs(x - y:real)``]
+QED
 
 val SEPARATE_CLOSED_COMPACT = store_thm ("SEPARATE_CLOSED_COMPACT",
  ``!s t:real->bool.
@@ -17363,20 +17390,22 @@ val CLOSED_SUBSTANDARD = store_thm ("CLOSED_SUBSTANDARD",
  ``closed {x:real | x = &0}``,
   REWRITE_TAC [GSPEC_EQ, CLOSED_SING]);
 
-val DIM_SUBSTANDARD = store_thm ("DIM_SUBSTANDARD",
-  ``dim {x:real | x = &0} = 0``,
+Theorem DIM_SUBSTANDARD :
+    dim {x:real | x = &0} = 0
+Proof
   REWRITE_TAC [dim, GSPEC_EQ] THEN MATCH_MP_TAC SELECT_UNIQUE THEN
   RW_TAC std_ss [] THEN EQ_TAC THENL
   [ONCE_REWRITE_TAC [MONO_NOT_EQ] THEN RW_TAC std_ss [] THEN
    ASM_CASES_TAC ``~(b SUBSET {0:real})`` THEN
    ASM_REWRITE_TAC [] THEN FULL_SIMP_TAC std_ss [SET_RULE
     ``b SUBSET {0:real} <=> (b = {}) \/ (b = {0})``] THENL
-   [DISJ2_TAC THEN DISJ2_TAC THEN SIMP_TAC std_ss [HAS_SIZE] THEN
+   [DISJ2_TAC THEN DISJ2_TAC THEN SIMP_TAC std_ss' [HAS_SIZE] THEN
     DISJ2_TAC THEN REWRITE_TAC [CARD_EMPTY] THEN METIS_TAC [],
     REWRITE_TAC [INDEPENDENT_SING]], ALL_TAC] THEN
   DISCH_TAC THEN EXISTS_TAC ``{}:real->bool`` THEN
   ASM_SIMP_TAC std_ss [SPAN_EMPTY, SUBSET_REFL, EMPTY_SUBSET, INDEPENDENT_EMPTY] THEN
-  ASM_REWRITE_TAC [HAS_SIZE_0]);
+  ASM_REWRITE_TAC [HAS_SIZE_0]
+QED
 
 (* ------------------------------------------------------------------------- *)
 (* Affine transformations of intervals.                                      *)
@@ -19987,13 +20016,14 @@ val HAUSDIST_SINGS = store_thm ("HAUSDIST_SINGS",
   SIMP_TAC std_ss [IN_SING, UNWIND_FORALL_THM2] THEN
   METIS_TAC[REAL_LE_REFL]);
 
-val HAUSDIST_EQ = store_thm ("HAUSDIST_EQ",
- ``!s t:real->bool s' t':real->bool.
+Theorem HAUSDIST_EQ :
+   !s t:real->bool s' t':real->bool.
         (!b. (!x. x IN s ==> setdist({x},t) <= b) /\
              (!y. y IN t ==> setdist({y},s) <= b) <=>
              (!x. x IN s' ==> setdist({x},t') <= b) /\
              (!y. y IN t' ==> setdist({y},s') <= b))
-        ==> (hausdist(s,t) = hausdist(s',t'))``,
+        ==> (hausdist(s,t) = hausdist(s',t'))
+Proof
   REPEAT STRIP_TAC THEN REWRITE_TAC[hausdist] THEN
   MATCH_MP_TAC(METIS[]
    ``(p <=> p') /\ (s = s')
@@ -20007,13 +20037,14 @@ val HAUSDIST_EQ = store_thm ("HAUSDIST_EQ",
   ASM_REWRITE_TAC[] THEN
   ONCE_REWRITE_TAC [METIS [] ``(a = b) = (~a = ~b:bool)``] THEN
   REWRITE_TAC [DE_MORGAN_THM] THEN
-  SIMP_TAC std_ss [NOT_FORALL_THM, MEMBER_NOT_EMPTY] THEN
+  SIMP_TAC std_ss' [NOT_FORALL_THM, MEMBER_NOT_EMPTY] THEN
   REWRITE_TAC[GSYM DE_MORGAN_THM] THEN AP_TERM_TAC THEN EQ_TAC THEN
   DISCH_THEN(fn th => POP_ASSUM MP_TAC THEN ASSUME_TAC th) THEN
   ASM_REWRITE_TAC[NOT_IN_EMPTY] THEN
   DISCH_THEN(MP_TAC o SPEC ``-(&1):real``) THEN
   SIMP_TAC std_ss [SETDIST_POS_LE, REAL_ARITH ``&0 <= x ==> ~(x <= -(&1:real))``] THEN
-  SET_TAC[]);
+  SET_TAC[]
+QED
 
 val HAUSDIST_TRANSLATION = store_thm ("HAUSDIST_TRANSLATION",
  ``!a s t:real->bool.

--- a/src/topology/topologyScript.sml
+++ b/src/topology/topologyScript.sml
@@ -25,15 +25,6 @@ val DISC_RW_KILL = DISCH_TAC THEN ONCE_ASM_REWRITE_TAC [] THEN
                    POP_ASSUM K_TAC;
 
 (*---------------------------------------------------------------------------*)
-(* Minimal amount of set notation is convenient                              *)
-(*---------------------------------------------------------------------------*)
-
-val COMPL_MEM = prove (
-  ``!P:'a->bool. !x. P x = ~(COMPL P x)``,
-    REPEAT GEN_TAC THEN REWRITE_TAC[COMPL_applied, IN_DEF] THEN
-    BETA_TAC THEN REWRITE_TAC[]);
-
-(*---------------------------------------------------------------------------*)
 (* Characterize an (alpha)topology                                           *)
 (*---------------------------------------------------------------------------*)
 
@@ -365,8 +356,8 @@ Proof
  >> REWRITE_TAC[closed_in, limpt]
  >> ASM_REWRITE_TAC [SUBSET_UNIV, GSYM COMPL_DEF, IN_UNIV]
  >> CONV_TAC(ONCE_DEPTH_CONV NOT_FORALL_CONV)
- >> FREEZE_THEN (fn th => ONCE_REWRITE_TAC[th]) (SPEC “S':'a->bool” COMPL_MEM)
- >> REWRITE_TAC []
+ >> ‘!x. S' x = ~COMPL S' x’ by rw [COMPL_applied, IN_APP]
+ >> ASM_REWRITE_TAC []
  >> SPEC_TAC(“COMPL(S':'a->bool)”,“S':'a->bool”)
  >> GEN_TAC >> REWRITE_TAC [NOT_IMP]
  >> CONV_TAC (ONCE_DEPTH_CONV NOT_EXISTS_CONV)


### PR DESCRIPTION
Hi,

this PR adds a few more theorems to `lebesgueTheory` with the purpose of extending the parameter of `probabilityTheory.expectation_const` from normal reals to all extended reals:
```
   [expectation_const]  Theorem (old)      
      ⊢ ∀p c. prob_space p ⇒ expectation p (λx. Normal c) = Normal c

   [expectation_const]  Theorem (new)
      ⊢ ∀p c. prob_space p ⇒ expectation p (λx. c) = c
```

Besides, I did some cleanup to `topologyTheory` (a local lemma is removed), and `real_topologyTheory`, in which the "lift_disj_eq", "lift_imp_disj"-related compatibility fixes are narrowed down to only 5 affected theorems, rendering `std_ss` unchanged.

In addition, after 9fe1ff9f2635920e0b708b9a2c0949a6ea559c27, the changed definition `topologyTheory.limpt` now can be used to re-define `real_topology.limit_point_of` in the following way:
```
   [limit_point_of_def]  Definition      
      ⊢ ∀x s. x limit_point_of s ⇔ limpt euclidean x s
```
while the previous definition now becomes a theorem. (It remains to convert more definitions in `real_topologyTheory` using those from general topology.)

--Chun