### PR TITLE
Fix Theorem-Proof goal selection in Vim mode

### DIFF
--- a/tools/vim/hol.src
+++ b/tools/vim/hol.src
@@ -237,7 +237,7 @@ nn <silent> <LocalLeader>r :call HOLCall(function("HOLF"),["proofManagerLib.rest
 nn <silent> <LocalLeader>c :call HOLINT()<CR>
 nn <silent> <LocalLeader>t :call HOLSelect('`\\|‘','`\\|’')<CR>
 nn <silent> <LocalLeader>T :call HOLSelect('``\\|“','``\\|”')<CR>
-nn <silent> <LocalLeader>a :call HOLSelect('Triviality\\|Theorem','Proof')<CR>-Vo+
+nn <silent> <LocalLeader>a :call HOLSelect('^Triviality\\|^Theorem','^Proof')<CR>-Vo+
 nn <silent> <LocalLeader>y :call HOLCall(function("HOLF"),["Globals.show_types:=not(!Globals.show_types)"])<CR>
 nn <silent> <LocalLeader>n :call HOLCall(function("HOLF"),["Feedback.set_trace \"PP.avoid_unicode\" (1 - Feedback.current_trace \"PP.avoid_unicode\")"])<CR>
 no <LocalLeader>h h


### PR DESCRIPTION
This is intended to fix an issue when goal terms containing the text `Proof` were not properly selected by `<LocalLeader>a`. In the following example, only the first two lines would be selected:
```
Theorem foo:
  foo /\
  barProof$foo ==>
    baz
Proof
...
```