### PR TITLE
Size combinator eqs

### DIFF
--- a/src/Boolify/src/EncodeScript.sml
+++ b/src/Boolify/src/EncodeScript.sml
@@ -541,9 +541,7 @@ val tree_ind = store_thm
    >> HO_MATCH_MP_TAC tree_induction
    >> RW_TAC std_ss [EVERY_DEF]
    >> Q.PAT_X_ASSUM `!x. Q x` MATCH_MP_TAC
-   >> Induct_on `l`
-   >> RW_TAC std_ss [EVERY_DEF, MEM]
-   >> METIS_TAC []);
+   >> FULL_SIMP_TAC std_ss [EVERY_MEM]);
 
 val (encode_tree_def, _) =
   Defn.tprove

--- a/src/datatype/DataSize.sig
+++ b/src/datatype/DataSize.sig
@@ -2,7 +2,8 @@ signature DataSize =
 sig
   include Abbrev
 
-  val define_size : thm -> TypeBasePure.typeBase
+  val define_size : {induction:thm, recursion:thm}
+                        -> TypeBasePure.typeBase
                         -> {def : thm,
                             const_tyopl : (term * (string*string)) list} option
 

--- a/src/datatype/Datatype.sml
+++ b/src/datatype/Datatype.sml
@@ -300,7 +300,7 @@ fun build_tyinfos db {induction,recursion} =
      val tyinfol = TypeBasePure.gen_datatype_info
                     {ax=recursion, ind=induction, case_defs=case_defs}
  in
-   case define_size recursion db
+   case define_size {induction = induction, recursion = recursion} db
     of NONE => (HOL_MESG "Couldn't define size function"; tyinfol)
      | SOME s => insert_size s tyinfol
     end

--- a/src/num/theories/basicSizeScript.sml
+++ b/src/num/theories/basicSizeScript.sml
@@ -8,7 +8,7 @@ val bool_size_def = new_definition
   ("bool_size_def", ``bool_size (b:bool) = 0``);
 
 val pair_size_def = new_definition
-  ("pair_size_def", ``pair_size f g = \(x,y). f x + g y``);
+  ("pair_size_def", ``pair_size f g (x, y) = 1 + (f x + g y)``);
 
 val one_size_def = new_definition
   ("one_size_def", ``one_size (x:one) = 0``);
@@ -23,7 +23,7 @@ val sum_size_def =
 val option_size_def =
  new_recursive_definition
    {def = ``(option_size f NONE = 0) /\
-            (option_size f (SOME x) = SUC (f x))``,
+            (option_size f (SOME x) = 1 + (f x))``,
     name="option_size_def",
     rec_axiom = optionTheory.option_Axiom};
 


### PR DESCRIPTION
These changes:
  - update pair and option size functions to match DataSize.define_size
  - prove & store a normalisation theorem `_size_eq` for every type with a size definition `_size_def`
  - slightly simplify a proof I was fixing when I tried a more aggressive version which actually changed `_size_def`