### PR TITLE
Add deprecate_real and prefer_real functions to realLib

### DIFF
--- a/src/real/realLib.sml
+++ b/src/real/realLib.sml
@@ -15,6 +15,37 @@ struct
 
   local open transcTheory in end;
 
-  open RealArith realSimps Diff isqrtLib;
+  open HolKernel RealArith realSimps Diff isqrtLib;
+
+  val operators = [("+", realSyntax.plus_tm),
+                   ("-", realSyntax.minus_tm),
+                   ("numeric_negate", realSyntax.negate_tm),
+                   ("*", realSyntax.mult_tm),
+                   ("/", realSyntax.div_tm),
+                   ("<", realSyntax.less_tm),
+                   ("<=", realSyntax.leq_tm),
+                   (">", realSyntax.greater_tm),
+                   (">=", realSyntax.geq_tm),
+                   ("**", realSyntax.exp_tm),
+                   (GrammarSpecials.fromNum_str, realSyntax.real_injection),
+                   (GrammarSpecials.num_injection, realSyntax.real_injection)];
+
+  fun deprecate_real () = let
+    fun doit (s, t) =
+       let val {Name,Thy,...} = dest_thy_const t in
+          Parse.temp_send_to_back_overload s {Name = Name, Thy = Thy}
+       end
+  in
+    List.app doit operators
+  end
+
+  fun prefer_real () = let
+    fun doit (s, t) =
+       let val {Name,Thy,...} = dest_thy_const t in
+          Parse.temp_bring_to_front_overload s {Name = Name, Thy = Thy}
+       end
+  in
+    List.app doit operators
+  end
 
 end


### PR DESCRIPTION
This adds functions similar to those in `intLib.sml` and `numLib.sml` to make the parser give precedence to reals if needed.