### PR TITLE
Enhanced lemmas for `real$sup` (supremum), etc.

### DIFF
--- a/src/integer/selftest.sml
+++ b/src/integer/selftest.sml
@@ -1,4 +1,6 @@
-open HolKernel Portable Parse boolLib intLib testutils
+open HolKernel Portable Parse boolLib;
+
+open intLib testutils;
 
 fun noamb_parse s = trace ("guess overloads", 0) Parse.Term [QUOTE s]
 fun okparse_exnstruct s = s = "Parse" orelse s = "Preterm"
@@ -49,3 +51,29 @@ val _ = List.app (ignore o rma_p) [
       (“((x:num) ** (y:num)):num”, "x ** y"),
       (“x:int / (y + 1)”, "x / (y + 1)")
     ]
+
+
+(* check prefer/deprecate rat *)
+val grammars = (type_grammar(),term_grammar());
+(* val _ = temp_set_grammars grammars *)
+
+val _ = intLib.prefer_int();
+val _ = tprint "Checking parse of 0 < x gives ints when ints are preferred";
+
+val expected1 = intSyntax.mk_less(intSyntax.zero_tm,
+                                  mk_var("x", intSyntax.int_ty))
+val _ = require_msg (check_result (aconv expected1)) term_to_string
+                    (quietly Parse.Term) ‘0 < x’
+
+val _ = intLib.deprecate_int();
+val _ = tprint "Checking parse of 0 < x gives nats when ints deprecated"
+
+val expected2 = numSyntax.mk_less(numSyntax.zero_tm,
+                                  mk_var("x", numSyntax.num))
+
+val _ = require_msg (check_result (aconv expected2)) term_to_string
+                    (quietly Parse.Term) ‘0 < x’
+
+val _ = temp_set_grammars grammars;
+
+val _ = Process.exit Process.success

--- a/src/probability/borelScript.sml
+++ b/src/probability/borelScript.sml
@@ -5342,74 +5342,15 @@ Proof
           THEN PROVE_TAC [REAL_LE_REFL, REAL_LE_TRANS]]
 QED
 
-(* cf. extrealTheory.sup_seq *)
-Theorem sup_sequence :
+Theorem sup_seq' : (* was: sup_sequence *)
     !f l. mono_increasing f ==> ((f --> l) sequentially =
           (sup (IMAGE (\n. Normal (f n)) UNIV) = Normal l))
 Proof
-  RW_TAC std_ss [] THEN EQ_TAC THENL
-  [RW_TAC std_ss [sup_eq] THENL
-   [POP_ASSUM (MP_TAC o ONCE_REWRITE_RULE [GSYM SPECIFICATION]) THEN
-    RW_TAC std_ss [IN_IMAGE,IN_UNIV] THEN RW_TAC std_ss [extreal_le_def] THEN
-    METIS_TAC [mono_increasing_suc,seq_mono_le,ADD1], ALL_TAC] THEN
-   KNOW_TAC ``!n:num. Normal (f n) <= y`` THENL
-   [RW_TAC std_ss [] THEN POP_ASSUM MATCH_MP_TAC THEN
-    ONCE_REWRITE_TAC [GSYM SPECIFICATION] THEN RW_TAC std_ss [IN_IMAGE,IN_UNIV] THEN
-    METIS_TAC [], ALL_TAC] THEN
-   Cases_on `y` THENL
-   [METIS_TAC [le_infty,extreal_not_infty],
-    METIS_TAC [le_infty],
-    METIS_TAC [seq_le_imp_lim_le,extreal_le_def]], ALL_TAC] THEN
-  RW_TAC std_ss [extreal_sup_def] THEN
-  KNOW_TAC ``(\r. IMAGE (\n. Normal ((f:num->real) n)) UNIV (Normal r)) =
-                  IMAGE f UNIV`` THENL
-  [RW_TAC std_ss [EXTENSION,IN_ABS,IN_IMAGE,IN_UNIV] THEN EQ_TAC THENL
-   [RW_TAC std_ss [] THEN POP_ASSUM (MP_TAC o ONCE_REWRITE_RULE [GSYM SPECIFICATION]) THEN
-    RW_TAC std_ss [IN_IMAGE,IN_UNIV], ALL_TAC] THEN
-   RW_TAC std_ss [] THEN ONCE_REWRITE_TAC [GSYM SPECIFICATION] THEN
-   RW_TAC std_ss [IN_UNIV,IN_IMAGE] THEN METIS_TAC [], ALL_TAC] THEN
-  FULL_SIMP_TAC std_ss [] THEN KNOW_TAC ``!n:num. Normal (f n) <= x`` THENL
-  [RW_TAC std_ss [] THEN Q.PAT_X_ASSUM `!y. P` MATCH_MP_TAC THEN
-   ONCE_REWRITE_TAC [GSYM SPECIFICATION] THEN RW_TAC std_ss [IN_UNIV,IN_IMAGE] THEN
-   METIS_TAC [], ALL_TAC] THEN
-  `x <> NegInf` by METIS_TAC [lt_infty,extreal_not_infty,lte_trans] THEN
-  `?z. x = Normal z` by METIS_TAC [extreal_cases] THEN
-  KNOW_TAC ``!n:num. f n <= z:real`` THENL
-  [RW_TAC std_ss [GSYM extreal_le_def] THEN FIRST_X_ASSUM MATCH_MP_TAC THEN
-   ONCE_REWRITE_TAC [GSYM SPECIFICATION] THEN SIMP_TAC std_ss [IN_IMAGE, IN_UNIV] THEN
-   METIS_TAC [], ALL_TAC] THEN
-  RW_TAC std_ss [LIM_SEQUENTIALLY, dist] THEN
-  (MP_TAC o Q.ISPECL [`IMAGE (f:num->real) UNIV`,`e:real/2`]) SUP_EPSILON THEN
-  SIMP_TAC std_ss [REAL_LT_HALF1] THEN
-  KNOW_TAC ``!y x z. IMAGE f UNIV x <=> x IN IMAGE (f:num->real) UNIV`` THENL
-  [RW_TAC std_ss [SPECIFICATION], DISCH_TAC] THEN
-  STRIP_TAC THEN KNOW_TAC ``(?z. !x. x IN IMAGE (f:num->real) UNIV ==> x <= z)`` THENL
-  [Q.EXISTS_TAC `z:real` THEN RW_TAC std_ss [IN_IMAGE,IN_UNIV] THEN
-   METIS_TAC [], DISCH_TAC] THEN
-  KNOW_TAC ``?x. x IN IMAGE (f:num->real) UNIV`` THENL
-  [RW_TAC std_ss [IN_UNIV,IN_IMAGE], ALL_TAC] THEN
-  RW_TAC std_ss [] THEN KNOW_TAC ``?x. x IN IMAGE (f:num->real) UNIV /\
-                                   real$sup (IMAGE f UNIV) <= x + e / 2`` THENL
-  [METIS_TAC [], DISCH_TAC] THEN
-  RW_TAC std_ss [GSYM ABS_BETWEEN, GREATER_EQ] THEN
-  FULL_SIMP_TAC std_ss [IN_IMAGE,IN_UNIV] THEN
-  Q.EXISTS_TAC `x''''` THEN RW_TAC std_ss [REAL_LT_SUB_RADD] THENL
-  [MATCH_MP_TAC REAL_LET_TRANS THEN Q.EXISTS_TAC `f x'''' + e / 2` THEN
-   RW_TAC std_ss [] THEN MATCH_MP_TAC REAL_LET_TRANS THEN
-   Q.EXISTS_TAC `(f:num->real) n + e / 2` THEN reverse CONJ_TAC THENL
-   [METIS_TAC [REAL_LET_ADD2,REAL_LT_HALF2,REAL_LE_REFL], ALL_TAC] THEN
-   RW_TAC std_ss [REAL_LE_RADD] THEN
-   METIS_TAC [mono_increasing_def], ALL_TAC] THEN
-  MATCH_MP_TAC REAL_LET_TRANS THEN Q.EXISTS_TAC `real$sup (IMAGE f UNIV)` THEN
-  RW_TAC std_ss [REAL_LT_ADDR] THEN
-  Q_TAC SUFF_TAC `!y. (\y. y IN IMAGE f UNIV) y ==> y <= real$sup (IMAGE f UNIV)` THENL
-  [METIS_TAC [IN_IMAGE, IN_UNIV], ALL_TAC] THEN
-  SIMP_TAC std_ss [IN_DEF] THEN
-  MATCH_MP_TAC REAL_SUP_UBOUND_LE THEN
-  KNOW_TAC ``!y x z. IMAGE (f:num->bool) UNIV x <=> x IN IMAGE f UNIV`` THENL
-  [RW_TAC std_ss [IN_DEF], DISCH_TAC] THEN
-  RW_TAC std_ss [IN_IMAGE, IN_UNIV] THEN
-  Q.EXISTS_TAC `z'` THEN RW_TAC std_ss []
+    rpt STRIP_TAC
+ >> Suff ‘(f --> l) sequentially <=> (f --> l)’
+ >- (Rewr' \\
+     MATCH_MP_TAC sup_seq >> art [])
+ >> REWRITE_TAC [LIM_SEQUENTIALLY_SEQ]
 QED
 
 Theorem countably_additive_lebesgue :
@@ -5467,7 +5408,7 @@ Proof
      REPEAT STRIP_TAC THEN REWRITE_TAC [extreal_of_num_def, extreal_le_def] THEN
      MATCH_MP_TAC INTEGRAL_COMPONENT_POS THEN
      ASM_SIMP_TAC std_ss [DROP_INDICATOR_POS_LE]) >> DISCH_TAC
- >> ASM_SIMP_TAC std_ss [GSYM sup_sequence, REAL_SUM_IMAGE_COUNT]
+ >> ASM_SIMP_TAC std_ss [GSYM sup_seq', REAL_SUM_IMAGE_COUNT]
  >> Know `!n m. sum (0,m) (\x. integral (line n) (indicator ((f:num->real->bool) x))) =
                 integral (line n) (indicator (BIGUNION {f i | i < m}))`
  THENL (* the rest works fine *)
@@ -5640,7 +5581,7 @@ Proof
   `!n. Normal (integral (line n) (indicator A)) =
   Normal ((\n. integral (line n) (indicator A)) n)` by METIS_TAC [] THEN
   SIMP_TAC std_ss [measure_lebesgue, GSYM IMAGE_DEF] THEN
-  ONCE_ASM_REWRITE_TAC [] THEN MATCH_MP_TAC sup_sequence THEN
+  ONCE_ASM_REWRITE_TAC [] THEN MATCH_MP_TAC sup_seq' THEN
   RW_TAC std_ss [mono_increasing_def] THEN MATCH_MP_TAC INTEGRAL_SUBSET_COMPONENT_LE THEN
   ASM_SIMP_TAC std_ss [LINE_MONO, lebesgueD, DROP_INDICATOR_POS_LE]
 QED

--- a/src/probability/extrealScript.sml
+++ b/src/probability/extrealScript.sml
@@ -24,8 +24,8 @@ val set_ss = std_ss ++ PRED_SET_ss;
 (*              Type Definiton                   *)
 (* ********************************************* *)
 
-val extreal_def = Datatype
-   `extreal = NegInf | PosInf | Normal real`;
+Datatype : extreal = NegInf | PosInf | Normal real
+End
 
 (* INFINITY, the vertical position of UTF8.chr 0x2212 is better than "-" *)
 val _ = Unicode.unicode_version {u = "+" ^ UTF8.chr 0x221E,
@@ -4534,65 +4534,80 @@ val extreal_inf_def = Define
 val _ = overload_on ("sup", Term `extreal_sup`);
 val _ = overload_on ("inf", Term `extreal_inf`);
 
-val le_sup_imp = store_thm
-  ("le_sup_imp", ``!p x. p x ==> x <= sup p``,
+Theorem le_sup_imp :
+    !p x. p x ==> x <= sup p
+Proof
     RW_TAC std_ss [extreal_sup_def, le_infty, le_refl]
  >> FULL_SIMP_TAC std_ss []
- >> Cases_on `x`
- >| [ RW_TAC std_ss [le_infty],
-     `x' < PosInf` by (Cases_on `x'` >> RW_TAC std_ss [lt_infty]) \\
+ >> Cases_on `x` (* 3 subgoals *)
+ >| [ (* goal 1 (of 3) *)
+      RW_TAC std_ss [le_infty],
+      (* goal 2 (of 3) *)
+      rename1 ‘y <> PosInf’ \\
+     `y < PosInf` by (Cases_on `y` >> RW_TAC std_ss [lt_infty]) \\
       METIS_TAC [let_trans, lt_refl],
+      (* goal 3 (of 3) *)
       RW_TAC std_ss [extreal_le_def] \\
       MATCH_MP_TAC REAL_IMP_LE_SUP \\
-      CONJ_TAC >- METIS_TAC [] \\
       reverse CONJ_TAC >- (Q.EXISTS_TAC `r` >> RW_TAC real_ss []) \\
-      Cases_on `x'` >| (* 3 subgoals *)
+      rename1 ‘y <> PosInf’ \\
+      Cases_on `y` >| (* 3 subgoals *)
       [ METIS_TAC [le_infty],
         RW_TAC std_ss [],
-        Q.EXISTS_TAC `r'` \\
+        rename1 ‘Normal z <> PosInf’ \\
+        Q.EXISTS_TAC `z` \\
         RW_TAC std_ss [] \\
-        METIS_TAC [extreal_le_def] ] ]);
+        METIS_TAC [extreal_le_def] ] ]
+QED
 
 val le_sup_imp' = store_thm
   ("le_sup_imp'", ``!p x. x IN p ==> x <= sup p``,
     REWRITE_TAC [IN_APP]
  >> PROVE_TAC [le_sup_imp]);
 
-val sup_le = store_thm
-  ("sup_le", ``!p x. sup p <= x <=> (!y. p y ==> y <= x)``,
+Theorem sup_le :
+    !p x. sup p <= x <=> (!y. p y ==> y <= x)
+Proof
     RW_TAC std_ss [extreal_sup_def, le_infty]
  >- (EQ_TAC >- RW_TAC std_ss [le_infty] >> METIS_TAC [])
  >> FULL_SIMP_TAC std_ss []
- >> Cases_on `x` (* 3 subgoals *)
- >| [ METIS_TAC [le_infty, extreal_not_infty],
-      METIS_TAC [le_infty],
-      Cases_on `x'` >| (* 3 gubgoals *)
-      [ METIS_TAC [le_infty],
-        RW_TAC std_ss [],
-        RW_TAC std_ss [extreal_le_def] \\
-        EQ_TAC
-        >- (RW_TAC std_ss [] \\
-            Cases_on `y` >|
-            [ METIS_TAC [le_infty],
-              METIS_TAC [le_infty,extreal_not_infty],
-              RW_TAC std_ss [extreal_le_def] \\
-              MATCH_MP_TAC REAL_LE_TRANS \\
-              Q.EXISTS_TAC `sup (\r. p (Normal r))` \\
-              RW_TAC std_ss [] \\
-              MATCH_MP_TAC REAL_IMP_LE_SUP \\
-              CONJ_TAC >- METIS_TAC [] \\
-              reverse CONJ_TAC >- (Q.EXISTS_TAC `r''` >> RW_TAC real_ss []) \\
-              Q.EXISTS_TAC `r'` \\
-              RW_TAC std_ss [] \\
-              METIS_TAC [extreal_le_def] ]) \\
-        RW_TAC std_ss [] \\
-        MATCH_MP_TAC REAL_IMP_SUP_LE \\
-        RW_TAC std_ss []
-        >- (Cases_on `x''` >| (* 3 subgoals *)
-            [ RW_TAC std_ss [],
-              METIS_TAC [le_infty, extreal_not_infty],
-              METIS_TAC [] ]) \\
-        METIS_TAC [extreal_le_def] ] ]);
+ >> Cases_on `x`
+ >- METIS_TAC [le_infty, extreal_not_infty]
+ >- METIS_TAC [le_infty]
+ >> rename1 ‘y <> PosInf’
+ >> Cases_on `y`
+ >- METIS_TAC [le_infty]
+ >- RW_TAC std_ss []
+ >> RW_TAC std_ss [extreal_le_def]
+ >> EQ_TAC
+ >- (RW_TAC std_ss [] \\
+     Cases_on `y` >| (* 3 subgoals *)
+     [ (* goal 1 (of 2) *)
+       METIS_TAC [le_infty],
+       (* goal 2 (of 3) *)
+       METIS_TAC [le_infty, extreal_not_infty],
+       (* goal 3 (of 3) *)
+       RW_TAC std_ss [extreal_le_def] \\
+       MATCH_MP_TAC REAL_LE_TRANS \\
+       Q.EXISTS_TAC `sup (\r. p (Normal r))` \\
+       RW_TAC std_ss [] \\
+       MATCH_MP_TAC REAL_IMP_LE_SUP \\
+       rename1 ‘p (Normal z)’ \\
+       reverse CONJ_TAC >- (Q.EXISTS_TAC `z` >> RW_TAC real_ss []) \\
+       rename1 ‘!y. p y ==> y <= Normal u’ \\
+       Q.EXISTS_TAC `u` \\
+       RW_TAC std_ss [] \\
+       METIS_TAC [extreal_le_def] ])
+ >> RW_TAC std_ss []
+ >> MATCH_MP_TAC REAL_IMP_SUP_LE
+ >> reverse (RW_TAC std_ss [])
+ >- METIS_TAC [extreal_le_def]
+ >> rename1 ‘z <> NegInf’
+ >> Cases_on `z`
+ >- RW_TAC std_ss []
+ >- METIS_TAC [le_infty, extreal_not_infty]
+ >> METIS_TAC []
+QED
 
 Theorem sup_le' : (* was: Sup_le_iff *)
     !p x. sup p <= x <=> (!y. y IN p ==> y <= x)
@@ -5164,7 +5179,7 @@ val sup_lt' = store_thm
     RW_TAC std_ss [IN_APP]
  >> REWRITE_TAC [sup_lt]);
 
-val sup_lt_epsilon = store_thm (* cf. SUP_EPSILON *)
+val sup_lt_epsilon = store_thm (* cf. realTheory.SUP_LT_EPSILON *)
   ("sup_lt_epsilon",
   ``!P e. (0 < e) /\ (?x. P x /\ x <> NegInf) /\ (sup P <> PosInf) ==>
           ?x. P x /\ sup P < x + e``,
@@ -7136,6 +7151,14 @@ val max_le2_imp = store_thm
     RW_TAC std_ss [max_le]
  >> RW_TAC std_ss [le_max]);
 
+(* cf. REAL_LT_MAX *)
+Theorem lt_max :
+    !x y z :extreal. x < max y z <=> x < y \/ x < z
+Proof
+    rw [extreal_lt_def]
+ >> METIS_TAC [max_le]
+QED
+
 Theorem max_refl[simp] :
     !x. max x x = x
 Proof
@@ -7573,11 +7596,8 @@ QED
 Theorem CROSS_COUNTABLE_UNIV :
     countable (univ(:num) CROSS univ(:num))
 Proof
-  RW_TAC std_ss [COUNTABLE_ALT]
-  >> `?(f :num -> num # num). BIJ f UNIV (UNIV CROSS UNIV)` by METIS_TAC [NUM_2D_BIJ_INV]
-  >> Q.EXISTS_TAC `f`
-  >> RW_TAC std_ss []
-  >> FULL_SIMP_TAC std_ss [BIJ_DEF, INJ_DEF, SURJ_DEF, CROSS_DEF, IN_UNIV]
+    MATCH_MP_TAC COUNTABLE_CROSS
+ >> REWRITE_TAC [COUNTABLE_NUM]
 QED
 
 (* `open interval` of extreal sets. c.f. `OPEN_interval` / `CLOSE_interval`
@@ -7900,6 +7920,21 @@ Proof
  >> EQ_TAC >> rw []
  >> ‘i = SUC n \/ i <= n’ by rw [] >- rw []
  >> FIRST_X_ASSUM MATCH_MP_TAC >> art []
+QED
+
+Theorem lt_max_fn_seq :
+    !f x y n. x < max_fn_seq f n y <=> ?i. i <= n /\ x < f i y
+Proof
+    NTAC 3 GEN_TAC
+ >> Induct_on ‘n’ >> rw [max_fn_seq_def, lt_max]
+ >> EQ_TAC >> rw []
+ >| [ (* goal 1 (of 3) *)
+      Q.EXISTS_TAC ‘i’ >> rw [],
+      (* goal 2 (of 3) *)
+      Q.EXISTS_TAC ‘SUC n’ >> rw [],
+      (* goal 3 (of 3) *)
+     ‘i = SUC n \/ i <= n’ by rw [] >- rw [] \\
+      DISJ1_TAC >> Q.EXISTS_TAC ‘i’ >> rw [] ]
 QED
 
 Theorem max_fn_seq_mono :

--- a/src/probability/real_borelScript.sml
+++ b/src/probability/real_borelScript.sml
@@ -1877,7 +1877,6 @@ Proof
  >> `b <= y + e <=> b - e <= y` by REAL_ARITH_TAC >> POP_ORW
  >> Q.UNABBREV_TAC `y`
  >> MATCH_MP_TAC REAL_IMP_LE_SUP >> rw []
- >- (Q.EXISTS_TAC `a` >> rw [REAL_LE_REFL])
  >- (Q.EXISTS_TAC `b` >> rw [] \\
      MATCH_MP_TAC REAL_LT_IMP_LE >> art [])
  >> Cases_on `a <= b - e`

--- a/src/probability/real_topologyScript.sml
+++ b/src/probability/real_topologyScript.sml
@@ -5317,6 +5317,12 @@ val LIM_SEQUENTIALLY = store_thm ("LIM_SEQUENTIALLY",
           !e. &0 < e ==> ?N. !n. N <= n ==> dist(s(n),l) < e``,
   REWRITE_TAC[tendsto, EVENTUALLY_SEQUENTIALLY] THEN MESON_TAC[]);
 
+Theorem LIM_SEQUENTIALLY_SEQ :
+    !s l. (s --> l) sequentially <=> (seq$--> s l)
+Proof
+    REWRITE_TAC [LIM_SEQUENTIALLY, seqTheory.SEQ, GREATER_EQ, dist]
+QED
+
 val LIM_EVENTUALLY = store_thm ("LIM_EVENTUALLY",
  ``!net f l. eventually (\x. f x = l) net ==> (f --> l) net``,
   REWRITE_TAC[eventually, LIM] THEN MESON_TAC[DIST_REFL]);

--- a/src/rational/ratLib.sml
+++ b/src/rational/ratLib.sml
@@ -498,7 +498,7 @@ val RAT_BASIC_ARITH_CONV =
 val RAT_BASIC_ARITH_TAC = CONV_TAC RAT_BASIC_ARITH_CONV;
 
 (* generic normalisation *)
-fun mk_rvar s = mk_var(s, rat);
+fun mk_rvar s = mk_var(s, rat_ty);
 val x = mk_rvar "x"
 val y = mk_rvar "y"
 val z = mk_rvar "z"

--- a/src/rational/ratSyntax.sig
+++ b/src/rational/ratSyntax.sig
@@ -3,7 +3,7 @@ sig
   type term = Term.term
   type hol_type = Abbrev.hol_type
 
-  val rat : hol_type
+  val rat_ty : hol_type (* was: rat : hol_type *)
 
   val rat_0_tm    : term
   val rat_1_tm    : term
@@ -39,6 +39,11 @@ sig
   val mk_rat_sub  : term * term -> term
   val mk_rat_mul  : term * term -> term
   val mk_rat_div  : term * term -> term
+
+  val mk_rat_les  : term * term -> term
+  val mk_rat_gre  : term * term -> term
+  val mk_rat_leq  : term * term -> term
+  val mk_rat_geq  : term * term -> term
 
   val dest_rat_nmr        : term -> term
   val dest_rat_dnm        : term -> term

--- a/src/rational/ratSyntax.sml
+++ b/src/rational/ratSyntax.sml
@@ -1,9 +1,17 @@
 structure ratSyntax :> ratSyntax =
 struct
 
-open HolKernel boolLib Parse ratTheory;
+open HolKernel boolLib ratTheory;
 
 val ERR = mk_HOL_ERR "ratSyntax";
+
+(* Fix the grammar used by this file (when it's really needed)
+structure Parse = struct
+  open Parse
+  val (Type,Term) = parse_from_grammars ratTheory.rat_grammars
+end
+ *)
+open Parse;
 
 (*--------------------------------------------------------------------------*
  * constants
@@ -11,13 +19,6 @@ val ERR = mk_HOL_ERR "ratSyntax";
 
 (*val int_ty = intSyntax.int_ty;*)
 val rat_ty = mk_thy_type{Tyop = "rat", Thy="rat", Args = []};
-
-(* old definitions:
-val rat_0_tm = prim_mk_const {Name="rat_0",Thy="rat"};
-val rat_1_tm = prim_mk_const {Name="rat_1",Thy="rat"};
- *)
-val rat_0_tm = “0q”;
-val rat_1_tm = “1q”;
 
 val rat_nmr_tm = prim_mk_const {Name="rat_nmr",Thy="rat"};
 val rat_dnm_tm = prim_mk_const {Name="rat_dnm",Thy="rat"};
@@ -36,6 +37,13 @@ val rat_gre_tm = prim_mk_const {Name="rat_gre",Thy="rat"};
 val rat_leq_tm = prim_mk_const {Name="rat_leq",Thy="rat"};
 val rat_geq_tm = prim_mk_const {Name="rat_geq",Thy="rat"};
 val rat_of_num_tm = prim_mk_const {Name = "rat_of_num", Thy = "rat"}
+
+(* old definitions:
+val rat_0_tm = prim_mk_const {Name="rat_0",Thy="rat"};
+val rat_1_tm = prim_mk_const {Name="rat_1",Thy="rat"};
+ *)
+val rat_0_tm = mk_comb(rat_of_num_tm, numSyntax.term_of_int 0);
+val rat_1_tm = mk_comb(rat_of_num_tm, numSyntax.term_of_int 1);
 
 (*--------------------------------------------------------------------------*
  * constructors

--- a/src/rational/ratSyntax.sml
+++ b/src/rational/ratSyntax.sml
@@ -1,14 +1,7 @@
 structure ratSyntax :> ratSyntax =
 struct
 
-open HolKernel boolLib Parse;
-
-(* interactive mode
-app load ["ratTheory"];
-*)
-
-open ratTheory;
-
+open HolKernel boolLib Parse ratTheory;
 
 val ERR = mk_HOL_ERR "ratSyntax";
 
@@ -17,10 +10,14 @@ val ERR = mk_HOL_ERR "ratSyntax";
  *--------------------------------------------------------------------------*)
 
 (*val int_ty = intSyntax.int_ty;*)
-val rat = mk_thy_type{Tyop = "rat", Thy="rat", Args = []};
+val rat_ty = mk_thy_type{Tyop = "rat", Thy="rat", Args = []};
 
+(* old definitions:
 val rat_0_tm = prim_mk_const {Name="rat_0",Thy="rat"};
 val rat_1_tm = prim_mk_const {Name="rat_1",Thy="rat"};
+ *)
+val rat_0_tm = “0q”;
+val rat_1_tm = “1q”;
 
 val rat_nmr_tm = prim_mk_const {Name="rat_nmr",Thy="rat"};
 val rat_dnm_tm = prim_mk_const {Name="rat_dnm",Thy="rat"};

--- a/src/rational/selftest.sml
+++ b/src/rational/selftest.sml
@@ -1,5 +1,8 @@
-open testutils
-open ratLib ratReduce
+open HolKernel Parse bossLib boolLib;
+
+open ratLib ratReduce;
+
+open testutils;
 
 fun mkt s c (t1, t2) i =
   (s ^ "(" ^ StringCvt.padLeft #"0" 2 (Int.toString i) ^ ")", c, t1, t2)
@@ -34,3 +37,37 @@ val _ = Lib.appi (fn i => fn p => convtest (rac p i)) [
   (“2/3q + 4”,     “14/3q”),
   (“2/3q + -4/6”,  “0q”)
 ]
+
+(* check prefer/deprecate rat *)
+val grammars = (type_grammar(),term_grammar());
+
+val _ = ratLib.prefer_rat();
+val _ = tprint "Checking parse of 0 < x gives rats when rats are preferred";
+val expected1 = ratSyntax.mk_rat_les(ratSyntax.rat_0_tm,
+                                     mk_var("x", ratSyntax.rat_ty));
+
+val _ = require_msg (check_result (aconv expected1)) term_to_string
+                    (quietly Parse.Term) ‘0 < x’
+
+(* val _ = temp_set_grammars grammars *)
+
+val _ = ratLib.deprecate_rat();
+val _ = tprint "Checking parse of 0 < x gives ints when rats deprecated"
+
+val expected2 = intSyntax.mk_less(intSyntax.zero_tm,
+                                  mk_var("x", intSyntax.int_ty))
+val _ = require_msg (check_result (aconv expected2)) term_to_string
+                    (quietly Parse.Term) ‘0 < x’
+
+val _ = intLib.deprecate_int();
+val _ = tprint "Checking parse of 0 < x gives nats when ints deprecated too"
+
+val expected3 = numSyntax.mk_less(numSyntax.zero_tm,
+                                  mk_var("x", numSyntax.num))
+
+val _ = require_msg (check_result (aconv expected3)) term_to_string
+                    (quietly Parse.Term) ‘0 < x’
+
+val _ = temp_set_grammars grammars;
+
+val _ = Process.exit Process.success

--- a/src/real/iterateScript.sml
+++ b/src/real/iterateScript.sml
@@ -914,6 +914,56 @@ val SUP_UNION = store_thm ("SUP_UNION",
   REPEAT STRIP_TAC THEN MATCH_MP_TAC SUP_UNIQUE THEN
   SIMP_TAC real_ss [FORALL_IN_UNION, REAL_MAX_LE] THEN METIS_TAC[SUP, REAL_LE_TRANS]);
 
+Theorem REAL_IMP_SUP_LE' :
+    !p x. (?r. r IN p) /\ (!r. r IN p ==> r <= x) ==> sup p <= x
+Proof
+    REWRITE_TAC [IN_APP, REAL_IMP_SUP_LE]
+QED
+
+Theorem REAL_IMP_LE_SUP' :
+    !p x. (?z. !r. r IN p ==> r <= z) /\ (?r. r IN p /\ x <= r) ==> x <= sup p
+Proof
+    REWRITE_TAC [IN_APP, REAL_IMP_LE_SUP]
+QED
+
+Theorem REAL_LE_SUP_EQ :
+    !p x : real.
+       (?y. y IN p) /\ (?y. !z. z IN p ==> z <= y) ==>
+       (x <= sup p <=> !y. (!z. z IN p ==> z <= y) ==> x <= y)
+Proof
+    REWRITE_TAC [IN_APP, REAL_LE_SUP]
+QED
+
+(* This requires REAL_SUP_LE_EQ + REAL_LE_SUP_EQ *)
+Theorem SUP_MONO :
+    !p q. (?b. !n. p n <= b) /\ (?c. !n. q n <= c) /\
+          (!n:num. p n <= q n) ==> sup (IMAGE p UNIV) <= sup (IMAGE q UNIV)
+Proof
+    rpt STRIP_TAC
+ >> Q.ABBREV_TAC ‘y = sup (IMAGE q UNIV)’
+ >> Q.ABBREV_TAC ‘s = IMAGE p UNIV’
+ >> Know ‘sup s <= y <=> !x. x IN s ==> x <= y’
+ >- (MATCH_MP_TAC REAL_SUP_LE_EQ \\
+     rw [Abbr ‘s’, Once EXTENSION] \\
+     Q.EXISTS_TAC ‘b’ >> rw [] >> art [])
+ >> Rewr'
+ >> rw [Abbr ‘s’, IN_IMAGE]
+ >> rename1 ‘p x <= y’
+ >> Q.UNABBREV_TAC ‘y’
+ >> Q.ABBREV_TAC ‘s = IMAGE q UNIV’
+ >> Know ‘p x <= sup s <=> !y. (!z. z IN s ==> z <= y) ==> p x <= y’
+ >- (MATCH_MP_TAC REAL_LE_SUP_EQ \\
+     rw [Abbr ‘s’, IN_IMAGE] \\
+     Q.EXISTS_TAC ‘c’ >> rw [] >> art [])
+ >> Rewr'
+ >> rw [Abbr ‘s’, IN_IMAGE]
+ (* here it indicates that ‘!n. p n <= q n’ is too strong *)
+ >> MATCH_MP_TAC REAL_LE_TRANS
+ >> Q.EXISTS_TAC ‘q x’ >> art []
+ >> POP_ASSUM MATCH_MP_TAC
+ >> Q.EXISTS_TAC ‘x’ >> rw []
+QED
+
 (* The original definition of "inf" in HOL Light (sets.ml) *)
 val inf_tm = ``@a:real. (!x. x IN s ==> a <= x) /\
                         !b. (!x. x IN s ==> b <= x) ==> b <= a``;


### PR DESCRIPTION
Hi,

there are 3 independent parts of this PR:

1. In `realTheory`, the theorem `REAL_IMP_LE_SUP` has a unnecessary antecedent `?r. p r` which is subsumed by another antecedent `?r. p r /\ x <= r`, thus can be eliminated:
```
   [REAL_IMP_LE_SUP]  Theorem (new version)      
      ⊢ ∀p x. (∃z. ∀r. p r ⇒ r ≤ z) ∧ (∃r. p r ∧ x ≤ r) ⇒ x ≤ sup p
```
This theorem is used several in probability scripts. After the changes the related proofs are slightly shorter.   In addition, more lemmas about `sup` are also added (one in `realTheory`, others in `iterateTheory`).

2. In `borelTheory`, the theorem `sup_sequence` is actually the same thing with `extrealTheory.sup_seq`, except for different definitions of real sequence convergence (`f --> l`). (The one from `real_topologyTheory` is more general.)
```
   [sup_sequence (old name)]  Theorem (borelTheory)     
      ⊢ ∀f l.
          mono_increasing f ⇒
          ((f --> l) sequentially ⇔
           sup (IMAGE (λn. Normal (f n)) 𝕌(:num)) = Normal l)

   [sup_seq]  Theorem (extrealTheory)     
      ⊢ ∀f l.
          mono_increasing f ⇒
          (f ⟶ l ⇔ sup (IMAGE (λn. Normal (f n)) 𝕌(:num)) = Normal l)
```
By proving the following equivalence theorem between the two notions (in `real_topologyTheory`), the long duplicated proof of `sup_sequence` can be eliminated (then the name can be changed to `sup_seq'` indicating it's now a simple corollary of `sup_seq`):
```
   [LIM_SEQUENTIALLY_SEQ]  Theorem (real_topologyTheory)      
      ⊢ ∀s l. (s ⟶ l) sequentially ⇔ seq$--> s l
```

3. Following discussion in previous PR #967, now I have added some regression tests for `prefer` and `deprecate` of rations and integers, following @mn200 's sample code for reals in `src/real/selftests.sml`.   I changed/fixed two term definitions `ratSyntax.sml` (for rationals 0 and 1), to make the related tests pass.

Regards,

Chun Tian