### PR TITLE
HOL Manual: a section for the overall syntax of Definition

### DIFF
--- a/Manual/Description/definitions.stex
+++ b/Manual/Description/definitions.stex
@@ -1,5 +1,63 @@
 \chapter{Advanced Definition Principles}\label{HOLdefinitions}
 
+\section{General-Purpose Definition}
+\label{sec:definition}
+
+\ml{Definition} takes a high-level specification of a \HOL{} function, and attempts to define the
+function in the logic. If this attempt is successful, the specification is derived from the
+definition. The derived specification is returned to the user, and also stored in the current
+theory. \ml{Definition} may be used to define \emph{abbreviations}, \emph{recursive functions},
+and \emph{mutually recursive functions}.
+
+\index{Definition@\ml{Definition}}
+The basic form of a \ml{Definition} is
+\begin{alltt}
+  Definition defname[\textit{attrs}]:
+    \textit{fn-spec}
+  End
+\end{alltt}
+Or
+\begin{alltt}
+  Definition defname[\textit{attrs}]:
+    \textit{fn-spec}
+  Termination
+    \textit{tactic}  
+  End
+\end{alltt}
+\index{Define@\ml{Define}}
+\index{tDefine@\ml{tDefine}}
+\index{xDefine@\ml{xDefine}}
+The latter form maps to a call to \ml{tDefine}; the former to \ml{xDefine} (or \ml{Define}).
+(See their entries of in \REFERENCE{} for more details.)
+The termination argument is only needed when
+defining certain recursive functions. (See Section~\ref{TFL} for more details on the support of
+recursive functions, and mutually recursive functions and the full syntax of the \textit{fn-spec} above.)
+
+\index{special syntactic forms for scripts!Definition@\ml{Definition}}
+Note that this is \emph{not} valid \ML{} syntax.
+Instead, \HOL{} is using lexical pre-processing to transform the above into something more complicated underneath.
+To make this reasonable, there are constraints introduced on the syntax above: all keywords (\ml{Definition},
+\ml{Termination} and \ml{End}) must appear in column $1$ of the input (hard against the left margin in one's input source file).
+
+In both cases, the \ml{defname} is taken to be the name of the theorem stored to disk
+(it does \emph{not} have a suffix such as \ml{_def} appended to it), and is also the name of the local SML binding.
+The attributes given by \textit{attrs} can be any standard attribute (such as \ml{simp}), and/or drawn from \ml{Definition}-specific options:
+
+\begin{itemize}
+\item The attribute \ml{schematic} alllows the definition to be \emph{schematic}.
+  (See Section~\ref{ss:recursionSchemas} for more details.)
+\item The attribute \ml{nocompute} stops the definition from being added to the global compset used by \ml{EVAL}.
+  This is equivalent to \ml{zDefine}.  \index{xDefine@\ml{xDefine}} (See Section~\ref{sec:computeLib} and
+  also the corresponding entry in \REFERENCE{} for more details.)
+\item The attribute \ml{induction=iname} makes the induction theorem that is automatically derived for definitions with interesting termination be called \ml{iname}.
+  If this is omitted, the name chosen will be derived from the \ml{defname} of the definition:
+  if \ml{defname} ends with \ml{_def} or \ml{_DEF}, the induction name will replace this suffix with \ml{_ind} or \ml{_IND} respectively; otherwise the induction name will simply be \ml{defname} with \ml{_ind} appended.
+\end{itemize}
+
+Note that, whether or not the \ml{induction=} attribute is used, the induction theorem is always
+made available as an SML binding under the appropriate name. This means that one does not need to follow one's definition with a call to something like \ml{DB.fetch} or \ml{theorem}
+just to make the induction theorem available at the SML level.
+
 \section{Datatypes}\label{sec:datatype}
 \index{type definitions, in HOL logic@type definitions, in \HOL{} logic!algebraic types}
 \index{Datatype@\ml{Datatype}|(}
@@ -1096,24 +1154,11 @@ This induction theorem follows the recursion structure of the function, and may 
 The definition technology is not always successful in attempting
 to make the specified definition, usually because an automatic
 termination proof fails; in that case, another entrypoint, \ml{Hol\_defn},
-which defers the termination proof to the user, can be used. %
-\index{special syntactic forms for scripts!Definition@\ml{Definition}}%
-Once a termination argument is found, it can be provided as part of the final \ml{Definition} syntax.
+which defers the termination proof to the user, can be used.
+Once a termination argument is found, it can be provided as part of the final \ml{Definition} syntax
+(See Section~\ref{sec:definition} for more details.)
 The technology underlying \ml{Definition} and \ml{Hol\_defn} is explained
-in detail in Slind~\cite{slind-thesis}.
-
-\index{Define@\ml{Define}}
-\index{Definition@\ml{Definition}}
-The basic form of a \ml{Definition} (without a termination argument) is
-\begin{alltt}
-  Definition defname:
-    \textit{fn-spec}
-  End
-\end{alltt}
-Note that this is \emph{not} valid \ML{} syntax.
-Instead, \HOL{} is using lexical pre-processing to transform the above into something more complicated underneath.
-To make this reasonable, there are constraints introduced on the syntax above: both keywords (\ml{Definition} and \ml{End}) must appear in column $1$ of the input (hard against the left margin in one's input source file).
-For example
+in detail in Slind~\cite{slind-thesis}. For example,
 \begin{session}
 \begin{alltt}
 >> Definition last0_def:
@@ -1123,7 +1168,8 @@ For example
    End
 \end{alltt}
 \end{session}
-The \textit{fn-spec} above is quoted syntax representing a
+
+The \textit{fn-spec} in the syntax of \ml{Definition} and \ml{Hol\_defn} is quoted syntax representing a
 conjunction of equations.
 The specified function(s) may be phrased using ML-style pattern-matching.
 The \textit{fn-spec} should conform with the grammar in Table
@@ -1199,7 +1245,7 @@ equations
 from the above ambiguous and incomplete equations. The odd-looking
 variable names are due to the pre-processing steps described above. The
 above result is only an intermediate value: in the final result returned
-by \ml{Define}, the last equation is droppped since it was not
+by \ml{Definition}, the last equation is droppped since it was not
 specified by the original input.
 \begin{hol}
 \begin{verbatim}
@@ -1245,7 +1291,7 @@ If the principal name ends with \ml{\_def} or with \ml{\_DEF}, then the inductio
 
 \subsection{Function definition examples}
  We will give a number of examples that display the range of functions
-that may be defined with \ml{Define}. First, we have a recursive function
+that may be defined with \ml{Definition}. First, we have a recursive function
 that uses ``destructors'' in the recursive call.
 
 \begin{hol}
@@ -1346,7 +1392,7 @@ are defined:
 \end{hol}
 
 Finally, \ml{Definition} may also be used to define non-recursive functions with complex pattern-matching.
-The pattern-matching pre-processing of {Define} can be convenient for this purpose, but can also generate a large number of equations.
+The pattern-matching pre-processing of \ml{Definition} can be convenient for this purpose, but can also generate a large number of equations.
 It may also return theorems that do not look quite like what was originally input.
 For more on this, see the discussion of case expressions (into which the clauses in a \ml{Definition} are converted internally) in Section~\ref{CaseExp}.
 
@@ -1852,6 +1898,7 @@ the termination conditions extracted for the definition are now provable, since 
 \end{session}
 
 \subsection{Recursion schemas}
+\label{ss:recursionSchemas}
 
 In higher order logic, very general patterns of recursion, known as
 \emph{recursion schemas} or sometimes \emph{program schemas}, can be

--- a/help/src-sml/Doc2Tex.sml
+++ b/help/src-sml/Doc2Tex.sml
@@ -181,7 +181,7 @@ val verbose = ref false
 val sections = [#"a", #"b", #"c", #"d", #"e", #"f", #"g", #"h",
                 #"i",       #"k", #"l", #"m", #"n", #"o", #"p",
                 #"q", #"r", #"s", #"t", #"u", #"v", #"w", #"x",
-                            #"a"]; (* last letter is a loopback *)
+                      #"z", #"a"]; (* the last letter is a loopback *)
 
 val current_section = ref 0; (* starting from A *)
 


### PR DESCRIPTION
Hi,

This is a small updates to «HOL Description».   The background (see #963 for more details) is that I was unable to find the corresponding "modern" syntax of `zDefine` by searching in that manual.    When the new syntax is introduced, old ML functions are all removed from the manual, but these functions are still in many core theory or other old user code, causing potential difficulties.

Furthermore, in «HOL Description», the introduction of the `Definition` facility and its syntax is current under the section "Recursive Functions", but more often a `Definition` is just used to define abbreviations.   So I think maybe it's better to move some contents to the beginning of chapter 6 (Advanced Definition Principles) as a new initial section, putting also some related contents from K13 release notes into it, to give a overall description of `Definition` and its possible attributes.

In the updated manual, I try to briefly mention all the `Define`-siblings (`xDefine`, `zDefine` and `tDefine`) so that by searching the manual code readers may find a link from the old API to the new syntax sugar. Cross-references are added as much as possible.

Also, the PDF bookmarks in «HOL Reference» should have the letter Z (for `zDefine`).

Regards,

Chun Tian