### PR TITLE
Update WF_REL_TAC to use size_eq, MEM_SPLIT etc

### DIFF
--- a/examples/formal-languages/context-free/NTpropertiesScript.sml
+++ b/examples/formal-languages/context-free/NTpropertiesScript.sml
@@ -144,8 +144,7 @@ Definition ptree_NTs_def:
   (ptree_NTs (Lf (l,_)) = case l of NT N => {N} | _ => ∅) ∧
   (ptree_NTs (Nd (n,_) subs) = n INSERT BIGUNION (IMAGE ptree_NTs (set subs)))
 Termination
-  WF_REL_TAC `measure ptree_size` >> Induct_on `subs` >> simp[] >> fs[] >>
-  rpt strip_tac >> res_tac >> asimp[]
+  WF_REL_TAC `measure (parsetree_size (K 0) (K 0) (K 0))`
 End
 
 Definition ptree_rptfree_def:
@@ -153,8 +152,7 @@ Definition ptree_rptfree_def:
   ptree_rptfree (Nd (N,_) subs) =
     ∀s. MEM s subs ⇒ ptree_rptfree s ∧ N ∉ ptree_NTs s
 Termination
-  WF_REL_TAC `measure ptree_size` >> Induct_on `subs` >> simp[] >> fs[] >>
-  rpt strip_tac >> res_tac >> asimp[]
+  WF_REL_TAC `measure (parsetree_size (K 0) (K 0) (K 0))`
 End
 
 Theorem nullableML_by_singletons:

--- a/examples/formal-languages/context-free/grammarScript.sml
+++ b/examples/formal-languages/context-free/grammarScript.sml
@@ -45,25 +45,12 @@ Definition ptree_list_loc_def:
   ptree_list_loc l = merge_list_locs (MAP ptree_loc l)
 End
 
-
-Definition ptree_size_def:
-  (ptree_size (Lf _) = 1) ∧
-  (ptree_size (Nd nt children) = 1 + SUM (MAP ptree_size children))
-Termination
-   WF_REL_TAC `measure (parsetree_size (K 1) (K 1) (K 1))` >>
-   Induct_on `children` >>
-   rw[definition "parsetree_size_def"] >- decide_tac >>
-   res_tac >> pop_assum (qspecl_then [`p_2`, `p_1`] mp_tac) >>
-   simp_tac (srw_ss()) [] >> decide_tac
-End
-
-Theorem ptree_size_def[simp,compute] =
-   CONV_RULE (DEPTH_CONV ETA_CONV) ptree_size_def;
-
 Definition ptree_head_def[simp]:
   (ptree_head (Lf (tok,l)) = tok) ∧
   (ptree_head (Nd (nt,l) children) = NT nt)
 End
+
+Overload ptree_size[local] = ``parsetree_size (K 0) (K 0) (K 0)``;
 
 Definition valid_ptree_def[simp,nocompute]:
   (valid_ptree G (Lf _) ⇔ T) ∧
@@ -71,19 +58,14 @@ Definition valid_ptree_def[simp,nocompute]:
     nt ∈ FDOM G.rules ∧ MAP ptree_head children ∈ G.rules ' nt ∧
     ∀pt. pt ∈ set children ⇒ valid_ptree G pt)
 Termination
-   WF_REL_TAC `measure (ptree_size o SND)` THEN
-   Induct_on `children` THEN SRW_TAC [][] THEN1 DECIDE_TAC THEN
-   RES_TAC THEN FULL_SIMP_TAC (srw_ss() ++ ARITH_ss) []
+   WF_REL_TAC `measure (ptree_size o SND)`
 End
 
 Definition ptree_fringe_def:
   (ptree_fringe (Lf (t,_)) = [t]) ∧
   (ptree_fringe (Nd _ children) = FLAT (MAP ptree_fringe children))
 Termination
-   WF_REL_TAC `measure ptree_size` THEN Induct_on `children` THEN
-   SRW_TAC [][ptree_size_def] THEN1 DECIDE_TAC THEN
-   FULL_SIMP_TAC (srw_ss() ++ ETA_ss) [ptree_size_def] THEN
-   RES_TAC THEN DECIDE_TAC
+   WF_REL_TAC `measure ptree_size`
 End
 
 Theorem ptree_fringe_def[simp,compute] =
@@ -101,8 +83,8 @@ Type lfptree = “:(α,β,one) parsetree”
 Definition real_fringe_def[simp]:
   (real_fringe (Lf t) = [t]) ∧
   (real_fringe (Nd n ptl) = FLAT (MAP real_fringe ptl))
-Termination WF_REL_TAC `measure ptree_size` >> Induct_on `ptl` >> dsimp[] >>
-            fs[] >> rpt strip_tac >> res_tac >> simp[]
+Termination
+  WF_REL_TAC `measure ptree_size`
 End
 
 Theorem MAP_TKI_11[simp]:
@@ -137,8 +119,7 @@ Definition valid_locs_def[simp]:
      l = merge_list_locs (MAP ptree_loc children) ∧
      ∀pt. MEM pt children ⇒ valid_locs pt)
 Termination
-  (WF_REL_TAC ‘measure ptree_size’ >> simp[] >> Induct >> dsimp[] >>
-   rpt strip_tac >> res_tac >> simp[])
+  WF_REL_TAC ‘measure ptree_size’
 End
 
 Definition valid_lptree_def:

--- a/examples/formal-languages/context-free/pegLib.sml
+++ b/examples/formal-languages/context-free/pegLib.sml
@@ -11,7 +11,8 @@ fun add_peg_compset cs =
     ,grammarTheory.ptree_fringe_def
     ,grammarTheory.complete_ptree_def
     ,grammarTheory.ptree_head_def
-    ,grammarTheory.ptree_size_def
+    ,grammarTheory.parsetree_size_def
+    ,combinTheory.K_THM
     ,pegTheory.subexprs_def
     ,pegTheory.wfG_def
     ,pegTheory.Gexprs_def

--- a/examples/formal-languages/context-free/selftest.sml
+++ b/examples/formal-languages/context-free/selftest.sml
@@ -95,10 +95,6 @@ val _ = app failtest [
 
 val _ = app tpp ["⟪2; 3⟫", "⟪ ⟫", "⟪SX_SYM \"foo\"⟫", "⟪ ⟪3 • 4⟫; ⟪3; 4⟫ ⟫"]
 
-val _ = tprint "Can EVAL ptree_size"
-val _ = require_msg (check_result (aconv “1n” o rhs o concl))
-                    (term_to_string o rhs o concl)
-                    EVAL “ptree_size (Lf x)”
 local
   val t = “TOK 1n”
   val _ = tprint "Can EVAL ptree_fringe"

--- a/examples/machine-code/lisp/lisp_proofScript.sml
+++ b/examples/machine-code/lisp/lisp_proofScript.sml
@@ -31,24 +31,7 @@ val x2sexp_def = tDefine "x2sexp" `
   (x2sexp (T,App f xs,yy) = list2sexp (x2sexp (F,Var "nil",f) :: MAP (\x. x2sexp (T,x,FunVar "nil")) xs)) /\
   (x2sexp (T,Ite cs,yy) = list2sexp (Sym "cond" :: MAP (\ (t1,t2).
        list2sexp [x2sexp (T,t1,FunVar "nil"); x2sexp (T,t2,FunVar "nil")]) cs))`
- (WF_REL_TAC `measure (\(x,y,z). if x then term_size y else func_size z)`
-  THEN REWRITE_TAC [CONJ_ASSOC]
-  THEN REVERSE STRIP_TAC THEN1 (REPEAT STRIP_TAC THEN DECIDE_TAC)
-  THEN REVERSE STRIP_TAC THEN1 (REPEAT STRIP_TAC THEN DECIDE_TAC)
-  THEN REVERSE STRIP_TAC THEN1 (REPEAT STRIP_TAC THEN DECIDE_TAC)
-  THEN REWRITE_TAC [GSYM CONJ_ASSOC]
-  THEN STRIP_TAC THEN1
-   (STRIP_TAC THEN Induct
-    THEN REWRITE_TAC [MEM,term_size_def] THEN REPEAT STRIP_TAC
-    THEN ASM_REWRITE_TAC [] THEN RES_TAC THEN DECIDE_TAC)
-  THEN STRIP_TAC THEN1
-   (Induct THEN (Cases ORELSE ALL_TAC)
-    THEN SIMP_TAC std_ss [MEM,term_size_def] THEN REPEAT STRIP_TAC
-    THEN ASM_REWRITE_TAC [] THEN RES_TAC THEN DECIDE_TAC)
-  THEN
-   (Induct THEN (Cases ORELSE ALL_TAC)
-    THEN SIMP_TAC std_ss [MEM,term_size_def] THEN REPEAT STRIP_TAC
-    THEN ASM_REWRITE_TAC [] THEN RES_TAC THEN DECIDE_TAC))
+ (WF_REL_TAC `measure (\(x,y,z). if x then term_size y else func_size z)`);
 
 val x2sexp = x2sexp_def |> CONJUNCTS |> map SPEC_ALL |> LIST_CONJ
 

--- a/examples/theorem-prover/lisp-runtime/bytecode/lisp_compilerScript.sml
+++ b/examples/theorem-prover/lisp-runtime/bytecode/lisp_compilerScript.sml
@@ -2868,20 +2868,7 @@ val term2sexp_def = tDefine "term2sexp" `
   (term2sexp (Fourth x) = list2sexp [Sym "FOURTH"; term2sexp x]) /\
   (term2sexp (Fifth x) = list2sexp [Sym "FIFTH"; term2sexp x]) /\
   (term2sexp (Defun fname ps s) = list2sexp [Sym "DEFUN"; Sym fname; list2sexp (MAP Sym ps); s])`
- (WF_REL_TAC `measure (term_size)` \\ SRW_TAC [] []
-  THEN1 (Induct_on `vs` \\ SRW_TAC [] [MEM,term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 DECIDE_TAC
-  THEN1 DECIDE_TAC
-  THEN1 (Induct_on `qs` \\ NTAC 2 (SRW_TAC [] [MEM,term_size_def]) \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 (Induct_on `qs` \\ NTAC 2 (SRW_TAC [] [MEM,term_size_def]) \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 DECIDE_TAC
-  THEN1 (Induct_on `ts` \\ SRW_TAC [] [MEM,term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 (Induct_on `ts` \\ SRW_TAC [] [MEM,term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 (Induct_on `ts` \\ SRW_TAC [] [MEM,term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 (Induct_on `ys` \\ SRW_TAC [] [MEM,term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 (Induct_on `zs` \\ NTAC 2 (SRW_TAC [] [MEM,term_size_def]) \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 (Induct_on `zs` \\ NTAC 2 (SRW_TAC [] [MEM,term_size_def]) \\ RES_TAC \\ DECIDE_TAC)
-  \\ DECIDE_TAC);
+ (WF_REL_TAC `measure (term_size)`);
 
 val fun_name_ok_def = Define `
   (fun_name_ok (Fun f) = ~MEM f reserved_names) /\
@@ -2905,20 +2892,7 @@ val no_bad_names_def = tDefine "no_bad_names" `
   (no_bad_names (Fourth x) = no_bad_names x) /\
   (no_bad_names (Fifth x) = no_bad_names x) /\
   (no_bad_names (Defun fname ps s) = T)`
- (WF_REL_TAC `measure (term_size)` \\ SRW_TAC [] []
-  THEN1 (Induct_on `vs` \\ SRW_TAC [] [MEM,term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 DECIDE_TAC
-  THEN1 DECIDE_TAC
-  THEN1 (Induct_on `qs` \\ NTAC 2 (SRW_TAC [] [MEM,term_size_def]) \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 (Induct_on `qs` \\ NTAC 2 (SRW_TAC [] [MEM,term_size_def]) \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 DECIDE_TAC
-  THEN1 (Induct_on `ts` \\ SRW_TAC [] [MEM,term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 (Induct_on `ts` \\ SRW_TAC [] [MEM,term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 (Induct_on `ts` \\ SRW_TAC [] [MEM,term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 (Induct_on `ys` \\ SRW_TAC [] [MEM,term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 (Induct_on `zs` \\ NTAC 2 (SRW_TAC [] [MEM,term_size_def]) \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 (Induct_on `zs` \\ NTAC 2 (SRW_TAC [] [MEM,term_size_def]) \\ RES_TAC \\ DECIDE_TAC)
-  \\ DECIDE_TAC);
+ (WF_REL_TAC `measure (term_size)`);
 
 val sexp2list_list2sexp = prove(
   ``!x. sexp2list (list2sexp x) = x``,

--- a/examples/theorem-prover/milawa-prover/milawa_execScript.sml
+++ b/examples/theorem-prover/milawa-prover/milawa_execScript.sml
@@ -739,9 +739,7 @@ val t2sexp_def = tDefine "t2sexp" `
   (t2sexp (mVar v) = Sym v) /\
   (t2sexp (mApp fc vs) = list2sexp (logic_func2sexp fc :: MAP t2sexp vs)) /\
   (t2sexp (mLamApp xs z ys) = list2sexp (list2sexp [Sym "LAMBDA"; list2sexp (MAP Sym xs); t2sexp z]::MAP t2sexp ys))`
- (WF_REL_TAC `measure (logic_term_size)` \\ SRW_TAC [] [] \\ REPEAT DECIDE_TAC
-  THEN1 (Induct_on `vs` \\ SRW_TAC [] [MEM,logic_term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 (Induct_on `ys` \\ SRW_TAC [] [MEM,logic_term_size_def] \\ RES_TAC \\ DECIDE_TAC));
+ (WF_REL_TAC `measure (logic_term_size)`);
 
 val f2sexp_def = Define `
   (f2sexp (Or x y) = list2sexp [Sym "POR*"; f2sexp x; f2sexp y]) /\

--- a/examples/theorem-prover/milawa-prover/milawa_logicScript.sml
+++ b/examples/theorem-prover/milawa-prover/milawa_logicScript.sml
@@ -69,10 +69,7 @@ val free_vars_def = tDefine "free_vars" `
   (free_vars (mVar v) = [v]) /\
   (free_vars (mApp fc vs) = FLAT (MAP free_vars vs)) /\
   (free_vars (mLamApp xs z ys) = FLAT (MAP free_vars ys))`
- (WF_REL_TAC `measure logic_term_size` \\ SRW_TAC [] []
-  THEN1 (Induct_on `vs` \\ SRW_TAC [] [MEM,logic_term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 (Induct_on `ys` \\ SRW_TAC [] [MEM,logic_term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  \\ DECIDE_TAC);
+ (WF_REL_TAC `measure logic_term_size`);
 
 val primitive_arity_def = Define `
   (primitive_arity logic_CONSP = 1) /\
@@ -109,10 +106,7 @@ val term_ok_def = tDefine "term_ok" `
   (term_ok ctxt (mLamApp xs y zs) =
      (LIST_TO_SET (free_vars y) SUBSET LIST_TO_SET xs) /\ ALL_DISTINCT xs /\
      EVERY (term_ok ctxt) zs /\ term_ok ctxt y /\ (LENGTH xs = LENGTH zs))`
- (WF_REL_TAC `measure (logic_term_size o SND)` \\ SRW_TAC [] [] THEN1 DECIDE_TAC
-  THEN1 (Induct_on `vs` \\ SRW_TAC [] [MEM,logic_term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 (Induct_on `zs` \\ SRW_TAC [] [MEM,logic_term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  \\ DECIDE_TAC);
+ (WF_REL_TAC `measure (logic_term_size o SND)`);
 
 val formula_ok_def = Define `
   (formula_ok ctxt (Not x) = formula_ok ctxt x) /\
@@ -464,10 +458,7 @@ val term_sub_def = tDefine "term_sub" `
   (term_sub ss (mVar v) = LOOKUP v ss (mVar v)) /\
   (term_sub ss (mApp fc vs) = mApp fc (MAP (term_sub ss) vs)) /\
   (term_sub ss (mLamApp xs z ys) = mLamApp xs z (MAP (term_sub ss) ys))`
- (WF_REL_TAC `measure (logic_term_size o SND)` \\ SRW_TAC [] []
-  THEN1 (Induct_on `vs` \\ SRW_TAC [] [MEM,logic_term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 (Induct_on `ys` \\ SRW_TAC [] [MEM,logic_term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  \\ DECIDE_TAC);
+ (WF_REL_TAC `measure (logic_term_size o SND)`);
 
 val formula_sub_def = Define `
   (formula_sub ss (Not x) = Not (formula_sub ss x)) /\

--- a/examples/theorem-prover/milawa-prover/milawa_proofpScript.sml
+++ b/examples/theorem-prover/milawa-prover/milawa_proofpScript.sml
@@ -280,10 +280,7 @@ val term_syntax_ok_def = tDefine "term_syntax_ok" `
      (LIST_TO_SET (free_vars y) SUBSET LIST_TO_SET xs) /\ ALL_DISTINCT xs /\
      EVERY var_ok xs /\
      EVERY (term_syntax_ok) zs /\ term_syntax_ok y /\ (LENGTH xs = LENGTH zs))`
- (WF_REL_TAC `measure (logic_term_size)` \\ SRW_TAC [] [] THEN1 DECIDE_TAC
-  THEN1 (Induct_on `vs` \\ SRW_TAC [] [MEM,logic_term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 (Induct_on `zs` \\ SRW_TAC [] [MEM,logic_term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  \\ DECIDE_TAC);
+ (WF_REL_TAC `measure (logic_term_size)`);
 
 val formula_syntax_ok_def = Define `
   (formula_syntax_ok (Not x) = formula_syntax_ok x) /\
@@ -313,10 +310,7 @@ val term_vars_ok_def = tDefine "term_vars_ok" `
   (term_vars_ok (mApp fc vs) = ~(fc = mFun "QUOTE") /\ EVERY (term_vars_ok) vs) /\
   (term_vars_ok (mLamApp xs y zs) =
      EVERY (term_vars_ok) zs /\ term_vars_ok y)`
- (WF_REL_TAC `measure (logic_term_size)` \\ SRW_TAC [] [] THEN1 DECIDE_TAC
-  THEN1 (Induct_on `vs` \\ SRW_TAC [] [MEM,logic_term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  THEN1 (Induct_on `zs` \\ SRW_TAC [] [MEM,logic_term_size_def] \\ RES_TAC \\ DECIDE_TAC)
-  \\ DECIDE_TAC);
+ (WF_REL_TAC `measure (logic_term_size)`);
 
 val logic_flag_term_vars_TERM = prove(
   ``logic_flag_term_vars (Sym "LIST") (Dot (t2sexp l) (Sym "NIL")) acc =

--- a/src/Boolify/src/EncodeScript.sml
+++ b/src/Boolify/src/EncodeScript.sml
@@ -548,10 +548,7 @@ val (encode_tree_def, _) =
   (Defn.Hol_defn "encode_tree"
    `encode_tree e (Node a ts) = APPEND (e a) (encode_list (encode_tree e) ts)`,
    TotalDefn.WF_REL_TAC `measure (tree_size (K 0) o SND)` >>
-   (Induct_on `ts` >>
-    RW_TAC list_ss [tree_size_def, K_THM]) >- DECIDE_TAC >>
-   RES_THEN (MP_TAC o SPEC_ALL) >>
-   SIMP_TAC arith_ss [K_THM]);
+   rw [] >> size_comb_tac >> simp []);
 
 val encode_tree_def =
   save_thm ("encode_tree_def", CONV_RULE (DEPTH_CONV ETA_CONV) encode_tree_def);
@@ -561,11 +558,7 @@ val (lift_tree_def, _) =
   (Defn.Hol_defn "lift_tree"
    `lift_tree p (Node a ts) <=> p a /\ EVERY (lift_tree p) ts`,
    TotalDefn.WF_REL_TAC `measure (tree_size (K 0) o SND)` >>
-   RW_TAC list_ss [tree_size_def, K_THM] >>
-   (Induct_on `ts` >>
-    RW_TAC list_ss [tree_size_def, K_THM]) >- DECIDE_TAC >>
-   RES_THEN (MP_TAC o SPEC_ALL) >>
-   SIMP_TAC arith_ss [K_THM]);
+   rw_tac bool_ss [] >> size_comb_tac >> simp []);
 
 val lift_tree_def =
   save_thm ("lift_tree_def", CONV_RULE (DEPTH_CONV ETA_CONV) lift_tree_def);

--- a/src/boss/bossLib.sig
+++ b/src/boss/bossLib.sig
@@ -167,6 +167,9 @@ sig
   (* name cases of an induction theorem *)
   val name_ind_cases : term list -> thm -> thm
 
+  (* convert aux size operators to combinators and use append rules *)
+  val size_comb_tac : tactic
+
   (* more simplification variants *)
   val fsrw_tac : simpLib.ssfrag list -> thm list -> tactic
   val simp : thm list -> tactic

--- a/src/boss/bossLib.sml
+++ b/src/boss/bossLib.sml
@@ -222,6 +222,16 @@ fun name_ind_cases nm_tms thm = let
 end
 
 (* ----------------------------------------------------------------------
+    useful for proving termination in rose-tree settings
+   ---------------------------------------------------------------------- *)
+
+val size_comb_tac =
+  full_simp_tac boolSimps.bool_ss [listTheory.MEM_SPLIT]
+  THEN CONV_TAC TotalDefn.size_eq_conv
+  THEN simp_tac boolSimps.bool_ss
+    [listTheory.list_size_append, listTheory.list_size_def]
+
+(* ----------------------------------------------------------------------
     convenient simplification aliases
    ---------------------------------------------------------------------- *)
 

--- a/src/boss/bossLib.sml
+++ b/src/boss/bossLib.sml
@@ -222,7 +222,7 @@ fun name_ind_cases nm_tms thm = let
 end
 
 (* ----------------------------------------------------------------------
-    useful for proving termination in rose-tree settings
+    useful for proving termination in fold and rose-tree settings
    ---------------------------------------------------------------------- *)
 
 val size_comb_tac =
@@ -230,6 +230,10 @@ val size_comb_tac =
   THEN CONV_TAC TotalDefn.size_eq_conv
   THEN simp_tac boolSimps.bool_ss
     [listTheory.list_size_append, listTheory.list_size_def]
+
+val _ = let
+  val sref = TotalDefn.termination_solve_simps
+in sref := ([listTheory.MEM_SPLIT, listTheory.list_size_append] @ ! sref) end
 
 (* ----------------------------------------------------------------------
     convenient simplification aliases

--- a/src/coalgebras/ltreeScript.sml
+++ b/src/coalgebras/ltreeScript.sml
@@ -689,11 +689,6 @@ Definition from_rose_def:
   from_rose (Rose a ts) = Branch a (fromList (MAP from_rose ts))
 Termination
   WF_REL_TAC `measure (rose_tree_size (K 0))` \\ rw []
-  \\ qsuff_tac
-       `!a ts. MEM a ts ==> rose_tree_size (K 0) a <= rose_tree1_size (K 0) ts`
-  THEN1 (rw [] \\ res_tac \\ fs []) \\ rpt (pop_assum kall_tac)
-  \\ Induct_on `ts` \\ fs [] \\ rw [] \\ res_tac
-  \\ fs [fetch "-" "rose_tree_size_def"]
 End
 
 Theorem rose_tree_induction = from_rose_ind;

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -1325,6 +1325,10 @@ Induct
      THEN REWRITE_TAC [MEM] THEN REPEAT STRIP_TAC
      THEN FIRST_ASSUM MATCH_MP_TAC THEN ASM_REWRITE_TAC[]]);
 
+val list_size_append = Q.store_thm("list_size_append",
+  `!f xs ys. list_size f (xs ++ ys) = list_size f xs + list_size f ys`,
+  GEN_TAC \\ Induct \\ FULL_SIMP_TAC arith_ss [APPEND, list_size_def]);
+
 val FOLDR_CONG = store_thm("FOLDR_CONG",
 Term
   ‘!l l' b b' (f:'a->'b->'b) f'.

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -1325,9 +1325,11 @@ Induct
      THEN REWRITE_TAC [MEM] THEN REPEAT STRIP_TAC
      THEN FIRST_ASSUM MATCH_MP_TAC THEN ASM_REWRITE_TAC[]]);
 
-val list_size_append = Q.store_thm("list_size_append",
-  `!f xs ys. list_size f (xs ++ ys) = list_size f xs + list_size f ys`,
-  GEN_TAC \\ Induct \\ FULL_SIMP_TAC arith_ss [APPEND, list_size_def]);
+Theorem list_size_append:
+  !f xs ys. list_size f (xs ++ ys) = list_size f xs + list_size f ys
+Proof
+  GEN_TAC \\ Induct \\ FULL_SIMP_TAC arith_ss [APPEND, list_size_def]
+QED
 
 val FOLDR_CONG = store_thm("FOLDR_CONG",
 Term

--- a/src/num/termination/TotalDefn.sig
+++ b/src/num/termination/TotalDefn.sig
@@ -14,11 +14,13 @@ sig
 
    val WF_thms : thm list ref
    val termination_simps : thm list ref
+   val termination_solve_simps : thm list ref
+
 
    val PRIM_WF_TAC        : thm list -> tactic
    val PRIM_TC_SIMP_CONV  : thm list -> conv
-   val PRIM_TC_SIMP_TAC   : thm list -> tactic
-   val PRIM_WF_REL_TAC    : term quotation -> thm list -> thm list -> tactic
+   val PRIM_TC_SIMP_TAC   : thm list -> thm list -> tactic
+   val PRIM_WF_REL_TAC    : term quotation -> thm list -> thm list -> thm list -> tactic
 
    val size_eq_conv : conv
    val WF_TAC       : tactic

--- a/src/num/termination/TotalDefn.sig
+++ b/src/num/termination/TotalDefn.sig
@@ -20,6 +20,7 @@ sig
    val PRIM_TC_SIMP_TAC   : thm list -> tactic
    val PRIM_WF_REL_TAC    : term quotation -> thm list -> thm list -> tactic
 
+   val size_eq_conv : conv
    val WF_TAC       : tactic
    val TC_SIMP_CONV : conv
    val TC_SIMP_TAC  : tactic

--- a/src/num/termination/TotalDefn.sml
+++ b/src/num/termination/TotalDefn.sml
@@ -507,6 +507,20 @@ fun PRIM_WF_REL_TAC q WFthms simps g =
 fun WF_REL_TAC q = Q.EXISTS_TAC q THEN STD_TERM_TAC;
 
 
+(*---------------------------------------------------------------------------*)
+(* Apply _size_eq theorems.                                                  *)
+(*---------------------------------------------------------------------------*)
+
+fun size_eq_conv tm = let
+    val tys = tm |> find_terms is_const |> map type_of
+      |> map (fst o strip_fun) |> List.concat
+      |> HOLset.fromList Type.compare |> HOLset.listItems
+    val size_eqs = mapfilter TypeBase.size_of tys
+      |> map fst |> mapfilter dest_thy_const
+      |> mapfilter (fn xs => fetch (#Thy xs) (#Name xs ^ "_eq"))
+  in simpLib.SIMP_CONV boolSimps.bool_ss size_eqs tm end
+
+
 (*---------------------------------------------------------------------------
        Definition principles that automatically attempt
        to prove termination. If the termination proof


### PR DESCRIPTION
Have WF_REL_TAC be able to clean up termination conjuncts as
well as the whole goal, and also make use of size_eqs, and
also have an extra (configurable) set of rewrites used only
if they remove a conjunct, which by default includes
MEM_SPLIT and list_size_append.

This allows a number of custom termination proofs to be reduced to
the relevant `WF_REL_TAC`. There's only a little breakage, for some
reason mostly in lisp-related examples. I've checked most CakeML
definitions are not affected.