### PR TITLE
Move two common HOL-Light lemmas (LT and LT_LE) to arithmeticTheory

### DIFF
--- a/src/num/theories/arithmeticScript.sml
+++ b/src/num/theories/arithmeticScript.sml
@@ -517,6 +517,22 @@ val LESS_EQ_0 = store_thm ("LESS_EQ_0",
   “!n. (n <= 0) = (n = 0)”,
   REWRITE_TAC [LESS_OR_EQ, NOT_LESS_0]) ;
 
+(*---------------------------------------------------------------------------
+ *  HOL Light compatibility
+ *---------------------------------------------------------------------------*)
+
+Theorem LT :
+    (!m:num. m < 0 <=> F) /\ (!m n. m < SUC n <=> (m = n) \/ m < n)
+Proof
+    METIS_TAC [LESS_THM, NOT_LESS_0]
+QED
+
+Theorem LT_LE :
+    !m n:num. m < n <=> m <= n /\ ~(m = n)
+Proof
+    METIS_TAC [LESS_NOT_EQ, LESS_OR_EQ]
+QED
+
 val _ = print "Now proving properties of subtraction\n"
 
 val SUB_0 = store_thm ("SUB_0",

--- a/src/pred_set/src/more_theories/cardinalScript.sml
+++ b/src/pred_set/src/more_theories/cardinalScript.sml
@@ -2153,14 +2153,6 @@ val LT_CASES = store_thm ("LT_CASES",
  ``!m n:num. (m < n) \/ (n < m) \/ (m = n)``,
   METIS_TAC [LESS_CASES, LESS_OR_EQ]);
 
-val LT = store_thm ("LT",
- ``(!m:num. m < 0 <=> F) /\ (!m n. m < SUC n <=> (m = n) \/ m < n)``,
-  METIS_TAC [LESS_THM, NOT_LESS_0]);
-
-val LT_LE = store_thm ("LT_LE",
- ``!m n:num. m < n <=> m <= n /\ ~(m = n)``,
-  METIS_TAC [LESS_NOT_EQ, LESS_OR_EQ]);
-
 val GE = store_thm ("GE",
   ``!n m:num. m >= n <=> n <= m``,
   METIS_TAC [GREATER_EQ]);

--- a/src/probability/borelScript.sml
+++ b/src/probability/borelScript.sml
@@ -5182,10 +5182,6 @@ Proof
   ASM_SIMP_TAC std_ss [LIM_CONST]
 QED
 
-val LT = prove ((* HOL Light compatibility *)
-  ``(!m:num. m < 0 <=> F) /\ (!m n. m < SUC n <=> (m = n) \/ m < n)``,
-    METIS_TAC [LESS_THM, NOT_LESS_0]);
-
 val LIMSEQ_indicator_UN = limseq_indicator_BIGUNION;
 
 Theorem sigma_algebra_lebesgue :

--- a/src/real/integralScript.sml
+++ b/src/real/integralScript.sml
@@ -512,36 +512,10 @@ val DINT_LINEAR = store_thm("DINT_LINEAR",
 (* Ordering properties of integral.                                          *)
 (* ------------------------------------------------------------------------- *)
 
-(*Auxiliary lemmas.*)
-val LT = store_thm("LT",
-  ``(!(m:num). m < 0 = F) /\ (!m n. m < SUC n = ((m = n) \/ m < n))``,
-  SIMP_TAC arith_ss[ZERO_LESS_EQ, LESS_OR_EQ]);
-
-val LE_0 = store_thm ("LE_0",``!(n:num). 0 <= n``,
-      INDUCT_TAC THEN ASM_REWRITE_TAC[LE]);
-
-val LT_0 = store_thm("LT_0",``!(n:num). 0 < SUC n``,
-      SIMP_TAC arith_ss[SUC_ONE_ADD]);
-val EQ_SUC = store_thm("EQ_SUC", ``!(m:num) (n:num). (SUC m = SUC n) = (m = n)``,
-        SIMP_TAC arith_ss[]);
-
-val LE_LT = store_thm("LE_LT",
-        ``!(m:num) (n:num). (m <= n) <=> (m < n) \/ (m = n)``,
-        REPEAT INDUCT_TAC THEN
-        ASM_SIMP_TAC arith_ss[LESS_EQ_MONO, LESS_MONO_EQ, EQ_SUC, ZERO_LESS_EQ, LT_0]
-        THEN REWRITE_TAC[LE, LT]);
-
-val LT_LE = store_thm("LT_LE",
-        ``!(m:num) (n:num). (m < n) <=> (m <= n) /\ ~(m = n)``,
-        REWRITE_TAC[LE_LT] THEN REPEAT GEN_TAC THEN EQ_TAC THENL
-         [DISCH_TAC THEN ASM_SIMP_TAC arith_ss[],
-          DISCH_THEN(CONJUNCTS_THEN2 STRIP_ASSUME_TAC MP_TAC) THEN
-          ASM_REWRITE_TAC[]]);
-
-val REAL_LT_MIN = store_thm("REAL_LT_MIN",
-  ``!x y z. z < min x y <=> z < x /\ z < y``,
-  RW_TAC boolSimps.bool_ss [min_def] THENL [PROVE_TAC[REAL_LTE_TRANS],
-  RULE_ASSUM_TAC(REWRITE_RULE[REAL_NOT_LE]) THEN PROVE_TAC[REAL_LT_TRANS]]);
+val LE_0   = arithmeticTheory.ZERO_LESS_EQ;
+val LT_0   = prim_recTheory.LESS_0;
+val EQ_SUC = prim_recTheory.INV_SUC_EQ;
+val LE_LT  = arithmeticTheory.LESS_OR_EQ;
 
 val INTEGRAL_LE = store_thm("INTEGRAL_LE",
   ``!f g a b i j.

--- a/src/real/polyScript.sml
+++ b/src/real/polyScript.sml
@@ -74,23 +74,7 @@ val SUC_INJ = prim_recTheory.INV_SUC_EQ
 
 val LT_SUC_LE = prove (Term`!m n. m < SUC n = m <= n`, ARITH_TAC);
 
-val LT = prove(
-  Term`(!m:num. m < 0 = F) /\ (!m n. m < SUC n = (m = n) \/ m < n)`,
-  ARITH_TAC);
-
-val LT_ADD_LCANCEL = prove (
-  Term`!m n p:num. m + n < m + p = n < p`,
-  ARITH_TAC);
-
-val LE_EXISTS = prove (
-  Term`!m n:num. m <= n = (?d. n = m + d)`,
-  REPEAT (STRIP_TAC ORELSE EQ_TAC)
-  THENL [
-    EXISTS_TAC (Term`n - m:num`),
-    ALL_TAC
-  ]
-  THEN POP_ASSUM (MP_TAC)
-  THEN ARITH_TAC);
+val LE_EXISTS = arithmeticTheory.LESS_EQ_EXISTS;
 
 val LE_SUC_LT = prove (
   Term`!m n. SUC m <= n = m < n`,


### PR DESCRIPTION
Hi,

This small PR moves two common HOL-Light lemmas (`LT` and `LT_LE`) to arithmeticTheory, so that many copies of them can be eliminated from various core theories. This change may also ease future porting work of theories from HOL Light.

Regards,

Chun Tian