### PR TITLE
More general topological and metric lemmas ported from HOL Light

### DIFF
--- a/examples/probability/large_numberScript.sml
+++ b/examples/probability/large_numberScript.sml
@@ -8,10 +8,12 @@
 open HolKernel Parse boolLib bossLib;
 
 open combinTheory arithmeticTheory pred_setTheory pred_setLib logrootTheory
-     realTheory realLib seqTheory transcTheory real_sigmaTheory iterateTheory
-     real_topologyTheory numLib;
+     numLib hurdUtils topologyTheory;
 
-open hurdUtils util_probTheory sigma_algebraTheory extrealTheory measureTheory
+open realTheory realLib seqTheory transcTheory real_sigmaTheory iterateTheory
+     real_topologyTheory;
+
+open util_probTheory sigma_algebraTheory extrealTheory measureTheory
      borelTheory lebesgueTheory martingaleTheory probabilityTheory;
 
 val _ = new_theory "large_number";

--- a/src/pred_set/src/more_theories/README
+++ b/src/pred_set/src/more_theories/README
@@ -22,6 +22,7 @@ ordinal:
   to get back a new ordinal). Derive the standard arithmetic
   operations, define constants such as ω and ε₀, and show that all
   ordinals have a standard "polynomial" representation.
+  (Also see [1] for more details.)
 
 ucord:
   Show the existence of uncountable ordinals if the underlying type is
@@ -42,3 +43,8 @@ ordinalNotation:
 
   Some minor additions to this theory show some of the connection with
   the other presentation of ordinals.
+
+[1] Norrish, M., Huffman, B.: Ordinals in HOL: Transfinite Arithmetic up to
+   (and Beyind) $\omega_1$. In: LNCS 7998 - Interactive Theorem Proving
+   (ITP 2013). pp. 133–146. Springer (2013).
+    URL: http://dx.doi.org/10.1007/978-3-642-39634-2_12

--- a/src/pred_set/src/more_theories/cardinalScript.sml
+++ b/src/pred_set/src/more_theories/cardinalScript.sml
@@ -1,3 +1,21 @@
+(* ========================================================================= *)
+(*  A basic theory of the cardinality partial order and equivalence          *)
+(*  relations (by Michael Norrish, see also README)                          *)
+(* ========================================================================= *)
+(*  Basic notions of cardinal arithmetic (by John Harrison from HOL-Light)   *)
+(* ------------------------------------------------------------------------- *)
+(*  HOL-Light's Cardinal Theory (Library/card.ml)                            *)
+(*                                                                           *)
+(*        (c) Copyright 2015                                                 *)
+(*                       Muhammad Qasim,                                     *)
+(*                       Osman Hasan,                                        *)
+(*                       Hardware Verification Group,                        *)
+(*                       Concordia University                                *)
+(*                                                                           *)
+(*            Contact:  <m_qasi@ece.concordia.ca>                            *)
+(*                                                                           *)
+(* ========================================================================= *)
+
 open HolKernel Parse boolLib bossLib mesonLib
 
 open boolSimps pred_setTheory set_relationTheory tautLib
@@ -1631,21 +1649,6 @@ val bijections_cardeq = Q.store_thm(
   >- (first_x_assum (qspecl_then [‘T’, ‘a’] mp_tac) >> simp[] >> rw[])
   >- (first_x_assum (qspecl_then [‘F’, ‘a’] mp_tac) >> simp[] >> rw[]));
 
-(* ========================================================================= *)
-(*                                                                           *)
-(*               HOL-light's Cardinal Theory (Library/card.ml)               *)
-(*                                                                           *)
-(*        (c) Copyright 2015                                                 *)
-(*                       Muhammad Qasim,                                     *)
-(*                       Osman Hasan,                                        *)
-(*                       Hardware Verification Group,                        *)
-(*                       Concordia University                                *)
-(*                                                                           *)
-(*            Contact:  <m_qasi@ece.concordia.ca>                            *)
-(*                                                                           *)
-(*      (merged into HOL4's cardinalTheory by Chun Tian <ctian@fbk.eu>)      *)
-(* ========================================================================= *)
-
 (* ------------------------------------------------------------------------- *)
 (* misc.                                                                     *)
 (* ------------------------------------------------------------------------- *)
@@ -3065,9 +3068,7 @@ QED
 (* Lemmas about countability.                                                *)
 (* ------------------------------------------------------------------------- *)
 
-val NUM_COUNTABLE = store_thm ("NUM_COUNTABLE",
- ``COUNTABLE univ(:num)``,
-  REWRITE_TAC[COUNTABLE, ge_c, CARD_LE_REFL]);
+Theorem NUM_COUNTABLE = num_countable
 
 val COUNTABLE_ALT_cardleq = store_thm
   ("COUNTABLE_ALT_cardleq",

--- a/src/pred_set/src/more_theories/cardinalScript.sml
+++ b/src/pred_set/src/more_theories/cardinalScript.sml
@@ -2314,8 +2314,6 @@ val GE_C = store_thm ("GE_C",
  ``!s t. s >=_c t <=> ?f. !y. y IN t ==> ?x. x IN s /\ (y = f x)``,
   REWRITE_TAC[ge_c, LE_C] THEN MESON_TAC[]);
 
-Overload COUNTABLE[inferior] = “countable”
-
 val COUNTABLE = store_thm
   ("COUNTABLE", ``!t. COUNTABLE t <=> univ(:num) >=_c t``,
     REWRITE_TAC [countable_def, cardgeq_def, cardleq_def]);

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -6344,6 +6344,9 @@ RWTAC [] THENL
 val countable_def = TotalDefn.Define `
   countable s = ?f. INJ f s (UNIV:num set)`;
 
+(* for HOL-Light compatibility, moved here from cardinalTheory *)
+Overload COUNTABLE[inferior] = “countable”
+
 val countable_image_nats = store_thm( "countable_image_nats",
   ``countable (IMAGE f univ(:num))``, SIMP_TAC
   (srw_ss())[countable_def] THEN METIS_TAC[SURJ_IMAGE, SURJ_INJ_INV]);

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -15,7 +15,7 @@ struct
 (* structure declaration is necessary so that Moscow ML does not get
    confused by the rebinding of structure Q below *)
 
-open HolKernel Parse boolLib Prim_rec pairLib numLib
+open HolKernel Parse boolLib Prim_rec pairLib numLib numpairTheory
      pairTheory numTheory prim_recTheory arithmeticTheory whileTheory
      BasicProvers metisLib mesonLib simpLib boolSimps dividesTheory;
 
@@ -6450,8 +6450,6 @@ Theorem COUNTABLE_IMAGE_NUM[simp]:
 Proof
    PROVE_TAC [COUNTABLE_NUM, image_countable]
 QED
-
-open numpairTheory
 
 val num_to_pair_def = TotalDefn.Define `num_to_pair n = (nfst n, nsnd n)`
 val pair_to_num_def = TotalDefn.Define `pair_to_num (m,n) = m *, n`

--- a/src/probability/probabilityScript.sml
+++ b/src/probability/probabilityScript.sml
@@ -13,10 +13,12 @@
 open HolKernel Parse boolLib bossLib;
 
 open pairTheory combinTheory optionTheory prim_recTheory arithmeticTheory
-     pred_setTheory pred_setLib realTheory realLib iterateTheory
-     seqTheory transcTheory real_sigmaTheory real_topologyTheory;
+     pred_setTheory pred_setLib topologyTheory hurdUtils;
 
-open hurdUtils util_probTheory extrealTheory sigma_algebraTheory measureTheory
+open realTheory realLib iterateTheory seqTheory transcTheory real_sigmaTheory
+     real_topologyTheory;
+
+open util_probTheory extrealTheory sigma_algebraTheory measureTheory
      real_borelTheory borelTheory lebesgueTheory martingaleTheory;
 
 val _ = new_theory "probability";

--- a/src/probability/util_probScript.sml
+++ b/src/probability/util_probScript.sml
@@ -10,10 +10,11 @@
 open HolKernel Parse boolLib bossLib;
 
 open metisLib pairTheory combinTheory pred_setTheory pred_setLib jrhUtils
-     arithmeticTheory realTheory realLib transcTheory seqTheory numLib
-     real_sigmaTheory numpairTheory hurdUtils RealArith;
+     arithmeticTheory numLib numpairTheory hurdUtils whileTheory;
 
-open whileTheory iterateTheory;
+open realTheory realLib transcTheory seqTheory real_sigmaTheory RealArith;
+
+open topologyTheory iterateTheory;
 
 val _ = new_theory "util_prob";
 
@@ -2371,28 +2372,6 @@ Proof
 QED
 
 Theorem REAL_RAT_DENSE = Q_DENSE_IN_REAL
-
-Theorem EXT_SKOLEM_THM :
-    !P Q. (!x. x IN P ==> ?y. Q x y) <=> ?f. !x. x IN P ==> Q x (f x)
-Proof
-    rpt STRIP_TAC
- >> reverse EQ_TAC >> rpt STRIP_TAC
- >- (Q.EXISTS_TAC `f x` \\
-     FIRST_X_ASSUM MATCH_MP_TAC >> art [])
- >> fs [GSYM RIGHT_EXISTS_IMP_THM, SKOLEM_THM]
- >> Q.EXISTS_TAC `f` >> art []
-QED
-
-Theorem EXT_SKOLEM_THM' :
-    !P Q. (!x. P x ==> ?y. Q x y) <=> ?f. !x. P x ==> Q x (f x)
-Proof
-    rpt STRIP_TAC
- >> reverse EQ_TAC >> rpt STRIP_TAC
- >- (Q.EXISTS_TAC `f x` \\
-     FIRST_X_ASSUM MATCH_MP_TAC >> art [])
- >> fs [GSYM RIGHT_EXISTS_IMP_THM, SKOLEM_THM]
- >> Q.EXISTS_TAC `f` >> art []
-QED
 
 val _ = export_theory ();
 

--- a/src/real/iterateScript.sml
+++ b/src/real/iterateScript.sml
@@ -1081,6 +1081,13 @@ val REAL_LE_INF_SUBSET = store_thm ("REAL_LE_INF_SUBSET",
   REPEAT STRIP_TAC THEN MATCH_MP_TAC REAL_LE_INF THEN
   MP_TAC(SPEC ``s:real->bool`` INF) THEN ASM_SET_TAC[]);
 
+Theorem REAL_INF_LE' :
+    !p x:real. (?y. y IN p) /\ (?y. !z. z IN p ==> y <= z) ==>
+               (inf p <= x <=> !y. (!z. z IN p ==> y <= z) ==> y <= x)
+Proof
+    REWRITE_TAC [IN_APP, REAL_INF_LE]
+QED
+
 val REAL_INF_BOUNDS = store_thm ("REAL_INF_BOUNDS",
  ``!s a b:real. ~(s = {}) /\ (!x. x IN s ==> a <= x /\ x <= b)
            ==> a <= inf s /\ inf s <= b``,
@@ -3579,14 +3586,6 @@ val REAL_SUB_POW_L1 = store_thm ("REAL_SUB_POW_L1",
 (* ------------------------------------------------------------------------- *)
 (* Some useful facts about real polynomial functions.                        *)
 (* ------------------------------------------------------------------------- *)
-
-val FORALL_IN_GSPEC = store_thm ("FORALL_IN_GSPEC",
- ``(!P f. (!z. z IN {f x | P x} ==> Q z) <=> (!x. P x ==> Q(f x))) /\
-   (!P f. (!z. z IN {f x y | P x y} ==> Q z) <=>
-          (!x y. P x y ==> Q(f x y))) /\
-   (!P f. (!z. z IN {f w x y | P w x y} ==> Q z) <=>
-          (!w x y. P w x y ==> Q(f w x y)))``,
-   SRW_TAC [][] THEN SET_TAC []);
 
 val REAL_SUB_POLYFUN = store_thm ("REAL_SUB_POLYFUN",
  ``!a x y n. 1 <= n

--- a/src/real/metricScript.sml
+++ b/src/real/metricScript.sml
@@ -1,13 +1,71 @@
 (*===========================================================================*)
 (* Metric spaces, including metric on real line                              *)
-(*===========================================================================*)
+(* ========================================================================= *)
+(* Formalization of general topological and metric spaces in HOL Light       *)
+(*                                                                           *)
+(*              (c) Copyright, John Harrison 1998-2017                       *)
+(*                (c) Copyright, Marco Maggesi 2014-2017                     *)
+(*             (c) Copyright, Andrea Gabrielli  2016-2017                    *)
+(* ========================================================================= *)
 
 open HolKernel Parse bossLib boolLib;
 
-open BasicProvers boolSimps simpLib mesonLib metisLib jrhUtils pairTheory
-     pairLib pred_setTheory quotientTheory realTheory topologyTheory;
+open arithmeticTheory numTheory boolSimps simpLib mesonLib metisLib jrhUtils
+     pairTheory pairLib quotientTheory pred_setTheory pred_setLib;
+
+open realTheory cardinalTheory topologyTheory;
 
 val _ = new_theory "metric";
+
+fun MESON ths tm = prove(tm,MESON_TAC ths);
+fun METIS ths tm = prove(tm,METIS_TAC ths);
+fun wrap a = [a];
+
+(* ------------------------------------------------------------------------- *)
+(* Handy lemmas switching between versions of limit arguments.               *)
+(* (originally from hol-light's misc.ml, line 747-772)                       *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem FORALL_POS_MONO :
+   !P. (!d e:real. d < e /\ P d ==> P e) /\ (!n. ~(n = 0) ==> P(inv(&n)))
+       ==> !e. &0 < e ==> P e
+Proof
+  MESON_TAC[REAL_ARCH_INV, REAL_LT_TRANS]
+QED
+
+Theorem FORALL_SUC :
+   (!n. n <> 0 ==> P n) <=> !n. P (SUC n)
+Proof
+   MESON_TAC[num_CASES, NOT_SUC]
+QED
+
+Theorem FORALL_POS_MONO_1 :
+   !P. (!d e. d < e /\ P d ==> P e) /\ (!n. P(inv(&n + &1)))
+       ==> !e. &0 < e ==> P e
+Proof
+    GEN_TAC >> REWRITE_TAC [REAL_OF_NUM_SUC]
+ >> STRIP_TAC
+ >> MATCH_MP_TAC FORALL_POS_MONO
+ >> ASM_REWRITE_TAC []
+ >> ASM_SIMP_TAC std_ss [FORALL_SUC]
+QED
+
+Theorem FORALL_POS_MONO_EQ :
+   !P. (!d e. d < e /\ P d ==> P e)
+       ==> ((!e. &0 < e ==> P e) <=> (!n. ~(n = 0) ==> P(inv(&n))))
+Proof
+  MESON_TAC[REAL_ARCH_INV, REAL_LT_INV_EQ, REAL_LT_TRANS, LE_1,
+            REAL_OF_NUM_LT]
+QED
+
+Theorem FORALL_POS_MONO_1_EQ :
+   !P. (!d e. d < e /\ P d ==> P e)
+       ==> ((!e. &0 < e ==> P e) <=> (!n. P(inv(&n + &1))))
+Proof
+  GEN_TAC THEN
+  DISCH_THEN(SUBST1_TAC o MATCH_MP FORALL_POS_MONO_EQ) THEN
+  SIMP_TAC std_ss [REAL_OF_NUM_SUC, GSYM FORALL_SUC]
+QED
 
 (*---------------------------------------------------------------------------*)
 (* Characterize an (alpha)metric                                             *)
@@ -101,6 +159,18 @@ Definition mtop :
     topology (\S'. !x. S' x ==> ?e. &0 < e /\ !y. (dist m)(x,y) < e ==> S' y)
 End
 
+(* for HOL Light compatibility *)
+Overload mtopology[inferior] = “mtop”
+Overload mdist[inferior] = “dist”
+
+(* NOTE: HOL4's ‘mspace’ definition is different with HOL-Light *)
+Definition mspace :
+    mspace m = topspace (mtop m)
+End
+
+(* |- !m. topspace (mtop m) = mspace m *)
+Theorem TOPSPACE_MTOPOLOGY = GEN_ALL (GSYM mspace)
+
 Theorem mtop_istopology :
     !m:('a)metric.
       istopology (\S'. !x. S' x ==>
@@ -152,6 +222,9 @@ Definition ball :
     B(m)(x,e) = \y. (dist m)(x,y) < e
 End
 
+(* for HOL Light compatibility *)
+Overload mball[inferior] = “B”;
+
 Theorem BALL_OPEN:
   !m:('a)metric. !x e. &0 < e ==> open_in(mtop(m))(B(m)(x,e))
 Proof
@@ -166,6 +239,7 @@ Proof
   ASM_REWRITE_TAC[METRIC_TRIANGLE]
 QED
 
+(* This is not good ... *)
 Theorem TOPSPACE_MTOP[simp]:
   topspace (mtop m) = UNIV
 Proof
@@ -182,6 +256,64 @@ val BALL_NEIGH = store_thm("BALL_NEIGH",
    [MATCH_MP_TAC BALL_OPEN,
     REWRITE_TAC[ball] THEN BETA_TAC THEN REWRITE_TAC[METRIC_SAME]] THEN
   POP_ASSUM ACCEPT_TAC);
+
+(*---------------------------------------------------------------------------*)
+(* HOL-Light compatibile theorems                                            *)
+(*---------------------------------------------------------------------------*)
+
+Theorem MDIST_REFL :
+   !m x:'a. x IN mspace m ==> mdist m (x,x) = &0
+Proof
+   rw [mspace, METRIC_SAME]
+QED
+
+Theorem mtopology :
+   !m. mtopology (m:'a metric) =
+       topology {u | u SUBSET mspace m /\
+                     !x:'a. x IN u ==> ?r. &0 < r /\ mball m (x,r) SUBSET u}
+Proof
+    rw [mtop, mspace, ball]
+ >> AP_TERM_TAC
+ >> rw [Once EXTENSION, IN_APP, SUBSET_DEF]
+QED
+
+Theorem mball :
+   !m x r. mball m (x:'a,r) =
+          {y | x IN mspace m /\ y IN mspace m /\ mdist m (x,y) < r}
+Proof
+   rw [mspace, ball, Once EXTENSION]
+QED
+
+Theorem IS_TOPOLOGY_METRIC_TOPOLOGY :
+    !m. istopology {u | u SUBSET mspace m /\
+                        !x:'a. x IN u ==> ?r. &0 < r /\ mball m (x,r) SUBSET u}
+Proof
+    GEN_TAC
+ >> Q_TAC SUFF_TAC
+     ‘{u | u SUBSET mspace m /\
+           !x:'a. x IN u ==> ?r. &0 < r /\ mball m (x,r) SUBSET u} =
+     (\S'. !x. S' x ==> ?e. 0 < e /\ !y. dist m (x,y) < e ==> S' y)’
+ >- (DISCH_THEN (ONCE_REWRITE_TAC o wrap) \\
+     REWRITE_TAC [mtop_istopology])
+ >> rw [mspace, ball, SUBSET_DEF, IN_APP, Once EXTENSION]
+QED
+
+Theorem OPEN_IN_MTOPOLOGY :
+   !(m:'a metric) u.
+     open_in (mtopology m) u <=>
+     u SUBSET mspace m /\
+     (!x. x IN u ==> ?r. &0 < r /\ mball m (x,r) SUBSET u)
+Proof
+    rw [MTOP_OPEN, mspace, ball, SUBSET_DEF, IN_APP]
+QED
+
+Theorem IN_MBALL :
+   !m x y:'a r.
+     y IN mball m (x,r) <=>
+     x IN mspace m /\ y IN mspace m /\ mdist m (x,y) < r
+Proof
+    rw [mball]
+QED
 
 (*---------------------------------------------------------------------------*)
 (* Characterize limit point in a metric topology                             *)
@@ -235,6 +367,10 @@ val ISMET_R1 = store_thm("ISMET_R1",
       “(a + b) + (c + d) = (d + a) + (c + b):real”] THEN
     REWRITE_TAC[REAL_ADD_LINV, REAL_ADD_LID]]);
 
+(* NOTE: the "usual" ‘mr2’ metric for 2-dimension Euclidean space is defined in
+  "src/probability/real_borelScript.sml". It cannot be moved here, because ‘mr2’
+   involves ‘sqrt’, which is defined in ‘transcTheory’ later. -- Chun Tian
+ *)
 Definition mr1 :
     mr1 = metric(\(x,y). abs(y - x))
 End
@@ -294,6 +430,432 @@ Proof
   CONV_TAC(RAND_CONV SYM_CONV) THEN
   MATCH_MP_TAC REAL_LT_IMP_NE THEN
   ASM_REWRITE_TAC[REAL_LT_HALF1]);
+
+(* ------------------------------------------------------------------------- *)
+(* F_sigma and G_delta sets in a topological space (ported from HOL Light)   *)
+(* ------------------------------------------------------------------------- *)
+
+(* The countable intersection class (general version)
+
+   The leading letter G is from the German word "Gebiet" meaning "region".
+   The greek letter "delta" stands for a countable intersection (in German,
+   "Durchschnitt"). See [1, p.310] (bibitem is at the bottom of this file.)
+
+   NOTE: the part ‘relative_to topspace top’ is necessary when ‘topspace top’
+   is not UNIV, because "a countable intersection of something" includes "a
+   countable intersection of nothing", and ‘BIGINTER {} = UNIV’, which may
+   go beyond the scope of ‘topspace top’. -- Chun Tian, 28 nov 2021
+ *)
+Definition gdelta_in :
+    gdelta_in (top:'a topology) =
+        (COUNTABLE INTERSECTION_OF open_in top) relative_to topspace top
+End
+
+(* The countable union class (general version)
+
+   The leading letter F is from the French word "ferme" meaning "closed".
+   The greek letter "sigma" stands for a countable union or sum (in German,
+   "Summe").
+ *)
+Definition fsigma_in :
+    fsigma_in (top:'a topology) = COUNTABLE UNION_OF closed_in top
+End
+
+Theorem FSIGMA_IN_ASCENDING :
+   !top s:'a->bool.
+        fsigma_in top s <=>
+        ?c. (!n. closed_in top (c n)) /\
+            (!n. c n SUBSET c(n + 1)) /\
+            UNIONS {c n | n IN univ(:num)} = s
+Proof
+  REWRITE_TAC[fsigma_in] THEN
+  SIMP_TAC std_ss [COUNTABLE_UNION_OF_ASCENDING, CLOSED_IN_EMPTY, CLOSED_IN_UNION] THEN
+  REWRITE_TAC[ADD1]
+QED
+
+Theorem GDELTA_IN_ALT :
+   !top s:'a->bool.
+        gdelta_in top s <=>
+        s SUBSET topspace top /\ (COUNTABLE INTERSECTION_OF open_in top) s
+Proof
+  SIMP_TAC std_ss [COUNTABLE_INTERSECTION_OF_RELATIVE_TO_ALT, gdelta_in,
+                   OPEN_IN_TOPSPACE] THEN
+  REWRITE_TAC[Once CONJ_ACI]
+QED
+
+Theorem FSIGMA_IN_SUBSET :
+   !top s:'a->bool. fsigma_in top s ==> s SUBSET topspace top
+Proof
+  GEN_TAC THEN SIMP_TAC std_ss [fsigma_in, FORALL_UNION_OF, UNIONS_SUBSET] THEN
+  SIMP_TAC std_ss [CLOSED_IN_SUBSET]
+QED
+
+Theorem GDELTA_IN_SUBSET :
+   !top s:'a->bool. gdelta_in top s ==> s SUBSET topspace top
+Proof
+  SIMP_TAC std_ss [GDELTA_IN_ALT]
+QED
+
+Theorem CLOSED_IMP_FSIGMA_IN :
+   !top s:'a->bool. closed_in top s ==> fsigma_in top s
+Proof
+  SIMP_TAC std_ss [fsigma_in, COUNTABLE_UNION_OF_INC]
+QED
+
+Theorem OPEN_IMP_GDELTA_IN :
+   !top s:'a->bool. open_in top s ==> gdelta_in top s
+Proof
+  REPEAT STRIP_TAC THEN REWRITE_TAC[gdelta_in] THEN
+  FIRST_ASSUM(SUBST1_TAC o MATCH_MP (SET_RULE ``s SUBSET u ==> s = u INTER s``) o
+    MATCH_MP OPEN_IN_SUBSET) THEN
+  MATCH_MP_TAC RELATIVE_TO_INC THEN
+  ASM_SIMP_TAC std_ss [COUNTABLE_INTERSECTION_OF_INC]
+QED
+
+Theorem FSIGMA_IN_EMPTY :
+   !top:'a topology. fsigma_in top {}
+Proof
+  SIMP_TAC std_ss [CLOSED_IMP_FSIGMA_IN, CLOSED_IN_EMPTY]
+QED
+
+Theorem GDELTA_IN_EMPTY :
+   !top:'a topology. gdelta_in top {}
+Proof
+  SIMP_TAC std_ss [OPEN_IMP_GDELTA_IN, OPEN_IN_EMPTY]
+QED
+
+Theorem FSIGMA_IN_TOPSPACE :
+   !top:'a topology. fsigma_in top (topspace top)
+Proof
+  SIMP_TAC std_ss [CLOSED_IMP_FSIGMA_IN, CLOSED_IN_TOPSPACE]
+QED
+
+Theorem GDELTA_IN_TOPSPACE :
+   !top:'a topology. gdelta_in top (topspace top)
+Proof
+  SIMP_TAC std_ss [OPEN_IMP_GDELTA_IN, OPEN_IN_TOPSPACE]
+QED
+
+Theorem FSIGMA_IN_UNIONS :
+   !top t:('a->bool)->bool.
+        COUNTABLE t /\ (!s. s IN t ==> fsigma_in top s)
+        ==> fsigma_in top (UNIONS t)
+Proof
+  REWRITE_TAC[fsigma_in, COUNTABLE_UNION_OF_UNIONS]
+QED
+
+Theorem FSIGMA_IN_UNION :
+   !top s t:'a->bool.
+        fsigma_in top s /\ fsigma_in top t ==> fsigma_in top (s UNION t)
+Proof
+  REWRITE_TAC[fsigma_in, COUNTABLE_UNION_OF_UNION]
+QED
+
+Theorem FSIGMA_IN_INTER :
+   !top s t:'a->bool.
+        fsigma_in top s /\ fsigma_in top t ==> fsigma_in top (s INTER t)
+Proof
+  GEN_TAC THEN REWRITE_TAC[fsigma_in] THEN
+  MATCH_MP_TAC COUNTABLE_UNION_OF_INTER THEN
+  REWRITE_TAC[CLOSED_IN_INTER]
+QED
+
+Theorem GDELTA_IN_INTERS :
+   !top t:('a->bool)->bool.
+        COUNTABLE t /\ ~(t = {}) /\ (!s. s IN t ==> gdelta_in top s)
+        ==> gdelta_in top (INTERS t)
+Proof
+  REWRITE_TAC[GDELTA_IN_ALT] THEN REPEAT STRIP_TAC THEN
+  ASM_SIMP_TAC std_ss [INTERS_SUBSET] THEN
+  ASM_SIMP_TAC std_ss [COUNTABLE_INTERSECTION_OF_INTERS]
+QED
+
+Theorem GDELTA_IN_INTER :
+   !top s t:'a->bool.
+        gdelta_in top s /\ gdelta_in top t ==> gdelta_in top (s INTER t)
+Proof
+  SIMP_TAC std_ss [GSYM INTERS_2, GDELTA_IN_INTERS, COUNTABLE_INSERT, COUNTABLE_EMPTY,
+           NOT_INSERT_EMPTY, FORALL_IN_INSERT, NOT_IN_EMPTY]
+QED
+
+Theorem GDELTA_IN_UNION :
+   !top s t:'a->bool.
+        gdelta_in top s /\ gdelta_in top t ==> gdelta_in top (s UNION t)
+Proof
+  SIMP_TAC std_ss [GDELTA_IN_ALT, UNION_SUBSET] THEN
+  MESON_TAC[COUNTABLE_INTERSECTION_OF_UNION, OPEN_IN_UNION]
+QED
+
+Theorem FSIGMA_IN_DIFF :
+   !top s t:'a->bool.
+        fsigma_in top s /\ gdelta_in top t ==> fsigma_in top (s DIFF t)
+Proof
+  GEN_TAC THEN SUBGOAL_THEN
+   ``!s:'a->bool. gdelta_in top s ==> fsigma_in top (topspace top DIFF s)``
+  ASSUME_TAC THENL
+  [ (* goal 1 (of 2) *)
+    SIMP_TAC std_ss [fsigma_in, gdelta_in, FORALL_RELATIVE_TO] THEN
+    SIMP_TAC std_ss [FORALL_INTERSECTION_OF, DIFF_INTERS, SET_RULE
+     ``s DIFF (s INTER t) = s DIFF t``] THEN
+    REPEAT STRIP_TAC THEN MATCH_MP_TAC COUNTABLE_UNION_OF_UNIONS THEN
+    ASM_SIMP_TAC std_ss [SIMPLE_IMAGE, COUNTABLE_IMAGE, FORALL_IN_IMAGE] THEN
+    ASM_SIMP_TAC std_ss [COUNTABLE_UNION_OF_INC, CLOSED_IN_DIFF,
+                 CLOSED_IN_TOPSPACE],
+    (* goal 2 (of 2) *)
+    REPEAT STRIP_TAC THEN
+    SUBGOAL_THEN ``s DIFF t:'a->bool = s INTER (topspace top DIFF t)``
+     (fn th => SUBST1_TAC th THEN ASM_SIMP_TAC std_ss [FSIGMA_IN_INTER]) THEN
+    FIRST_ASSUM(MP_TAC o MATCH_MP FSIGMA_IN_SUBSET) THEN ASM_SET_TAC[] ]
+QED
+
+Theorem GDELTA_IN_DIFF :
+   !top s t:'a->bool.
+        gdelta_in top s /\ fsigma_in top t ==> gdelta_in top (s DIFF t)
+Proof
+  GEN_TAC THEN SUBGOAL_THEN
+   ``!s:'a->bool. fsigma_in top s ==> gdelta_in top (topspace top DIFF s)``
+  ASSUME_TAC THENL
+  [ (* goal 1 (of 2) *)
+    SIMP_TAC std_ss [fsigma_in, gdelta_in, FORALL_UNION_OF, DIFF_UNIONS] THEN
+    REPEAT STRIP_TAC THEN MATCH_MP_TAC RELATIVE_TO_INC THEN
+    MATCH_MP_TAC COUNTABLE_INTERSECTION_OF_INTERS THEN
+    ASM_SIMP_TAC std_ss [SIMPLE_IMAGE, COUNTABLE_IMAGE, FORALL_IN_IMAGE] THEN
+    ASM_SIMP_TAC std_ss [COUNTABLE_INTERSECTION_OF_INC, OPEN_IN_DIFF,
+                 OPEN_IN_TOPSPACE],
+    (* goal 2 (of 2) *)
+    REPEAT STRIP_TAC THEN
+    SUBGOAL_THEN ``s DIFF t:'a->bool = s INTER (topspace top DIFF t)``
+     (fn th => SUBST1_TAC th THEN ASM_SIMP_TAC std_ss [GDELTA_IN_INTER]) THEN
+    FIRST_ASSUM(MP_TAC o MATCH_MP GDELTA_IN_SUBSET) THEN ASM_SET_TAC[] ]
+QED
+
+Theorem GDELTA_IN_FSIGMA_IN :
+   !top s:'a->bool.
+       gdelta_in top s <=>
+       s SUBSET topspace top /\ fsigma_in top (topspace top DIFF s)
+Proof
+  REPEAT GEN_TAC THEN EQ_TAC THEN
+  SIMP_TAC std_ss [GDELTA_IN_SUBSET, FSIGMA_IN_DIFF, FSIGMA_IN_TOPSPACE] THEN
+  STRIP_TAC THEN FIRST_ASSUM(SUBST1_TAC o MATCH_MP (SET_RULE
+   ``s SUBSET u ==> s = u DIFF (u DIFF s)``)) THEN
+  ASM_SIMP_TAC std_ss [GDELTA_IN_DIFF, GDELTA_IN_TOPSPACE]
+QED
+
+Theorem FSIGMA_IN_GDELTA_IN :
+   !top s:'a->bool.
+        fsigma_in top s <=>
+        s SUBSET topspace top /\ gdelta_in top (topspace top DIFF s)
+Proof
+  REPEAT GEN_TAC THEN EQ_TAC THEN
+  SIMP_TAC std_ss [FSIGMA_IN_SUBSET, GDELTA_IN_DIFF, GDELTA_IN_TOPSPACE] THEN
+  STRIP_TAC THEN FIRST_ASSUM(SUBST1_TAC o MATCH_MP (SET_RULE
+   ``s SUBSET u ==> s = u DIFF (u DIFF s)``)) THEN
+  ASM_SIMP_TAC std_ss [FSIGMA_IN_DIFF, FSIGMA_IN_TOPSPACE]
+QED
+
+Theorem GDELTA_IN_DESCENDING :
+   !top s:'a->bool.
+        gdelta_in top s <=>
+        ?c. (!n. open_in top (c n)) /\
+            (!n. c(n + 1) SUBSET c n) /\
+            INTERS {c n | n IN univ(:num)} = s
+Proof
+  REPEAT GEN_TAC THEN REWRITE_TAC[GDELTA_IN_FSIGMA_IN] THEN
+  REWRITE_TAC[FSIGMA_IN_ASCENDING] THEN EQ_TAC THENL
+  [ (* goal 1 (of 2) *)
+    DISCH_THEN(CONJUNCTS_THEN2 ASSUME_TAC
+     (Q.X_CHOOSE_THEN `c:num->'a->bool` STRIP_ASSUME_TAC)),
+    (* goal 2 (of 2) *)
+    DISCH_THEN(Q.X_CHOOSE_THEN `c:num->'a->bool` STRIP_ASSUME_TAC) THEN
+    CONJ_TAC THENL
+    [ FIRST_X_ASSUM(SUBST1_TAC o SYM) THEN MATCH_MP_TAC INTERS_SUBSET THEN
+      ASM_SIMP_TAC std_ss [OPEN_IN_SUBSET, FORALL_IN_GSPEC] THEN SET_TAC[],
+      ALL_TAC ] ] THEN
+  Q.EXISTS_TAC `\n. topspace top DIFF (c:num->'a->bool) n` THEN
+  ASM_SIMP_TAC std_ss [OPEN_IN_DIFF, CLOSED_IN_DIFF, OPEN_IN_TOPSPACE,
+    CLOSED_IN_TOPSPACE, SET_RULE ``s SUBSET t ==> u DIFF t SUBSET u DIFF s``]
+  THENL
+  [ (* goal 1 (of 2) *)
+    FIRST_X_ASSUM(MP_TAC o MATCH_MP (SET_RULE
+     ``u = t DIFF s ==> s SUBSET t ==> s = t DIFF u``)) THEN
+    ASM_REWRITE_TAC[] THEN DISCH_THEN SUBST1_TAC THEN
+    REWRITE_TAC[DIFF_UNIONS],
+    (* goal 2 (of 2) *)
+    FIRST_X_ASSUM(SUBST1_TAC o SYM) THEN REWRITE_TAC[DIFF_INTERS] ] THEN
+  SIMP_TAC std_ss [SET_RULE ``{g y | y IN {f x | x IN s}} = {g(f x) | x IN s}``] THEN
+  SIMP_TAC std_ss [SET_RULE ``s = t INTER s <=> s SUBSET t``] THEN
+  MATCH_MP_TAC INTERS_SUBSET THEN
+  ASM_SIMP_TAC std_ss [OPEN_IN_SUBSET, FORALL_IN_GSPEC] THEN SET_TAC[]
+QED
+
+Theorem FSIGMA_IN_RELATIVE_TO :
+   !top s:'a->bool.
+        (fsigma_in top relative_to s) = fsigma_in (subtopology top s)
+Proof
+  REWRITE_TAC[fsigma_in, COUNTABLE_UNION_OF_RELATIVE_TO] THEN
+  REWRITE_TAC[CLOSED_IN_RELATIVE_TO]
+QED
+
+Theorem FSIGMA_IN_RELATIVE_TO_TOPSPACE :
+   !top:'a topology. fsigma_in top relative_to (topspace top) = fsigma_in top
+Proof
+   rw [FSIGMA_IN_RELATIVE_TO, SUBTOPOLOGY_TOPSPACE]
+QED
+
+Theorem FSIGMA_IN_SUBTOPOLOGY :
+   !top u s:'a->bool.
+         fsigma_in (subtopology top u) s <=>
+         ?t. fsigma_in top t /\ s = t INTER u
+Proof
+  REPEAT GEN_TAC THEN REWRITE_TAC[GSYM FSIGMA_IN_RELATIVE_TO] THEN
+  REWRITE_TAC[relative_to] THEN MESON_TAC[INTER_COMM]
+QED
+
+Theorem GDELTA_IN_RELATIVE_TO :
+   !top s:'a->bool.
+        (gdelta_in top relative_to s) = gdelta_in (subtopology top s)
+Proof
+  REWRITE_TAC[gdelta_in, RELATIVE_TO_RELATIVE_TO] THEN
+  ONCE_REWRITE_TAC[COUNTABLE_INTERSECTION_OF_RELATIVE_TO] THEN
+  REWRITE_TAC[OPEN_IN_RELATIVE_TO] THEN
+  REWRITE_TAC[SUBTOPOLOGY_SUBTOPOLOGY, TOPSPACE_SUBTOPOLOGY] THEN
+  SIMP_TAC std_ss [SET_RULE ``s INTER (u INTER s) = u INTER s``]
+QED
+
+Theorem GDELTA_IN_SUBTOPOLOGY :
+   !top u s:'a->bool.
+         gdelta_in (subtopology top u) s <=>
+         ?t. gdelta_in top t /\ s = t INTER u
+Proof
+  REPEAT GEN_TAC THEN REWRITE_TAC[GSYM GDELTA_IN_RELATIVE_TO] THEN
+  REWRITE_TAC[relative_to] THEN MESON_TAC[INTER_COMM]
+QED
+
+Theorem FSIGMA_IN_FSIGMA_SUBTOPOLOGY :
+   !top s t:'a->bool.
+        fsigma_in top s
+        ==> (fsigma_in (subtopology top s) t <=>
+             fsigma_in top t /\ t SUBSET s)
+Proof
+  REPEAT STRIP_TAC THEN REWRITE_TAC[FSIGMA_IN_SUBTOPOLOGY] THEN
+  EQ_TAC THEN STRIP_TAC THEN ASM_SIMP_TAC std_ss [INTER_SUBSET, FSIGMA_IN_INTER] THEN
+  Q.EXISTS_TAC `t:'a->bool` THEN ASM_REWRITE_TAC[] THEN ASM_SET_TAC[]
+QED
+
+Theorem GDELTA_IN_GDELTA_SUBTOPOLOGY :
+   !top s t:'a->bool.
+        gdelta_in top s
+        ==> (gdelta_in (subtopology top s) t <=>
+             gdelta_in top t /\ t SUBSET s)
+Proof
+  REPEAT STRIP_TAC THEN REWRITE_TAC[GDELTA_IN_SUBTOPOLOGY] THEN
+  EQ_TAC THEN STRIP_TAC THEN ASM_SIMP_TAC std_ss [INTER_SUBSET, GDELTA_IN_INTER] THEN
+  Q.EXISTS_TAC `t:'a->bool` THEN ASM_REWRITE_TAC[] THEN ASM_SET_TAC[]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Metrizable spaces (ported from HOL Light)                                 *)
+(* ------------------------------------------------------------------------- *)
+
+Definition metrizable_space :
+    metrizable_space top = ?m. top = mtopology m
+End
+
+Theorem METRIZABLE_SPACE_MTOPOLOGY :
+   !m. metrizable_space (mtopology m)
+Proof
+  REWRITE_TAC[metrizable_space] THEN MESON_TAC[]
+QED
+
+Theorem FORALL_METRIC_TOPOLOGY :
+   !P. (!m:'a metric. P (mtopology m) (mspace m)) <=>
+       !top. metrizable_space top ==> P top (topspace top)
+Proof
+  SIMP_TAC std_ss [metrizable_space, LEFT_IMP_EXISTS_THM, Once TOPSPACE_MTOPOLOGY]
+QED
+
+Theorem FORALL_METRIZABLE_SPACE :
+   !P. (!top. metrizable_space top ==> P top (topspace top)) <=>
+       (!m:'a metric. P (mtopology m) (mspace m))
+Proof
+  REWRITE_TAC[FORALL_METRIC_TOPOLOGY]
+QED
+
+Theorem EXISTS_METRIZABLE_SPACE :
+   !P. (?top. metrizable_space top /\ P top (topspace top)) <=>
+       (?m:'a metric. P (mtopology m) (mspace m))
+Proof
+  SIMP_TAC pure_ss [MESON[] ``(?(x :'a metric). P x) <=> ~(!x. ~P x)``] THEN
+  SIMP_TAC pure_ss [FORALL_METRIC_TOPOLOGY] THEN MESON_TAC[]
+QED
+
+(* key result *)
+Theorem CLOSED_IMP_GDELTA_IN :
+   !top s:'a->bool.
+        metrizable_space top /\ closed_in top s ==> gdelta_in top s
+Proof
+  SIMP_TAC std_ss [IMP_CONJ, RIGHT_FORALL_IMP_THM, FORALL_METRIZABLE_SPACE] THEN
+  REPEAT STRIP_TAC THEN
+  ASM_CASES_TAC ``s:'a->bool = {}`` THEN ASM_REWRITE_TAC[GDELTA_IN_EMPTY] THEN
+  SUBGOAL_THEN
+   ``s:'a->bool =
+    INTERS
+     {{x | x IN mspace m /\
+           ?y. y IN s /\ mdist m (x,y) < inv(&n + &1)} | n IN univ(:num)}``
+  SUBST1_TAC THENL
+  [ (* goal 1 (of 2) *)
+    GEN_REWRITE_TAC I empty_rewrites [EXTENSION] THEN Q.X_GEN_TAC `x:'a` THEN
+    RW_TAC std_ss [INTERS_GSPEC, IN_UNIV, GSPECIFICATION] THEN EQ_TAC THENL
+    [ (* goal 1.1 (of 2) *)
+      DISCH_TAC THEN Q.X_GEN_TAC `n:num` THEN
+      SUBGOAL_THEN ``(x:'a) IN mspace m`` ASSUME_TAC THENL
+      [ ASM_MESON_TAC[CLOSED_IN_SUBSET, SUBSET_DEF, TOPSPACE_MTOPOLOGY],
+        ASM_REWRITE_TAC[] THEN Q.EXISTS_TAC `x:'a` THEN
+        ASM_SIMP_TAC std_ss [MDIST_REFL, REAL_LT_INV_EQ] THEN rw [] ],
+      (* goal 1.2 (of 2) *)
+      ASM_CASES_TAC ``(x:'a) IN mspace m`` THEN ASM_REWRITE_TAC[] THEN
+      Q.ABBREV_TAC ‘P = \e. ?y. y IN s /\ dist m (x,y) < e’ \\
+      ASM_SIMP_TAC std_ss [] \\
+      Q_TAC KNOW_TAC ‘(!n. P (inv (&n + 1))) <=> (!e. 0 < e ==> P e)’
+      >- (ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
+          MATCH_MP_TAC FORALL_POS_MONO_1_EQ \\
+          rw [Abbr ‘P’] >> Q.EXISTS_TAC ‘y’ >> METIS_TAC [REAL_LT_TRANS]) \\
+      DISCH_THEN (ONCE_REWRITE_TAC o wrap) \\
+      rw [Abbr ‘P’] \\
+      FIRST_ASSUM(MP_TAC o GEN_REWRITE_RULE I empty_rewrites [closed_in]) THEN
+      REWRITE_TAC[OPEN_IN_MTOPOLOGY, NOT_FORALL_THM, NOT_IMP] THEN
+      DISCH_THEN(MP_TAC o SPEC ``x:'a`` o CONJUNCT2 o CONJUNCT2) THEN
+      ASM_REWRITE_TAC[IN_DIFF, TOPSPACE_MTOPOLOGY, SUBSET_DEF, IN_MBALL] THEN
+      ASM_MESON_TAC[CLOSED_IN_SUBSET, SUBSET_DEF, TOPSPACE_MTOPOLOGY] ],
+    (* goal 2 (of 2) *)
+    MATCH_MP_TAC GDELTA_IN_INTERS THEN
+    SIMP_TAC std_ss [SIMPLE_IMAGE, COUNTABLE_IMAGE, NUM_COUNTABLE] THEN
+    REWRITE_TAC[IMAGE_EQ_EMPTY, FORALL_IN_IMAGE, UNIV_NOT_EMPTY, IN_UNIV] THEN
+    Q.X_GEN_TAC `n:num` THEN MATCH_MP_TAC OPEN_IMP_GDELTA_IN THEN
+    SIMP_TAC std_ss [OPEN_IN_MTOPOLOGY, SUBSET_RESTRICT] THEN
+    Q.X_GEN_TAC `x:'a` \\
+    RW_TAC std_ss [GSPECIFICATION] \\
+    Q.EXISTS_TAC `inv(&n + &1) - mdist m (x:'a,y)` THEN
+    ASM_SIMP_TAC std_ss [SUBSET_DEF, IN_MBALL, REAL_SUB_LT, GSPECIFICATION] THEN
+    Q.X_GEN_TAC `z:'a` THEN STRIP_TAC THEN ASM_REWRITE_TAC[] THEN
+    Q.EXISTS_TAC `y:'a` THEN ASM_REWRITE_TAC[] THEN
+    ONCE_REWRITE_TAC [METRIC_SYM] \\
+    MATCH_MP_TAC REAL_LET_TRANS \\
+    Q.EXISTS_TAC ‘dist m (y,x) + dist m (x,z)’ >> REWRITE_TAC [METRIC_TRIANGLE] \\
+    ‘y IN mspace m’ (* not really used (in HOL4) *)
+       by ASM_MESON_TAC[CLOSED_IN_SUBSET, SUBSET_DEF, TOPSPACE_MTOPOLOGY] \\
+    METIS_TAC [REAL_LT_SUB_LADD, METRIC_SYM, REAL_ADD_COMM] ]
+QED
+
+Theorem OPEN_IMP_FSIGMA_IN :
+   !top s:'a->bool.
+        metrizable_space top /\ open_in top s ==> fsigma_in top s
+Proof
+  REPEAT STRIP_TAC THEN
+  ASM_SIMP_TAC std_ss [FSIGMA_IN_GDELTA_IN, OPEN_IN_SUBSET] THEN
+  MATCH_MP_TAC CLOSED_IMP_GDELTA_IN THEN
+  ASM_SIMP_TAC std_ss [CLOSED_IN_DIFF, CLOSED_IN_TOPSPACE]
+QED
 
 val _ = remove_ovl_mapping "B" {Name = "B", Thy = "metric"};
 

--- a/src/real/realScript.sml
+++ b/src/real/realScript.sml
@@ -2764,6 +2764,7 @@ val REAL_ADD_RDISTRIB = save_thm ("REAL_ADD_RDISTRIB", REAL_RDISTRIB);
 val REAL_OF_NUM_ADD = save_thm ("REAL_OF_NUM_ADD", REAL_ADD);
 
 val REAL_OF_NUM_LE = save_thm ("REAL_OF_NUM_LE", REAL_LE);
+val REAL_OF_NUM_LT = save_thm ("REAL_OF_NUM_LT", REAL_LT);
 
 val REAL_OF_NUM_MUL = save_thm ("REAL_OF_NUM_MUL", REAL_MUL);
 

--- a/src/topology/Holmakefile
+++ b/src/topology/Holmakefile
@@ -1,3 +1,5 @@
+INCLUDES = ../pred_set/src/more_theories
+
 .PHONY: all
 all: $(DEFAULT_TARGETS)
 

--- a/src/topology/topologyScript.sml
+++ b/src/topology/topologyScript.sml
@@ -1,19 +1,31 @@
-(*===========================================================================*)
-(*  General Topology (from hol-light)                                        *)
+(* ========================================================================= *)
+(*  General Topology in Euclidean space (from hol-light's topology.ml)       *)
 (*                                                                           *)
-(*              (c) Copyright, John Harrison 1998-2015                       *)
+(*              (c) Copyright, John Harrison 1998-2017                       *)
 (*                (c) Copyright, Valentina Bruno 2010                        *)
-(*               (c) Copyright, Marco Maggesi 2014-2015                      *)
+(*               (c) Copyright, Marco Maggesi 2014-2017                      *)
+(*             (c) Copyright, Andrea Gabrielli 2016-2017                     *)
+(* ========================================================================= *)
+(*  Basic Set Theory (using predicates as sets) (from hol-light's sets.ml)   *)
+(*                                                                           *)
+(*       John Harrison, University of Cambridge Computer Laboratory          *)
+(*                                                                           *)
+(*            (c) Copyright, University of Cambridge 1998                    *)
+(*              (c) Copyright, John Harrison 1998-2016                       *)
+(*              (c) Copyright, Marco Maggesi 2012-2017                       *)
+(*             (c) Copyright, Andrea Gabrielli 2012-2017                     *)
 (* ========================================================================= *)
 
 (* NOTE: this script is loaded after "integerTheory", before "realTheory", only
    general topology theorems without using real numbers should be put here.
 
-   see real_topologyTheory for elementary topology in Euclidean space.
+   see real_topologyTheory for Elementary Topology in Euclidean space.
  *)
 
-open HolKernel Parse bossLib boolLib BasicProvers boolSimps simpLib mesonLib
-     metisLib pairTheory pairLib pred_setTheory
+open HolKernel Parse bossLib boolLib;
+
+open boolSimps simpLib mesonLib metisLib pairTheory pairLib tautLib
+     pred_setTheory arithmeticTheory cardinalTheory;
 
 val _ = new_theory "topology";
 
@@ -23,6 +35,24 @@ fun METIS ths tm = prove(tm,METIS_TAC ths);
 fun K_TAC _ = ALL_TAC;
 val DISC_RW_KILL = DISCH_TAC THEN ONCE_ASM_REWRITE_TAC [] THEN
                    POP_ASSUM K_TAC;
+fun wrap a = [a];
+
+(* Begin of minimal hol-light compatibility layer *)
+Theorem IMP_CONJ      = cardinalTheory.CONJ_EQ_IMP
+Theorem IMP_IMP       = boolTheory.AND_IMP_INTRO
+Theorem FINITE_SUBSET = pred_setTheory.SUBSET_FINITE_I
+Theorem LE_0          = arithmeticTheory.ZERO_LESS_EQ
+
+Theorem FINITE_INDUCT_STRONG :
+   !P:('a->bool)->bool.
+        P {} /\ (!x s. P s /\ ~(x IN s) /\ FINITE s ==> P(x INSERT s))
+        ==> !s. FINITE s ==> P s
+Proof
+   METIS_TAC [FINITE_INDUCT]
+QED
+
+val REPLICATE_TAC = NTAC;
+(* End of minimal hol-light compatibility layer *)
 
 (*---------------------------------------------------------------------------*)
 (* Characterize an (alpha)topology                                           *)
@@ -692,6 +722,1437 @@ Proof
    (X_CHOOSE_THEN ``t':'a->bool`` STRIP_ASSUME_TAC)) THEN
   EXISTS_TAC ``s' INTER t':'a->bool`` >> ASM_SIMP_TAC std_ss [CLOSED_IN_INTER]>>
   REPEAT (POP_ASSUM MP_TAC) THEN SET_TAC[]
+QED
+
+Theorem SUBTOPOLOGY_SUBTOPOLOGY :
+   !top s t:'a->bool.
+        subtopology (subtopology top s) t = subtopology top (s INTER t)
+Proof
+  REPEAT GEN_TAC THEN ONCE_REWRITE_TAC[subtopology] THEN
+  REWRITE_TAC[OPEN_IN_SUBTOPOLOGY] THEN
+  SIMP_TAC std_ss [SET_RULE ``{f x | ?y. P y /\ x = g y} = {f(g y) | P y}``] THEN
+  REWRITE_TAC[INTER_ASSOC]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* HOL Light compatibility layer (sets.ml)                                   *)
+(* ------------------------------------------------------------------------- *)
+
+(* moved here from util_probTheory *)
+Theorem EXT_SKOLEM_THM :
+    !P Q. (!x. x IN P ==> ?y. Q x y) <=> ?f. !x. x IN P ==> Q x (f x)
+Proof
+    rpt STRIP_TAC
+ >> reverse EQ_TAC >> rpt STRIP_TAC
+ >- (Q.EXISTS_TAC `f x` \\
+     FIRST_X_ASSUM MATCH_MP_TAC >> rw [])
+ >> fs [GSYM RIGHT_EXISTS_IMP_THM, SKOLEM_THM]
+ >> Q.EXISTS_TAC `f` >> rw []
+QED
+
+(* applied version, used in ‘example/probability’ *)
+Theorem EXT_SKOLEM_THM' = REWRITE_RULE [IN_APP] EXT_SKOLEM_THM
+
+(* HOL Light compatibility layer (sets.ml) *)
+Overload UNIONS[inferior] = “BIGUNION”
+Overload INTERS[inferior] = “BIGINTER”
+
+Theorem COUNTABLE_SUBSET_NUM = COUNTABLE_NUM
+Theorem FINITE_IMAGE         = IMAGE_FINITE
+Theorem IN_INTERS            = IN_BIGINTER
+Theorem IN_UNIONS            = IN_BIGUNION
+Theorem INTER_UNIONS         = INTER_BIGUNION
+Theorem INTERS_0             = BIGINTER_EMPTY
+Theorem INTERS_1             = BIGINTER_SING
+Theorem INTERS_2             = BIGINTER_2
+Theorem INTERS_INSERT        = BIGINTER_INSERT
+Theorem UNIONS_0             = BIGUNION_EMPTY
+Theorem UNIONS_1             = BIGUNION_SING
+Theorem UNIONS_2             = BIGUNION_2
+Theorem UNIONS_UNION         = BIGUNION_UNION
+Theorem UNIONS_INSERT        = BIGUNION_INSERT
+Theorem UNIONS_SUBSET        = BIGUNION_SUBSET
+
+Theorem EMPTY_GSPEC :
+   {x | F} = {}
+Proof SET_TAC[]
+QED
+
+Theorem UNIV_GSPEC :
+   {x | T} = UNIV
+Proof SET_TAC[]
+QED
+
+Theorem SING_GSPEC :
+   (!a. {x | x = a} = {a}) /\ (!a. {x | a = x} = {a})
+Proof SET_TAC[]
+QED
+
+Theorem IN_GSPEC :
+   !s. {x | x IN s} = s
+Proof SET_TAC[]
+QED
+
+Theorem SUBSET_RESTRICT :
+   !s P. {x | x IN s /\ P x} SUBSET s
+Proof SET_TAC []
+QED
+
+(* This version is considered as "applied" as ‘COMPL’ itself doesn't appear:
+
+   |- !s. univ(:'a) DIFF (univ(:'a) DIFF s) = s
+ *)
+Theorem COMPL_COMPL_applied = REWRITE_RULE [COMPL_DEF] COMPL_COMPL
+
+(* |- !f s. {f x | x IN s} = IMAGE f s *)
+Theorem SIMPLE_IMAGE = GSYM IMAGE_DEF
+
+Theorem FORALL_IN_GSPEC :
+   (!P f. (!z. z IN {f x | P x} ==> Q z) <=> (!x. P x ==> Q(f x))) /\
+   (!P f. (!z. z IN {f x y | P x y} ==> Q z) <=>
+          (!x y. P x y ==> Q(f x y))) /\
+   (!P f. (!z. z IN {f w x y | P w x y} ==> Q z) <=>
+          (!w x y. P w x y ==> Q(f w x y)))
+Proof
+   SRW_TAC [][] THEN SET_TAC []
+QED
+
+Theorem EXISTS_IN_GSPEC :
+   (!P f. (?z. z IN {f x | P x} /\ Q z) <=> (?x. P x /\ Q(f x))) /\
+   (!P f. (?z. z IN {f x y | P x y} /\ Q z) <=>
+          (?x y. P x y /\ Q(f x y))) /\
+   (!P f. (?z. z IN {f w x y | P w x y} /\ Q z) <=>
+          (?w x y. P w x y /\ Q(f w x y)))
+Proof
+  SRW_TAC [][] THEN SET_TAC []
+QED
+
+Theorem UNIONS_IMAGE :
+   !f s. UNIONS (IMAGE f s) = {y | ?x. x IN s /\ y IN f x}
+Proof
+    rpt GEN_TAC
+ >> rw [Once EXTENSION]
+ >> EQ_TAC >> rw [] >> rename1 ‘x IN f t’
+ >- (Q.EXISTS_TAC ‘t’ >> rw [])
+ >> Q.EXISTS_TAC ‘f t’ >> rw []
+ >> Q.EXISTS_TAC ‘t’ >> rw []
+QED
+
+Theorem INTERS_IMAGE :
+   !f s. INTERS (IMAGE f s) = {y | !x. x IN s ==> y IN f x}
+Proof
+    rpt GEN_TAC
+ >> rw [Once EXTENSION]
+ >> EQ_TAC >> rw [] >> rename1 ‘x IN f t’
+ >- (FIRST_X_ASSUM MATCH_MP_TAC \\
+     Q.EXISTS_TAC ‘t’ >> rw [])
+ >> FIRST_X_ASSUM MATCH_MP_TAC >> rw []
+QED
+
+Theorem DIFF_INTERS :
+   !u s. u DIFF INTERS s = UNIONS {u DIFF t | t IN s}
+Proof
+    rpt GEN_TAC
+ >> rw [Once EXTENSION]
+ >> EQ_TAC >> rw []
+ >- (Q.EXISTS_TAC ‘u DIFF P’ >> rw [] \\
+     Q.EXISTS_TAC ‘P’ >> rw [])
+ >- fs []
+ >> Q.EXISTS_TAC ‘t’ >> fs []
+QED
+
+Theorem INTERS_GSPEC :
+   (!P f. INTERS {f x | P x} = {a | !x. P x ==> a IN (f x)}) /\
+   (!P f. INTERS {f x y | P x y} = {a | !x y. P x y ==> a IN (f x y)}) /\
+   (!P f. INTERS {f x y z | P x y z} =
+                {a | !x y z. P x y z ==> a IN (f x y z)})
+Proof
+  rpt STRIP_TAC >> GEN_REWRITE_TAC I empty_rewrites [EXTENSION] \\
+  rw [IN_INTERS] >> MESON_TAC []
+QED
+
+Theorem UNIONS_GSPEC :
+   (!P f. UNIONS {f x | P x} = {a | ?x. P x /\ a IN (f x)}) /\
+   (!P f. UNIONS {f x y | P x y} = {a | ?x y. P x y /\ a IN (f x y)}) /\
+   (!P f. UNIONS {f x y z | P x y z} =
+            {a | ?x y z. P x y z /\ a IN (f x y z)})
+Proof
+  rpt STRIP_TAC >> GEN_REWRITE_TAC I empty_rewrites [EXTENSION] \\
+  rw [IN_UNIONS] >> MESON_TAC []
+QED
+
+Theorem INTER_INTERS :
+   (!f s:'a->bool. s INTER INTERS f =
+           if f = {} then s else INTERS {s INTER t | t IN f}) /\
+   (!f s:'a->bool. INTERS f INTER s =
+           if f = {} then s else INTERS {t INTER s | t IN f})
+Proof
+    CONJ_ASM1_TAC
+ >- (rpt STRIP_TAC THEN COND_CASES_TAC THEN
+     ASM_SIMP_TAC std_ss [INTERS_0, INTER_UNIV, INTERS_GSPEC] THEN
+     rw [Once EXTENSION, IN_INTERS] \\
+     EQ_TAC >> rw [] \\
+     fs [GSYM MEMBER_NOT_EMPTY] >> PROVE_TAC [])
+ >> POP_ASSUM (ACCEPT_TAC o (ONCE_REWRITE_RULE [INTER_COMM]))
+QED
+
+Theorem INTERS_UNIONS :
+   !s. INTERS s = UNIV DIFF (UNIONS {UNIV DIFF t | t IN s})
+Proof
+  REWRITE_TAC[GSYM DIFF_INTERS] THEN SET_TAC[]
+QED
+
+Theorem UNIONS_INTERS :
+   !s. UNIONS s = UNIV DIFF (INTERS {UNIV DIFF t | t IN s})
+Proof
+    GEN_TAC
+ >> rw [Once EXTENSION]
+ >> EQ_TAC >> rw []
+ >- (rename1 ‘x IN t’ \\
+     Q.EXISTS_TAC ‘univ(:'a) DIFF t’ \\
+     rw [] >> Q.EXISTS_TAC ‘t’ >> rw [])
+ >> fs []
+ >> Q.EXISTS_TAC ‘t’ >> rw []
+QED
+
+(* NOTE: HOL4's BIGINTER_SUBSET doesn't have ‘u <> {}’ *)
+Theorem INTERS_SUBSET :
+   !u s:'a->bool.
+    ~(u = {}) /\ (!t. t IN u ==> t SUBSET s) ==> INTERS u SUBSET s
+Proof
+  SET_TAC[]
+QED
+
+(* essentially same as HOL4's BIGINTER_SUBSET but looks more reasonable *)
+Theorem INTERS_SUBSET_STRONG :
+   !u s:'a->bool. (?t. t IN u /\ t SUBSET s) ==> INTERS u SUBSET s
+Proof
+  SET_TAC[]
+QED
+
+Theorem DIFF_UNIONS :
+   !u s. u DIFF UNIONS s = u INTER INTERS {u DIFF t | t IN s}
+Proof
+  SIMP_TAC std_ss [INTERS_GSPEC] THEN SET_TAC[]
+QED
+
+Theorem DIFF_UNIONS_NONEMPTY :
+   !u s. ~(s = {}) ==> u DIFF UNIONS s = INTERS {u DIFF t | t IN s}
+Proof
+  SIMP_TAC std_ss [INTERS_GSPEC] THEN SET_TAC[]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Pairwise property over sets and lists (from real_topologyTheory)          *)
+(* ------------------------------------------------------------------------- *)
+
+val _ = hide "pairwise"; (* pred_setTheory *)
+
+val pairwise = new_definition ("pairwise",
+  ``pairwise r s <=> !x y. x IN s /\ y IN s /\ ~(x = y) ==> r x y``);
+
+val PAIRWISE_EMPTY = store_thm ("PAIRWISE_EMPTY",
+ ``!r. pairwise r {} <=> T``,
+  REWRITE_TAC[pairwise, NOT_IN_EMPTY] THEN MESON_TAC[]);
+
+val PAIRWISE_SING = store_thm ("PAIRWISE_SING",
+ ``!r x. pairwise r {x} <=> T``,
+  REWRITE_TAC[pairwise, IN_SING] THEN MESON_TAC[]);
+
+val PAIRWISE_MONO = store_thm ("PAIRWISE_MONO",
+ ``!r s t. pairwise r s /\ t SUBSET s ==> pairwise r t``,
+  REWRITE_TAC[pairwise] THEN SET_TAC[]);
+
+val PAIRWISE_INSERT = store_thm ("PAIRWISE_INSERT",
+ ``!r x s.
+        pairwise r (x INSERT s) <=>
+        (!y. y IN s /\ ~(y = x) ==> r x y /\ r y x) /\
+        pairwise r s``,
+  REWRITE_TAC[pairwise, IN_INSERT] THEN MESON_TAC[]);
+
+val PAIRWISE_IMAGE = store_thm ("PAIRWISE_IMAGE",
+ ``!r f. pairwise r (IMAGE f s) <=>
+         pairwise (\x y. ~(f x = f y) ==> r (f x) (f y)) s``,
+  REWRITE_TAC[pairwise, IN_IMAGE] THEN MESON_TAC[]);
+
+(* ------------------------------------------------------------------------- *)
+(* Useful idioms for being a suitable union/intersection of somethings.      *)
+(* (ported from HOL Light)                                                   *)
+(* ------------------------------------------------------------------------- *)
+
+val _ = set_fixity "UNION_OF"        (Infixr 601);
+val _ = set_fixity "INTERSECTION_OF" (Infixr 601);
+
+Definition UNION_OF :
+   P UNION_OF Q = \s. ?u. P u /\ (!c. c IN u ==> Q c) /\ UNIONS u = s
+End
+
+Definition INTERSECTION_OF :
+   P INTERSECTION_OF Q = \s. ?u. P u /\ (!c. c IN u ==> Q c) /\ INTERS u = s
+End
+
+Theorem UNION_OF_INC :
+   !P Q s:'a->bool. P {s} /\ Q s ==> (P UNION_OF Q) s
+Proof
+  REPEAT STRIP_TAC THEN SIMP_TAC std_ss [UNION_OF] THEN
+  Q.EXISTS_TAC `{s:'a->bool}` THEN ASM_SIMP_TAC std_ss [UNIONS_1, IN_SING]
+QED
+
+Theorem INTERSECTION_OF_INC :
+   !P Q s:'a->bool. P {s} /\ Q s ==> (P INTERSECTION_OF Q) s
+Proof
+  REPEAT STRIP_TAC THEN SIMP_TAC std_ss [INTERSECTION_OF] THEN
+  Q.EXISTS_TAC `{s:'a->bool}` THEN ASM_SIMP_TAC std_ss [INTERS_1, IN_SING]
+QED
+
+Theorem UNION_OF_MONO :
+   !P Q Q' s:'a->bool.
+        (P UNION_OF Q) s /\ (!x. Q x ==> Q' x) ==> (P UNION_OF Q') s
+Proof
+  SIMP_TAC std_ss [UNION_OF] THEN MESON_TAC[]
+QED
+
+Theorem INTERSECTION_OF_MONO :
+   !P Q Q' s:'a->bool.
+        (P INTERSECTION_OF Q) s /\ (!x. Q x ==> Q' x)
+        ==> (P INTERSECTION_OF Q') s
+Proof
+  SIMP_TAC std_ss [INTERSECTION_OF] THEN MESON_TAC[]
+QED
+
+Theorem FORALL_UNION_OF :
+   (!s. (P UNION_OF Q) s ==> R s) <=>
+   (!t. P t /\ (!c. c IN t ==> Q c) ==> R(UNIONS t))
+Proof
+  SIMP_TAC std_ss [UNION_OF] THEN MESON_TAC[]
+QED
+
+Theorem FORALL_INTERSECTION_OF :
+   (!s. (P INTERSECTION_OF Q) s ==> R s) <=>
+   (!t. P t /\ (!c. c IN t ==> Q c) ==> R(INTERS t))
+Proof
+  SIMP_TAC std_ss [INTERSECTION_OF] THEN MESON_TAC[]
+QED
+
+Theorem UNION_OF_EMPTY :
+   !P Q:('a->bool)->bool. P {} ==> (P UNION_OF Q) {}
+Proof
+  REPEAT STRIP_TAC THEN SIMP_TAC std_ss [UNION_OF] THEN
+  Q.EXISTS_TAC `{}:('a->bool)->bool` THEN
+  ASM_SIMP_TAC std_ss [UNIONS_0, NOT_IN_EMPTY]
+QED
+
+Theorem INTERSECTION_OF_EMPTY :
+   !P Q:('a->bool)->bool. P {} ==> (P INTERSECTION_OF Q) UNIV
+Proof
+  REPEAT STRIP_TAC THEN SIMP_TAC std_ss [INTERSECTION_OF] THEN
+  Q.EXISTS_TAC `{}:('a->bool)->bool` THEN
+  ASM_SIMP_TAC std_ss [INTERS_0, NOT_IN_EMPTY]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* The ARBITRARY and FINITE cases of UNION_OF / INTERSECTION_OF              *)
+(* ------------------------------------------------------------------------- *)
+
+Definition ARBITRARY :
+    ARBITRARY (s:('a->bool)->bool) <=> T
+End
+
+Theorem ARBITRARY_UNION_OF_ALT :
+   !B s:'a->bool.
+        (ARBITRARY UNION_OF B) s <=>
+        !x. x IN s ==>  ?u. u IN B /\ x IN u /\ u SUBSET s
+Proof
+  GEN_TAC THEN SIMP_TAC std_ss [FORALL_AND_THM, TAUT
+   `(p <=> q) <=> (p ==> q) /\ (q ==> p)`] THEN
+  SIMP_TAC std_ss [FORALL_UNION_OF, ARBITRARY] THEN
+  CONJ_TAC THENL [SET_TAC[], ALL_TAC] THEN
+  Q.X_GEN_TAC `s:'a->bool` THEN DISCH_TAC THEN
+  SIMP_TAC std_ss [ARBITRARY, UNION_OF] THEN
+  Q.EXISTS_TAC `{u:'a->bool | u IN B /\ u SUBSET s}` THEN ASM_SET_TAC[]
+QED
+
+Theorem ARBITRARY_UNION_OF_EMPTY :
+   !P:('a->bool)->bool. (ARBITRARY UNION_OF P) {}
+Proof
+  SIMP_TAC std_ss [UNION_OF_EMPTY, ARBITRARY]
+QED
+
+Theorem ARBITRARY_INTERSECTION_OF_EMPTY :
+   !P:('a->bool)->bool. (ARBITRARY INTERSECTION_OF P) UNIV
+Proof
+  SIMP_TAC std_ss [INTERSECTION_OF_EMPTY, ARBITRARY]
+QED
+
+Theorem ARBITRARY_UNION_OF_INC :
+   !P s:'a->bool. P s ==> (ARBITRARY UNION_OF P) s
+Proof
+  SIMP_TAC std_ss [UNION_OF_INC, ARBITRARY]
+QED
+
+Theorem ARBITRARY_INTERSECTION_OF_INC :
+   !P s:'a->bool. P s ==> (ARBITRARY INTERSECTION_OF P) s
+Proof
+  SIMP_TAC std_ss [INTERSECTION_OF_INC, ARBITRARY]
+QED
+
+Theorem ARBITRARY_UNION_OF_COMPLEMENT :
+   !P s. (ARBITRARY UNION_OF P) s <=>
+         (ARBITRARY INTERSECTION_OF (\s. P(univ(:'a) DIFF s))) (univ(:'a) DIFF s)
+Proof
+  REPEAT GEN_TAC THEN SIMP_TAC std_ss [UNION_OF, INTERSECTION_OF] THEN
+  EQ_TAC THEN
+  DISCH_THEN(Q.X_CHOOSE_THEN `u:('a->bool)->bool` STRIP_ASSUME_TAC) THEN
+  Q.EXISTS_TAC `IMAGE (\c. univ(:'a) DIFF c) u` THEN
+  ASM_SIMP_TAC std_ss [ARBITRARY, FORALL_IN_IMAGE, COMPL_COMPL_applied] THEN
+  ONCE_REWRITE_TAC [UNIONS_INTERS, INTERS_UNIONS] THEN
+  SIMP_TAC std_ss [SET_RULE ``{f y | y IN IMAGE g s} = IMAGE (\x. f(g x)) s``] THEN
+  ASM_SIMP_TAC std_ss [IMAGE_ID, COMPL_COMPL_applied]
+QED
+
+Theorem ARBITRARY_INTERSECTION_OF_COMPLEMENT :
+   !P s. (ARBITRARY INTERSECTION_OF P) s <=>
+         (ARBITRARY UNION_OF (\s. P(univ(:'a) DIFF s))) (univ(:'a) DIFF s)
+Proof
+  SIMP_TAC std_ss [ARBITRARY_UNION_OF_COMPLEMENT] THEN
+  SIMP_TAC std_ss [ETA_AX, COMPL_COMPL_applied]
+QED
+
+Theorem ARBITRARY_UNION_OF_IDEMPOT :
+   !P:('a->bool)->bool.
+        ARBITRARY UNION_OF ARBITRARY UNION_OF P = ARBITRARY UNION_OF P
+Proof
+  GEN_TAC THEN SIMP_TAC std_ss [FUN_EQ_THM] THEN Q.X_GEN_TAC `s:'a->bool` THEN
+  EQ_TAC THEN SIMP_TAC std_ss [ARBITRARY_UNION_OF_INC] THEN
+  SIMP_TAC std_ss [UNION_OF, LEFT_IMP_EXISTS_THM] THEN
+  Q.X_GEN_TAC `u:('a->bool)->bool` THEN
+  DISCH_THEN(CONJUNCTS_THEN2 ASSUME_TAC MP_TAC) THEN
+  DISCH_THEN(CONJUNCTS_THEN2 MP_TAC (SUBST1_TAC o SYM)) THEN
+  rw [EXT_SKOLEM_THM] \\
+  Q.EXISTS_TAC
+    `IMAGE SND {(s,t) | s IN u /\ t IN (f:('a->bool)->('a->bool)->bool) s}` THEN
+  ASM_SIMP_TAC std_ss [ARBITRARY] THEN
+  SIMP_TAC std_ss [FORALL_IN_IMAGE, FORALL_IN_GSPEC] THEN
+  CONJ_TAC THENL [ASM_SET_TAC[], SIMP_TAC std_ss [UNIONS_IMAGE]] THEN
+  SIMP_TAC std_ss [EXISTS_IN_GSPEC] THEN ASM_SET_TAC[]
+QED
+
+Theorem ARBITRARY_INTERSECTION_OF_IDEMPOT :
+   !P:('a->bool)->bool.
+        ARBITRARY INTERSECTION_OF ARBITRARY INTERSECTION_OF P =
+        ARBITRARY INTERSECTION_OF P
+Proof
+    RW_TAC (std_ss ++ ETA_ss) [FUN_EQ_THM, COMPL_COMPL_applied,
+                               ARBITRARY_INTERSECTION_OF_COMPLEMENT]
+ >> SIMP_TAC std_ss [ARBITRARY_UNION_OF_IDEMPOT]
+QED
+
+Theorem ARBITRARY_UNION_OF_UNIONS :
+   !P u:('a->bool)->bool.
+        (!s. s IN u ==> (ARBITRARY UNION_OF P) s)
+        ==> (ARBITRARY UNION_OF P) (UNIONS u)
+Proof
+  REPEAT STRIP_TAC THEN ONCE_REWRITE_TAC [GSYM ARBITRARY_UNION_OF_IDEMPOT] THEN
+  ONCE_REWRITE_TAC [UNION_OF] THEN SIMP_TAC std_ss [] THEN
+  Q.EXISTS_TAC `u:('a->bool)->bool` THEN ASM_SIMP_TAC std_ss [ARBITRARY]
+QED
+
+Theorem ARBITRARY_UNION_OF_UNION :
+   !P s t. (ARBITRARY UNION_OF P) s /\ (ARBITRARY UNION_OF P) t
+           ==> (ARBITRARY UNION_OF P) (s UNION t)
+Proof
+  REPEAT STRIP_TAC THEN SIMP_TAC std_ss [GSYM UNIONS_2] THEN
+  MATCH_MP_TAC ARBITRARY_UNION_OF_UNIONS THEN
+  ASM_SIMP_TAC std_ss [ARBITRARY, FORALL_IN_INSERT] THEN
+  SIMP_TAC std_ss [ARBITRARY, NOT_IN_EMPTY]
+QED
+
+Theorem ARBITRARY_INTERSECTION_OF_INTERS :
+   !P u:('a->bool)->bool.
+        (!s. s IN u ==> (ARBITRARY INTERSECTION_OF P) s)
+        ==> (ARBITRARY INTERSECTION_OF P) (INTERS u)
+Proof
+  REPEAT STRIP_TAC THEN
+  ONCE_REWRITE_TAC [GSYM ARBITRARY_INTERSECTION_OF_IDEMPOT] THEN
+  ONCE_REWRITE_TAC [INTERSECTION_OF] THEN SIMP_TAC std_ss [] THEN
+  Q.EXISTS_TAC `u:('a->bool)->bool` THEN ASM_SIMP_TAC std_ss [ARBITRARY]
+QED
+
+Theorem ARBITRARY_INTERSECTION_OF_INTER :
+   !P s t. (ARBITRARY INTERSECTION_OF P) s /\ (ARBITRARY INTERSECTION_OF P) t
+           ==> (ARBITRARY INTERSECTION_OF P) (s INTER t)
+Proof
+  REPEAT STRIP_TAC THEN SIMP_TAC std_ss [GSYM INTERS_2] THEN
+  MATCH_MP_TAC ARBITRARY_INTERSECTION_OF_INTERS THEN
+  ASM_SIMP_TAC std_ss [ARBITRARY, FORALL_IN_INSERT] THEN
+  SIMP_TAC std_ss [ARBITRARY, NOT_IN_EMPTY]
+QED
+
+Theorem ARBITRARY_UNION_OF_INTER_EQ :
+   !P:('a->bool)->bool.
+        (!s t. (ARBITRARY UNION_OF P) s /\ (ARBITRARY UNION_OF P) t
+               ==> (ARBITRARY UNION_OF P) (s INTER t)) <=>
+        (!s t. P s /\ P t ==> (ARBITRARY UNION_OF P) (s INTER t))
+Proof
+  GEN_TAC THEN
+  EQ_TAC THENL [MESON_TAC[ARBITRARY_UNION_OF_INC], DISCH_TAC] THEN
+  REPEAT GEN_TAC THEN
+  GEN_REWRITE_TAC (LAND_CONV o ONCE_DEPTH_CONV) empty_rewrites [UNION_OF] THEN
+  SIMP_TAC std_ss [] THEN DISCH_THEN(STRIP_ASSUME_TAC o GSYM) THEN
+  ASM_SIMP_TAC std_ss [INTER_UNIONS] THEN
+  REPLICATE_TAC 2
+   (MATCH_MP_TAC ARBITRARY_UNION_OF_UNIONS THEN
+    ASM_SIMP_TAC std_ss [SIMPLE_IMAGE, ARBITRARY, FORALL_IN_IMAGE] THEN
+    REPEAT STRIP_TAC)
+QED
+
+Theorem ARBITRARY_UNION_OF_INTER :
+   !P:('a->bool)->bool.
+        (!s t. P s /\ P t ==> P(s INTER t))
+        ==> (!s t. (ARBITRARY UNION_OF P) s /\ (ARBITRARY UNION_OF P) t
+                   ==> (ARBITRARY UNION_OF P) (s INTER t))
+Proof
+  RW_TAC std_ss [ARBITRARY_UNION_OF_INTER_EQ,
+                 ARBITRARY_UNION_OF_INC]
+QED
+
+Theorem ARBITRARY_INTERSECTION_OF_UNION_EQ :
+   !P:('a->bool)->bool.
+        (!s t. (ARBITRARY INTERSECTION_OF P) s /\
+               (ARBITRARY INTERSECTION_OF P) t
+               ==> (ARBITRARY INTERSECTION_OF P) (s UNION t)) <=>
+        (!s t. P s /\ P t ==> (ARBITRARY INTERSECTION_OF P) (s UNION t))
+Proof
+  ONCE_REWRITE_TAC [ARBITRARY_INTERSECTION_OF_COMPLEMENT] THEN
+  SIMP_TAC std_ss [SET_RULE
+    ``UNIV DIFF (s UNION t) = (UNIV DIFF s) INTER (UNIV DIFF t)``] THEN
+  SIMP_TAC std_ss [MESON[COMPL_COMPL_applied] ``(!s. P(UNIV DIFF s)) <=> (!s. P s)``] THEN
+  SIMP_TAC std_ss [ARBITRARY_UNION_OF_INTER_EQ] THEN
+  SIMP_TAC std_ss [SET_RULE
+   ``s INTER t = UNIV DIFF ((UNIV DIFF s) UNION (UNIV DIFF t))``] THEN
+  SIMP_TAC std_ss [MESON[COMPL_COMPL_applied] ``(!s. P(UNIV DIFF s)) <=> (!s. P s)``] THEN
+  SIMP_TAC std_ss [COMPL_COMPL_applied]
+QED
+
+Theorem ARBITRARY_INTERSECTION_OF_UNION :
+   !P:('a->bool)->bool.
+        (!s t. P s /\ P t ==> P(s UNION t))
+        ==> (!s t. (ARBITRARY INTERSECTION_OF P) s /\
+                   (ARBITRARY INTERSECTION_OF P) t
+                   ==> (ARBITRARY INTERSECTION_OF P) (s UNION t))
+Proof
+  SIMP_TAC std_ss [ARBITRARY_INTERSECTION_OF_UNION_EQ] THEN
+  MESON_TAC[ARBITRARY_INTERSECTION_OF_INC]
+QED
+
+Theorem FINITE_UNION_OF_EMPTY :
+   !P:('a->bool)->bool. (FINITE UNION_OF P) {}
+Proof
+  SIMP_TAC std_ss [UNION_OF_EMPTY, FINITE_EMPTY]
+QED
+
+Theorem FINITE_INTERSECTION_OF_EMPTY :
+   !P:('a->bool)->bool. (FINITE INTERSECTION_OF P) UNIV
+Proof
+  SIMP_TAC std_ss [INTERSECTION_OF_EMPTY, FINITE_EMPTY]
+QED
+
+Theorem FINITE_UNION_OF_INC :
+   !P s:'a->bool. P s ==> (FINITE UNION_OF P) s
+Proof
+  SIMP_TAC std_ss [UNION_OF_INC, FINITE_SING]
+QED
+
+Theorem FINITE_INTERSECTION_OF_INC :
+   !P s:'a->bool. P s ==> (FINITE INTERSECTION_OF P) s
+Proof
+  SIMP_TAC std_ss [INTERSECTION_OF_INC, FINITE_SING]
+QED
+
+Theorem FINITE_UNION_OF_COMPLEMENT :
+   !P s. (FINITE UNION_OF P) s <=>
+         (FINITE INTERSECTION_OF (\s. P(univ(:'a) DIFF s))) (univ(:'a) DIFF s)
+Proof
+  REPEAT GEN_TAC THEN SIMP_TAC std_ss [UNION_OF, INTERSECTION_OF] THEN
+  EQ_TAC THEN
+  DISCH_THEN(Q.X_CHOOSE_THEN `u:('a->bool)->bool` STRIP_ASSUME_TAC) THEN
+  Q.EXISTS_TAC `IMAGE (\c. univ(:'a) DIFF c) u` THEN
+  ASM_SIMP_TAC std_ss [FINITE_IMAGE, FORALL_IN_IMAGE, COMPL_COMPL_applied] THEN
+  ONCE_REWRITE_TAC [UNIONS_INTERS, INTERS_UNIONS] THEN
+  SIMP_TAC std_ss [SET_RULE ``{f y | y IN IMAGE g s} = IMAGE (\x. f(g x)) s``] THEN
+  ASM_SIMP_TAC std_ss [IMAGE_ID, COMPL_COMPL_applied]
+QED
+
+Theorem FINITE_INTERSECTION_OF_COMPLEMENT :
+   !P s. (FINITE INTERSECTION_OF P) s <=>
+         (FINITE UNION_OF (\s. P(univ(:'a) DIFF s))) (univ(:'a) DIFF s)
+Proof
+  SIMP_TAC std_ss [FINITE_UNION_OF_COMPLEMENT] THEN
+  SIMP_TAC (std_ss ++ ETA_ss) [COMPL_COMPL_applied]
+QED
+
+Theorem FINITE_UNION_OF_IDEMPOT :
+   !P:('a->bool)->bool.
+        FINITE UNION_OF FINITE UNION_OF P = FINITE UNION_OF P
+Proof
+  GEN_TAC THEN SIMP_TAC std_ss [FUN_EQ_THM] THEN Q.X_GEN_TAC `s:'a->bool` THEN
+  EQ_TAC THEN SIMP_TAC std_ss [FINITE_UNION_OF_INC] THEN
+  SIMP_TAC std_ss [UNION_OF, LEFT_IMP_EXISTS_THM] THEN
+  Q.X_GEN_TAC `u:('a->bool)->bool` THEN
+  DISCH_THEN(CONJUNCTS_THEN2 ASSUME_TAC MP_TAC) THEN
+  DISCH_THEN(CONJUNCTS_THEN2 MP_TAC (SUBST1_TAC o SYM)) THEN
+  rw [EXT_SKOLEM_THM] \\
+  Q.EXISTS_TAC
+    `IMAGE SND {(s,t) | s IN u /\ t IN (f:('a->bool)->('a->bool)->bool) s}` THEN
+
+  ASM_SIMP_TAC std_ss [FINITE_IMAGE, FINITE_PRODUCT_DEPENDENT] THEN
+  SIMP_TAC std_ss [FORALL_IN_IMAGE, FORALL_IN_GSPEC] THEN
+  CONJ_TAC THENL [ASM_SET_TAC[], SIMP_TAC std_ss [UNIONS_IMAGE]] THEN
+  SIMP_TAC std_ss [EXISTS_IN_GSPEC] THEN ASM_SET_TAC[]
+QED
+
+Theorem FINITE_INTERSECTION_OF_IDEMPOT :
+   !P:('a->bool)->bool.
+        FINITE INTERSECTION_OF FINITE INTERSECTION_OF P =
+        FINITE INTERSECTION_OF P
+Proof
+  RW_TAC (std_ss ++ ETA_ss) [FUN_EQ_THM, COMPL_COMPL_applied,
+                             FINITE_INTERSECTION_OF_COMPLEMENT] THEN
+  SIMP_TAC std_ss [FINITE_UNION_OF_IDEMPOT]
+QED
+
+Theorem FINITE_UNION_OF_UNIONS :
+   !P u:('a->bool)->bool.
+        FINITE u /\ (!s. s IN u ==> (FINITE UNION_OF P) s)
+        ==> (FINITE UNION_OF P) (UNIONS u)
+Proof
+  REPEAT STRIP_TAC THEN ONCE_REWRITE_TAC [GSYM FINITE_UNION_OF_IDEMPOT] THEN
+  ONCE_REWRITE_TAC [UNION_OF] THEN SIMP_TAC std_ss [] THEN
+  Q.EXISTS_TAC `u:('a->bool)->bool` THEN ASM_SIMP_TAC std_ss []
+QED
+
+Theorem FINITE_UNION_OF_UNION :
+    !P s t. (FINITE UNION_OF P) s /\ (FINITE UNION_OF P) t
+           ==> (FINITE UNION_OF P) (s UNION t)
+Proof
+  REPEAT STRIP_TAC THEN SIMP_TAC std_ss [GSYM UNIONS_2] THEN
+  MATCH_MP_TAC FINITE_UNION_OF_UNIONS THEN
+  ASM_SIMP_TAC std_ss [FINITE_INSERT, FORALL_IN_INSERT] THEN
+  SIMP_TAC std_ss [FINITE_EMPTY, NOT_IN_EMPTY]
+QED
+
+Theorem FINITE_INTERSECTION_OF_INTERS :
+   !P u:('a->bool)->bool.
+        FINITE u /\ (!s. s IN u ==> (FINITE INTERSECTION_OF P) s)
+        ==> (FINITE INTERSECTION_OF P) (INTERS u)
+Proof
+  REPEAT STRIP_TAC THEN
+  ONCE_REWRITE_TAC [GSYM FINITE_INTERSECTION_OF_IDEMPOT] THEN
+  ONCE_REWRITE_TAC [INTERSECTION_OF] THEN SIMP_TAC std_ss [] THEN
+  Q.EXISTS_TAC `u:('a->bool)->bool` THEN ASM_SIMP_TAC std_ss []
+QED
+
+Theorem FINITE_INTERSECTION_OF_INTER :
+   !P s t. (FINITE INTERSECTION_OF P) s /\ (FINITE INTERSECTION_OF P) t
+           ==> (FINITE INTERSECTION_OF P) (s INTER t)
+Proof
+  REPEAT STRIP_TAC THEN SIMP_TAC std_ss [GSYM INTERS_2] THEN
+  MATCH_MP_TAC FINITE_INTERSECTION_OF_INTERS THEN
+  ASM_SIMP_TAC std_ss [FINITE_INSERT, FORALL_IN_INSERT] THEN
+  SIMP_TAC std_ss [FINITE_EMPTY, NOT_IN_EMPTY]
+QED
+
+Theorem FINITE_UNION_OF_INTER_EQ :
+   !P:('a->bool)->bool.
+        (!s t. (FINITE UNION_OF P) s /\ (FINITE UNION_OF P) t
+                   ==> (FINITE UNION_OF P) (s INTER t)) <=>
+        (!s t. P s /\ P t ==> (FINITE UNION_OF P) (s INTER t))
+Proof
+  GEN_TAC THEN
+  EQ_TAC THENL [MESON_TAC[FINITE_UNION_OF_INC], DISCH_TAC] THEN
+  REPEAT GEN_TAC THEN
+  GEN_REWRITE_TAC (LAND_CONV o ONCE_DEPTH_CONV) empty_rewrites [UNION_OF] THEN
+  SIMP_TAC std_ss [] THEN DISCH_THEN(STRIP_ASSUME_TAC o GSYM) THEN
+  ASM_SIMP_TAC std_ss [INTER_UNIONS] THEN
+  REPLICATE_TAC 2
+   (MATCH_MP_TAC FINITE_UNION_OF_UNIONS THEN
+    ASM_SIMP_TAC std_ss [SIMPLE_IMAGE, FINITE_IMAGE, FORALL_IN_IMAGE] THEN
+    REPEAT STRIP_TAC)
+QED
+
+Theorem FINITE_UNION_OF_INTER :
+    !P:('a->bool)->bool.
+        (!s t. P s /\ P t ==> P(s INTER t))
+        ==> (!s t. (FINITE UNION_OF P) s /\ (FINITE UNION_OF P) t
+                   ==> (FINITE UNION_OF P) (s INTER t))
+Proof
+  SIMP_TAC std_ss [FINITE_UNION_OF_INTER_EQ] THEN
+  MESON_TAC[FINITE_UNION_OF_INC]
+QED
+
+Theorem FINITE_INTERSECTION_OF_UNION_EQ :
+    !P:('a->bool)->bool.
+        (!s t. (FINITE INTERSECTION_OF P) s /\
+               (FINITE INTERSECTION_OF P) t
+               ==> (FINITE INTERSECTION_OF P) (s UNION t)) <=>
+        (!s t. P s /\ P t ==> (FINITE INTERSECTION_OF P) (s UNION t))
+Proof
+  ONCE_REWRITE_TAC [FINITE_INTERSECTION_OF_COMPLEMENT] THEN
+  SIMP_TAC std_ss [SET_RULE
+    ``UNIV DIFF (s UNION t) = (UNIV DIFF s) INTER (UNIV DIFF t)``] THEN
+  SIMP_TAC std_ss [MESON[COMPL_COMPL_applied] ``(!s. P(UNIV DIFF s)) <=> (!s. P s)``] THEN
+  SIMP_TAC std_ss [FINITE_UNION_OF_INTER_EQ] THEN
+  SIMP_TAC std_ss [SET_RULE
+   ``s INTER t = UNIV DIFF ((UNIV DIFF s) UNION (UNIV DIFF t))``] THEN
+  SIMP_TAC std_ss [MESON[COMPL_COMPL_applied] ``(!s. P(UNIV DIFF s)) <=> (!s. P s)``] THEN
+  SIMP_TAC std_ss [COMPL_COMPL_applied]
+QED
+
+Theorem FINITE_INTERSECTION_OF_UNION :
+   !P:('a->bool)->bool.
+        (!s t. P s /\ P t ==> P(s UNION t))
+        ==> (!s t. (FINITE INTERSECTION_OF P) s /\
+                   (FINITE INTERSECTION_OF P) t
+                   ==> (FINITE INTERSECTION_OF P) (s UNION t))
+Proof
+  SIMP_TAC std_ss [FINITE_INTERSECTION_OF_UNION_EQ] THEN
+  MESON_TAC[FINITE_INTERSECTION_OF_INC]
+QED
+
+Theorem COUNTABLE_UNION_OF_EMPTY :
+   !P:('a->bool)->bool. (COUNTABLE UNION_OF P) {}
+Proof
+  SIMP_TAC std_ss [UNION_OF_EMPTY, COUNTABLE_EMPTY]
+QED
+
+Theorem COUNTABLE_INTERSECTION_OF_EMPTY :
+   !P:('a->bool)->bool. (COUNTABLE INTERSECTION_OF P) UNIV
+Proof
+  SIMP_TAC std_ss [INTERSECTION_OF_EMPTY, COUNTABLE_EMPTY]
+QED
+
+Theorem COUNTABLE_UNION_OF_INC :
+   !P s:'a->bool. P s ==> (COUNTABLE UNION_OF P) s
+Proof
+  SIMP_TAC std_ss [UNION_OF_INC, COUNTABLE_SING]
+QED
+
+Theorem COUNTABLE_INTERSECTION_OF_INC :
+   !P s:'a->bool. P s ==> (COUNTABLE INTERSECTION_OF P) s
+Proof
+  SIMP_TAC std_ss [INTERSECTION_OF_INC, COUNTABLE_SING]
+QED
+
+Theorem COUNTABLE_UNION_OF_COMPLEMENT :
+   !P s. (COUNTABLE UNION_OF P) s <=>
+         (COUNTABLE INTERSECTION_OF (\s. P(univ(:'a) DIFF s))) (univ(:'a) DIFF s)
+Proof
+  REPEAT GEN_TAC THEN SIMP_TAC std_ss [UNION_OF, INTERSECTION_OF] THEN
+  EQ_TAC THEN
+  DISCH_THEN(Q.X_CHOOSE_THEN `u:('a->bool)->bool` STRIP_ASSUME_TAC) THEN
+  Q.EXISTS_TAC `IMAGE (\c. univ(:'a) DIFF c) u` THEN
+  ASM_SIMP_TAC std_ss [COUNTABLE_IMAGE, FORALL_IN_IMAGE, COMPL_COMPL_applied] THEN
+  ONCE_REWRITE_TAC[UNIONS_INTERS, INTERS_UNIONS] THEN
+  Q.ABBREV_TAC ‘g = \c. univ(:'a) DIFF c’ \\
+  ASM_SIMP_TAC std_ss [] \\
+ ‘{g t | t | t IN IMAGE g u} = IMAGE (\x. g (g x)) u’
+     by (rw [Once EXTENSION] >> METIS_TAC []) \\
+  rw [Abbr ‘g’, IMAGE_ID, COMPL_COMPL_applied]
+QED
+
+Theorem COUNTABLE_INTERSECTION_OF_COMPLEMENT :
+   !P s. (COUNTABLE INTERSECTION_OF P) s <=>
+         (COUNTABLE UNION_OF (\s. P(univ(:'a) DIFF s))) (univ(:'a) DIFF s)
+Proof
+  REWRITE_TAC[COUNTABLE_UNION_OF_COMPLEMENT] THEN
+  SIMP_TAC (std_ss ++ ETA_ss) [COMPL_COMPL_applied]
+QED
+
+Theorem COUNTABLE_UNION_OF_EXPLICIT :
+   !P s:'a->bool.
+        P {}
+        ==> ((COUNTABLE UNION_OF P) s <=>
+             ?t. (!n. P(t n)) /\ UNIONS {t n | n IN univ(:num)} = s)
+Proof
+  REPEAT STRIP_TAC THEN EQ_TAC THEN
+  SIMP_TAC std_ss [UNION_OF, LEFT_IMP_EXISTS_THM] THENL
+  [ (* goal 1 (of 2) *)
+    Q.X_GEN_TAC `u:('a->bool)->bool` THEN
+    ASM_CASES_TAC ``u:('a->bool)->bool = {}`` THENL
+    [ (* goal 1.1 (of 2) *)
+      ASM_REWRITE_TAC[UNIONS_0] THEN
+      DISCH_THEN(SUBST1_TAC o SYM o last o CONJUNCTS) THEN
+      Q.EXISTS_TAC `(\n. {}):num->'a->bool` THEN
+      ASM_SIMP_TAC std_ss [UNIONS_GSPEC, NOT_IN_EMPTY, EMPTY_GSPEC],
+      (* goal 1.2 (of 2) *)
+      STRIP_TAC THEN
+      MP_TAC(Q.ISPEC `u:('a->bool)->bool` COUNTABLE_AS_IMAGE) THEN
+      RW_TAC std_ss [] >> fs [IN_IMAGE] \\
+      Q.EXISTS_TAC ‘f’ >> ASM_SET_TAC[] ],
+    (* goal 2 (of 2) *)
+    Q.X_GEN_TAC `t:num->'a->bool` THEN STRIP_TAC THEN
+    Q.EXISTS_TAC `{t n:'a->bool | n IN univ(:num)}` THEN
+    ASM_REWRITE_TAC[FORALL_IN_GSPEC] THEN
+    rw [SIMPLE_IMAGE, COUNTABLE_IMAGE, COUNTABLE_SUBSET_NUM] THEN
+    ASM_REWRITE_TAC [] ]
+QED
+
+Theorem COUNTABLE_UNION_OF_ASCENDING :
+   !P s:'a->bool.
+        P {} /\ (!t u. P t /\ P u ==> P(t UNION u))
+        ==> ((COUNTABLE UNION_OF P) s <=>
+             ?t. (!n. P(t n)) /\
+                 (!n. t n SUBSET t(SUC n)) /\
+                 UNIONS {t n | n IN univ(:num)} = s)
+Proof
+  REPEAT STRIP_TAC THEN
+  ASM_SIMP_TAC std_ss [COUNTABLE_UNION_OF_EXPLICIT, IN_UNIV] THEN
+  reverse EQ_TAC >- METIS_TAC [] \\
+  DISCH_THEN(Q.X_CHOOSE_THEN `t:num->'a->bool` STRIP_ASSUME_TAC) THEN
+  Q.EXISTS_TAC `(\n. UNIONS {t m | m <= n}):num->'a->bool` THEN
+  RULE_ASSUM_TAC(REWRITE_RULE[FORALL_IN_IMAGE, IN_UNIV]) THEN
+  REWRITE_TAC[] THEN REPEAT CONJ_TAC THENL
+  [ (* goal 1 (of 3) *)
+    Induct_on ‘n’ >> rw [LE]
+    >- (‘BIGUNION {t m | m = 0} = t 0’ by rw [Once EXTENSION] \\
+        POP_ASSUM (ASM_REWRITE_TAC o wrap)) \\
+    SIMP_TAC std_ss [SET_RULE ``{f x | P x \/ Q x} = {f x | P x} UNION {f x | Q x}``,
+                     SET_RULE ``{f x | x = a} = {f a}``, UNIONS_UNION] THEN
+    ASM_SIMP_TAC std_ss [UNIONS_1] \\
+    FIRST_X_ASSUM MATCH_MP_TAC >> fs [],
+    (* goal 2 (of 3) *)
+    RW_TAC std_ss [UNIONS_GSPEC, LE] THEN SET_TAC[],
+    (* goal 3 (of 3) *)
+    FIRST_X_ASSUM(SUBST1_TAC o SYM o last o CONJUNCTS) THEN
+    SIMP_TAC std_ss [UNIONS_GSPEC, IN_UNIV] \\
+    rw [Once EXTENSION] \\
+    EQ_TAC >> rw [] >- (Q.EXISTS_TAC ‘m’ >> rw []) \\
+    qexistsl_tac [‘n’, ‘n’] >> rw [] ]
+QED
+
+Theorem COUNTABLE_UNION_OF_IDEMPOT :
+   !P:('a->bool)->bool.
+        COUNTABLE UNION_OF COUNTABLE UNION_OF P = COUNTABLE UNION_OF P
+Proof
+  GEN_TAC THEN REWRITE_TAC[FUN_EQ_THM] THEN Q.X_GEN_TAC `s:'a->bool` THEN
+  EQ_TAC THEN REWRITE_TAC[COUNTABLE_UNION_OF_INC] THEN
+  SIMP_TAC std_ss [UNION_OF, LEFT_IMP_EXISTS_THM] THEN
+  Q.X_GEN_TAC `u:('a->bool)->bool` THEN
+  DISCH_THEN(CONJUNCTS_THEN2 ASSUME_TAC MP_TAC) THEN
+  DISCH_THEN(CONJUNCTS_THEN2 MP_TAC (SUBST1_TAC o SYM)) THEN
+  rw [EXT_SKOLEM_THM] \\
+  Q.EXISTS_TAC
+    `IMAGE SND {s,t | s IN u /\ t IN (f:('a->bool)->('a->bool)->bool) s}` THEN
+  ASM_SIMP_TAC std_ss [COUNTABLE_IMAGE, COUNTABLE_PRODUCT_DEPENDENT] THEN
+  REWRITE_TAC[FORALL_IN_IMAGE, FORALL_IN_GSPEC] THEN
+  rw [] >- METIS_TAC [SND] \\
+  REWRITE_TAC[UNIONS_IMAGE] THEN
+  REWRITE_TAC[EXISTS_IN_GSPEC] THEN ASM_SET_TAC[]
+QED
+
+Theorem COUNTABLE_INTERSECTION_OF_IDEMPOT :
+   !P:('a->bool)->bool.
+        COUNTABLE INTERSECTION_OF COUNTABLE INTERSECTION_OF P =
+        COUNTABLE INTERSECTION_OF P
+Proof
+  RW_TAC (std_ss ++ ETA_ss)
+         [COMPL_COMPL_applied, FUN_EQ_THM, COUNTABLE_INTERSECTION_OF_COMPLEMENT] THEN
+  REWRITE_TAC[COUNTABLE_UNION_OF_IDEMPOT]
+QED
+
+Theorem COUNTABLE_UNION_OF_UNIONS :
+   !P u:('a->bool)->bool.
+        COUNTABLE u /\ (!s. s IN u ==> (COUNTABLE UNION_OF P) s)
+        ==> (COUNTABLE UNION_OF P) (UNIONS u)
+Proof
+  REPEAT STRIP_TAC THEN ONCE_REWRITE_TAC[GSYM COUNTABLE_UNION_OF_IDEMPOT] THEN
+  ONCE_REWRITE_TAC[UNION_OF] THEN SIMP_TAC std_ss [] THEN
+  Q.EXISTS_TAC `u:('a->bool)->bool` THEN ASM_REWRITE_TAC[]
+QED
+
+Theorem COUNTABLE_UNION_OF_UNION :
+   !P s t. (COUNTABLE UNION_OF P) s /\ (COUNTABLE UNION_OF P) t
+           ==> (COUNTABLE UNION_OF P) (s UNION t)
+Proof
+  REPEAT STRIP_TAC THEN REWRITE_TAC[GSYM UNIONS_2] THEN
+  MATCH_MP_TAC COUNTABLE_UNION_OF_UNIONS THEN
+  ASM_REWRITE_TAC[COUNTABLE_INSERT, FORALL_IN_INSERT] THEN
+  REWRITE_TAC[COUNTABLE_EMPTY, NOT_IN_EMPTY]
+QED
+
+Theorem COUNTABLE_INTERSECTION_OF_INTERS :
+   !P u:('a->bool)->bool.
+        COUNTABLE u /\ (!s. s IN u ==> (COUNTABLE INTERSECTION_OF P) s)
+        ==> (COUNTABLE INTERSECTION_OF P) (INTERS u)
+Proof
+  REPEAT STRIP_TAC THEN
+  ONCE_REWRITE_TAC[GSYM COUNTABLE_INTERSECTION_OF_IDEMPOT] THEN
+  ONCE_REWRITE_TAC[INTERSECTION_OF] THEN SIMP_TAC std_ss [] THEN
+  Q.EXISTS_TAC `u:('a->bool)->bool` THEN ASM_REWRITE_TAC[]
+QED
+
+Theorem COUNTABLE_INTERSECTION_OF_INTER :
+   !P s t. (COUNTABLE INTERSECTION_OF P) s /\ (COUNTABLE INTERSECTION_OF P) t
+           ==> (COUNTABLE INTERSECTION_OF P) (s INTER t)
+Proof
+  REPEAT STRIP_TAC THEN REWRITE_TAC[GSYM INTERS_2] THEN
+  MATCH_MP_TAC COUNTABLE_INTERSECTION_OF_INTERS THEN
+  ASM_REWRITE_TAC[COUNTABLE_INSERT, FORALL_IN_INSERT] THEN
+  REWRITE_TAC[COUNTABLE_EMPTY, NOT_IN_EMPTY]
+QED
+
+Theorem COUNTABLE_UNION_OF_INTER_EQ :
+   !P:('a->bool)->bool.
+        (!s t. (COUNTABLE UNION_OF P) s /\ (COUNTABLE UNION_OF P) t
+                   ==> (COUNTABLE UNION_OF P) (s INTER t)) <=>
+        (!s t. P s /\ P t ==> (COUNTABLE UNION_OF P) (s INTER t))
+Proof
+  GEN_TAC THEN
+  EQ_TAC THENL [MESON_TAC[COUNTABLE_UNION_OF_INC], DISCH_TAC] THEN
+  REPEAT GEN_TAC THEN
+  GEN_REWRITE_TAC (LAND_CONV o ONCE_DEPTH_CONV) empty_rewrites [UNION_OF] THEN
+  SIMP_TAC std_ss [] THEN DISCH_THEN(STRIP_ASSUME_TAC o GSYM) THEN
+  ASM_REWRITE_TAC[INTER_UNIONS] THEN
+  REPLICATE_TAC 2
+   (MATCH_MP_TAC COUNTABLE_UNION_OF_UNIONS THEN
+    ASM_SIMP_TAC std_ss [SIMPLE_IMAGE, COUNTABLE_IMAGE, FORALL_IN_IMAGE] THEN
+    REPEAT STRIP_TAC)
+QED
+
+Theorem COUNTABLE_UNION_OF_INTER :
+   !P:('a->bool)->bool.
+        (!s t. P s /\ P t ==> P(s INTER t))
+        ==> (!s t. (COUNTABLE UNION_OF P) s /\ (COUNTABLE UNION_OF P) t
+                   ==> (COUNTABLE UNION_OF P) (s INTER t))
+Proof
+  REWRITE_TAC[COUNTABLE_UNION_OF_INTER_EQ] THEN
+  MESON_TAC[COUNTABLE_UNION_OF_INC]
+QED
+
+Theorem COUNTABLE_INTERSECTION_OF_UNION_EQ :
+   !P:('a->bool)->bool.
+        (!s t. (COUNTABLE INTERSECTION_OF P) s /\
+               (COUNTABLE INTERSECTION_OF P) t
+               ==> (COUNTABLE INTERSECTION_OF P) (s UNION t)) <=>
+        (!s t. P s /\ P t ==> (COUNTABLE INTERSECTION_OF P) (s UNION t))
+Proof
+  ONCE_REWRITE_TAC[COUNTABLE_INTERSECTION_OF_COMPLEMENT] THEN
+  REWRITE_TAC[SET_RULE
+    ``UNIV DIFF (s UNION t) = (UNIV DIFF s) INTER (UNIV DIFF t)``] THEN
+  SIMP_TAC std_ss [MESON[COMPL_COMPL_applied] ``(!s. P(UNIV DIFF s)) <=> (!s. P s)``] THEN
+  SIMP_TAC std_ss [COUNTABLE_UNION_OF_INTER_EQ] THEN
+  REWRITE_TAC[SET_RULE
+   ``s INTER t = UNIV DIFF ((UNIV DIFF s) UNION (UNIV DIFF t))``] THEN
+  SIMP_TAC std_ss [MESON[COMPL_COMPL_applied] ``(!s. P(UNIV DIFF s)) <=> (!s. P s)``] THEN
+  REWRITE_TAC[COMPL_COMPL_applied]
+QED
+
+Theorem COUNTABLE_INTERSECTION_OF_UNION :
+   !P:('a->bool)->bool.
+        (!s t. P s /\ P t ==> P(s UNION t))
+        ==> (!s t. (COUNTABLE INTERSECTION_OF P) s /\
+                   (COUNTABLE INTERSECTION_OF P) t
+                   ==> (COUNTABLE INTERSECTION_OF P) (s UNION t))
+Proof
+  REWRITE_TAC[COUNTABLE_INTERSECTION_OF_UNION_EQ] THEN
+  MESON_TAC[COUNTABLE_INTERSECTION_OF_INC]
+QED
+
+Theorem COUNTABLE_INTERSECTION_OF_UNIONS_NONEMPTY :
+   !P u:('a->bool)->bool.
+        (!s t. P s /\ P t ==> P (s UNION t)) /\
+        FINITE u /\ ~(u = {}) /\
+        (!s. s IN u ==> (COUNTABLE INTERSECTION_OF P) s)
+        ==> (COUNTABLE INTERSECTION_OF P) (UNIONS u)
+Proof
+  REWRITE_TAC[IMP_CONJ, RIGHT_FORALL_IMP_THM] THEN
+  rpt GEN_TAC THEN DISCH_TAC THEN
+  RULE_ASSUM_TAC(REWRITE_RULE[IMP_IMP, RIGHT_IMP_FORALL_THM]) THEN
+  Q.SPEC_TAC (‘u’, ‘u’) \\
+  HO_MATCH_MP_TAC FINITE_INDUCT_STRONG THEN
+  SIMP_TAC std_ss [FORALL_IN_INSERT, NOT_INSERT_EMPTY] THEN
+  qx_genl_tac [`s:'a->bool`, `u:('a->bool)->bool`] THEN
+  ASM_CASES_TAC ``u:('a->bool)->bool = {}`` THEN
+  ASM_SIMP_TAC std_ss [UNIONS_1] THEN REWRITE_TAC[UNIONS_INSERT] THEN
+  REPEAT STRIP_TAC THEN
+  FIRST_ASSUM(MATCH_MP_TAC o MATCH_MP COUNTABLE_INTERSECTION_OF_UNION) THEN
+  ASM_SIMP_TAC std_ss []
+QED
+
+Theorem COUNTABLE_INTERSECTION_OF_UNIONS :
+   !P u:('a->bool)->bool.
+        (COUNTABLE INTERSECTION_OF P) {} /\
+        (!s t. P s /\ P t ==> P (s UNION t)) /\
+        FINITE u /\
+        (!s. s IN u ==> (COUNTABLE INTERSECTION_OF P) s)
+        ==> (COUNTABLE INTERSECTION_OF P) (UNIONS u)
+Proof
+  REPEAT GEN_TAC THEN
+  DISCH_THEN(CONJUNCTS_THEN2 ASSUME_TAC MP_TAC) THEN
+  ASM_CASES_TAC ``u:('a->bool)->bool = {}`` THEN
+  ASM_REWRITE_TAC[UNIONS_0] THEN STRIP_TAC THEN
+  MATCH_MP_TAC COUNTABLE_INTERSECTION_OF_UNIONS_NONEMPTY THEN
+  ASM_REWRITE_TAC[]
+QED
+
+Theorem COUNTABLE_UNION_OF_INTERS_NONEMPTY :
+   !P u:('a->bool)->bool.
+        (!s t. P s /\ P t ==> P (s INTER t)) /\
+        FINITE u /\ ~(u = {}) /\
+        (!s. s IN u ==> (COUNTABLE UNION_OF P) s)
+        ==> (COUNTABLE UNION_OF P) (INTERS u)
+Proof
+  REWRITE_TAC[IMP_CONJ, RIGHT_FORALL_IMP_THM] THEN
+  rpt GEN_TAC THEN DISCH_TAC THEN
+  RULE_ASSUM_TAC(REWRITE_RULE[IMP_IMP, RIGHT_IMP_FORALL_THM]) THEN
+  Q.SPEC_TAC (‘u’, ‘u’) \\
+  HO_MATCH_MP_TAC FINITE_INDUCT_STRONG THEN
+  REWRITE_TAC[FORALL_IN_INSERT, NOT_INSERT_EMPTY] THEN
+  qx_genl_tac [`s:'a->bool`, `u:('a->bool)->bool`] THEN
+  ASM_CASES_TAC ``u:('a->bool)->bool = {}`` THEN
+  ASM_SIMP_TAC std_ss [INTERS_1] THEN REWRITE_TAC[INTERS_INSERT] THEN
+  REPEAT STRIP_TAC THEN
+  FIRST_ASSUM(MATCH_MP_TAC o MATCH_MP COUNTABLE_UNION_OF_INTER) THEN
+  ASM_SIMP_TAC std_ss []
+QED
+
+Theorem COUNTABLE_UNION_OF_INTERS :
+   !P u:('a->bool)->bool.
+        (COUNTABLE UNION_OF P) univ(:'a) /\
+        (!s t. P s /\ P t ==> P (s INTER t)) /\
+        FINITE u /\
+        (!s. s IN u ==> (COUNTABLE UNION_OF P) s)
+        ==> (COUNTABLE UNION_OF P) (INTERS u)
+Proof
+  REPEAT GEN_TAC THEN
+  DISCH_THEN(CONJUNCTS_THEN2 ASSUME_TAC MP_TAC) THEN
+  ASM_CASES_TAC ``u:('a->bool)->bool = {}`` THEN
+  ASM_REWRITE_TAC[INTERS_0] THEN STRIP_TAC THEN
+  MATCH_MP_TAC COUNTABLE_UNION_OF_INTERS_NONEMPTY THEN
+  ASM_REWRITE_TAC[]
+QED
+
+Theorem COUNTABLE_DISJOINT_UNION_OF_IDEMPOT :
+   !P:('a->bool)->bool.
+        ((COUNTABLE INTER pairwise DISJOINT) UNION_OF
+         (COUNTABLE INTER pairwise DISJOINT) UNION_OF P) =
+        (COUNTABLE INTER pairwise DISJOINT) UNION_OF P
+Proof
+  GEN_TAC THEN REWRITE_TAC[FUN_EQ_THM] THEN Q.X_GEN_TAC `s:'a->bool` THEN
+  reverse EQ_TAC
+  >- (MATCH_MP_TAC(REWRITE_RULE[IMP_CONJ] UNION_OF_INC) THEN
+      rw [INTER_DEF, IN_APP, COUNTABLE_SING, PAIRWISE_SING]) \\
+  SIMP_TAC std_ss [SET_RULE ``s INTER t = \x. s x /\ t x``] \\
+  SIMP_TAC std_ss [UNION_OF, LEFT_IMP_EXISTS_THM] THEN
+  Q.X_GEN_TAC `u:('a->bool)->bool` THEN
+  DISCH_THEN(CONJUNCTS_THEN2 ASSUME_TAC MP_TAC) THEN
+  DISCH_THEN(CONJUNCTS_THEN2 MP_TAC (SUBST1_TAC o SYM)) THEN
+  rw [EXT_SKOLEM_THM] \\
+  Q.EXISTS_TAC
+    `IMAGE SND {s,t | s IN u /\ t IN (f:('a->bool)->('a->bool)->bool) s}` THEN
+  ASM_SIMP_TAC std_ss [COUNTABLE_IMAGE, COUNTABLE_PRODUCT_DEPENDENT] THEN
+  SIMP_TAC std_ss [FORALL_IN_IMAGE, FORALL_IN_GSPEC] THEN
+  REWRITE_TAC[UNIONS_IMAGE, EXISTS_IN_GSPEC, PAIRWISE_IMAGE] THEN
+  CONJ_TAC THENL [REWRITE_TAC[pairwise], ASM_SET_TAC[]] THEN
+  SIMP_TAC std_ss [IMP_CONJ, RIGHT_FORALL_IMP_THM, FORALL_IN_GSPEC] THEN
+  MAP_EVERY (fn x => Q.X_GEN_TAC x THEN DISCH_TAC)
+   [`s1:'a->bool`, `t1:'a->bool`, `s2:'a->bool`, `t2:'a->bool`] THEN
+  DISCH_THEN(K ALL_TAC) THEN ASM_CASES_TAC ``s2:'a->bool = s1`` THEN
+  RULE_ASSUM_TAC(REWRITE_RULE[pairwise]) THENL
+  [ ASM_MESON_TAC[], ASM_SET_TAC[] ]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* A somewhat cheap but handy way of getting localized forms of various      *)
+(* topological concepts (open, closed, borel, fsigma, gdelta etc.)           *)
+(* ------------------------------------------------------------------------- *)
+
+val _ = set_fixity "relative_to" (Infixl 500);
+
+Definition relative_to :
+   (P relative_to s) t = ?u. P u /\ s INTER u = t
+End
+
+Theorem RELATIVE_TO_UNIV :
+    !P s. (P relative_to univ(:'a)) s <=> P s
+Proof
+  REWRITE_TAC[relative_to, INTER_UNIV] THEN MESON_TAC[]
+QED
+
+Theorem RELATIVE_TO_IMP_SUBSET :
+   !P s t. (P relative_to s) t ==> t SUBSET s
+Proof
+  REWRITE_TAC[relative_to] THEN SET_TAC[]
+QED
+
+Theorem FORALL_RELATIVE_TO :
+   (!s. (P relative_to u) s ==> Q s) <=>
+   (!s. P s ==> Q(u INTER s))
+Proof
+  REWRITE_TAC[relative_to] THEN MESON_TAC[]
+QED
+
+Theorem RELATIVE_TO_INC :
+   !P u s. P s ==> (P relative_to u) (u INTER s)
+Proof
+  REWRITE_TAC[relative_to] THEN MESON_TAC[]
+QED
+
+Theorem RELATIVE_TO :
+   (P relative_to u) = {u INTER s | P s}
+Proof
+    rw [Once EXTENSION, relative_to, IN_APP]
+ >> SET_TAC []
+QED
+
+Theorem RELATIVE_TO_RELATIVE_TO :
+   !P:('a->bool)->bool s t.
+        P relative_to s relative_to t = P relative_to (s INTER t)
+Proof
+    rw [Once EXTENSION, RELATIVE_TO]
+ >> EQ_TAC >> rw [] >> rename1 ‘P u’
+ >- (Q.EXISTS_TAC ‘u’ >> METIS_TAC [INTER_ASSOC, INTER_COMM])
+ >> Q.EXISTS_TAC ‘s INTER u’
+ >> CONJ_TAC >- METIS_TAC [INTER_ASSOC, INTER_COMM]
+ >> Q.EXISTS_TAC ‘u’ >> rw []
+QED
+
+Theorem RELATIVE_TO_COMPL :
+   !P u s:'a->bool.
+        s SUBSET u
+        ==> ((P relative_to u) (u DIFF s) <=>
+             ((\c. P(UNIV DIFF c)) relative_to u) s)
+Proof
+    rpt STRIP_TAC >> REWRITE_TAC [relative_to]
+ >> EQ_TAC >> rw []
+ >- (rename1 ‘P w’ \\
+     Q.EXISTS_TAC ‘univ(:'a) DIFF w’ >> rw [COMPL_COMPL_applied] \\
+     ASM_SET_TAC [])
+ >> rename1 ‘u INTER w SUBSET u’
+ >> Q.EXISTS_TAC ‘univ(:'a) DIFF w’ >> rw []
+ >> ASM_SET_TAC []
+QED
+
+Theorem RELATIVE_TO_SUBSET :
+   !P s t:'a->bool. s SUBSET t /\ P s ==> (P relative_to t) s
+Proof
+  REPEAT STRIP_TAC THEN REWRITE_TAC[relative_to] THEN
+  Q.EXISTS_TAC `s:'a->bool` THEN ASM_SET_TAC[]
+QED
+
+Theorem RELATIVE_TO_SUBSET_TRANS :
+   !P u s t:'a->bool.
+      (P relative_to u) s /\ s SUBSET t /\ t SUBSET u ==> (P relative_to t) s
+Proof
+  REPEAT GEN_TAC THEN DISCH_THEN(CONJUNCTS_THEN2 MP_TAC STRIP_ASSUME_TAC) THEN
+  REWRITE_TAC[relative_to] THEN
+  HO_MATCH_MP_TAC MONO_EXISTS THEN ASM_SET_TAC[]
+QED
+
+Theorem RELATIVE_TO_MONO :
+   !P Q.
+     (!s. P s ==> Q s) ==> !u. (P relative_to u) s ==> (Q relative_to u) s
+Proof
+  REWRITE_TAC[relative_to] THEN MESON_TAC[]
+QED
+
+Theorem RELATIVE_TO_SUBSET_INC :
+   !P u s:'a->bool.
+        s SUBSET u /\ P s ==> (P relative_to u) s
+Proof
+  REWRITE_TAC[relative_to] THEN
+  MESON_TAC[SET_RULE ``s SUBSET u ==> u INTER s = s``]
+QED
+
+Theorem RELATIVE_TO_INTER :
+   !P s. (!c d:'a->bool. P c /\ P d ==> P(c INTER d))
+         ==> !c d. (P relative_to s) c /\ (P relative_to s) d
+                   ==> (P relative_to s) (c INTER d)
+Proof
+  REPEAT GEN_TAC THEN DISCH_TAC THEN REPEAT GEN_TAC THEN
+  REWRITE_TAC[relative_to] THEN DISCH_THEN(CONJUNCTS_THEN2
+   (Q.X_CHOOSE_THEN `c':'a->bool` (STRIP_ASSUME_TAC o GSYM))
+   (Q.X_CHOOSE_THEN `d':'a->bool` (STRIP_ASSUME_TAC o GSYM))) THEN
+  Q.EXISTS_TAC `c' INTER d':'a->bool` THEN
+  ASM_SIMP_TAC std_ss [] THEN ASM_SET_TAC[]
+QED
+
+Theorem RELATIVE_TO_UNION :
+   !P s. (!c d:'a->bool. P c /\ P d ==> P(c UNION d))
+         ==> !c d. (P relative_to s) c /\ (P relative_to s) d
+                   ==> (P relative_to s) (c UNION d)
+Proof
+  REPEAT GEN_TAC THEN DISCH_TAC THEN REPEAT GEN_TAC THEN
+  REWRITE_TAC[relative_to] THEN DISCH_THEN(CONJUNCTS_THEN2
+   (Q.X_CHOOSE_THEN `c':'a->bool` (STRIP_ASSUME_TAC o GSYM))
+   (Q.X_CHOOSE_THEN `d':'a->bool` (STRIP_ASSUME_TAC o GSYM))) THEN
+  Q.EXISTS_TAC `c' UNION d':'a->bool` THEN
+  ASM_SIMP_TAC std_ss [] THEN ASM_SET_TAC[]
+QED
+
+Theorem ARBITRARY_UNION_OF_RELATIVE_TO :
+   !P u:'a->bool.
+        ((ARBITRARY UNION_OF P) relative_to u) =
+        (ARBITRARY UNION_OF (P relative_to u))
+Proof
+  REWRITE_TAC[FUN_EQ_THM] THEN
+  REPEAT STRIP_TAC THEN SIMP_TAC std_ss [UNION_OF, relative_to] THEN
+  EQ_TAC THENL
+  [ (* goal 1 (of 2) *)
+    DISCH_THEN(Q.X_CHOOSE_THEN `t:'a->bool`
+     (CONJUNCTS_THEN2 MP_TAC (SUBST1_TAC o SYM))) THEN
+    DISCH_THEN(Q.X_CHOOSE_THEN `f:('a->bool)->bool`
+     (STRIP_ASSUME_TAC o GSYM)) THEN
+    Q.EXISTS_TAC `{u INTER c | (c:'a->bool) IN f}` THEN
+    ASM_REWRITE_TAC[INTER_UNIONS] THEN
+    ASM_SIMP_TAC std_ss [SIMPLE_IMAGE, ARBITRARY, FORALL_IN_IMAGE] THEN
+    ASM_MESON_TAC[],
+    (* goal 2 (of 2) *)
+    DISCH_THEN(Q.X_CHOOSE_THEN `f:('a->bool)->bool` STRIP_ASSUME_TAC) THEN
+    Q.PAT_X_ASSUM ‘!c. c IN f ==> _’ MP_TAC \\
+    rw [EXT_SKOLEM_THM] \\
+    rename1 ‘!c. c IN f ==> P (g c) /\ u INTER g c = c’ \\
+    Q.EXISTS_TAC `UNIONS (IMAGE (g:('a->bool)->('a->bool)) f)` THEN
+    CONJ_TAC THENL [ALL_TAC, ASM_SET_TAC[]] THEN
+    Q.EXISTS_TAC `IMAGE (g:('a->bool)->('a->bool)) f` THEN
+    ASM_SIMP_TAC std_ss [ARBITRARY, FORALL_IN_IMAGE] ]
+QED
+
+Theorem FINITE_UNION_OF_RELATIVE_TO :
+   !P u:'a->bool.
+        ((FINITE UNION_OF P) relative_to u) =
+        (FINITE UNION_OF (P relative_to u))
+Proof
+  REWRITE_TAC[FUN_EQ_THM] THEN
+  REPEAT STRIP_TAC THEN SIMP_TAC std_ss [UNION_OF, relative_to]
+  THEN EQ_TAC THENL
+  [ (* goal 1 (of 2) *)
+    DISCH_THEN(Q.X_CHOOSE_THEN `t:'a->bool`
+     (CONJUNCTS_THEN2 MP_TAC (SUBST1_TAC o SYM))) THEN
+    DISCH_THEN(Q.X_CHOOSE_THEN `f:('a->bool)->bool`
+     (STRIP_ASSUME_TAC o GSYM)) THEN
+    Q.EXISTS_TAC `{u INTER c | (c:'a->bool) IN f}` THEN
+    ASM_REWRITE_TAC[INTER_UNIONS] THEN
+    ASM_SIMP_TAC std_ss [SIMPLE_IMAGE, FINITE_IMAGE, FORALL_IN_IMAGE] THEN
+    ASM_MESON_TAC[],
+    (* goal 2 (of 2) *)
+    DISCH_THEN(Q.X_CHOOSE_THEN `f:('a->bool)->bool` STRIP_ASSUME_TAC) THEN
+    Q.PAT_X_ASSUM ‘!c. c IN f ==> _’ MP_TAC \\
+    rw [EXT_SKOLEM_THM] \\
+    rename1 ‘!c. c IN f ==> P (g c) /\ u INTER g c = c’ \\
+    Q.EXISTS_TAC `UNIONS (IMAGE (g:('a->bool)->('a->bool)) f)` THEN
+    CONJ_TAC THENL [ALL_TAC, ASM_SET_TAC[]] THEN
+    Q.EXISTS_TAC `IMAGE (g:('a->bool)->('a->bool)) f` THEN
+    ASM_SIMP_TAC std_ss [FINITE_IMAGE, FORALL_IN_IMAGE] ]
+QED
+
+Theorem COUNTABLE_UNION_OF_RELATIVE_TO :
+   !P u:'a->bool.
+        ((COUNTABLE UNION_OF P) relative_to u) =
+        (COUNTABLE UNION_OF (P relative_to u))
+Proof
+  REWRITE_TAC[FUN_EQ_THM] THEN
+  REPEAT STRIP_TAC THEN SIMP_TAC std_ss [UNION_OF, relative_to]
+  THEN EQ_TAC THENL
+  [ (* goal 1 (of 2) *)
+    DISCH_THEN(Q.X_CHOOSE_THEN `t:'a->bool`
+     (CONJUNCTS_THEN2 MP_TAC (SUBST1_TAC o SYM))) THEN
+    DISCH_THEN(Q.X_CHOOSE_THEN `f:('a->bool)->bool`
+     (STRIP_ASSUME_TAC o GSYM)) THEN
+    Q.EXISTS_TAC `{u INTER c | (c:'a->bool) IN f}` THEN
+    ASM_REWRITE_TAC[INTER_UNIONS] THEN
+    ASM_SIMP_TAC std_ss [SIMPLE_IMAGE, COUNTABLE_IMAGE, FORALL_IN_IMAGE] THEN
+    ASM_MESON_TAC[],
+    (* goal 2 (of 2) *)
+    DISCH_THEN(Q.X_CHOOSE_THEN `f:('a->bool)->bool` STRIP_ASSUME_TAC) THEN
+    Q.PAT_X_ASSUM ‘!c. c IN f ==> _’ MP_TAC \\
+    rw [EXT_SKOLEM_THM] \\
+    rename1 ‘!c. c IN f ==> P (g c) /\ u INTER g c = c’ \\
+    Q.EXISTS_TAC `UNIONS (IMAGE (g:('a->bool)->('a->bool)) f)` THEN
+    CONJ_TAC THENL [ALL_TAC, ASM_SET_TAC[]] THEN
+    Q.EXISTS_TAC `IMAGE (g:('a->bool)->('a->bool)) f` THEN
+    ASM_SIMP_TAC std_ss [COUNTABLE_IMAGE, FORALL_IN_IMAGE] ]
+QED
+
+Theorem ARBITRARY_INTERSECTION_OF_RELATIVE_TO :
+   !P u:'a->bool.
+        ((ARBITRARY INTERSECTION_OF P) relative_to u) =
+        ((ARBITRARY INTERSECTION_OF (P relative_to u)) relative_to u)
+Proof
+  REPEAT GEN_TAC THEN GEN_REWRITE_TAC I empty_rewrites [FUN_EQ_THM] THEN
+  Q.X_GEN_TAC `s:'a->bool` THEN REWRITE_TAC[INTERSECTION_OF, relative_to] THEN
+  BETA_TAC THEN EQ_TAC THENL
+  [ (* goal 1 (of 2) *)
+    DISCH_THEN(Q.X_CHOOSE_THEN `t:'a->bool`
+     (CONJUNCTS_THEN2 MP_TAC (SUBST1_TAC o SYM))) THEN
+    DISCH_THEN(Q.X_CHOOSE_THEN `f:('a->bool)->bool`
+     (STRIP_ASSUME_TAC o GSYM)) THEN
+    Q.EXISTS_TAC `INTERS {u INTER c | (c:'a->bool) IN f}` THEN CONJ_TAC THENL
+    [ (* goal 1.1 (of 2) *)
+      Q.EXISTS_TAC `{u INTER c | (c:'a->bool) IN f}` THEN
+      ASM_SIMP_TAC std_ss [ARBITRARY, SIMPLE_IMAGE, FORALL_IN_IMAGE] THEN
+      ASM_MESON_TAC[],
+      (* goal 1.2 (of 2) *)
+      ASM_REWRITE_TAC[] THEN ONCE_REWRITE_TAC[INTER_INTERS] THEN
+      SIMP_TAC std_ss [SIMPLE_IMAGE, IMAGE_EQ_EMPTY, INTERS_IMAGE, FORALL_IN_IMAGE,
+                  SET_RULE ``u INTER (u INTER s) = u INTER s``] ],
+    (* goal 2 (of 2) *)
+    DISCH_THEN(Q.X_CHOOSE_THEN `t:'a->bool`
+     (CONJUNCTS_THEN2 MP_TAC (SUBST1_TAC o SYM))) THEN
+    DISCH_THEN(Q.X_CHOOSE_THEN `f:('a->bool)->bool` STRIP_ASSUME_TAC) THEN
+    Q.PAT_X_ASSUM ‘!c. c IN f ==> _’ MP_TAC \\
+    rw [EXT_SKOLEM_THM] \\
+    rename1 ‘!c. c IN f ==> P (g c) /\ u INTER g c = c’ \\
+    Q.EXISTS_TAC `INTERS (IMAGE (g:('a->bool)->('a->bool)) f)` THEN
+    CONJ_TAC THENL [ALL_TAC, ASM_SET_TAC[]] THEN
+    Q.EXISTS_TAC `IMAGE (g:('a->bool)->('a->bool)) f` THEN
+    ASM_SIMP_TAC std_ss [ARBITRARY, FORALL_IN_IMAGE] ]
+QED
+
+Theorem FINITE_INTERSECTION_OF_RELATIVE_TO :
+   !P u:'a->bool.
+        ((FINITE INTERSECTION_OF P) relative_to u) =
+        ((FINITE INTERSECTION_OF (P relative_to u)) relative_to u)
+Proof
+  REPEAT GEN_TAC THEN GEN_REWRITE_TAC I empty_rewrites [FUN_EQ_THM] THEN
+  Q.X_GEN_TAC `s:'a->bool` THEN REWRITE_TAC[INTERSECTION_OF, relative_to] THEN
+  BETA_TAC THEN EQ_TAC THENL
+  [ (* goal 1 (of 2) *)
+    DISCH_THEN(Q.X_CHOOSE_THEN `t:'a->bool`
+     (CONJUNCTS_THEN2 MP_TAC (SUBST1_TAC o SYM))) THEN
+    DISCH_THEN(Q.X_CHOOSE_THEN `f:('a->bool)->bool`
+     (STRIP_ASSUME_TAC o GSYM)) THEN
+    Q.EXISTS_TAC `INTERS {u INTER c | (c:'a->bool) IN f}` THEN CONJ_TAC THENL
+    [ (* goal 1.1 (of 2) *)
+      Q.EXISTS_TAC `{u INTER c | (c:'a->bool) IN f}` THEN
+      ASM_SIMP_TAC std_ss [FINITE_IMAGE, SIMPLE_IMAGE, FORALL_IN_IMAGE] THEN
+      ASM_MESON_TAC[],
+      (* goal 1.2 (of 2) *)
+      ASM_REWRITE_TAC[] THEN ONCE_REWRITE_TAC[INTER_INTERS] THEN
+      SIMP_TAC std_ss [SIMPLE_IMAGE, IMAGE_EQ_EMPTY, INTERS_IMAGE, FORALL_IN_IMAGE,
+                  SET_RULE ``u INTER (u INTER s) = u INTER s``] ],
+    (* goal 2 (of 2) *)
+    DISCH_THEN(Q.X_CHOOSE_THEN `t:'a->bool`
+     (CONJUNCTS_THEN2 MP_TAC (SUBST1_TAC o SYM))) THEN
+    DISCH_THEN(Q.X_CHOOSE_THEN `f:('a->bool)->bool` STRIP_ASSUME_TAC) THEN
+    Q.PAT_X_ASSUM ‘!c. c IN f ==> _’ MP_TAC \\
+    rw [EXT_SKOLEM_THM] \\
+    rename1 ‘!c. c IN f ==> P (g c) /\ u INTER g c = c’ \\
+    Q.EXISTS_TAC `INTERS (IMAGE (g:('a->bool)->('a->bool)) f)` THEN
+    CONJ_TAC THENL [ALL_TAC, ASM_SET_TAC[]] THEN
+    Q.EXISTS_TAC `IMAGE (g:('a->bool)->('a->bool)) f` THEN
+    ASM_SIMP_TAC std_ss [FINITE_IMAGE, FORALL_IN_IMAGE] ]
+QED
+
+Theorem COUNTABLE_INTERSECTION_OF_RELATIVE_TO :
+   !P u:'a->bool.
+        ((COUNTABLE INTERSECTION_OF P) relative_to u) =
+        ((COUNTABLE INTERSECTION_OF (P relative_to u)) relative_to u)
+Proof
+  REPEAT GEN_TAC THEN GEN_REWRITE_TAC I empty_rewrites [FUN_EQ_THM] THEN
+  Q.X_GEN_TAC `s:'a->bool` THEN REWRITE_TAC[INTERSECTION_OF, relative_to] THEN
+  BETA_TAC THEN EQ_TAC THENL
+  [ (* goal 1 (of 2) *)
+    DISCH_THEN(Q.X_CHOOSE_THEN `t:'a->bool`
+     (CONJUNCTS_THEN2 MP_TAC (SUBST1_TAC o SYM))) THEN
+    DISCH_THEN(Q.X_CHOOSE_THEN `f:('a->bool)->bool`
+     (STRIP_ASSUME_TAC o GSYM)) THEN
+    Q.EXISTS_TAC `INTERS {u INTER c | (c:'a->bool) IN f}` THEN CONJ_TAC THENL
+    [ Q.EXISTS_TAC `{u INTER c | (c:'a->bool) IN f}` THEN
+      ASM_SIMP_TAC std_ss [COUNTABLE_IMAGE, SIMPLE_IMAGE, FORALL_IN_IMAGE] THEN
+      ASM_MESON_TAC[],
+      ASM_REWRITE_TAC[] THEN ONCE_REWRITE_TAC[INTER_INTERS] THEN
+      ASM_SIMP_TAC std_ss [SIMPLE_IMAGE, IMAGE_EQ_EMPTY, INTERS_IMAGE, FORALL_IN_IMAGE,
+                  SET_RULE ``u INTER (u INTER s) = u INTER s``] ],
+    DISCH_THEN(Q.X_CHOOSE_THEN `t:'a->bool`
+     (CONJUNCTS_THEN2 MP_TAC (SUBST1_TAC o SYM))) THEN
+    DISCH_THEN(Q.X_CHOOSE_THEN `f:('a->bool)->bool` STRIP_ASSUME_TAC) THEN
+    Q.PAT_X_ASSUM ‘!c. c IN f ==> _’ MP_TAC \\
+    rw [EXT_SKOLEM_THM] \\
+    rename1 ‘!c. c IN f ==> P (g c) /\ u INTER g c = c’ \\
+    Q.EXISTS_TAC `INTERS (IMAGE (g:('a->bool)->('a->bool)) f)` THEN
+    CONJ_TAC THENL [ALL_TAC, ASM_SET_TAC[]] THEN
+    Q.EXISTS_TAC `IMAGE (g:('a->bool)->('a->bool)) f` THEN
+    ASM_SIMP_TAC std_ss [COUNTABLE_IMAGE, FORALL_IN_IMAGE] ]
+QED
+
+Theorem FINITE_INTERSECTION_OF_RELATIVE_TO_ALT :
+   !P u s:'a->bool.
+        P u ==> ((FINITE INTERSECTION_OF P relative_to u) s <=>
+                 (FINITE INTERSECTION_OF P) s /\ s SUBSET u)
+Proof
+  REPEAT STRIP_TAC THEN EQ_TAC THEN SIMP_TAC std_ss [RELATIVE_TO_SUBSET_INC] THEN
+  Q.SPEC_TAC(`s:'a->bool`,`s:'a->bool`) THEN
+  SIMP_TAC std_ss [FORALL_RELATIVE_TO, FORALL_INTERSECTION_OF] THEN
+  REWRITE_TAC[INTER_SUBSET, GSYM INTERS_INSERT] THEN
+  REPEAT STRIP_TAC THEN MATCH_MP_TAC FINITE_INTERSECTION_OF_INTERS THEN
+  ASM_REWRITE_TAC[FINITE_INSERT, FORALL_IN_INSERT] THEN
+  ASM_SIMP_TAC std_ss [FINITE_INTERSECTION_OF_INC]
+QED
+
+Theorem COUNTABLE_INTERSECTION_OF_RELATIVE_TO_ALT :
+   !P u s:'a->bool.
+        P u ==> ((COUNTABLE INTERSECTION_OF P relative_to u) s <=>
+                 (COUNTABLE INTERSECTION_OF P) s /\ s SUBSET u)
+Proof
+  REPEAT STRIP_TAC THEN EQ_TAC THEN SIMP_TAC std_ss [RELATIVE_TO_SUBSET_INC] THEN
+  Q.SPEC_TAC(`s:'a->bool`,`s:'a->bool`) THEN
+  SIMP_TAC std_ss [FORALL_RELATIVE_TO, FORALL_INTERSECTION_OF] THEN
+  REWRITE_TAC[INTER_SUBSET, GSYM INTERS_INSERT] THEN
+  REPEAT STRIP_TAC THEN MATCH_MP_TAC COUNTABLE_INTERSECTION_OF_INTERS THEN
+  ASM_REWRITE_TAC[COUNTABLE_INSERT, FORALL_IN_INSERT] THEN
+  ASM_SIMP_TAC std_ss [COUNTABLE_INTERSECTION_OF_INC]
+QED
+
+Theorem ARBITRARY_UNION_OF_NONEMPTY_FINITE_INTERSECTION :
+   !u:('a->bool)->bool.
+        ARBITRARY UNION_OF ((\s. FINITE s /\ ~(s = {})) INTERSECTION_OF u) =
+        ARBITRARY UNION_OF (FINITE INTERSECTION_OF u relative_to UNIONS u)
+Proof
+  GEN_TAC THEN MATCH_MP_TAC SUBSET_ANTISYM THEN
+  REWRITE_TAC[REWRITE_RULE[IN_APP] SUBSET_DEF] THEN
+  CONJ_TAC THEN Q.X_GEN_TAC `s:'a->bool` THENL
+  [ (* goal 1 (of 2) *)
+    MATCH_MP_TAC(REWRITE_RULE[IMP_CONJ_ALT] UNION_OF_MONO) THEN
+    REWRITE_TAC[FORALL_INTERSECTION_OF] THEN Q.X_GEN_TAC `t:('a->bool)->bool` THEN
+    STRIP_TAC THEN REWRITE_TAC[INTERSECTION_OF, relative_to] THEN
+    Q.EXISTS_TAC `INTERS t:'a->bool` THEN
+    CONJ_TAC THENL [ASM_MESON_TAC[], ASM_SET_TAC[]],
+    (* goal 2 (of 2) *)
+    GEN_REWRITE_TAC (RAND_CONV o RATOR_CONV) empty_rewrites
+      [GSYM ARBITRARY_UNION_OF_IDEMPOT] THEN
+    MATCH_MP_TAC(REWRITE_RULE[IMP_CONJ_ALT] UNION_OF_MONO) THEN
+    SIMP_TAC std_ss [FORALL_RELATIVE_TO, FORALL_INTERSECTION_OF] THEN
+    Q.X_GEN_TAC `t:('a->bool)->bool` THEN STRIP_TAC THEN
+    ASM_CASES_TAC ``t:('a->bool)->bool = {}`` THENL
+    [ (* goal 2.1 (of 2) *)
+      ASM_REWRITE_TAC[INTERS_0, INTER_UNIV] THEN
+      MATCH_MP_TAC ARBITRARY_UNION_OF_UNIONS THEN
+      Q.X_GEN_TAC `r:'a->bool` THEN DISCH_TAC THEN
+      MATCH_MP_TAC UNION_OF_INC THEN
+      REWRITE_TAC[ARBITRARY] THEN MATCH_MP_TAC INTERSECTION_OF_INC THEN
+      REWRITE_TAC[NOT_INSERT_EMPTY, FINITE_SING] THEN
+      fs [IN_APP],
+      (* goal 2.2 (of 2) *)
+      MATCH_MP_TAC UNION_OF_INC THEN
+      SIMP_TAC std_ss [ARBITRARY, INTERSECTION_OF] THEN
+      Q.EXISTS_TAC `t:('a->bool)->bool` THEN ASM_SET_TAC[] ] ]
+QED
+
+Theorem OPEN_IN_RELATIVE_TO :
+   !top s:'a->bool.
+        (open_in top relative_to s) = open_in (subtopology top s)
+Proof
+  REWRITE_TAC[relative_to, OPEN_IN_SUBTOPOLOGY, FUN_EQ_THM] THEN
+  MESON_TAC[INTER_COMM]
+QED
+
+Theorem CLOSED_IN_RELATIVE_TO :
+   !top s:'a->bool.
+        (closed_in top relative_to s) = closed_in (subtopology top s)
+Proof
+  REWRITE_TAC[relative_to, CLOSED_IN_SUBTOPOLOGY, FUN_EQ_THM] THEN
+  MESON_TAC[INTER_COMM]
 QED
 
 val _ = export_theory();


### PR DESCRIPTION
Hi,

this PR can be seen as a small improvement of HOL4's general topology and metric library by porting more related lemmas from HOL Light (mainly its `sets.ml` and `metric.ml`).  (I do this for future improvements in measure theory, however.) Previously there were few theorems in HOL4's `topologyTheory` and `metricTheory`, now they are charged with more results.

The end of the chain of newly ported theorems is the following non-trivial result (in `metricTheory`) showing that, in any metrizable (topological) space, any closed set is in _gdelta_, i.e., can be expressed as a countable intersection of open sets.  
```
   [CLOSED_IMP_GDELTA_IN]  Theorem      
      ⊢ ∀top s. metrizable_space top ∧ closed_in top s ⇒ gdelta_in top s
```
This generalized the following existing theorem in `real_topologyTheory` (and making its proof greatly simplified):
```
   [CLOSED_AS_GDELTA]  Theorem      
      ⊢ ∀s. closed s ⇒ gdelta s
```

The above theorem `CLOSED_IMP_GDELTA_IN` requires the following definitions and related lemmas, all ported from HOL Light:
```
   [gdelta_in]  Definition      
      ⊢ ∀top.
          gdelta_in top =
          countable INTERSECTION_OF open_in top relative_to topspace top

   [metrizable_space]  Definition      
      ⊢ ∀top. metrizable_space top ⇔ ∃m. top = mtop m

   [INTERSECTION_OF]  Definition      
      ⊢ ∀P Q.
          P INTERSECTION_OF Q =
          (λs. ∃u. P u ∧ (∀c. c ∈ u ⇒ Q c) ∧ BIGINTER u = s)

   [relative_to]  Definition      
      ⊢ ∀P s t. (P relative_to s) t ⇔ ∃u. P u ∧ s ∩ u = t
```
There are also `fsigma_in` and `UNION_OF`, as dual versions of `gdelta_in` and `INTERSECTION_OF`.   HOL Light has very nice formalization of set generators such as `{FINITE|COUNTABLE|ARBITRARY UNION_OF ...`, now they are also available in HOL4. Below is list of their theorems in `topologyTheory`:
```
    val ARBITRARY_INTERSECTION_OF_COMPLEMENT : thm
    val ARBITRARY_INTERSECTION_OF_EMPTY : thm
    val ARBITRARY_INTERSECTION_OF_IDEMPOT : thm
    val ARBITRARY_INTERSECTION_OF_INC : thm
    val ARBITRARY_INTERSECTION_OF_INTER : thm
    val ARBITRARY_INTERSECTION_OF_INTERS : thm
    val ARBITRARY_INTERSECTION_OF_RELATIVE_TO : thm
    val ARBITRARY_INTERSECTION_OF_UNION : thm
    val ARBITRARY_INTERSECTION_OF_UNION_EQ : thm
    val ARBITRARY_UNION_OF_ALT : thm
    val ARBITRARY_UNION_OF_COMPLEMENT : thm
    val ARBITRARY_UNION_OF_EMPTY : thm
    val ARBITRARY_UNION_OF_IDEMPOT : thm
    val ARBITRARY_UNION_OF_INC : thm
    val ARBITRARY_UNION_OF_INTER : thm
    val ARBITRARY_UNION_OF_INTER_EQ : thm
    val ARBITRARY_UNION_OF_NONEMPTY_FINITE_INTERSECTION : thm
    val ARBITRARY_UNION_OF_RELATIVE_TO : thm
    val ARBITRARY_UNION_OF_UNION : thm
    val ARBITRARY_UNION_OF_UNIONS : thm
    val COUNTABLE_DISJOINT_UNION_OF_IDEMPOT : thm
    val COUNTABLE_INTERSECTION_OF_COMPLEMENT : thm
    val COUNTABLE_INTERSECTION_OF_EMPTY : thm
    val COUNTABLE_INTERSECTION_OF_IDEMPOT : thm
    val COUNTABLE_INTERSECTION_OF_INC : thm
    val COUNTABLE_INTERSECTION_OF_INTER : thm
    val COUNTABLE_INTERSECTION_OF_INTERS : thm
    val COUNTABLE_INTERSECTION_OF_RELATIVE_TO : thm
    val COUNTABLE_INTERSECTION_OF_RELATIVE_TO_ALT : thm
    val COUNTABLE_INTERSECTION_OF_UNION : thm
    val COUNTABLE_INTERSECTION_OF_UNIONS : thm
    val COUNTABLE_INTERSECTION_OF_UNIONS_NONEMPTY : thm
    val COUNTABLE_INTERSECTION_OF_UNION_EQ : thm
    val COUNTABLE_UNION_OF_ASCENDING : thm
    val COUNTABLE_UNION_OF_COMPLEMENT : thm
    val COUNTABLE_UNION_OF_EMPTY : thm
    val COUNTABLE_UNION_OF_EXPLICIT : thm
    val COUNTABLE_UNION_OF_IDEMPOT : thm
    val COUNTABLE_UNION_OF_INC : thm
    val COUNTABLE_UNION_OF_INTER : thm
    val COUNTABLE_UNION_OF_INTERS : thm
    val COUNTABLE_UNION_OF_INTERS_NONEMPTY : thm
    val COUNTABLE_UNION_OF_INTER_EQ : thm
    val COUNTABLE_UNION_OF_RELATIVE_TO : thm
    val COUNTABLE_UNION_OF_UNION : thm
    val COUNTABLE_UNION_OF_UNIONS : thm
    val FINITE_INTERSECTION_OF_COMPLEMENT : thm
    val FINITE_INTERSECTION_OF_EMPTY : thm
    val FINITE_INTERSECTION_OF_IDEMPOT : thm
    val FINITE_INTERSECTION_OF_INC : thm
    val FINITE_INTERSECTION_OF_INTER : thm
    val FINITE_INTERSECTION_OF_INTERS : thm
    val FINITE_INTERSECTION_OF_RELATIVE_TO : thm
    val FINITE_INTERSECTION_OF_RELATIVE_TO_ALT : thm
    val FINITE_INTERSECTION_OF_UNION : thm
    val FINITE_INTERSECTION_OF_UNION_EQ : thm
    val FINITE_UNION_OF_COMPLEMENT : thm
    val FINITE_UNION_OF_EMPTY : thm
    val FINITE_UNION_OF_IDEMPOT : thm
    val FINITE_UNION_OF_INC : thm
    val FINITE_UNION_OF_INTER : thm
    val FINITE_UNION_OF_INTER_EQ : thm
    val FINITE_UNION_OF_RELATIVE_TO : thm
    val FINITE_UNION_OF_UNION : thm
    val FINITE_UNION_OF_UNIONS : thm
```

Most of these HOL Light theorems are ported to HOL4 by only changing their OCaml grammar to SML grammar.  To achieve this goal, I have made a basic compatibility layer for HOL Light's set theory in `topologyTheory` by exporting some set-theoretic theorems with their exact names and statements in HOL Light, so that later more HOL Light set/topology theorems can be ported easily by just opening `topologyTheory`, which seems a suitable place to put this compatibility layer.

NOTE: now `topologyTheory` depends on `cardinalTheory`. This seems reasonable as many deep topology results depend on cardinality results of some sets.

Regards,

Chun Tian
