### PR TITLE
Dependency cleanup (iterateTheory and transcTheory)

### DIFF
--- a/src/float/floatScript.sml
+++ b/src/float/floatScript.sml
@@ -5,7 +5,8 @@
 open HolKernel boolLib bossLib
 open pairTheory pred_setTheory prim_recTheory numTheory arithmeticTheory
      realTheory ieeeTheory
-open numLib realLib Ho_Rewrite
+
+open numLib realSimps RealArith Ho_Rewrite
 
 val () = new_theory "float"
 
@@ -883,10 +884,6 @@ val ERROR_BOUND_SMALL1 = Q.prove (
   \\ simp [REAL_POW_LT, REAL_SUB_LDISTRIB, REAL_POS_NZ, REAL_INV_MUL]
   \\ NO_STRIP_FULL_SIMP_TAC (srw_ss()) [AC REAL_MUL_ASSOC REAL_MUL_COMM]
   )
-
-val REAL_LE_INV2 = Q.prove (
-  `!x y. 0 < x /\ x <= y ==> inv y <= inv x`,
-  metis_tac [REAL_LE_LT, REAL_LT_INV])
 
 val ERROR_BOUND_SMALL = Q.prove (
   `!k x. inv (2 pow (SUC k)) <= abs x /\ abs x < inv (2 pow k) /\

--- a/src/float/ieeeScript.sml
+++ b/src/float/ieeeScript.sml
@@ -14,10 +14,7 @@ infix ## |-> THEN THENL THENC ORELSE ORELSEC THEN_TCL ORELSE_TCL;
  * Next, bring in extra tools used.                                          *
  *---------------------------------------------------------------------------*)
 
-(*app load ["realTheory", "bossLib", "pred_setTheory","transcTheory","arithmeticTheory","Num_conv"];
-*)
-
-open realTheory bossLib pred_setTheory transcTheory arithmeticTheory Num_conv;
+open realTheory bossLib pred_setTheory arithmeticTheory Num_conv;
 
 (*---------------------------------------------------------------------------*
  * Create the theory.                                                        *

--- a/src/floating-point/binary_ieeeLib.sml
+++ b/src/floating-point/binary_ieeeLib.sml
@@ -8,7 +8,7 @@ structure binary_ieeeLib :> binary_ieeeLib =
 struct
 
 open HolKernel Parse boolLib bossLib
-open realLib wordsLib binary_ieeeSyntax
+open realSyntax realSimps RealArith wordsLib binary_ieeeSyntax
 
 structure Parse =
 struct
@@ -398,9 +398,9 @@ local
                  (ties_to_even (boolSyntax.mk_conj (c, boolSyntax.mk_neg rx))))
       end
    val lt_thm =
-      Drule.MATCH_MP (realLib.REAL_ARITH ``(a <= b <=> F) ==> b < a: real``)
+      Drule.MATCH_MP (REAL_ARITH ``(a <= b <=> F) ==> b < a: real``)
    val le_thm =
-      Drule.MATCH_MP (realLib.REAL_ARITH ``(a < b <=> F) ==> b <= a: real``)
+      Drule.MATCH_MP (REAL_ARITH ``(a < b <=> F) ==> b <= a: real``)
    fun mk_w (n, ty) = wordsSyntax.mk_n2w (numLib.mk_numeral n, ty)
    fun float_of_triple ((t, w), (s, e, f)) =
      binary_ieeeSyntax.mk_floating_point

--- a/src/pred_set/src/more_theories/cardinalScript.sml
+++ b/src/pred_set/src/more_theories/cardinalScript.sml
@@ -1653,6 +1653,26 @@ val bijections_cardeq = Q.store_thm(
 (* misc.                                                                     *)
 (* ------------------------------------------------------------------------- *)
 
+Theorem FORALL_IN_GSPEC :
+   (!P f. (!z. z IN {f x | P x} ==> Q z) <=> (!x. P x ==> Q(f x))) /\
+   (!P f. (!z. z IN {f x y | P x y} ==> Q z) <=>
+          (!x y. P x y ==> Q(f x y))) /\
+   (!P f. (!z. z IN {f w x y | P w x y} ==> Q z) <=>
+          (!w x y. P w x y ==> Q(f w x y)))
+Proof
+   SRW_TAC [][] THEN SET_TAC []
+QED
+
+Theorem EXISTS_IN_GSPEC :
+   (!P f. (?z. z IN {f x | P x} /\ Q z) <=> (?x. P x /\ Q(f x))) /\
+   (!P f. (?z. z IN {f x y | P x y} /\ Q z) <=>
+          (?x y. P x y /\ Q(f x y))) /\
+   (!P f. (?z. z IN {f w x y | P w x y} /\ Q z) <=>
+          (?w x y. P w x y /\ Q(f w x y)))
+Proof
+  SRW_TAC [][] THEN SET_TAC []
+QED
+
 val LEFT_IMP_EXISTS_THM = store_thm ("LEFT_IMP_EXISTS_THM",
  ``!P Q. (?x. P x) ==> Q <=> (!x. P x ==> Q)``,
  SIMP_TAC std_ss [PULL_EXISTS]);

--- a/src/pred_set/src/more_theories/topologyScript.sml
+++ b/src/pred_set/src/more_theories/topologyScript.sml
@@ -823,26 +823,6 @@ Theorem COMPL_COMPL_applied = REWRITE_RULE [COMPL_DEF] COMPL_COMPL
 (* |- !f s. {f x | x IN s} = IMAGE f s *)
 Theorem SIMPLE_IMAGE = GSYM IMAGE_DEF
 
-Theorem FORALL_IN_GSPEC :
-   (!P f. (!z. z IN {f x | P x} ==> Q z) <=> (!x. P x ==> Q(f x))) /\
-   (!P f. (!z. z IN {f x y | P x y} ==> Q z) <=>
-          (!x y. P x y ==> Q(f x y))) /\
-   (!P f. (!z. z IN {f w x y | P w x y} ==> Q z) <=>
-          (!w x y. P w x y ==> Q(f w x y)))
-Proof
-   SRW_TAC [][] THEN SET_TAC []
-QED
-
-Theorem EXISTS_IN_GSPEC :
-   (!P f. (?z. z IN {f x | P x} /\ Q z) <=> (?x. P x /\ Q(f x))) /\
-   (!P f. (?z. z IN {f x y | P x y} /\ Q z) <=>
-          (?x y. P x y /\ Q(f x y))) /\
-   (!P f. (?z. z IN {f w x y | P w x y} /\ Q z) <=>
-          (?w x y. P w x y /\ Q(f w x y)))
-Proof
-  SRW_TAC [][] THEN SET_TAC []
-QED
-
 Theorem UNIONS_IMAGE :
    !f s. UNIONS (IMAGE f s) = {y | ?x. x IN s /\ y IN f x}
 Proof

--- a/src/real/iterateScript.sml
+++ b/src/real/iterateScript.sml
@@ -20,7 +20,7 @@ open HolKernel Parse boolLib bossLib;
 open numLib unwindLib tautLib Arith prim_recTheory combinTheory quotientTheory
      arithmeticTheory jrhUtils pairTheory mesonLib pred_setTheory hurdUtils;
 
-open realTheory realLib transcTheory;
+open realTheory RealArith realSimps;
 open wellorderTheory cardinalTheory;
 
 val _ = new_theory "iterate";
@@ -127,22 +127,6 @@ val FORALL_FINITE_SUBSET_IMAGE = store_thm ("FORALL_FINITE_SUBSET_IMAGE",
                             (\t. FINITE t /\ t SUBSET s ==> P (IMAGE f t)) t``] THEN
    ONCE_REWRITE_TAC [MESON[] ``(!x. P x) <=> ~(?x. ~P x)``] THEN
    SIMP_TAC std_ss [NOT_IMP, GSYM CONJ_ASSOC, EXISTS_FINITE_SUBSET_IMAGE]);
-
-val FORALL_IN_GSPEC = store_thm ("FORALL_IN_GSPEC",
- ``(!P f. (!z. z IN {f x | P x} ==> Q z) <=> (!x. P x ==> Q(f x))) /\
-   (!P f. (!z. z IN {f x y | P x y} ==> Q z) <=>
-          (!x y. P x y ==> Q(f x y))) /\
-   (!P f. (!z. z IN {f w x y | P w x y} ==> Q z) <=>
-          (!w x y. P w x y ==> Q(f w x y)))``,
-   SRW_TAC [][] THEN SET_TAC []);
-
-val EXISTS_IN_GSPEC = store_thm ("EXISTS_IN_GSPEC",
- ``(!P f. (?z. z IN {f x | P x} /\ Q z) <=> (?x. P x /\ Q(f x))) /\
-   (!P f. (?z. z IN {f x y | P x y} /\ Q z) <=>
-          (?x y. P x y /\ Q(f x y))) /\
-   (!P f. (?z. z IN {f w x y | P w x y} /\ Q z) <=>
-          (?w x y. P w x y /\ Q(f w x y)))``,
-  SRW_TAC [][] THEN SET_TAC[]);
 
 val EMPTY_BIGUNION = store_thm ("EMPTY_BIGUNION",
  ``!s. (BIGUNION s = {}) <=> !t. t IN s ==> (t = {})``,
@@ -4448,38 +4432,6 @@ val PRODUCT_DELTA = store_thm ("PRODUCT_DELTA",
          (if a IN s then b else &1)``,
   REWRITE_TAC[product, GSYM NEUTRAL_REAL_MUL] THEN
   SIMP_TAC std_ss [ITERATE_DELTA, MONOIDAL_REAL_MUL]);
-
-Theorem LN_PRODUCT :
-    !f s. FINITE s /\ (!x. x IN s ==> &0 < f x) ==>
-          ln (product s f) = sum s (\x. ln (f x))
-Proof
-    rpt STRIP_TAC
- >> NTAC 2 (POP_ASSUM MP_TAC)
- >> Q.SPEC_TAC (‘s’, ‘s’)
- >> HO_MATCH_MP_TAC FINITE_INDUCT
- >> rw [PRODUCT_CLAUSES, SUM_CLAUSES, LN_1]
- >> ‘0 < f e’ by PROVE_TAC []
- >> ‘0 < product s f’ by (MATCH_MP_TAC PRODUCT_POS_LT >> rw [])
- >> rw [LN_MUL]
-QED
-
-(* added ‘n <> 0 /\ (!x. x IN s ==> &0 <= f x)’ to hol-light's statements *)
-Theorem ROOT_PRODUCT :
-    !n f s. FINITE s /\ n <> 0 /\ (!x. x IN s ==> &0 <= f x)
-        ==> root n (product s f) = product s (\i. root n (f i))
-Proof
-    rpt STRIP_TAC
- >> Cases_on ‘n’ >- fs []
- >> rename1 ‘SUC n <> 0’
- >> POP_ASSUM MP_TAC
- >> Q.PAT_X_ASSUM ‘FINITE s’ MP_TAC
- >> Q.SPEC_TAC (‘s’, ‘s’)
- >> HO_MATCH_MP_TAC FINITE_INDUCT
- >> rw [PRODUCT_CLAUSES, ROOT_1]
- >> ‘0 <= f e’ by PROVE_TAC []
- >> ‘0 <= product s f’ by (MATCH_MP_TAC PRODUCT_POS_LE >> rw [])
- >> rw [ROOT_MUL]
-QED
 
 (* ------------------------------------------------------------------------- *)
 (* Extend congruences.                                                       *)

--- a/src/real/real_sigmaScript.sml
+++ b/src/real/real_sigmaScript.sml
@@ -952,6 +952,42 @@ val jensen_pos_concave_SIGMA = store_thm
 (* Ported from hol-light (AGM stands for "arithmetic and geometric means")   *)
 (* ------------------------------------------------------------------------- *)
 
+(* moved here from iterateTheory (which does not depend on transcTheory now) *)
+Theorem LN_PRODUCT :
+    !f s. FINITE s /\ (!x. x IN s ==> &0 < f x) ==>
+          ln (product s f) = sum s (\x. ln (f x))
+Proof
+    rpt STRIP_TAC
+ >> NTAC 2 (POP_ASSUM MP_TAC)
+ >> Q.SPEC_TAC (‘s’, ‘s’)
+ >> HO_MATCH_MP_TAC FINITE_INDUCT
+ >> rw [PRODUCT_CLAUSES, SUM_CLAUSES, LN_1]
+ >> ‘0 < f e’ by PROVE_TAC []
+ >> ‘0 < product s f’ by (MATCH_MP_TAC PRODUCT_POS_LT >> rw [])
+ >> rw [LN_MUL]
+QED
+
+(* moved here from iterateTheory (which does not depend on transcTheory now)
+
+   NOTE: added ‘n <> 0 /\ (!x. x IN s ==> &0 <= f x)’ to hol-light's statements
+ *)
+Theorem ROOT_PRODUCT :
+    !n f s. FINITE s /\ n <> 0 /\ (!x. x IN s ==> &0 <= f x)
+        ==> root n (product s f) = product s (\i. root n (f i))
+Proof
+    rpt STRIP_TAC
+ >> Cases_on ‘n’ >- fs []
+ >> rename1 ‘SUC n <> 0’
+ >> POP_ASSUM MP_TAC
+ >> Q.PAT_X_ASSUM ‘FINITE s’ MP_TAC
+ >> Q.SPEC_TAC (‘s’, ‘s’)
+ >> HO_MATCH_MP_TAC FINITE_INDUCT
+ >> rw [PRODUCT_CLAUSES, ROOT_1]
+ >> ‘0 <= f e’ by PROVE_TAC []
+ >> ‘0 <= product s f’ by (MATCH_MP_TAC PRODUCT_POS_LE >> rw [])
+ >> rw [ROOT_MUL]
+QED
+
 (* NOTE: changed ‘0 <= x i’ (hol-light) to ‘0 < x i’ *)
 Theorem AGM_GEN :
     !a x s. FINITE s /\ sum s a = &1 /\ (!i. i IN s ==> &0 <= a i /\ &0 < x i)


### PR DESCRIPTION
Hi,

this small PR doesn't add any new theorem nor modify any existing proof. It only removes dependency on `transcTheory` from `iterateTheory`, making it a direct secondary theory after `realTheory`, and also from `src/floating-point` (the 2nd commit), as the further step of a previous commit 2fa1a06eb7e3b3bf67c20baa42eb70e4347a39c4.

In the attached sreenshot, we can see that now ieee-floating theories are completely separated from topology- and transcendental functions, and the position of `iterateTheory` is much "higher", as an immediate child of `realTheory`. This makes more senses.

P. S. currently we have two versions of differential- and intergral- calculus, the old one is hidding in `src/real` (`seq`, `lim`, `transc` and `integral`), the new one is in `src/probability` (`derivative` and `integration`). Merging them without breaking any compatibility is possible but requires a long time to work on (without any academic value, of course.)

Regards,

Chun Tian

<img width="699" alt="Schermata 2021-12-08 alle 12 54 37" src="https://user-images.githubusercontent.com/163421/145204638-2740a57e-f92f-452e-ab06-19da4f933030.png">
