### PR TITLE
Re-support old Emacs versions by eliminating IF-LET*

### DIFF
--- a/tools/hol-mode.src
+++ b/tools/hol-mode.src
@@ -844,19 +844,24 @@ region instead. With prefix ARG prompt for a file-name to load."
 
 (defun hol--find-alternate-executable (dir0 original-name0)
   (let ((dir (expand-file-name dir0))
-        (original-name (expand-file-name original-name0)))
+        (original-name (expand-file-name original-name0))
+        executable)
     ;; check for lastmaker file
-    (if-let*
-        (((file-readable-p ".HOLMK/lastmaker"))
-         ((> 500 (file-attribute-size (file-attributes ".HOLMK/lastmaker"))))
-         (lines (with-temp-buffer
-                  (insert-file-contents-literally ".HOLMK/lastmaker")
-                  (split-string (buffer-string) "\n" t)))
-         ((not (null lines)))
-         (dir1 (file-name-directory (car lines)))
-         (name (concat dir1 "hol"))
-         ((not (equal name original-name))))
-        (list (concat dir1 "hol") "(honouring last build in this directory)")
+    (if (and (file-readable-p ".HOLMK/lastmaker")
+             (> 500 (file-attribute-size (file-attributes ".HOLMK/lastmaker")))
+             (let ((lines (with-temp-buffer
+                            (insert-file-contents-literally ".HOLMK/lastmaker")
+                            (split-string (buffer-string) "\n" t))))
+               (and (not (null lines))
+                    (let* ((dir1 (file-name-directory (car lines)))
+                           (name (concat dir1 "hol")))
+                      (and (not (equal name original-name))
+                           (setq executable
+                                 (list (concat dir1 "hol")
+                                       "(honouring last build in this directory)")))))))
+        ;; then
+        executable
+      ;; else
       (while (and (not (hol--looks-like-root-holdir dir))
                   (not (equal "/" dir)))
         (setq dir (file-name-directory (directory-file-name dir))))


### PR DESCRIPTION
Hi,

currently in `tools/hol-mode.src` there's a single use of `IF-LET*` Lisp macro (introduced in Emacs 26.1, I think) stopping the entire HOL emacs lisp mode from running on older Emacs versions (24 and 25).  This issue has been driving me crazy, because the **best** Emacs environment on macOS, Aquamacs [1], its latest versions (3.5 and 3.6 beta 2) are still based on Emacs 25.x. It may still take years to see Aquamacs 4 coming out (based on Emacs 28) as the author has planned.

I hope you can do me a favor by accepting this PR so that I don't need to keep the local changes in every of my HOL working directories.  The patch can also benefit Emacs+HOL users on Ubuntu 18.04, Solaris 10 and 11, and other operating systems in which no official prebuilt Emacs 27 is easily available.

Regards,

Chun Tian

[1] http://aquamacs.org