### PR TITLE
Automatic proofs that datatypes are countable

### DIFF
--- a/src/pred_set/src/more_theories/countable_typesLib.sig
+++ b/src/pred_set/src/more_theories/countable_typesLib.sig
@@ -1,0 +1,7 @@
+signature countable_typesLib =
+sig
+  include Abbrev
+
+  val mk_countable : hol_type -> thm
+
+end

--- a/src/pred_set/src/more_theories/countable_typesLib.sml
+++ b/src/pred_set/src/more_theories/countable_typesLib.sml
@@ -1,0 +1,96 @@
+structure countable_typesLib :> countable_typesLib = struct
+
+open pred_setTheory countable_typesTheory boolTheory
+open bossLib HolKernel Tactic Tactical boolSyntax Drule Rewrite Hol_pp
+
+fun goal_tac gt = (fn (asms, gl) => gt gl (asms, gl)) : tactic
+
+fun find_toplevel_cases xs [] = xs
+  | find_toplevel_cases xs (t :: ts) = if is_comb t
+  then find_toplevel_cases ((if TypeBase.is_case t then [t] else []) @ xs)
+    (rator t :: rand t :: ts)
+  else find_toplevel_cases xs ts
+
+val var_case_tac = goal_tac (fn gl => let
+    val xs = find_toplevel_cases [] [gl] |> map (#2 o TypeBase.dest_case)
+        |> filter is_var
+  in case xs of
+    [] => NO_TAC
+    | v :: _ => tmCases_on v []
+        \\ simp_tac bool_ss [TypeBase.case_def_of (type_of v)]
+ end)
+
+val countable_tm = concl inj_countable |> strip_forall |> snd
+    |> dest_imp |> snd |> rator
+
+fun mk_countable_lemma ty = let
+    val ind = TypeBase.induction_of ty
+    val conses = find_terms (fn t => is_comb t andalso is_var (rator t)) (concl ind)
+      |> map rand |> filter (not o is_var)
+    val size_thm = snd (TypeBase.size_of ty)
+    val sizes = strip_conj (concl size_thm) |> map (lhs o snd o strip_forall)
+      |> map rator |> HOLset.fromList Term.compare |> HOLset.listItems
+    val lemma_tys = map (fst o dom_rng o type_of) sizes
+    fun ty_n ty = total (index (fn ty2 => ty2 = ty)) lemma_tys
+    val ex_param_tys = map (snd o strip_comb) conses |> List.concat |> map type_of
+      |> HOLset.fromList Type.compare |> HOLset.listItems
+      |> filter (not o Option.isSome o ty_n)
+    val assms = map (curry mk_icomb countable_tm o pred_setSyntax.mk_univ) ex_param_tys
+    val sum_ty = sumSyntax.list_mk_sum lemma_tys
+    val u_sum_ty = pred_setSyntax.mk_univ sum_ty
+    val _ = print ("Making countable lemma for: ")
+    val _ = Hol_pp.print_term u_sum_ty
+    val _ = print ("\n")
+    fun mk_sum t = let
+        val n = Option.valOf (ty_n (type_of t))
+        val t2 = if n = length lemma_tys - 1 then t
+          else sumSyntax.mk_inl (t, sumSyntax.list_mk_sum (List.drop (lemma_tys, n + 1)))
+      in foldr (fn (ty, t) => sumSyntax.mk_inr (t, ty)) t2 (List.take (lemma_tys, n)) end
+    fun mk_rec t = let
+        val xs = snd (strip_comb t) |> filter (Option.isSome o ty_n o type_of)
+      in listSyntax.mk_list (map mk_sum xs, sum_ty) end
+    fun mk_ints (i, t) = let
+        val xs = snd (strip_comb t) |> filter (not o Option.isSome o ty_n o type_of)
+        val ns = map (fn x => mk_comb (mk_var ("f", type_of x --> numSyntax.num), x)) xs
+      in listSyntax.mk_list ([numSyntax.term_of_int i] @ ns, numSyntax.num) end
+    fun mk_case i t = (mk_sum t, pairSyntax.mk_pair (mk_ints (i, t), mk_rec t))
+    val f = TypeBase.mk_pattern_fn (mapi mk_case conses)
+    fun ss x y = list_mk_icomb (basicSizeSyntax.sum_size_tm, [x, y])
+    val m1 = list_mk_rbinop ss sizes
+    fun mk_k0 ty = mk_abs (mk_var ("x", ty), numSyntax.zero_tm)
+    val m = subst (map (fn f => f |-> mk_k0 (fst (dom_rng (type_of f)))) (free_vars m1)) m1
+    val lemma = countable_split |> ISPEC u_sum_ty |> SPECL [f, m]
+    val prop = mk_imp (list_mk_conj (T :: assms), snd (dest_imp (concl lemma)))
+    val ty_ss = foldr (fn (sf, ss) => ss ++ sf) list_ss (map simpLib.type_ssfrag lemma_tys)
+    val lemma2 = TAC_PROOF (([], prop),
+      disch_tac
+      \\ match_mp_tac (GEN_ALL lemma)
+      \\ full_simp_tac bool_ss [countable_def]
+      \\ rpt (FIRST_ASSUM (MAP_FIRST EXISTS_TAC o free_vars o concl))
+      \\ simp_tac bool_ss [INJ_DEF, IN_UNIV]
+      \\ rpt (FIRST [conj_tac, gen_tac, var_case_tac])
+      \\ simp_tac ty_ss []
+      \\ simp_tac arith_ss [DISJ_IMP_THM, basicSizeTheory.sum_size_def, size_thm]
+      \\ full_simp_tac bool_ss [INJ_IFF, IN_UNIV]
+    )
+  in REWRITE_RULE [countable_Usum, IMP_CONJ_THM] lemma2 end
+
+fun mk_countable ty = let
+    val final_concl = mk_icomb (countable_tm, pred_setSyntax.mk_univ ty)
+    val lemmas = [unit_countable, num_countable]
+    fun mk_thm lemmas = let open ConseqConv
+      in DEPTH_CONSEQ_CONV (CONSEQ_REWRITE_CONV ([], lemmas, []))
+          CONSEQ_CONV_STRENGTHEN_direction final_concl end
+    val thm = mk_thm (mk_countable_lemma ty :: lemmas)
+    fun loop (thm, lemmas) = let
+        val thm = mk_thm (thm :: lemmas)
+        val tys = find_terms pred_setSyntax.is_univ (concl thm)
+          |> map (fst o dom_rng o pred_setSyntax.dest_univ)
+          |> filter (fn ty2 => ty2 <> ty andalso can TypeBase.induction_of ty2)
+      in case tys of [] => thm
+        | (ty2 :: _) => loop (thm, mk_countable_lemma ty2 :: lemmas)
+      end
+  in loop (thm, lemmas) |> REWRITE_RULE [] end
+
+end
+

--- a/src/pred_set/src/more_theories/countable_typesScript.sml
+++ b/src/pred_set/src/more_theories/countable_typesScript.sml
@@ -1,0 +1,79 @@
+open HolKernel bossLib boolTheory pred_setTheory;
+
+open Tactic Tactical;
+
+val _ = new_theory "countable_types";
+
+Theorem unit_countable:
+  countable (UNIV : unit set)
+Proof
+  simp [countable_def, INJ_DEF]
+QED
+
+Theorem list_countable:
+  countable Lset <=> countable (BIGUNION (IMAGE set Lset))
+Proof
+  EQ_TAC \\ rw []
+  >- (
+    irule bigunion_countable
+    \\ simp [PULL_EXISTS, image_countable, finite_countable]
+  )
+  \\ qspec_then `IMAGE (\n. {xs | LENGTH xs = n /\
+        EVERY (\x. x IN BIGUNION (IMAGE set Lset)) xs}) UNIV`
+    mp_tac bigunion_countable
+  \\ simp []
+  \\ reverse impl_tac
+  >- (
+    rw [] \\ drule_then irule subset_countable
+    \\ simp [SUBSET_DEF, PULL_EXISTS, listTheory.EVERY_MEM]
+    \\ metis_tac []
+  )
+  \\ simp [PULL_EXISTS]
+  \\ Induct
+  \\ simp []
+  \\ csimp []
+  \\ dxrule_then dxrule cross_countable
+  \\ rw []
+  \\ qspec_then `\xs. (TL xs, HD xs)` irule inj_countable
+  \\ first_assum (irule_at Any)
+  \\ simp [INJ_IFF, listTheory.LENGTH_CONS, PULL_EXISTS]
+  \\ metis_tac []
+QED
+
+Theorem countable_split:
+  ! (X : 'a set) (f : 'a -> (num list # 'a list)) (m : 'a -> num).
+  INJ f X UNIV /\
+  (!x y. x IN X /\ MEM y (SND (f x)) ==> y IN X /\ m y < m x)
+  ==>
+  countable X
+Proof
+  rw []
+  \\ qspec_then `IMAGE (\n. {x | m x < n /\ x IN X}) UNIV`
+    mp_tac bigunion_countable
+  \\ simp []
+  \\ impl_tac
+  >- (
+    simp [PULL_EXISTS]
+    \\ Induct
+    \\ simp []
+    \\ qspec_then `f` irule inj_countable
+    \\ qexists_tac `f`
+    \\ qexists_tac `UNIV CROSS {xs | EVERY (\x. m x < n /\ x IN X) xs}`
+    \\ irule_at Any cross_countable
+    \\ simp [list_countable]
+    \\ drule_then (irule_at Any) subset_countable
+    \\ fs [SUBSET_DEF, PULL_EXISTS, INJ_DEF, listTheory.EVERY_MEM]
+    \\ rw []
+    \\ res_tac
+    \\ simp []
+  )
+  >- (
+    rw []
+    \\ drule_then irule subset_countable
+    \\ simp [SUBSET_DEF, PULL_EXISTS]
+    \\ metis_tac [prim_recTheory.LESS_SUC_REFL]
+  )
+QED
+
+val _ = export_theory ();
+

--- a/src/pred_set/src/selftest.sml
+++ b/src/pred_set/src/selftest.sml
@@ -1,5 +1,7 @@
 open HolKernel boolLib Parse PFset_conv
 open pred_setSimps
+open bossLib testutils
+local open countable_typesLib in end
 
 val _ = let
   open testutils
@@ -116,6 +118,31 @@ val _ = set_grammar_ancestry ["pred_set"]
 val _ = print "Setting grammar ancestry to be [\"pred_set\"]\n"
 val _ = set_trace "PP.avoid_unicode" 1
 val _ = List.app testutils.tpp tpp_cases
+
+open countable_typesLib;
+
+val _ = quietly Datatype `rose_tricky = RT_Empty | RT_List (num list) ((rose_tricky) list)`
+
+val _ = tprint "Testing mk_countable on rose-type datatype rose_tricky."
+val _ = require (check_result (fn thm => not (is_imp (concl thm))))
+    mk_countable ``: rose_tricky``;
+
+val _ = quietly Datatype `
+  rose_awful = RA_Empty | RA_List ((rose_awful_aux) list)
+  ;
+  rose_awful_aux = RAA_Empty | RAA (rose_awful) num 'a num (rose_awful)
+`
+
+val _ = quietly Datatype `
+  tier2 = T2_Empty ('a -> num) | T2_Loop (tier2 list) (num list rose_awful)
+`
+
+val _ = quietly Datatype `
+  tier3 = T3_Empty | T3_x ('a tier2) num
+`;
+
+val _ = tprint "Testing mk_countable on compound datatype tier3."
+val _ = require is_result mk_countable ``: 'a tier3``
 
 val _ =
     Process.exit


### PR DESCRIPTION
Some setup theory and a library that automatically proves that
datatypes defined in the TypeBase are countable.

I think I put the theory in the right place, it's unclear though whether
the relevant code belongs under 'more_theories'.