### PR TITLE
Fixed incorrect results of MiniSat 1.x on Linux/ARM where "char" is unsigned

### DIFF
--- a/src/HolSat/sat_solvers/minisat/Solver.C
+++ b/src/HolSat/sat_solvers/minisat/Solver.C
@@ -253,7 +253,7 @@ public:
 
 void Solver::analyze(Clause* confl, vec<Lit>& out_learnt, int& out_btlevel)
 {
-    vec<char>&     seen  = analyze_seen;
+    vec<int8_t>&   seen  = analyze_seen;
     int            pathC = 0;
     Lit            p     = lit_Undef;
     bool           sconfl;
@@ -418,7 +418,7 @@ void Solver::analyzeFinal(Clause* confl, bool skip_first)
         if (proof != NULL) conflict_id = proof->last();
         return; }
 
-    vec<char>&     seen  = analyze_seen;
+    vec<int8_t>& seen = analyze_seen;
     if (proof != NULL) proof->beginChain(confl->id());
     for (int i = skip_first ? 1 : 0; i < confl->size(); i++){
         Var     x = var((*confl)[i]);

--- a/src/HolSat/sat_solvers/minisat/Solver.h
+++ b/src/HolSat/sat_solvers/minisat/Solver.h
@@ -63,7 +63,7 @@ protected:
     VarOrder            order;            // Keeps track of the decision variable order.
 
     vec<vec<Clause*> >  watches;          // 'watches[lit]' is a list of constraints watching 'lit' (will go there if literal becomes true).
-    vec<char>           assigns;          // The current assignments (lbool:s stored as char:s).
+    vec<int8_t>         assigns;          // The current assignments (lbool:s stored as int8_t:s).
     vec<Lit>            trail;            // Assignment stack; stores all assigments made in the order they were made.
     vec<int>            trail_lim;        // Separator indices for different decision levels in 'trail[]'.
     vec<Clause*>        reason;           // 'reason[var]' is the clause that implied the variables current value, or 'NULL' if none.
@@ -77,7 +77,7 @@ protected:
 
     // Temporaries (to reduce allocation overhead). Each variable is prefixed by the method in which is used:
     //
-    vec<char>           analyze_seen;
+    vec<int8_t>         analyze_seen;
     vec<Lit>            analyze_stack;
     vec<Lit>            analyze_toclear;
     Clause*             propagate_tmpbin;

--- a/src/HolSat/sat_solvers/minisat/SolverTypes.h
+++ b/src/HolSat/sat_solvers/minisat/SolverTypes.h
@@ -107,7 +107,7 @@ inline Clause* Clause_new(bool learnt, const vec<Lit>& ps, ClauseId id = ClauseI
     assert(sizeof(Lit)      == sizeof(uint));
     assert(sizeof(float)    == sizeof(uint));
     assert(sizeof(ClauseId) == sizeof(uint));
-    void*   mem = xmalloc<char>(sizeof(Clause) + sizeof(uint)*(ps.size() + (int)learnt + (int)(id != ClauseId_NULL)));
+    void*   mem = xmalloc<int8_t>(sizeof(Clause) + sizeof(uint)*(ps.size() + (int)learnt + (int)(id != ClauseId_NULL)));
     return new (mem) Clause(learnt, ps, id); }
 
 

--- a/src/HolSat/sat_solvers/minisat/VarOrder.h
+++ b/src/HolSat/sat_solvers/minisat/VarOrder.h
@@ -34,13 +34,13 @@ struct VarOrder_lt {
 };
 
 class VarOrder {
-    const vec<char>&    assigns;     // var->val. Pointer to external assignment table.
+    const vec<int8_t>&  assigns;     // var->val. Pointer to external assignment table.
     const vec<double>&  activity;    // var->act. Pointer to external activity table.
     Heap<VarOrder_lt>   heap;
     double              random_seed; // For the internal random number generator
 
 public:
-    VarOrder(const vec<char>& ass, const vec<double>& act) :
+    VarOrder(const vec<int8_t>& ass, const vec<double>& act) :
         assigns(ass), activity(act), heap(VarOrder_lt(act)), random_seed(91648253)
         { }
 


### PR DESCRIPTION
See #962 for the original issue report and related discussions. The credits are totally of Oskar Abrahamsson (@oskarabrahamsson) who found the root causes and the solution.

Below are something that I also never knew before: it seems that in C90 ("seems" as I have no access to its ISO standard documentation), there are 3 _distinct_ types: `char`, `signed char` and `unsigned char`, and whether `char` is signed or unsigned is implementation-specific (by "implementation" it means `compiler+OS+arch`). For example, I found the following notes in «Oracle® Developer Studio 12.6: C User's Guide» (Appendix F. Implementation-Defined ISO/IEC C90 Behavior) [1]:
```
F.1.4.8 (6.2.1.1) Whether a plain char has the same range of values as signed char or unsigned char:
A char is treated as a signed char.
```

So far all compilers I can access on Linux/ARM (GCC and LLVM) treat `char` as `unsigned char`, which is different with what the MiniSat authors were expecting. Changing all string-irrelevant `char` uses to `signed char` should also work, but changing them to modern `int8_t` is more reasonable.

Lessions (I, not sure others) learnt: 

1. `char`, `signed char` and `unsigned char` ...
2. Never trust SAT solvers blindly (e.g. Isabelle includes MiniSat 2.x which has no proof logging features).
3. Don't trust SAT people who optimize their programs in _this_ way (to win SAT competitions) can lead to polynomial-time-complexity algorithms (thus prove `P = NP`) one day in the future...

and

4. Try UndefinedBehaviorSanitizer (UBSan) [2] first on weird-behavior C/C++ programs next time.

[1] https://docs.oracle.com/cd/E77782_01/html/E77788/bjazt.html#scrolltoc
[2] https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html