### PR TITLE
vimhol terminal

### DIFF
--- a/tools/vim/README.md
+++ b/tools/vim/README.md
@@ -24,7 +24,8 @@ All files are located under tools/vim
 - `filetype.vim`: Template filetype.vim for automatically running hol.vim when
   vim starts.
 - `vimhol.sh`: Wraps hol and vim side-by-side in tmux. Below you find the
-  description of its usage.
+  description of its usage. See below for an alternative approach of running
+  an hol interactive session within vim.
 - `README.md`: Documentation. (This file.)
 
 ## Quickstart
@@ -48,9 +49,18 @@ The remedy is to read the fifo: either start hol (if everything is set up
 correctly) or simply cat `$(HOLDIR)/tools/vim/fifo` (or `$(VIMHOL_FIFO)` if you
 are using a custom fifo path).
 
+## HOL interactive session inside the vim editor
+
+Neovim and some versions of vim can run the interactive HOL session (HOL repl) in a terminal buffer within the editor, right next to a file buffer.
+Vim supports this feature if `:echo has('terminal')` prints `1`.
+For the supported versions, this plugin offers additional keyboard mappings to open and close a HOL session, as documented below in the section *key mappings for the HOL repl buffer*.
+Whenever a HOL session is started, a new unique fifo is created.
+
+Read more in the documentation on [vim terminal buffers](https://vimhelp.org/terminal.txt.html) (or [neovim terminal buffers](https://neovim.io/doc/user/nvim_terminal_emulator.html)).
+
 ## Key mappings
 
-(These are all set up at the bottom of `hol.vim`)
+(These are all set up in `hol.vim`)
 
 The following commands work in visual mode:
 
@@ -88,6 +98,21 @@ Command     | Description
 `hh`        | A normal h (usually means move cursor left). This one works in both normal and visual modes.
 `hy`        | Toggle HOL's show types trace.
 `hn`        | Toggle HOL's `PP.avoid_unicode` trace.
+
+## Key mappings for the HOL repl buffer
+
+For the HOL repl hosted by vim the following commands work in normal mode of
+any `*Script.sml` file:
+
+Command     | Description
+:---------- | :-----------------------------------
+`hx`        | Open a HOL session inside (neo)vim at the path of the currently edited file.
+`hX`        | Close the HOL session.
+`hw`        | Send region (visual and normal mode). Writes directly into the HOL session buffer and does not need a fifo.
+`hC`        | Send HOL to `use` the file defined in the `$HOL_CONFIG` environment variable, if any. This is handy to teach custom heaps to load Vimhol (if `$HOL_CONFIG` contains the path to `hol-config.sml`, for example `~/.hol-config.sml`).
+
+The terminal buffer that is hosting the HOL repl can be navigated as usual (if in normal mode).
+In vim, to leave insert mode of a terminal buffer and return to Terminal-Normal mode press `CTRL-\ CTRL-N`, as documented in [`:help terminal-typing`](https://vimhelp.org/terminal.txt.html#terminal-typing).
 
 ## Automatic stripping
 

--- a/tools/vim/README.md
+++ b/tools/vim/README.md
@@ -109,7 +109,6 @@ Command     | Description
 `hx`        | Open a HOL session inside (neo)vim at the path of the currently edited file.
 `hX`        | Close the HOL session.
 `hw`        | Send region (visual and normal mode). Writes directly into the HOL session buffer and does not need a fifo.
-`hC`        | Send HOL to `use` the file defined in the `$HOL_CONFIG` environment variable, if any. This is handy to teach custom heaps to load Vimhol (if `$HOL_CONFIG` contains the path to `hol-config.sml`, for example `~/.hol-config.sml`).
 
 The terminal buffer that is hosting the HOL repl can be navigated as usual (if in normal mode).
 In vim, to leave insert mode of a terminal buffer and return to Terminal-Normal mode press `CTRL-\ CTRL-N`, as documented in [`:help terminal-typing`](https://vimhelp.org/terminal.txt.html#terminal-typing).

--- a/tools/vim/hol.src
+++ b/tools/vim/hol.src
@@ -309,8 +309,6 @@ nn <buffer><silent> <LocalLeader>X :call HOLREPLsend("\<C-D>")<CR>
 " send current line (or highlighted section) to terminal
 vn <buffer><silent> <LocalLeader>w "0y:call HOLREPLsend(getreg('0',1) . ";\n")<CR>
 nm <buffer><silent><expr> <LocalLeader>w "V".maplocalleader."w"
-" load the $HOL_CONFIG for non-standard HOL heaps
-nn <buffer><silent> <LocalLeader>C :call HOLREPLsend("Option.app use $ Process.getEnv \"HOL_CONFIG\";\n")<CR>
 
 let b:did_hol = 1
 " vim: ft=vim

--- a/tools/vim/hol.src
+++ b/tools/vim/hol.src
@@ -3,10 +3,13 @@ if exists("b:did_hol")
 endif
 
 let s:defaultholpipe =
-if empty($VIMHOL_FIFO)
-  let s:holpipe = s:defaultholpipe
-else
-  let s:holpipe = $VIMHOL_FIFO
+" initialise pipe if yet unset
+if ! has_key(s:,'holpipe')
+  if empty($VIMHOL_FIFO)
+    let s:holpipe = s:defaultholpipe
+  else
+    let s:holpipe = $VIMHOL_FIFO
+  endif
 endif
 let s:holtogglequiet = "val _ = HOL_Interactive.toggle_quietdec();"
 
@@ -17,6 +20,7 @@ setlocal nobuflisted
 setlocal noswapfile
 let s:holnr = bufnr("")
 hide
+
 
 let s:tmpprefix =
 fu! TempName()
@@ -241,6 +245,69 @@ nn <silent> <LocalLeader>a :call HOLSelect('^Triviality\\|^Theorem','^Proof')<CR
 nn <silent> <LocalLeader>y :call HOLCall(function("HOLF"),["Globals.show_types:=not(!Globals.show_types)"])<CR>
 nn <silent> <LocalLeader>n :call HOLCall(function("HOLF"),["Feedback.set_trace \"PP.avoid_unicode\" (1 - Feedback.current_trace \"PP.avoid_unicode\")"])<CR>
 no <LocalLeader>h h
+
+if ! exists('$HOLDIR') || (!has('terminal') && ! has('nvim'))
+  let b:did_hol = 1
+  " skip terminal feature
+  finish
+endif
+
+" if exists use readline wrapper
+if executable('rlwrap')
+  let s:rlwrap_str = 'rlwrap '
+else
+  let s:rlwrap_str = ''
+endif
+
+function! HOLREPLnew()
+  let l:cmd = getenv('HOLDIR') . '/bin/hol'
+  if ! executable(l:cmd)
+    echoerr 'hol command not found: ' . l:cmd
+    return 0
+  endif
+  let s:holpipe = tempname()
+  call system('mkfifo '. s:holpipe)
+  "echom "holrepl pipe " . s:holpipe
+  let options = {
+  \  "cwd": expand('%:p:h'),
+  \  "vertical": 1,
+  \  "env": {
+  \    "VIMHOL_FIFO": s:holpipe
+  \  }}
+  echom 'holrepl cmd: ' . s:rlwrap_str . l:cmd
+  if has('nvim') " neovim terminal
+    let options.stdin = "null"
+    vsplit | enew
+    let l:terminal_job_id = termopen(s:rlwrap_str . l:cmd, options)
+    let g:hol_repl = {'buf': bufnr(''), 'job': l:terminal_job_id}
+    " scroll to end of terminal buffer
+    silent! normal G
+  else " vim terminal
+    rightbelow let g:hol_repl = term_start(s:rlwrap_str . l:cmd, options)
+    call term_setkill(g:hol_repl, 'term')
+  endif
+  wincmd p
+endfunction
+
+if has('nvim')
+  function! HOLREPLsend(text)
+    call chansend(g:hol_repl.job, a:text)
+  endfunction
+else
+  function! HOLREPLsend(text)
+    call term_sendkeys(g:hol_repl, a:text)
+  endfunction
+endif
+
+" open a new hol terminal
+nn <silent> <LocalLeader>x :call HOLREPLnew()<CR>
+" close a hol_repl buffer
+nn <silent> <LocalLeader>X :call HOLREPLsend("\<C-D>")<CR>
+" send current line (or highlighted section) to terminal
+vn <silent> <LocalLeader>w "0y:call HOLREPLsend(getreg('0',1) . ";\n")<CR>
+nm <silent><expr> <LocalLeader>w "V".maplocalleader."w"
+" load the $HOL_CONFIG for non-standard HOL heaps
+nn <silent> <LocalLeader>C :call HOLREPLsend("Option.app use $ Process.getEnv \"HOL_CONFIG\";\n")<CR>
 
 let b:did_hol = 1
 " vim: ft=vim

--- a/tools/vim/hol.src
+++ b/tools/vim/hol.src
@@ -211,40 +211,40 @@ endf
 if !(exists("maplocalleader"))
   let maplocalleader = "\\"
 endif
-vn <silent> <LocalLeader>l :call YankThenHOLCall(function("HOLLoadSendQuiet"),[])<CR>
-vn <silent> <LocalLeader>L :call YankThenHOLCall(function("HOLLoad"),[])<CR>
-vn <silent> <LocalLeader>s :call YankThenHOLCall(function("HOLSend"),[])<CR>
-vn <silent> <LocalLeader>u :call YankThenHOLCall(function("HOLSendQuiet"),[])<CR>
-vn <silent> <LocalLeader>g :call YankThenHOLCall(function("HOLGoal"),[])<CR>
-vn <silent> <LocalLeader>G :call YankThenHOLCall(function("HOLUQGoal"),[])<CR>
-vn <silent> <LocalLeader>e :call YankThenHOLCall(function("HOLExpand"),[])<CR>
-vn <silent> <LocalLeader>S :call YankThenHOLCall(function("HOLSubgoal"),[])<CR>
-vn <silent> <LocalLeader>F :call YankThenHOLCall(function("HOLSuffices"),[])<CR>
-vn <silent> <LocalLeader>P :call YankThenHOLCall(function("HOLPattern"),[])<CR>
-nm <silent><expr> <LocalLeader>l "V".maplocalleader."l"
-nm <silent><expr> <LocalLeader>L "V".maplocalleader."L"
-nm <silent><expr> <LocalLeader>s "V".maplocalleader."s"
-nm <silent><expr> <LocalLeader>u "V".maplocalleader."u"
-nm <silent><expr> <LocalLeader>g "V".maplocalleader."g"
-nm <silent><expr> <LocalLeader>G "V".maplocalleader."G"
-nm <silent><expr> <LocalLeader>e "V".maplocalleader."e"
-nm <silent><expr> <LocalLeader>S "V".maplocalleader."S"
-nm <silent><expr> <LocalLeader>F "V".maplocalleader."F"
-nm <silent><expr> <LocalLeader>P "V".maplocalleader."P"
-nn <silent> <LocalLeader>R :<C-U>call HOLRotate()<CR>
-nn <silent> <LocalLeader>b :<C-U>call HOLRepeat("proofManagerLib.backup();")<CR>
-nn <silent> <LocalLeader>B :<C-U>call HOLRepeat("proofManagerLib.restore();")<CR>
-nn <silent> <LocalLeader>v :call HOLCall(function("HOLF"),["proofManagerLib.save()"])<CR>
-nn <silent> <LocalLeader>d :<C-U>call HOLRepeat("proofManagerLib.drop();")<CR>
-nn <silent> <LocalLeader>p :call HOLCall(function("HOLF"),["proofManagerLib.p()"])<CR>
-nn <silent> <LocalLeader>r :call HOLCall(function("HOLF"),["proofManagerLib.restart()"])<CR>
-nn <silent> <LocalLeader>c :call HOLINT()<CR>
-nn <silent> <LocalLeader>t :call HOLSelect('`\\|‘','`\\|’')<CR>
-nn <silent> <LocalLeader>T :call HOLSelect('``\\|“','``\\|”')<CR>
-nn <silent> <LocalLeader>a :call HOLSelect('^Triviality\\|^Theorem','^Proof')<CR>-Vo+
-nn <silent> <LocalLeader>y :call HOLCall(function("HOLF"),["Globals.show_types:=not(!Globals.show_types)"])<CR>
-nn <silent> <LocalLeader>n :call HOLCall(function("HOLF"),["Feedback.set_trace \"PP.avoid_unicode\" (1 - Feedback.current_trace \"PP.avoid_unicode\")"])<CR>
-no <LocalLeader>h h
+vn <buffer><silent> <LocalLeader>l :call YankThenHOLCall(function("HOLLoadSendQuiet"),[])<CR>
+vn <buffer><silent> <LocalLeader>L :call YankThenHOLCall(function("HOLLoad"),[])<CR>
+vn <buffer><silent> <LocalLeader>s :call YankThenHOLCall(function("HOLSend"),[])<CR>
+vn <buffer><silent> <LocalLeader>u :call YankThenHOLCall(function("HOLSendQuiet"),[])<CR>
+vn <buffer><silent> <LocalLeader>g :call YankThenHOLCall(function("HOLGoal"),[])<CR>
+vn <buffer><silent> <LocalLeader>G :call YankThenHOLCall(function("HOLUQGoal"),[])<CR>
+vn <buffer><silent> <LocalLeader>e :call YankThenHOLCall(function("HOLExpand"),[])<CR>
+vn <buffer><silent> <LocalLeader>S :call YankThenHOLCall(function("HOLSubgoal"),[])<CR>
+vn <buffer><silent> <LocalLeader>F :call YankThenHOLCall(function("HOLSuffices"),[])<CR>
+vn <buffer><silent> <LocalLeader>P :call YankThenHOLCall(function("HOLPattern"),[])<CR>
+nm <buffer><silent><expr> <LocalLeader>l "V".maplocalleader."l"
+nm <buffer><silent><expr> <LocalLeader>L "V".maplocalleader."L"
+nm <buffer><silent><expr> <LocalLeader>s "V".maplocalleader."s"
+nm <buffer><silent><expr> <LocalLeader>u "V".maplocalleader."u"
+nm <buffer><silent><expr> <LocalLeader>g "V".maplocalleader."g"
+nm <buffer><silent><expr> <LocalLeader>G "V".maplocalleader."G"
+nm <buffer><silent><expr> <LocalLeader>e "V".maplocalleader."e"
+nm <buffer><silent><expr> <LocalLeader>S "V".maplocalleader."S"
+nm <buffer><silent><expr> <LocalLeader>F "V".maplocalleader."F"
+nm <buffer><silent><expr> <LocalLeader>P "V".maplocalleader."P"
+nn <buffer><silent> <LocalLeader>R :<C-U>call HOLRotate()<CR>
+nn <buffer><silent> <LocalLeader>b :<C-U>call HOLRepeat("proofManagerLib.backup();")<CR>
+nn <buffer><silent> <LocalLeader>B :<C-U>call HOLRepeat("proofManagerLib.restore();")<CR>
+nn <buffer><silent> <LocalLeader>v :call HOLCall(function("HOLF"),["proofManagerLib.save()"])<CR>
+nn <buffer><silent> <LocalLeader>d :<C-U>call HOLRepeat("proofManagerLib.drop();")<CR>
+nn <buffer><silent> <LocalLeader>p :call HOLCall(function("HOLF"),["proofManagerLib.p()"])<CR>
+nn <buffer><silent> <LocalLeader>r :call HOLCall(function("HOLF"),["proofManagerLib.restart()"])<CR>
+nn <buffer><silent> <LocalLeader>c :call HOLINT()<CR>
+nn <buffer><silent> <LocalLeader>t :call HOLSelect('`\\|‘','`\\|’')<CR>
+nn <buffer><silent> <LocalLeader>T :call HOLSelect('``\\|“','``\\|”')<CR>
+nn <buffer><silent> <LocalLeader>a :call HOLSelect('^Triviality\\|^Theorem','^Proof')<CR>-Vo+
+nn <buffer><silent> <LocalLeader>y :call HOLCall(function("HOLF"),["Globals.show_types:=not(!Globals.show_types)"])<CR>
+nn <buffer><silent> <LocalLeader>n :call HOLCall(function("HOLF"),["Feedback.set_trace \"PP.avoid_unicode\" (1 - Feedback.current_trace \"PP.avoid_unicode\")"])<CR>
+no <buffer><LocalLeader>h h
 
 if ! exists('$HOLDIR') || (!has('terminal') && ! has('nvim'))
   let b:did_hol = 1
@@ -300,14 +300,14 @@ else
 endif
 
 " open a new hol terminal
-nn <silent> <LocalLeader>x :call HOLREPLnew()<CR>
+nn <buffer><silent> <LocalLeader>x :call HOLREPLnew()<CR>
 " close a hol_repl buffer
-nn <silent> <LocalLeader>X :call HOLREPLsend("\<C-D>")<CR>
+nn <buffer><silent> <LocalLeader>X :call HOLREPLsend("\<C-D>")<CR>
 " send current line (or highlighted section) to terminal
-vn <silent> <LocalLeader>w "0y:call HOLREPLsend(getreg('0',1) . ";\n")<CR>
-nm <silent><expr> <LocalLeader>w "V".maplocalleader."w"
+vn <buffer><silent> <LocalLeader>w "0y:call HOLREPLsend(getreg('0',1) . ";\n")<CR>
+nm <buffer><silent><expr> <LocalLeader>w "V".maplocalleader."w"
 " load the $HOL_CONFIG for non-standard HOL heaps
-nn <silent> <LocalLeader>C :call HOLREPLsend("Option.app use $ Process.getEnv \"HOL_CONFIG\";\n")<CR>
+nn <buffer><silent> <LocalLeader>C :call HOLREPLsend("Option.app use $ Process.getEnv \"HOL_CONFIG\";\n")<CR>
 
 let b:did_hol = 1
 " vim: ft=vim

--- a/tools/vim/hol.src
+++ b/tools/vim/hol.src
@@ -13,13 +13,16 @@ if ! has_key(s:,'holpipe')
 endif
 let s:holtogglequiet = "val _ = HOL_Interactive.toggle_quietdec();"
 
-new
-setlocal buftype=nofile
-setlocal bufhidden=hide
-setlocal nobuflisted
-setlocal noswapfile
-let s:holnr = bufnr("")
-hide
+" create the hidden buffer once
+if ! has_key(s:,'holnr') || ! bufexists(s:holnr)
+  new
+  setlocal buftype=nofile
+  setlocal bufhidden=hide
+  setlocal nobuflisted
+  setlocal noswapfile
+  let s:holnr = bufnr("")
+  hide
+endif
 
 
 let s:tmpprefix =


### PR DESCRIPTION
For supported vim (or neovim) editors these changes make it possible to open a HOL repl session within the editor next to an opened file buffer (at the focussed buffer's working directory). In addition the vimhol shortcuts are disabled for files other than HOL4 script files.