### PR TITLE
Use SHELL as replacements of "/bin/sh" if necessary

### DIFF
--- a/tools-poly/Holmake/unix-systeml.sml
+++ b/tools-poly/Holmake/unix-systeml.sml
@@ -97,6 +97,7 @@ val OS = ""
 
 val DEPDIR = ""
 val GNUMAKE = ""
+val SHELL = ""
 val DYNLIB = ""
 val version = ""
 val ML_SYSNAME = ""

--- a/tools-poly/Holmake/winNT-systeml.sml
+++ b/tools-poly/Holmake/winNT-systeml.sml
@@ -53,6 +53,7 @@ val MOSMLDIR =
 val OS =
 val DEPDIR =
 val GNUMAKE =
+val SHELL =
 val DYNLIB =
 val version =
 val release =

--- a/tools-poly/configure.sml
+++ b/tools-poly/configure.sml
@@ -253,6 +253,7 @@ in
    "val OS ="       --> ("val OS = "^quote OS^"\n"),
    "val DEPDIR ="   --> ("val DEPDIR = "^quote DEPDIR^"\n"),
    "val GNUMAKE ="  --> ("val GNUMAKE = "^quote GNUMAKE^"\n"),
+   "val SHELL ="    --> ("val SHELL = "^quote SHELL^"\n"),
    "val DYNLIB ="   --> ("val DYNLIB = "^Bool.toString dynlib_available^"\n"),
    "val version ="  --> ("val version = "^Int.toString version_number^"\n"),
    "val ML_SYSNAME =" --> "val ML_SYSNAME = \"poly\"\n",
@@ -542,7 +543,7 @@ val _ =
       val target_boss = fullPath [holdir, "bin", "hol"]
       val hol0_heap   = protect(fullPath[HOLDIR,"bin", "hol.state0"])
       val hol_heapcalc=
-            "\"$(" ^ protect(fullPath[HOLDIR,"bin","heapname"]) ^ ")\""
+            "`" ^ protect(fullPath[HOLDIR,"bin","heapname"]) ^ "`"
       fun TP s = protect(fullPath[HOLDIR, "tools-poly", s])
       val prelude = ["Arbint", "Arbrat", TP "prelude.ML"]
       val prelude2 = prelude @ [TP "prelude2.ML"]

--- a/tools-poly/smart-configure.sml
+++ b/tools-poly/smart-configure.sml
@@ -72,6 +72,7 @@ val polymllibdir = "";
 val DOT_PATH = SOME "";
 val MLTON = SOME "";
 val GNUMAKE = "";
+val SHELL = "";
 val POLY_LDFLAGS = [] : string list;
 val POLY_LDFLAGS_STATIC = [] : string list;
 
@@ -236,6 +237,17 @@ val GNUMAKE:string  =
       end
     else GNUMAKE
 
+val SHELL:string  =
+    if SHELL = "" then
+      let
+        val _ = determining "SHELL"
+      in
+        case OS.Process.getEnv "SHELL" of
+            NONE => "/bin/sh"
+          | SOME s => s
+      end
+    else SHELL
+
 val polylibinstruction =
     "Please write file tools-poly/poly-includes.ML to specify it.\n\
     \This file should include a line of the form\n\n\
@@ -313,6 +325,7 @@ verdict ("holdir", holdir);
 optverdict ("DOT_PATH", DOT_PATH);
 optverdict ("MLTON", MLTON);
 verdict ("GNUMAKE", GNUMAKE);
+verdict ("SHELL", SHELL);
 
 val MV = dfltverdict ("MV", find_in_bin_or_path "mv");
 val CP = dfltverdict ("CP", find_in_bin_or_path "cp");

--- a/tools/Holmake/Systeml.sig
+++ b/tools/Holmake/Systeml.sig
@@ -30,6 +30,7 @@ sig
   val OS : string
   val DEPDIR : string
   val GNUMAKE : string
+  val SHELL : string
   val DYNLIB : bool
   val ML_SYSNAME : string
   val DOT_PATH : string option

--- a/tools/Holmake/poly/ProcessMultiplexor.sml
+++ b/tools/Holmake/poly/ProcessMultiplexor.sml
@@ -209,7 +209,7 @@ struct
     end
 
   fun mk_shell_command {cline,extra_env} : command =
-    {executable = "/bin/sh", nm_args = ["/bin/sh", "-c", cline],
+    {executable = Systeml.SHELL, nm_args = [Systeml.SHELL, "-c", cline],
      env = extra_env @ Posix.ProcEnv.environ()}
   fun simple_shell s = mk_shell_command {cline = s, extra_env = []}
   fun shellcommand s =

--- a/tools/Holmake/poly/multibuild.sml
+++ b/tools/Holmake/poly/multibuild.sml
@@ -136,7 +136,7 @@ fun graphbuild optinfo g =
         Posix.ProcEnv.environ()
     fun cline_to_command (s, args) = {executable = s, nm_args = args, env = env}
     fun shell_command s =
-      {executable = "/bin/sh", nm_args = ["/bin/sh", "-c", s], env = env}
+      {executable = Systeml.SHELL, nm_args = [Systeml.SHELL, "-c", s], env = env}
 
     val tgtcomplete = tgtcompletion_cb dirmap
     fun really_needed nI = #status nI = Pending{needed=true}

--- a/tools/Holmake/unix-systeml.sml
+++ b/tools/Holmake/unix-systeml.sml
@@ -102,6 +102,7 @@ val CC = ""
 
 val DEPDIR = ""
 val GNUMAKE = ""
+val SHELL = ""
 val DYNLIB = ""
 val version = ""
 val ML_SYSNAME = ""

--- a/tools/Holmake/winNT-systeml.sml
+++ b/tools/Holmake/winNT-systeml.sml
@@ -92,6 +92,7 @@ val POLY_LDFLAGS_STATIC = []
 val CC = ""
 val DEPDIR = ""
 val GNUMAKE = ""
+val SHELL = ""
 val DYNLIB = ""
 val version = ""
 val ML_SYSNAME = ""

--- a/tools/buildutils.sml
+++ b/tools/buildutils.sml
@@ -81,6 +81,7 @@ val HOLDIR = Systeml.HOLDIR
 val EXECUTABLE = Systeml.xable_string (fullPath [HOLDIR, "bin", "build"])
 val DEPDIR = Systeml.DEPDIR
 val GNUMAKE = Systeml.GNUMAKE
+val SHELL = Systeml.SHELL
 val DYNLIB = Systeml.DYNLIB
 
 fun SYSTEML clist = Process.isSuccess (Systeml.systeml clist)

--- a/tools/configure-mosml.sml
+++ b/tools/configure-mosml.sml
@@ -186,6 +186,7 @@ val dynlib_available = (load "Dynlib"; true) handle _ => false;
 
 val DOT_PATH = SOME "";
 val GNUMAKE = "";
+val SHELL = "";
 
 val _ = let
   val override = Path.concat(holdir, "config-override")
@@ -203,6 +204,13 @@ val GNUMAKE = if GNUMAKE = "" then
                      NONE => "make"
                    | SOME s => s)
               else GNUMAKE;
+
+val SHELL = if SHELL = "" then
+               (determining "SHELL";
+                case OS.Process.getEnv "SHELL" of
+                     NONE => "/bin/sh"
+                   | SOME s => s)
+            else SHELL;
 
 val mosmldir = let
   val _ = determining "mosmldir"
@@ -267,6 +275,7 @@ verdict ("mosmldir", mosmldir);
 verdict ("holdir", holdir);
 verdict ("dynlib_available", Bool.toString dynlib_available);
 verdict ("GNUMAKE", GNUMAKE);
+verdict ("SHELL", SHELL);
 optverdict ("DOT_PATH", DOT_PATH);
 val MV = dfltverdict ("MV", find_in_bin_or_path "mv");
 val CP = dfltverdict ("CP", find_in_bin_or_path "cp");

--- a/tools/configure.sml
+++ b/tools/configure.sml
@@ -178,6 +178,7 @@ in
    "val CC ="       --> ("val CC = "^quote CC^"\n"),
    "val DEPDIR ="   --> ("val DEPDIR = "^quote DEPDIR^"\n"),
    "val GNUMAKE ="  --> ("val GNUMAKE = "^quote GNUMAKE^"\n"),
+   "val SHELL ="    --> ("val SHELL = "^quote SHELL^"\n"),
    "val DYNLIB ="   --> ("val DYNLIB = "^Bool.toString dynlib_available^"\n"),
    "val version ="  --> ("val version = "^Int.toString version_number^"\n"),
    "val ML_SYSNAME =" --> "val ML_SYSNAME = \"mosml\"\n",


### PR DESCRIPTION
Hi,

This is Solaris 10 x86. When building recent HOL it throws the following error when executing shell commands:
```
for i in *.uo *.ui *.sig ; do ln -fs `pwd`/$i /export/home/binghe/ML/HOL/sigobj ; done && for i in *.sig ; do echo `pwd`/$(basename $i .sig) >> /export/home/binghe/ML/HOL/sigobj/SRCFILES ; done
sh: syntax error at line 1: `(' unexpected
*** FATAL: Build failed in directory /export/home/binghe/ML/HOL/src/parallel_builds/core (exited with code 1)
```

This is because Solaris 10 uses the original Bourne shell `/bin/sh` which doesn't support the shell command syntax (I guest the part `$(basename $i .sig)` is the problem).    All Linux systems, on the other hand, uses the GNU Bourne Again Shell (bash) which works well with HOL.   Note that `/bin/bash` is not available in all Unix systems, e.g. FreeBSD (where user can install `/usr/local/bin/bash`.)

Just like the previous issues with the original BSD `make` vs GNU `gmake`, the present PR resolves the building issue by allowing user to customize the shell command program with the `SHELL` variable.   By default, the value of `SHELL` inherits the value of the environment variable of the same name.

HOL also generates several script files like `$(HOLDIR)/bin/hol` and `$(HOLDIR)/bin/hol.bare` which has `#!/bin/sh` as the first line (the running shell). There's no need to change them, but in `$(HOLDIR)/bin/hol` the use of `$()` is not compatible with the original Bourne shell. I changed it to use backquotes instead, which is supported.

P. S. currently Poly/ML also has some issues. See https://github.com/polyml/polyml/issues/171 for one of them. (The other is the uses of `/bin/sh` in `polyc`, whose syntax also goes beyond the original Bourne shell.)   But any way, now I can successfully build and use HOL on Solaris 10.

Chun