### PR TITLE
Cheatsheet updates

### DIFF
--- a/Manual/Cheatsheet/cheatsheet.md
+++ b/Manual/Cheatsheet/cheatsheet.md
@@ -236,6 +236,10 @@ It is often useful to perform case splits over the course of a proof.
 : Given a variable `p` of a pair type, instantiates `p` to `(p0,p1,...,pn)`.
   This provides better naming than `Cases_on`, and requires fewer case splits for `n`-tuples where `n` is greater than 2.
 
+`pairarg_tac`
+: Searches the goal and assumptions for `(λ(x,y,...). body) arg`, and introduces the assumption `arg = (x,y,...)`.
+  This can often provide better naming than `PairCases_on`.
+
 `CASE_TAC`
 : Case splits the smallest `case` expression in the goal.
 
@@ -306,6 +310,9 @@ In many cases, we may want to state exactly how the goal should be taken apart (
 
 `conj_asm{1,2}_tac`
 : Like `conj_tac`, but adds the first/second conjunct (respectively) as an assumption for the other subgoal.
+
+`disj{1,2}_tac`
+: Reduces a goal of the form `p \/ q` into `p` or `q` respectively.
 
 `gen_tac`
 : Removes a top-level `∀`-quantified variable.

--- a/Manual/Cheatsheet/cheatsheet.md
+++ b/Manual/Cheatsheet/cheatsheet.md
@@ -283,11 +283,11 @@ Maintainable and readable files require organised proofs - in particular, carefu
 <code>&grave;<i>term</i>&grave; suffices_by <i>tactic</i></code>
 : Like `qsuff_tac`, but solves the first subgoal (i.e. that the supplied term implies the goal) using the given tactic.
 
-<code><i>tactic1</i> >~ [&grave;<i>pat</i>&grave;s]</code>
-: Performs *`tactic1`* and then searches for the first subgoal with subterms matching the supplied patterns.
+<code><i>tactic</i> >~ [&grave;<i>pat</i>&grave;s]</code>
+: Performs *`tactic`* and then searches for the first subgoal with subterms matching the supplied patterns.
   [Renames](#renaming-and-abbreviating) these subterms to match the patterns, and brings the goal into focus as the current goal.
 
-<code><i>tactic1</i> >>~ [&grave;<i>pat</i>&grave;s]</code>
+<code><i>tactic</i> >>~ [&grave;<i>pat</i>&grave;s]</code>
 : Like `>~`, but can match/rename multiple goals and bring them all to the top of the goal-stack.
 
 <code>rpt <i>tactic</i></code>


### PR DESCRIPTION
- Add `pairarg_tac` and `disj{1,2}_tac` to the cheatsheet (thanks to @myreen and @samsa1 respectively for the suggestions)
- Superficial change: convert a couple of instances of `tactic1` to `tactic` when there is no `tactic2`