### PR TITLE
vimhol: enable vimhol for any `*.sml` file

### DIFF
--- a/tools-poly/configure.sml
+++ b/tools-poly/configure.sml
@@ -516,7 +516,7 @@ val _ =
     output(tar3, "use "^(qstr tar2));
     closeOut tar3;
     output(tar4,"augroup filetypedetect\n");
-    output(tar4,"  au BufRead,BufNewFile *?Script.sml let maplocalleader = \"h\" | source "^tar1^"\n");
+    output(tar4,"  au BufRead,BufNewFile *.sml let maplocalleader = \"h\" | source "^tar1^"\n");
     output(tar4,"  \" recognise pre-munger files as latex source\n");
     output(tar4,"  au BufRead,BufNewFile *.htex setlocal filetype=htex syntax=tex\n");
     output(tar4,"  \"Uncomment the line below to automatically load Unicode\n");


### PR DESCRIPTION
The changes of 544d89d only enable the vim keymappings for buffers of
`*Script.sml` files. It should also be possible to interact with the HOL
repl from other files, like `*Lib.sml`.

Fixes Github issue #999