### PR TITLE
Update «HOL Description» for inequalities of L^p function spaces

### DIFF
--- a/Manual/Description/Holmakefile
+++ b/Manual/Description/Holmakefile
@@ -27,7 +27,9 @@ tactics.tex: tactics.stex $(PS_STUFF)
 theories.tex: theories.stex $(PS_STUFF) $(dprot $(SIGOBJ)/realTheory.uo)
 	$(PS_COMMAND)
 
-math.tex: math.stex $(PS_STUFF) $(dprot $(SIGOBJ)/probabilityTheory.uo) ../../examples/probability/large_numberTheory.uo
+math.tex: math.stex $(PS_STUFF) $(dprot $(SIGOBJ)/probabilityTheory.uo) \
+	$(HOLDIR)/examples/probability/large_numberTheory.uo \
+	$(HOLDIR)/examples/probability/lebesgue_measureTheory.uo
 	$(PS_COMMAND)
 
 PatternMatchesLib.tex: PatternMatchesLib.stex $(PS_STUFF)

--- a/Manual/Description/math.stex
+++ b/Manual/Description/math.stex
@@ -493,10 +493,13 @@ non-empty set \holtxt{s} we have \holtxt{lambda s = 0}, it's not true
 that all subsets of s has also the measure 0, as some of them
 may not be Borel sets at all. The completion of \holtxt{lborel} is called
 \emph{Lebesgue measure space}, denoted by \holtxt{lebesgue}.
-In \HOL{}, it is defined directly by Henstock-Kurzweil integration
+In \theory{extreal} theory (at \ml{\$(HOLDIR)/examples/probability} directory),
+it is defined directly by Henstock-Kurzweil Integration
 (see Section~\ref{sec:integration}):
 \begin{hol}
 \begin{alltt}
+>>__ load "lebesgue_measureTheory";
+>>__ open lebesgue_measureTheory;
 ##thm lebesgue_def
 ##thm line
 \end{alltt}
@@ -787,7 +790,11 @@ the (iterated) integrals to be finite:
 \begin{hol}
 \begin{alltt}
 ##thm TONELLI
+\end{alltt}
+\end{hol}
 
+\begin{hol}
+\begin{alltt}
 ##thm FUBINI
 \end{alltt}
 \end{hol}
@@ -814,6 +821,7 @@ The general version of product space is defined on any pair operation:
 \begin{hol}
 \begin{alltt}
 ##thm general_cross_def
+
 ##thm general_prod_def
 \end{alltt}
 \end{hol}
@@ -828,6 +836,78 @@ For instance, the following theorem is the general version of \texttt{EXISTENCE_
 ##thm existence_of_prod_measure_general
 \end{alltt}
 \end{hol}
+
+\paragraph{$\mathcal{L}^p$ spaces, semi-norm and important inequalities}
+
+\HOL{} provides a minimal formalization of the function spaces $\mathcal{L}^p$,
+currently in \theoryimp{martingaleTheory}.
+
+Let $(X, \mathscr{A}, \mu)$ be some measure space. Here we discuss
+functions whose (absolute) $p$th power is integrable ($1\leqslant p <\infty$).
+More precisely, we are interested in the sets:
+\begin{equation*}
+  \mathcal{L}^p(\mu) := \left\{ u \colon X\rightarrow\overline{\mathbb{R}} \colon u\in\mathcal{M}(\mathscr{A}),
+  \int |u|^p \mathrm{d}\mu < \infty \right\},\qquad p\in[1,\infty).
+\end{equation*}
+Or formally:
+\begin{hol}
+\begin{alltt}
+##thm function_space_alt_finite
+\end{alltt}
+\end{hol}
+
+It is convenient to have the following \emph{semi-norm} notation:
+\begin{equation*}
+  \|u\|_p := \left ( \int \left |u(x) \right |^p \mu(\mathrm{d}x) \right )^{1/p},\qquad p\in[1,\infty).
+\end{equation*}
+Or formally:
+\begin{hol}
+\begin{alltt}
+##thm seminorm_normal
+\end{alltt}
+\end{hol}
+
+Clearly, $u\in\mathcal{L}^p(\mu)$ if, and only if, $u\in\mathcal{M}(\mathscr{A})$ and $\|u\|_p <\infty$.
+Furthermore, $\|u\|_p$ implies that $u(x) = 0$ for almost every $x$.
+\begin{hol}
+\begin{alltt}
+##thm function_space_alt_seminorm
+
+##thm seminorm_eq_0
+\end{alltt}
+\end{hol}
+
+The triangle inequality for $\|\cdot\|_p$ and deeper results on $\mathcal{L}^p$ depends on the
+following elementary inequality (Young's inequality):
+\begin{hol}
+\begin{alltt}
+##thm young_inequality
+\end{alltt}
+\end{hol}
+Then the following fundamental \emph{H\"older's inequality} is proved:
+\begin{hol}
+\begin{alltt}
+##thm Hoelder_inequality
+\end{alltt}
+\end{hol}
+
+Holder's inequality with $p = q = 2$ is usually called the \emph{Cauchy-Schwarz inequality}:
+\begin{hol}
+\begin{alltt}
+##thm Cauchy_Schwarz_inequality
+\end{alltt}
+\end{hol}
+
+Another consequence of Holder's inequality is the \emph{Minkowski} or \emph{triangle
+inequality for $\|\cdot\|_p$}:
+\begin{hol}
+\begin{alltt}
+##thm Minkowski_inequality
+\end{alltt}
+\end{hol}
+Holder's inequality is useful in Probability Theory, for example, for
+proving that the sum of random variables having finite second moments
+(i.e.~finite variance), has still finite second moments.
 
 \subsection{Probability Theory}
 \label{sec:prob}

--- a/src/probability/martingaleScript.sml
+++ b/src/probability/martingaleScript.sml
@@ -6760,6 +6760,25 @@ Proof
  >> rw [normal_powr]
 QED
 
+Theorem function_space_alt_seminorm :
+    !p m f. measure_space m /\ 1 <= p /\ p <> PosInf ==>
+           (f IN function_space p m <=>
+            f IN Borel_measurable (m_space m,measurable_sets m) /\
+            seminorm p m f < PosInf)
+Proof
+    RW_TAC std_ss [GSYM lt_infty]
+ >> EQ_TAC
+ >| [ (* goal 1 (of 2) *)
+      rpt STRIP_TAC >- rfs [function_space_alt_finite] \\
+      METIS_TAC [seminorm_not_infty],
+      (* goao 2 (of 2) *)
+      rw [function_space_alt_finite, seminorm_normal] \\
+      CCONTR_TAC \\
+     ‘0 < p’ by PROVE_TAC [lte_trans, lt_01] \\
+     ‘0 < inv p’ by PROVE_TAC [inv_pos'] \\
+      gs [infty_powr] ]
+QED
+
 (* Theorem 13.2 (Hoelder's inequality) [1, p.117]
 
    TODO: also prove the case for ‘p = PosInf’ (q = 1) or ‘q = PosInf’ (p = 1)

--- a/src/probability/measureScript.sml
+++ b/src/probability/measureScript.sml
@@ -120,6 +120,9 @@ val measure_space_def = Define
    `measure_space m <=>
       sigma_algebra (m_space m, measurable_sets m) /\ positive m /\ countably_additive m`;
 
+(* ‘measurable_space m’ is the sigma_algebra of ‘measure_space m’ *)
+Overload measurable_space = “\m. m_space m, measurable_sets m”
+
 (* The set of measure-preserving measurable mappings.
    NOTE: ``measure_space m1 /\ measure_space m2`` was removed. *)
 val measure_preserving_def = Define

--- a/src/res_quan/src/hurdUtils.sml
+++ b/src/res_quan/src/hurdUtils.sml
@@ -1037,7 +1037,19 @@ in
   val STRONG_CONJ_TAC :tactic = MATCH_MP_TAC th >> CONJ_TAC
 end;
 
-val STRONG_DISJ_TAC = CONV_TAC (REWR_CONV (GSYM IMP_DISJ_THM)) >> STRIP_TAC;
+(* --------------------------------------------------------------------- *)
+(* STRONG_DISJ_TAC : tactic                                              *)
+(*                                                                       *)
+(* If the goal is (asms, ~A \/ B) then the tactic returns a new goal of  *)
+(* the form (asms UNION {A}, B). (It's "stronger" than DISJ2_TAC in that *)
+(* A is not completely abandoned and thus still useful in proving B.)    *)
+(*                                                                       *)
+(* By using ONCE_REWRITE_TAC[DISJ_COMM] first, a similar stronger tactic *)
+(* than DISJ1_TAC can be obtained.                                       *)
+(* --------------------------------------------------------------------- *)
+
+val STRONG_DISJ_TAC :tactic =
+    CONV_TAC (REWR_CONV (GSYM IMP_DISJ_THM)) >> STRIP_TAC;
 
 (* --------------------------------------------------------------------- *)
 (* FORWARD_TAC : (thm list -> thm list) -> tactic                        *)


### PR DESCRIPTION
Hi,

this PR updates «HOL Description» for recently added (#972, #1009) important inequalities of L^p function spaces. More importantly, it fixes the broken build of this manual due to the moving of `lebesgue_def` into examples in #1009.  For the documentation purposes (mostly), I added one more small theorem in `martingaleTheory`.

In `hurdUtils`, I try to add some inline documentation for `STRONG_DISJ_TAC`, beside `STRONG_CONJ_TAC`. This is done in a separate comment friendly to `git log`.

Regards,

Chun Tian

