### PR TITLE
Fix script compatibility with vanilla /bin/sh

### DIFF
--- a/tools-poly/configure.sml
+++ b/tools-poly/configure.sml
@@ -542,7 +542,7 @@ val _ =
       val target_boss = fullPath [holdir, "bin", "hol"]
       val hol0_heap   = protect(fullPath[HOLDIR,"bin", "hol.state0"])
       val hol_heapcalc=
-            "\"$(" ^ protect(fullPath[HOLDIR,"bin","heapname"]) ^ ")\""
+            "`" ^ protect(fullPath[HOLDIR,"bin","heapname"]) ^ "`"
       fun TP s = protect(fullPath[HOLDIR, "tools-poly", s])
       val prelude = ["Arbint", "Arbrat", TP "prelude.ML"]
       val prelude2 = prelude @ [TP "prelude2.ML"]

--- a/tools/Holmake/Holmake_types.sml
+++ b/tools/Holmake/Holmake_types.sml
@@ -386,7 +386,7 @@ val base_environment0 = let
         [LIT "for i in *.uo *.ui *.sig ; do ln -fs `pwd`/$i ",
          VREF "SIGOBJ",
          LIT " ; done && \
-             \for i in *.sig ; do echo `pwd`/$(basename $i .sig) >> ",
+             \for i in *.sig ; do echo `pwd`/`basename $i .sig` >> ",
          VREF "SIGOBJ",
          LIT "/SRCFILES ; done"]),
        ("MLLEX", [VREF "protect $(HOLDIR)/tools/mllex/mllex.exe"]),


### PR DESCRIPTION
currently HOL generates shell scripts code which is not compatible with vanilla `/bin/sh`, i.e. the original Bourne Shell. (see also #1002 for some old discussions.)  It seems that the `$(...)` syntax is not supported. Instead, we can use backquotes instead. The changes here shouldn't break anything but will make HOL buildable in old Unix systems like Solaris 10.
