### PR TITLE
Fix broken proofs after changing several extreal lemmas [simp]

### DIFF
--- a/examples/probability/large_numberScript.sml
+++ b/examples/probability/large_numberScript.sml
@@ -18,6 +18,8 @@ open util_probTheory sigma_algebraTheory extrealTheory measureTheory
 
 val _ = new_theory "large_number";
 
+(* val _ = intLib.deprecate_int(); *)
+
 (* "In the formal construction of a course in the theory of probability, limit
     theorems appear as a kind of superstructure over elementary chapters, in
     which all problems have finite, purely arithmetical character. In reality,
@@ -2998,11 +3000,10 @@ val LLN_IID_shared_tactics =
      MATCH_MP_TAC bounded_imp_finite_second_moments >> art [] \\
      CONJ_TAC >- FULL_SIMP_TAC std_ss [real_random_variable_def] \\
      Q.EXISTS_TAC ‘&SUC n’ \\
-     NTAC 3 (POP_ASSUM K_TAC) \\
+     NTAC 3 (POP_ASSUM K_TAC) (* useless assumptions *) \\
     ‘Y = (\n. f n o X n)’
        by (rw [Abbr ‘Y’, Abbr ‘f’, truncated_def, o_DEF]) >> POP_ORW \\
-     rw [Abbr ‘f’]
-     >- (rw [abs_0, extreal_of_num_def, extreal_le_eq, extreal_abs_def]) \\
+     rw [Abbr ‘f’] \\
      MATCH_MP_TAC lt_imp_le \\
      FULL_SIMP_TAC std_ss [GSYM extreal_lt_def, extreal_of_num_def,
                            extreal_le_eq, extreal_abs_def])
@@ -3154,7 +3155,6 @@ Proof
          FULL_SIMP_TAC std_ss [prob_space_def, p_space_def, events_def,
                                prob_def, real_random_variable_def] \\
          HO_MATCH_MP_TAC integrable_mul_indicator >> art [] \\
-         CONJ_TAC >- METIS_TAC [abs_not_infty] \\
          MATCH_MP_TAC (REWRITE_RULE [o_DEF] integrable_abs) >> art []) >> DISCH_TAC \\
      Know ‘!i. i < k ==>
                expectation p (\x. Y i x pow 2) <= a n *
@@ -3175,7 +3175,6 @@ Proof
              HO_MATCH_MP_TAC integrable_mul_indicator \\
              FULL_SIMP_TAC std_ss [prob_space_def, p_space_def, events_def,
                                    prob_def, real_random_variable_def] \\
-             CONJ_TAC >- METIS_TAC [abs_not_infty] \\
              MATCH_MP_TAC (REWRITE_RULE [o_DEF] integrable_abs) >> art []) >> Rewr' \\
          MATCH_MP_TAC (REWRITE_RULE [GSYM expectation_def] integral_mono) >> simp [] \\
          STRONG_CONJ_TAC >- FULL_SIMP_TAC std_ss [prob_space_def] \\
@@ -3240,14 +3239,6 @@ Proof
              MATCH_MP_TAC MEASURE_SPACE_UNION >> art [] \\
              FULL_SIMP_TAC std_ss [random_variable_def, p_space_def, events_def] \\
              METIS_TAC [IN_MEASURABLE_BOREL_ALL_MEASURE]) >> DISCH_TAC \\
-         CONJ_TAC (* measure < PosInf *)
-         >- (MATCH_MP_TAC let_trans >> Q.EXISTS_TAC ‘measure p (m_space p)’ \\
-             reverse CONJ_TAC >- rw [GSYM lt_infty, extreal_of_num_def] \\
-             MATCH_MP_TAC INCREASING >> art [] \\
-             CONJ_TAC >- (MATCH_MP_TAC MEASURE_SPACE_INCREASING >> art []) \\
-             reverse CONJ_TAC >- (MATCH_MP_TAC MEASURE_SPACE_SPACE >> art []) \\
-             rw [SUBSET_DEF]) \\
-         CONJ_TAC >- METIS_TAC [abs_not_infty] \\
          MATCH_MP_TAC (REWRITE_RULE [o_DEF] integrable_abs) >> art []) \\
      DISCH_TAC \\
      Know ‘!i. k <= i /\ i < n ==>
@@ -3642,14 +3633,7 @@ Proof
                  MATCH_MP_TAC MEASURE_SPACE_UNION >> art [] \\
                  FULL_SIMP_TAC std_ss [real_random_variable, p_space_def, events_def] \\
                  METIS_TAC [IN_MEASURABLE_BOREL_ALL_MEASURE]) >> DISCH_TAC \\
-             CONJ_TAC
-             >- (MATCH_MP_TAC let_trans >> Q.EXISTS_TAC ‘measure p (m_space p)’ \\
-                 reverse CONJ_TAC >- (rw [GSYM lt_infty, extreal_of_num_def]) \\
-                 MATCH_MP_TAC INCREASING >> simp [MEASURE_SPACE_SPACE] \\
-                 CONJ_TAC >- (MATCH_MP_TAC MEASURE_SPACE_INCREASING >> art []) \\
-                 rw [SUBSET_DEF]) \\
              FULL_SIMP_TAC std_ss [real_random_variable_def, p_space_def] \\
-             CONJ_TAC >- METIS_TAC [abs_not_infty] \\
              MATCH_MP_TAC (REWRITE_RULE [o_DEF] integrable_abs) >> art []) \\
          MATCH_MP_TAC le_lmul_imp >> art [abs_pos] \\
          MATCH_MP_TAC INDICATOR_FN_MONO >> rw [SUBSET_DEF]) \\
@@ -4061,15 +4045,6 @@ Proof
                    ({x | sqrt 1 <= X 0 x} INTER m_space p)’ by SET_TAC [] >> POP_ORW \\
                  MATCH_MP_TAC MEASURE_SPACE_UNION >> art [] \\
                  METIS_TAC [IN_MEASURABLE_BOREL_ALL_MEASURE]) >> DISCH_TAC \\
-             CONJ_TAC (* measure < PosInf *)
-             >- (MATCH_MP_TAC let_trans \\
-                 Q.EXISTS_TAC ‘measure p (m_space p)’ \\
-                 reverse CONJ_TAC >- (rw [GSYM lt_infty, extreal_of_num_def]) \\
-                 MATCH_MP_TAC INCREASING >> rw [MEASURE_SPACE_SPACE]
-                 >- (MATCH_MP_TAC MEASURE_SPACE_INCREASING >> art []) \\
-                 rw [SUBSET_DEF]) \\
-             CONJ_TAC (* abs <> PosInf /\ abs <> NegInf *)
-             >- (NTAC 2 STRIP_TAC >> METIS_TAC [abs_not_infty]) \\
              MATCH_MP_TAC (REWRITE_RULE [o_DEF] integrable_abs) >> art []) \\
          CONJ_TAC >- (MATCH_MP_TAC (REWRITE_RULE [o_DEF] integrable_abs) >> art []) \\
          rpt STRIP_TAC \\
@@ -4130,15 +4105,6 @@ Proof
                ({x | sqrt (&SUC i) <= X 0 x} INTER m_space p)’ by SET_TAC [] >> POP_ORW \\
              MATCH_MP_TAC MEASURE_SPACE_UNION >> art [] \\
              METIS_TAC [IN_MEASURABLE_BOREL_ALL_MEASURE]) >> DISCH_TAC \\
-         CONJ_TAC (* measure < PosInf *)
-         >- (MATCH_MP_TAC let_trans \\
-             Q.EXISTS_TAC ‘measure p (m_space p)’ \\
-             reverse CONJ_TAC >- (rw [GSYM lt_infty, extreal_of_num_def]) \\
-             MATCH_MP_TAC INCREASING >> rw [MEASURE_SPACE_SPACE]
-             >- (MATCH_MP_TAC MEASURE_SPACE_INCREASING >> art []) \\
-             rw [SUBSET_DEF]) \\
-         CONJ_TAC (* abs <> PosInf /\ abs <> NegInf *)
-         >- (NTAC 2 STRIP_TAC >> METIS_TAC [abs_not_infty]) \\
          MATCH_MP_TAC (REWRITE_RULE [o_DEF] integrable_abs) >> art []) >> Rewr \\
      RW_TAC std_ss [] \\
      MATCH_MP_TAC le_lmul_imp >> REWRITE_TAC [abs_pos] \\
@@ -4180,6 +4146,15 @@ Proof
  >> SIMP_TAC std_ss [Abbr ‘M’, Abbr ‘Z’, Abbr ‘Y’, Abbr ‘m’]
  >> MATCH_MP_TAC truncated_vars_expectation' >> art []
 QED
+
+(* |- !p X.
+        prob_space p /\ (!n. real_random_variable (X n) p) /\
+        pairwise_indep_vars p X (\n. Borel) univ(:num) /\
+        identical_distribution p X Borel univ(:num) /\ integrable p (X 0) ==>
+        ((\n x. SIGMA (\i. X i x) (count (SUC n)) / &SUC n) -->
+         (\x. expectation p (X 0))) (in_probability p)
+ *)
+Theorem WLLN_IID_applied = SIMP_RULE std_ss [LLN_alt_converge_PR_IID] WLLN_IID
 
 (* ------------------------------------------------------------------------- *)
 (*  The Strong Law of Large Numbers for IID random variables                 *)
@@ -6000,6 +5975,7 @@ Theorem SLLN_IID_applied = SIMP_RULE std_ss [LLN_alt_converge_AE_IID] SLLN_IID
 (* The 'diverge' part of SLLN_IID
 
    This is Theorem 5.4.2 (Part 2) of [2, p.133], the strongest version among others.
+   See also Theorem 4 (Converse to the strong law of large numbers) of [11, p.241].
 
    The original version requires total independence, which is, however, only used by
    Borel-Cantelli Lemma (Part 2), which also has a version for pairwise independence
@@ -6336,6 +6312,10 @@ val _ = html_theory "large_number";
       Statistics, A.N. Shiryayev (eds.), Springer Netherlands (1992).
   [9] Schilling, R.L.: Measures, Integrals and Martingales (Second Edition).
       Cambridge University Press (2017).
+ [10] Feller, W.: An Introduction to Probability Theory and Its Applications, vol 1, 3rd edition.
+      John Wiley & Sons, Inc., New York, N.Y. (2004).
+ [11] Feller, W.: An Introduction to Probability Theory and Its Applications, vol 2, 2rd edition.
+      John Wiley & Sons, Inc., New York, N.Y. (1967).
  [12] Etemadi, N.: An elementary proof of the strong law of large numbers.
       Z. Wahrsch. Verw. Gebiete. 55, 119-122 (1981).
  [13] Gnedenko, B.V., Kolmogorov, A.N.: Limit distributions for sums of independent random

--- a/src/probability/borelScript.sml
+++ b/src/probability/borelScript.sml
@@ -276,11 +276,11 @@ val middle_tactics =
        rw [extreal_not_infty, real_normal, extreal_lt_eq, extreal_le_eq],
        (* goal 2 (of 3) *)
        rename1 ‘a <= real y’ >> REWRITE_TAC [GSYM extreal_le_eq] \\
-       Suff ‘Normal (real y) = y’ >- rw [] \\
+       Suff ‘Normal (real y) = y’ >- RW_TAC std_ss [] \\
        MATCH_MP_TAC normal_real >> art [],
        (* goal 3 (of 3) *)
        rename1 ‘real y < b’ >> REWRITE_TAC [GSYM extreal_lt_eq] \\
-       Suff ‘Normal (real y) = y’ >- rw [] \\
+       Suff ‘Normal (real y) = y’ >- RW_TAC std_ss [] \\
        MATCH_MP_TAC normal_real >> art [] ])
  >> DISCH_TAC
  (* applying SIGMA_SUBSET *)
@@ -304,11 +304,11 @@ val middle_tactics =
            rw [extreal_not_infty, real_normal, extreal_lt_eq, extreal_le_eq],
            (* goal 2 (of 3) *)
            rename1 ‘a <= real y’ >> REWRITE_TAC [GSYM extreal_le_eq] \\
-           Suff ‘Normal (real y) = y’ >- rw [] \\
+           Suff ‘Normal (real y) = y’ >- RW_TAC std_ss [] \\
            MATCH_MP_TAC normal_real >> art [],
            (* goal 3 (of 3) *)
            rename1 ‘real y < b’ >> REWRITE_TAC [GSYM extreal_lt_eq] \\
-           Suff ‘Normal (real y) = y’ >- rw [] \\
+           Suff ‘Normal (real y) = y’ >- RW_TAC std_ss [] \\
            MATCH_MP_TAC normal_real >> art [] ]) \\
      Know ‘{x | q <= x /\ x < r} = {}’
      >- (rw [Once EXTENSION, NOT_IN_EMPTY] \\
@@ -346,11 +346,11 @@ val middle_tactics' =
        rw [extreal_not_infty, real_normal, extreal_lt_eq, extreal_le_eq],
        (* goal 2 (of 3) *)
        rename1 ‘a < real y’ >> REWRITE_TAC [GSYM extreal_lt_eq] \\
-       Suff ‘Normal (real y) = y’ >- rw [] \\
+       Suff ‘Normal (real y) = y’ >- RW_TAC std_ss [] \\
        MATCH_MP_TAC normal_real >> art [],
        (* goal 3 (of 3) *)
        rename1 ‘real y <= b’ >> REWRITE_TAC [GSYM extreal_le_eq] \\
-       Suff ‘Normal (real y) = y’ >- rw [] \\
+       Suff ‘Normal (real y) = y’ >- RW_TAC std_ss [] \\
        MATCH_MP_TAC normal_real >> art [] ])
  >> DISCH_TAC
  (* applying SIGMA_SUBSET *)
@@ -374,11 +374,11 @@ val middle_tactics' =
            rw [extreal_not_infty, real_normal, extreal_lt_eq, extreal_le_eq],
            (* goal 2 (of 3) *)
            rename1 ‘q < real y’ >> REWRITE_TAC [GSYM extreal_lt_eq] \\
-           Suff ‘Normal (real y) = y’ >- rw [] \\
+           Suff ‘Normal (real y) = y’ >- RW_TAC std_ss [] \\
            MATCH_MP_TAC normal_real >> art [],
            (* goal 3 (of 3) *)
            rename1 ‘real y <= r’ >> REWRITE_TAC [GSYM extreal_le_eq] \\
-           Suff ‘Normal (real y) = y’ >- rw [] \\
+           Suff ‘Normal (real y) = y’ >- RW_TAC std_ss [] \\
            MATCH_MP_TAC normal_real >> art [] ]) \\
      Know ‘{x | q < x /\ x <= r} = {}’
      >- (rw [Once EXTENSION, NOT_IN_EMPTY] \\
@@ -484,6 +484,10 @@ Proof
        Suff ‘{x | x < Normal a} IN (IMAGE (\a. {x | x < Normal a}) UNIV)’
        >- METIS_TAC [SIGMA_SUBSET_SUBSETS, SUBSET_DEF] \\
        rw [IN_IMAGE] >> Q.EXISTS_TAC ‘a’ >> rw [] ]) >> DISCH_TAC
+ (* adding new assumptions:
+    3.  Abbrev (R = IMAGE Normal univ(:real))
+    4.  R IN S
+  *)
  >> early_tactics
  (* applying SIGMA_ALGEBRA_RESTRICT *)
  >> Know ‘sigma_algebra (R,IMAGE (\s. s INTER R) S)’
@@ -491,6 +495,11 @@ Proof
      Q.EXISTS_TAC ‘space (sigma UNIV (IMAGE (\a. {x | x < Normal a}) UNIV))’ \\
      rw [Abbr ‘S’, SPACE])
  >> DISCH_TAC
+ (* adding new assumptions:
+    6.  sigma_algebra (univ(:real),IMAGE real_set S)
+    7.  !a b. a <= b ==> {x | a <= x /\ x < b} IN IMAGE real_set S
+    8.  subsets borel SUBSET IMAGE real_set S
+  *)
  >> middle_tactics
  (* stage work *)
  >> simp [SUBSET_DEF, Borel]
@@ -2939,10 +2948,10 @@ val IN_MEASURABLE_BOREL_MUL_INDICATOR_EQ = store_thm
            >> METIS_TAC [mul_rzero, mul_rone])
  >> POP_ORW >> art []);
 
-val IN_MEASURABLE_BOREL_MAX = store_thm
-  ("IN_MEASURABLE_BOREL_MAX",
-  ``!a f g. sigma_algebra a /\ f IN measurable a Borel /\ g IN measurable a Borel
-        ==> (\x. max (f x) (g x)) IN measurable a Borel``,
+Theorem IN_MEASURABLE_BOREL_MAX :
+    !a f g. sigma_algebra a /\ f IN measurable a Borel /\ g IN measurable a Borel
+        ==> (\x. max (f x) (g x)) IN measurable a Borel
+Proof
     RW_TAC std_ss [IN_MEASURABLE_BOREL, extreal_max_def, IN_FUNSET, IN_UNIV]
  >> `!c. {x | (if f x <= g x then g x else f x) < c} = {x | f x < c} INTER {x | g x < c}`
         by (RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER] \\
@@ -2953,12 +2962,13 @@ val IN_MEASURABLE_BOREL_MAX = store_thm
  >> `!c. {x | (if f x <= g x then g x else f x) < c} INTER space a =
          ({x | f x < c} INTER space a) INTER ({x | g x < c} INTER space a)`
         by METIS_TAC [INTER_ASSOC, INTER_COMM, INTER_IDEMPOT]
- >> METIS_TAC [sigma_algebra_def, ALGEBRA_INTER]);
+ >> METIS_TAC [sigma_algebra_def, ALGEBRA_INTER]
+QED
 
-val IN_MEASURABLE_BOREL_MIN = store_thm
-  ("IN_MEASURABLE_BOREL_MIN",
-  ``!a f g. sigma_algebra a /\ f IN measurable a Borel /\ g IN measurable a Borel
-        ==> (\x. min (f x) (g x)) IN measurable a Borel``,
+Theorem IN_MEASURABLE_BOREL_MIN :
+    !a f g. sigma_algebra a /\ f IN measurable a Borel /\ g IN measurable a Borel
+        ==> (\x. min (f x) (g x)) IN measurable a Borel
+Proof
     RW_TAC std_ss [IN_MEASURABLE_BOREL, extreal_min_def, IN_FUNSET, IN_UNIV]
  >> Know `!c. {x | (if f x <= g x then f x else g x) < c} =
               {x | f x < c} UNION {x | g x < c}`
@@ -2969,7 +2979,21 @@ val IN_MEASURABLE_BOREL_MIN = store_thm
  >> `!c. {x | (if f x <= g x then f x else g x) < c} INTER space a =
          ({x | f x < c} INTER space a) UNION ({x | g x < c} INTER space a)`
        by ASM_SET_TAC []
- >> METIS_TAC [sigma_algebra_def, ALGEBRA_UNION]);
+ >> METIS_TAC [sigma_algebra_def, ALGEBRA_UNION]
+QED
+
+(* see extrealTheory.max_fn_seq_def *)
+Theorem IN_MEASURABLE_BOREL_MAX_FN_SEQ :
+    !a f. sigma_algebra a /\ (!i. f i IN measurable a Borel) ==>
+          !n. max_fn_seq f n IN measurable a Borel
+Proof
+    rpt GEN_TAC >> STRIP_TAC
+ >> Induct_on ‘n’ >> rw [max_fn_seq_def]
+ >> ‘max_fn_seq f (SUC n) = \x. max (max_fn_seq f n x) (f (SUC n) x)’
+      by rw [max_fn_seq_def, FUN_EQ_THM]
+ >> POP_ORW
+ >> MATCH_MP_TAC IN_MEASURABLE_BOREL_MAX >> rw []
+QED
 
 (* TODO: ‘!n x. x IN space a ==> fn n x <= fn (SUC n) x’ (MONO) is unnecessary *)
 Theorem IN_MEASURABLE_BOREL_MONO_SUP :
@@ -5302,53 +5326,31 @@ Proof
   METIS_TAC [SUBSET_REFL]
 QED
 
-Theorem AE_impl :
-    !P M Q. measure_space M /\ (P ==> (AE x::M. Q x)) ==>
-           (AE x::M. (P ==> Q x))
-Proof
-    Cases
- >- (RW_TAC bool_ss [AE_ALT] >> POP_ASSUM MP_TAC \\
-     rw [EXTENSION] >> Q.EXISTS_TAC `N` \\
-     RW_TAC std_ss [] >> METIS_TAC[IN_DEF])
- >> RW_TAC bool_ss [AE_ALT]
- >> rw [EXTENSION]
- >> Q.EXISTS_TAC `{}`
- >> RW_TAC bool_ss [null_set_def, NOT_IN_EMPTY,
-                    MEASURE_SPACE_EMPTY_MEASURABLE]
- >> RW_TAC std_ss [MEASURE_EMPTY]
-QED
-
-(* NOTE: what's the role of ‘countable (t i)’ *)
-Theorem AE_all_countable :
-    !(t :num->num->bool) M (P :num->'a->bool).
-       measure_space M ==>
-       ((!i:num. countable (t i) ==> AE x::M. P i x) <=>
-        (!i. AE x::M. (\x. P i x) x))
-Proof
-    RW_TAC std_ss[]
- >> EQ_TAC
- >- (RW_TAC (srw_ss()) [AE_ALT] \\
-     FIRST_X_ASSUM (MP_TAC o Q.SPEC `i`) \\
-     FULL_SIMP_TAC (srw_ss()) [COUNTABLE_NUM])
- >> RW_TAC (srw_ss()) [AE_ALT]
-QED
-
-Theorem AE_all_S :
-    !M S' P. measure_space M ==>
-             (!i. (S' i ==> (AE x::M. (\x. P i x) x))) ==>
-             (!(i':num). AE x::M. (\x. (S' (i':num)) ==> (P :num->'a->bool) i' x) x)
+(* Quantifier movement conversions for AE *)
+Theorem RIGHT_IMP_AE_THM : (* was: AE_impl *)
+    !m P Q. measure_space m ==> ((P ==> AE x::m. Q x) <=> (AE x::m. P ==> Q x))
 Proof
     rpt STRIP_TAC
- >> `(\x. (S' (i' :num)) ==> P i' x) x =
-     ((\(i' :num) x. (S' (i' :num))  ==> P i' x) (i' :num)) x`
-       by RW_TAC std_ss []
- >> POP_ORW
- >> Q.SPEC_TAC (`i'`, `i`)
- >> dep_rewrite.DEP_REWRITE_TAC [GSYM AE_all_countable]
- >> RW_TAC std_ss []
- >> POP_ORW
- >> RW_TAC std_ss[]
- >> metis_tac [AE_impl]
+ >> EQ_TAC >> RW_TAC bool_ss [AE_DEF]
+ >- (Cases_on ‘P’ >- (fs [] >> Q.EXISTS_TAC ‘N’ >> rw []) \\
+     rw [] >> Q.EXISTS_TAC ‘{}’ \\
+     MATCH_MP_TAC NULL_SET_EMPTY >> art [])
+ >> Q.EXISTS_TAC ‘N’ >> rw []
+QED
+
+Theorem RIGHT_IMP_AE_THM' : (* was: AE_all_S *)
+    !m P Q. measure_space m ==>
+           ((!i. P i ==> AE x::m. Q i x) <=> (!i. AE x::m. P i ==> Q i x))
+Proof
+    rpt STRIP_TAC
+ >> reverse EQ_TAC >> RW_TAC bool_ss [AE_DEF]
+ >- (Q.PAT_X_ASSUM ‘!i. _’ (MP_TAC o Q.SPEC ‘i’) >> STRIP_TAC \\
+     Q.EXISTS_TAC ‘N’ >> rw [])
+ >> Cases_on ‘P i’
+ >- (Q.PAT_X_ASSUM ‘!i. _’ (MP_TAC o Q.SPEC ‘i’) >> STRIP_TAC \\
+     POP_ASSUM MP_TAC >> RW_TAC bool_ss [])
+ >> rw [] >> Q.EXISTS_TAC ‘{}’
+ >> MATCH_MP_TAC NULL_SET_EMPTY >> art []
 QED
 
 (* NOTE: the need of complete measure space is necessary if P is a generic property.
@@ -7818,9 +7820,8 @@ Theorem BOREL_2D :
 Proof
     Q.ABBREV_TAC ‘S = ^borel_2d_tm2’
  >> ONCE_REWRITE_TAC [GSYM SPACE]
- >> Know ‘space (Borel CROSS Borel) = space S’
- >- rw [SPACE_BOREL_2D, Abbr ‘S’]
- >> Rewr'
+ >> ‘space (Borel CROSS Borel) = space S’ by rw [SPACE_BOREL_2D, Abbr ‘S’]
+ >> POP_ORW
  >> Suff ‘subsets (Borel CROSS Borel) = subsets S’ >- rw []
  >> MATCH_MP_TAC SUBSET_ANTISYM
  (* stage work *)
@@ -7960,12 +7961,11 @@ Proof
        Know ‘r <> PosInf /\ r <> NegInf’
        >- (CONJ_TAC >> CCONTR_TAC >> fs [lt_infty]) >> STRIP_TAC \\
        Q.EXISTS_TAC ‘(real q,real r)’ >> rw [normal_real] \\ (* 4 subgoals, same tactics *)
-       rw [GSYM extreal_lt_eq, normal_real] ])
+       RW_TAC std_ss [GSYM extreal_lt_eq, normal_real] ])
  (* stage work (tedious part) *)
  >> REWRITE_TAC [prod_sigma_def]
- >> Know ‘space Borel CROSS space Borel = space S’
- >- (rw [Abbr ‘S’, SPACE_BOREL, CROSS_UNIV])
- >> Rewr'
+ >> ‘space Borel CROSS space Borel = space S’ by rw [Abbr ‘S’, SPACE_BOREL, CROSS_UNIV]
+ >> POP_ORW
  >> MATCH_MP_TAC SIGMA_SUBSET
  (* applying BOREL_2D_lemma3 *)
  >> CONJ_TAC >- rw [BOREL_2D_lemma3, Abbr ‘S’]
@@ -7996,7 +7996,6 @@ Proof
           rename1 ‘FST z IN B’ >> Cases_on ‘z’ >> fs [] ],
         (* goal 2.3 (of 2) *)
         qexistsl_tac [‘B’, ‘{}’] >> rw [] ],
-
       (* goal 3 (of 16) *)
       qexistsl_tac [‘{}’, ‘{}’, ‘IMAGE Normal B’, ‘{}’] \\
       rw [UNION_EMPTY, CROSS_EMPTY] >| (* 2 subgoals *)
@@ -8009,7 +8008,6 @@ Proof
           rename1 ‘FST z IN B’ >> Cases_on ‘z’ >> fs [] ],
         (* goal 3.3 (of 2) *)
         qexistsl_tac [‘B’, ‘{}’] >> rw [] ],
-
       (* goal 4 (of 16) *)
       qexistsl_tac [‘{}’, ‘{}’, ‘IMAGE Normal B’, ‘IMAGE Normal B’] \\
       rw [UNION_EMPTY, CROSS_EMPTY] >| (* 3 subgoals *)
@@ -8024,7 +8022,6 @@ Proof
         qexistsl_tac [‘B’, ‘{}’] >> rw [],
         (* goal 4.3 (of 3) *)
         qexistsl_tac [‘B’, ‘{}’] >> rw [] ],
-
       (* goal 5 (of 16) *)
       qexistsl_tac [‘{}’, ‘IMAGE Normal B'’, ‘{}’, ‘{}’] \\
       rw [UNION_EMPTY, CROSS_EMPTY] >| (* 2 subgoals *)
@@ -8037,7 +8034,6 @@ Proof
           rename1 ‘FST z IN B’ >> Cases_on ‘z’ >> fs [] ],
         (* goal 5.2 (of 2) *)
         qexistsl_tac [‘B'’, ‘{}’] >> rw [] ],
-
       (* goal 6 (of 16) *)
       qexistsl_tac [‘{}’, ‘(IMAGE Normal B') UNION {NegInf}’, ‘{}’, ‘IMAGE Normal B’] \\
       rw [UNION_EMPTY, CROSS_EMPTY] >| (* 3 subgoals *)
@@ -8052,7 +8048,6 @@ Proof
         qexistsl_tac [‘B'’, ‘{NegInf}’] >> rw [],
         (* goal 6.3 (of 3) *)
         qexistsl_tac [‘B’, ‘{}’] >> rw [] ],
-
       (* goal 7 (of 16) *)
       qexistsl_tac [‘{}’, ‘(IMAGE Normal B') UNION {PosInf}’, ‘IMAGE Normal B’, ‘{}’] \\
       rw [UNION_EMPTY, CROSS_EMPTY] >| (* 3 subgoals *)
@@ -8067,7 +8062,6 @@ Proof
         qexistsl_tac [‘B'’, ‘{PosInf}’] >> rw [],
         (* goal 7.3 (of 3) *)
         qexistsl_tac [‘B’, ‘{}’] >> rw [] ],
-
       (* goal 8 (of 16) *)
       qexistsl_tac [‘{}’, ‘(IMAGE Normal B') UNION {NegInf; PosInf}’,
                     ‘IMAGE Normal B’, ‘IMAGE Normal B’] \\
@@ -8085,7 +8079,6 @@ Proof
         qexistsl_tac [‘B’, ‘{}’] >> rw [],
         (* goal 8.4 (of 4) *)
         qexistsl_tac [‘B’, ‘{}’] >> rw [] ],
-
       (* goal 9 (of 16) *)
       qexistsl_tac [‘IMAGE Normal B'’, ‘{}’, ‘{}’, ‘{}’] \\
       rw [UNION_EMPTY, CROSS_EMPTY] >| (* 2 subgoals *)
@@ -8098,7 +8091,6 @@ Proof
           rename1 ‘FST z IN B’ >> Cases_on ‘z’ >> fs [] ],
         (* goal 9.2 (of 2) *)
         qexistsl_tac [‘B'’, ‘{}’] >> rw [] ],
-
       (* goal 10 (of 16) *)
       qexistsl_tac [‘(IMAGE Normal B') UNION {NegInf}’, ‘{}’,
                     ‘{}’, ‘IMAGE Normal B’] \\
@@ -8114,7 +8106,6 @@ Proof
         qexistsl_tac [‘B'’, ‘{NegInf}’] >> rw [],
         (* goal 10.3 (of 3) *)
         qexistsl_tac [‘B’, ‘{}’] >> rw [] ],
-
       (* goal 11 (of 16) *)
       qexistsl_tac [‘(IMAGE Normal B') UNION {PosInf}’, ‘{}’,
                     ‘IMAGE Normal B’, ‘{}’] \\
@@ -8130,7 +8121,6 @@ Proof
         qexistsl_tac [‘B'’, ‘{PosInf}’] >> rw [],
         (* goal 11.3 (of 3) *)
         qexistsl_tac [‘B’, ‘{}’] >> rw [] ],
-
       (* goal 12 (of 16) *)
       qexistsl_tac [‘(IMAGE Normal B') UNION {NegInf;PosInf}’, ‘{}’,
                     ‘IMAGE Normal B’, ‘IMAGE Normal B’] \\
@@ -8148,7 +8138,6 @@ Proof
         qexistsl_tac [‘B’, ‘{}’] >> rw [],
         (* goal 12.4 (of 4) *)
         qexistsl_tac [‘B’, ‘{}’] >> rw [] ],
-
       (* goal 13 (of 16) *)
       qexistsl_tac [‘IMAGE Normal B'’, ‘IMAGE Normal B'’, ‘{}’, ‘{}’] \\
       rw [UNION_EMPTY, CROSS_EMPTY] >| (* 3 subgoals *)
@@ -8163,7 +8152,6 @@ Proof
         qexistsl_tac [‘B'’, ‘{}’] >> rw [],
         (* goal 13.3 (of 3) *)
         qexistsl_tac [‘B'’, ‘{}’] >> rw [] ],
-
       (* goal 14 (of 16) *)
       qexistsl_tac [‘(IMAGE Normal B') UNION {NegInf}’,
                     ‘(IMAGE Normal B') UNION {NegInf}’,
@@ -8182,7 +8170,6 @@ Proof
         qexistsl_tac [‘B'’, ‘{NegInf}’] >> rw [],
         (* goal 14.4 (of 4) *)
         qexistsl_tac [‘B’, ‘{NegInf;PosInf}’] >> rw [] ],
-
       (* goal 15 (of 16) *)
       qexistsl_tac [‘(IMAGE Normal B') UNION {PosInf}’,
                     ‘(IMAGE Normal B') UNION {PosInf}’,
@@ -8201,7 +8188,6 @@ Proof
         qexistsl_tac [‘B'’, ‘{PosInf}’] >> rw [],
         (* goal 15.4 (of 4) *)
         qexistsl_tac [‘B’, ‘{NegInf;PosInf}’] >> rw [] ],
-
       (* goal 16 (of 16) *)
       qexistsl_tac [‘(IMAGE Normal B') UNION {NegInf;PosInf}’,
                     ‘(IMAGE Normal B') UNION {NegInf;PosInf}’,
@@ -8725,32 +8711,18 @@ QED
 
 val _ = augment_srw_ss [realSimps.REAL_ARITH_ss];
 
-(*  TODO: Remove as the following are [simp]s:
-        EXTREAL_SUM_IMAGE_EMPTY
-        extreal_le_simp
-        extreal_lt_simp
-        extreal_0_simp
-        extreal_1_simp
-*)
-val name_to_thname = fn (t,s) => ({Thy = t, Name = s}, DB.fetch t s);
-val mk_local_simp = augment_srw_ss o single o
-    simpLib.rewrites_with_names o single o name_to_thname;
-val _ = mk_local_simp ("extreal","EXTREAL_SUM_IMAGE_EMPTY");
-val _ = mk_local_simp ("extreal","extreal_le_simp");
-val _ = mk_local_simp ("extreal","extreal_lt_simp");
-val _ = mk_local_simp ("extreal","extreal_0_simp");
-val _ = mk_local_simp ("extreal","extreal_1_simp");
-
 (*** IN_MEASURABLE_BOREL Theorems ***)
 
-Theorem IN_MEASURABLE_BOREL_CONG:
-    !a b f g. a = b /\ (!x. x IN space b ==> f x = g x) ==> (f IN Borel_measurable a <=> g IN Borel_measurable b)
+(* There is already an IN_MEASURABLE_BOREL_CONG earlier in this theory *)
+Theorem IN_MEASURABLE_BOREL_CONG':
+    !a f g. (!x. x IN space a ==> f x = g x) ==>
+            (f IN Borel_measurable a <=> g IN Borel_measurable a)
 Proof
     rw[] >> eq_tac >> rw[] >> dxrule_at_then (Pos $ el 2) irule IN_MEASURABLE_BOREL_EQ' >> simp[]
 QED
 
 Theorem IN_MEASURABLE_BOREL_COMP:
-    !a b f g h. sigma_algebra a /\ sigma_algebra b /\ f IN Borel_measurable b /\ g IN measurable a b /\
+    !a b f g h. f IN Borel_measurable b /\ g IN measurable a b /\
         (!x. x IN space a ==> h x = f (g x)) ==> h IN Borel_measurable a
 Proof
     rw[] >> dxrule_all_then assume_tac MEASURABLE_COMP >>
@@ -8758,7 +8730,7 @@ Proof
 QED
 
 Theorem IN_MEASURABLE_BOREL_COMP_BOREL:
-    !a f g h. sigma_algebra a /\ f IN Borel_measurable Borel /\ g IN Borel_measurable a /\
+    !a f g h. f IN Borel_measurable Borel /\ g IN Borel_measurable a /\
         (!x. x IN space a ==> h x = f (g x)) ==> h IN Borel_measurable a
 Proof
     rw[] >> dxrule_all_then assume_tac MEASURABLE_COMP >>

--- a/src/probability/extrealScript.sml
+++ b/src/probability/extrealScript.sml
@@ -3988,16 +3988,20 @@ val EXTREAL_SUM_IMAGE_DEF = new_definition
   ``EXTREAL_SUM_IMAGE f s = ITSET (\e acc. f e + acc) s (0 :extreal)``);
 
 (* Now theorems about EXTREAL_SUM_IMAGE itself *)
-(* TODO: make [simp] *)
-val EXTREAL_SUM_IMAGE_EMPTY = store_thm
-  ("EXTREAL_SUM_IMAGE_EMPTY", ``!f. EXTREAL_SUM_IMAGE f {} = 0``,
-    SIMP_TAC (srw_ss()) [ITSET_THM, EXTREAL_SUM_IMAGE_DEF]);
+Theorem EXTREAL_SUM_IMAGE_EMPTY[simp] :
+    !f. EXTREAL_SUM_IMAGE f {} = 0
+Proof
+    SRW_TAC [][ITSET_THM, EXTREAL_SUM_IMAGE_DEF]
+QED
 
-(* this is provable by (old) EXTREAL_SUM_IMAGE_THM but using original definition is much
-   easier, because CHOICE and REST from singleton can be easily eliminated. *)
-val EXTREAL_SUM_IMAGE_SING = store_thm
-  ("EXTREAL_SUM_IMAGE_SING[simp]", ``!f e. EXTREAL_SUM_IMAGE f {e} = f e``,
-    SRW_TAC [][EXTREAL_SUM_IMAGE_DEF, ITSET_THM, add_rzero]);
+(* This is provable by (old) EXTREAL_SUM_IMAGE_THM but using original definition is much
+   easier, because CHOICE and REST from singleton can be easily eliminated.
+ *)
+Theorem EXTREAL_SUM_IMAGE_SING[simp] :
+    !f e. EXTREAL_SUM_IMAGE f {e} = f e
+Proof
+    SRW_TAC [][EXTREAL_SUM_IMAGE_DEF, ITSET_THM, add_rzero]
+QED
 
 (* This new theorem provides a "complete" picture for EXTREAL_SUM_IMAGE. *)
 val EXTREAL_SUM_IMAGE_THM = store_thm
@@ -4205,10 +4209,9 @@ Theorem EXTREAL_SUM_IMAGE_FINITE_CONST : (* was: extreal_sum_image_finite_corr *
 Proof
     rw []
  >> Cases_on ‘P = {}’ >> simp []
- >- rw [EXTREAL_SUM_IMAGE_THM, mul_lzero]
  >> ‘?m. m IN P’ by metis_tac [MEMBER_NOT_EMPTY]
  >> ‘x = f m’ by fs [] >> rw []
- >> irule EXTREAL_SUM_IMAGE_FINITE_SAME >> rw[]
+ >> irule EXTREAL_SUM_IMAGE_FINITE_SAME >> rw []
 QED
 
 val EXTREAL_SUM_IMAGE_ZERO = store_thm
@@ -8441,6 +8444,12 @@ Definition max_fn_seq_def :
    (max_fn_seq g (SUC n) x = max (max_fn_seq g n x) (g (SUC n) x))
 End
 
+Theorem max_fn_seq_0[simp] :
+    !g. max_fn_seq g 0 = g 0
+Proof
+    rw [FUN_EQ_THM, max_fn_seq_def]
+QED
+
 Theorem max_fn_seq_cong :
     !f g x. (!n. f n x = g n x) ==> !n. max_fn_seq f n x = max_fn_seq g n x
 Proof
@@ -9570,24 +9579,6 @@ QED
       in order to manipulate the simplifier without breaking anything
       - Jared Yeager                                                    *)
 
-(*** Simplification Definitions ***)
-
-(*  TODO:
-    These next two definitions can be deleted once all of the following are [simp]s:
-        EXTREAL_SUM_IMAGE_EMPTY
-        extreal_le_simp
-        extreal_lt_simp
-        extreal_0_simp
-        extreal_1_simp
-*)
-val name_to_thname = fn s => ({Thy = "extreal", Name = s}, DB.fetch "extreal" s);
-
-val mk_local_simp = augment_srw_ss o single o
-    simpLib.rewrites_with_names o single o name_to_thname;
-
-(* TODO: remove once EXTREAL_SUM_IMAGE_EMPTY is a [simp] *)
-val _ = mk_local_simp "EXTREAL_SUM_IMAGE_EMPTY";
-
 (*** Basic Theorems ***)
 
 Theorem normal_0:
@@ -9608,46 +9599,34 @@ Proof
     ‘Normal (-1) = -(Normal 1)’ suffices_by simp[normal_1] >> simp[extreal_ainv_def]
 QED
 
-(* TODO: make [simp] *)
-(* breaks borel$Borel_def, I think *)
-Theorem extreal_le_simp:
+Theorem extreal_le_simps[simp]:
     (!x y. Normal x <= Normal y <=> x <= y) /\ (!x. NegInf <= x <=> T) /\ (!x. x <= PosInf <=> T) /\
     (!x. Normal x <= NegInf <=> F) /\ (!x. PosInf <= Normal x <=> F) /\ (PosInf <= NegInf <=> F)
 Proof
     rw[extreal_le_def] >> Cases_on ‘x’ >> simp[extreal_le_def]
 QED
 
-(* TODO: remove once extreal_le_simp is a [simp] *)
-val _ = mk_local_simp "extreal_le_simp";
-
-(* TODO: make [simp] *)
-(* breaks borel$Borel_def, I think *)
-Theorem extreal_lt_simp:
+Theorem extreal_lt_simps[simp]:
     (!x y. Normal x < Normal y <=> x < y) /\ (!x. x < NegInf <=> F) /\ (!x. PosInf < x <=> F) /\
     (!x. Normal x < PosInf <=> T) /\ (!x. NegInf < Normal x <=> T) /\ (NegInf < PosInf <=> T)
 Proof
     simp[extreal_lt_eq] >> rw[extreal_lt_def]
 QED
 
-(* TODO: remove once extreal_le_simp is a [simp] *)
-val _ = mk_local_simp "extreal_lt_simp";
-
-(* TODO: make [simp] *)
-(* breaks martingale$ext_limsup_thm, I think *)
-Theorem extreal_0_simp:
-    (0 <= PosInf <=> T) /\ (0 < PosInf <=> T) /\ (PosInf <= 0 <=> F) /\ (PosInf < 0 <=> F) /\ (0 = PosInf <=> F) /\ (PosInf = 0 <=> F) /\
-    (0 <= NegInf <=> F) /\ (0 < NegInf <=> F) /\ (NegInf <= 0 <=> T) /\ (NegInf < 0 <=> T) /\ (0 = NegInf <=> F) /\ (NegInf = 0 <=> F) /\
+Theorem extreal_0_simps[simp]:
+    (0 <= PosInf <=> T) /\ (0 < PosInf <=> T) /\
+    (PosInf <= 0 <=> F) /\ (PosInf < 0 <=> F) /\
+    (0 = PosInf <=> F) /\ (PosInf = 0 <=> F) /\
+    (0 <= NegInf <=> F) /\ (0 < NegInf <=> F) /\
+    (NegInf <= 0 <=> T) /\ (NegInf < 0 <=> T) /\
+    (0 = NegInf <=> F) /\ (NegInf = 0 <=> F) /\
     (!r. 0 <= Normal r <=> 0 <= r) /\ (!r. 0 < Normal r <=> 0 < r) /\ (!r. 0 = Normal r <=> r = 0) /\
     (!r. Normal r <= 0 <=> r <= 0) /\ (!r. Normal r < 0 <=> r < 0) /\ (!r. Normal r = 0 <=> r = 0)
 Proof
     simp[GSYM normal_0]
 QED
 
-(* TODO: remove once extreal_0_simp is a [simp] *)
-val _ = mk_local_simp "extreal_0_simp";
-
-(* TODO: make [simp] *)
-Theorem extreal_1_simp:
+Theorem extreal_1_simps[simp]:
     (1 <= PosInf <=> T) /\ (1 < PosInf <=> T) /\ (PosInf <= 1 <=> F) /\
     (PosInf < 1 <=> F) /\ (1 = PosInf <=> F) /\ (PosInf = 1 <=> F) /\
     (1 <= NegInf <=> F) /\ (1 < NegInf <=> F) /\ (NegInf <= 1 <=> T) /\
@@ -9657,9 +9636,6 @@ Theorem extreal_1_simp:
 Proof
     simp[GSYM normal_1]
 QED
-
-(* TODO: remove once extreal_1_simp is a [simp] *)
-val _ = mk_local_simp "extreal_1_simp";
 
 (* do NOT add to a simpset, way too much overhead *)
 Theorem ineq_imp:

--- a/src/probability/extrealSimps.sig
+++ b/src/probability/extrealSimps.sig
@@ -1,10 +1,6 @@
 signature extrealSimps = sig
 
-(* This ssfrag is now just redundant, as everything in it is/will be simps
-
 (* Extended real inequality simps to generally be used with augment_srw_ss *)
-val EXT_INEQ_ss : simpLib.ssfrag
-
-*)
+val extreal_SS : simpLib.ssfrag;
 
 end

--- a/src/probability/extrealSimps.sml
+++ b/src/probability/extrealSimps.sml
@@ -1,18 +1,17 @@
 structure extrealSimps :> extrealSimps = struct
 
 open HolKernel Parse boolLib bossLib;
-open simpLib;
-open extrealTheory;
+open simpLib extrealTheory;
 
-val name_to_thname = fn s => ({Thy = "extreal", Name = s}, DB.fetch "extreal" s);
+fun name_to_thname s = ({Thy = "extreal", Name = s}, DB.fetch "extreal" s);
 
-(* This ssfrag is now just redundant, as everything in it is/will be simps
+val extreal_SS = named_rewrites_with_names
+   "extreal" $ map name_to_thname
+  ["extreal_le_simps",
+   "extreal_lt_simps",
+   "extreal_0_simps",
+   "extreal_1_simps"];
 
-val EXT_INEQ_ss = named_rewrites_with_names "EXT_INEQ" $ map name_to_thname [
-    "extreal_le_simp","extreal_lt_simp","extreal_0_simp","extreal_1_simp"];
-
-val _ = register_frag EXT_INEQ_ss;
-
-*)
+val _ = register_frag extreal_SS;
 
 end

--- a/src/probability/martingaleScript.sml
+++ b/src/probability/martingaleScript.sml
@@ -852,9 +852,11 @@ Proof
          Q.EXISTS_TAC ‘n’ >> rw []) >> DISCH_TAC \\
      Know ‘abs (real (sup {a n | i <= n} - inf {a n | i <= n})) =
                 real (sup {a n | i <= n} - inf {a n | i <= n})’
-     >- (rw [abs_refl, GSYM extreal_le_eq, GSYM extreal_of_num_def] \\
+     >- (rw [abs_refl] \\
+         RW_TAC std_ss [GSYM extreal_le_eq, GSYM extreal_of_num_def] \\
          Suff ‘Normal (real (sup {a n | i <= n} - inf {a n | i <= n})) =
-                             sup {a n | i <= n} - inf {a n | i <= n}’ >- rw [] \\
+                             sup {a n | i <= n} - inf {a n | i <= n}’
+         >- RW_TAC std_ss [] \\
          MATCH_MP_TAC normal_real \\
         ‘?r. sup {a n | i <= n} = Normal r’ by METIS_TAC [extreal_cases] >> POP_ORW \\
         ‘?z. inf {a n | i <= n} = Normal z’ by METIS_TAC [extreal_cases] >> POP_ORW \\
@@ -910,19 +912,21 @@ Proof
         ‘?z. inf {a n | i <= n} = Normal z’ by METIS_TAC [extreal_cases] >> POP_ORW \\
          rw [extreal_sub_def]) >> STRIP_TAC \\
      Know ‘abs (real (Q i)) = real (Q i)’
-     >- (rw [abs_refl, GSYM extreal_le_eq, GSYM extreal_of_num_def] \\
-         Suff ‘Normal (real (Q i)) = Q i’ >- rw [] \\
+     >- (rw [abs_refl] \\
+         RW_TAC std_ss [GSYM extreal_le_eq, GSYM extreal_of_num_def] \\
+         Suff ‘Normal (real (Q i)) = Q i’ >- RW_TAC std_ss [] \\
          MATCH_MP_TAC normal_real >> rw []) >> Rewr' \\
      Q.PAT_X_ASSUM ‘!n. N <= n ==> abs (real (P n)) < e’
        (fn th => ASSUME_TAC (MATCH_MP th (ASSUME “N <= (i :num)”))) \\
      Know ‘abs (real (P i)) = real (P i)’
-     >- (rw [abs_refl, GSYM extreal_le_eq, GSYM extreal_of_num_def] \\
-         Suff ‘Normal (real (P i)) = P i’ >- rw [] \\
+     >- (rw [abs_refl] \\
+         RW_TAC std_ss [GSYM extreal_le_eq, GSYM extreal_of_num_def] \\
+         Suff ‘Normal (real (P i)) = P i’ >- RW_TAC std_ss [] \\
          MATCH_MP_TAC normal_real >> rw []) >> DISCH_THEN (fs o wrap) \\
      MATCH_MP_TAC REAL_LET_TRANS \\
      Q.EXISTS_TAC ‘real (P i)’ >> art [] \\
      REWRITE_TAC [GSYM extreal_le_eq] \\
-     rw [normal_real])
+     RW_TAC std_ss [normal_real])
  >> DISCH_TAC
  (* final stage *)
  >> rw [LIM_SEQUENTIALLY_real_normal]
@@ -1126,8 +1130,8 @@ Proof
         ‘?a. u i x = Normal a’ by METIS_TAC [extreal_cases] >> POP_ORW \\
         ‘?b. f x   = Normal b’ by METIS_TAC [extreal_cases] >> POP_ORW \\
          rw [extreal_sub_def, extreal_abs_def]) >> Rewr' \\
-     rw [abs_abs, GSYM extreal_lt_eq] \\
-     Suff ‘Normal (real (abs (u i x - f x))) = abs (u i x - f x)’ >- rw [] \\
+     RW_TAC std_ss [abs_abs, GSYM extreal_lt_eq] \\
+     Suff ‘Normal (real (abs (u i x - f x))) = abs (u i x - f x)’ >- RW_TAC std_ss [] \\
      MATCH_MP_TAC normal_real \\
     ‘?a. u i x = Normal a’ by METIS_TAC [extreal_cases] >> POP_ORW \\
     ‘?b. f x   = Normal b’ by METIS_TAC [extreal_cases] >> POP_ORW \\

--- a/src/probability/measureScript.sml
+++ b/src/probability/measureScript.sml
@@ -3,7 +3,7 @@
 (* Authors: Tarek Mhamdi, Osman Hasan, Sofiene Tahar (2013, 2015) [2]        *)
 (* HVG Group, Concordia University, Montreal                                 *)
 (*                                                                           *)
-(* Measures are now in the range [0, +infinity] (type: 'a set -> extreal)    *)
+(* Measures are now in the range [0, PosInf] (type: 'a set -> extreal)       *)
 (* ------------------------------------------------------------------------- *)
 (* Based on the work of Joe Hurd [4] (2001) and Aaron Coble [7] (2010)       *)
 (* Cambridge University.                                                     *)
@@ -23,7 +23,8 @@ open HolKernel Parse boolLib bossLib;
 open prim_recTheory arithmeticTheory optionTheory pairTheory
      numpairTheory combinTheory pred_setTheory pred_setLib;
 
-open realTheory realLib seqTheory transcTheory real_sigmaTheory;
+open realTheory realLib metricTheory seqTheory transcTheory real_sigmaTheory
+     real_topologyTheory;
 
 open hurdUtils util_probTheory extrealTheory sigma_algebraTheory;
 
@@ -756,15 +757,14 @@ val MEASURE_SPACE_DIFF = store_thm
    METIS_TAC [measure_space_def,sigma_algebra_def,subsets_def,
               (REWRITE_RULE [subsets_def] (Q.SPEC `(m_space m,measurable_sets m)` ALGEBRA_DIFF))]);
 
-Theorem MEASURE_SPACE_SPACE :
-    !m. measure_space m ==> m_space m IN measurable_sets m
+Theorem MEASURE_SPACE_MSPACE_MEASURABLE :
+    !m. measure_space m ==> (m_space m) IN measurable_sets m
 Proof
-    RW_TAC std_ss [measure_space_def, sigma_algebra_def, subsets_def]
- >> MATCH_MP_TAC
-      (REWRITE_RULE [space_def, subsets_def]
-                    (Q.SPEC `(m_space m,measurable_sets m)` ALGEBRA_SPACE))
- >> ASM_REWRITE_TAC []
+    RW_TAC std_ss [measure_space_def, sigma_algebra_def, algebra_def, subsets_def, space_def]
+ >> METIS_TAC [DIFF_EMPTY]
 QED
+
+Theorem MEASURE_SPACE_SPACE = MEASURE_SPACE_MSPACE_MEASURABLE
 
 Theorem MEASURE_SPACE_COMPL :
     !m s. measure_space m /\ s IN measurable_sets m ==>
@@ -784,26 +784,23 @@ val MEASURE_SPACE_BIGUNION = store_thm
      (Q.SPEC `(m_space m,measurable_sets m)`)) SIGMA_ALGEBRA_FN
  >> METIS_TAC [measure_space_def]);
 
-val MEASURE_SPACE_IN_MSPACE = store_thm
-  ("MEASURE_SPACE_IN_MSPACE",
-  ``!m A. measure_space m /\ A IN measurable_sets m ==> (!x. x IN A ==> x IN m_space m)``,
-   METIS_TAC [measure_space_def,sigma_algebra_def,algebra_def,measurable_sets_def,
-              space_def,subset_class_def,subsets_def,SUBSET_DEF]);
+(* NOTE: changed order of universal quantifiers *)
+Theorem MEASURE_SPACE_SUBSET_MSPACE :
+    !m s. measure_space m /\ s IN measurable_sets m ==> s SUBSET m_space m
+Proof
+    RW_TAC std_ss [measure_space_def, sigma_algebra_def, algebra_def,
+                   subset_class_def, subsets_def, space_def]
+QED
 
-val MEASURE_SPACE_SUBSET_MSPACE = store_thm
-  ("MEASURE_SPACE_SUBSET_MSPACE",
-  ``!A m. measure_space m /\ A IN measurable_sets m ==> A SUBSET m_space m``,
-  RW_TAC std_ss [measure_space_def, sigma_algebra_def, algebra_def,subset_class_def,
-                 subsets_def, space_def]);
+Theorem MEASURE_SPACE_IN_MSPACE :
+   !m s. measure_space m /\ s IN measurable_sets m ==> (!x. x IN s ==> x IN m_space m)
+Proof
+   METIS_TAC [MEASURE_SPACE_SUBSET_MSPACE, SUBSET_DEF]
+QED
 
 val MEASURE_SPACE_EMPTY_MEASURABLE = store_thm
   ("MEASURE_SPACE_EMPTY_MEASURABLE",``!m. measure_space m ==> {} IN measurable_sets m``,
    RW_TAC std_ss [measure_space_def, sigma_algebra_def, algebra_def,subsets_def, space_def]);
-
-val MEASURE_SPACE_MSPACE_MEASURABLE = store_thm
-  ("MEASURE_SPACE_MSPACE_MEASURABLE",``!m. measure_space m ==> (m_space m) IN measurable_sets m``,
-    RW_TAC std_ss [measure_space_def, sigma_algebra_def, algebra_def, subsets_def, space_def]
- >> METIS_TAC [DIFF_EMPTY]);
 
 val MEASURE_SPACE_BIGINTER = store_thm
   ("MEASURE_SPACE_BIGINTER",
@@ -1075,11 +1072,7 @@ val MONOTONE_CONVERGENCE_BIGINTER2 = store_thm
          (inf (IMAGE (measure m o f) univ(:num)) = measure m (BIGINTER (IMAGE f UNIV)))``,
     METIS_TAC [MONOTONE_CONVERGENCE_BIGINTER]);
 
-val MEASURABLE_SETS_SUBSET_SPACE = store_thm
-  ("MEASURABLE_SETS_SUBSET_SPACE",
-  ``!m s. measure_space m /\ s IN measurable_sets m ==> s SUBSET m_space m``,
-    RW_TAC std_ss [measure_space_def, sigma_algebra_def, algebra_def, subsets_def, space_def,
-                   subset_class_def]);
+Theorem MEASURABLE_SETS_SUBSET_SPACE = MEASURE_SPACE_SUBSET_MSPACE
 
 val IN_MEASURE_PRESERVING = store_thm
   ("IN_MEASURE_PRESERVING",
@@ -5402,121 +5395,112 @@ val limsup_suminf_indicator_space = store_thm
 (***********************)
 
 (*  These do not require addition simplifier manipulations on my part. It would
-      probably be more appropriate to add these in the proper places above.
-      - Jared Yeager                                                                   *)
+    probably be more appropriate to add these in the proper places above.
+    - Jared Yeager
+ *)
 
 val _ = reveal "C";
 
-(*  TODO: Remove as the following are [simp]s:
-        EXTREAL_SUM_IMAGE_EMPTY
-        extreal_le_simp
-        extreal_lt_simp
-        extreal_0_simp
-        extreal_1_simp
-*)
-val name_to_thname = fn (t,s) => ({Thy = t, Name = s}, DB.fetch t s);
-val mk_local_simp = augment_srw_ss o single o
-    simpLib.rewrites_with_names o single o name_to_thname;
-val _ = mk_local_simp ("extreal","EXTREAL_SUM_IMAGE_EMPTY");
-val _ = mk_local_simp ("extreal","extreal_le_simp");
-val _ = mk_local_simp ("extreal","extreal_lt_simp");
-val _ = mk_local_simp ("extreal","extreal_0_simp");
-val _ = mk_local_simp ("extreal","extreal_1_simp");
-
 (*** measure_space Theorems ***)
 
-Theorem measure_space_measure_eq:
-    !sp sts mu nu. measure_space (sp,sts,mu) /\ (!s. s IN sts ==> nu s = mu s) ==>
-        measure_space (sp,sts,nu)
+Theorem measure_space_eq' : (* was: measure_space_measure_eq *)
+    !sp sts u v. measure_space (sp,sts,u) /\ (!s. s IN sts ==> u s = v s) ==>
+                 measure_space (sp,sts,v)
 Proof
-    rw[measure_space_def,positive_def,countably_additive_def]
-    >- (‘EMPTY IN sts’ suffices_by rw[] >> drule SIGMA_ALGEBRA_EMPTY >> simp[])
-    >- (irule ext_suminf_eq >> rw[] >> first_x_assum $ irule o GSYM >> fs[FUNSET])
+    rpt STRIP_TAC
+ >> MP_TAC (Q.SPECL [‘(sp,sts,u)’, ‘(sp,sts,v)’] measure_space_eq)
+ >> rw []
 QED
 
 Theorem measure_space_cong:
-    !X Y sig tau mu nu. X = Y /\ sig = tau /\ (!s. s IN tau ==> mu s = nu s) ==>
-        (measure_space (X,sig,mu) <=> measure_space (Y,tau,nu))
+    !sp sts u v. (!s. s IN sts ==> u s = v s) ==>
+                 (measure_space (sp,sts,u) <=> measure_space (sp,sts,v))
 Proof
-    rw[] >> eq_tac >> rw[] >> dxrule_at_then (Pos $ el 1) irule measure_space_measure_eq >> simp[]
+    rw[] >> eq_tac >> rw[]
+ >> dxrule_at_then (Pos $ el 1) irule measure_space_eq' >> simp[]
 QED
 
 Theorem measure_space_add:
-    !sa mu nu mnu. measure_space (space sa,subsets sa,mu) /\
-        measure_space (space sa,subsets sa,nu) /\
-        (!s. s IN subsets sa ==> mnu s = mu s + nu s) ==>
-        measure_space (space sa,subsets sa,mnu)
+    !a mu nu p. measure_space (space a,subsets a,mu) /\
+                measure_space (space a,subsets a,nu) /\
+               (!s. s IN subsets a ==> p s = mu s + nu s) ==>
+                measure_space (space a,subsets a,p)
 Proof
-    rw[measure_space_def,positive_def,countably_additive_def,m_space_def,measurable_sets_def,measure_def]
-    >- (dxrule_then assume_tac $ SIGMA_ALGEBRA_EMPTY >> fs[])
-    >- (irule le_add >> fs[])
-    >- ((qspecl_then [‘mu o f’,‘nu o f’] assume_tac) ext_suminf_add >> rfs[o_DEF,FUNSET])
+    rw [measure_space_def, positive_def, countably_additive_def,
+        m_space_def, measurable_sets_def, measure_def]
+ >- (dxrule_then assume_tac $ SIGMA_ALGEBRA_EMPTY >> fs[])
+ >- (irule le_add >> fs[])
+ >> (qspecl_then [‘mu o f’,‘nu o f’] assume_tac) ext_suminf_add
+ >> rfs[o_DEF,FUNSET]
 QED
 
 Theorem measure_space_sum:
-    !sa mui nu s. FINITE s /\ sigma_algebra sa /\
-        (!i. i IN s ==> measure_space (space sa,subsets sa,mui i)) /\
-        (!t. t IN subsets sa ==> nu t = EXTREAL_SUM_IMAGE (C mui t) s) ==>
-        measure_space (space sa,subsets sa,nu)
+    !a f m s. FINITE s /\ sigma_algebra a /\
+        (!i. i IN s ==> measure_space (space a,subsets a,f i)) /\
+        (!t. t IN subsets a ==> m t = EXTREAL_SUM_IMAGE (C f t) s) ==>
+        measure_space (space a,subsets a,m)
 Proof
-    ‘!(s:'b->bool). FINITE s ==> !(sa:'a algebra) mui nu. sigma_algebra sa /\
-        (!i. i IN s ==> measure_space (space sa,subsets sa,mui i)) /\
-        (!t. t IN subsets sa ==> nu t = EXTREAL_SUM_IMAGE (C mui t) s) ==>
-        measure_space (space sa,subsets sa,nu)’ suffices_by (rw[] >>
+    ‘!(s:'b->bool). FINITE s ==> !(a:'a algebra) f m. sigma_algebra a /\
+        (!i. i IN s ==> measure_space (space a,subsets a,f i)) /\
+        (!t. t IN subsets a ==> m t = EXTREAL_SUM_IMAGE (C f t) s) ==>
+        measure_space (space a,subsets a,m)’ suffices_by (rw[] >>
         last_x_assum $ drule_then assume_tac >> pop_assum $ drule_all_then assume_tac >> simp[]) >>
     Induct_on ‘s’ >> rw[]
-    >- (fs[EXTREAL_SUM_IMAGE_EMPTY] >> irule measure_space_measure_eq >>
+    >- (fs[EXTREAL_SUM_IMAGE_EMPTY] >> irule measure_space_eq' \\
         qexists_tac ‘K 0’ >> simp[] >> dxrule_then assume_tac measure_space_trivial >>
         fs[sigma_finite_measure_space_def,K_DEF]) >>
-    last_x_assum $ qspecl_then [‘sa’,‘mui’,‘λt. EXTREAL_SUM_IMAGE (C mui t) s’] assume_tac >> rfs[] >>
-    irule measure_space_add >> qexistsl_tac [‘mui e’,‘(λt. EXTREAL_SUM_IMAGE (C mui t) s)’] >>
+    last_x_assum $ qspecl_then [‘a’,‘f’,‘\t. EXTREAL_SUM_IMAGE (C f t) s’] assume_tac >> rfs[] >>
+    irule measure_space_add >> qexistsl_tac [‘f e’,‘(\t. EXTREAL_SUM_IMAGE (C f t) s)’] >>
     simp[] >> qx_gen_tac ‘t’ >> rw[] >>
-    qspecl_then [‘C mui t’,‘s’,‘e’]
+    qspecl_then [‘C f t’,‘s’,‘e’]
         (fn th => assume_tac th >> rfs[DELETE_NON_ELEMENT_RWT] >> pop_assum irule) $
         SIMP_RULE bool_ss [GSYM RIGHT_FORALL_IMP_THM] EXTREAL_SUM_IMAGE_PROPERTY >>
     DISJ1_TAC >> rw[] >> irule pos_not_neginf >> fs[measure_space_def,positive_def]
 QED
 
 Theorem measure_space_suminf:
-    !sa mun nu. (!n. measure_space (space sa,subsets sa,mun n)) /\
-        (!s. s IN subsets sa ==> nu s = suminf (C mun s)) ==>
-        measure_space (space sa,subsets sa,nu)
+    !a g m. (!n. measure_space (space a,subsets a,g n)) /\
+        (!s. s IN subsets a ==> m s = suminf (C g s)) ==>
+        measure_space (space a,subsets a,m)
 Proof
-    rw[measure_space_def,positive_def,countably_additive_def,m_space_def,measurable_sets_def,measure_def] >>
-    fs[GSYM RIGHT_AND_FORALL_THM]
-    >- (dxrule_then assume_tac $ SIGMA_ALGEBRA_EMPTY >> simp[ext_suminf_0,C_DEF])
-    >- (irule ext_suminf_pos >> rw[])
-    >- (‘suminf (nu o f) = suminf (λi. suminf (C mun (f i)))’ by (
-            irule ext_suminf_eq >> rw[] >> rfs[FUNSET]) >>
-        pop_assum SUBST1_TAC >> simp[C_DEF,o_DEF] >>
-        qspec_then ‘C mun o f’ (irule o SIMP_RULE (srw_ss ()) []) ext_suminf_nested >>
-        rw[] >> last_x_assum $ irule o cj 2 >> fs[FUNSET])
+    rw [measure_space_def,positive_def,countably_additive_def]
+ >> fs[GSYM RIGHT_AND_FORALL_THM]
+ >- (dxrule_then assume_tac $ SIGMA_ALGEBRA_EMPTY >> simp[ext_suminf_0,C_DEF])
+ >- (irule ext_suminf_pos >> rw[])
+ >> ‘suminf (m o f) = suminf (\i. suminf (C g (f i)))’
+      by (irule ext_suminf_eq >> rw[] >> rfs[FUNSET])
+ >> pop_assum SUBST1_TAC >> simp[C_DEF,o_DEF]
+ >> qspec_then ‘C g o f’ (irule o SIMP_RULE (srw_ss ()) []) ext_suminf_nested
+ >> rw [] >> last_x_assum $ irule o cj 2
+ >> fs[FUNSET]
 QED
 
 Theorem measure_space_cmul:
-    !sa mu nu c. measure_space (space sa,subsets sa,mu) /\ 0 <= c /\
-        (!s. s IN subsets sa ==> nu s = c * mu s) ==>
-        measure_space (space sa,subsets sa,nu)
+    !a u v c. measure_space (space a,subsets a,u) /\ 0 <= c /\
+        (!s. s IN subsets a ==> v s = c * u s) ==>
+        measure_space (space a,subsets a,v)
 Proof
-    rw[measure_space_def,positive_def,countably_additive_def,m_space_def,measurable_sets_def,measure_def]
-    >- (dxrule_then assume_tac $ SIGMA_ALGEBRA_EMPTY >> fs[])
-    >- (irule le_mul >> fs[])
-    >- ((qspecl_then [‘mu o f’,‘c’] assume_tac) ext_suminf_cmul >> rfs[o_DEF,FUNSET])
+    rw[measure_space_def,positive_def,countably_additive_def]
+ >- (dxrule_then assume_tac $ SIGMA_ALGEBRA_EMPTY >> fs[])
+ >- (irule le_mul >> fs[])
+ >> (qspecl_then [‘u o f’,‘c’] assume_tac) ext_suminf_cmul
+ >> rfs[o_DEF,FUNSET]
 QED
 
 Theorem measure_space_dirac_measure:
-    !sa x. sigma_algebra sa ==> measure_space (space sa,subsets sa,C indicator_fn x)
+    !a x. sigma_algebra a ==> measure_space (space a,subsets a,C indicator_fn x)
 Proof
-    simp[measure_space_def,positive_def,countably_additive_def,
-        m_space_def,measurable_sets_def,measure_def,indicator_fn_def] >>
-    rw[] >> rw[] >> fs[]
-    >- (rename [‘x IN f n’] >>
-        ‘(C indicator_fn x o f) = (λi. if i = n then 1 else 0:extreal)’ suffices_by rw[ext_suminf_sing_general] >>
+    simp[measure_space_def,positive_def,countably_additive_def,indicator_fn_def]
+ >> rw[] >> rw[] >> fs[]
+ >- (rename [‘x IN f n’] >>
+        ‘(C indicator_fn x o f) = (\i. if i = n then 1 else 0:extreal)’
+            suffices_by rw[ext_suminf_sing_general] \\
         rw[FUN_EQ_THM,o_DEF,indicator_fn_def] >> Cases_on ‘i = n’ >> simp[] >>
         last_x_assum (qspecl_then [‘i’,‘n’] assume_tac) >> rfs[DISJOINT_DEF,EXTENSION] >>
         pop_assum $ qspec_then ‘x’ assume_tac >> rfs[])
-    >- (irule ext_suminf_zero >> rw[indicator_fn_def] >> first_x_assum $ qspec_then ‘f n’ assume_tac >>
-        rfs[] >> first_x_assum $ qspec_then ‘n’ assume_tac >> fs[])
+ >> irule ext_suminf_zero >> rw[indicator_fn_def]
+ >> first_x_assum $ qspec_then ‘f n’ assume_tac
+ >> rfs[] >> first_x_assum $ qspec_then ‘n’ assume_tac >> fs[]
 QED
 
 val _ = export_theory ();

--- a/src/probability/probabilityScript.sml
+++ b/src/probability/probabilityScript.sml
@@ -2644,6 +2644,17 @@ Proof
  >> rw [extreal_mul_def]
 QED
 
+Theorem finite_second_moments_ainv :
+    !p X. prob_space p /\ real_random_variable X p /\ finite_second_moments p X ==>
+          finite_second_moments p (\x. -X x)
+Proof
+    rpt STRIP_TAC
+ >> Know ‘(\x. -X x) = (\x. Normal (-1) * X x)’
+ >- RW_TAC std_ss [FUN_EQ_THM, Once neg_minus1, extreal_of_num_def, extreal_ainv_def]
+ >> Rewr'
+ >> MATCH_MP_TAC finite_second_moments_cmul >> art []
+QED
+
 Theorem finite_second_moments_cdiv :
     !p X c. prob_space p /\ real_random_variable X p /\
             finite_second_moments p X /\ c <> 0 ==>
@@ -2653,6 +2664,18 @@ Proof
  >> MATCH_MP_TAC finite_second_moments_cmul >> art []
 QED
 
+Theorem finite_second_moments_cong :
+    !p X Y. prob_space p /\ (!x. x IN p_space p ==> X x = Y x) ==>
+           (finite_second_moments p X <=> finite_second_moments p Y)
+Proof
+    RW_TAC std_ss [finite_second_moments_def, second_moment_def, moment_def]
+ >> Suff ‘!a. expectation p (\x. (X x - a) pow 2) =
+              expectation p (\x. (Y x - a) pow 2)’ >- rw []
+ >> Q.X_GEN_TAC ‘a’
+ >> MATCH_MP_TAC expectation_cong >> rw []
+QED
+
+(* An easy corollary of Minkowski_inequality *)
 Theorem finite_second_moments_add :
     !p X Y. prob_space p /\
             real_random_variable X p /\ real_random_variable Y p /\
@@ -2666,21 +2689,9 @@ Proof
  >> fs [real_random_variable, p_space_def, events_def]
  >> Suff ‘(\x. X x + Y x) IN L2_space p’
  >- rw [L2_space_alt_integrable_square]
- (* applying Minkowski_inequality *)
  >> MP_TAC (Q.SPECL [‘2’, ‘p’, ‘X’, ‘Y’] Minkowski_inequality)
  >> ‘1 <= (2 :extreal)’ by rw [extreal_of_num_def, extreal_le_eq]
  >> rw [L2_space_alt_integrable_square]
-QED
-
-Theorem finite_second_moments_cong :
-    !p X Y. prob_space p /\ (!x. x IN p_space p ==> X x = Y x) ==>
-           (finite_second_moments p X <=> finite_second_moments p Y)
-Proof
-    RW_TAC std_ss [finite_second_moments_def, second_moment_def, moment_def]
- >> Suff ‘!a. expectation p (\x. (X x - a) pow 2) =
-              expectation p (\x. (Y x - a) pow 2)’ >- rw []
- >> Q.X_GEN_TAC ‘a’
- >> MATCH_MP_TAC expectation_cong >> rw []
 QED
 
 Theorem finite_second_moments_sum :
@@ -2715,6 +2726,39 @@ Proof
       MATCH_MP_TAC real_random_variable_sum >> RW_TAC std_ss [],
       (* goal 3 (of 3) *)
       METIS_TAC [] ]
+QED
+
+Theorem finite_second_moments_sub :
+    !p X Y. prob_space p /\
+            real_random_variable X p /\ real_random_variable Y p /\
+            finite_second_moments p X /\ finite_second_moments p Y ==>
+            finite_second_moments p (\x. X x - Y x)
+Proof
+    rpt STRIP_TAC
+ >> Know ‘finite_second_moments p (\x. X x - Y x) <=>
+          finite_second_moments p (\x. X x + -Y x)’
+ >- (MATCH_MP_TAC finite_second_moments_cong >> rw [] \\
+     MATCH_MP_TAC extreal_sub_add >> METIS_TAC [real_random_variable])
+ >> Rewr'
+ >> HO_MATCH_MP_TAC finite_second_moments_add >> rw []
+ >| [ (* goal 1 (of 2) *)
+      MATCH_MP_TAC real_random_variable_ainv >> art [],
+      (* goal 2 (of 2) *)
+      MATCH_MP_TAC finite_second_moments_ainv >> art [] ]
+QED
+
+(* An easy corollary of Cauchy_Schwarz_inequality *)
+Theorem finite_second_moments_imp_integrable_mul :
+    !p X Y. prob_space p /\
+            real_random_variable X p /\ real_random_variable Y p /\
+            finite_second_moments p X /\ finite_second_moments p Y ==>
+            integrable p (\x. X x * Y x)
+Proof
+    rpt STRIP_TAC
+ >> rfs [finite_second_moments_eq_integrable_square, prob_space_def]
+ >> fs [real_random_variable, p_space_def, events_def]
+ >> MP_TAC (Q.SPECL [‘p’, ‘X’, ‘Y’] Cauchy_Schwarz_inequality)
+ >> rw [L2_space_alt_integrable_square]
 QED
 
 Theorem expectation_real_affine :


### PR DESCRIPTION
Hi,

the main purpose of this PR is to fix those leftovers in #1006, where the following extreal lemmas should be put into automatic simplifier `[simp]`:
```
        EXTREAL_SUM_IMAGE_EMPTY
        extreal_le_simp(s)
        extreal_lt_simp(s)
        extreal_0_simp(s)
        extreal_1_simp(s)
```
but several largest proofs will be broken (once `[simp]` were added), either because some proof branches now disappeared, or tactics like `rw [GSYM extreal_le_eq]` now causes loops.  But I found all these broken proofs easy to fix, just I have to replay these long proofs to find the broken places.

The following example (retrieved from the proof of `borelTheory.Borel_def`) shows why automatically simplify `Normal x <= Normal y` to `x <= y` sometimes is not good. Consider the following proof state (note that here the goal is *above* the dash line):
```
        a ≤ real y
   ------------------------------------
    8.  y ≠ +∞
    9.  y ≠ −∞
   10.  Normal a ≤ y
```
The proof is the following steps
```
1.   REWRITE_TAC [GSYM extreal_le_eq] \\
2.   Suff ‘Normal (real y) = y’ >- ˙ \\
3.   MATCH_MP_TAC normal_real >> ASM_REWRITE_TAC []
```
First step, the goal is rewritten to `Normal a ≤ Normal (real y)`, then if one can prove that `Normal (real y) = y` (by `normal_real`, easy), the goal will match the assumption 10 and the proof completes.  At the beginning of the 2nd step, right after `hurdUtils.Suff` (= `Q_TAC SUFF_TAC`, we have:
```
        Normal (real y) = y ⇒ Normal a ≤ Normal (real y)
   ------------------------------------
    8.  y ≠ +∞
    9.  y ≠ −∞
   10.  Normal a ≤ y
```
Previously the proof uses `rw []` (instead of `RW_TAC std_ss []` now) to simply complete the proof, but now unfortunately `rw []` will first rewrite `Normal a ≤ Normal (real y)` back to the initial goal `a ≤ real y`, causing the broken proof.   I would say this is a *mistake* of previous (broken) proofs, because using `rw []` here, although literally very short, is actually a waste.

In the `extrealSimps` structure (newly added in #1006 but contents are disabled), I have re-enabled (and renamed)  `extreal_SS` which contains `["extreal_le_simps", "extreal_lt_simps", "extreal_0_simps", "extreal_1_simps"]`. I think we can add some selftests in the future. Currently it's not used anywhere but I think this structure can be a good place for other non-trivial extreal simplification or decision procedure in the future.   Note that the simplification of extreal expressions is harder than the case of reals, because of 1) unspecific arithmetics of infinities, 2) unspecific devision-by-zero. In particular, AC (`add_comm` and `add_assoc`) do not hold without further antecedents.  (I found `examples/pgcl/src/posrealTools.sml` a good start to work on.)

Besides, I have renamed a few theorems added in #1006, or renamed their quantifiers, or removed some unnecessary antecedents. In particular, the direct reason that `large_numberTheory` were broken currently, is that there are two `IN_MEASURABLE_BOREL_CONG` in `borelTheory`, i.e. the newly added one overrides the old one. Now I have changed the new one to `IN_MEASURABLE_BOREL_CONG'` (also with simplified statements).

## Other changes from ongoing work

In addition, some new properties about `finite_second_moments` are added in `probabilityTheory`, with supporting lemmas in dependent theories.

Also, previously the theorem `integrable_mul_indicator` has two many unnecessary antecedents. By using new proof methods, now `measure m s < +∞` and `(∀x. x ∈ m_space m ⇒ f x ≠ −∞ ∧ f x ≠ +∞)` are all unnecessary. 
```
    [integrable_mul_indicator]  Theorem      
      ⊢ ∀m s f.
          measure_space m ∧ s ∈ measurable_sets m ∧ measure m s < +∞ ∧
          (∀x. x ∈ m_space m ⇒ f x ≠ −∞ ∧ f x ≠ +∞) ∧ integrable m f ⇒
          integrable m (λx. f x * 𝟙 s x)
```
Since this theorem is only used in a few large proofs in examples. I directly removed these antecedents and then simplified the related proofs in `large_numberTheory`.