### PR TITLE
Add modal tableaux KT and S4

### DIFF
--- a/examples/logic/modal-tableaux/tableauKScript.sml
+++ b/examples/logic/modal-tableaux/tableauKScript.sml
@@ -439,6 +439,7 @@ Proof
   simp[sat_def] >> metis_tac[tableau_complete]
 QED
 
+(*
 Theorem PERM_leading_contradiction:
   PERM Γ₁ Γ₂ ⇒ (contradiction Γ₁ = NONE ⇔ contradiction Γ₂ = NONE)
 Proof
@@ -808,5 +809,6 @@ strip_tacrw[]recInduct_on ‘PERM’ >> simp[] >> rw[]
                 simp[contradiction_EQ_NONE] >>
                 metis_tac[PERM_MEM_EQ]) >>
           simp[] >>
+*)
 *)
 val _ = export_theory();

--- a/examples/logic/modal-tableaux/tableauKScript.sml
+++ b/examples/logic/modal-tableaux/tableauKScript.sml
@@ -7,9 +7,9 @@
 *)
 
 open HolKernel Parse boolLib bossLib;
-
-open pairTheory pred_setTheory listTheory
-open sortingTheory
+open pairTheory pred_setTheory listTheory;
+open sortingTheory;
+open relationTheory mp_then;
 val _ = new_theory "tableauK";
 
 Datatype: form = Var num | NVar num | Conj form form | Disj form form
@@ -19,6 +19,10 @@ val _ = export_rewrites ["form_size_def"]
 
 Datatype: model = <| rel : α -> α -> bool ; valt : α -> num -> bool ;
                      worlds : α set |>
+End
+
+Definition reflexive_M:
+  reflexive_M m ⇔ ∀w. w ∈ m.worlds ⇒ m.rel w w
 End
 
 Definition forces_def[simp]:
@@ -411,7 +415,7 @@ Proof
   simp[Once tableau_def] >> simp[AllCaseEqs()] >> rw[] >>
   fs[MEM_MAP, PULL_EXISTS, MEM_undia, MEM_unbox]
   >- ((* K rule *)
-      rw[] >> fs[RIGHT_AND_OVER_OR, EXISTS_OR_THM] >>
+      rw[] >>
       first_x_assum (drule_then (drule_then assume_tac)) >>
       rename [‘MEM (Dia d) Γ’] >>
       reverse (Cases_on ‘forces M w (Dia d)’) >- metis_tac[] >>

--- a/examples/logic/modal-tableaux/tableauKTScript.sml
+++ b/examples/logic/modal-tableaux/tableauKTScript.sml
@@ -1,0 +1,759 @@
+(* See:
+
+     Wu and Goré, "Verified Decision Procedures for Modal Logics", ITP 2019
+
+   for inspiration
+
+*)
+
+open HolKernel Parse boolLib bossLib;
+
+open pairTheory pred_setTheory listTheory relationTheory;
+open mp_then;
+open tableauKTheory;
+
+val _ = new_theory "tableauKT";
+
+Definition trule_def[simp]:
+  trule Σ (Box f :: rest) = (Box f::Σ, f::rest) ∧
+  trule Σ (f :: rest) = ((\x. x) ## CONS f) (trule Σ rest) ∧
+  trule Σ [] = (Σ, [])
+End
+
+Definition is_boxed_def[simp]:
+  (is_boxed (Box _) ⇔ T) ∧ (is_boxed _ ⇔ F)
+End
+
+Definition is_dia_def[simp]:
+  (is_dia (Dia _) ⇔ T) ∧ (is_dia _ ⇔ F)
+End
+
+Definition scmap2_def[simp]:
+  scmap2 f _ [] = SOME [] ∧
+  scmap2 f Σ (h :: t) =
+    case f Σ h of
+       NONE => NONE
+     | SOME fsh => OPTION_MAP (CONS fsh) (scmap2 f Σ t)
+End
+
+Definition modal_size_def[simp]:
+  modal_size (Var a) = 0 ∧
+  modal_size (Box a) = 1 + modal_size a ∧
+  modal_size (Dia a) = 1 + modal_size a ∧
+  modal_size (NVar a) = 0 ∧
+  modal_size (Conj a0 a1) = modal_size a0 + modal_size a1 ∧
+  modal_size (Disj a0 a1) = modal_size a0 + modal_size a1
+End
+
+Definition max_list_def[simp]:
+  max_list []     = 0 ∧
+  max_list (h::t) = MAX h (max_list t)
+End
+
+Definition degree_def[simp]:
+  degree ([],[])    = 0 ∧
+  degree (s::Σ, Γ) = MAX (modal_size s) (degree (Σ, Γ)) ∧
+  degree (Σ, g::Γ) = MAX (modal_size g) (degree (Σ, Γ))
+End
+
+Definition unbox_single_def[simp]:
+  unbox_single (Box f) = f ∧
+  unbox_single p = p
+End
+
+Theorem trule_all_unboxed[simp]:
+  EVERY ($¬ ∘ is_boxed) Γ ⇒ trule Σ Γ = (Σ, Γ)
+Proof
+  Induct_on `Γ` >> rw[] >> Cases_on`h` >> fs[]
+QED
+
+
+(* Formulae from the history remains in the history after trule *)
+Theorem trule_mem_left:
+  ∀f l r. MEM f l ⇒ MEM f (FST (trule l r))
+Proof
+  Induct_on `r` >> rw[]
+  >> first_x_assum drule
+  >> rw[]
+  >> Cases_on `h` >> rw[]
+QED
+
+(* Formulae from the formulae set either goes into history or stay in the set *)
+Theorem trule_mem_right_simp[simp]:
+∀f l r. MEM f r ⇒ MEM f (FST (trule l r)) ∨ MEM f (SND (trule l r))
+Proof
+ Induct_on `r` >> Cases_on `f` >> simp[] >> fs[]
+  >> Cases_on `h` >> simp[] >> metis_tac[]
+QED
+
+
+(* in the right -> either stays in the right or moved to left with trule *)
+Theorem trule_mem_right:
+  ∀f l r. MEM f r ⇒
+          is_boxed f ∧
+            MEM f (FST (trule l r)) ∧
+              MEM (HD (unbox [f])) (SND (trule l r)) ∨
+          MEM f (SND (trule l r))
+Proof
+  Induct_on `r` >> Cases_on `f` >> simp[] >> fs[] >>
+  rw[OR_INTRO_THM2] >> rw[] >>
+  Cases_on `h` >> simp[] >> first_x_assum drule >> rw[] >>
+  metis_tac[OR_INTRO_THM1]
+QED
+
+
+(* Formulae that ends up in the hisotry after trule are either
+    1. from the history at the beginning or
+    2. is from the formulae set and is boxed*)
+Theorem trule_mem_left_rev:
+   ∀f l r. MEM f (FST (trule l r)) ⇒ MEM f l ∨ is_boxed f ∧ MEM f r
+Proof
+  Induct_on `r` >> rw[] >>
+  Cases_on `f` >> simp[] >> fs[] >>
+  Cases_on `h` >> simp[] >> fs[] >> first_x_assum drule >>
+  rw[] >> metis_tac[]
+QED
+
+(* If all formulae in the history are boxed then
+   all formulae in the history after trule are still all boxed *)
+Theorem trule_all_box:
+  ∀f l r. (∀p. MEM p l ⇒ is_boxed p) ⇒
+          MEM f (FST (trule l r)) ⇒
+          is_boxed f
+Proof
+  Induct_on `r` >> rw[] >>
+  Cases_on `f` >> simp[] >> fs[]
+  >- (Cases_on `h` >> simp[] >> fs[] >>
+      first_x_assum drule >> rw[] >> qexists_tac `Var n` >> rw[])
+  >- (Cases_on `h` >> simp[] >> fs[] >>
+      first_x_assum drule >> rw[] >> qexists_tac `NVar n` >> rw[])
+  >- (Cases_on `h` >> simp[] >> fs[] >>
+      first_x_assum drule >> rw[] >> qexists_tac `Conj f' f0` >> rw[])
+  >- (Cases_on `h` >> simp[] >> fs[] >>
+      first_x_assum drule >> rw[] >> qexists_tac `Disj f' f0` >> rw[])
+  >- (Cases_on `h` >> simp[] >> fs[] >>
+      first_x_assum drule >> rw[] >> qexists_tac `Dia f'` >> rw[])
+QED
+
+Theorem trule_result:
+∀Sg p f s.
+  (EVERY ($¬ ∘ is_boxed) p) ⇒
+  (trule Sg (p ++ [Box f] ++ s) = ((Box f)::Sg, p ++ [f] ++ s))
+Proof
+  ho_match_mp_tac trule_ind >> fs[] >> rw[]
+QED
+
+Theorem unbox_trule_left:
+  ∀l r f. MEM f (unbox l) ⇒ MEM f (unbox (FST (trule l r)))
+Proof
+  ho_match_mp_tac trule_ind >> rw[]
+QED
+
+Theorem scmap2_empt[simp]:
+  scmap2 f s [] = SOME []
+Proof
+  rw[]
+QED
+
+Theorem scmap2_CONG[defncong]:
+  ∀l1 l1' l2 l2' f1 f2.
+     (l1 = l1') ∧ (l2 = l2') ∧ (∀e l.l = l1 ∧ MEM e l2' ⇒ f1 l e = f2 l e)
+     ⇒ (scmap2 f1 l1 l2 = scmap2 f2 l1' l2')
+Proof
+  rw[] >> Induct_on ‘l2’ >> rw[]
+QED
+
+Theorem scmap2_MEM:
+  ∀l0 l e f S. scmap2 f S l0 = SOME l ∧ MEM e l ⇒ ∃e0. MEM e0 l0 ∧ f S e0 = SOME e
+Proof
+  Induct >> dsimp[AllCaseEqs()]
+QED
+
+Theorem scmap2_MEM2:
+  ∀l0 l e0 f S. scmap2 f S l0 = SOME l ∧ MEM e0 l0 ⇒ ∃e. MEM e l ∧ f S e0 = SOME e
+Proof
+  Induct >> dsimp[AllCaseEqs()]
+QED
+
+Theorem scmap2_EQ_NONE[simp]:
+  ∀l f. scmap2 f s l = NONE ⇔ ∃e. MEM e l ∧ f s e = NONE
+Proof
+  Induct >> dsimp[AllCaseEqs()] >> metis_tac[TypeBase.nchotomy_of “:α option”]
+QED
+
+Theorem max_2_lists[simp]:
+  ∀l1 l2. max_list (l1++l2) = MAX (max_list l1) (max_list l2)
+Proof
+  Induct_on`l1` >> simp[] >> Induct_on`l2` >> simp[]
+  >> rw[] >> simp[arithmeticTheory.MAX_ASSOC]
+QED
+
+Theorem max_list_diff[simp]:
+  ∀l1 l2 l3. (max_list l2 < max_list l3) ⇒ max_list (l1++l2) <= max_list (l1++l3)
+Proof
+  rw[]
+QED
+
+
+Theorem degree_thm[simp]:
+  degree (Σ, g::Γ) = MAX (modal_size g) (degree (Σ, Γ))
+Proof
+  Induct_on`Σ` >> simp[AC arithmeticTheory.MAX_COMM arithmeticTheory.MAX_ASSOC]
+QED
+
+Theorem degree_max_list:
+∀Σ Γ.  degree (Σ, Γ) = max_list (MAP modal_size (Σ++Γ))
+Proof
+  Induct_on`Σ` >> Induct_on`Γ` >> simp[]
+QED
+
+Theorem degree_trule[simp]:
+  ∀Σ Γ. degree (trule Σ Γ) = degree (Σ, Γ)
+Proof
+  Induct_on`Γ` >> simp[]
+  >> Cases_on `h`>> rw[] >> Cases_on`trule Σ Γ` >> simp[]
+  >- metis_tac[]
+  >- metis_tac[]
+  >- metis_tac[]
+  >- metis_tac[]
+  >- (simp[arithmeticTheory.MAX_DEF] >> metis_tac[])
+  >> metis_tac[]
+QED
+
+Theorem not_not_f[simp]:
+  $¬ o $¬ o f = f
+Proof
+  simp[FUN_EQ_THM]
+QED
+
+Theorem trule_length:
+  ∀Σ Γ. EXISTS is_boxed Γ ⇒
+        degree (trule Σ Γ) = degree (Σ,Γ) ∧
+        gsize (SND (trule Σ Γ)) < gsize Γ
+Proof
+  rw[] >>
+  Induct_on `Γ`
+  >- simp[]
+  >> rw[]
+  >> Cases_on `h` >> fs[]
+QED
+
+Theorem degree_inv[simp]:
+∀Σ Γ Σ' Γ'. (Σ = Σ') ∧ ((max_list $ MAP modal_size Γ) < (max_list $ MAP modal_size Γ'))
+            ⇒ degree (Σ, Γ) <= degree (Σ', Γ')
+Proof
+  rw[degree_max_list]
+QED
+
+Theorem conjsplit_degree:
+  ∀Σ Γ Γ'. conjsplit Γ = SOME Γ' ⇒
+           degree (Σ,Γ') < degree (Σ,Γ) ∨
+           degree (Σ,Γ') = degree (Σ,Γ) ∧ gsize Γ' < gsize Γ
+Proof
+  Induct_on `Γ` >> simp[] >> Cases_on `h` >> rw[] >> fs[] (*  *)
+  >- simp[arithmeticTheory.MAX_DEF]
+  >> first_x_assum (qspec_then `Σ` assume_tac) >> drule conjsplit_size
+  >> simp[arithmeticTheory.MAX_DEF]
+QED
+
+Theorem disjsplit_degree_p1:
+  ∀Σ Γ p1 p2. disjsplit Γ = SOME (p1, p2) ⇒
+           degree (Σ,p1) < degree (Σ,Γ) ∨
+           degree (Σ,p1) = degree (Σ,Γ) ∧ gsize p1 < gsize Γ
+Proof
+  Induct_on `Γ` >> simp[] >> Cases_on `h` >> rw[] >>
+  fs[pairTheory.PAIR_MAP, pairTheory.PAIR_FST_SND_EQ, pairTheory.PAIR]
+  >- (first_x_assum (qspec_then `Σ` assume_tac) >>
+      `disjsplit Γ = SOME (FST z,SND z)` by fs[] >>
+      drule disjsplit_size >> simp[arithmeticTheory.MAX_DEF])
+  >- (Cases_on `0 < modal_size f0` >> simp[] >>
+      fs[arithmeticTheory.NOT_LESS, arithmeticTheory.MAX_DEF])
+  >> first_x_assum (qspec_then `Σ` assume_tac) >>
+  `disjsplit Γ = SOME (FST z,SND z)` by fs[] >>
+  drule disjsplit_size >> simp[arithmeticTheory.MAX_DEF]
+QED
+
+Theorem disjsplit_degree_p2:
+  ∀Σ Γ p1 p2. disjsplit Γ = SOME (p1, p2) ⇒
+           degree (Σ,p2) < degree (Σ,Γ) ∨
+           degree (Σ,p2) = degree (Σ,Γ) ∧ gsize p2 < gsize Γ
+Proof
+  Induct_on `Γ` >> simp[] >> Cases_on `h` >> rw[] >>
+  fs[pairTheory.PAIR_MAP, pairTheory.PAIR_FST_SND_EQ, pairTheory.PAIR]
+  >- (first_x_assum (qspec_then `Σ` assume_tac) >>
+      `disjsplit Γ = SOME (FST z,SND z)` by fs[] >>
+      drule disjsplit_size >> simp[arithmeticTheory.MAX_DEF])
+  >- (Cases_on `0 < modal_size f0` >> simp[] >>
+      fs[arithmeticTheory.NOT_LESS, arithmeticTheory.MAX_DEF])
+  >> first_x_assum (qspec_then `Σ` assume_tac) >>
+  `disjsplit Γ = SOME (FST z,SND z)` by fs[] >>
+  drule disjsplit_size >> simp[arithmeticTheory.MAX_DEF]
+QED
+
+Theorem KT_K_degree:
+  ∀a Γ Σ. MEM a (MAP (λd. d :: unbox Σ) (undia Γ)) ⇒
+          degree([],a) < degree(Σ, Γ)
+Proof
+  Induct_on ‘Γ’ >> simp[undia_def, unbox_def] >> Cases >>
+  simp[undia_def, unbox_def] >> rw[]
+  >- (Induct_on `Σ` >> rw[unbox_def] >> Cases_on`h` >> simp[])
+  >> Cases_on`a` >> simp[]
+QED
+
+Definition tableau_KT_def:
+  tableau_KT Σ Γ =
+    case contradiction Γ of
+      SOME i => NONE
+    | NONE =>
+        case conjsplit Γ of
+          SOME Γ' => tableau_KT Σ Γ'
+        | NONE => case disjsplit Γ of
+                    SOME (Γ1, Γ2) =>
+                        (case tableau_KT Σ Γ1 of
+                            SOME m => SOME m
+                          | NONE =>
+                            case tableau_KT Σ Γ2 of SOME m => SOME m | NONE => NONE)
+                  | NONE => if EXISTS is_boxed Γ then tableau_KT (FST (trule Σ Γ)) (SND (trule Σ Γ))
+                            else  if EXISTS is_dia Γ then
+                                    let
+                                      children = scmap2 tableau_KT [] (MAP (λd. d :: (unbox Σ))
+                                                                      (undia Γ))
+                                    in
+                                      case children of
+                                          SOME ms => SOME (Nd (unvar Γ) ms)
+                                        | NONE => NONE
+                                  else SOME (Nd (unvar Γ) [])
+Termination
+  WF_REL_TAC `(inv_image ((<) LEX (<)) (λ(Σ,Γ). (degree (Σ,Γ), SUM $ MAP form_size Γ)))`
+  >> rw[]
+  >- rw[KT_K_degree]
+  >- rw[conjsplit_degree]
+  >- rw[disjsplit_degree_p2]
+  >- rw[disjsplit_degree_p1]
+  >> metis_tac[trule_length]
+End
+
+(*
+Definition tableau_KT_root_def:
+  tableau_KT_root Γ = tableau_KT [] Γ
+End
+*)
+
+val f1 = ``Disj (NVar 0) (Dia (Var 0))``
+val KT_test_1 = EVAL ``tableau_KT [] [^f1]``
+val f2 = ``Conj (NVar 0) (Dia (Var 0))``
+val KT_test_2 = EVAL ``tableau_KT [] [^f2]``
+val f3 = ``Conj (Var 1) (Box (NVar 1))``
+val KT_test_3 = EVAL ``tableau_KT [] [^f3]``
+val test = EVAL``tableau_KT [Box (Var 2); Box (NVar 2)] [Var 1]``;
+
+Theorem mem_snd_trule:
+ ∀Σ Γ. MEM f (SND (trule Σ Γ)) ⇒ MEM f Γ ∨ MEM (Box f) Γ
+Proof
+  ho_match_mp_tac trule_ind >> rw[] >> fs[]
+QED
+
+Theorem mem_fst_trule:
+ ∀Σ Γ. MEM f (FST (trule Σ Γ)) ⇒ MEM f Σ ∨ MEM f Γ
+Proof
+  ho_match_mp_tac trule_ind >> rw[] >> fs[]
+QED
+
+Definition dia_decos_def:
+  dia_decos (Dia d) = d ∧
+  dia_decos p = p
+End
+
+Theorem dia_decos_dia[simp]:
+ ∀p. is_dia p ⇒ Dia (dia_decos p) = p
+Proof
+ rw[] >> Cases_on `p` >> fs[is_dia_def] >>
+ metis_tac[dia_decos_def]
+QED
+
+Theorem exist_dia[simp]:
+ ∀Γ. EXISTS is_dia Γ ⇒ ∃f. MEM f Γ ∧ is_dia f
+Proof
+  rw[] >> Induct_on `Γ` >> rw[]
+  >- (qexists_tac `h` >> rw[])
+  >> fs[] >> qexists_tac`f` >> rw[]
+QED
+
+Theorem tableau_KT_complete:
+  ∀Σ Γ. tableau_KT Σ Γ = NONE ⇒ ∀M w. w ∈ M.worlds ∧ reflexive_M M ⇒ ∃f. MEM f (Γ++Σ) ∧ ¬forces M w f
+Proof
+  ho_match_mp_tac tableau_KT_ind >> ntac 2 gen_tac >> strip_tac >>
+  simp[Once tableau_KT_def] >> simp[AllCaseEqs()] >> rw[] >>
+  fs[MEM_MAP, PULL_EXISTS, MEM_undia, MEM_unbox]
+  >- ((* T rule *)
+      rw[] >> `∃f.
+                (MEM f (SND (trule Σ Γ)) ∨ MEM f (FST (trule Σ Γ))) ∧
+                ¬forces M w f` by fs[] >> simp[]
+      >- (drule mem_snd_trule >> rw[]
+          >- metis_tac[]
+          >> qexists_tac `Box f` >> fs[reflexive_M] >> metis_tac[])
+      >> drule mem_fst_trule >> rw[]
+      >- metis_tac[]
+      >> qexists_tac `f` >> rw[])
+  >- ((* K rule *)
+      rw[] >> first_x_assum (drule_then (drule_then strip_assume_tac)) >>
+      reverse (Cases_on ‘forces M w (Dia d)’)
+      >- metis_tac[]
+      >> fs[] >> `∃f. MEM (Box f) Σ ∧ ¬forces M v f` by metis_tac[] >>
+       qexists_tac ‘Box f’ >> simp[] >> metis_tac[])
+  >- (rpt (first_x_assum (drule_then strip_assume_tac))
+      >- (drule_all disjsplit_MEM2 >> metis_tac[forces_def])
+      >> metis_tac[])
+  >- (first_x_assum (drule_then (drule_then strip_assume_tac))
+      >- (drule_all conjsplit_MEM2 >> metis_tac[forces_def])
+      >> metis_tac[])
+  >> (rename [‘contradiction Γ = SOME j’] >>
+      drule_then strip_assume_tac contradiction_EQ_SOME >>
+      Cases_on ‘M.valt w j’
+      >- (qexists_tac ‘NVar j’ >> simp[]) >>
+      qexists_tac ‘Var j’ >> simp[])
+QED
+
+Definition T_tree_model_def:
+  T_tree_model t =
+    <| rel := RC tree_rel ;
+       valt := λt v. case t of Nd vs _ => MEM v vs ;
+       worlds := { t' | RTC tree_rel t t' }
+    |>
+End
+
+Theorem T_tree_model_thm[simp]:
+  ((T_tree_model t).valt = λu v. case u of Nd vs _ => MEM v vs) ∧
+  (T_tree_model t).rel = RC tree_rel ∧
+  m ∈ (T_tree_model m).worlds
+Proof
+  simp[T_tree_model_def]
+QED
+
+Definition subtree_def:
+  subtree t1 t2 ⇔ tree_rel^* t2 t1
+End
+
+Theorem FINITE_T_tree_model_worlds[simp]:
+  ∀t. FINITE (T_tree_model t).worlds
+Proof
+  simp[T_tree_model_def] >> Induct >> simp[tree_rel_def] >>
+  simp[Once relationTheory.RTC_CASES1] >> simp[GSPEC_OR, tree_rel_def] >>
+  qmatch_abbrev_tac ‘FINITE s’ >>
+  ‘s = BIGUNION (IMAGE (λt. { u | RTC tree_rel t u }) (set ts))’
+    by (simp[Abbr‘s’, Once EXTENSION, PULL_EXISTS] >> metis_tac[]) >>
+  simp[PULL_EXISTS]
+QED
+
+Theorem scmap2_MAP:
+  scmap2 f l1 (MAP g l2) = scmap2 (λx y. f x (g y)) l1 l2
+Proof
+  Induct_on `l2` >> rw[]
+QED
+
+Definition reflexive_sequent_def:
+  reflexive_sequent (Σ,Γ) ⇔
+  ∀𝜑 v l. MEM (Box 𝜑) Σ ⇒
+          (∀f. MEM f Γ ⇒
+                  forces (T_tree_model (Nd v l)) (Nd v l) f) ∧
+          (∀s. MEM s l ⇒
+                (∀𝜓. MEM (Box 𝜓) Σ ⇒ forces (T_tree_model s) s 𝜓))
+  ⇒
+  forces (T_tree_model (Nd v l)) (Nd v l) 𝜑
+End
+
+Theorem reflexive_sequent_trule1:
+  reflexive_sequent (Σ, Box f::Γ) ⇒ reflexive_sequent (Box f::Σ, f::Γ)
+Proof
+  dsimp[reflexive_sequent_def, DISJ_IMP_THM, FORALL_AND_THM, RC_DEF,
+       tree_rel_def] >> rw[] >>
+  last_x_assum irule >> rw[] >>
+  irule forces_grows_backward >>
+  rename [‘forces _ wld f’, ‘MEM wld l’] >>
+  qexists_tac ‘T_tree_model wld’ >> simp[] >>
+  dsimp[T_tree_model_def, SUBSET_DEF, RC_DEF] >>
+  conj_tac >- metis_tac[RTC_RULES_RIGHT1] >>
+  rw[] >> irule (RTC_RULES |> SPEC_ALL |> CONJUNCT2) >> simp[tree_rel_def] >>
+  metis_tac[]
+QED
+
+Theorem reflexive_small_Gamma:
+  reflexive_sequent (Σ, Γ) ⇒ reflexive_sequent (Σ, f::Γ)
+Proof
+  rw[reflexive_sequent_def, DISJ_IMP_THM, FORALL_AND_THM]
+QED
+
+Theorem exists_split_first:
+  EXISTS P lst ⇒ ∃p s e. lst = p ++ [e] ++ s ∧ P e ∧ EVERY ($¬ o P) p
+Proof
+  Induct_on `lst` >> simp[] >> rw[]
+  >- (qexistsl_tac [`[]`, `lst`, `h`] >> simp[])
+  >> fs[] >> Cases_on `P h` >> simp[]
+  >- (qexistsl_tac [`[]`, `lst`, `h`] >> simp[])
+  >> qexistsl_tac [`h::p`, `s`, `e`] >> simp[]
+QED
+
+Theorem reflexive_sequent_trule:
+∀Σ Γ. reflexive_sequent (Σ,Γ) ⇒ reflexive_sequent (trule Σ Γ)
+Proof
+  rw[] >> Cases_on `EVERY ($¬ ∘ is_boxed) Γ` >> simp[] >>
+  `EXISTS is_boxed Γ` by metis_tac[EXISTS_NOT_EVERY] >>
+  `∃p f s. Γ = (p ++ [Box f] ++ s) ∧ EVERY ($¬ ∘ is_boxed) p`
+    by (drule exists_split_first >> rw[] >>
+        qexistsl_tac [`p`,`unbox_single e`, `s`] >> rw[] >>
+        Cases_on`e` >> fs[]) >>
+  rw[trule_result] >>
+  dsimp[reflexive_sequent_def, DISJ_IMP_THM, FORALL_AND_THM, RC_DEF,
+     tree_rel_def] >> rw[] >>
+  fs[reflexive_sequent_def, DISJ_IMP_THM, FORALL_AND_THM, RC_DEF,
+     tree_rel_def] >> rw[] >>
+  last_x_assum irule >> rw[] >> simp[] >>
+  irule forces_grows_backward >>
+  rename [‘forces _ wld f’, ‘MEM wld l’] >>
+  qexists_tac ‘T_tree_model wld’ >> simp[] >>
+  dsimp[T_tree_model_def, SUBSET_DEF, RC_DEF] >>
+  conj_tac >- metis_tac[RTC_RULES_RIGHT1] >>
+  rw[] >> irule (RTC_RULES |> SPEC_ALL |> CONJUNCT2) >> simp[tree_rel_def] >>
+  metis_tac[]
+QED
+
+Theorem forces_single_step_back:
+  forces (T_tree_model w) w f ∧ MEM w ws
+⇒
+  forces (T_tree_model (Nd root ws)) w f
+Proof
+  rw[] >> irule forces_grows_backward >> qexists_tac `T_tree_model w` >> rw[]
+  >- (fs[T_tree_model_def, tree_rel_def, RC_DEF]
+      >- metis_tac[]
+      >> rw[] >> metis_tac[RTC_RULES_RIGHT1, tree_rel_def])
+  >> rw[T_tree_model_def, SUBSET_DEF] >> metis_tac[tree_rel_def, RTC_RULES]
+QED
+
+Theorem forces_every_literal:
+  contradiction Γ = NONE ∧
+  conjsplit Γ = NONE ∧
+  disjsplit Γ = NONE ∧
+  EVERY ($¬ ∘ is_boxed) Γ ∧
+  EVERY ($¬ ∘ is_dia) Γ
+⇒
+  ∀f. MEM f Γ ⇒ forces (T_tree_model  (Nd (unvar Γ) []))  (Nd (unvar Γ) []) f
+Proof
+  rw[] >>
+  fs[EVERY_MEM, conjsplit_EQ_NONE, disjsplit_EQ_NONE, contradiction_EQ_NONE] >>
+  first_x_assum (drule_then assume_tac) >>
+  first_x_assum (drule_then assume_tac) >>
+  Cases_on ‘f’ >> fs[] >>
+  metis_tac[]
+QED
+
+Theorem reflexive_sequent_disj_right:
+  contradiction Γ = NONE ∧
+  conjsplit Γ = NONE ∧
+  disjsplit Γ = SOME (Γ1,Γ2) ∧
+  tableau_KT Σ Γ1 = NONE ∧
+  tableau_KT Σ Γ2 = SOME t ∧
+  reflexive_sequent (Σ,Γ)
+⇒
+  reflexive_sequent (Σ,Γ2)
+Proof
+  rw[reflexive_sequent_def] >> first_x_assum (drule_then strip_assume_tac) >>
+  `∀f. MEM f Γ ⇒ forces (T_tree_model (Nd v l)) (Nd v l) f`
+    by (rw[] >> drule_then assume_tac MEM_disjsplit >>
+        first_x_assum (drule_then strip_assume_tac)
+        >- (first_x_assum (drule_then assume_tac) >> rw[forces_def])
+        >> first_x_assum (drule_then assume_tac) >> rw[]) >>
+  fs[]
+QED
+
+Theorem reflexive_sequent_disj_left:
+  contradiction Γ = NONE ∧
+  conjsplit Γ = NONE ∧
+  disjsplit Γ = SOME (Γ1,Γ2) ∧
+  tableau_KT Σ Γ1 = SOME t ∧
+  reflexive_sequent (Σ,Γ)
+⇒
+  reflexive_sequent (Σ,Γ1)
+Proof
+  rw[reflexive_sequent_def] >> first_x_assum (drule_then strip_assume_tac) >>
+  `∀f. MEM f Γ ⇒ forces (T_tree_model (Nd v l)) (Nd v l) f`
+    by (rw[] >> drule_then assume_tac MEM_disjsplit >>
+        first_x_assum (drule_then strip_assume_tac)
+        >- (first_x_assum (drule_then assume_tac) >> rw[forces_def])
+        >> first_x_assum (drule_then assume_tac) >> rw[]) >>
+  fs[]
+QED
+
+Theorem reflexive_sequent_conj:
+  contradiction Γ = NONE ∧
+  conjsplit Γ = SOME Γ' ∧
+  tableau_KT Σ Γ' = SOME t ∧
+  reflexive_sequent (Σ,Γ)
+⇒
+  reflexive_sequent (Σ,Γ')
+Proof
+  rw[reflexive_sequent_def] >> first_x_assum (drule_then strip_assume_tac) >>
+  `∀f. MEM f Γ ⇒ forces (T_tree_model (Nd v l)) (Nd v l) f`
+    by (rw[] >> drule_then assume_tac MEM_conjsplit >>
+        first_x_assum (drule_then strip_assume_tac)
+        >- (first_assum (drule_then assume_tac) >>
+            first_assum (drule_then assume_tac) >> rw[forces_def])
+        >> first_x_assum (drule_then assume_tac) >> rw[]) >>
+  fs[]
+QED
+
+(* TODO: wrap it: for all Σ Γ, if tableau_KT Σ Γ closes, then there must exist a tree model ... *)
+Theorem tableau_KT_sound:
+   ∀Σ Γ t. tableau_KT Σ Γ = SOME t ⇒
+            (∀f. MEM f Σ ⇒ is_boxed f) ⇒
+            reflexive_sequent (Σ,Γ) ⇒
+           ∀f. MEM f (Σ++Γ) ⇒
+           forces (T_tree_model t) t f
+Proof
+  ho_match_mp_tac tableau_KT_ind >> qx_genl_tac [‘Σ’, ‘Γ’] >> strip_tac >>
+  qx_gen_tac `t` >> simp[Once tableau_KT_def] >>
+  simp[AllCaseEqs()] >> strip_tac
+(* T rule *)
+  >- (fs[] >> strip_tac >> strip_tac >> drule_then assume_tac trule_all_box >>
+      `∀f. MEM f (FST (trule Σ Γ)) ⇒ is_boxed f` by metis_tac[] >>
+      first_x_assum (drule_then assume_tac) >> (* strip didn't do anything *)
+      simp[DISJ_IMP_THM, FORALL_AND_THM] >>
+      rw[]
+      >- (drule_then assume_tac trule_mem_left >>
+          drule_then assume_tac reflexive_sequent_trule >>
+          metis_tac[])
+      >> drule_then assume_tac trule_mem_right_simp >>
+         drule_then assume_tac reflexive_sequent_trule >>
+         metis_tac[])
+(* K rule *)
+  >- (fs[MEM_MAP, PULL_EXISTS] >>
+      qpat_x_assum `EXISTS _ _ ⇒ _` (fn _ => all_tac) >> (* removes assumption 1 *)
+      fs[reflexive_sequent_def, DISJ_IMP_THM, FORALL_AND_THM, RC_DEF,
+      tree_rel_def] >> rw[]
+      (* MEM f history *)
+      >- (first_assum (drule_then assume_tac) >> Cases_on `f` >> fs[] >>
+          rw[] >> fs[RC_DEF]
+          (* Current world *)
+          >- (rw[] >> first_x_assum irule >> rw[]
+             (* MEM f formulae (different f) *)
+              >- (Cases_on `f` >> fs[] >> rw[]
+                  >- (fs[contradiction_EQ_NONE] >> metis_tac[])
+                  >- (fs[conjsplit_EQ_NONE] >> metis_tac[])
+                  >- (fs[conjsplit_EQ_NONE] >> metis_tac[])
+                  >- (fs[disjsplit_EQ_NONE] >> metis_tac[])
+                  >- (fs[EVERY_MEM] >> last_x_assum drule >> rw[])
+                  >> fs[MEM_undia] >> last_x_assum (drule_then assume_tac) >>
+                  fs[scmap2_MAP] >> drule scmap2_MEM2 >> rw[] >>
+                  fs[MEM_undia] >>
+                  first_x_assum (drule_then (qx_choose_then `w` strip_assume_tac)) >>
+                  qexists_tac `w` >> rw[]
+                  >- (rw[T_tree_model_def] >> irule RTC_SINGLE >> simp[tree_rel_def])
+                  >- (rw[RC_DEF, tree_rel_def])
+                  >> first_x_assum (drule_then strip_assume_tac) >>
+                  metis_tac[forces_single_step_back])
+              (* MEM (Box psi) History *)
+              >> fs[scmap2_MAP] >> drule scmap2_MEM >> rw[] >> fs[MEM_undia] >>
+                 first_x_assum (drule_then strip_assume_tac) >>
+                 last_x_assum (drule_then strip_assume_tac) >>
+                 first_x_assum (drule_then strip_assume_tac) >>
+                 fs[MEM_unbox]
+              )
+          (* Next world *)
+          >> fs[tree_rel_def] >> fs[scmap2_MAP] >> drule scmap2_MEM >> rw[] >>
+          fs[MEM_undia] >> first_x_assum (drule_then strip_assume_tac) >>
+          last_x_assum (drule_then strip_assume_tac) >>
+          first_x_assum (drule_then strip_assume_tac) >>
+          fs[MEM_unbox] >> first_x_assum (drule_then assume_tac) >>
+          metis_tac[forces_single_step_back])
+      (* MEM f formulae*)
+      >> Cases_on `f` >> fs[]
+      >- (fs[contradiction_EQ_NONE] >> metis_tac[])
+      >- (fs[conjsplit_EQ_NONE] >> metis_tac[])
+      >- (fs[disjsplit_EQ_NONE] >> metis_tac[])
+      >- (fs[EVERY_MEM] >> last_x_assum drule >> rw[])
+      >> fs[MEM_undia] >> last_x_assum (drule_then assume_tac) >>
+      fs[scmap2_MAP] >> drule scmap2_MEM2 >> rw[] >> fs[MEM_undia] >>
+      first_x_assum (drule_then (qx_choose_then `w` strip_assume_tac)) >>
+      qexists_tac `w` >> rw[]
+      >- (rw[T_tree_model_def] >> irule RTC_SINGLE >> simp[tree_rel_def])
+      >- (rw[RC_DEF, tree_rel_def])
+      >> first_x_assum (drule_then strip_assume_tac) >>
+      metis_tac[forces_single_step_back])
+(* All Literals *)
+  >- (rw[]
+      >- (fs[reflexive_sequent_def, DISJ_IMP_THM, FORALL_AND_THM, RC_DEF,
+            tree_rel_def] >> rw[] >>
+          first_x_assum (drule_then strip_assume_tac) >> Cases_on `f` >>
+          fs[] >> first_x_assum (drule_then strip_assume_tac) >>
+          rw[] >> fs[tree_rel_def, RC_DEF] >> drule forces_every_literal >>
+          rw[])
+      >> drule forces_every_literal >> rw[])
+(* Disj right *)
+  >- (qpat_x_assum `∀Σ' Γ'.
+       _ ∧ _ ∧ _ ∧ ¬EXISTS is_boxed Γ ∧ EXISTS is_dia Γ ∧ _
+        ==> _ ` (fn _ => all_tac) >>
+      qpat_x_assum `∀Γ'.
+        _ ∧ conjsplit Γ = SOME Γ' ==> _ ` (fn _ => all_tac) >>
+      qpat_x_assum `∀Σ' Γ' Γ2. _ ` (fn _ => all_tac) >> rw[]
+      >- (last_x_assum (drule_then strip_assume_tac) >>
+          rfs[] >> drule_then strip_assume_tac reflexive_sequent_disj_right >>
+          rfs[])
+      >>  last_x_assum (drule_then strip_assume_tac) >>
+          rfs[] >> drule_then strip_assume_tac reflexive_sequent_disj_right >>
+          rfs[] >>  first_x_assum (drule_then strip_assume_tac) >>
+          first_x_assum (drule_then strip_assume_tac) >>
+          first_x_assum (drule_then strip_assume_tac) >>
+          drule_then assume_tac MEM_disjsplit >>
+          first_x_assum (drule_then strip_assume_tac)
+          >- (first_x_assum (drule_then strip_assume_tac) >>
+              fs[DISJ_IMP_THM])
+          >> fs[DISJ_IMP_THM, FORALL_AND_THM])
+(* Disj left *)
+  >- (qpat_x_assum `∀Σ' Γ'.
+       _ ∧ _ ∧ _ ∧ ¬EXISTS is_boxed Γ ∧ EXISTS is_dia Γ ∧ _
+         ==> _ ` (fn _ => all_tac) >>
+      qpat_x_assum `∀Γ'.
+        _ ∧ conjsplit Γ = SOME Γ' ==> _ ` (fn _ => all_tac) >>
+      qpat_x_assum `∀Σ' Γ1 Γ'. _ ∧ _ ∧ disjsplit Γ = SOME Σ' ∧
+        Σ' = (Γ1,Γ') ∧ tableau_KT Σ Γ1 = NONE ⇒ _ ` (fn _ => all_tac) >>
+      rw[]
+      >- (last_x_assum (drule_then strip_assume_tac) >>
+          rfs[] >> drule_then strip_assume_tac reflexive_sequent_disj_left >>
+          rfs[])
+      >>  last_x_assum (drule_then strip_assume_tac) >>
+          rfs[] >> drule_then strip_assume_tac reflexive_sequent_disj_left >>
+          rfs[] >>  first_x_assum (drule_then strip_assume_tac) >>
+          first_x_assum (drule_then strip_assume_tac) >>
+          first_x_assum (drule_then strip_assume_tac) >>
+          drule_then assume_tac MEM_disjsplit >>
+          first_x_assum (drule_then strip_assume_tac)
+          >- (first_x_assum (drule_then strip_assume_tac) >>
+              fs[DISJ_IMP_THM])
+          >> fs[DISJ_IMP_THM, FORALL_AND_THM])
+(* Conj *)
+  >> qpat_x_assum `∀Σ' Γ'.
+       _ ∧ _ ∧ _ ∧ ¬EXISTS is_boxed Γ ∧ EXISTS is_dia Γ ∧ _
+         ==> _ ` (fn _ => all_tac) >>
+  qpat_x_assum `∀Σ' Γ1 Γ'. _ ∧ _ ∧ disjsplit Γ = SOME Σ' ∧
+    Σ' = (Γ1,Γ') ∧ tableau_KT Σ Γ1 = NONE ⇒ _ ` (fn _ => all_tac) >>
+  qpat_x_assum `∀Σ' Γ' Γ2. _ ` (fn _ => all_tac) >> rw[]
+  >- (last_x_assum (drule_then strip_assume_tac) >> rfs[] >>
+      drule_then strip_assume_tac reflexive_sequent_conj >> rfs[])
+  >> last_x_assum (drule_then strip_assume_tac) >> rfs[] >>
+  drule_then strip_assume_tac reflexive_sequent_conj >> rfs[] >>
+  first_x_assum (drule_then strip_assume_tac) >>
+  first_x_assum (drule_then strip_assume_tac) >>
+  drule_then assume_tac MEM_conjsplit >>
+  first_x_assum (drule_then strip_assume_tac)
+  >- (first_x_assum (drule_then strip_assume_tac) >> fs[DISJ_IMP_THM])
+  >> fs[DISJ_IMP_THM, FORALL_AND_THM]
+QED
+
+
+(*
+TODO
+  1. Define a new language which has ``not`` symbol;
+  2. Function(NNF) which converts any given formulae into NNF;
+  3. Prove using controposition in HOL
+  if the set GAMMA = {NNF NotPhi}, if GAMMA closes then Phi is valid;
+*)
+val _ = export_theory();

--- a/examples/logic/modal-tableaux/tableauS4Script.sml
+++ b/examples/logic/modal-tableaux/tableauS4Script.sml
@@ -1,0 +1,1707 @@
+(* See:
+
+     Wu and Goré, "Verified Decision Procedures for Modal Logics", ITP 2019
+
+   for inspiration
+
+*)
+
+open HolKernel Parse boolLib bossLib;
+
+open pairTheory pred_setTheory listTheory relationTheory;
+open mp_then;
+open tableauKTTheory;
+open tableauKTheory;
+open arithmeticTheory;
+
+val _ = new_theory "tableauS4";
+
+Datatype:
+  premodel = Nd α (premodel list)
+End
+
+Definition pt_rel_def:
+  pt_rel t1 t2 ⇔ ∃vs ts. t1 = Nd vs ts ∧ MEM t2 ts
+End
+
+Definition get_htk[simp]:
+  get_htk (Nd (id, htk, request) l) = htk
+End
+
+Definition get_id[simp]:
+  get_id (Nd (id, htk, request) l) = id
+End
+
+Definition get_request[simp]:
+  get_request (Nd (id, htk, request) l) = request
+End
+
+Definition get_kids[simp]:
+  get_kids (Nd a l) = l
+End
+
+val _ = add_record_field("htk", ``get_htk``)
+val _ = add_record_field("id", ``get_id``)
+val _ = add_record_field("request", ``get_request``)
+val _ = add_record_field("l", ``get_kids``)
+
+Datatype:
+  S4_sequent = <|
+          As : (form # form list) list;
+          Ss : (form # form list) option;
+          Hs : form list;
+          Sg : form list;
+          Gm : form list;
+         |>
+End
+
+Type S4_result = ``:(S4_sequent #
+                           form list #
+                           (form # form list) list)
+                          premodel``
+
+Overload CLOSED = “NONE : S4_result option”
+
+Overload OPEN = “SOME :  S4_result -> S4_result option”
+
+Definition closure_list_conc_def[simp]:
+  closure_list_conc [] = [] ∧
+  closure_list_conc (Conj f1 f2::rest) = Conj f1 f2::closure_list_conc [f1] ⧺ closure_list_conc [f2] ⧺ closure_list_conc rest ∧
+  closure_list_conc (Disj f1 f2::rest) = Disj f1 f2::closure_list_conc [f1] ⧺ closure_list_conc [f2] ⧺ closure_list_conc rest ∧
+  closure_list_conc (Box f::rest) = Box f :: closure_list_conc [f] ++ (closure_list_conc rest) ∧
+  closure_list_conc (Dia f::rest) = Dia f :: closure_list_conc [f] ++ (closure_list_conc rest) ∧
+  closure_list_conc (f::rest) = f :: (closure_list_conc rest)
+Termination
+  WF_REL_TAC `measure (SUM o MAP form_size)` >> rw[]
+End
+
+Theorem mem_lst_closure:
+  ∀s l. MEM s l ⇒ MEM s (closure_list_conc l)
+Proof
+  Induct_on `l` >> rw[] >> Cases_on `h` >> fs[]
+QED
+
+Theorem sublist_closure:
+  ∀f lst h. MEM f (closure_list_conc lst) ⇒  MEM f (closure_list_conc (h::lst))
+Proof
+  rw[] >> Induct_on `lst` >> rw[] >>
+  Cases_on `f=h` >> rw[]
+  >- (Cases_on `f` >> rw[])
+  >> Cases_on `f=h'` >> rw[]
+  >> Cases_on `h` >> rw[]
+QED
+
+Theorem mem_closure:
+  ∀f e lst. MEM e lst ∧ MEM f (closure_list_conc [e]) ⇒ MEM f (closure_list_conc lst)
+Proof
+  Induct_on `lst` >> rw[]
+  >- (Cases_on `e` >> fs[])
+  >> metis_tac[FORALL_AND_THM, sublist_closure]
+QED
+
+Theorem transitive_closure:
+  ∀p f h. MEM p (closure_list_conc [f]) ∧ MEM f (closure_list_conc [h])
+          ⇒ MEM p (closure_list_conc [h])
+Proof
+  rw[] >> Induct_on `h`
+  >- (Cases_on `f` >> fs[MEM])
+  >- (Cases_on `f` >> fs[MEM])
+  >- (Induct_on `f` >> fs[] >> rw[] >> rw[])
+  >- (Induct_on `f` >> fs[] >> rw[] >> rw[])
+  >- (Induct_on `f` >> fs[] >> rw[] >> rw[])
+  >> (Induct_on `f` >> fs[] >> rw[] >> rw[])
+QED
+
+Theorem mem_closure_of_closure:
+∀f lst.  MEM f (closure_list_conc lst) ⇒
+        (∀p. MEM p (closure_list_conc [f]) ⇒ MEM p (closure_list_conc lst))
+Proof
+  Induct_on `lst` >> rw[] >>
+  Cases_on `MEM f (closure_list_conc [h])`
+  >- metis_tac[transitive_closure, MEM, mem_closure]
+  >> `closure_list_conc (h::lst) =
+      closure_list_conc [h] ++
+      (closure_list_conc lst)` by (Cases_on `h` >> fs[]) >>
+  fs[] >> `MEM p (closure_list_conc lst)` suffices_by simp[] >>
+  metis_tac[mem_closure]
+QED
+
+Theorem mem_closure_self:
+  ∀f. MEM f (closure_list_conc [f])
+Proof
+  Cases_on `f` >> rw[]
+QED
+
+Theorem box_subformula_closure:
+  ∀l f. MEM (Box f) (closure_list_conc l) ⇒ MEM f (closure_list_conc l)
+Proof
+  ho_match_mp_tac closure_list_conc_ind >> rw[]
+  >> metis_tac[mem_closure_self]
+QED
+
+Theorem form_size_none_zero:
+  0 < form_size f
+Proof
+  Induct_on `f` >> rw[]
+QED
+
+Theorem in_subset:
+  ∀p s l1 l2. p ∈ (set l1) ∧ (set l1 ⊆ (set l2)) ⇒ p ∈ (set l2)
+Proof
+  Induct_on `l1` >> rw[] >> rw[]
+QED
+
+Theorem head_list_mem:
+  ∀l s r. l = s::r ⇒ MEM s l
+Proof
+  fs[]
+QED
+
+Theorem tail_list_subset:
+  ∀l s r. l = s::r ⇒ set r ⊆ set l
+Proof
+  rw[INSERT_DEF, SUBSET_DEF]
+QED
+
+Theorem in_psubset:
+  ∀p s l1 l2. p ∈ (set l1) ∧ (set l1 PSUBSET (set l2)) ⇒ p ∈ (set l2)
+Proof
+  Induct_on `l1` >> rw[] >> fs[INSERT_DEF, PSUBSET_DEF, SUBSET_DEF]
+QED
+
+Theorem mem_subset:
+  ∀p s l1 l2. MEM p l1 ∧ (set l1 ⊆ (set l2)) ⇒ MEM p l2
+Proof
+  metis_tac[in_subset]
+QED
+
+Theorem mem_psubset:
+  ∀p s l1 l2. MEM p l1 ∧ (set l1 PSUBSET (set l2)) ⇒ MEM p l2
+Proof
+  metis_tac[in_psubset]
+QED
+
+Theorem sublist_to_subset:
+  ∀l1 l2. (∀x. MEM x l1 ⇒ MEM x l2) ⇒ set l1 ⊆ set l2
+Proof
+  Induct_on `l1` >> rw[SUBSET_DEF]
+QED
+
+Theorem gsize_head:
+  ∀l e l1. l = e::l1 ⇒ gsize l = form_size e + gsize l1
+Proof
+  Induct_on `l1` >> rw[]
+QED
+
+Theorem gsize_append:
+  ∀l1 l2. gsize (l1++l2) = gsize l1 + gsize l2
+Proof
+  Induct_on `l1` >> rw[] >> rw[SUM_APPEND]
+QED
+
+Theorem gsize_mem:
+  ∀f l. MEM f l ⇒ form_size f <= gsize l
+Proof
+  Induct_on `l` >> fs[MEM] >> rw[]
+  >- (Cases_on `f` >> rw[]) >>
+  first_x_assum (drule_then strip_assume_tac) >>
+  metis_tac[arithmeticTheory.LESS_EQ_TRANS, arithmeticTheory.LESS_EQ_ADD]
+QED
+
+Theorem gsize_mem_single:
+  ∀f l. MEM f l ∧ gsize l <= form_size f ==> l = [f]
+Proof
+  Induct_on `l` >> rw[]
+  >- (`form_size f = 0 + form_size f` by rw[] >>
+      `gsize l + form_size f ≤ 0 + form_size f` by fs[] >>
+      `gsize l ≤ 0` by metis_tac[arithmeticTheory.LE_ADD_RCANCEL] >>
+      Cases_on `l` >> rw[] >> Cases_on `h` >> fs[form_size_def])
+  >> `gsize l ≤ form_size f` by fs[arithmeticTheory.LESS_EQ_TRANS, arithmeticTheory.LESS_EQ_ADD] >>
+  first_x_assum (drule_then strip_assume_tac) >>
+  first_x_assum (drule_then strip_assume_tac) >>
+  fs[] >> Cases_on `h` >> fs[form_size_def]
+QED
+
+Theorem non_empty_list_length:
+  ∀l. l ≠ [] ⇒ LENGTH l > 0
+Proof
+  Induct_on `l` >> rw[]
+QED
+
+Theorem proper_subset:
+  ∀a l1 l2. ALL_DISTINCT l1 ∧ a ∉ set l1 ∧ a ∈ set l2 ∧ set l1 ⊆ set l2 ⇒ gsize l1 < gsize l2
+Proof
+  Induct_on `l1` >> rw[]
+  >- (Induct_on `l2` >> rw[]
+      >- (`0 < form_size a` suffices_by rw[] >> simp[form_size_none_zero])
+      >> `0 < form_size h` suffices_by rw[] >> simp[form_size_none_zero])
+  >> `∃t1 t2. l2 = t1 ⧺ h::t2` by metis_tac[MEM_SPLIT] >>
+  `gsize l1 + form_size h < gsize (t1 ⧺ h::t2)` suffices_by rw[] >>
+  simp[gsize_append] >> `gsize l1 < gsize t1 + gsize t2` suffices_by rw[] >>
+  `gsize l1 < gsize (t1++t2)` suffices_by rw[gsize_append] >>
+  first_x_assum irule >> rw[]
+  >- (qexists_tac `a` >> rw[] >> fs[] >> fs[])
+  >> fs[SUBSET_DEF] >> metis_tac[]
+QED
+
+Theorem proper_psubset:
+  ∀a l1 l2. ALL_DISTINCT l1 ∧ a ∉ set l1 ∧ a ∈ set l2 ∧ set l1 ⊂ set l2 ⇒ gsize l1 < gsize l2
+Proof
+  metis_tac[proper_subset, PSUBSET_DEF]
+QED
+
+Theorem gsize_filter:
+  ∀l f. gsize (FILTER (λy. f ≠ y) l) <= gsize l
+Proof
+  Induct_on `l` >> rw[] >> metis_tac[arithmeticTheory.LESS_EQ_ADD, arithmeticTheory.LESS_EQ_TRANS]
+QED
+
+Theorem gsize_filter_sml_sub_single:
+  ∀l f. MEM f l ⇒ gsize (FILTER (λy. f ≠ y) l) <= gsize l − form_size f
+Proof
+  Induct_on `l` >> rw[]
+  >- (`gsize l - form_size f >= 0` by (Induct_on `l` >> rw[]) >>
+      Cases_on `gsize l - form_size f = 0`
+      >- (Cases_on `l = [f]` >> fs[MEM] >> `form_size f <= gsize l` by rw[gsize_mem] >>
+          `gsize l = form_size f` by fs[] >> drule gsize_mem_single >> rw[]) >>
+      fs[arithmeticTheory.NOT_LESS_EQUAL] >> first_x_assum (drule_then strip_assume_tac) >>
+      `gsize l + form_size h − form_size f = gsize l − form_size f + form_size h` by fs[arithmeticTheory.SUB_RIGHT_ADD] >>
+    metis_tac[arithmeticTheory.LESS_EQ_MONO_ADD_EQ])
+  >> rw[gsize_filter]
+QED
+
+Theorem all_distinct_psubst:
+  ∀a l1 l2. ALL_DISTINCT l1 ∧ set l1 ⊂ set l2 ⇒ gsize l1 < gsize l2
+Proof
+  Induct_on `l1` >> rw[]
+  >- (Induct_on `l2` >> rw[] >> Cases_on `h` >> fs[]) >>
+  fs[PSUBSET_DEF, SUBSET_DEF, INSERT_DEF] >>
+  `gsize l1 < gsize l2 - form_size h` suffices_by rw[] >>
+  `∃p. p ≠ h ∧ MEM p l2 ∧ ¬MEM p l1`
+    by (SPOSE_NOT_THEN ASSUME_TAC >>
+        fs[EXTENSION] >> Cases_on `x = h` >> fs[] >>
+        qpat_x_assum ` ∀l2'.
+            (∀x. MEM x l1 ⇒ MEM x l2') ∧ (∃x. MEM x l1 ⇎ MEM x l2') ⇒
+            gsize l1 < gsize l2'` (fn _ => all_tac) >>
+        last_assum (drule_then strip_assume_tac) >> metis_tac[]) >>
+  `set l1 ≠ set (FILTER ($≠ h) l2)`
+    by (fs[EXTENSION] >> qexists_tac `p` >> fs[MEM_FILTER] >> metis_tac[]) >>
+  `(∀x. MEM x l1 ⇒ MEM x (FILTER ($≠ h) l2))`
+    by (rw[] >> fs[MEM_FILTER] >> metis_tac[]) >>
+  last_assum (drule_then strip_assume_tac) >>
+  first_x_assum (drule_then strip_assume_tac) >> fs[] >>
+  metis_tac[gsize_filter_sml_sub_single ,LESS_LESS_EQ_TRANS]
+QED
+
+Definition wfm_S4_sequent:
+  wfm_S4_sequent Γ0 s ⇔ ALL_DISTINCT s.Sg ∧ ALL_DISTINCT s.Hs ∧
+                        set s.Sg PSUBSET set (closure_list_conc [Γ0]) ∧
+                        set s.Hs SUBSET set (closure_list_conc [Γ0]) ∧
+                        set s.Gm SUBSET set (closure_list_conc [Γ0]) ∧
+                        EVERY is_boxed s.Sg ∧
+                        (∀x. MEM x s.Hs ⇒ MEM (Dia x) (closure_list_conc [Γ0])) ∧
+                        (∀p. MEM p s.Hs ⇒ MEM (p, s.Sg) s.As) ∧
+                        (∀q r. s.Ss = SOME (q, r) ⇒ MEM q s.Gm ∧ set r ⊆ set s.Gm)
+End
+
+(* pluck the first element from list that satisfies P,
+   otherwise return NONE *)
+Definition pluck_def:
+  pluck P []     = NONE ∧
+  pluck P (h::t) = if P h then SOME (h, t)
+                   else (case pluck P t of NONE => NONE
+                                          |SOME (a, b) => SOME (a, h::b))
+End
+
+Definition dest_box_def:
+  dest_box (Box f) = SOME f ∧
+  dest_box f = NONE
+End
+
+Definition trule_s4_def:
+  trule_s4 s = case pluck is_boxed s.Gm of
+                 NONE        => NONE
+               | SOME(b, rest) =>
+                     if MEM b s.Sg then
+                        SOME (b, s with <| Ss := NONE ; Gm := THE (dest_box b)::rest |>)
+                     else
+                        SOME (b, s with <| Ss := NONE;
+                                           Hs := [];
+                                           Sg := b::s.Sg;
+                                           Gm := THE (dest_box b)::rest;  |>)
+End
+
+Theorem pluck_eq_some_append:
+  ∀l h rest. pluck P l = SOME (h, rest) ⇒
+             P h ∧ ∃p s. l = p++[h]++s ∧ rest = p++s
+Proof
+  Induct_on `l` >> rw[pluck_def, AllCaseEqs()] >> rw[]
+  >-(qexistsl_tac [`[]`, `l`] >> rw[])
+  >> first_x_assum (drule_then strip_assume_tac) >> rw[] >>
+  qexistsl_tac [`h::p`, `s`] >> rw[]
+QED
+
+Theorem trule_s4_length:
+∀s f s'.
+    trule_s4 s = SOME (f, s') ⇒
+    (gsize s.Sg < gsize s'.Sg) ∨
+    (gsize s.Sg = gsize s'.Sg ∧ gsize s.Hs = gsize s'.Hs ∧
+      gsize s'.Gm < gsize s.Gm)
+Proof
+  simp[trule_s4_def, AllCaseEqs(), PULL_EXISTS] >> rw[]
+  >-(simp[] >> drule pluck_eq_some_append >> rw[] >> simp[SUM_APPEND] >>
+     Cases_on `b` >> fs[dest_box_def] >> rw[])
+  >> simp[] >> drule pluck_eq_some_append >> rw[] >> Cases_on `b` >> fs[dest_box_def] >> rw[]
+QED
+
+Theorem f_neq_box_f[simp]:
+  ∀f. f ≠ Box f
+Proof
+  Induct_on `f` >> rw[]
+QED
+
+Theorem f_neq_dia_f[simp]:
+  ∀f. f ≠ Dia f
+Proof
+  Induct_on `f` >> rw[]
+QED
+
+Definition add_rule:
+  add_rule rule (Nd (s, r) lst) = Nd (s, rule) [Nd (s, r) lst]
+End
+
+Definition conjsplit_s4_def[simp]:
+  (conjsplit_s4 (Conj f1 f2 :: rest) = SOME (Conj f1 f2, f1 :: f2 :: rest)) ∧
+  (conjsplit_s4 (f :: rest) = OPTION_MAP (I ## CONS f) (conjsplit_s4 rest)) ∧
+  (conjsplit_s4 [] = NONE)
+End
+
+Definition disjsplit_s4_def[simp]:
+  disjsplit_s4 (Disj f1 f2 :: rest) = SOME (Disj f1 f2, (f1::rest, f2::rest)) ∧
+  disjsplit_s4 (f :: rest) = OPTION_MAP (I ## (CONS f ## CONS f)) (disjsplit_s4 rest) ∧
+  disjsplit_s4 [] = NONE
+End
+
+Theorem conjsplit_s4_size:
+  ∀Γ fs f. conjsplit_s4 Γ = SOME (f, fs) ⇒
+         SUM (MAP form_size fs) < SUM (MAP form_size Γ)
+Proof
+  Induct >> simp[conjsplit_s4_def] >> Cases >>
+  simp[conjsplit_s4_def, FORALL_PROD, PULL_EXISTS]
+QED
+
+Theorem disjsplit_s4_size:
+  ∀Γ fs1 fs2. disjsplit_s4 Γ = SOME (f, (fs1, fs2)) ⇒
+                  SUM (MAP form_size fs1) < SUM (MAP form_size Γ) ∧
+                  SUM (MAP form_size fs2) < SUM (MAP form_size Γ)
+Proof
+  Induct_on ‘Γ’ >> simp[disjsplit_def] >> Cases >>
+  simp[disjsplit_def, FORALL_PROD, PULL_EXISTS]
+QED
+
+Definition s4_request_local[simp]:
+  s4_request_local [] _ = [] ∧
+  s4_request_local (s::xs) sg = (s, sg)::(s4_request_local xs sg)
+End
+
+(* tableau_S4 Ancestors Signatures History Sigma Gamma *)
+Definition tableau_S4_def:
+  tableau_S4 Γ0 s = if  ¬ wfm_S4_sequent Γ0 s then CLOSED else
+    case contradiction s.Gm of
+      SOME i => CLOSED
+    | NONE =>
+        case conjsplit_s4 s.Gm of
+          SOME (pf, Γ') => (case tableau_S4 Γ0 (s with <| Ss:=NONE; Gm:=Γ'; |>) of
+                                 NONE => NONE
+                              |  SOME (Nd (id, h, r) cs) => SOME (Nd (s, pf::h, r) cs))
+        | NONE => case disjsplit_s4 s.Gm of
+                    SOME (pf, (Γ1, Γ2)) =>  (case tableau_S4 Γ0 (s with <| Ss:=NONE; Gm:=Γ1; |>) of
+                                                SOME (Nd (id, h, r) cs) => SOME (Nd (s, pf::h, r) cs)
+                                              | NONE =>
+                                                case tableau_S4 Γ0 (s with <| Ss:=NONE; Gm:=Γ2; |>) of
+                                                    SOME (Nd (id, h, r) cs) => SOME (Nd (s, pf::h, r) cs)
+                                                  | NONE => NONE)
+                  | NONE => if EXISTS is_boxed s.Gm then (case trule_s4 s of
+                                                            SOME (pf, s') => (case tableau_S4 Γ0 s' of
+                                                                                NONE => NONE
+                                                                              | SOME (Nd (id, h, r) cs) => SOME (Nd (s, pf::h, r) cs))
+                                                          | NONE => NONE)
+                            else  if EXISTS is_dia s.Gm then
+                                    let
+                                      children = scmap (λdf. tableau_S4 Γ0 (s with <| As := (df, s.Sg)::s.As;
+                                                                                      Ss := SOME (df, s.Sg);
+                                                                                      Hs := df::s.Hs;
+                                                                                      Gm := df::s.Sg |>))
+                                                (FILTER (λf. ¬ MEM f s.Hs) (undia s.Gm))
+                                    in
+                                      case children of
+                                          SOME ms => SOME (Nd (s, s.Gm, s4_request_local s.Hs s.Sg) ms)
+                                        | NONE => CLOSED
+                                  else SOME (Nd (s, s.Gm, s4_request_local s.Hs s.Sg) [])
+Termination
+  WF_REL_TAC `(inv_image ((<) LEX ((<) LEX (<)))
+    (λ(Γ0,s). ((SUM $ MAP form_size (closure_list_conc [Γ0])) - (SUM $ MAP form_size s.Sg))
+    ,    ( ((SUM $ MAP form_size (closure_list_conc [Γ0])) - (SUM $ MAP form_size s.Hs))
+         , (SUM $ MAP form_size s.Gm) )))` >> rpt conj_tac
+  >-(* S4 *)
+     (rw[] >> DISJ1_TAC >> fs[wfm_S4_sequent] >> csimp[] >> rw[form_size_none_zero] >>
+      fs[MEM_FILTER] >> fs[MEM_undia] >>
+      `MEM (Dia df) (closure_list_conc [Γ0])` by metis_tac[mem_subset] >>
+      drule mem_closure_of_closure >> rw[] >>
+      `MEM df (closure_list_conc [Dia df])`
+        by (rw[] >> metis_tac[mem_closure_self]) >>
+      fs[] >> fs[DISJ_IMP_THM, FORALL_AND_THM] >>
+      first_x_assum (drule_then strip_assume_tac) >>
+      `gsize s.Hs < gsize (closure_list_conc [Γ0])` suffices_by rw[] >>
+      irule proper_subset >> metis_tac[])
+  >- (rw[] >> fs[wfm_S4_sequent] >> drule_all trule_s4_length >> rw[]
+      >- (DISJ1_TAC >> simp[] >>
+          `gsize s.Sg < gsize (closure_list_conc [Γ0])` suffices_by simp[] >>
+          qpat_x_assum `ALL_DISTINCT s.Hs` (fn _ => all_tac) >>
+          drule all_distinct_psubst >> rw[] >>
+          first_x_assum (drule_then strip_assume_tac))
+      >> simp[])
+  >- rw[conjsplit_s4_size]
+  >- (rw[] >> drule disjsplit_s4_size >> simp[])
+  >> rw[] >> metis_tac[disjsplit_s4_size]
+End
+
+Definition final_tableau_S4_def:
+  final_tableau_S4 f = tableau_S4 f <|   As := [];
+                                         Ss := NONE;
+                                         Hs := [];
+                                         Sg := [];
+                                         Gm := [f]
+                                      |>
+End
+
+Theorem tableau_S4_s_eq_id:
+  ∀Γ0 s id h r cs. tableau_S4 Γ0 s = SOME (Nd (id,h,r) cs) ⇒ s = id
+Proof
+  rw[Once tableau_S4_def] >> fs[AllCaseEqs()]
+QED
+
+Definition transitive_M:
+  transitive_M m ⇔ ∀u v w. u ∈ m.worlds ∧ v ∈ m.worlds ∧ w ∈ m.worlds ∧
+                           m.rel u v ∧ m.rel v w
+                          ⇒ m.rel u w
+End
+
+Theorem sublist_subset:
+  ∀l h v. l = h::v ⇒ set v SUBSET set l
+Proof
+  Induct_on `l` >> rw[INSERT_DEF, SUBSET_DEF]
+QED
+
+Theorem sublist_psubset:
+  ∀l1 h v. l1 = h::v ⇒ set v PSUBSET set l1 ∨ set v = set l1
+Proof
+  Induct_on `l1` >> rw[INSERT_DEF] >> Cases_on `set l1 ⊂ {y | y = h ∨ MEM y l1}` >> rw[] >>
+  fs[PSUBSET_DEF, SUBSET_DEF]
+QED
+
+Theorem psubset_subset:
+  ∀l2 l3 l1. l1 PSUBSET l2 ∧ l2 ⊆ l3 ⇒ l1 PSUBSET l3
+Proof
+  rw[SUBSET_DEF, PSUBSET_DEF] >> SPOSE_NOT_THEN ASSUME_TAC >>
+  `∀x. x ∈ l2 ⇒ x ∈ l1` by fs[] >> `l1 SUBSET l2` by fs[SUBSET_DEF] >>
+  `l2 SUBSET l1` by fs[SUBSET_DEF] >>
+  `l1 = l2` by metis_tac[SUBSET_ANTISYM]
+QED
+
+Theorem closure_ele_literal:
+  ∀p. ∃f. MEM f (closure_list_conc [p]) ∧ (is_literal f)
+Proof
+  Induct_on `p`
+  >- rw[]
+  >- rw[]
+  >> fs[] >> qexists_tac `f` >> rw[] >> irule mem_closure_of_closure >>
+  qexists_tac `p` >> rw[] >> metis_tac[mem_closure_self]
+QED
+
+Theorem closure_lst_literal:
+  ∀p. p = [] ∨ ∃f. MEM f (closure_list_conc p) ∧ (is_literal f)
+Proof
+  Induct_on `p` >> rw[]
+  >- metis_tac[closure_ele_literal]
+  >> qexists_tac `f` >> rw[] >> drule sublist_closure >> rw[]
+QED
+
+Theorem wfm_S4_trule:
+  ∀s Γ0 p q. wfm_S4_sequent Γ0 s ∧ trule_s4 s = SOME (p, q) ⇒ wfm_S4_sequent Γ0 q
+Proof
+  simp[trule_s4_def, AllCaseEqs(), PULL_EXISTS] >> rw[]
+  >-(drule pluck_eq_some_append >> rw[] >> fs[wfm_S4_sequent] >>
+     Cases_on `b` >> fs[dest_box_def] >> metis_tac[box_subformula_closure])
+  >> drule pluck_eq_some_append >> rw[] >> fs[wfm_S4_sequent] >>
+  Cases_on `b` >> fs[dest_box_def] >> reverse(rw[])
+  >- metis_tac[box_subformula_closure]
+  >> rw[PSUBSET_DEF, SUBSET_DEF, INSERT_DEF] >> rw[]
+  >- metis_tac[PSUBSET_DEF, SUBSET_DEF]
+  >> simp[EXTENSION] >> qspec_then `Γ0` (qx_choose_then `ff` strip_assume_tac) closure_ele_literal >>
+  qexists_tac `ff` >> simp[] >> rpt strip_tac
+  >- fs[is_literal_def]
+  >> `is_boxed ff` by metis_tac[EVERY_MEM] >> Cases_on `ff` >> fs[is_boxed_def, is_literal_def]
+QED
+
+Theorem mem_trule_gamma:
+  ∀s f p q. trule_s4 s = SOME (p, q) ∧ MEM f q.Gm ⇒ MEM f s.Gm ∨ MEM (Box f) s.Gm
+Proof
+  simp[trule_s4_def, AllCaseEqs(), PULL_EXISTS] >> rw[] >> fs[] >>
+  drule pluck_eq_some_append >> rw[] >> Cases_on `b` >> fs[dest_box_def]
+QED
+
+Theorem mem_trule_sigma:
+  ∀s f p q. trule_s4 s = SOME (p, q) ∧ MEM f q.Sg ==> MEM f s.Gm ∨ MEM f s.Sg
+Proof
+  simp[trule_s4_def, AllCaseEqs(), PULL_EXISTS] >> rw[] >> fs[] >>
+  drule pluck_eq_some_append >> rw[] >> Cases_on `b` >> fs[dest_box_def]
+QED
+
+Theorem undia_dia_in_closure:
+  MEM df (undia s.Gm) ∧
+  set s.Gm ⊆ set (closure_list_conc [Γ0])
+  ⇒
+  MEM df (closure_list_conc [Γ0])
+Proof
+  fs[MEM_undia] >> rw[] >>
+  `MEM (Dia df) (closure_list_conc [Γ0])` by metis_tac[mem_subset] >>
+  drule mem_closure_of_closure >> rw[] >> metis_tac[mem_closure_self]
+QED
+
+Theorem mem_closure_head_tail:
+  ∀h r f. MEM f (closure_list_conc (h::r)) ⇒
+          MEM f (closure_list_conc [h]) ∨ MEM f (closure_list_conc r)
+Proof
+  rw[] >> Cases_on `MEM f (closure_list_conc [h])` >> rw[] >>
+  `closure_list_conc (h::r) = (closure_list_conc [h]) ++ (closure_list_conc r)`
+    by (Cases_on `h` >> fs[]) >> fs[]
+QED
+
+Theorem closure_subset_closure:
+  ∀l1 l2. set l1 ⊆ set (closure_list_conc l2) ⇒
+          set (closure_list_conc l1) ⊆ set (closure_list_conc l2)
+Proof
+  Induct_on `l1` >> rw[] >> rw[] >>
+  fs[SUBSET_DEF] >> rw[] >>
+  Cases_on `MEM x (closure_list_conc [h])` >> fs[]
+  >- metis_tac[mem_closure_of_closure]
+  >> drule mem_closure_head_tail >> rw[]
+QED
+
+Theorem MEM_disjsplit1:
+  ∀Γ Γ1 Γ2 f1.
+     MEM f1 Γ1 ∧ disjsplit_s4 Γ = SOME (f, (Γ1,Γ2)) ⇒
+     MEM f1 Γ ∨ (∃f2. MEM f2 Γ2 ∧ MEM (Disj f1 f2) Γ)
+Proof
+  ho_match_mp_tac disjsplit_s4_ind >> rw[]
+  >- (fs[] >> rw[] >> metis_tac[])
+  >> Cases_on `z` >> fs[] >> Cases_on `r` >> fs[] >> metis_tac[]
+QED
+
+Theorem MEM_disjsplit2:
+  ∀Γ Γ1 Γ2 f2.
+     MEM f2 Γ2 ∧ disjsplit_s4 Γ = SOME (f, (Γ1,Γ2)) ⇒
+     MEM f2 Γ ∨ (∃f1. MEM f1 Γ1 ∧ MEM (Disj f1 f2) Γ)
+Proof
+  ho_match_mp_tac disjsplit_s4_ind >> rw[]
+  >- (fs[] >> rw[] >> metis_tac[])
+  >> Cases_on `z` >> fs[] >> Cases_on `r` >> fs[] >> metis_tac[]
+QED
+
+Theorem wfm_S4_Disj:
+∀s Γ0 Γ1 Γ2.   wfm_S4_sequent Γ0 s ∧ disjsplit_s4 s.Gm = SOME (f, (Γ1,Γ2))
+               ⇒
+               wfm_S4_sequent Γ0 (s with <|Ss := NONE; Gm := Γ1|>) ∧
+               wfm_S4_sequent Γ0 (s with <|Ss := NONE; Gm := Γ2|>)
+Proof
+  rw[wfm_S4_sequent]
+  >- (simp[SUBSET_DEF] >> rw[] >> drule_all MEM_disjsplit1 >> rw[]
+      >- metis_tac[SUBSET_DEF]
+      >> `MEM (Disj x f2) (closure_list_conc [Γ0])` by  metis_tac[SUBSET_DEF] >>
+         drule mem_closure_of_closure >> rw[] >> metis_tac[mem_closure_self])
+  >> simp[SUBSET_DEF] >> rw[] >> drule_all MEM_disjsplit2 >> rw[]
+  >- metis_tac[SUBSET_DEF]
+  >> `MEM (Disj f1 x) (closure_list_conc [Γ0])` by  metis_tac[SUBSET_DEF] >>
+  drule mem_closure_of_closure >> rw[] >> metis_tac[mem_closure_self]
+QED
+
+Theorem conjsplit_s4_MEM2:
+  ∀Γ₀ Γ ϕ. conjsplit_s4 Γ₀ = SOME (f, Γ) ∧ MEM ϕ Γ ⇒
+           MEM ϕ Γ₀ ∨ (∃ϕ'. MEM (Conj ϕ ϕ') Γ₀) ∨
+           (∃ϕ'. MEM (Conj ϕ' ϕ) Γ₀)
+Proof
+  Induct >> simp[] >> Cases
+  >- (rw[] >> Cases_on `z` >> fs[] >>
+      Cases_on `ϕ = Var n` >> fs[] >> Cases_on `MEM ϕ r` >> fs[]
+      >> `MEM ϕ (Var n::r)` by metis_tac[] >> fs[] >> fs[])
+  >- (rw[] >> Cases_on `z` >> fs[] >>
+      Cases_on `ϕ = NVar n` >> fs[] >> Cases_on `MEM ϕ r` >> fs[]
+      >> `MEM ϕ (NVar n::r)` by metis_tac[] >> fs[] >> fs[])
+  >- (rpt strip_tac >> rw[] >> fs[conjsplit_s4_def] >> Cases_on `MEM ϕ Γ₀` >> fs[] >>
+      `MEM ϕ (f'::f0::Γ₀)` by metis_tac[] >> fs[] >> metis_tac[])
+  >- (rw[] >> Cases_on `z` >> fs[] >>
+      Cases_on `ϕ = Disj f' f0` >> fs[] >> Cases_on `MEM ϕ r` >> fs[]
+      >> `MEM ϕ ((Disj f' f0)::r)` by metis_tac[] >> fs[] >> fs[])
+  >- (rw[] >> Cases_on `z` >> fs[] >>
+      Cases_on `ϕ = Box f'` >> fs[] >> Cases_on `MEM ϕ r` >> fs[]
+      >> `MEM ϕ (Box f'::r)` by metis_tac[] >> fs[] >> fs[])
+  >- (rw[] >> Cases_on `z` >> fs[] >>
+      Cases_on `ϕ = Dia f'` >> fs[] >> Cases_on `MEM ϕ r` >> fs[]
+      >> `MEM ϕ (Dia f'::r)` by metis_tac[] >> fs[] >> fs[])
+QED
+
+Theorem wfm_S4_Conj:
+∀s Γ0 Γ'.  wfm_S4_sequent Γ0 s ∧ conjsplit_s4 s.Gm = SOME (f, Γ')
+           ⇒
+           wfm_S4_sequent Γ0 (s with <|Ss := NONE; Gm := Γ'|>)
+Proof
+  rw[wfm_S4_sequent] >> simp[SUBSET_DEF] >> rw[] >> drule_all conjsplit_s4_MEM2 >> rw[]
+  >- metis_tac[SUBSET_DEF]
+  >- (`MEM (Conj x ϕ') (closure_list_conc [Γ0])` by metis_tac[SUBSET_DEF] >>
+      drule mem_closure_of_closure >> rw[] >> metis_tac[mem_closure_self])
+  >> `MEM (Conj ϕ' x) (closure_list_conc [Γ0])` by metis_tac[SUBSET_DEF] >>
+  drule mem_closure_of_closure >> rw[] >> metis_tac[mem_closure_self]
+QED
+
+Theorem wfm_S4_Transitive:
+  ∀Γ0 s m w. tableau_S4 Γ0 s = SOME m ∧
+             wfm_S4_sequent Γ0 s ∧
+             RTC pt_rel m w ⇒
+             wfm_S4_sequent Γ0 w.id
+Proof
+  ho_match_mp_tac tableau_S4_ind >> ntac 2 gen_tac >> strip_tac >>
+  simp[Once tableau_S4_def] >> simp[AllCaseEqs()] >> rw[]
+  (* Trule *)
+  >-(fs[] >> rw[] >> first_x_assum (qspec_then `w` ASSUME_TAC) >>
+     fs[Once RTC_CASES1] >> rw[] >> first_x_assum irule >> reverse (rw[])
+     >- metis_tac[wfm_S4_trule]
+     >> drule tableau_S4_s_eq_id >> rw[] >> DISJ2_TAC >>
+     qexists_tac `u` >> fs[pt_rel_def])
+  (* S4 *)
+  >-(fs[] >> rw[] >> fs[Once RTC_CASES1] >> rw[] >> fs[pt_rel_def] >>
+     drule scmap_MEM >> rw[] >> fs[MEM_FILTER, MEM_undia] >>
+     first_x_assum (drule_then strip_assume_tac) >>
+     first_x_assum (drule_then strip_assume_tac) >>
+     first_x_assum (drule_then strip_assume_tac) >>
+     first_x_assum (drule_then strip_assume_tac) >>
+     `wfm_S4_sequent Γ0
+          (s with
+           <|As := (e0,s.Sg)::s.As; Ss := SOME (e0,s.Sg); Hs := e0::s.Hs;
+             Gm := e0::s.Sg|>)`
+                by (first_x_assum (qspec_then `w` (fn _ => all_tac)) >>
+                    fs[wfm_S4_sequent] >> rw[]
+                    >-(`MEM (Dia e0) (closure_list_conc [Γ0])` by metis_tac[SUBSET_DEF] >>
+                       drule mem_closure_of_closure >> rw[] >>
+                       metis_tac[mem_closure_self])
+                    >-(`MEM (Dia e0) (closure_list_conc [Γ0])` by metis_tac[SUBSET_DEF] >>
+                       drule mem_closure_of_closure >> rw[] >>
+                       metis_tac[mem_closure_self])
+                    >- metis_tac[SUBSET_DEF, PSUBSET_DEF]
+                    >- metis_tac[SUBSET_DEF]
+                    >- metis_tac[SUBSET_DEF]
+                    >- metis_tac[]
+                    >> rw[SUBSET_DEF, INSERT_DEF]) >>
+     first_x_assum (qspec_then `w` ASSUME_TAC) >>
+     first_x_assum (drule_then strip_assume_tac) >>
+     first_x_assum irule >> metis_tac[RTC_CASES1, pt_rel_def])
+  (* Literal *)
+  >-(fs[] >> rw[] >> fs[Once RTC_CASES1] >> rw[] >> fs[pt_rel_def])
+  (* DISJ2 *)
+  >-(fs[] >> rw[] >> fs[Once RTC_CASES1] >> rw[] >> fs[pt_rel_def] >>
+     metis_tac[wfm_S4_Disj])
+  (* DISJ1 *)
+  >-(fs[] >> rw[] >> fs[Once RTC_CASES1] >> rw[] >> fs[pt_rel_def] >>
+     metis_tac[wfm_S4_Disj])
+  >> fs[] >> rw[] >> fs[Once RTC_CASES1] >> rw[] >> fs[pt_rel_def] >>
+  metis_tac[wfm_S4_Conj]
+QED
+
+Theorem pluck_eq_none:
+  ∀P l. pluck P l = NONE ⇒ ¬EXISTS P l
+Proof
+  Induct_on `l` >> rw[pluck_def] >> rw[EVERY_MEM] >> fs[EXISTS_MEM, EVERY_MEM, AllCaseEqs()]
+QED
+
+Theorem disjsplit_s4_MEM2:
+  ∀Γ Γ1 Γ2 f1 f2.
+     MEM f1 Γ1 ∧ MEM f2 Γ2 ∧ disjsplit_s4 Γ = SOME (pf, Γ1,Γ2) ⇒
+     MEM f1 Γ ∨ MEM f2 Γ ∨ MEM (Disj f1 f2) Γ
+Proof
+  Induct >> simp[] >> Cases >> simp[PULL_EXISTS, EXISTS_PROD] >> metis_tac[]
+QED
+
+Theorem tableau_S4_complete:
+  ∀Γ0 s. wfm_S4_sequent Γ0 s ⇒
+         tableau_S4 Γ0 s = CLOSED ⇒
+         ∀M w.
+             w ∈ M.worlds ∧ reflexive_M M ∧ transitive_M M ⇒
+             ∃f. MEM f (s.Gm++s.Sg) ∧ ¬forces M w f
+Proof
+   ho_match_mp_tac tableau_S4_ind >> ntac 2 gen_tac >>
+   strip_tac >> simp[Once tableau_S4_def] >>
+   simp[AllCaseEqs()] >> rw[]
+   >- (* Trule contradiction *)
+      (fs[] >> rw[] >> fs[trule_s4_def, AllCaseEqs(), PULL_EXISTS] >>
+       metis_tac[pluck_eq_none])
+   >- (* Trule *)
+      (fs[] >> rw[] >> `wfm_S4_sequent Γ0 s'` by metis_tac[wfm_S4_trule] >>
+       first_x_assum (qspec_then `ARB` (fn _ => all_tac)) >>
+       first_x_assum (drule_all_then strip_assume_tac)
+       >- (*   MEM f s'.Gm *)
+          (rw[] >> drule mem_trule_gamma >> rw[] >>
+           first_x_assum (drule_then strip_assume_tac)
+           >- (qexists_tac `f` >> metis_tac[])
+           >> qexists_tac `Box f` >> rw[] >> qexists_tac `w` >> fs[reflexive_M])
+       >> (*  MEM f s'.Sg *) metis_tac[mem_trule_sigma])
+   >- (* S4 *)
+      (fs[MEM_FILTER] >> qpat_x_assum `∀pf s'. EXISTS is_boxed s.Gm ∧ trule_s4 s = SOME (pf,s') ⇒ _` (fn _ => all_tac) >>
+       first_x_assum (drule_then (drule_then strip_assume_tac)) >>
+       first_x_assum (first_assum o mp_then (Pos last) strip_assume_tac) >>
+       first_assum (first_assum o mp_then (Pos last) strip_assume_tac) >>
+       first_x_assum (first_assum o mp_then (Pos last) strip_assume_tac) >>
+       qpat_x_assum `wfm_S4_sequent Γ0
+          (s with
+           <|As := (df,s.Sg)::s.As; Ss := SOME (df,s.Sg); Hs := df::s.Hs;
+             Gm := df::s.Sg|>) ∧
+        tableau_S4 Γ0
+          (s with
+           <|As := (df,s.Sg)::s.As; Ss := SOME (df,s.Sg); Hs := df::s.Hs;
+             Gm := df::s.Sg|>) =
+        NONE ⇒
+        ∃f. ((f = df ∨ MEM f s.Sg) ∨ MEM f s.Sg) ∧ ¬forces M w f` mp_tac >> impl_tac
+       (* wfm *)
+       >- (fs[wfm_S4_sequent] >> rw[]
+           >- (rw[PSUBSET_DEF, INSERT_DEF] >> metis_tac[undia_dia_in_closure])
+           >- metis_tac[undia_dia_in_closure]
+           >- fs[PSUBSET_DEF, SUBSET_DEF]
+           >> fs[MEM_undia, EXTENSION, SUBSET_DEF, mem_subset]) >> rw[]
+       (* ∃f. (f = df ∨ MEM f s.Sg) ∧ ¬forces M w f *)
+       >- (Cases_on `forces M w (Dia df)`
+           >- (fs[] >>
+               `wfm_S4_sequent Γ0 (s with
+                    <|As := (df,s.Sg)::s.As; Ss := SOME (df,s.Sg);
+                      Hs := df::s.Hs; Gm := df::s.Sg|>)`
+                  by (fs[wfm_S4_sequent] >> rw[]
+                      >- metis_tac[undia_dia_in_closure]
+                      >- metis_tac[undia_dia_in_closure]
+                      >- fs[PSUBSET_DEF, SUBSET_DEF]
+                      >> fs[MEM_undia, mem_subset]
+                      >- metis_tac[SUBSET_DEF]
+                      >> rw[SUBSET_DEF, INSERT_DEF]) >>
+               `∃f. ((f = df ∨ MEM f s.Sg) ∨ MEM f s.Sg) ∧ ¬forces M v f` by metis_tac[]
+                >- metis_tac[]
+                >> qexists_tac `f` >> rw[] >> fs[wfm_S4_sequent] >>
+                   fs[EVERY_MEM] >> first_x_assum (drule_then strip_assume_tac) >>
+                   `∃p. Box p = f` by (Cases_on `f` >> fs[is_boxed_def]) >> rw[] >>
+                   fs[reflexive_M] >> qexists_tac `v'` >> rw[] >> fs[transitive_M] >>
+                   metis_tac[])
+           >> fs[MEM_undia] >> qexists_tac `Dia df` >> rw[])
+       >- (qexists_tac `f` >> fs[])
+       >> (qexists_tac `f` >> fs[]))
+   >- (* Disj *)
+      (drule_all_then strip_assume_tac wfm_S4_Disj >> fs[] >>
+       rpt (first_x_assum (drule_all_then strip_assume_tac))
+       >- (drule_all disjsplit_s4_MEM2 >> rw[]
+           >- metis_tac[]
+           >- metis_tac[]
+           >> qexists_tac `Disj f f'` >> rw[] >> metis_tac[])
+       >> metis_tac[])
+   >- (* Con j *)
+      (drule_all_then strip_assume_tac wfm_S4_Conj >> fs[] >>
+       rpt (first_x_assum (drule_all_then strip_assume_tac))
+       >- (drule_all conjsplit_s4_MEM2 >> rw[]
+           >- metis_tac[]
+           >- (qexists_tac `Conj f ϕ'` >> rw[])
+           >> qexists_tac `Conj ϕ' f` >> rw[])
+       >> metis_tac[])
+   >> (* Literal *)fs[] >>
+      rename [‘contradiction Γ = SOME j’] >>
+      drule_then strip_assume_tac contradiction_EQ_SOME >>
+      Cases_on ‘M.valt w j’
+      >- (qexists_tac ‘NVar j’ >> simp[]) >>
+      qexists_tac ‘Var j’ >> simp[]
+QED
+
+Theorem final_tableau_S4_complete:
+  ∀f.  final_tableau_S4 f = CLOSED ⇒
+       ∀M w.
+         w ∈ M.worlds ∧ reflexive_M M ∧ transitive_M M ⇒
+         ¬forces M w f
+Proof
+  rw[final_tableau_S4_def] >> drule_at (Pos $ el 2) tableau_S4_complete >>
+  rw[] >> first_x_assum irule >> rw[] >>
+  simp[wfm_S4_sequent] >> rw[PSUBSET_DEF]
+  >- (Cases_on `f` >> fs[]) >> metis_tac[mem_closure_self]
+QED
+
+Definition pre_hintikka_def:
+  pre_hintikka l =
+    (
+      contradiction l = NONE ∧
+      (∀f1 f2. MEM (Conj f1 f2) l ⇒ MEM f1 l ∧ MEM f2 l) ∧
+      (∀f1 f2. MEM (Disj f1 f2) l ⇒ MEM f1 l ∨ MEM f2 l) ∧
+      (∀f. MEM (Box f) l ⇒ MEM f l)
+    )
+End
+
+Theorem tableau_S4_s_eq_id':
+  ∀Γ0 s m. tableau_S4 Γ0 s = SOME m ⇒ m.id = s
+Proof
+  Cases_on `m` >> PairCases_on `a` >> rw[Once tableau_S4_def] >> fs[AllCaseEqs()]
+QED
+
+Theorem pre_hintikka_box_cons:
+  ∀f h. pre_hintikka h ∧ MEM f h ⇒ pre_hintikka ((Box f)::h)
+Proof
+  rw[pre_hintikka_def] >> rw[DISJ_IMP_THM, FORALL_AND_THM] >> metis_tac[]
+QED
+
+Theorem conjsplit_s4_EQ_NONE:
+  ∀Γ. conjsplit_s4 Γ = NONE ⇔ ∀f1 f2. ¬(MEM (Conj f1 f2) Γ)
+Proof
+  Induct >> simp[] >> Cases >> simp[] >> metis_tac[]
+QED
+
+Theorem disjsplit_s4_EQ_NONE:
+  ∀Γ. disjsplit_s4 Γ = NONE ⇔ ∀f1 f2. ¬(MEM (Disj f1 f2) Γ)
+Proof
+  Induct >> simp[] >> Cases >> simp[] >> metis_tac[]
+QED
+
+Theorem pre_hintikka_s4:
+∀G.
+  contradiction G = NONE ∧
+  conjsplit_s4 G = NONE ∧
+  disjsplit_s4 G = NONE ∧
+  EVERY ($¬ ∘ is_boxed) G
+  ⇒
+  pre_hintikka G
+Proof
+  rw[pre_hintikka_def]
+  >- metis_tac[conjsplit_s4_EQ_NONE]
+  >- metis_tac[conjsplit_s4_EQ_NONE]
+  >- metis_tac[disjsplit_s4_EQ_NONE]
+  >> fs[EVERY_MEM] >> metis_tac[is_boxed_def]
+QED
+
+Theorem pre_hintikka_disj_left_cons:
+  ∀f1 h. pre_hintikka h ∧ MEM f1 h ⇒ ∀f2. pre_hintikka ((Disj f1 f2)::h)
+Proof
+  rw[pre_hintikka_def] >> rw[DISJ_IMP_THM, FORALL_AND_THM] >> metis_tac[]
+QED
+
+Theorem disj_s4_pf_eq_some:
+  ∀s pf s1 s2. disjsplit_s4 s = SOME (pf, s1, s2) ⇒
+    ∃f1 f2. pf = (Disj f1 f2) ∧ MEM f1 s1 ∧ MEM f2 s2 ∧
+      set s ⊆ pf INSERT set s1 ∧ set s ⊆ pf INSERT set s2
+Proof
+  ho_match_mp_tac disjsplit_s4_ind >> rw[disjsplit_s4_def] >> rw[SUBSET_DEF] >>
+  TRY (PairCases_on `z` >> fs[]) >> fs[SUBSET_DEF] >> metis_tac[]
+QED
+
+Theorem disj_s4_g2_in_g0:
+  ∀s pf s1 s2. disjsplit_s4 s = SOME (pf, s1, s2) ⇒ set s2 ⊆ set (closure_list_conc s)
+Proof
+  ho_match_mp_tac disjsplit_s4_ind >> rw[SUBSET_DEF]
+  >-(Cases_on `x = f2` >> fs[] >> rw[]
+     >- metis_tac[mem_closure_self]
+     >> metis_tac[mem_lst_closure])
+  >-(PairCases_on `z` >> fs[] >> rw[] >> Cases_on `x = Var v2` >> fs[])
+  >> PairCases_on `z` >> fs[] >> rw[] >> Cases_on `x = NVar v2` >> fs[]
+QED
+
+Theorem disj_s4_g1_in_g0:
+  ∀s pf s1 s2. disjsplit_s4 s = SOME (pf, s1, s2) ⇒ set s1 ⊆ set (closure_list_conc s)
+Proof
+  ho_match_mp_tac disjsplit_s4_ind >> rw[SUBSET_DEF]
+  >-(Cases_on `x = f1` >> fs[] >> rw[]
+     >- metis_tac[mem_closure_self]
+     >> metis_tac[mem_lst_closure])
+  >-(PairCases_on `z` >> fs[] >> rw[] >> Cases_on `x = Var v2` >> fs[])
+  >> PairCases_on `z` >> fs[] >> rw[] >> Cases_on `x = NVar v2` >> fs[]
+QED
+
+Theorem pre_hintikka_disj_right_cons:
+  ∀f2 h. pre_hintikka h ∧ MEM f2 h ⇒ ∀f1. pre_hintikka ((Disj f1 f2)::h)
+Proof
+  rw[pre_hintikka_def] >> rw[DISJ_IMP_THM, FORALL_AND_THM] >> metis_tac[]
+QED
+
+Theorem pre_hintikka_conj_cons:
+  ∀f1 f2 h. pre_hintikka h ∧ MEM f1 h ∧ MEM f2 h ⇒ pre_hintikka ((Conj f1 f2)::h)
+Proof
+  rw[pre_hintikka_def] >> rw[DISJ_IMP_THM, FORALL_AND_THM] >> metis_tac[]
+QED
+
+Theorem conj_s4_pf_eq_some:
+  ∀s pf s1 s2 g. conjsplit_s4 s = SOME (pf, g) ⇒
+    ∃f1 f2. pf = (Conj f1 f2) ∧ MEM f1 g ∧ MEM f2 g ∧ set s ⊆ pf INSERT set g
+Proof
+  ho_match_mp_tac conjsplit_s4_ind >> rw[conjsplit_s4_def] >> rw[SUBSET_DEF] >>
+  TRY (PairCases_on `z` >> fs[]) >> fs[SUBSET_DEF] >> metis_tac[]
+QED
+
+Theorem premodel_size_thm[simp] = definition "premodel_size_def"
+
+Definition thm_3_17_prop:
+  thm_3_17_prop (Nd (id, h, r) cs) ⇔ pre_hintikka h ∧
+                                     set id.Gm ⊆ set h ∧
+                                     ∀s. MEM s cs ⇒ thm_3_17_prop s
+Termination
+  WF_REL_TAC `measure (premodel_size (K 1))`
+End
+ (* >> Induct_on `cs` >> fs[] >> rw[]
+  >- rw[] >> first_x_assum (drule_then strip_assume_tac) >> simp[]
+End *)
+(* TODO: Not sure why this part of the termination proof
+         is no longer needed *)
+
+
+Theorem thm_3_17_prop_RTC:
+  ∀m w. thm_3_17_prop m ⇒ RTC pt_rel m w ⇒ thm_3_17_prop w
+Proof
+  Induct_on `RTC` >> rw[] >> Cases_on `m` >> PairCases_on `a` >>
+  fs[thm_3_17_prop] >> fs[pt_rel_def]
+QED
+
+Theorem thm_3_17:
+  ∀Γ0 s m.
+    tableau_S4 Γ0 s = OPEN m ⇒ thm_3_17_prop m
+Proof
+  ho_match_mp_tac tableau_S4_ind >> ntac 3 strip_tac >> simp[Once tableau_S4_def] >>
+  simp[AllCaseEqs()] >> rpt gen_tac >> strip_tac >> fs[]
+  >- (* trule *)
+    (rw[] >> fs[thm_3_17_prop] >> rw[] >>
+     drule tableau_S4_s_eq_id >> rw[] >> drule pre_hintikka_box_cons >> rw[] >>
+     fs[trule_s4_def, AllCaseEqs(), PULL_EXISTS]
+     (* MEM b s.Sg ==> pre_hintikka,  *)
+     >-(rw[] >> fs[wfm_S4_sequent, EVERY_MEM] >> `is_boxed b` by metis_tac[] >>
+        Cases_on `b` >> fs[] >> rw[] >> fs[dest_box_def])
+     (* not MEM b s.Sg ==> pre_hintikka *)
+     >-(rw[] >> fs[] >> drule pluck_eq_some_append >> rw[] >> fs[] >> rw[] >>
+        Cases_on `b` >> fs[dest_box_def])
+     (* MEM b s.Sg ==> sbst *)
+     >-(rw[] >> fs[] >> drule pluck_eq_some_append >> rw[] >> fs[] >> rw[] >>
+        Cases_on `b` >> fs[dest_box_def] >> rw[] >> fs[SUBSET_DEF])
+     (* not MEM b s.Sg ==> sbst *)
+     >> rw[] >> fs[] >> drule pluck_eq_some_append >> rw[] >> fs[] >> rw[] >>
+        Cases_on `b` >> fs[dest_box_def] >> rw[] >> fs[SUBSET_DEF])
+  >- (* s4 *)
+    (rw[] >> fs[thm_3_17_prop] >> rw[]
+     >- metis_tac[pre_hintikka_s4]
+     >> last_x_assum irule >> drule_all scmap_MEM >> rw[MEM_FILTER, MEM_undia] >> metis_tac[])
+  >- (* request *)
+    (rw[] >> fs[thm_3_17_prop] >> rw[] >> metis_tac[pre_hintikka_s4])
+  >- (* disj right *)
+    (rw[] >> fs[thm_3_17_prop] >> rw[]
+     >- (drule_then strip_assume_tac disj_s4_pf_eq_some >> rw[] >>
+        irule pre_hintikka_disj_right_cons >> rw[] >>
+        drule_then strip_assume_tac tableau_S4_s_eq_id >> rw[] >> fs[] >>
+        metis_tac[SUBSET_DEF])
+     >> drule_then strip_assume_tac tableau_S4_s_eq_id >> rw[] >> fs[] >>
+        drule_then strip_assume_tac disj_s4_pf_eq_some >> rw[] >> fs[SUBSET_DEF] >>
+        metis_tac[])
+  >- (* disj left *)
+    (rw[] >> fs[thm_3_17_prop] >> rw[]
+     >- (drule_then strip_assume_tac disj_s4_pf_eq_some >> rw[] >>
+        irule pre_hintikka_disj_left_cons >> rw[] >>
+        drule_then strip_assume_tac tableau_S4_s_eq_id >> rw[] >> fs[] >>
+        metis_tac[SUBSET_DEF])
+     >> drule_then strip_assume_tac tableau_S4_s_eq_id >> rw[] >> fs[] >>
+        drule_then strip_assume_tac disj_s4_pf_eq_some >> rw[] >> fs[SUBSET_DEF] >>
+        metis_tac[])
+  >> (* conj *)
+     rw[] >> fs[thm_3_17_prop] >> rw[]
+     >- (drule_then strip_assume_tac conj_s4_pf_eq_some >> rw[] >>
+        drule_then strip_assume_tac pre_hintikka_conj_cons >> rw[] >>
+        drule_then strip_assume_tac tableau_S4_s_eq_id >> rw[] >> fs[] >>
+        metis_tac[SUBSET_DEF])
+     >> drule_then strip_assume_tac tableau_S4_s_eq_id >> rw[] >> fs[] >>
+        drule_then strip_assume_tac conj_s4_pf_eq_some >> rw[] >> fs[SUBSET_DEF] >>
+        metis_tac[]
+QED
+
+Theorem trule_sg_subset:
+  ∀id f pf id'. MEM f id.Sg ∧ trule_s4 id = SOME (pf, id') ⇒ MEM f id'.Sg
+Proof
+  simp[trule_s4_def, AllCaseEqs(), PULL_EXISTS] >> rw[] >> fs[]
+QED
+
+Theorem trule_s4_pf_sg:
+  ∀id pf id'. trule_s4 id = SOME (pf, id') ⇒ MEM pf id'.Sg
+Proof
+  simp[trule_s4_def, AllCaseEqs(), PULL_EXISTS] >> rw[] >> fs[]
+QED
+
+Theorem trule_s4_As_eq:
+  ∀id pf id'. trule_s4 id = SOME (pf, id') ⇒ id.As = id'.As
+Proof
+  simp[trule_s4_def, AllCaseEqs(), PULL_EXISTS] >> rw[] >> fs[]
+QED
+
+Theorem his_sig_pair_in_local:
+  ∀p hs sg.  MEM (p,sg) (s4_request_local hs sg) ⇔ MEM p hs
+Proof
+  Induct_on `hs` >> rw[] >> first_x_assum (drule_then strip_assume_tac) >>
+  metis_tac[]
+QED
+
+Theorem all_his_id_sg:
+  ∀g d hs sg. MEM (g, d) (s4_request_local hs sg) ⇒ d = sg
+Proof
+  Induct_on `hs` >> rw[] >> first_x_assum drule >> simp[]
+QED
+
+Definition thm_3_19_prop[simp]:
+  thm_3_19_prop (Nd (id, h, r) l) ⇔
+            (∀s p. MEM s l ∧ MEM p id.Sg ⇒ MEM p (get_htk s)) ∧
+            (∀s p. MEM s l ∧ MEM (Box p) h ⇒ MEM (Box p) (get_htk s)) ∧
+            (∀p.
+                 MEM (Dia p) h ⇒
+                 (∃d. MEM (p,d) r) ∨ ∃s. MEM s l ∧ MEM p (get_htk s)) ∧
+            (∀g d p. MEM (g,d) r ∧ MEM (Box p) (h ⧺ id.Sg) ⇒ MEM (Box p) d) ∧
+            set r ⊆ set id.As ∧
+            (∀s. MEM s l ⇒ thm_3_19_prop s)
+Termination
+  WF_REL_TAC `measure (premodel_size (K 1))`
+End
+(* >> Induct_on `l` >> fs[] >> rw[]
+  >- rw[] >> first_x_assum (drule_then strip_assume_tac) >> simp[]
+End *)
+(* TODO: Not sure why this part of the termination proof
+         is no longer needed *)
+
+Definition thm_3_19_prop':
+  thm_3_19_prop' m ⇔
+            (∀s p. MEM s m.l ∧ MEM p m.id.Sg ⇒ MEM p (get_htk s)) ∧
+            (∀s p. MEM s m.l ∧ MEM (Box p) m.htk ⇒ MEM (Box p) (get_htk s)) ∧
+            (∀p.
+                 MEM (Dia p) m.htk ⇒
+                 (∃d. MEM (p,d) m.request) ∨ ∃s. MEM s m.l ∧ MEM p (get_htk s)) ∧
+            (∀g d p. MEM (g,d) m.request ∧ MEM (Box p) (m.htk ⧺ m.id.Sg) ⇒ MEM (Box p) d) ∧
+            set m.request ⊆ set m.id.As ∧
+            (∀s. MEM s m.l ⇒ thm_3_19_prop' s)
+Termination
+  WF_REL_TAC `measure (premodel_size (K 1))` >>
+  Cases_on `m` >> PairCases_on `a` >> Induct_on `l` >> fs[] >> rw[]
+  >- rw[] >> first_x_assum (drule_then strip_assume_tac) >> simp[]
+End
+
+Theorem thm_3_19_prop_RTC:
+  ∀m w. thm_3_19_prop m ⇒ RTC pt_rel m w ⇒ thm_3_19_prop w
+Proof
+  Induct_on `RTC` >> rw[] >> Cases_on `m` >> PairCases_on `a` >>
+  fs[thm_3_19_prop] >> fs[pt_rel_def]
+QED
+
+Theorem thm_3_19_2_RTC_pt_rel:
+  ∀w s p. thm_3_19_prop w ⇒ RTC pt_rel w s ∧ MEM (Box p) w.htk ⇒ MEM (Box p) s.htk
+Proof
+  Induct_on `RTC` >> rw[] >> Cases_on `w` >> PairCases_on `a` >>
+  fs[thm_3_19_prop] >> fs[pt_rel_def]
+QED
+
+val S4_sequent_component_equality = DB.fetch "-" "S4_sequent_component_equality"
+(*
+h: htk
+r: request
+*)
+Theorem thm_3_19:
+   ∀Γ0 Γ m.
+            tableau_S4 Γ0 Γ = OPEN m ⇒
+            thm_3_19_prop m
+Proof
+  ho_match_mp_tac tableau_S4_ind >> ntac 3 strip_tac >>
+  ONCE_REWRITE_TAC[tableau_S4_def] >> simp_tac(srw_ss ())[AllCaseEqs()] >>
+  rpt strip_tac
+  (* Trule *)
+  >- (rw[] >> fs[]
+      >- (fs[] >> rw[] >> drule_then SUBST_ALL_TAC tableau_S4_s_eq_id >>
+        metis_tac[trule_sg_subset])
+      >- (fs[] >> rw[] >> fs[] >> rw[] >> drule_then SUBST_ALL_TAC tableau_S4_s_eq_id >>
+          metis_tac[trule_s4_pf_sg])
+      >- (fs[] >> rw[] >> drule_then SUBST_ALL_TAC tableau_S4_s_eq_id >>
+          fs[] >> rw[] >> fs[trule_s4_def, AllCaseEqs(), PULL_EXISTS] >>
+          fs[] >> rw[] >> drule pluck_eq_some_append >> rw[])
+      >- (fs[] >> rw[] >> drule_then SUBST_ALL_TAC tableau_S4_s_eq_id >>
+          fs[] >> rw[] >> metis_tac[trule_s4_pf_sg])
+      >- (fs[] >> rw[] >> drule_then SUBST_ALL_TAC tableau_S4_s_eq_id >>
+          metis_tac[trule_sg_subset])
+      >- (fs[] >> rw[] >> drule_then SUBST_ALL_TAC tableau_S4_s_eq_id >>
+          metis_tac[trule_sg_subset])
+      >- (fs[] >> rw[] >> drule_then SUBST_ALL_TAC tableau_S4_s_eq_id >>
+          metis_tac[trule_s4_As_eq]))
+  (* S4 *)
+  >- (fs[AllCaseEqs()] >> rw[]
+      >- (fs[] >> rw[] >> first_x_assum (qspecl_then [`f`, `gamma`] (K all_tac)) >>
+          fs[AllCaseEqs(), MEM_FILTER] >> rw[] >> drule_all scmap_MEM >>
+          rw[MEM_FILTER] >> first_x_assum (drule_then drule) >> Cases_on `s` >>
+          PairCases_on `a` >> disch_then $ drule_then strip_assume_tac >>
+          simp[] >> drule thm_3_17 >> fs[thm_3_17_prop] >> rw[] >>
+          drule_then (SUBST_ALL_TAC o SYM) tableau_S4_s_eq_id >> fs[] >>
+          metis_tac[SUBSET_DEF])
+      >- (fs[] >> rw[] >> first_x_assum (qspecl_then [`f`, `gamma`] (K all_tac)) >>
+          fs[AllCaseEqs(), MEM_FILTER] >> fs[EVERY_MEM] >> first_x_assum drule >>
+          rw[])
+      >- (fs[] >> rw[] >> first_x_assum (qspecl_then [`f`, `gamma`] (K all_tac)) >>
+          fs[AllCaseEqs(), MEM_FILTER] >> rw[] >> Cases_on `MEM p Γ.Hs`
+          >- (fs[wfm_S4_sequent] >> first_x_assum drule >> rw[] >>
+              DISJ1_TAC >> qexists_tac `Γ.Sg` >> metis_tac[his_sig_pair_in_local])
+          >> first_x_assum drule >> fs[MEM_undia] >> strip_tac >> drule scmap_MEM2 >>
+          simp[MEM_FILTER, MEM_undia] >> disch_then drule_all >> rw[] >>
+          Cases_on `e` >> PairCases_on `a` >> first_x_assum drule >> rw[] >>
+          DISJ2_TAC >> qexists_tac `(Nd (a0,a1,a2) l)` >> rw[] >> drule thm_3_17 >> fs[thm_3_17_prop] >>
+          rw[] >> drule_then (SUBST_ALL_TAC o SYM) tableau_S4_s_eq_id >> fs[])
+      >- (fs[] >> rw[] >> first_x_assum (qspecl_then [`f`, `gamma`] (K all_tac)) >>
+          fs[AllCaseEqs(), MEM_FILTER] >> rw[] >> fs[EVERY_MEM] >> metis_tac[is_boxed_def])
+      >- (fs[] >> rw[] >> first_x_assum (qspecl_then [`f`, `gamma`] (K all_tac)) >>
+          fs[AllCaseEqs(), MEM_FILTER] >> rw[] >> fs[wfm_S4_sequent] >>
+          metis_tac[all_his_id_sg])
+      >- (fs[] >> rw[] >> first_x_assum (qspecl_then [`f`, `gamma`] (K all_tac)) >>
+          fs[AllCaseEqs(), MEM_FILTER] >> rw[] >> fs[wfm_S4_sequent] >>
+          rw[SUBSET_DEF] >> Cases_on `x` >> drule all_his_id_sg >> rw[] >>
+          metis_tac[his_sig_pair_in_local])
+      >- (fs[MEM_FILTER] >> drule scmap_MEM >> rw[MEM_FILTER] >>
+          first_x_assum drule >> rw[] >> metis_tac[]))
+  (* Litral *)
+  >- (rw[] >> fs[]
+      >- (fs[EVERY_MEM] >> first_x_assum drule >> metis_tac[is_dia_def])
+      >- (fs[EVERY_MEM] >> first_x_assum drule >> metis_tac[is_boxed_def])
+      >- (drule all_his_id_sg >> rw[])
+      >- (rw[SUBSET_DEF] >> Cases_on `x` >> drule all_his_id_sg >> rw[] >>
+          fs[wfm_S4_sequent] >> metis_tac[his_sig_pair_in_local]))
+  (* disj2 *)
+  >- (rw[] >> fs[]
+      >- (`Γ with <|Ss := NONE; Gm := Γ2|> = id` by metis_tac[tableau_S4_s_eq_id] >>
+          `Γ.Sg = id.Sg` by fs[S4_sequent_component_equality] >> fs[])
+      >- (fs[] >> rw[] >> drule disj_s4_pf_eq_some >> rw[] >> fs[])
+      >- (fs[] >> rw[] >> drule disj_s4_pf_eq_some >> rw[] >> fs[])
+      >- (fs[] >> rw[] >> drule disj_s4_pf_eq_some >> rw[] >> fs[] >> metis_tac[])
+      >- (fs[] >> rw[] >> fs[wfm_S4_sequent] >>
+          `Γ with <|Ss := NONE; Gm := Γ2|> = id` by metis_tac[tableau_S4_s_eq_id] >>
+          `Γ.Sg = id.Sg` by fs[S4_sequent_component_equality] >> fs[] >>
+          metis_tac[])
+      >- (fs[] >> rw[] >> fs[wfm_S4_sequent] >>
+          `Γ with <|Ss := NONE; Gm := Γ2|> = id` by metis_tac[tableau_S4_s_eq_id] >>
+          `Γ.Sg = id.Sg` by fs[S4_sequent_component_equality] >> fs[] >>
+          metis_tac[])
+      >- (fs[] >> rw[] >> `Γ with <|Ss := NONE; Gm := Γ2|> = id` by metis_tac[tableau_S4_s_eq_id] >>
+          `Γ.As = id.As` by fs[S4_sequent_component_equality] >> fs[]))
+  (* disj1 *)
+  >- (rw[] >> fs[]
+      >- (`Γ with <|Ss := NONE; Gm := Γ1|> = id` by metis_tac[tableau_S4_s_eq_id] >>
+          `Γ.Sg = id.Sg` by fs[S4_sequent_component_equality] >> fs[])
+      >- (fs[] >> rw[] >> drule disj_s4_pf_eq_some >> rw[] >> fs[])
+      >- (fs[] >> rw[] >> drule disj_s4_pf_eq_some >> rw[] >> fs[])
+      >- (fs[] >> rw[] >> drule disj_s4_pf_eq_some >> rw[] >> fs[] >> metis_tac[])
+      >- (fs[] >> rw[] >> fs[wfm_S4_sequent] >>
+          `Γ with <|Ss := NONE; Gm := Γ1|> = id` by metis_tac[tableau_S4_s_eq_id] >>
+          `Γ.Sg = id.Sg` by fs[S4_sequent_component_equality] >> fs[] >>
+          metis_tac[])
+      >- (fs[] >> rw[] >> fs[wfm_S4_sequent] >>
+          `Γ with <|Ss := NONE; Gm := Γ1|> = id` by metis_tac[tableau_S4_s_eq_id] >>
+          `Γ.Sg = id.Sg` by fs[S4_sequent_component_equality] >> fs[] >>
+          metis_tac[])
+      >- (fs[] >> rw[] >> `Γ with <|Ss := NONE; Gm := Γ1|> = id` by metis_tac[tableau_S4_s_eq_id] >>
+          `Γ.As = id.As` by fs[S4_sequent_component_equality] >> fs[]))
+  (* conj *)
+  >- (rw[] >> fs[]
+      >- (`Γ with <|Ss := NONE; Gm := Γ'|> = id` by metis_tac[tableau_S4_s_eq_id] >>
+          `Γ.Sg = id.Sg` by fs[S4_sequent_component_equality] >> fs[])
+      >- (fs[] >> rw[] >> drule conj_s4_pf_eq_some >> rw[] >> fs[])
+      >- (fs[] >> rw[] >> drule conj_s4_pf_eq_some >> rw[] >> fs[])
+      >- (fs[] >> rw[] >> drule conj_s4_pf_eq_some >> rw[] >> fs[] >> metis_tac[])
+      >- (fs[] >> rw[] >> fs[wfm_S4_sequent] >>
+          `Γ with <|Ss := NONE; Gm := Γ'|> = id` by metis_tac[tableau_S4_s_eq_id] >>
+          `Γ.Sg = id.Sg` by fs[S4_sequent_component_equality] >> fs[] >>
+          metis_tac[])
+      >- (fs[] >> rw[] >> fs[wfm_S4_sequent] >>
+          `Γ with <|Ss := NONE; Gm := Γ'|> = id` by metis_tac[tableau_S4_s_eq_id] >>
+          `Γ.Sg = id.Sg` by fs[S4_sequent_component_equality] >> fs[] >>
+          metis_tac[])
+      >- (fs[] >> rw[] >> `Γ with <|Ss := NONE; Gm := Γ'|> = id` by metis_tac[tableau_S4_s_eq_id] >>
+          `Γ.As = id.As` by fs[S4_sequent_component_equality] >> fs[]))
+QED
+
+Theorem pt_rel_attach:
+  ∀u cs s. MEM u cs ∧ RTC pt_rel u s ⇒ (∀id h r. RTC pt_rel (Nd (id, h, r) cs) s)
+Proof
+  rw[] >> simp[Once RTC_CASES1, pt_rel_def] >> metis_tac[]
+QED
+
+Theorem pt_rel_attach_r':
+  ∀u v w. RTC pt_rel u v ∧ MEM w v.l ⇒ RTC pt_rel u w
+Proof
+  rw[] >> Cases_on `v` >> fs[] >>
+  simp[Once RTC_CASES2, pt_rel_def] >>
+  metis_tac[]
+QED
+
+Theorem trule_s4_Ss_reset:
+  ∀s pf s'. trule_s4 s = SOME (pf, s') ⇒ s'.Ss = NONE
+Proof
+  simp[trule_s4_def, AllCaseEqs(), PULL_EXISTS] >> rw[] >> fs[]
+QED
+
+Definition thm_3_20_prop:
+  thm_3_20_prop m ⇔
+      (∀s r. RTC pt_rel m s ∧ MEM r s.request ⇒
+        MEM r m.id.As ∨ ∃d. RTC pt_rel m d ∧ SOME r = d.id.Ss) ∧
+      (∀s. pt_rel m s ⇒ thm_3_20_prop s)
+Termination
+  WF_REL_TAC `measure (premodel_size (K 1))` >> Cases_on `m` >> rw[pt_rel_def] >>
+  Induct_on `l` >> fs[] >> rw[]
+  >- simp[]
+  >> fs[]
+End
+
+Theorem thm_3_20_prop_RTC:
+  ∀m w. thm_3_20_prop m ⇒ RTC pt_rel m w ⇒ thm_3_20_prop w
+Proof
+  Induct_on `RTC` >> rw[] >> Cases_on `m` >> PairCases_on `a` >>
+  pop_assum mp_tac >> simp[Once thm_3_20_prop]
+QED
+
+(* thm_3_20 *)
+Theorem s4_fulfillment:
+   ∀Γ0 Γ m s.
+            tableau_S4 Γ0 Γ = OPEN m ⇒ thm_3_20_prop m
+Proof
+  ho_match_mp_tac tableau_S4_ind >> ntac 3 strip_tac >>
+  ONCE_REWRITE_TAC[tableau_S4_def] >> ONCE_REWRITE_TAC[tableau_S4_def] >>
+  rewrite_tac[AllCaseEqs()] >> rpt strip_tac
+  >- fs[]
+  >- fs[]
+  (* trule *)
+  >- (Cases_on `x` >> fs[] >> rw[] >> first_x_assum (qspec_then `x:form` (K all_tac)) >>
+      Cases_on `tableau_S4 Γ0 r` >> fs[] >> Cases_on `x` >> PairCases_on `a` >> fs[] >>
+      fs[Once thm_3_20_prop] >> rw[]
+      (* current *)
+      >- (qpat_x_assum `RTC _ _ _` mp_tac >> simp[SimpL ``$==>``, Once RTC_CASES1] >>
+          strip_tac
+          (* fulfilled in As *)
+          >- (rw[] >> fs[] >> drule thm_3_19 >> fs[thm_3_19_prop] >> rw[] >> drule trule_s4_As_eq >>
+              rw[] >> drule tableau_S4_s_eq_id >> rw[] >> metis_tac[SUBSET_DEF])
+          (* fulfilled in descendant *)
+          >> fs[pt_rel_def] >> drule_all pt_rel_attach >> rw[] >>
+          first_x_assum (qspecl_then [`a0`, `a1`, `a2`] (ASSUME_TAC)) >>
+          last_x_assum (drule_all_then strip_assume_tac)
+          >- (drule trule_s4_As_eq >> rw[] >> drule tableau_S4_s_eq_id >> rw[])
+          >> qpat_x_assum `RTC _ _ _` mp_tac >> simp[SimpL ``$==>``, Once RTC_CASES1] >> rw[]
+          >- (fs[] >> drule trule_s4_Ss_reset >> rw[] >> drule tableau_S4_s_eq_id >> rw[] >> fs[])
+          >> fs[pt_rel_def] >> metis_tac[pt_rel_attach])
+      (* descendant *)
+      >> fs[pt_rel_def])
+  (* S4 *)
+  >- (fs[] >> rw[] >> first_x_assum (qspecl_then [`pf`, `gm`] (K all_tac)) >>
+      fs[MEM_FILTER, AllCaseEqs()] >> rw[] >> simp[Once thm_3_20_prop] >> rw[]
+       (* current *)
+       >- (qpat_x_assum `RTC _ _ _` mp_tac >> simp[SimpL ``$==>``, Once RTC_CASES1] >> rw[]
+           >- (fs[] >> fs[wfm_S4_sequent] >> Cases_on `r` >> drule all_his_id_sg >>
+               rw[] >> metis_tac[his_sig_pair_in_local])
+           >> drule scmap_MEM >> rw[MEM_FILTER, MEM_undia] >>
+           `MEM u ms` by fs[pt_rel_def] >>
+           first_x_assum (drule_all_then strip_assume_tac) >>
+           fs[MEM_undia] >> first_x_assum (drule_all_then strip_assume_tac) >>
+           fs[Once thm_3_20_prop] >> first_x_assum (drule_all_then strip_assume_tac)
+           >- (`RTC pt_rel (Nd (Γ,Γ.Gm,s4_request_local Γ.Hs Γ.Sg) ms) u` by metis_tac[RTC_CASES1] >>
+               Cases_on `u` >> PairCases_on `a` >> drule tableau_S4_s_eq_id >>
+               rw[] >> fs[] >> DISJ2_TAC >>
+               qexists_tac
+               `(Nd
+                 (Γ with
+                  <|As := (e0,Γ.Sg)::Γ.As; Ss := SOME (e0,Γ.Sg); Hs := e0::Γ.Hs;
+                    Gm := e0::Γ.Sg|>,a1,a2) l)` >> rw[])
+           >> DISJ2_TAC >> fs[pt_rel_def] >> drule_all pt_rel_attach >> metis_tac[])
+        (* descendant *)
+        >> drule scmap_MEM >> rw[MEM_FILTER, MEM_undia] >>
+           `MEM s ms` by fs[pt_rel_def] >>
+           first_x_assum (drule_all_then strip_assume_tac) >>
+           first_x_assum (drule_then strip_assume_tac) >> fs[MEM_undia])
+  (* Literal *)
+  >- (fs[] >> rw[] >> first_x_assum (qspecl_then [`pf`, `gm`] (K all_tac)) >>
+      first_x_assum (qspecl_then [`pf`] (K all_tac)) >> simp[Once thm_3_20_prop] >> rw[]
+      (* current *)
+      >- (fs[Once RTC_CASES1]
+          >- (fs[wfm_S4_sequent] >>
+              `MEM r (s4_request_local Γ.Hs Γ.Sg)` by metis_tac[get_request] >>
+              Cases_on `r` >> drule all_his_id_sg >> rw[] >>
+             `MEM q Γ.Hs` by metis_tac[his_sig_pair_in_local] >> metis_tac[])
+          >> fs[pt_rel_def])
+      (* descendant *)
+      >> fs[pt_rel_def])
+  (* disj2 *)
+  >- (fs[] >> rw[] >> PairCases_on `x` >> fs[] >> simp[Once thm_3_20_prop] >> rw[]
+      (* current fulfillment *)
+      >- (fs[Once RTC_CASES1]
+          >-(Cases_on `tableau_S4 Γ0 (Γ with <|Ss := NONE; Gm := x1|>)` >> fs[]
+             >-(Cases_on `tableau_S4 Γ0 (Γ with <|Ss := NONE; Gm := x2|>)` >> fs[] >>
+                Cases_on `x` >> PairCases_on `a` >> fs[] >> drule thm_3_19 >> rw[] >>
+                drule tableau_S4_s_eq_id >> rw[] >> fs[] >> metis_tac[SUBSET_DEF])
+             >> Cases_on `x` >> PairCases_on `a` >> fs[] >> drule thm_3_19 >> rw[]
+             >> drule tableau_S4_s_eq_id >> rw[] >> fs[] >> metis_tac[SUBSET_DEF])
+          >> Cases_on `tableau_S4 Γ0 (Γ with <|Ss := NONE; Gm := x1|>)` >> fs[]
+          >-(Cases_on `tableau_S4 Γ0 (Γ with <|Ss := NONE; Gm := x2|>)` >> fs[] >>
+             Cases_on `x` >> PairCases_on `a` >> fs[] >> fs[pt_rel_def, Once thm_3_20_prop] >>
+             rw[] >> drule pt_rel_attach >> rw[] >>
+             first_x_assum (qspecl_then [`s`, `a0`, `a1`, `a2`] (ASSUME_TAC)) >>
+             first_x_assum drule >> rw[] >> last_x_assum (drule_all_then strip_assume_tac)
+             >-(drule tableau_S4_s_eq_id >> rw[] >> fs[])
+             >> qpat_x_assum `RTC pt_rel (_ _ _) d` mp_tac >> simp[Once RTC_CASES1] >>
+                rw[pt_rel_def]
+                >- (drule tableau_S4_s_eq_id >> rw[] >> fs[])
+                >> DISJ2_TAC >> qexists_tac `d` >> rw[RIGHT_AND_OVER_OR] >>
+                DISJ2_TAC >> qexists_tac `u'` >> rw[])
+          >> Cases_on `x` >> PairCases_on `a` >> fs[] >> fs[pt_rel_def, Once thm_3_20_prop] >>
+             rw[] >> drule pt_rel_attach >> rw[] >>
+             first_x_assum (qspecl_then [`s`, `a0`, `a1`, `a2`] (ASSUME_TAC)) >>
+             first_x_assum drule >> rw[] >> last_x_assum (drule_all_then strip_assume_tac)
+             >-(drule tableau_S4_s_eq_id >> rw[] >> fs[])
+             >> qpat_x_assum `RTC pt_rel (_ _ _) d` mp_tac >> simp[Once RTC_CASES1] >>
+                rw[pt_rel_def]
+                >- (drule tableau_S4_s_eq_id >> rw[] >> fs[])
+                >> DISJ2_TAC >> qexists_tac `d` >> rw[RIGHT_AND_OVER_OR] >>
+                DISJ2_TAC >> qexists_tac `u'` >> rw[])
+      (* descendant fulfillment*)
+      >> Cases_on `tableau_S4 Γ0 (Γ with <|Ss := NONE; Gm := x1|>)` >> fs[]
+         >-(Cases_on `tableau_S4 Γ0 (Γ with <|Ss := NONE; Gm := x2|>)` >> fs[] >>
+            Cases_on `x` >> PairCases_on `a` >> fs[] >> rw[] >> fs[Once thm_3_20_prop] >>
+            `pt_rel (Nd (a0,a1,a2) l) s` by fs[pt_rel_def] >> metis_tac[thm_3_20_prop])
+         >> Cases_on `x` >> PairCases_on `a` >> fs[] >> rw[] >> fs[Once thm_3_20_prop] >>
+            `pt_rel (Nd (a0,a1,a2) l) s` by fs[pt_rel_def] >> metis_tac[thm_3_20_prop])
+  (* disj1 *)
+  >- (fs[] >> rw[] >> PairCases_on `x` >> fs[] >> simp[Once thm_3_20_prop] >> rw[]
+      (* current fulfillment *)
+      >- (fs[Once RTC_CASES1]
+          >-(Cases_on `tableau_S4 Γ0 (Γ with <|Ss := NONE; Gm := x1|>)` >> fs[]
+             >> Cases_on `x` >> PairCases_on `a` >> fs[] >> drule thm_3_19 >> rw[]
+             >> drule tableau_S4_s_eq_id >> rw[] >> fs[] >> metis_tac[SUBSET_DEF])
+          >> Cases_on `tableau_S4 Γ0 (Γ with <|Ss := NONE; Gm := x1|>)` >> fs[]
+          >> Cases_on `x` >> PairCases_on `a` >> fs[] >> fs[pt_rel_def, Once thm_3_20_prop]
+          >> rw[] >> drule pt_rel_attach >> rw[]
+          >> first_x_assum (qspecl_then [`s`, `a0`, `a1`, `a2`] (ASSUME_TAC))
+          >> first_x_assum drule >> rw[] >> last_x_assum (drule_all_then strip_assume_tac)
+          >-(drule tableau_S4_s_eq_id >> rw[] >> fs[])
+          >> qpat_x_assum `RTC pt_rel (_ _ _) d` mp_tac >> simp[Once RTC_CASES1] >>
+             rw[pt_rel_def]
+             >- (drule tableau_S4_s_eq_id >> rw[] >> fs[])
+             >> DISJ2_TAC >> qexists_tac `d` >> rw[RIGHT_AND_OVER_OR] >>
+             DISJ2_TAC >> qexists_tac `u'` >> rw[])
+      (* descendant fulfillment*)
+      >> Cases_on `tableau_S4 Γ0 (Γ with <|Ss := NONE; Gm := x1|>)` >> fs[]
+      >> Cases_on `x` >> PairCases_on `a` >> fs[] >> rw[] >> fs[Once thm_3_20_prop]
+      >> `pt_rel (Nd (a0,a1,a2) l) s` by fs[pt_rel_def] >> metis_tac[thm_3_20_prop])
+  (* conj *)
+  >> fs[] >> rw[]
+QED
+
+(*
+A state s reaches a state t by one step,
+  if t is a child of s,
+  or the signature of t is in the request of s.
+*)
+
+Definition reach_step:
+  reach_step m s t ⇔ MEM t s.l ∨ ∃sig. RTC pt_rel m t ∧ t.id.Ss = SOME sig ∧ MEM sig s.request
+End
+
+Definition s4_tree_model:
+  s4_tree_model m =
+    <|  rel    := RTC (reach_step m);
+        valt   := (λs v. MEM (Var v) s.htk);
+        worlds := {m' | RTC (reach_step m) m m'}
+    |>
+End
+
+
+Theorem reach_step_from_root:
+∀f m x w.
+  final_tableau_S4 f = OPEN m ⇒
+    RTC (reach_step m) x w ⇒
+      RTC pt_rel m x ⇒
+      RTC pt_rel m w
+Proof
+  simp[final_tableau_S4_def] >> ntac 2 gen_tac >> Induct_on `RTC` >>
+  rw[] >> first_x_assum (drule_then strip_assume_tac) >> fs[reach_step] >>
+  first_x_assum irule >> irule (CONJUNCT2 $ SPEC_ALL $ RTC_RULES_RIGHT1) >>
+  simp[pt_rel_def] >> simp[PULL_EXISTS] >> Cases_on `x` >> fs[] >> metis_tac[]
+QED
+
+Theorem reach_step_from_root':
+∀x w.
+    RTC (reach_step m) x w ⇒
+      RTC pt_rel m x ⇒
+      RTC pt_rel m w
+Proof
+  Induct_on `RTC` >>
+  rw[] >> fs[reach_step] >> metis_tac[pt_rel_attach_r']
+QED
+
+Definition tableau_S4_Ss_eq_Gm_prop:
+  tableau_S4_Ss_eq_Gm_prop m ⇔
+  (m.id.Ss = NONE ∨ ∃p sg. m.id.Ss = SOME (p, sg) ∧ set (p::sg) ⊆ set m.id.Gm) ∧
+  (∀s. pt_rel m s ⇒ tableau_S4_Ss_eq_Gm_prop s)
+Termination
+  WF_REL_TAC `measure (premodel_size (K 1))` >> Cases_on `m` >> rw[pt_rel_def] >>
+  Induct_on `l` >> fs[] >> rw[]
+  >- simp[]
+  >> fs[]
+End
+
+Theorem tableau_S4_Ss_eq_Gm_prop_RTC:
+  ∀m w. tableau_S4_Ss_eq_Gm_prop m ⇒ RTC pt_rel m w ⇒ tableau_S4_Ss_eq_Gm_prop w
+Proof
+  Induct_on `RTC` >> rw[] >> pop_assum mp_tac >> simp[Once tableau_S4_Ss_eq_Gm_prop]
+QED
+
+Theorem tableau_S4_Ss_eq_Gm:
+  ∀Γ0 s m. tableau_S4 Γ0 s = OPEN m ⇒
+           wfm_S4_sequent Γ0 s ⇒
+           tableau_S4_Ss_eq_Gm_prop m
+Proof
+  ho_match_mp_tac tableau_S4_ind >> ntac 3 strip_tac >>
+  simp[Once tableau_S4_Ss_eq_Gm_prop] >> simp[Once tableau_S4_def] >>
+  simp[AllCaseEqs()] >> ntac 2 strip_tac
+  (* Trule *)
+  >-(rw[] >> fs[] >> rw[]
+     >-(fs[wfm_S4_sequent] >> Cases_on `s.Ss` >> fs[] >>
+        Cases_on `x` >> qexistsl_tac [`q`, `r'`] >> rw[] >> metis_tac[SUBSET_DEF])
+     >> first_x_assum (qspec_then `df` (K all_tac)) >>
+     drule wfm_S4_trule >> rw[] >> first_x_assum (drule_then strip_assume_tac) >>
+     `pt_rel (Nd (id, h, r) cs) s''` by fs[pt_rel_def] >> metis_tac[tableau_S4_Ss_eq_Gm_prop])
+  (* S4 *)
+  >-(rw[] >> fs[] >> rw[]
+     >-(first_x_assum (qspecl_then [`pf`, `gm`] (K all_tac)) >> fs[wfm_S4_sequent] >>
+        Cases_on `s.Ss` >> fs[] >> Cases_on `x` >> qexistsl_tac [`q`, `r`] >> rw[])
+     >> first_x_assum (qspecl_then [`pf`, `gm`] (K all_tac)) >>
+     fs[pt_rel_def] >> rw[] >> drule scmap_MEM >> rw[] >> first_x_assum drule >> rw[] >>
+     `wfm_S4_sequent Γ0
+          (s with
+           <|As := (e0,s.Sg)::s.As; Ss := SOME (e0,s.Sg); Hs := e0::s.Hs;
+             Gm := e0::s.Sg|>)` by (fs[wfm_S4_sequent] >> rw[]
+                                    >- fs[MEM_FILTER]
+                                    >-(fs[MEM_FILTER] >> metis_tac[undia_dia_in_closure])
+                                    >-(fs[MEM_FILTER] >> metis_tac[undia_dia_in_closure])
+                                    >- fs[PSUBSET_DEF, SUBSET_DEF]
+                                    >- fs[MEM_FILTER, MEM_undia, SUBSET_DEF]
+                                    >- metis_tac[]
+                                    >- metis_tac[]
+                                    >> rw[SUBSET_DEF]) >> metis_tac[])
+  (* Literal *)
+  >-(rw[] >> fs[] >> rw[]
+     >-(fs[wfm_S4_sequent] >> rw[] >> Cases_on `s.Ss` >> fs[] >> Cases_on `x` >> metis_tac[])
+     >> fs[pt_rel_def] >> rw[])
+  (* disj2 *)
+  >-(rw[] >> fs[] >> rw[]
+     >-(fs[wfm_S4_sequent] >> rw[] >> Cases_on `s.Ss` >> fs[] >> Cases_on `x` >> metis_tac[])
+     >> `pt_rel (Nd (id, h, r) cs) s'` by fs[pt_rel_def] >>
+     `wfm_S4_sequent Γ0 (s with <|Ss := NONE; Gm := Γ2|>)`
+        by (fs[wfm_S4_sequent] >> drule disj_s4_g2_in_g0 >> rw[] >>
+            `set (closure_list_conc s.Gm) ⊆ set (closure_list_conc [Γ0])`
+                 by fs[closure_subset_closure] >> metis_tac[SUBSET_DEF]) >>
+     metis_tac[tableau_S4_Ss_eq_Gm_prop])
+  (* disj1 *)
+  >-(rw[] >> fs[] >> rw[]
+     >-(fs[wfm_S4_sequent] >> rw[] >> Cases_on `s.Ss` >> fs[] >> Cases_on `x` >> metis_tac[])
+     >> `pt_rel (Nd (id, h, r) cs) s'` by fs[pt_rel_def] >>
+     `wfm_S4_sequent Γ0 (s with <|Ss := NONE; Gm := Γ1|>)`
+        by (fs[wfm_S4_sequent] >> drule disj_s4_g1_in_g0 >> rw[] >>
+            `set (closure_list_conc s.Gm) ⊆ set (closure_list_conc [Γ0])`
+                 by fs[closure_subset_closure] >> metis_tac[SUBSET_DEF]) >>
+     metis_tac[tableau_S4_Ss_eq_Gm_prop])
+  (* conj *)
+  >> rw[] >> fs[] >> rw[]
+  >-(fs[wfm_S4_sequent] >> rw[] >> Cases_on `s.Ss` >> fs[] >> Cases_on `x` >> metis_tac[])
+  >> `pt_rel (Nd (id, h, r) cs) s'` by fs[pt_rel_def] >>
+  `wfm_S4_sequent Γ0 (s with <|Ss := NONE; Gm := Γ'|>)`
+      by (fs[wfm_S4_sequent] >> drule conjsplit_s4_MEM2 >> rw[] >> fs[SUBSET_DEF] >> rw[] >>
+          first_x_assum (drule_then strip_assume_tac)
+          >- metis_tac[]
+          >> first_x_assum (drule_then strip_assume_tac) >> drule mem_closure_of_closure >>
+             rw[] >> metis_tac[mem_closure_self]) >>
+   metis_tac[tableau_S4_Ss_eq_Gm_prop]
+QED
+
+Theorem RTC_pt_rel_imp_RTC_reach_step:
+  ∀x w. RTC pt_rel x w ⇒ x = m ⇒ RTC (reach_step m) x w
+Proof
+  ho_match_mp_tac RTC_INDUCT_RIGHT1 >> rw[] >> fs[pt_rel_def] >>
+  `(reach_step m) w w'` by rw[reach_step] >>
+  metis_tac[RTC_CASES2]
+QED
+
+Theorem reach_step_preserve_box:
+∀w v.
+    reach_step m w v ⇒
+    MEM (Box p) w.htk ⇒
+    thm_3_19_prop w ⇒
+    thm_3_17_prop v ⇒
+    wfm_S4_sequent Γ0 v.id ⇒
+    MEM (Box p) v.htk
+Proof
+  rw[reach_step] >- (Cases_on `w` >> PairCases_on `a` >> fs[thm_3_19_prop]) >>
+  fs[wfm_S4_sequent] >> Cases_on `sig` >> first_x_assum drule >> rw[] >>
+  Cases_on `w` >> PairCases_on `a` >> fs[thm_3_19_prop] >>
+  `MEM (Box p) r` by metis_tac[] >>
+  Cases_on `v` >> PairCases_on `a` >> fs[thm_3_17_prop] >>
+  metis_tac[SUBSET_DEF]
+QED
+
+Theorem RTC_reach_step_reserve_box:
+∀w v.
+    RTC (reach_step m) w v ∧
+    RTC pt_rel m w ∧
+    MEM (Box p) w.htk ∧
+    thm_3_19_prop m ∧
+    thm_3_17_prop m ∧
+    (∀s. RTC pt_rel m s ⇒ wfm_S4_sequent Γ0 s.id) ⇒
+    MEM (Box p) v.htk
+Proof
+  Induct_on `RTC` >> rw[] >> fs[] >>
+  first_x_assum irule >> rw[]
+  >- (irule reach_step_preserve_box >> rw[]
+      >-(irule thm_3_17_prop_RTC >> qexists_tac `m` >> rw[] >>
+         fs[reach_step] >> metis_tac[pt_rel_attach_r'])
+      >-(drule reach_step_from_root' >> rw[] >>
+         fs[reach_step] >> metis_tac[pt_rel_attach_r'])
+      >> qexistsl_tac [`m`,`w`] >> metis_tac[thm_3_19_prop_RTC])
+  >> fs[reach_step] >> metis_tac[pt_rel_attach_r']
+QED
+
+(* thm_3_22*)
+Theorem tableau_S4_sound:
+  ∀f m. final_tableau_S4 f = OPEN m ⇒
+          ∀w. w ∈ (s4_tree_model m).worlds ⇒
+               ∀p. MEM p w.htk ⇒
+                   forces (s4_tree_model m) w p
+Proof
+  simp[PULL_FORALL] >> Induct_on `p`
+  (* Var *)
+  >-(simp[forces_def, s4_tree_model])
+  (* NVAr *)
+  >-(simp[forces_def, s4_tree_model] >> rpt strip_tac >>
+     drule reach_step_from_root >> strip_tac >> first_x_assum (drule_then strip_assume_tac) >>
+     `RTC pt_rel m m` by metis_tac[RTC_def] >> first_x_assum (drule_then strip_assume_tac) >>
+     fs[final_tableau_S4_def] >> drule thm_3_17 >> strip_tac >>
+     drule thm_3_17_prop_RTC >> strip_tac >>
+     first_x_assum (drule_then strip_assume_tac) >>
+     Cases_on `w` >> PairCases_on `a` >> fs[thm_3_17_prop] >>
+     fs[pre_hintikka_def] >> metis_tac[contradiction_EQ_NONE])
+  (* Conj *)
+  >-(simp[forces_def, s4_tree_model] >> rpt strip_tac >>
+     `w ∈ (s4_tree_model m).worlds` by fs[s4_tree_model] >>
+     drule reach_step_from_root >> strip_tac >> first_x_assum (drule_then strip_assume_tac) >>
+     `RTC pt_rel m m` by metis_tac[RTC_def] >> first_x_assum (drule_then strip_assume_tac) >>
+     fs[final_tableau_S4_def] >> drule thm_3_17 >> strip_tac >>
+     drule thm_3_17_prop_RTC >> strip_tac >>
+     first_x_assum (drule_then strip_assume_tac) >>
+     Cases_on `w` >> PairCases_on `a` >> fs[thm_3_17_prop] >>
+     fs[pre_hintikka_def] >> first_x_assum (drule_then strip_assume_tac)
+     >-(last_x_assum (drule_then strip_assume_tac) >>
+        first_x_assum (drule_then strip_assume_tac) >>
+        fs[] >> first_x_assum (drule_then strip_assume_tac) >> fs[s4_tree_model])
+     >> first_x_assum (drule_then strip_assume_tac) >>
+        first_x_assum (drule_then strip_assume_tac) >>
+        fs[] >> first_x_assum (drule_then strip_assume_tac) >> fs[s4_tree_model])
+  (* Disj *)
+  >-(simp[forces_def, s4_tree_model] >> rpt strip_tac >>
+     `w ∈ (s4_tree_model m).worlds` by fs[s4_tree_model] >>
+     drule reach_step_from_root >> strip_tac >> first_x_assum (drule_then strip_assume_tac) >>
+     `RTC pt_rel m m` by metis_tac[RTC_def] >> first_x_assum (drule_then strip_assume_tac) >>
+     fs[final_tableau_S4_def] >> drule thm_3_17 >> strip_tac >>
+     drule thm_3_17_prop_RTC >> strip_tac >>
+     first_x_assum (drule_then strip_assume_tac) >>
+     Cases_on `w` >> PairCases_on `a` >> fs[thm_3_17_prop] >>
+     fs[pre_hintikka_def] >> first_x_assum (drule_then strip_assume_tac) >>
+     last_x_assum (drule_then strip_assume_tac) >>
+     first_x_assum (drule_then strip_assume_tac) >>
+     fs[] >> first_x_assum (drule_then strip_assume_tac) >> fs[s4_tree_model])
+  (* Box *)
+  >-(simp[forces_def, s4_tree_model] >> rpt strip_tac >>
+     `v ∈ (s4_tree_model m).worlds` by fs[s4_tree_model] >>
+     first_x_assum (drule_then strip_assume_tac) >>
+     first_x_assum (drule_then strip_assume_tac) >>
+     fs[s4_tree_model] >> last_x_assum irule >> rw[] >>
+     drule reach_step_from_root >> rw[] >>
+     first_assum (qspecl_then [`m`, `v`] (ASSUME_TAC)) >>
+     `RTC pt_rel m m` by metis_tac[RTC_def] >> first_x_assum (drule_all_then strip_assume_tac) >>
+     fs[final_tableau_S4_def] >> drule thm_3_17 >> rw[] >>
+     drule thm_3_17_prop_RTC >> rw[] >> first_assum (drule_then strip_assume_tac) >>
+     `MEM (Box p) v.htk` suffices_by (Cases_on `v` >> PairCases_on `a` >> fs[thm_3_17_prop] >>
+                                      fs[pre_hintikka_def] >> metis_tac[]) >>
+     drule thm_3_19 >> rw[] >>
+     drule thm_3_19_prop_RTC >> rw[] >> first_assum (drule_then strip_assume_tac) >>
+     `w ∈ (s4_tree_model m).worlds` by fs[s4_tree_model] >>
+     last_assum (qspecl_then [`m`, `w`] (ASSUME_TAC)) >>
+     `RTC pt_rel m m` by metis_tac[RTC_def] >> first_x_assum (drule_all_then strip_assume_tac) >>
+     fs[] >> rw[] >> first_assum (drule_then strip_assume_tac) >>
+     `thm_3_17_prop w` by fs[] >>
+     `wfm_S4_sequent f <|As := []; Ss := NONE; Hs := []; Sg := []; Gm := [f]|>`
+        by (simp[wfm_S4_sequent] >> rw[PSUBSET_DEF]
+            >- (Cases_on `f` >> fs[])
+            >> metis_tac[mem_closure_self]) >>
+     drule tableau_S4_Ss_eq_Gm >> rw[] >>
+     drule tableau_S4_Ss_eq_Gm_prop_RTC >> rw[] >>
+     drule wfm_S4_Transitive >> rw[] >>
+     irule RTC_reach_step_reserve_box >> qexistsl_tac [`m`, `w`, `f`] >> rw[])
+  (* Dia *)
+  >> simp[forces_def, s4_tree_model] >> rpt strip_tac >>
+  `w ∈ (s4_tree_model m).worlds` by fs[s4_tree_model] >>
+  drule reach_step_from_root >> rw[] >>
+  first_assum (qspecl_then [`m`, `w`] (ASSUME_TAC)) >>
+  `RTC pt_rel m m` by metis_tac[RTC_def] >> first_x_assum (drule_all_then strip_assume_tac) >>
+  fs[final_tableau_S4_def] >> drule thm_3_19 >> rw[] >>
+  drule thm_3_19_prop_RTC >> rw[] >> first_x_assum (drule_then strip_assume_tac) >>
+  last_x_assum (drule_then strip_assume_tac) >>
+  `(∀p. MEM (Dia p) w.htk ⇒ (∃d. MEM (p,d) w.request) ∨ ∃s. MEM s w.l ∧ MEM p s.htk)`
+    by (Cases_on `w` >> PairCases_on `a` >> fs[]) >>
+  first_x_assum (drule_then strip_assume_tac)
+  (* 3_19: MEM (p,d) w.request *)
+  >-(drule s4_fulfillment >> rw[] >>
+     fs[Once thm_3_20_prop] >> rw[] >>
+     first_x_assum (drule_all_then strip_assume_tac)
+     (* 3_20: MEM (p,d) m.id.As *)
+     >-(drule tableau_S4_s_eq_id' >> rw[] >> fs[])
+     (* 3_20:  pt_rel⃰ m d' /\  SOME (p,d) = d'.id.Ss *)
+     >> qexists_tac `d'` >> rw[]
+     >- metis_tac[RTC_pt_rel_imp_RTC_reach_step]
+     >- (rw[Once RTC_CASES1] >> fs[] >>
+         DISJ2_TAC >> qexists_tac `d'` >> rw[reach_step] >>
+         DISJ2_TAC >> qexists_tac `(p,d)` >> fs[])
+     >> fs[s4_tree_model] >> first_x_assum irule >> rw[]
+     >-(drule tableau_S4_Ss_eq_Gm >> rw[] >>
+        `wfm_S4_sequent f <|As := []; Ss := NONE; Hs := []; Sg := []; Gm := [f]|>`
+            by (simp[wfm_S4_sequent] >> rw[PSUBSET_DEF]
+                >- (Cases_on `f` >> fs[])
+                >> metis_tac[mem_closure_self]) >>
+        first_x_assum (drule_then strip_assume_tac) >>
+        drule tableau_S4_Ss_eq_Gm_prop_RTC >> rw[] >>
+        first_x_assum (drule_then strip_assume_tac) >>
+        fs[Once tableau_S4_Ss_eq_Gm_prop] >> fs[] >> rw[]
+        >> drule thm_3_17 >> rw[] >> drule thm_3_17_prop_RTC >> rw[] >>
+        first_x_assum drule >> rw[] >>
+        Cases_on `d'` >> PairCases_on `a` >> rw[] >>
+        fs[thm_3_17_prop] >> metis_tac[SUBSET_DEF])
+     >> drule RTC_pt_rel_imp_RTC_reach_step >> rw[])
+  (* 3_19: MEM s w.l ∧ MEM p s.htk *)
+  >> qexists_tac `s` >> rw[]
+  >-(simp[Once RTC_CASES2] >> DISJ2_TAC >> qexists_tac `w` >> rw[reach_step])
+  >-(simp[Once RTC_CASES2] >> DISJ2_TAC >> qexists_tac `w` >> rw[reach_step])
+  >> first_x_assum (qspec_then `s` ASSUME_TAC) >> fs[s4_tree_model] >>
+  first_x_assum irule >> rw[] >> rw[Once RTC_CASES2] >> DISJ2_TAC >>
+  qexists_tac `w` >> rw[reach_step]
+QED
+
+Theorem tableau_S4_local_sound:
+  ∀f m. final_tableau_S4 f = OPEN m ⇒
+          forces (s4_tree_model m) m f
+Proof
+  rw[] >> drule tableau_S4_sound >> rw[] >> first_x_assum irule >> rw[]
+  >-(fs[final_tableau_S4_def] >> drule thm_3_17 >> rw[] >>
+     Cases_on `m` >> PairCases_on `a` >> fs[thm_3_17_prop] >>
+     drule tableau_S4_s_eq_id >> rw[] >> fs[])
+  >> simp[s4_tree_model]
+QED
+
+val _ = export_theory();


### PR DESCRIPTION
Lines 442-813 in K are commented out for now because they break proofs in S4. 
Added reflexive_M definition in K. 

Two termination proofs in S4 no longer need the majority part of their originally proof, haven't figured out why (search for TODO in the file to see them).