### PR TITLE
Added some stronger versions of existing integral and integrability results.

### DIFF
--- a/examples/probability/large_numberScript.sml
+++ b/examples/probability/large_numberScript.sml
@@ -2184,13 +2184,10 @@ Proof
      [ (* goal 1 (of 3) *)
        MATCH_MP_TAC IN_MEASURABLE_BOREL_CMUL >> BETA_TAC \\
        qexistsl_tac [‘\x. SIGMA (\i. W i x) (count (SUC k))’, ‘inv r’] \\
-       FULL_SIMP_TAC std_ss [prob_space_def, p_space_def, events_def] \\
-       CONJ_TAC >- FULL_SIMP_TAC std_ss [measure_space_def] \\
+       FULL_SIMP_TAC std_ss [prob_space_def, p_space_def, events_def] >> simp [] \\
        MATCH_MP_TAC (INST_TYPE [“:'b” |-> “:num”] IN_MEASURABLE_BOREL_SUM) >> rw [] \\
-       qexistsl_tac [‘W’, ‘count (SUC k)’] >> rw [FINITE_COUNT, IN_COUNT] >|
-       [ FULL_SIMP_TAC std_ss [measure_space_def],
-         FULL_SIMP_TAC std_ss [real_random_variable, p_space_def, events_def],
-         FULL_SIMP_TAC std_ss [real_random_variable, p_space_def, events_def] ],
+       qexistsl_tac [‘W’, ‘count (SUC k)’] >> rw [FINITE_COUNT, IN_COUNT] \\
+       FULL_SIMP_TAC std_ss [real_random_variable, p_space_def, events_def],
        (* goal 2 (of 3) *)
       ‘?z. SIGMA (\i. W i x) (count (SUC k)) = Normal z’ by METIS_TAC [extreal_cases] >> POP_ORW \\
        rw [extreal_mul_def, extreal_not_infty],
@@ -2363,10 +2360,8 @@ Proof
        FULL_SIMP_TAC std_ss [prob_space_def, p_space_def, events_def] \\
        CONJ_TAC >- FULL_SIMP_TAC std_ss [measure_space_def] \\
        MATCH_MP_TAC (INST_TYPE [“:'b” |-> “:num”] IN_MEASURABLE_BOREL_SUM) >> rw [] \\
-       qexistsl_tac [‘W’, ‘count n’] >> rw [FINITE_COUNT, IN_COUNT] >|
-       [ FULL_SIMP_TAC std_ss [measure_space_def],
-         FULL_SIMP_TAC std_ss [real_random_variable, p_space_def, events_def],
-         FULL_SIMP_TAC std_ss [real_random_variable, p_space_def, events_def] ],
+       qexistsl_tac [‘W’, ‘count n’] >> rw [FINITE_COUNT, IN_COUNT] \\
+       FULL_SIMP_TAC std_ss [real_random_variable, p_space_def, events_def],
        (* goal 2 (of 3) *)
       ‘?z. SIGMA (\i. W i x) (count n) = Normal z’ by METIS_TAC [extreal_cases] >> POP_ORW \\
        rw [extreal_mul_def, extreal_not_infty],

--- a/src/probability/extrealScript.sml
+++ b/src/probability/extrealScript.sml
@@ -9839,6 +9839,36 @@ Proof
     NTAC 2 (Cases_on ‘n’ >> fs[extreal_pow_alt,EVEN] >> rename [‘EVEN n’]) >> simp[GSYM neg_minus1]
 QED
 
+Theorem sub_le_sub_imp:
+    !w x y z. w <= x /\ z <= y ==> w - y <= x - z
+Proof
+    rw[] >> irule le_trans >> qexists_tac ‘x - y’ >> simp[le_lsub_imp,le_rsub_imp]
+QED
+
+Theorem le_negl:
+    !x y. -x <= y <=> -y <= x
+Proof
+    rw[] >> ‘-x <= - -y <=> -y <= x’ suffices_by simp[] >> simp[le_neg,Excl "neg_neg"]
+QED
+
+Theorem le_negr:
+    !x y. x <= -y <=> y <= -x
+Proof
+    rw[] >> ‘- -x <= -y <=> y <= -x’ suffices_by simp[] >> simp[le_neg,Excl "neg_neg"]
+QED
+
+Theorem leeq_trans:
+    !x:extreal y z. x <= y /\ y = z ==> x <= z
+Proof
+    simp[]
+QED
+
+Theorem eqle_trans:
+    !x:extreal y z. x = y /\ y <= z ==> x <= z
+Proof
+    simp[]
+QED
+
 val _ = export_theory();
 
 (* References:

--- a/src/probability/extrealSimps.sig
+++ b/src/probability/extrealSimps.sig
@@ -1,6 +1,6 @@
 signature extrealSimps = sig
 
 (* Extended real inequality simps to generally be used with augment_srw_ss *)
-val extreal_SS : simpLib.ssfrag;
+val EXTREAL_ss : simpLib.ssfrag;
 
 end

--- a/src/probability/extrealSimps.sml
+++ b/src/probability/extrealSimps.sml
@@ -5,13 +5,13 @@ open simpLib extrealTheory;
 
 fun name_to_thname s = ({Thy = "extreal", Name = s}, DB.fetch "extreal" s);
 
-val extreal_SS = named_rewrites_with_names
-   "extreal" $ map name_to_thname
+val EXTREAL_ss = named_rewrites_with_names
+   "EXTREAL" $ map name_to_thname
   ["extreal_le_simps",
    "extreal_lt_simps",
    "extreal_0_simps",
    "extreal_1_simps"];
 
-val _ = register_frag extreal_SS;
+val _ = register_frag EXTREAL_ss;
 
 end

--- a/src/probability/lebesgueScript.sml
+++ b/src/probability/lebesgueScript.sml
@@ -10868,7 +10868,7 @@ val mk_local_simp = augment_srw_ss o single o
     simpLib.rewrites_with_names o single o name_to_thname;
 val _ = mk_local_simp("measure","MEASURE_SPACE_SIGMA_ALGEBRA");
 
-val _ = augment_srw_ss [realSimps.REAL_ARITH_ss];
+(* val _ = augment_srw_ss [realSimps.REAL_ARITH_ss]; *)
 
 (*** integral and integrable Theorems with fewer preconditions ***)
 
@@ -11040,7 +11040,8 @@ Proof
     qspecl_then [‘m’,‘λx. P x /\ Q x’,‘R’] (resolve_then Any (qspecl_then
         [‘m’,‘λx. f x - g x = f x + -g x’,‘λx. g x = (Normal o real o g) x’,‘λx. f x = (Normal o real o f) x’] $
         irule o SIMP_RULE (srw_ss ()) []) AE_INTER o SIMP_RULE (srw_ss ()) []) AE_subset >>
-    fs[] >> rw[] >> NTAC 2 $ pop_assum SUBST1_TAC >> simp[extreal_add_def,extreal_sub_def,extreal_ainv_def]
+    fs[] >> rw[] >> NTAC 2 $ pop_assum SUBST1_TAC >>
+    simp[extreal_add_def,extreal_sub_def,extreal_ainv_def,real_sub]
 QED
 
 Theorem integrable_sub':
@@ -11056,7 +11057,8 @@ Proof
     qspecl_then [‘m’,‘λx. P x /\ Q x’,‘R’] (resolve_then Any (qspecl_then
         [‘m’,‘λx. f x + -g x = f x - g x’,‘λx. g x = (Normal o real o g) x’,‘λx. f x = (Normal o real o f) x’] $
         irule o SIMP_RULE (srw_ss ()) []) AE_INTER o SIMP_RULE (srw_ss ()) []) AE_subset >>
-    fs[] >> rw[] >> NTAC 2 $ pop_assum SUBST1_TAC >> simp[extreal_add_def,extreal_sub_def,extreal_ainv_def]
+    fs[] >> rw[] >> NTAC 2 $ pop_assum SUBST1_TAC >>
+    simp[extreal_add_def,extreal_sub_def,extreal_ainv_def,real_sub]
 QED
 
 val _ = export_theory ();

--- a/src/probability/lebesgueScript.sml
+++ b/src/probability/lebesgueScript.sml
@@ -41,12 +41,6 @@ fun METIS ths tm = prove (tm, METIS_TAC ths);
 
 val _ = hide "I";
 
-(* TODO: remove once MEASURE_SPACE_SIGMA_ALGEBRA is a simp *)
-val name_to_thname = fn (t,s) => ({Thy = t, Name = s}, DB.fetch t s);
-val mk_local_simp = augment_srw_ss o single o
-    simpLib.rewrites_with_names o single o name_to_thname;
-val _ = mk_local_simp("measure","MEASURE_SPACE_SIGMA_ALGEBRA");
-
 (* ************************************************************************* *)
 (* Basic Definitions                                                         *)
 (* ************************************************************************* *)
@@ -10866,14 +10860,6 @@ QED
 (*  I add these results at the end
       in order to manipulate the simplifier without breaking anything
       - Jared Yeager                                                    *)
-
-(*
-(* TODO: remove once MEASURE_SPACE_SIGMA_ALGEBRA is a simp *)
-val name_to_thname = fn (t,s) => ({Thy = t, Name = s}, DB.fetch t s);
-val mk_local_simp = augment_srw_ss o single o
-    simpLib.rewrites_with_names o single o name_to_thname;
-val _ = mk_local_simp("measure","MEASURE_SPACE_SIGMA_ALGEBRA");
-*)
 
 (*** integral and integrable Theorems with fewer preconditions ***)
 

--- a/src/probability/lebesgueScript.sml
+++ b/src/probability/lebesgueScript.sml
@@ -41,6 +41,12 @@ fun METIS ths tm = prove (tm, METIS_TAC ths);
 
 val _ = hide "I";
 
+(* TODO: remove once MEASURE_SPACE_SIGMA_ALGEBRA is a simp *)
+val name_to_thname = fn (t,s) => ({Thy = t, Name = s}, DB.fetch t s);
+val mk_local_simp = augment_srw_ss o single o
+    simpLib.rewrites_with_names o single o name_to_thname;
+val _ = mk_local_simp("measure","MEASURE_SPACE_SIGMA_ALGEBRA");
+
 (* ************************************************************************* *)
 (* Basic Definitions                                                         *)
 (* ************************************************************************* *)
@@ -4805,8 +4811,7 @@ Proof
  >> CONJ_TAC
  >- (GEN_TAC \\
      MATCH_MP_TAC (INST_TYPE [beta |-> ``:num``] IN_MEASURABLE_BOREL_SUM) \\
-     qexistsl_tac [`f`, `count i`] >> rw [FINITE_COUNT]
-     >- FULL_SIMP_TAC std_ss [measure_space_def] \\
+     qexistsl_tac [`f`, `count i`] >> rw [FINITE_COUNT] \\
      METIS_TAC [lt_infty, lte_trans, num_not_infty])
  >> CONJ_TAC >- RW_TAC std_ss [FINITE_COUNT, EXTREAL_SUM_IMAGE_POS]
  >> RW_TAC std_ss [ext_mono_increasing_def]
@@ -10862,13 +10867,13 @@ QED
       in order to manipulate the simplifier without breaking anything
       - Jared Yeager                                                    *)
 
+(*
 (* TODO: remove once MEASURE_SPACE_SIGMA_ALGEBRA is a simp *)
 val name_to_thname = fn (t,s) => ({Thy = t, Name = s}, DB.fetch t s);
 val mk_local_simp = augment_srw_ss o single o
     simpLib.rewrites_with_names o single o name_to_thname;
 val _ = mk_local_simp("measure","MEASURE_SPACE_SIGMA_ALGEBRA");
-
-(* val _ = augment_srw_ss [realSimps.REAL_ARITH_ss]; *)
+*)
 
 (*** integral and integrable Theorems with fewer preconditions ***)
 

--- a/src/probability/martingaleScript.sml
+++ b/src/probability/martingaleScript.sml
@@ -23,12 +23,6 @@ val _ = hide "S";
 
 fun METIS ths tm = prove(tm, METIS_TAC ths);
 
-(* TODO: remove once MEASURE_SPACE_SIGMA_ALGEBRA is a simp *)
-val name_to_thname = fn (t,s) => ({Thy = t, Name = s}, DB.fetch t s);
-val mk_local_simp = augment_srw_ss o single o
-    simpLib.rewrites_with_names o single o name_to_thname;
-val _ = mk_local_simp("measure","MEASURE_SPACE_SIGMA_ALGEBRA");
-
 (* "The theory of martingales as we know it now goes back to Doob and most of
     the material of this and the following chapter can be found in his seminal
     monograph [2] from 1953.

--- a/src/probability/measureScript.sml
+++ b/src/probability/measureScript.sml
@@ -5503,7 +5503,6 @@ Proof
  >> rfs[] >> first_x_assum $ qspec_then ‘n’ assume_tac >> fs[]
 QED
 
-(* TODO: I suggest this be made a [simp] *)
 Theorem MEASURE_SPACE_SIGMA_ALGEBRA[simp]:
     (!m. measure_space (m:'a m_space) ==> sigma_algebra (measurable_space m)) /\
     (!sa mu. measure_space ((space sa,subsets sa,mu):'a m_space) ==> sigma_algebra sa) /\

--- a/src/probability/measureScript.sml
+++ b/src/probability/measureScript.sml
@@ -5503,6 +5503,15 @@ Proof
  >> rfs[] >> first_x_assum $ qspec_then ‘n’ assume_tac >> fs[]
 QED
 
+(* TODO: I suggest this be made a [simp] *)
+Theorem MEASURE_SPACE_SIGMA_ALGEBRA:
+    (!m. measure_space (m:'a m_space) ==> sigma_algebra (measurable_space m)) /\
+    (!sa mu. measure_space ((space sa,subsets sa,mu):'a m_space) ==> sigma_algebra sa) /\
+    (!sp sts mu. measure_space ((sp,sts,mu):'a m_space) ==> sigma_algebra (sp,sts))
+Proof
+    simp[measure_space_def]
+QED
+
 val _ = export_theory ();
 
 (* References:

--- a/src/probability/measureScript.sml
+++ b/src/probability/measureScript.sml
@@ -5504,7 +5504,7 @@ Proof
 QED
 
 (* TODO: I suggest this be made a [simp] *)
-Theorem MEASURE_SPACE_SIGMA_ALGEBRA:
+Theorem MEASURE_SPACE_SIGMA_ALGEBRA[simp]:
     (!m. measure_space (m:'a m_space) ==> sigma_algebra (measurable_space m)) /\
     (!sa mu. measure_space ((space sa,subsets sa,mu):'a m_space) ==> sigma_algebra sa) /\
     (!sp sts mu. measure_space ((sp,sts,mu):'a m_space) ==> sigma_algebra (sp,sts))

--- a/src/probability/measureScript.sml
+++ b/src/probability/measureScript.sml
@@ -5504,9 +5504,7 @@ Proof
 QED
 
 Theorem MEASURE_SPACE_SIGMA_ALGEBRA[simp]:
-    (!m. measure_space (m:'a m_space) ==> sigma_algebra (measurable_space m)) /\
-    (!sa mu. measure_space ((space sa,subsets sa,mu):'a m_space) ==> sigma_algebra sa) /\
-    (!sp sts mu. measure_space ((sp,sts,mu):'a m_space) ==> sigma_algebra (sp,sts))
+    !m. measure_space m ==> sigma_algebra (measurable_space m)
 Proof
     simp[measure_space_def]
 QED


### PR DESCRIPTION
This PR aims to provide versions of `integral_` and `integrable_` results for additions, finite summation, and subtraction with as few preconditions as possible. Specifically removing the preconditions that the functions involved be finite everywhere. Intuitively, these preconditions are unnecessary because these functions are already integrable, and thus already finite almost everywhere.

In order to help with this, and number of lemmas about almost everywhere are also proven in `borelTheory`. And of course, some random mathematical lemmas in `extrealTheory`.

Also, I renamed the extreal simpset fragment to `EXTREAL_ss`, so the naming convention is consistent with other simpset fragments.

Finally, this PR should not be excepted as-is, and I make it to solicit feedback. Before this PR is accepted, there is a single theorem in `measureTheory` that I think should perhaps be a [simp] (and was a [simp] in my personal work):
```
MEASURE_SPACE_SIGMA_ALGEBRA:
   ⊢ (∀m. measure_space m ⇒ sigma_algebra (measurable_space m)) ∧
     (∀sa mu. measure_space (space sa,subsets sa,mu) ⇒ sigma_algebra sa) ∧
     ∀sp sts mu. measure_space (sp,sts,mu) ⇒ sigma_algebra (sp,sts)
```
The first conjunct has frequently proved useful to me, but the later two are less common and would require `SF SFY_ss` for the simplifier to leverage them. So I wanted to get some judgement on if this should become a [simp] as-is, become something else that is a [simp], or not become a simp at all.