### PR TITLE
Bosslib shorthands

### DIFF
--- a/Manual/Cheatsheet/cheatsheet.md
+++ b/Manual/Cheatsheet/cheatsheet.md
@@ -331,12 +331,12 @@ In many cases, we may want to state exactly how the goal should be taken apart (
 : For a goal of the form `(A ==> B) ==> C`, splits into the two subgoals `A` and `B ==> C`.
   `impl_keep_tac` is a variant which keeps `A` as an assumption in the `B ==> C` subgoal.
 
-<code>qexists_tac &grave;<i>term</i>&grave;</code>
+<code>qexists &grave;<i>term</i>&grave;</code>
 : Instantiates a top-level `∃` quantifer with the supplied term.
 
-<code>Q.REFINE_EXISTS_TAC &grave;<i>term</i>&grave;</code>
+<code>qrefine &grave;<i>term</i>&grave;</code>
 : Refines a top-level `∃` quantifer using the supplied term - any free variables in the term become`∃`-quantified.
-  For example, for a goal `∃ n : num. if n = 0 then P n else Q n`, applying ``Q.REFINE_EXISTS_TAC `SUC k` >> simp[]`` produces the goal `∃ k : num. Q (SUC k)` (where `SUC` is the successor function).
+  For example, for a goal `∃ n : num. if n = 0 then P n else Q n`, applying ``qrefine `SUC k` >> simp[]`` produces the goal `∃ k : num. Q (SUC k)` (where `SUC` is the successor function).
 
 <code>goal_assum $ drule_at Any</code>
 : For a goal of the form `∃ vars . P1 /\ ... /\ Pn` (where the `vars` may be free in the `Pi`), attempts to match the `Pi` against the assumptions.

--- a/src/boss/bossLib.sig
+++ b/src/boss/bossLib.sig
@@ -115,6 +115,7 @@ sig
   val SIMP_CONV         : simpset -> thm list -> conv
   val SIMP_RULE         : simpset -> thm list -> thm -> thm
   val SRULE             : thm list -> thm -> thm (* uses srw_ss() *)
+  val SCONV             : thm list -> conv (* uses srw_ss() *)
   val SIMP_TAC          : simpset -> thm list -> tactic
   val simp_tac          : simpset -> thm list -> tactic
   val ASM_SIMP_TAC      : simpset -> thm list -> tactic
@@ -205,6 +206,9 @@ sig
   val qx_choosel_then : term quotation list -> thm_tactic -> thm_tactic
   val qexists_tac : term quotation -> tactic
   val qexistsl_tac : term quotation list -> tactic
+  val qexists : term quotation -> tactic
+  val qexistsl : term quotation list -> tactic
+  val qrefine : term quotation -> tactic
   val qsuff_tac : term quotation -> tactic
   val qid_spec_tac : term quotation -> tactic
   val qspec_tac : term quotation * term quotation -> tactic

--- a/src/boss/bossLib.sml
+++ b/src/boss/bossLib.sml
@@ -278,6 +278,7 @@ val gvs = stateful (cfg true true true) []
 val rgs = stateful (cfg false true false) []
 
 fun SRULE ths th = SIMP_RULE (srw_ss()) ths th (* don't eta-reduce *)
+fun SCONV ths tm = SIMP_CONV (srw_ss()) ths tm (* don't eta-reduce *)
 
 (* Without loss of generality tactics *)
 val wlog_tac = wlog_tac
@@ -289,6 +290,9 @@ val wlog_then = wlog_then
   val qx_choose_then = Q.X_CHOOSE_THEN
   val qexists_tac : term quotation -> tactic = Q.EXISTS_TAC
   val qexistsl_tac = map_every qexists_tac
+  val qexists = qexists_tac
+  val qexistsl = qexistsl_tac
+  val qrefine = Q.REFINE_EXISTS_TAC
   val qsuff_tac : term quotation -> tactic = Q_TAC SUFF_TAC
   val qspec_tac = Q.SPEC_TAC
   val qid_spec_tac : term quotation -> tactic = Q.ID_SPEC_TAC


### PR DESCRIPTION
As discussed offline, add the following shorthands:
- `qrefine` for `Q.REFINE_EXISTS_TAC`
- `qexists` and `qexistsl` for `qexists_tac` and `qexistsl_tac` respectively
- `SCONV ths tm` for `SIMP_CONV (srw_ss()) ths tm`

Also update the cheatsheet to match.