### PR TITLE
Cumulative fixes of HOL4 OpenTheory builds (--otknl)

### DIFF
--- a/examples/probability/.gitignore
+++ b/examples/probability/.gitignore
@@ -1,3 +1,4 @@
 *Theory.html
 *Theory.lst
 /heap
+*.html

--- a/examples/probability/Holmakefile
+++ b/examples/probability/Holmakefile
@@ -4,7 +4,9 @@ INCLUDES = $(HOLDIR)/src/probability $(HOLDIR)/src/n-bit $(HOLDIR)/src/real \
 EXTRA_CLEANS = heap \
 	$(patsubst %Theory.uo,%Theory.html,$(DEFAULT_TARGETS)) \
 	$(patsubst %Theory.uo,%Theory.lst,$(DEFAULT_TARGETS)) \
-	hol4-large-numbers.art hol4-large-numbers.html hol4-large-numbers.log
+	hol4-large-numbers.art  hol4-large-numbers-only.art \
+	hol4-large-numbers.html hol4-large-numbers-only.html \
+	hol4-large-numbers.log  hol4-large-numbers-only.log
 
 ifdef POLY
 HOLHEAP = heap
@@ -54,8 +56,25 @@ hol4-large-numbers.art: hol4-large-numbers.thy large_number.ot.art \
 			$(HOLDIR)/src/opentheory/hol4.int
 	opentheory info --article -o $@ $<
 
-# This optional step takes about ~52GB memory but (only) two hours to complete.
+# With the rebuilt OpenTheory/Mlton (-default-type intinf), this step only takes
+# 2 minutes (otherwise 2 hours with OpenTheory/PolyML)
+
+# "&> file (aka >& file) is not part of the official POSIX shell spec, but has been
+# added to many Bourne shells as a convenience extension (it originally comes from
+# csh). In a portable shell script (and if you don't need portability, why are you
+# writing a shell script?), use > file 2>&1 only." (from stackoverflow)
 hol4-large-numbers.html: hol4-large-numbers.art
-	opentheory info --inference --document -o $@ $<
+	opentheory info --inference --document -o $@ $< \
+		> hol4-large-numbers.log 2>&1
+
+# A smaller version containing only theorems useful for proving LLN (and LLN itself)
+hol4-large-numbers-only.art: hol4-large-numbers-only.thy large_number.ot.art \
+			$(HOLDIR)/src/opentheory/hol4.int
+	opentheory info --article -o $@ $<
+
+# TODO: how to show ALL theorems in this article?
+hol4-large-numbers-only.html: hol4-large-numbers-only.art
+	opentheory info --inference --document -o $@ $< \
+		> hol4-large-numbers-only.log 2>&1
 
 endif

--- a/examples/probability/Holmakefile
+++ b/examples/probability/Holmakefile
@@ -3,7 +3,8 @@ INCLUDES = $(HOLDIR)/src/probability $(HOLDIR)/src/n-bit $(HOLDIR)/src/real \
 
 EXTRA_CLEANS = heap \
 	$(patsubst %Theory.uo,%Theory.html,$(DEFAULT_TARGETS)) \
-	$(patsubst %Theory.uo,%Theory.lst,$(DEFAULT_TARGETS))
+	$(patsubst %Theory.uo,%Theory.lst,$(DEFAULT_TARGETS)) \
+	hol4-large-numbers.art hol4-large-numbers.html hol4-large-numbers.log
 
 ifdef POLY
 HOLHEAP = heap
@@ -11,7 +12,6 @@ OBJS = real/realLib n-bit/fcpLib res_quan/src/hurdUtils probability/probabilityT
 FULL_OBJPATHS = $(patsubst %,$(HOLDIR)/src/%.uo,$(OBJS)) \
                 $(HOLDIR)/sigobj/posetTheory.uo
 HEAP0 = $(HOLDIR)/src/probability/heap
-
 
 all: $(HOLHEAP)
 
@@ -22,3 +22,40 @@ endif
 all: $(DEFAULT_TARGETS)
 
 .PHONY: all
+
+ifeq ($(KERNELID),otknl)
+ARTFILES = $(patsubst %Script.sml,%.ot.art,$(wildcard *Script.sml))
+
+all: $(ARTFILES)
+
+# NOTE: the following targets are not included in "all". OpenTheory binary built
+# by Poly/ML (with Int.maxInt = NONE, i.e., --enable-intinf-as-int) must be used
+# here, since OpenTheory built by the Mlton (otherwise recommended!) will report
+# (integer?) "Overflow".  With PolyML built OT, this step takes (on 2019 MacBook
+# Pro) about 6 hours with 8 CPU cores (the total CPU time is ~8 hours) and ~52GB
+# memory to complete.  -- Chun Tian, Apr 8, 2022
+#
+# To easily switch between OpenTheory built by different SML platforms, below is
+# my recommended softlinks in my $(HOME)/bin:
+#
+# opentheory -> opentheory.mlton
+# opentheory.mlton -> ../ML/opentheory/bin/mlton/opentheory
+# opentheory.mosml -> ../ML/opentheory/bin/mosml/opentheory
+# opentheory.polyml -> ../ML/opentheory/bin/polyml/opentheory
+#
+# UPDATE: another (better) way is to rebuild OpenTheory with MLton by adding the
+# following MLton command-line option:
+#
+#   MLTON_OPTS += -default-type intinf
+#
+# into OpenTheory's Makefile (right after the line with "MLTON_OPTS = ..."), and
+# this may enable computers with 32GB memory to finish this build.
+hol4-large-numbers.art: hol4-large-numbers.thy large_number.ot.art \
+			$(HOLDIR)/src/opentheory/hol4.int
+	opentheory info --article -o $@ $<
+
+# This optional step takes about ~52GB memory but (only) two hours to complete.
+hol4-large-numbers.html: hol4-large-numbers.art
+	opentheory info --inference --document -o $@ $<
+
+endif

--- a/examples/probability/hol4-large-numbers-only.thy
+++ b/examples/probability/hol4-large-numbers-only.thy
@@ -1,0 +1,115 @@
+name: hol-large-numbers-only
+version: 1.0
+description: HOL and OT theories towards to the Law of Large Numbers
+author: Chun Tian <binghe.lisp@gmail.com>
+license: MIT
+show: "HOL4"
+show: "Data.Bool"
+show: "Data.Option"
+show: "Data.Unit"
+show: "Data.Sum"
+show: "Data.Pair"
+show: "Data.List"
+show: "Function"
+show: "Relation"
+show: "Number.Natural"
+show: "Number.Real"
+main {
+  import: base
+  import: hol-base
+  import: hol-set
+  import: hol-real
+  import: hol-extreal
+  import: hol-analysis
+  import: hol-probability
+  article: "large_number.ot.art"
+  interpretation: "../../src/opentheory/hol4.int"
+}
+base {
+  package: base-1.221
+}
+hol-base {
+  import: base
+  package: hol-base-1.3
+}
+hol-sort {
+  import: base
+  import: hol-base
+  package: hol-sort-1.1
+}
+hol-string {
+  import: base
+  import: hol-base
+  import: hol-sort
+  package: hol-string-1.2
+}
+hol-words {
+  import: base
+  import: hol-base
+  import: hol-string
+  package: hol-words-1.3
+}
+hol-ring {
+  import: base
+  import: hol-base
+  import: hol-sort
+  package: hol-ring-1.2
+}
+hol-res-quan {
+  import: base
+  import: hol-base
+  package: hol-res-quan-1.2
+}
+hol-quotient {
+  import: base
+  import: hol-base
+  import: hol-res-quan
+  package: hol-quotient-1.2
+}
+hol-set {
+  import: base
+  import: hol-base
+  import: hol-quotient  
+  package: hol-set-1.0
+}
+hol-integer {
+  import: base
+  import: hol-base
+  import: hol-words
+  import: hol-string
+  import: hol-ring
+  import: hol-quotient
+  package: hol-integer-1.2
+}
+hol-real {
+  import: base
+  import: hol-base
+  import: hol-set
+  import: hol-integer
+  package: hol-real-1.2
+}
+hol-analysis {
+  import: base
+  import: hol-base
+  import: hol-set
+  import: hol-real
+  package: hol-analysis-1.1
+}
+hol-extreal {
+  import: base
+  import: hol-base
+  import: hol-set
+  import: hol-real
+  package: hol-extreal-1.0
+}
+hol-probability {
+  import: base
+  import: hol-base
+  import: hol-set
+  import: hol-real
+  import: hol-analysis
+  import: hol-extreal
+  import: hol-words
+  import: hol-sort
+  package: hol-probability-1.1
+}

--- a/examples/probability/hol4-large-numbers.thy
+++ b/examples/probability/hol4-large-numbers.thy
@@ -1,0 +1,125 @@
+name: hol-large-numbers
+version: 1.0
+description: HOL theories up to the Law of Large Numbers (including OpenTheory base)
+author: Chun Tian <binghe.lisp@gmail.com>
+license: MIT
+show: "HOL4"
+show: "Data.Bool"
+show: "Data.Option"
+show: "Data.Unit"
+show: "Data.Sum"
+show: "Data.Pair"
+show: "Data.List"
+show: "Function"
+show: "Relation"
+show: "Number.Natural"
+show: "Number.Real"
+main {
+  import: base
+  import: hol-base
+  import: hol-set
+  import: hol-real
+  import: hol-extreal
+  import: hol-analysis
+  import: hol-probability
+  import: large-number
+}
+base {
+  package: base-1.221
+}
+hol-base {
+  import: base
+  package: hol-base-1.3
+}
+hol-sort {
+  import: base
+  import: hol-base
+  package: hol-sort-1.1
+}
+hol-string {
+  import: base
+  import: hol-base
+  import: hol-sort
+  package: hol-string-1.2
+}
+hol-words {
+  import: base
+  import: hol-base
+  import: hol-string
+  package: hol-words-1.3
+}
+hol-ring {
+  import: base
+  import: hol-base
+  import: hol-sort
+  package: hol-ring-1.2
+}
+hol-res-quan {
+  import: base
+  import: hol-base
+  package: hol-res-quan-1.2
+}
+hol-quotient {
+  import: base
+  import: hol-base
+  import: hol-res-quan
+  package: hol-quotient-1.2
+}
+hol-set {
+  import: base
+  import: hol-base
+  import: hol-quotient  
+  package: hol-set-1.0
+}
+hol-integer {
+  import: base
+  import: hol-base
+  import: hol-words
+  import: hol-string
+  import: hol-ring
+  import: hol-quotient
+  package: hol-integer-1.2
+}
+hol-real {
+  import: base
+  import: hol-base
+  import: hol-set
+  import: hol-integer
+  package: hol-real-1.2
+}
+hol-analysis {
+  import: base
+  import: hol-base
+  import: hol-set
+  import: hol-real
+  package: hol-analysis-1.1
+}
+hol-extreal {
+  import: base
+  import: hol-base
+  import: hol-set
+  import: hol-real
+  package: hol-extreal-1.0
+}
+hol-probability {
+  import: base
+  import: hol-base
+  import: hol-set
+  import: hol-real
+  import: hol-analysis
+  import: hol-extreal
+  import: hol-words
+  import: hol-sort
+  package: hol-probability-1.1
+}
+large-number {
+  import: base
+  import: hol-base
+  import: hol-set
+  import: hol-real
+  import: hol-extreal
+  import: hol-analysis
+  import: hol-probability
+  article: "large_number.ot.art"
+  interpretation: "../../src/opentheory/hol4.int"
+}

--- a/src/bag/Holmakefile
+++ b/src/bag/Holmakefile
@@ -14,11 +14,26 @@ all: bag-selftest.log
 
 endif
 
-
 ifdef HOLBUILD
 all: link-to-sigobj
 link-to-sigobj: $(DEFAULT_TARGETS)
 	$(HOL_LNSIGOBJ)
 
 .PHONY: link-to-sigobj
+endif
+
+ifeq ($(KERNELID),otknl)
+ARTFILES = $(patsubst %Script.sml,%.ot.art,$(wildcard *Script.sml))
+
+all: $(ARTFILES) hol4-bag.art
+
+hol4-bag-unint.art: hol4-bag-unint.thy $(ARTFILES)
+	opentheory info --article -o $@ $<
+
+hol4-bag.art: hol4-bag.thy hol4-bag-unint.art ../opentheory/hol4.int
+	opentheory info --article -o $@ $<
+
+install: hol4-bag.thy hol4-bag.art
+	opentheory install --reinstall $<
+
 endif

--- a/src/bag/hol4-bag-unint.thy
+++ b/src/bag/hol4-bag-unint.thy
@@ -1,0 +1,16 @@
+name: hol-bag-unint
+version: 1.0
+description: HOL bag theory (before re-interpretation)
+author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
+license: MIT
+main {
+  import: bag
+  import: prime-factor
+}
+bag {
+  article: "bag.ot.art"
+}
+prime-factor {
+  import: bag
+  article: "primeFactor.ot.art"
+}

--- a/src/bag/hol4-bag.thy
+++ b/src/bag/hol4-bag.thy
@@ -1,20 +1,18 @@
-name: hol-string
-version: 1.2
-description: HOL string theories
+name: hol-bag
+version: 1.0
+description: HOL bag theory
 author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
 license: MIT
 requires: base
 requires: hol-base
-requires: hol-sort
 show: "HOL4"
 show: "Data.Bool"
 show: "Data.List"
 show: "Data.Pair"
-show: "Data.Option"
 show: "Function"
 show: "Number.Natural"
 show: "Relation"
 main {
-  article: "hol4-string-unint.art"
+  article: "hol4-bag-unint.art"
   interpretation: "../opentheory/hol4.int"
 }

--- a/src/boss/Holmakefile
+++ b/src/boss/Holmakefile
@@ -53,6 +53,7 @@ ARTS = bool_defs.ot.art \
   ../num/extra_theories/numeral_bit.ot.art \
   ../datatype/ind_type.ot.art \
   ../pred_set/src/pred_set.ot.art \
+  ../pred_set/src/set_relation.ot.art \
   ../list/src/list.ot.art \
   ../list/src/rich_list.ot.art \
   ../list/src/indexedLists.ot.art \
@@ -74,7 +75,9 @@ prove_base_assums.art: prove_base_assums.otd base-theorems.art hol4-assums.art
 hol4-base.art: hol4-base.thy hol4-base-unint.art ../opentheory/hol4.int \
                bool_defs.ot.art prove_base_assums.ot.art
 	opentheory info --article -o $@ $<
-	opentheory install --reinstall hol4-base.thy
+
+install: hol4-base.thy hol4-base.art 
+	opentheory install --reinstall $<
 
 all: hol4-base.art
 

--- a/src/boss/hol4-base-unint.thy
+++ b/src/boss/hol4-base-unint.thy
@@ -5,32 +5,34 @@ author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
 license: MIT
 main {
   import: bool
+  import: normal-forms
   import: marker
+  import: num
   import: combin
+  import: sat
   import: relation
   import: one
   import: pair
-  import: poset
-  import: option
-  import: sat
-  import: sum
-  import: num
   import: prim-rec
   import: arithmetic
+  import: sum
+  import: poset
   import: numeral
+  import: option
   import: basic-size
   import: while
-  import: numpair
   import: divides
-  import: logroot
-  import: gcd
-  import: bit
-  import: numeral-bit
-  import: pred-set
+  import: numpair
   import: ind-type
+  import: gcd
+  import: pred-set
   import: list
   import: rich-list
+  import: logroot
+  import: set-relation
   import: indexed-lists
+  import: bit
+  import: numeral-bit
   import: numposrep
 }
 bool {
@@ -40,6 +42,10 @@ bool {
   interpret: const "HOL4.bool_defs.IN" as "HOL4.bool.IN"
   interpret: const "HOL4.bool_defs.TYPE_DEFINITION" as "HOL4.bool.TYPE_DEFINITION"
   interpret: const "HOL4.bool_defs.ARB" as "HOL4.bool.ARB"
+}
+normal-forms {
+  import: bool
+  article: "../metis/normalForms.ot.art"
 }
 marker {
   import: bool
@@ -53,6 +59,7 @@ combin {
 relation {
   import: bool
   import: combin
+  import: sat
   article: "../relation/relation.ot.art"
 }
 one {
@@ -114,9 +121,9 @@ basic-size {
   article: "../num/theories/basicSize.ot.art"
 }
 while {
-  import: arithmetic
   import: bool
   import: combin
+  import: arithmetic
   article: "../num/theories/while.ot.art"
 }
 numpair {
@@ -181,9 +188,6 @@ numeral-bit {
   import: bit
   article: "../num/extra_theories/numeral_bit.ot.art"
 }
-normal-forms {
-  article: "../metis/normalForms.ot.art"
-}
 pred-set {
   import: bool
   import: combin
@@ -199,6 +203,16 @@ pred-set {
   import: marker
   import: divides
   article: "../pred_set/src/pred_set.ot.art"
+}
+set-relation {
+  import: bool
+  import: marker
+  import: pred-set
+  import: pair
+  import: arithmetic
+  import: option
+  import: relation
+  article: "../pred_set/src/set_relation.ot.art"
 }
 ind-type {
   import: bool
@@ -219,11 +233,11 @@ list {
   article: "../list/src/list.ot.art"
 }
 rich-list {
-  import: arithmetic
   import: bool
   import: marker
   import: combin
   import: list
+  import: arithmetic
   import: pred-set
   article: "../list/src/rich_list.ot.art"
 }
@@ -231,6 +245,7 @@ indexed-lists {
   import: bool
   import: list
   import: relation
+  import: pred-set
   article: "../list/src/indexedLists.ot.art"
 }
 numposrep {

--- a/src/boss/prove_base_assumsScript.sml
+++ b/src/boss/prove_base_assumsScript.sml
@@ -1,22 +1,37 @@
-(* To replay this script, first use "hol.bare" then load "bossLib" before open it. *)
+(* To replay this script, first use "hol.bare" then (maybe) > load "bossLib" *)
 
 open HolKernel boolLib bossLib BasicProvers;
-
 open OpenTheoryReader;
+
+(* NOTE: currently there are 96 "assumptions" (stored in the variable 'goals'),
+   each represents a theorem defined in boolTheory and used by theories in hol-
+   base package (see hol4-base-unint.thy for the list of these HOL4 theories).
+   These "assumptions" must be proved by theorems from OpenTheory base package,
+   accessible by 'amatch' on 'base_thms'.
+
+   Extra assumptions are those theorems defined in boolTheory but were used in
+   subsequent OpenTheory packages beyond hol-base such as hol-res-quan. If any
+   necessary assumption is missing here, it will show up later appear as extra
+   assumptions in $(HOLDIR)src/real/prove_real_assumsScript.sml, beyond the 22
+   assumptions connecting OT and HOL4 reals.
+ *)
 
 val Thy = "prove_base_assums";
 
 val _ = new_theory Thy;
 
+val ERR = mk_HOL_ERR Thy;
+
 val _ = new_constant("base-1.221",alpha);
 
-fun fix_tyop {abs={Name="_",Thy=athy},rep={Name="_",Thy=rthy},args,ax,name={Thy=tthy,Tyop=tyop}} =
-  {abs={Name=(tyop^"_abs"),Thy=athy},
-   rep={Name=(tyop^"_rep"),Thy=rthy},
-   name={Thy=tthy,Tyop=tyop},
-   args=args,
-   ax=ax}
-| fix_tyop x = x
+fun fix_tyop {abs={Name="_",Thy=athy},
+              rep={Name="_",Thy=rthy},args,ax,name={Thy=tthy,Tyop=tyop}} =
+   {abs  = {Name=(tyop^"_abs"),Thy=athy},
+    rep  = {Name=(tyop^"_rep"),Thy=rthy},
+    name = {Thy=tthy,Tyop=tyop},
+    args = args,
+    ax   = ax}
+  | fix_tyop x = x
 
 fun const_name ([],"=") = {Thy="min",Name="="}
   | const_name ([],"select") = {Thy="min",Name="@"}
@@ -103,7 +118,9 @@ val _ = Net.itnet (fn th => (Thm.delete_proof th; K ())) base_thms ();
 fun itpred P th acc = if P th then th::acc else acc;
 fun amatch tm = Net.itnet (itpred (DB.matches tm)) base_thms [];
 
+(* NOTE: perhaps the change of constant names here is due to OpenTheory updates *)
 val _ = new_constant("hol-base-assums-1.0",alpha);
+val _ = new_constant("hol-base-unsat-1.0",alpha);
 
 local
   fun find_tyop {name={Tyop,...},...} =
@@ -275,10 +292,21 @@ val th5 = store_thm("th5", el 5 goals |> concl,
   \\ disch_then(SUBST_ALL_TAC o EQT_INTRO)
   \\ REFL_TAC);
 
+(* |- !f g M N. M = N /\ (!x. x = N ==> f x = g x) ==> LET f M = LET g N *)
+val th6 = store_thm (* was: LET_CONG *)
+  ("th6", el 6 goals |> concl,
+  rpt strip_tac
+  \\ VAR_EQ_TAC
+  \\ PURE_REWRITE_TAC[LET_DEF]
+  \\ CONV_TAC(DEPTH_CONV BETA_CONV)
+  \\ first_x_assum match_mp_tac
+  \\ REFL_TAC);
+
 (* |- !x x' y y'.
           (x <=> x') /\ (x' ==> (y <=> y')) ==> (x ==> y <=> x' ==> y')
  *)
-val th6 = store_thm("th6", el 6 goals |> concl,
+val th7 = store_thm
+  ("th7", el 7 goals |> concl,
   rpt strip_tac
   \\ last_x_assum SUBST_ALL_TAC
   \\ Q.ISPEC_THEN`x'`FULL_STRUCT_CASES_TAC bool_cases
@@ -293,38 +321,45 @@ val cons_11 = hd (amatch ``Data_List_cons  _ _ = Data_List_cons _ _``);
           Data_List_cons a0 a1 = Data_List_cons a0' a1' <=>
           a0 = a0' /\ a1 = a1'
  *)
-val th7 = store_thm("th7", el 7 goals |> concl, MATCH_ACCEPT_TAC cons_11);
+val th8 = store_thm
+  ("th8", el 8 goals |> concl, MATCH_ACCEPT_TAC cons_11);
 
 val app_if = hd (amatch ``f (if b then x else y) = if b then f x else f y``);
 
 (* |- !f b x y. f (if b then x else y) = if b then f x else f y *)
-val th8 = store_thm("th8", el 8 goals |> concl, MATCH_ACCEPT_TAC app_if);
+val th9 = store_thm
+  ("th9", el 9 goals |> concl, MATCH_ACCEPT_TAC app_if);
 
 val demorgan = hd (amatch``(b \/ a) /\ (c \/ a)``);
 
 (* |- !A B C. B /\ C \/ A <=> (B \/ A) /\ (C \/ A) *)
-val th9 = store_thm("th9", el 9 goals |> concl, MATCH_ACCEPT_TAC demorgan);
+val th10 = store_thm
+  ("th10", el 10 goals |> concl, MATCH_ACCEPT_TAC demorgan);
 
 val or_assoc = hd (amatch``(a \/ b) \/ c``);
 
 (* |- !A B C. A \/ B \/ C <=> (A \/ B) \/ C *)
-val th10 = store_thm("th10", el 10 goals |> concl, MATCH_ACCEPT_TAC (GSYM or_assoc));
+val th11 = store_thm
+  ("th11", el 11 goals |> concl, MATCH_ACCEPT_TAC (GSYM or_assoc));
 
 val or_distrib_and = hd (amatch``(b \/ c) /\ a <=> _``);
 
 (* |- !A B C. (B \/ C) /\ A <=> B /\ A \/ C /\ A *)
-val th11 = store_thm("th11", el 11 goals |> concl, MATCH_ACCEPT_TAC or_distrib_and);
+val th12 = store_thm
+  ("th12", el 12 goals |> concl, MATCH_ACCEPT_TAC or_distrib_and);
 
 val and_assoc = hd (amatch``(a /\ b) /\ c``);
 
 (* |- !t1 t2 t3. t1 /\ t2 /\ t3 <=> (t1 /\ t2) /\ t3 *)
-val th12 = store_thm("th12", el 12 goals |> concl, MATCH_ACCEPT_TAC (GSYM and_assoc));
+val th13 = store_thm
+  ("th13", el 13 goals |> concl, MATCH_ACCEPT_TAC (GSYM and_assoc));
 
 val if_T = hd (amatch ``if T then t1 else t2``);
 val if_F = hd (amatch ``if F then t1 else t2``);
 
 (* |- !t1 t2. ?fn. fn T = t1 /\ fn F = t2 *)
-val th13 = store_thm("th13", el 13 goals |> concl,
+val th14 = store_thm
+  ("th14", el 14 goals |> concl,
   rpt gen_tac
   \\ qexists_tac`\b. if b then t1 else t2`
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
@@ -334,7 +369,8 @@ val th13 = store_thm("th13", el 13 goals |> concl,
 val not_or = hd(amatch``~(_ \/ _)``);
 
 (* |- !A B. (~(A /\ B) <=> ~A \/ ~B) /\ (~(A \/ B) <=> ~A /\ ~B) *)
-val th14 = store_thm("th14", el 14 goals |> concl,
+val th15 = store_thm
+  ("th15", el 15 goals |> concl,
   rpt gen_tac
   \\ PURE_REWRITE_TAC[not_and,not_or]
   \\ conj_tac \\ REFL_TAC);
@@ -348,7 +384,8 @@ val ex_imp = hd(amatch``((?x. _) ==> _) <=> _``);
           ((?x. P x) /\ Q <=> ?x. P x /\ Q) /\
           (Q /\ (?x. P x) <=> ?y. Q /\ P y)
  *)
-val th15 = store_thm("th15", el 15 goals |> concl,
+val th16 = store_thm
+  ("th16", el 16 goals |> concl,
   rpt gen_tac
   \\ PURE_REWRITE_TAC[and_ex,ex_and,ex_imp]
   \\ rpt conj_tac \\ REFL_TAC);
@@ -363,14 +400,16 @@ val imp_all = hd(amatch``(_ ==> (!x. _)) <=> _``);
           ((!x. P x) /\ Q <=> !x. P x /\ Q) /\
           (Q /\ (!x. P x) <=> !x. Q /\ P x)
  *)
-val th16 = store_thm("th16", el 16 goals |> concl,
+val th17 = store_thm
+  ("th17", el 17 goals |> concl,
   rpt gen_tac
   \\ PURE_REWRITE_TAC[and_all,all_and,all_imp,imp_all]
   \\ rpt conj_tac \\ REFL_TAC);
 
 (* |- !t1 t2. (if T then t1 else t2) = t1 /\ (if F then t1 else t2) = t2
  *)
-val th17 = store_thm("th17", el 17 goals |> concl,
+val th18 = store_thm
+  ("th18", el 18 goals |> concl,
   rpt gen_tac \\ MATCH_ACCEPT_TAC (CONJ (SPEC_ALL if_T) (SPEC_ALL if_F)));
 
 val forall_eq = hd(amatch``!x. (x = t) ==> _``);
@@ -380,7 +419,8 @@ val ex_def = hd(amatch``$? = _``);
 val select_ax = hd(amatch ``p t ==> p ($@ p)``);
 
 (* |- !P t. (!x. x = t ==> P x) ==> $? P *)
-val th18 = store_thm("th18", el 18 goals |> concl,
+val th19 = store_thm
+  ("th19", el 19 goals |> concl,
   PURE_REWRITE_TAC[forall_eq,ex_def]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ MATCH_ACCEPT_TAC select_ax);
@@ -388,7 +428,8 @@ val th18 = store_thm("th18", el 18 goals |> concl,
 val eta_ax = hd(amatch``!f. (\x. f x) = f``);
 
 (* |- !P Q. (?x. P x) /\ (!x. P x ==> Q x) ==> Q ($@ P) *)
-val th19 = store_thm("th19", el 19 goals |> concl,
+val th20 = store_thm
+  ("th20", el 20 goals |> concl,
   PURE_REWRITE_TAC[ex_def]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt strip_tac
@@ -397,7 +438,8 @@ val th19 = store_thm("th19", el 19 goals |> concl,
   \\ first_x_assum ACCEPT_TAC);
 
 (* |- !t1 t2. (t1 ==> t2) ==> (t2 ==> t1) ==> (t1 <=> t2) *)
-val th20 = store_thm("th20", el 20 goals |> concl,
+val th21 = store_thm
+  ("th21", el 21 goals |> concl,
   rpt strip_tac
   \\ Q.ISPEC_THEN`t1`mp_tac bool_cases
   \\ PURE_REWRITE_TAC[or_def]
@@ -412,16 +454,20 @@ val th20 = store_thm("th20", el 20 goals |> concl,
   \\ PURE_REWRITE_TAC[T_imp,T_iff,imp_T,F_imp,F_iff,imp_F]
   \\ disch_then ACCEPT_TAC);
 
+val IMP_ANTISYM_AX = th21;
+
 val suc_11 = hd(amatch``Number_Natural_suc _ = Number_Natural_suc _``);
 
 (* |- !m n. Number_Natural_suc m = Number_Natural_suc n ==> m = n *)
-val th21 = store_thm("th21", el 21 goals |> concl,
+val th22 = store_thm
+  ("th22", el 22 goals |> concl,
   rpt gen_tac \\ MATCH_ACCEPT_TAC (#1 (EQ_IMP_RULE (SPEC_ALL suc_11))));
 
 val forall_or = el 2 (amatch``_ <=> (!x. P x) \/ Q``);
 
 (* |- !Q P. (!x. P x \/ Q) <=> (!x. P x) \/ Q *)
-val th22 = store_thm("th22", el 22 goals |> concl, MATCH_ACCEPT_TAC forall_or);
+val th23 = store_thm
+  ("th23", el 23 goals |> concl, MATCH_ACCEPT_TAC forall_or);
 
 val null_eq = hd(amatch``Data_List_null t <=> (_ = Data_List_nil)``);
 val last_cons = hd(amatch``Data_List_last (Data_List_cons h t) = COND _ _ _``);
@@ -430,20 +476,23 @@ val last_cons = hd(amatch``Data_List_last (Data_List_cons h t) = COND _ _ _``);
           Data_List_last (Data_List_cons h t) =
           if t = Data_List_nil then h else Data_List_last t
  *)
-val th23 = store_thm("th23", el 23 goals |> concl,
+val th24 = store_thm
+  ("th24", el 24 goals |> concl,
   MATCH_ACCEPT_TAC(PURE_REWRITE_RULE[null_eq]last_cons));
 
 val not_T = hd(amatch``~T``);
 
 (* |- !t1 t2. (t1 <=> t2) <=> t1 /\ t2 \/ ~t1 /\ ~t2 *)
-val th24 = store_thm("th24", el 24 goals |> concl,
+val th25 = store_thm
+  ("th25", el 25 goals |> concl,
   rpt gen_tac
   \\ Q.ISPEC_THEN`t1`FULL_STRUCT_CASES_TAC bool_cases
   \\ PURE_REWRITE_TAC[T_iff,T_and,not_T,F_and,or_F,not_F,F_or,F_iff]
   \\ REFL_TAC);
 
 (* |- !t1 t2. (t1 <=> t2) <=> (t1 ==> t2) /\ (t2 ==> t1) *)
-val th25 = store_thm("th25", el 25 goals |> concl,
+val th26 = store_thm
+  ("th26", el 26 goals |> concl,
   rpt gen_tac
   \\ Q.ISPEC_THEN`t1`FULL_STRUCT_CASES_TAC bool_cases
   \\ PURE_REWRITE_TAC[T_iff,F_iff,T_imp,F_imp,imp_T,imp_F,and_T,T_and]
@@ -452,31 +501,55 @@ val th25 = store_thm("th25", el 25 goals |> concl,
 val ext = hd(amatch``(!x. f x = g x) <=> _``);
 
 (* |- !f g. f = g <=> !x. f x = g x *)
-val th26 = store_thm("th26", el 26 goals |> concl,
-  MATCH_ACCEPT_TAC (GSYM ext));
+val th27 = store_thm
+  ("th27", el 27 goals |> concl, MATCH_ACCEPT_TAC (GSYM ext));
 
 (* |- !A B. (A <=> B \/ A) <=> B ==> A *)
-val th27 = store_thm("th27", el 27 goals |> concl,
+val th28 = store_thm("th28", el 28 goals |> concl,
   rpt gen_tac
   \\ Q.ISPEC_THEN`A`FULL_STRUCT_CASES_TAC bool_cases
   \\ PURE_REWRITE_TAC[T_iff,or_T,F_iff,or_F,imp_T,imp_F]
   \\ REFL_TAC);
 
+(* |- !A B. A ==> B <=> ~A \/ B *)
+val IMP_DISJ_THM = store_thm
+  ("IMP_DISJ_THM", concl boolTheory.IMP_DISJ_THM,
+  rpt gen_tac
+  \\ qspec_then`A`FULL_STRUCT_CASES_TAC bool_cases
+  \\ PURE_REWRITE_TAC[T_imp,not_T,F_imp,not_F,F_or,T_or]
+  \\ REFL_TAC);
+
+(* |- !A B. A \/ B <=> ~A ==> B (DISJ_EQ_IMP) *)
+val th29 = save_thm
+  ("th29", (* this proof is from boolScript.sml *)
+  let
+    val lemma = not_not |> SPEC ``A:bool``
+  in
+    IMP_DISJ_THM
+    |> SPECL [``~A:bool``,``B:bool``]
+    |> SYM
+    |> CONV_RULE
+      ((RATOR_CONV o RAND_CONV o RATOR_CONV o RAND_CONV)
+         (fn tm => lemma))
+    |> GENL [``A:bool``,``B:bool``]
+  end);
+
+val _ = if concl th29 ~~ concl (el 29 goals) then ()
+        else raise ERR "th29" "assumptions changed";
+
 val cons_neq_nil = hd(amatch``Data_List_cons _ _ <> Data_List_nil``);
 
 (* |- !a1 a0. Data_List_nil <> Data_List_cons a0 a1 *)
-val th28 = store_thm("th28", el 28 goals |> concl, MATCH_ACCEPT_TAC (GSYM cons_neq_nil));
+val th30 = store_thm
+  ("th30", el 30 goals |> concl, MATCH_ACCEPT_TAC (GSYM cons_neq_nil));
 
 val some_neq_none = hd(amatch``_ <> Data_Option_none``);
 
-(* |- !x. Data_Option_none <> Data_Option_some x *)
-val th29 = store_thm("th29", el 29 goals |> concl, MATCH_ACCEPT_TAC (GSYM some_neq_none));
-
-(* |- !t.
-          (T ==> t <=> t) /\ (t ==> T <=> T) /\ (F ==> t <=> T) /\
+(* |- !t. (T ==> t <=> t) /\ (t ==> T <=> T) /\ (F ==> t <=> T) /\
           (t ==> t <=> T) /\ (t ==> F <=> ~t)
  *)
-val th30 = store_thm("th30", el 30 goals |> concl,
+val th31 = store_thm
+  ("th31", el 31 goals |> concl,
   gen_tac
   \\ conj_tac >- MATCH_ACCEPT_TAC T_imp
   \\ conj_tac >- MATCH_ACCEPT_TAC imp_T
@@ -484,11 +557,11 @@ val th30 = store_thm("th30", el 30 goals |> concl,
   \\ conj_tac >- MATCH_ACCEPT_TAC (EQT_INTRO (SPEC_ALL imp_i))
   \\ MATCH_ACCEPT_TAC imp_F);
 
-(* |- !t.
-          (T \/ t <=> T) /\ (t \/ T <=> T) /\ (F \/ t <=> t) /\
+(* |- !t. (T \/ t <=> T) /\ (t \/ T <=> T) /\ (F \/ t <=> t) /\
           (t \/ F <=> t) /\ (t \/ t <=> t)
  *)
-val th31 = store_thm("th31", el 31 goals |> concl,
+val th32 = store_thm
+  ("th32", el 32 goals |> concl,
   gen_tac
   \\ conj_tac >- MATCH_ACCEPT_TAC T_or
   \\ conj_tac >- MATCH_ACCEPT_TAC or_T
@@ -496,11 +569,11 @@ val th31 = store_thm("th31", el 31 goals |> concl,
   \\ conj_tac >- MATCH_ACCEPT_TAC or_F
   \\ MATCH_ACCEPT_TAC or_i);
 
-(* |- !t.
-          (T /\ t <=> t) /\ (t /\ T <=> t) /\ (F /\ t <=> F) /\
+(* |- !t. (T /\ t <=> t) /\ (t /\ T <=> t) /\ (F /\ t <=> F) /\
           (t /\ F <=> F) /\ (t /\ t <=> t)
  *)
-val th32 = store_thm("th32", el 32 goals |> concl,
+val th33 = store_thm
+  ("th33", el 33 goals |> concl,
   gen_tac
   \\ conj_tac >- MATCH_ACCEPT_TAC T_and
   \\ conj_tac >- MATCH_ACCEPT_TAC and_T
@@ -508,11 +581,11 @@ val th32 = store_thm("th32", el 32 goals |> concl,
   \\ conj_tac >- MATCH_ACCEPT_TAC and_F
   \\ MATCH_ACCEPT_TAC and_i);
 
-(* |- !t.
-          ((T <=> t) <=> t) /\ ((t <=> T) <=> t) /\ ((F <=> t) <=> ~t) /\
+(* |- !t. ((T <=> t) <=> t) /\ ((t <=> T) <=> t) /\ ((F <=> t) <=> ~t) /\
           ((t <=> F) <=> ~t)
  *)
-val th33 = store_thm("th33", el 33 goals |> concl,
+val th34 = store_thm
+  ("th34", el 34 goals |> concl,
   gen_tac
   \\ conj_tac >- MATCH_ACCEPT_TAC T_iff
   \\ conj_tac >- MATCH_ACCEPT_TAC iff_T
@@ -522,19 +595,22 @@ val th33 = store_thm("th33", el 33 goals |> concl,
 val select_eq = hd(amatch``@y. y = x``)
 
 (* |- !x. (@y. x = y) = x *)
-val th34 = store_thm("th34", el 34 goals |> concl,
+val th35 = store_thm
+  ("th35", el 35 goals |> concl,
   CONV_TAC(QUANT_CONV(LAND_CONV(RAND_CONV(ABS_CONV SYM_CONV))))
   \\ MATCH_ACCEPT_TAC select_eq);
 
 (* |- !t. t ==> F <=> (t <=> F) *)
-val th35 = store_thm("th35", el 35 goals |> concl,
+val th36 = store_thm
+  ("th36", el 36 goals |> concl,
   PURE_REWRITE_TAC[imp_F, iff_F]
   \\ gen_tac \\ REFL_TAC);
 
 val refl = hd(amatch``!x. x = x``);
 
 (* |- !x. x = x <=> T *)
-val th36 = store_thm("th36", el 36 goals |> concl,
+val th37 = store_thm
+  ("th37", el 37 goals |> concl,
   gen_tac \\ MATCH_ACCEPT_TAC(EQT_INTRO(SPEC_ALL refl)));
 
 val eq_trans = hd(amatch``(x = y) /\ (y = z) ==> _``);
@@ -544,7 +620,8 @@ val eq_trans = hd(amatch``(x = y) /\ (y = z) ==> _``);
           (!x y. f x y = f y x) ==>
           !x y z. f x (f y z) = f y (f x z)
  *)
-val th37 = store_thm("th37", el 37 goals |> concl,
+val th38 = store_thm
+  ("th38", el 38 goals |> concl,
   rpt strip_tac
   \\ first_assum(qspecl_then[`x`,`y`,`z`]SUBST_ALL_TAC)
   \\ last_assum(qspecl_then[`f x y`,`z`]SUBST_ALL_TAC)
@@ -555,19 +632,18 @@ val th37 = store_thm("th37", el 37 goals |> concl,
 
 val less_zero = hd(amatch``Number_Natural_less Number_Natural_zero n <=> _ <> _``);
 val div_mod = hd(amatch``Number_Natural_times (Number_Natural_div k n) n``);
-
 val less_mod = hd(amatch``Number_Natural_less (Number_Natural_mod _ _)``);
 
 (* |- !n.
           Number_Natural_less Number_Natural_zero n ==>
-          !k.
-              k =
+          !k. k =
               Number_Natural_plus
                 (Number_Natural_times (Number_Natural_div k n) n)
                 (Number_Natural_mod k n) /\
               Number_Natural_less (Number_Natural_mod k n) n
  *)
-val th38 = store_thm("th38", el 38 goals |> concl,
+val th39 = store_thm
+  ("th39", el 39 goals |> concl,
   PURE_REWRITE_TAC[less_zero]
   \\ gen_tac
   \\ disch_then(fn th => (strip_assume_tac (MATCH_MP less_mod th) >>
@@ -579,11 +655,11 @@ val th38 = store_thm("th38", el 38 goals |> concl,
 
 val list_ind = hd(amatch``_ ==> !(l:'a Data_List_list). P l``);
 
-(* |- !P.
-          P Data_List_nil /\ (!t. P t ==> !h. P (Data_List_cons h t)) ==>
+(* |- !P. P Data_List_nil /\ (!t. P t ==> !h. P (Data_List_cons h t)) ==>
           !l. P l
  *)
-val th39 = store_thm("th39", el 39 goals |> concl,
+val th40 = store_thm
+  ("th40", el 40 goals |> concl,
   rpt strip_tac
   \\ match_mp_tac list_ind
   \\ conj_tac >- first_assum ACCEPT_TAC
@@ -591,25 +667,52 @@ val th39 = store_thm("th39", el 39 goals |> concl,
   \\ first_assum MATCH_ACCEPT_TAC);
 
 (* |- !t. (t ==> F) ==> ~t *)
-val th40 = store_thm("th40", el 40 goals |> concl,
+val th41 = store_thm
+  ("th41", el 41 goals |> concl,
   imp_F |> SPEC_ALL |> EQ_IMP_RULE |> #1 |> MATCH_ACCEPT_TAC);
 
-(* |- !t. ~t ==> t ==> F *)
-val th41 = store_thm("th41", el 41 goals |> concl,
+(* |- !t. ~t ==> t ==> F (boolTheory.F_IMP) *)
+val th42 = store_thm
+  ("th42", el 42 goals |> concl,
   imp_F |> SPEC_ALL |> EQ_IMP_RULE |> #2 |> MATCH_ACCEPT_TAC);
 
-(* |- !A. A ==> ~A ==> F *)
-val th42 = store_thm("th42", el 42 goals |> concl,
-  PURE_REWRITE_TAC[GSYM imp_F]
-  \\ gen_tac
-  \\ disch_then(fn th => disch_then(ACCEPT_TAC o C MP th)));
-
 (* |- !t. F ==> t *)
-val th43 = store_thm("th43", el 43 goals |> concl,
+val th43 = store_thm
+  ("th43", el 43 goals |> concl,
   MATCH_ACCEPT_TAC(EQT_ELIM(SPEC_ALL F_imp)));
 
-val unpair = hd(amatch``Data_Pair_comma (Data_Pair_fst _) _``);
+(* |- (!x. P x ==> Q x) ==> (?x. P x) ==> ?x'. Q x' *)
+val th44 = store_thm
+  ("th44", el 44 goals |> concl,
+  rpt strip_tac
+  \\ first_x_assum(fn th => first_x_assum (assume_tac o MATCH_MP th))
+  \\ qexists_tac`x`
+  \\ first_assum ACCEPT_TAC);
 
+(* |- (!x. P x ==> Q x) ==> (!x. P x) ==> !x. Q x *)
+val th45 = store_thm
+  ("th45", el 45 goals |> concl,
+  rpt strip_tac
+  \\ first_x_assum match_mp_tac
+  \\ first_x_assum(qspec_then`x`ACCEPT_TAC));
+
+(* |- (x ==> y) /\ (z ==> w) ==> x \/ z ==> y \/ w *)
+val th46 = store_thm
+  ("th46", el 46 goals |> concl,
+  rpt strip_tac
+  \\ first_x_assum(fn th => first_x_assum (assume_tac o MATCH_MP th))
+  \\ TRY (disj1_tac >> first_assum ACCEPT_TAC)
+  \\ TRY (disj2_tac >> first_assum ACCEPT_TAC));
+
+(* |- (x ==> y) /\ (z ==> w) ==> x /\ z ==> y /\ w *)
+val th47 = store_thm
+  ("th47", el 47 goals |> concl,
+   rpt strip_tac
+  \\ first_x_assum(fn th => first_x_assum (assume_tac o MATCH_MP th))
+  \\ first_x_assum(fn th => first_x_assum (assume_tac o MATCH_MP th))
+  \\ first_assum ACCEPT_TAC);
+
+val unpair = hd(amatch``Data_Pair_comma (Data_Pair_fst _) _``);
 val unzip_nil = hd(amatch``Data_List_unzip Data_List_nil``);
 val unzip_cons = hd(amatch``Data_List_unzip (Data_List_cons _ _)``);
 
@@ -623,7 +726,8 @@ val unzip_cons = hd(amatch``Data_List_unzip (Data_List_cons _ _)``);
             (Data_List_cons (Data_Pair_snd x)
                (Data_Pair_snd (Data_List_unzip l)))
  *)
-val th44 = store_thm("th44", el 44 goals |> concl,
+val th48 = store_thm
+  ("th48", el 48 goals |> concl,
   conj_tac >- MATCH_ACCEPT_TAC unzip_nil
   \\ PURE_REWRITE_TAC[unzip_cons]
   \\ rpt gen_tac
@@ -639,7 +743,8 @@ val reverse_cons = hd(amatch``Data_List_reverse (Data_List_cons _ _)``);
           Data_List_append (Data_List_reverse t)
             (Data_List_cons h Data_List_nil)
  *)
-val th45 = store_thm("th45", el 45 goals |> concl,
+val th49 = store_thm
+  ("th49", el 49 goals |> concl,
   conj_tac >- MATCH_ACCEPT_TAC reverse_nil
   \\ MATCH_ACCEPT_TAC reverse_cons);
 
@@ -651,7 +756,8 @@ val concat_cons = hd(amatch``Data_List_concat (Data_List_cons _ _)``);
           Data_List_concat (Data_List_cons h t) =
           Data_List_append h (Data_List_concat t)
  *)
-val th46 = store_thm("th46", el 46 goals |> concl,
+val th50 = store_thm
+  ("th50", el 50 goals |> concl,
   conj_tac >- MATCH_ACCEPT_TAC concat_nil
   \\ MATCH_ACCEPT_TAC concat_cons);
 
@@ -665,7 +771,8 @@ val fact_suc = hd(amatch``Number_Natural_factorial (Number_Natural_suc _)``);
           Number_Natural_times (Number_Natural_suc n)
             (Number_Natural_factorial n)
  *)
-val th47 = store_thm("th47", el 47 goals |> concl,
+val th51 = store_thm
+  ("th51", el 51 goals |> concl,
   conj_tac >- MATCH_ACCEPT_TAC fact_zero
   \\ MATCH_ACCEPT_TAC fact_suc);
 
@@ -677,7 +784,8 @@ val length_cons = hd(amatch``Data_List_length (Data_List_cons _ _)``);
           Data_List_length (Data_List_cons h t) =
           Number_Natural_suc (Data_List_length t)
  *)
-val th48 = store_thm("th48", el 48 goals |> concl,
+val th52 = store_thm
+  ("th52", el 52 goals |> concl,
   conj_tac >- MATCH_ACCEPT_TAC length_nil
   \\ MATCH_ACCEPT_TAC length_cons);
 
@@ -697,7 +805,8 @@ val null_cons = hd(amatch``Data_List_null (Data_List_cons _ _)``);
 (* |- (Data_List_null Data_List_nil <=> T) /\
       !h t. Data_List_null (Data_List_cons h t) <=> F
  *)
-val th49 = store_thm("th49", el 49 goals |> concl,
+val th53 = store_thm
+  ("th53", el 53 goals |> concl,
   conj_tac >- MATCH_ACCEPT_TAC (EQT_INTRO null_nil)
   \\ MATCH_ACCEPT_TAC (EQF_INTRO (SPEC_ALL null_cons)));
 
@@ -707,7 +816,8 @@ val odd_cons = hd(amatch``Number_Natural_odd (Number_Natural_suc _)``);
 (* |- (Number_Natural_odd Number_Natural_zero <=> F) /\
       !n. Number_Natural_odd (Number_Natural_suc n) <=> ~Number_Natural_odd n
  *)
-val th50 = store_thm("th50", el 50 goals |> concl,
+val th54 = store_thm
+  ("th54", el 54 goals |> concl,
   conj_tac >- MATCH_ACCEPT_TAC (EQF_INTRO odd_nil)
   \\ MATCH_ACCEPT_TAC odd_cons);
 
@@ -715,13 +825,24 @@ val even_nil = hd(amatch``Number_Natural_even Number_Natural_zero``);
 val even_cons = hd(amatch``Number_Natural_even (Number_Natural_suc _)``);
 
 (* |- (Number_Natural_even Number_Natural_zero <=> T) /\
-      !n.
-          Number_Natural_even (Number_Natural_suc n) <=>
-          ~Number_Natural_even n
+      !n. Number_Natural_even (Number_Natural_suc n) <=> ~Number_Natural_even n
  *)
-val th51 = store_thm("th51", el 51 goals |> concl,
+val th55 = store_thm
+  ("th55", el 55 goals |> concl,
   conj_tac >- MATCH_ACCEPT_TAC (EQT_INTRO even_nil)
   \\ MATCH_ACCEPT_TAC even_cons);
+
+val left_11 = hd(amatch``Data_Sum_left _ = Data_Sum_left _``);
+val right_11 = hd(amatch``Data_Sum_right _ = Data_Sum_right _``);
+
+(* |- (!x x'. Data_Sum_left x = Data_Sum_left x' <=> x = x') /\
+      !y y'. Data_Sum_right y = Data_Sum_right y' <=> y = y'
+ *)
+val th56 = store_thm
+  ("th56", el 56 goals |> concl,
+    conj_tac
+ >| [ MATCH_ACCEPT_TAC left_11,
+      MATCH_ACCEPT_TAC right_11 ]);
 
 val map_none = hd(amatch``Data_Option_map _ Data_Option_none = _``)
 val map_some = hd(amatch``Data_Option_map _ (Data_Option_some _) = _``)
@@ -729,7 +850,8 @@ val map_some = hd(amatch``Data_Option_map _ (Data_Option_some _) = _``)
 (* |- (!f x. Data_Option_map f (Data_Option_some x) = Data_Option_some (f x)) /\
       !f. Data_Option_map f Data_Option_none = Data_Option_none
  *)
-val th52 = store_thm("th52", el 52 goals |> concl,
+val th57 = store_thm
+  ("th57", el 57 goals |> concl,
   conj_tac >- MATCH_ACCEPT_TAC map_some
   \\ MATCH_ACCEPT_TAC map_none);
 
@@ -742,7 +864,8 @@ val filter_cons = hd(amatch``Data_List_filter _ (Data_List_cons _ _)``);
           if P h then Data_List_cons h (Data_List_filter P t)
           else Data_List_filter P t
  *)
-val th53 = store_thm("th53", el 53 goals |> concl,
+val th58 = store_thm
+  ("th58", el 58 goals |> concl,
   conj_tac >- MATCH_ACCEPT_TAC filter_nil
   \\ MATCH_ACCEPT_TAC filter_cons);
 
@@ -753,7 +876,8 @@ val any_cons = hd(amatch``Data_List_any _ (Data_List_cons _ _)``);
       !P h t.
           Data_List_any P (Data_List_cons h t) <=> P h \/ Data_List_any P t
  *)
-val th54 = store_thm("th54", el 54 goals |> concl,
+val th59 = store_thm
+  ("th59", el 59 goals |> concl,
   conj_tac >- MATCH_ACCEPT_TAC (EQF_INTRO (SPEC_ALL any_nil))
   \\ MATCH_ACCEPT_TAC any_cons);
 
@@ -764,7 +888,8 @@ val all_cons = hd(amatch``Data_List_all _ (Data_List_cons _ _)``);
       !P h t.
           Data_List_all P (Data_List_cons h t) <=> P h /\ Data_List_all P t
  *)
-val th55 = store_thm("th55", el 55 goals |> concl,
+val th60 = store_thm
+  ("th60", el 60 goals |> concl,
   conj_tac >- MATCH_ACCEPT_TAC (EQT_INTRO (SPEC_ALL all_nil))
   \\ MATCH_ACCEPT_TAC all_cons);
 
@@ -776,7 +901,8 @@ val map_cons = hd(amatch``Data_List_map _ (Data_List_cons _ _)``);
           Data_List_map f (Data_List_cons h t) =
           Data_List_cons (f h) (Data_List_map f t)
  *)
-val th56 = store_thm("th56", el 56 goals |> concl,
+val th61 = store_thm
+  ("th61", el 61 goals |> concl,
   conj_tac >- MATCH_ACCEPT_TAC map_nil
   \\ MATCH_ACCEPT_TAC map_cons);
 
@@ -788,7 +914,8 @@ val append_cons = hd(amatch``Data_List_append (Data_List_cons _ _) _ = Data_List
           Data_List_append (Data_List_cons h l1) l2 =
           Data_List_cons h (Data_List_append l1 l2)
  *)
-val th57 = store_thm("th57", el 57 goals |> concl,
+val th62 = store_thm
+  ("th62", el 62 goals |> concl,
   conj_tac >- MATCH_ACCEPT_TAC append_nil
   \\ MATCH_ACCEPT_TAC append_cons);
 
@@ -802,7 +929,8 @@ val power_suc = hd(amatch``Number_Natural_power _ (Number_Natural_suc _)``);
           Number_Natural_power m (Number_Natural_suc n) =
           Number_Natural_times m (Number_Natural_power m n)
  *)
-val th58  = store_thm("th58", el 58 goals |> concl,
+val th63 = store_thm
+  ("th63", el 63 goals |> concl,
   conj_tac >- MATCH_ACCEPT_TAC power_zero
   \\ MATCH_ACCEPT_TAC power_suc);
 
@@ -817,7 +945,8 @@ val times_zero_comm = PURE_ONCE_REWRITE_RULE [times_comm] times_zero;
           Number_Natural_times (Number_Natural_suc m) n =
           Number_Natural_plus (Number_Natural_times m n) n
  *)
-val th59  = store_thm("th59", el 59 goals |> concl,
+val th64 = store_thm
+  ("th64", el 64 goals |> concl,
   conj_tac >- MATCH_ACCEPT_TAC times_zero_comm
   \\ MATCH_ACCEPT_TAC
       (PURE_ONCE_REWRITE_RULE[plus_comm](PURE_ONCE_REWRITE_RULE[times_comm]times_suc)));
@@ -830,34 +959,18 @@ val plus_suc = hd(amatch``Number_Natural_plus _ (Number_Natural_suc _)``);
           Number_Natural_plus (Number_Natural_suc m) n =
           Number_Natural_suc (Number_Natural_plus m n)
  *)
-val th60  = store_thm("th60", el 60 goals |> concl,
+val th65 = store_thm
+  ("th65", el 65 goals |> concl,
   conj_tac >- MATCH_ACCEPT_TAC (PURE_ONCE_REWRITE_RULE[plus_comm]plus_zero)
   \\ MATCH_ACCEPT_TAC (PURE_ONCE_REWRITE_RULE[plus_comm]plus_suc));
 
 (* |- (!t. ~~t <=> t) /\ (~T <=> F) /\ (~F <=> T) *)
-val th61 = store_thm("th61", el 61 goals |> concl,
+val th66 = store_thm
+  ("th66", el 66 goals |> concl,
   PURE_REWRITE_TAC[not_not,iff_F,iff_T,truth,not_F,and_T]
   \\ gen_tac \\ REFL_TAC);
 
-val isSome_some = hd(amatch``Data_Option_isSome (Data_Option_some _)``);
-val isSome_none = hd(amatch``Data_Option_isSome (Data_Option_none)``);
-
-(* |- (!x. Data_Option_isSome (Data_Option_some x) <=> T) /\
-      (Data_Option_isSome Data_Option_none <=> F)
- *)
-val th62 = store_thm("th62", el 62 goals |> concl,
-  conj_tac >- MATCH_ACCEPT_TAC (EQT_INTRO (SPEC_ALL isSome_some))
-  \\ MATCH_ACCEPT_TAC (EQF_INTRO isSome_none));
-
-val isNone_some = hd(amatch``Data_Option_isNone (Data_Option_some _)``);
-val isNone_none = hd(amatch``Data_Option_isNone (Data_Option_none)``);
-
-(* |- (!x. Data_Option_isNone (Data_Option_some x) <=> F) /\
-      (Data_Option_isNone Data_Option_none <=> T)
- *)
-val th63 = store_thm("th63", el 63 goals |> concl,
-  conj_tac >- MATCH_ACCEPT_TAC (EQF_INTRO (SPEC_ALL isNone_some))
-  \\ MATCH_ACCEPT_TAC (EQT_INTRO isNone_none));
+val NOT_CLAUSES = th66;
 
 val isRight_right = hd(amatch``Data_Sum_isRight (Data_Sum_right _)``);
 val isRight_left = hd(amatch``Data_Sum_isRight (Data_Sum_left _)``);
@@ -865,78 +978,47 @@ val isRight_left = hd(amatch``Data_Sum_isRight (Data_Sum_left _)``);
 (* |- (!x. Data_Sum_isRight (Data_Sum_right x)) /\
       !y. ~Data_Sum_isRight (Data_Sum_left y)
  *)
-val th64 = store_thm("th64", el 64 goals |> concl,
-  conj_tac >- MATCH_ACCEPT_TAC isRight_right
-  \\ MATCH_ACCEPT_TAC isRight_left);
+val th67 = store_thm
+  ("th67", el 67 goals |> concl,
+    conj_tac
+ >| [ PURE_REWRITE_TAC [iff_T] >> MATCH_ACCEPT_TAC isRight_right,
+      PURE_REWRITE_TAC [iff_F] >> MATCH_ACCEPT_TAC isRight_left ]);
 
 val isLeft_right = hd(amatch``Data_Sum_isLeft (Data_Sum_right _)``);
 val isLeft_left = hd(amatch``Data_Sum_isLeft (Data_Sum_left _)``);
 
-(* |- (!x. Data_Sum_isLeft (Data_Sum_left x)) /\
-      !y. ~Data_Sum_isLeft (Data_Sum_right y)
+(* |- (!x. Data_Sum_isLeft (Data_Sum_left x) <=> T) /\
+      !y. Data_Sum_isLeft (Data_Sum_right y) <=> F
  *)
-val th65 = store_thm("th65", el 65 goals |> concl,
-  conj_tac >- MATCH_ACCEPT_TAC isLeft_left
-  \\ MATCH_ACCEPT_TAC isLeft_right);
+val th68 = store_thm
+  ("th68", el 68 goals |> concl,
+    conj_tac
+ >| [ PURE_REWRITE_TAC [iff_T] >> MATCH_ACCEPT_TAC isLeft_left,
+      PURE_REWRITE_TAC [iff_F] >> MATCH_ACCEPT_TAC isLeft_right ]);
 
-(* |- (!x. P x ==> Q x) ==> (?x. P x) ==> ?x'. Q x' *)
-val th66 = store_thm("th66", el 66 goals |> concl,
-  rpt strip_tac
-  \\ first_x_assum(fn th => first_x_assum (assume_tac o MATCH_MP th))
-  \\ qexists_tac`x`
-  \\ first_assum ACCEPT_TAC);
+val isSome_some = hd(amatch``Data_Option_isSome (Data_Option_some _)``);
+val isSome_none = hd(amatch``Data_Option_isSome (Data_Option_none)``);
 
-(* |- (!x. P x ==> Q x) ==> (!x. P x) ==> !x. Q x *)
-val th67 = store_thm("th67", el 67 goals |> concl,
-  rpt strip_tac
-  \\ first_x_assum match_mp_tac
-  \\ first_x_assum(qspec_then`x`ACCEPT_TAC));
+(* |- (!x. Data_Option_isSome (Data_Option_some x) <=> T) /\
+      (Data_Option_isSome Data_Option_none <=> F)
+ *)
+val th69 = store_thm
+  ("th69", el 69 goals |> concl,
+    conj_tac
+ >| [ MATCH_ACCEPT_TAC (EQT_INTRO (SPEC_ALL isSome_some)),
+      MATCH_ACCEPT_TAC (EQF_INTRO isSome_none) ]);
 
-(* |- (x ==> y) /\ (z ==> w) ==> x \/ z ==> y \/ w *)
-val th68 = store_thm("th68", el 68 goals |> concl,
-  rpt strip_tac
-  \\ first_x_assum(fn th => first_x_assum (assume_tac o MATCH_MP th))
-  \\ TRY (disj1_tac >> first_assum ACCEPT_TAC)
-  \\ TRY (disj2_tac >> first_assum ACCEPT_TAC));
+val isNone_some = hd(amatch``Data_Option_isNone (Data_Option_some _)``);
+val isNone_none = hd(amatch``Data_Option_isNone (Data_Option_none)``);
 
-(* |- (x ==> y) /\ (z ==> w) ==> x /\ z ==> y /\ w *)
-val th69 = store_thm("th69", el 69 goals |> concl,
-   rpt strip_tac
-  \\ first_x_assum(fn th => first_x_assum (assume_tac o MATCH_MP th))
-  \\ first_x_assum(fn th => first_x_assum (assume_tac o MATCH_MP th))
-  \\ first_assum ACCEPT_TAC);
-
-(* |- (~A ==> F) ==> (A ==> F) ==> F *)
-val th70 = store_thm("th70", el 70 goals |> concl,
-  PURE_REWRITE_TAC[imp_F]
-  \\ disch_then ACCEPT_TAC);
-
-(* |- ~(p \/ q) ==> ~q *)
-val th71 = store_thm("th71", el 71 goals |> concl,
-  PURE_REWRITE_TAC[not_or]
-  \\ strip_tac);
-
-(* |- ~(p \/ q) ==> ~p *)
-val th72 = store_thm("th72", el 72 goals |> concl,
-  PURE_REWRITE_TAC[not_or]
-  \\ strip_tac);
-
-val not_imp = hd(amatch``~(_ ==> _)``);
-
-(* |- ~(p ==> q) ==> ~q *)
-val th73 = store_thm("th73", el 73 goals |> concl,
-  PURE_REWRITE_TAC[not_imp]
-  \\ strip_tac);
-
-(* |- ~(p ==> q) ==> p *)
-val th74 = store_thm("th74", el 74 goals |> concl,
-  PURE_REWRITE_TAC[not_imp]
-  \\ strip_tac);
-
-(* |- ~~p ==> p *)
-val th75 = store_thm("th75", el 75 goals |> concl,
-  PURE_REWRITE_TAC[not_not]
-  \\ strip_tac);
+(* |- (!x. Data_Option_isNone (Data_Option_some x) <=> F) /\
+      (Data_Option_isNone Data_Option_none <=> T)
+ *)
+val th70 = store_thm
+  ("th70", el 70 goals |> concl,
+    conj_tac
+ >| [ MATCH_ACCEPT_TAC (EQF_INTRO (SPEC_ALL isNone_some)),
+      MATCH_ACCEPT_TAC (EQT_INTRO isNone_none) ]);
 
 val tc_def = hd(amatch``!x. Relation_transitiveClosure x = _``);
 
@@ -950,11 +1032,11 @@ val transitive_thm = hd(amatch``Relation_transitive s <=> _``);
 
 (* |- Relation_transitiveClosure =
       (\R a b.
-           !P.
-               (!x y. R x y ==> P x y) /\ (!x y z. P x y /\ P y z ==> P x z) ==>
+           !P. (!x y. R x y ==> P x y) /\ (!x y z. P x y /\ P y z ==> P x z) ==>
                P a b)
  *)
-val th76 = store_thm("th76", el 76 goals |> concl,
+val th71 = store_thm
+  ("th71", el 71 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm]
   \\ PURE_REWRITE_TAC[tc_def,bigIntersect_thm,mem_fromPred]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
@@ -971,11 +1053,19 @@ val wellFounded_thm = hd(amatch``Relation_wellFounded r <=> !p. (?x. _) ==> _``)
 (* |- Relation_wellFounded =
       (\R. !B. (?w. B w) ==> ?min. B min /\ !b. R b min ==> ~B b)
  *)
-val th77 = store_thm("th77", el 77 goals |> concl,
+val th72 = store_thm
+  ("th72", el 72 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm]
   \\ PURE_REWRITE_TAC[wellFounded_thm]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ gen_tac \\ REFL_TAC);
+
+(* |- !A. A ==> ~A ==> F *)
+val F_IMP2 = store_thm
+  ("F_IMP2", “!A. A ==> ~A ==> F”,
+  PURE_REWRITE_TAC[GSYM imp_F]
+  \\ gen_tac
+  \\ disch_then(fn th => disch_then(ACCEPT_TAC o C MP th)));
 
 val less_thm = hd(amatch``Number_Natural_less _ _ <=> ?x. _``);
 val less_refl = hd(amatch``Number_Natural_less x x``);
@@ -1002,11 +1092,12 @@ val trichotomy = hd(amatch``_ \/ _ \/ (_ = _)``);
 (* |- Number_Natural_less =
       (\m n. ?P. (!n. P (Number_Natural_suc n) ==> P n) /\ P m /\ ~P n)
  *)
-val th78 = store_thm("th78", el 78 goals |> concl,
+val th73 = store_thm
+  ("th73", el 73 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm]
   \\ qx_genl_tac[`a`,`b`]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
-  \\ match_mp_tac (PURE_REWRITE_RULE[and_imp_intro]th20)
+  \\ match_mp_tac (PURE_REWRITE_RULE[and_imp_intro] IMP_ANTISYM_AX)
   \\ conj_tac \\ strip_tac
   >- (
     qexists_tac`\x. Number_Natural_less x b`
@@ -1049,7 +1140,7 @@ val th78 = store_thm("th78", el 78 goals |> concl,
   \\ qspecl_then[`a`,`b`]strip_assume_tac trichotomy
   >- (
     qspec_then`Number_Natural_less a b`(match_mp_tac o EQT_ELIM) F_imp
-    \\ qspec_then`~(P b)`(match_mp_tac o UNDISCH) th42
+    \\ qspec_then`~(P b)`(match_mp_tac o UNDISCH) F_IMP2
     \\ PURE_REWRITE_TAC[not_not]
     \\ first_x_assum match_mp_tac
     \\ first_assum ACCEPT_TAC )
@@ -1059,13 +1150,15 @@ val th78 = store_thm("th78", el 78 goals |> concl,
   \\ PURE_REWRITE_TAC[F_imp]);
 
 (* |- Relation_transitive = (\R. !x y z. R x y /\ R y z ==> R x z) *)
-val th79 = store_thm("th79", el 79 goals |> concl,
+val th74 = store_thm
+  ("th74", el 74 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,transitive_thm]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ gen_tac \\ REFL_TAC);
 
 (* |- Relation_subrelation = (\R1 R2. !x y. R1 x y ==> R2 x y) *)
-val th80 = store_thm("th80", el 80 goals |> concl,
+val th75 = store_thm
+  ("th75", el 75 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,subrelation_thm]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
@@ -1076,7 +1169,8 @@ val mem_union = hd(amatch``Set_member _ (Set_union _ _) <=> _``);
 val mem_toSet = hd(amatch``Set_member _ (Relation_toSet _)``);
 
 (* |- Relation_union = (\R1 R2 x y. R1 x y \/ R2 x y) *)
-val th81 = store_thm("th81", el 81 goals |> concl,
+val th76 = store_thm
+  ("th76", el 76 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,union_thm,fromSet_thm,mem_union,mem_toSet]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
@@ -1086,7 +1180,8 @@ val intersect_thm = hd(amatch``Relation_intersect x y = _``);
 val mem_inter = hd(amatch``Set_member _ (Set_intersect _ _)``);
 
 (* |- Relation_intersect = (\R1 R2 x y. R1 x y /\ R2 x y) *)
-val th82 = store_thm("th82", el 82 goals |> concl,
+val th77 = store_thm
+  ("th77", el 77 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,intersect_thm,fromSet_thm,mem_inter,mem_toSet]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
@@ -1095,7 +1190,8 @@ val greatereq_thm = hd(amatch``Number_Natural_greatereq _ _``);
 val greater_thm = hd(amatch``Number_Natural_greater _ _ = _``);
 
 (* |- Number_Natural_greatereq = (\m n. Number_Natural_greater m n \/ m = n) *)
-val th83 = store_thm("th83", el 83 goals |> concl,
+val th78 = store_thm
+  ("th78", el 78 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,greatereq_thm,less_or_eq,greater_thm]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac
@@ -1103,7 +1199,8 @@ val th83 = store_thm("th83", el 83 goals |> concl,
   \\ REFL_TAC);
 
 (* |- Number_Natural_lesseq = (\m n. Number_Natural_less m n \/ m = n) *)
-val th84 = store_thm("th84", el 84 goals |> concl,
+val th79 = store_thm
+  ("th79", el 79 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,less_or_eq]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
@@ -1112,7 +1209,8 @@ val min_thm = hd(amatch``Number_Natural_min _ _ = COND _ _ _``);
 val if_id = hd(amatch``if _ then x else x``);
 
 (* |- Number_Natural_min = (\m n. if Number_Natural_less m n then m else n) *)
-val th85 = store_thm("th85", el 85 goals |> concl,
+val th80 = store_thm
+  ("th80", el 80 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,min_thm,less_or_eq]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac
@@ -1127,7 +1225,8 @@ val th85 = store_thm("th85", el 85 goals |> concl,
 val max_thm = hd(amatch``Number_Natural_max _ _ = COND _ _ _``);
 
 (* |- Number_Natural_max = (\m n. if Number_Natural_less m n then n else m) *)
-val th86 = store_thm("th86", el 86 goals |> concl,
+val th81 = store_thm
+  ("th81", el 81 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,max_thm,less_or_eq]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac
@@ -1151,7 +1250,8 @@ val plus_suc1 = hd(amatch``Number_Natural_plus (Number_Natural_suc _) _``);
            Number_Natural_plus n
              (Number_Natural_plus n (Number_Natural_suc Number_Natural_zero)))
  *)
-val th87 = store_thm("th87", el 87 goals |> concl,
+val th82 = store_thm
+  ("th82", el 82 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,bit1_thm,plus_suc]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ gen_tac
@@ -1168,7 +1268,8 @@ val th87 = store_thm("th87", el 87 goals |> concl,
 val irreflexive_thm = hd(amatch``Relation_irreflexive _ = _``);
 
 (* |- Relation_irreflexive = (\R. !x. ~R x x) *)
-val th88 = store_thm("th88", el 88 goals |> concl,
+val th83 = store_thm
+  ("th83", el 83 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm, irreflexive_thm]
   \\ CONV_TAC (DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac
@@ -1177,7 +1278,8 @@ val th88 = store_thm("th88", el 88 goals |> concl,
 val reflexive_thm = hd(amatch``Relation_reflexive _ = _``);
 
 (* |- Relation_reflexive = (\R. !x. R x x) *)
-val th89 = store_thm("th89", el 89 goals |> concl,
+val th84 = store_thm
+  ("th84", el 84 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm, reflexive_thm]
   \\ CONV_TAC (DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
@@ -1185,13 +1287,15 @@ val th89 = store_thm("th89", el 89 goals |> concl,
 val o_thm = hd(amatch``(Function_o _ _) _ = _``);
 
 (* |- Function_o = (\f g x. f (g x)) *)
-val th90 = store_thm("th90", el 90 goals |> concl,
+val th85 = store_thm
+  ("th85", el 85 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,o_thm]
   \\ CONV_TAC (DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
 
 (* |- Number_Natural_greater = (\m n. Number_Natural_less n m) *)
-val th91 = store_thm("th91", el 91 goals |> concl,
+val th86 = store_thm
+  ("th86", el 86 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,greater_thm]
   \\ CONV_TAC (DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
@@ -1199,98 +1303,37 @@ val th91 = store_thm("th91", el 91 goals |> concl,
 val skk = hd(amatch``Function_Combinator_s _ _ = Function_id``);
 
 (* |- Function_id = Function_Combinator_s Function_const Function_const *)
-val th92 = store_thm("th92", el 92 goals |> concl,
+val th87 = store_thm
+  ("th87", el 87 goals |> concl,
   PURE_REWRITE_TAC[skk] \\ REFL_TAC);
-
-(* |- ~(A \/ B) ==> F <=> (A ==> F) ==> ~B ==> F *)
-val th93 = store_thm("th93", el 93 goals |> concl,
-  Q.ISPEC_THEN`A`FULL_STRUCT_CASES_TAC bool_cases
-  \\ PURE_REWRITE_TAC[not_or,imp_F,not_and,not_not,T_or,not_T,F_imp,F_or,T_imp]
-  \\ REFL_TAC);
-
-(* |- ~(~A \/ B) ==> F <=> A ==> ~B ==> F *)
-val th94 = store_thm("th94", el 94 goals |> concl,
-  Q.ISPEC_THEN`A`FULL_STRUCT_CASES_TAC bool_cases
-  \\ PURE_REWRITE_TAC[not_or,imp_F,not_and,not_not,T_or,not_T,F_imp,F_or,T_imp,not_F]
-  \\ REFL_TAC);
-
-(* |- (p <=> if q then r else s) <=>
-      (p \/ q \/ ~s) /\ (p \/ ~r \/ ~q) /\ (p \/ ~r \/ ~s) /\
-      (~q \/ r \/ ~p) /\ (q \/ s \/ ~p)
- *)
-val th95 = store_thm("th95", el 95 goals |> concl,
-  Q.ISPEC_THEN`q`FULL_STRUCT_CASES_TAC bool_cases
-  \\ PURE_REWRITE_TAC[if_T,T_or,not_T,or_T,or_F,T_and,F_or,and_T]
-  \\ Q.ISPEC_THEN`p`FULL_STRUCT_CASES_TAC bool_cases
-  \\ PURE_REWRITE_TAC[T_iff,T_or,not_T,or_F,T_and,F_iff,F_or,not_F,if_F,or_T,and_T]
-  \\ TRY REFL_TAC
-  \\ Q.ISPEC_THEN`r`FULL_STRUCT_CASES_TAC bool_cases
-  \\ PURE_REWRITE_TAC[not_T,F_or,F_and,not_F,T_or,T_and,and_T,and_i]
-  \\ REFL_TAC);
-
-(* |- (p <=> (q <=> r)) <=>
-      (p \/ q \/ r) /\ (p \/ ~r \/ ~q) /\ (q \/ ~r \/ ~p) /\ (r \/ ~q \/ ~p)
- *)
-val th96 = store_thm("th96", el 96 goals |> concl,
-  Q.ISPEC_THEN`p`FULL_STRUCT_CASES_TAC bool_cases
-  \\ PURE_REWRITE_TAC[T_iff,T_or,not_T,or_F,T_and,F_iff,F_or,not_F,or_T,and_T]
-  \\ Q.ISPEC_THEN`q`FULL_STRUCT_CASES_TAC bool_cases
-  \\ PURE_REWRITE_TAC[T_iff,T_or,not_T,or_F,T_and,F_iff,F_or,not_F,or_T,and_T,not_not]
-  \\ REFL_TAC);
-
-(* |- (p <=> q /\ r) <=> (p \/ ~q \/ ~r) /\ (q \/ ~p) /\ (r \/ ~p) *)
-val th97 = store_thm("th97", el 97 goals |> concl,
-  Q.ISPEC_THEN`p`FULL_STRUCT_CASES_TAC bool_cases
-  \\ PURE_REWRITE_TAC[T_iff,T_or,not_T,or_F,T_and,F_iff,F_or,not_F,or_T,and_T,not_and]
-  \\ REFL_TAC);
-
-(* |- (p <=> q \/ r) <=> (p \/ ~q) /\ (p \/ ~r) /\ (q \/ r \/ ~p) *)
-val th98 = store_thm("th98", el 98 goals |> concl,
-  Q.ISPEC_THEN`p`FULL_STRUCT_CASES_TAC bool_cases
-  \\ PURE_REWRITE_TAC[T_iff,T_or,not_T,or_F,T_and,F_iff,F_or,not_F,or_T,and_T,not_and,not_or]
-  \\ REFL_TAC);
-
-(* |- (p <=> q ==> r) <=> (p \/ q) /\ (p \/ ~r) /\ (~q \/ r \/ ~p) *)
-val th99 = store_thm("th99", el 99 goals |> concl,
-  Q.ISPEC_THEN`p`FULL_STRUCT_CASES_TAC bool_cases
-  \\ PURE_REWRITE_TAC[T_iff,T_or,not_T,or_F,T_and,F_iff,F_or,not_F,or_T,and_T,not_imp]
-  \\ TRY REFL_TAC
-  \\ Q.ISPEC_THEN`q`FULL_STRUCT_CASES_TAC bool_cases
-  \\ PURE_REWRITE_TAC[T_imp,not_T,F_imp,not_F,F_or,T_or]
-  \\ REFL_TAC);
-
-(* |- (p <=> ~q) <=> (p \/ q) /\ (~q \/ ~p) *)
-val th100 = store_thm("th100", el 100 goals |> concl,
-  Q.ISPEC_THEN`p`FULL_STRUCT_CASES_TAC bool_cases
-  \\ PURE_REWRITE_TAC[T_iff,T_or,not_T,or_F,T_and,F_iff,F_or,not_F,or_T,and_T,not_not]
-  \\ REFL_TAC);
 
 val comma_11 = hd(amatch``Data_Pair_comma _ _ = Data_Pair_comma _ _``);
 
 (* |- Data_Pair_comma x y = Data_Pair_comma a b <=> x = a /\ y = b *)
-val th101 = store_thm("th101", el 101 goals |> concl,
+val th88 = store_thm
+  ("th88", el 88 goals |> concl,
   MATCH_ACCEPT_TAC comma_11);
 
-val right_11 = hd(amatch``Data_Sum_right _ = Data_Sum_right _``);
-
 (* |- Data_Sum_right x = Data_Sum_right y <=> x = y *)
-val th102 = store_thm("th102", el 102 goals |> concl,
+val th89 = store_thm
+  ("th89", el 89 goals |> concl,
   MATCH_ACCEPT_TAC right_11);
 
-val left_11 = hd(amatch``Data_Sum_left _ = Data_Sum_left _``);
-
 (* |- Data_Sum_left x = Data_Sum_left y <=> x = y *)
-val th103 = store_thm("th103", el 103 goals |> concl,
+val th90 = store_thm
+  ("th90", el 90 goals |> concl,
   MATCH_ACCEPT_TAC left_11);
 
 (* |- (?!x. P x) <=> (?x. P x) /\ !x y. P x /\ P y ==> x = y *)
-val th104 = store_thm("th104", el 104 goals |> concl,
+val th91 = store_thm
+  ("th91", el 91 goals |> concl,
   MATCH_ACCEPT_TAC ex_unique_thm);
 
 val exists_simp = hd(amatch “(?x. t) <=> t”);
 
 (* |- (?!x. F) <=> F *)
-val th105 = store_thm("th105", el 105 goals |> concl,
+val th92 = store_thm
+  ("th92", el 92 goals |> concl,
   PURE_REWRITE_TAC [BETA_RULE (SPEC “\x:'a. F” ex_unique_thm)] \\
   PURE_REWRITE_TAC [SPEC “F” exists_simp, F_and] \\
   REFL_TAC);
@@ -1298,13 +1341,15 @@ val th105 = store_thm("th105", el 105 goals |> concl,
 val one_thm = hd(amatch``_ = Data_Unit_unit``);
 
 (* |- Data_Unit_unit = @x. T *)
-val th106 = store_thm("th106", el 106 goals |> concl,
+val th93 = store_thm
+  ("th93", el 93 goals |> concl,
   PURE_ONCE_REWRITE_TAC[one_thm] \\ REFL_TAC);
 
 val universe_thm = hd(amatch``Relation_universe _ _``);
 
 (* |- Relation_universe = (\x y. T) *)
-val th107 = store_thm("th107", el 107 goals |> concl,
+val th94 = store_thm
+  ("th94", el 94 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,EQT_INTRO(SPEC_ALL universe_thm)]
   \\ CONV_TAC (DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
@@ -1312,16 +1357,27 @@ val th107 = store_thm("th107", el 107 goals |> concl,
 val empty_thm = hd(amatch``Relation_empty _ _``);
 
 (* |- Relation_empty = (\x y. F) *)
-val th108 = store_thm("th108", el 108 goals |> concl,
+val th95 = store_thm
+  ("th95", el 95 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,EQF_INTRO (SPEC_ALL empty_thm)]
   \\ CONV_TAC (DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
 
 (* |- Number_Natural_zero = Number_Natural_zero *)
-val th109 = store_thm("th108", el 109 goals |> concl,
+val th96 = store_thm
+  ("th96", el 96 goals |> concl,
   REFL_TAC);
 
-(* other theorems from boolTheory *)
+(* Now raise an error if the above th95 is not the last one *)
+val _ = if List.length goals <> 96 then
+            (raise ERR "-" "assumptions changed")
+        else ();
+
+(* Other theorems (from boolTheory, used by other OT packages)
+
+   NOTE: The following extra theorems are defined in boolTheory but are used by
+   theories beyond hol-base.
+ *)
 
 (* |- (y ==> x) /\ (z ==> w) ==> (x ==> z) ==> y ==> w *)
 val MONO_IMP = store_thm("MONO_IMP", concl boolTheory.MONO_IMP,
@@ -1329,21 +1385,21 @@ val MONO_IMP = store_thm("MONO_IMP", concl boolTheory.MONO_IMP,
   \\ rpt(first_x_assum match_mp_tac)
   \\ first_x_assum ACCEPT_TAC);
 
-(* |- !A B. A ==> B <=> ~A \/ B *)
-val IMP_DISJ_THM = store_thm("IMP_DISJ_THM", concl boolTheory.IMP_DISJ_THM,
-  rpt gen_tac
-  \\ qspec_then`A`FULL_STRUCT_CASES_TAC bool_cases
-  \\ PURE_REWRITE_TAC[T_imp,not_T,F_imp,not_F,F_or,T_or]
-  \\ REFL_TAC)
+val mono_not = hd (amatch “(y ==> x) ==> ~x ==> ~y”);
 
-(* |- !f g M N. M = N /\ (!x. x = N ==> f x = g x) ==> LET f M = LET g N *)
-val LET_CONG = store_thm("LET_CONG", concl boolTheory.LET_CONG,
-  rpt strip_tac
-  \\ VAR_EQ_TAC
-  \\ PURE_REWRITE_TAC[LET_DEF]
-  \\ CONV_TAC(DEPTH_CONV BETA_CONV)
-  \\ first_x_assum match_mp_tac
-  \\ REFL_TAC)
+(* |- (y ==> x) ==> ~x ==> ~y *)
+val MONO_NOT = store_thm
+  ("MONO_NOT", concl boolTheory.MONO_NOT,
+    MATCH_ACCEPT_TAC mono_not);
+
+val mono_not_eq = hd (amatch “~t1 ==> ~t2 <=> t2 ==> t1”);
+val eq_sym_eq = hd (amatch “x = y <=> y = x”);
+
+(* |- y ==> x <=> ~x ==> ~y *)
+val MONO_NOT_EQ = store_thm
+  ("MONO_NOT_EQ", concl boolTheory.MONO_NOT_EQ,
+    PURE_ONCE_REWRITE_TAC [eq_sym_eq]
+ >> MATCH_ACCEPT_TAC mono_not_eq);
 
 (* |- P (let x = M in N x) <=> (let x = M in P (N x)) *)
 val LET_RAND = store_thm("LET_RAND", concl boolTheory.LET_RAND,
@@ -1358,8 +1414,9 @@ val BOOL_EQ_DISTINCT = store_thm("BOOL_EQ_DISTINCT", concl boolTheory.BOOL_EQ_DI
 (* |- (!t1 t2. (if T then t1 else t2) = t1) /\
       !t1 t2. (if F then t1 else t2) = t2
  *)
-val bool_case_thm = store_thm("bool_case_thm", concl boolTheory.bool_case_thm,
-  PURE_REWRITE_TAC[th17]
+val bool_case_thm = store_thm
+  ("bool_case_thm", concl boolTheory.bool_case_thm,
+  PURE_REWRITE_TAC[th18]
   \\ conj_tac \\ rpt gen_tac \\ REFL_TAC);
 
 val forall_bool = hd(amatch``(!b:bool. P b) <=> _``)
@@ -1368,14 +1425,95 @@ val forall_bool = hd(amatch``(!b:bool. P b) <=> _``)
 val FORALL_BOOL = store_thm("FORALL_BOOL", concl boolTheory.FORALL_BOOL,
   MATCH_ACCEPT_TAC forall_bool);
 
+val cond_expand = hd(amatch ``(if b then t1 else t2) <=> _``);
+
+(* |- !b t1 t2. (if b then t1 else t2) <=> (b ==> t1) /\ (~b ==> t2)
+ *)
+val COND_EXPAND_IMP = save_thm
+  ("COND_EXPAND_IMP", (* this proof is from boolScript.sml *)
+ let val b    = “b:bool”
+     val t1   = “t1:bool”
+     val t2   = “t2:bool”
+     val nb   = mk_neg b;
+     val nnb  = mk_neg nb;
+     val imp_th1  = SPECL [b, t1] IMP_DISJ_THM;
+     val imp_th2a = SPECL [nb, t2] IMP_DISJ_THM
+     val imp_th2b = SUBST_CONV [nnb |-> (SPEC b (CONJUNCT1 NOT_CLAUSES))]
+                     (mk_disj (nnb, t2)) (mk_disj (nnb, t2))
+     val imp_th2  = TRANS imp_th2a imp_th2b
+     val new_rhs = “(b ==> t1) /\ (~b ==> t2)”;
+     val subst = [mk_imp(b,t1) |-> imp_th1,
+                  mk_imp(nb,t2) |-> imp_th2]
+     val th1 = SUBST_CONV subst new_rhs new_rhs
+     val th2 = TRANS (SPECL [b,t1,t2] cond_expand) (SYM th1)
+ in
+    GENL [b,t1,t2] th2
+ end);
+
+fun IMP_ANTISYM_RULE th1 th2 =
+  let val (ant,conseq) = dest_imp(concl th1)
+  in
+     MP (MP (SPEC conseq (SPEC ant IMP_ANTISYM_AX)) th1) th2
+  end;
+
+(* |- !P P' Q Q'. (~Q ==> (P <=> P')) /\ (~P' ==> (Q <=> Q')) ==>
+                  (P \/ Q <=> P' \/ Q') *)
+val OR_CONG = save_thm
+  ("OR_CONG", (* this proof is from boolScript.sml *)
+ let val P = mk_var("P",Type.bool)
+     val P' = mk_var("P'",Type.bool)
+     val Q = mk_var("Q",Type.bool)
+     val Q' = mk_var("Q'",Type.bool)
+     val notQ = mk_neg Q
+     val notP' = mk_neg P'
+     val PorQ = mk_disj(P,Q)
+     val P'orQ' = mk_disj(P',Q')
+     val PeqP'= mk_eq(P,P')
+     val QeqQ'= mk_eq(Q,Q')
+     val ctm1 = mk_imp(notQ,PeqP')
+     val ctm2 = mk_imp(notP',QeqQ')
+     val th1 = ASSUME PorQ
+     val th2 = ASSUME P
+     val th3 = ASSUME Q
+     val th4 = ASSUME ctm1
+     val th5 = ASSUME ctm2
+     val th6 = SUBS [SPEC Q (CONJUNCT1 NOT_CLAUSES)]
+                    (SUBS [SPECL[notQ, PeqP'] IMP_DISJ_THM] th4)
+     val th7 = SUBS [SPEC P' (CONJUNCT1 NOT_CLAUSES)]
+                    (SUBS [SPECL[notP', QeqQ'] IMP_DISJ_THM] th5)
+     val th8 = ASSUME P'
+     val th9 = DISJ1 th8 Q'
+     val th10 = ASSUME QeqQ'
+     val th11 = SUBS [th10] th3
+     val th12 = DISJ2 P' th11
+     val th13 = ASSUME PeqP'
+     val th14 = MK_COMB(REFL(mk_const("\\/",bool-->bool-->bool)),th13)
+     val th15 = EQ_MP (MK_COMB (th14,th10)) th1
+     val th16 = DISJ_CASES th6 th12 th15
+     val th17 = DISCH PorQ (DISJ_CASES th7 th9 th16)
+     val th18 = ASSUME P'orQ'
+     val th19 = DISJ2 P th3
+     val th20 = DISJ1 (SUBS [SYM th13] th8) Q
+     val th21 = EQ_MP (SYM (MK_COMB(th14,th10))) th18
+     val th22 = DISJ_CASES th7 th20 th21
+     val th23 = DISCH P'orQ' (DISJ_CASES th6 th19 th22)
+     val th24 = IMP_ANTISYM_RULE th17 th23
+     val th25 = SUBS [SPECL [ctm1,ctm2,concl th24] and_imp_intro]
+                     (DISCH ctm1 (DISCH ctm2 th24))
+ in
+   GENL [P,P',Q,Q'] th25
+ end);
+(* NOTE: COND_EXPAND_IMP and OR_CONG were reported by hol-bag *)
+
 val exists_refl = hd(amatch ``?x. x = a``)
 
 (* |- ?rep. TYPE_DEFINITION ($= ARB) rep *)
 val itself_tydef = prim_type_definition({Thy="prove_base_assums",Tyop="itself"},
   SPEC boolSyntax.arb exists_refl |> CONV_RULE(QUANT_CONV SYM_CONV))
 
-val _ = Parse.hide"the_value"
-val the_value_def = new_definition("the_value_def",``the_value = (ARB:'a prove_base_assums$itself)``)
+val _ = Parse.hide "the_value";
+val the_value_def = new_definition
+  ("the_value_def", ``the_value = (ARB:'a prove_base_assums$itself)``);
 
 val itself_unique = Q.store_thm("itself_unique",
   `!i. i = the_value`,
@@ -1398,7 +1536,11 @@ val itself_induction = store_thm("itself_induction",
   \\ PURE_ONCE_REWRITE_TAC[itself_unique]
   \\ first_assum ACCEPT_TAC);
 
-val itself_Axiom = store_thm("itself_Axiom", ``!e. ?f. f the_value = e``,
+(* |- !(e :'b). ?(f :'a prove_base_assums$itself -> 'b).
+        f (the_value :'a prove_base_assums$itself) = e
+ *)
+val itself_Axiom = store_thm
+  ("itself_Axiom", ``!(e :'b). ?f. f the_value = e``,
   gen_tac
   \\ qexists_tac`\x. e`
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
@@ -1424,7 +1566,7 @@ val RES_SELECT_DEF = new_definition("RES_SELECT_DEF",concl boolTheory.RES_SELECT
 (* |- !P f. RES_FORALL P f <=> !x. x IN P ==> f x *)
 val RES_FORALL_THM = store_thm("RES_FORALL_THM",
   Term.subst [boolSyntax.res_forall_tm |-> lhs(concl RES_FORALL_DEF)]
-    (concl RES_FORALL_THM),
+    (concl boolTheory.RES_FORALL_THM),
   PURE_REWRITE_TAC[RES_FORALL_DEF]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
@@ -1432,15 +1574,42 @@ val RES_FORALL_THM = store_thm("RES_FORALL_THM",
 (* |- !P f. RES_EXISTS P f <=> ?x. x IN P /\ f x *)
 val RES_EXISTS_THM = store_thm("RES_EXISTS_THM",
   Term.subst [boolSyntax.res_exists_tm |-> lhs(concl RES_EXISTS_DEF)]
-    (concl RES_EXISTS_THM),
+    (concl boolTheory.RES_EXISTS_THM),
   PURE_REWRITE_TAC[RES_EXISTS_DEF]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
 
+val not_exists_thm = hd (amatch ``~(?x. p x) <=> _``);
+val and_F = hd(amatch``t /\ F <=> _``);
+
+(* |- (?x::P. F) <=> F *)
+val RES_EXISTS_FALSE = store_thm
+  ("RES_EXISTS_FALSE",
+  Term.subst [boolSyntax.res_exists_tm |-> lhs(concl RES_EXISTS_DEF)]
+    (concl boolTheory.RES_EXISTS_FALSE),
+    PURE_REWRITE_TAC [RES_EXISTS_DEF]
+ >> NTAC 2 (CONV_TAC(DEPTH_CONV BETA_CONV))
+ >> PURE_REWRITE_TAC [and_F, iff_F]
+ >> PURE_REWRITE_TAC [BETA_RULE (SPEC “\x:'a. F” not_exists_thm)]
+ >> GEN_TAC
+ >> PURE_REWRITE_TAC [not_F, truth]);
+
+(* |- (!x::P. T) <=> T *)
+val RES_FORALL_TRUE = store_thm
+  ("RES_FORALL_TRUE",
+  Term.subst [boolSyntax.res_forall_tm |-> lhs(concl RES_FORALL_DEF)]
+    (concl boolTheory.RES_FORALL_TRUE),
+    PURE_REWRITE_TAC [RES_FORALL_DEF]
+ >> NTAC 2 (CONV_TAC(DEPTH_CONV BETA_CONV))
+ >> PURE_REWRITE_TAC [imp_T, iff_T]
+ >> GEN_TAC
+ >> PURE_REWRITE_TAC [truth]);
+(* NOTE: RES_EXISTS_FALSE and RES_FORALL_TRUE were reported by hol-res-quan *)
+
 (* !P f. RES_SELECT P f = @x. x IN P /\ f x *)
 val RES_SELECT_THM = store_thm("RES_SELECT_THM",
   Term.subst [boolSyntax.res_select_tm |-> lhs(concl RES_SELECT_DEF)]
-    (concl RES_SELECT_THM),
+    (concl boolTheory.RES_SELECT_THM),
   PURE_REWRITE_TAC[RES_SELECT_DEF]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
@@ -1451,11 +1620,11 @@ val RES_SELECT_THM = store_thm("RES_SELECT_THM",
  *)
 val RES_FORALL_CONG = store_thm("RES_FORALL_CONG",
   Term.subst [boolSyntax.res_forall_tm |-> lhs(concl RES_FORALL_DEF)]
-    (concl RES_FORALL_CONG),
+    (concl boolTheory.RES_FORALL_CONG),
   disch_then SUBST_ALL_TAC
   \\ PURE_REWRITE_TAC[RES_FORALL_THM]
   \\ strip_tac
-  \\ PURE_REWRITE_TAC[th25]
+  \\ PURE_REWRITE_TAC[th26]
   \\ conj_tac \\ rpt strip_tac
   \\ rpt (first_x_assum(qspec_then`x`mp_tac))
   \\ PURE_ASM_REWRITE_TAC[T_imp]
@@ -1468,11 +1637,11 @@ val RES_FORALL_CONG = store_thm("RES_FORALL_CONG",
  *)
 val RES_EXISTS_CONG = store_thm("RES_EXISTS_CONG",
   Term.subst [boolSyntax.res_exists_tm |-> lhs(concl RES_EXISTS_DEF)]
-    (concl RES_EXISTS_CONG),
+    (concl boolTheory.RES_EXISTS_CONG),
   disch_then SUBST_ALL_TAC
   \\ PURE_REWRITE_TAC[RES_EXISTS_THM]
   \\ strip_tac
-  \\ PURE_REWRITE_TAC[th25]
+  \\ PURE_REWRITE_TAC[th26]
   \\ conj_tac \\ rpt strip_tac
   \\ qexists_tac`x`
   \\ rpt (first_x_assum(qspec_then`x`mp_tac))
@@ -1487,7 +1656,7 @@ val RES_EXISTS_UNIQUE_THM = store_thm("RES_EXISTS_UNIQUE_THM",
   Term.subst [boolSyntax.res_exists1_tm |-> lhs(concl RES_EXISTS_UNIQUE_DEF),
               boolSyntax.res_exists_tm |-> lhs(concl RES_EXISTS_DEF),
               boolSyntax.res_forall_tm |-> lhs(concl RES_FORALL_DEF)]
-    (concl RES_EXISTS_UNIQUE_THM),
+    (concl boolTheory.RES_EXISTS_UNIQUE_THM),
   PURE_REWRITE_TAC[RES_EXISTS_UNIQUE_DEF]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
@@ -1502,7 +1671,8 @@ val RES_ABSTRACT_EXISTS = prove(
   let
     val fvar = mk_var("f",type_of boolSyntax.res_abstract_tm)
   in
-    mk_exists(fvar, Term.subst [boolSyntax.res_abstract_tm|->fvar] (concl RES_ABSTRACT_DEF))
+    mk_exists(fvar, Term.subst [boolSyntax.res_abstract_tm|->fvar]
+                      (concl boolTheory.RES_ABSTRACT_DEF))
   end,
   qexists_tac`\p m x. if x IN p then m x else ARB x`
   \\ PURE_REWRITE_TAC[GSYM fun_eq_thm]

--- a/src/coalgebras/Holmakefile
+++ b/src/coalgebras/Holmakefile
@@ -4,7 +4,7 @@ all: $(DEFAULT_TARGETS) selftest.exe
 .PHONY: all
 
 ifeq ($(KERNELID),otknl)
-BARE_THYS = llist lbtree path # ltree is temporarily removed
+BARE_THYS = llist lbtree path itree # ltree has problems
 
 all: hol4-coalgebras.art
 
@@ -13,6 +13,15 @@ hol4-coalgebras-unint.art: hol4-coalgebras-unint.thy $(patsubst %,%.ot.art,$(BAR
 
 hol4-coalgebras.art: hol4-coalgebras.thy hol4-coalgebras-unint.art ../opentheory/hol4.int
 	opentheory info --article -o $@ $<
+
+install: hol4-coalgebras.thy hol4-coalgebras.art
+	opentheory install --reinstall $<
+
+ltree.art: ltree.otd
+itree.art: itree.otd
+lbtree.art: lbtree.otd
+llist.art: llist.otd
+path.art: path.otd
 endif
 
 selftest.exe: selftest.uo llistTheory.uo

--- a/src/coalgebras/hol4-coalgebras-unint.thy
+++ b/src/coalgebras/hol4-coalgebras-unint.thy
@@ -2,11 +2,15 @@ name: hol-coalgebras
 version: 1.0
 description: HOL coalgebras theories (before re-interpretation)
 author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
-license: GPL
+license: MIT
 main {
   import: llist
   import: lbtree
   import: path
+  import: bisimulation
+}
+bisimulation {
+  article: "../relation/bisimulation.ot.art"
 }
 llist {
   article: "llist.ot.art"

--- a/src/coalgebras/hol4-coalgebras.thy
+++ b/src/coalgebras/hol4-coalgebras.thy
@@ -1,10 +1,12 @@
 name: hol-coalgebras
-version: 1.0
+version: 1.1
 description: HOL coalgebras theories
 author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
-license: GPL
+license: MIT
 requires: base
 requires: hol-base
+requires: hol-set
+requires: hol-finite-maps
 show: "HOL4"
 show: "Data.Bool"
 show: "Data.List"

--- a/src/coalgebras/itree.otd
+++ b/src/coalgebras/itree.otd
@@ -1,0 +1,4 @@
+skipthm itree_el_TY_DEF
+skipthm datatype_itree
+skipthm datatype_itree_el
+skipthm datatype_itree_next

--- a/src/coalgebras/lbtree.otd
+++ b/src/coalgebras/lbtree.otd
@@ -1,0 +1,1 @@
+skipthm lbtree_TY_DEF

--- a/src/coalgebras/llist.otd
+++ b/src/coalgebras/llist.otd
@@ -1,0 +1,1 @@
+skipthm llist_TY_DEF

--- a/src/coalgebras/ltree.otd
+++ b/src/coalgebras/ltree.otd
@@ -1,0 +1,4 @@
+skipthm ltree_TY_DEF
+skipthm rose_tree_TY_DEF
+skipthm datatype_ltree
+skipthm datatype_rose_tree

--- a/src/coalgebras/path.otd
+++ b/src/coalgebras/path.otd
@@ -1,0 +1,1 @@
+skipthm path_TY_DEF

--- a/src/coretypes/option.otd
+++ b/src/coretypes/option.otd
@@ -13,5 +13,4 @@ delproof option_Axiom
 delproof option_induction
 delproof option_nchotomy
 delproof SOME_11
-delproof NOT_NONE_SOME
 delproof NOT_SOME_NONE

--- a/src/coretypes/optionScript.sml
+++ b/src/coretypes/optionScript.sml
@@ -736,9 +736,22 @@ val some_EQ = store_thm(
   CONJ_TAC THEN DEEP_INTRO_TAC some_intro THEN SRW_TAC [][]);
 val _ = export_rewrites ["some_EQ"]
 
+(* |- !M M' v f.
+        M = M' /\ (M' = NONE ==> v = v') /\ (!x. M' = SOME x ==> f x = f' x) ==>
+        option_CASE M v f = option_CASE M' v' f'
+ *)
 val option_case_cong =
   save_thm("option_case_cong",
       Prim_rec.case_cong_thm option_nchotomy option_case_def);
+
+(* another similar theorem, moved here from cardinalTheory:
+   |- option_CASE x v f <=> (x = NONE ==> v) /\ !x'. x = SOME x' ==> f x'
+ *)
+Theorem option_imp_elim =
+        TypeBase.case_pred_imp_of “:'a option”
+     |> INST_TYPE [beta |-> bool]
+     |> Q.SPEC ‘I’
+     |> REWRITE_RULE [combinTheory.I_THM]
 
 val OPTION_ALL_def = new_recursive_definition {
   def = ``(OPTION_ALL P NONE <=> T) /\ (OPTION_ALL P (SOME (x:'a)) <=> P x)``,
@@ -764,6 +777,14 @@ val option_case_eq = Q.store_thm(
   ‘(option_CASE (opt:'a option) nc sc = v) <=>
    ((opt = NONE) /\ (nc = v) \/ ?x. (opt = SOME x) /\ (sc x = v))’,
   OPTION_CASES_TAC “opt:'a option” THEN SRW_TAC[][EQ_SYM_EQ, option_case_def]);
+
+(* OpenTheory fix: hol-set reports the following 1 unsatisfied assumption *)
+Theorem option_case_eq' :
+   (option_CASE (x:'a option) v f = v') <=>
+   ((x = NONE) /\ (v = v') \/ ?a. (x = SOME a) /\ (f a = v'))
+Proof
+   REWRITE_TAC [option_case_eq]
+QED
 
 val S = PP.add_string and NL = PP.NL and B = PP.block PP.CONSISTENT 0
 

--- a/src/finite_maps/Holmakefile
+++ b/src/finite_maps/Holmakefile
@@ -2,6 +2,7 @@ INCLUDES = ../sort ../n-bit ../bag ../res_quan/src ../string \
            ../pred_set/src/more_theories
 
 all: $(DEFAULT_TARGETS) selftest.exe
+.PHONY: all
 
 selftest.exe: selftest.uo sptreeSyntax.uo sptreeTheory.uo
 	$(HOLMOSMLC) -o $@ $<
@@ -20,4 +21,20 @@ all: link-to-sigobj
 .PHONY: link-to-sigobj
 link-to-sigobj: $(DEFAULT_TARGETS)
 	$(HOL_LNSIGOBJ)
+endif
+
+ifeq ($(KERNELID),otknl)
+ARTFILES = $(patsubst %Script.sml,%.ot.art,$(wildcard *Script.sml))
+
+all: $(ARTFILES) hol4-finite-maps.art
+
+hol4-finite-maps-unint.art: hol4-finite-maps-unint.thy $(ARTFILES)
+	opentheory info --article -o $@ $<
+
+hol4-finite-maps.art: hol4-finite-maps.thy hol4-finite-maps-unint.art ../opentheory/hol4.int
+	opentheory info --article -o $@ $<
+
+install: hol4-finite-maps.thy hol4-finite-maps.art
+	opentheory install --reinstall $<
+
 endif

--- a/src/finite_maps/hol4-finite-maps-unint.thy
+++ b/src/finite_maps/hol4-finite-maps-unint.thy
@@ -1,0 +1,16 @@
+name: hol-finite-maps-unint
+version: 1.0
+description: HOL finite maps (before re-interpretation)
+author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
+license: MIT
+main {
+  import: finite-map
+  import: alist
+}
+finite-map {
+  article: "finite_map.ot.art"
+}
+alist {
+  import: finite-map
+  article: "alist.ot.art"
+}

--- a/src/finite_maps/hol4-finite-maps.thy
+++ b/src/finite_maps/hol4-finite-maps.thy
@@ -1,26 +1,24 @@
-name: hol-probability
-version: 1.1
-description: HOL probability theory
+name: hol-finite-maps
+version: 1.0
+description: HOL finite maps
 author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
 license: MIT
 requires: base
 requires: hol-base
-requires: hol-set
-requires: hol-real
-requires: hol-extreal
-requires: hol-words
 requires: hol-sort
-requires: hol-analysis
+requires: hol-words
+requires: hol-bag
 show: "HOL4"
 show: "Data.Bool"
+show: "Data.Option"
+show: "Data.Unit"
 show: "Data.Sum"
 show: "Data.Pair"
 show: "Data.List"
 show: "Function"
 show: "Relation"
 show: "Number.Natural"
-show: "Number.Real"
 main {
-  article: "hol4-probability-unint.art"
+  article: "hol4-finite-maps-unint.art"
   interpretation: "../opentheory/hol4.int"
 }

--- a/src/floating-point/Holmakefile
+++ b/src/floating-point/Holmakefile
@@ -29,10 +29,17 @@ fp64Syntax.uo: fp-functor.uo fp64Syntax.sml
 
 ifeq ($(KERNELID),otknl)
 ARTFILES = $(patsubst %Script.sml,%.ot.art,$(wildcard *Script.sml))
-all: $(ARTFILES) hol4-floating-point-unint.art
+
+all: $(ARTFILES) hol4-floating-point.art
 
 hol4-floating-point-unint.art: hol4-floating-point-unint.thy $(ARTFILES)
 	opentheory info --article -o $@ $<
+
+hol4-floating-point.art: hol4-floating-point.thy hol4-floating-point-unint.art ../opentheory/hol4.int
+	opentheory info --article -o $@ $<
+
+install: hol4-floating-point.thy hol4-floating-point.art
+	opentheory install --reinstall $<
 
 binary_ieee.art: binary_ieee.otd
 endif

--- a/src/floating-point/hol4-floating-point.thy
+++ b/src/floating-point/hol4-floating-point.thy
@@ -5,6 +5,7 @@ author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
 license: MIT
 requires: base
 requires: hol-base
+requires: hol-set
 requires: hol-words
 requires: hol-integer
 requires: hol-real

--- a/src/integer/Holmakefile
+++ b/src/integer/Holmakefile
@@ -13,7 +13,7 @@ selftest.exe: selftest.uo intLib.uo
 ifeq ($(KERNELID),otknl)
 ARTFILES = $(patsubst %Script.sml,%.ot.art,$(wildcard *Script.sml))
 
-all: $(ARTFILES) hol4-integer-unint.art hol4-integer.art
+all: $(ARTFILES) hol4-integer.art
 
 DeepSyntax.art: DeepSyntax.otd
 
@@ -22,6 +22,9 @@ hol4-integer-unint.art: hol4-integer-unint.thy $(ARTFILES)
 
 hol4-integer.art: hol4-integer.thy hol4-integer-unint.art ../opentheory/hol4.int
 	opentheory info --article -o $@ $<
+
+install: hol4-integer.thy hol4-integer.art
+	opentheory install --reinstall $<
 endif
 
 ifdef HOLSELFTESTLEVEL

--- a/src/integer/hol4-integer.thy
+++ b/src/integer/hol4-integer.thy
@@ -1,5 +1,5 @@
 name: hol-integer
-version: 1.1
+version: 1.2
 description: HOL integer theories
 author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
 license: MIT
@@ -11,11 +11,11 @@ requires: hol-ring
 requires: hol-quotient
 show: "HOL4"
 show: "Data.Bool"
-show: "Data.List"
 show: "Data.Pair"
+show: "Data.List"
 show: "Function"
-show: "Number.Natural"
 show: "Relation"
+show: "Number.Natural"
 main {
   article: "hol4-integer-unint.art"
   interpretation: "../opentheory/hol4.int"

--- a/src/monad/more_monads/Holmakefile
+++ b/src/monad/more_monads/Holmakefile
@@ -15,10 +15,16 @@ selftest.exe: selftest.uo $(dprot $(SIGOBJ)/term_pp.uo) state_transformerTheory.
 
 ifeq($(KERNELID),otknl)
 ARTFILES = $(patsubst %Script.sml,%.ot.art,$(wildcard *Script.sml))
-all: $(ARTFILES) hol4-monad-unint.art
+all: $(ARTFILES) hol4-monad.art
 
 hol4-monad-unint.art: hol4-monad-unint.thy $(ARTFILES)
 	opentheory info --article -o $@ $<
+
+hol4-monad.art: hol4-monad.thy hol4-monad-unint.art ../../opentheory/hol4.int
+	opentheory info --article -o $@ $<
+
+install: hol4-monad.thy hol4-monad.art
+	opentheory install --reinstall $<
 endif
 
 ifdef HOLSELFTESTLEVEL

--- a/src/monad/more_monads/hol4-monad.thy
+++ b/src/monad/more_monads/hol4-monad.thy
@@ -1,5 +1,5 @@
 name: hol-monad
-version: 1.1
+version: 1.2
 description: HOL monad theories
 author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
 license: MIT

--- a/src/n-bit/Holmakefile
+++ b/src/n-bit/Holmakefile
@@ -10,13 +10,17 @@ EXTRA_CLEANS = selftest.exe n-bit-selftest.log
 
 ifeq ($(KERNELID),otknl)
 ARTFILES = $(patsubst %Script.sml,%.ot.art,$(wildcard *Script.sml))
-all: $(ARTFILES)
+
+all: $(ARTFILES) hol4-words.art
 
 hol4-words-unint.art: hol4-words-unint.thy $(ARTFILES)
 	opentheory info --article -o $@ $<
 
 hol4-words.art: hol4-words.thy hol4-words-unint.art ../opentheory/hol4.int
 	opentheory info --article -o $@ $<
+
+install: hol4-words.thy hol4-words.art
+	opentheory install --reinstall $<
 
 fcp.art: fcp.otd
 

--- a/src/n-bit/hol4-words.thy
+++ b/src/n-bit/hol4-words.thy
@@ -1,5 +1,5 @@
 name: hol-words
-version: 1.2
+version: 1.3
 description: n-bit words
 author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
 license: MIT
@@ -10,7 +10,6 @@ show: "HOL4"
 show: "Data.Bool"
 show: "Data.List"
 show: "Data.Pair"
-show: "Data.Option"
 show: "Function"
 show: "Number.Natural"
 show: "Relation"

--- a/src/opentheory/compat/HOL4boolScript.sml
+++ b/src/opentheory/compat/HOL4boolScript.sml
@@ -1,4 +1,5 @@
 open HolKernel boolLib bossLib OpenTheoryMap OpenTheoryBoolTheory
+open OpenTheoryReader
 
 val Thy = "HOL4bool"
 val _ = new_theory Thy

--- a/src/opentheory/compat/HOL4combinScript.sml
+++ b/src/opentheory/compat/HOL4combinScript.sml
@@ -1,4 +1,5 @@
 open HolKernel boolLib bossLib OpenTheoryMap OpenTheoryFunctionTheory
+open OpenTheoryReader
 
 val Thy = "HOL4combin"
 val _ = new_theory Thy

--- a/src/opentheory/compat/Holmakefile
+++ b/src/opentheory/compat/Holmakefile
@@ -1,13 +1,13 @@
 boolpkg=bool-1.37
 functionpkg=function-1.55
-relationpkg=relation-1.61
-setpkg=set-1.72
+relationpkg=relation-1.63
+setpkg=set-1.85
 
-all: HOL4bool.ot.art\
-	HOL4combin.ot.art\
-	$(HOLDIR)/src/HolSat/sat.ot.art\
-	$(HOLDIR)/src/combin/combin.ot.art\
+all: HOL4bool.ot.art HOL4combin.ot.art \
+	$(HOLDIR)/src/HolSat/sat.ot.art \
+	$(HOLDIR)/src/combin/combin.ot.art \
 	$(HOLDIR)/src/relation/relation.ot.art
+
 .PHONY: all
 
 OpenTheoryBoolScript.sml: $(boolpkg).art

--- a/src/opentheory/compat/OpenTheoryBoolScript.sml
+++ b/src/opentheory/compat/OpenTheoryBoolScript.sml
@@ -1,21 +1,27 @@
-open HolKernel boolSyntax Opentheory
-val Thy = "OpenTheoryBool"
-val pkg = "bool-1.37"
-val _ = new_theory Thy
+open HolKernel boolSyntax OpenTheoryReader;
+
+val Thy = "OpenTheoryBool";
+val pkg = "bool-1.37";
+
+val _ = new_theory Thy;
 val file = pkg^".art"
 
-val ERR=mk_HOL_ERR Thy
+val ERR = mk_HOL_ERR Thy;
 
 val _ = new_constant("dummy",alpha)
 val _ = OpenTheoryMap.OpenTheory_const_name{const={Thy=Thy,Name="dummy"},name=([],pkg)}
+
+fun define_const {Name,Thy} tm =
+    mk_thm([],(mk_eq(mk_thy_const {Name=Name,Thy=Thy,Ty=type_of tm},tm)));
 
 val (reader:reader) = {
   const_name = const_name_in_map,
   tyop_name = tyop_name_in_map,
   define_tyop = define_tyop_in_thy,
-  define_const = fn {Name,Thy} => fn tm => mk_thm([],(mk_eq(mk_thy_const {Name=Name,Thy=Thy,Ty=type_of tm},tm))),
+  define_const = define_const,
   axiom = K mk_thm
 };
+
 val thms = read_article file reader;
 val _ = Net.itnet (fn th => fn n => (save_thm("th"^Int.toString(n),th); n+1)) thms 0;
 

--- a/src/opentheory/compat/OpenTheoryFunctionScript.sml
+++ b/src/opentheory/compat/OpenTheoryFunctionScript.sml
@@ -1,4 +1,6 @@
-open HolKernel boolSyntax Opentheory
+open HolKernel boolSyntax
+open OpenTheoryReader
+
 val Thy = "OpenTheoryFunction"
 val pkg = "function-1.55"
 val _ = new_theory Thy

--- a/src/opentheory/compat/OpenTheoryRelationScript.sml
+++ b/src/opentheory/compat/OpenTheoryRelationScript.sml
@@ -1,4 +1,6 @@
 open HolKernel boolSyntax Opentheory
+open OpenTheoryReader
+
 val Thy = "OpenTheoryRelation"
 val pkg = "relation-1.61"
 val _ = new_theory Thy

--- a/src/pred_set/src/more_theories/Holmakefile
+++ b/src/pred_set/src/more_theories/Holmakefile
@@ -17,7 +17,21 @@ link-to-sigobj: $(DEFAULT_TARGETS)
 endif
 
 ifeq ($(KERNELID),otknl)
-all: topology.ot.art
+BARE_THYS = cardinal ordinal topology wellorder
+
+all: hol4-set.art
+
+hol4-set-unint.art: hol4-set-unint.thy $(patsubst %,%.ot.art,$(BARE_THYS))
+	opentheory info --article -o $@ $<
+
+hol4-set.art: hol4-set.thy hol4-set-unint.art ../../../opentheory/hol4.int
+	opentheory info --article -o $@ $<
+
+install: hol4-set.thy hol4-set.art
+	opentheory install --reinstall $<
+
+ordinal.art: ordinal.otd
+
 endif
 
 ifdef HOLSELFTESTLEVEL

--- a/src/pred_set/src/more_theories/cardinalScript.sml
+++ b/src/pred_set/src/more_theories/cardinalScript.sml
@@ -21,7 +21,7 @@ open HolKernel Parse boolLib bossLib mesonLib
 open boolSimps pred_setTheory set_relationTheory tautLib
 
 open prim_recTheory arithmeticTheory numTheory numLib pairTheory
-open sumTheory ind_typeTheory wellorderTheory;
+open optionTheory sumTheory ind_typeTheory wellorderTheory;
 
 val _ = new_theory "cardinal";
 
@@ -137,14 +137,14 @@ val cardeq_INSERT = store_thm(
                         | SOME n => f (n + 1)` >>
   fs[INJ_DEF] >>
   `!x y. (f x = f y) <=> (x = y)` by metis_tac[] >> rw[] >| [
-    rw[optionTheory.option_case_compute],
-    DEEP_INTRO_TAC optionTheory.some_intro >> rw[] >>
+    rw[option_case_compute],
+    DEEP_INTRO_TAC some_intro >> rw[] >>
     metis_tac [DECIDE ``0 <> x + 1``],
-    DEEP_INTRO_TAC optionTheory.some_intro >> rw[] >>
+    DEEP_INTRO_TAC some_intro >> rw[] >>
     metis_tac [DECIDE ``0 <> x + 1``],
     pop_assum mp_tac >>
-    DEEP_INTRO_TAC optionTheory.some_intro >> simp[] >>
-    DEEP_INTRO_TAC optionTheory.some_intro >> simp[]
+    DEEP_INTRO_TAC some_intro >> simp[] >>
+    DEEP_INTRO_TAC some_intro >> simp[]
   ]);
 
 (* !s. INFINITE s ==> x INSERT s =~ s
@@ -484,7 +484,7 @@ val SET_SQUARED_CARDEQ_SET = store_thm(
                      qmatch_abbrev_tac `FST XX IN ss /\ SND XX IN ss` >>
                      `XX = sf a`
                         by (simp[Abbr`XX`] >>
-                            DEEP_INTRO_TAC optionTheory.some_intro >>
+                            DEEP_INTRO_TAC some_intro >>
                             simp[FORALL_PROD] >> metis_tac[]) >>
                      `BIJ sf ss (ss CROSS ss)` by metis_tac[] >> simp[] >>
                      pop_assum mp_tac >> simp_tac (srw_ss())[better_BIJ] >>
@@ -496,11 +496,11 @@ val SET_SQUARED_CARDEQ_SET = store_thm(
                      qmatch_abbrev_tac `(XX1 = XX2) ==> (a1 = a2)` >>
                      `XX1 = f1 a1`
                         by (simp[Abbr`XX1`] >>
-                            DEEP_INTRO_TAC optionTheory.some_intro >>
+                            DEEP_INTRO_TAC some_intro >>
                             simp[FORALL_PROD] >> metis_tac[]) >>
                      `XX2 = f2 a2`
                         by (simp[Abbr`XX2`] >>
-                            DEEP_INTRO_TAC optionTheory.some_intro >>
+                            DEEP_INTRO_TAC some_intro >>
                             simp[FORALL_PROD] >> metis_tac[]) >>
                      map_every markerLib.RM_ABBREV_TAC ["XX1", "XX2"] >>
                      rw[] >>
@@ -529,7 +529,7 @@ val SET_SQUARED_CARDEQ_SET = store_thm(
                      `?x. x IN s2 /\ (f2 x = (a,b))`
                        by metis_tac [SURJ_DEF, BIJ_DEF] >>
                      map_every qexists_tac [`x`, `s2`, `f2`] >>
-                     simp[] >> DEEP_INTRO_TAC optionTheory.some_intro >>
+                     simp[] >> DEEP_INTRO_TAC some_intro >>
                      simp[FORALL_PROD] >>
                      Tactical.REVERSE conj_tac >- metis_tac[] >>
                      map_every qx_gen_tac [`s3`, `f3`] >> strip_tac >>
@@ -543,7 +543,7 @@ val SET_SQUARED_CARDEQ_SET = store_thm(
                  `?x. x IN s1 /\ (f1 x = (a,b))`
                    by metis_tac[BIJ_DEF, SURJ_DEF] >>
                  map_every qexists_tac [`x`, `s1`, `f1`] >> simp[] >>
-                 DEEP_INTRO_TAC optionTheory.some_intro >>
+                 DEEP_INTRO_TAC some_intro >>
                  simp[FORALL_PROD] >>
                  Tactical.REVERSE conj_tac >- metis_tac[] >>
                  map_every qx_gen_tac [`s3`, `f3`] >> strip_tac >>
@@ -557,7 +557,7 @@ val SET_SQUARED_CARDEQ_SET = store_thm(
              asm_simp_tac (srw_ss() ++ DNF_ss)
                           [Abbr`BigF`, Abbr`BigSet`,
                            DECIDE ``~p\/q = (p ==> q)``, FORALL_PROD]>>
-             strip_tac >> DEEP_INTRO_TAC optionTheory.some_intro >>
+             strip_tac >> DEEP_INTRO_TAC some_intro >>
              simp[FORALL_PROD] >> metis_tac[]) >>
          qexists_tac `(BigSet, BigF)` >> conj_tac
          >- ((* (BigSet, BigF) IN range rr *)
@@ -570,7 +570,7 @@ val SET_SQUARED_CARDEQ_SET = store_thm(
          >- (simp[Abbr`BigSet`] >> match_mp_tac SUBSET_BIGUNION_I >>
              simp[pairTheory.EXISTS_PROD] >> metis_tac[]) >>
          qx_gen_tac `x` >> strip_tac >> simp[Abbr`BigF`] >>
-         DEEP_INTRO_TAC optionTheory.some_intro >>
+         DEEP_INTRO_TAC some_intro >>
          simp[FORALL_PROD] >> metis_tac[]) >>
   PRINT_TAC "proved that upper bound works" >>
   `?Mf. Mf IN maximal_elements A rr` by metis_tac [zorns_lemma] >>
@@ -878,7 +878,7 @@ val set_exp_card_cong = store_thm(
   csimp[] >> csimp[] >>
   `(f b = NONE) \/ ?a. f b = SOME a` by (Cases_on `f b` >> simp[]) >> simp[] >>
   SELECT_ELIM_TAC >> simp[] >>
-  metis_tac [optionTheory.SOME_11]);
+  metis_tac [SOME_11]);
 
 val set_exp_cardle_cong = Q.store_thm(
   "set_exp_cardle_cong",
@@ -900,19 +900,19 @@ val set_exp_cardle_cong = Q.store_thm(
       dsimp[] >>
       Cases_on ‘?ci. ci IN c /\ (cdf ci = di)’ >> fs[]
       >- (‘(some ci. ci IN c /\ (cdf ci = di)) = SOME ci’
-             by (DEEP_INTRO_TAC optionTheory.some_intro >> simp[] >>
+             by (DEEP_INTRO_TAC some_intro >> simp[] >>
                  metis_tac[INJ_DEF]) >>
           simp[] >>
           ‘?ai. ai IN a /\ (caf ci = SOME ai)’ by metis_tac[] >>
           metis_tac[INJ_DEF]) >>
       ‘(some ci. ci IN c /\ (cdf ci = di)) = NONE’
-         by (DEEP_INTRO_TAC optionTheory.some_intro >> simp[]) >>
+         by (DEEP_INTRO_TAC some_intro >> simp[]) >>
       simp[CHOICE_DEF]) >>
   rename [‘caf1 = caf2’] >> simp[FUN_EQ_THM] >>
   qx_gen_tac ‘ci’ >> Cases_on‘ci IN c’ >> simp[] >>
   ‘cdf ci IN d’ by metis_tac[INJ_DEF] >>
   ‘(some ci'. ci' IN c /\ (cdf ci' = cdf ci)) = SOME ci’
-    by (DEEP_INTRO_TAC optionTheory.some_intro >> simp[] >>
+    by (DEEP_INTRO_TAC some_intro >> simp[] >>
         metis_tac[INJ_DEF]) >>
   first_assum (fn th => Q_TAC (mp_tac o AP_THM th) ‘cdf ci’) >> BETA_TAC >>
   simp[] >>
@@ -1007,8 +1007,8 @@ Proof
       >- (simp[EXTENSION] >> simp[FUN_EQ_THM, FORALL_PROD] >>
           simp[Once EQ_IMP_THM] >> rw[] >> rename [‘f1 a = f2 a’] >>
           Cases_on ‘f1 a’ >>
-          metis_tac[optionTheory.SOME_11, optionTheory.NOT_SOME_NONE]) >>
-      metis_tac[optionTheory.SOME_11, optionTheory.NOT_SOME_NONE])
+          metis_tac[SOME_11, NOT_SOME_NONE]) >>
+      metis_tac[SOME_11, NOT_SOME_NONE])
 QED
 
 Theorem CARD_LE_EXP:
@@ -1054,15 +1054,15 @@ val INFINITE_cardleq_INSERT = store_thm(
           Cases_on `some n. f y = g n` >> fs[INJ_DEF]) >>
       map_every qx_gen_tac [`i`, `j`] >> strip_tac >> Cases_on `i = x` >>
       Cases_on `j = x` >> simp[]
-      >- (DEEP_INTRO_TAC optionTheory.some_intro >> simp[] >> fs[INJ_DEF])
-      >- (DEEP_INTRO_TAC optionTheory.some_intro >> simp[] >> fs[INJ_DEF]) >>
-      ntac 2 (DEEP_INTRO_TAC optionTheory.some_intro) >> simp[] >>
+      >- (DEEP_INTRO_TAC some_intro >> simp[] >> fs[INJ_DEF])
+      >- (DEEP_INTRO_TAC some_intro >> simp[] >> fs[INJ_DEF]) >>
+      ntac 2 (DEEP_INTRO_TAC some_intro) >> simp[] >>
       fs[INJ_DEF] >> qx_gen_tac `m` >> strip_tac >>
       qx_gen_tac `n` >> rpt strip_tac >>
       metis_tac [DECIDE ``(n + 1 = m + 1) <=> (m = n)``])
   >- fs[INJ_DEF] >>
   qx_gen_tac `y` >> simp[] >> Cases_on `x = y` >> simp[] >>
-  Cases_on `y IN s` >> simp[] >> DEEP_INTRO_TAC optionTheory.some_intro >>
+  Cases_on `y IN s` >> simp[] >> DEEP_INTRO_TAC some_intro >>
   simp[] >> fs[INJ_DEF] >> metis_tac [DECIDE ``0 <> n + 1``])
 
 val list_def = Define`
@@ -1098,9 +1098,8 @@ val list_BIGUNION_EXP = store_thm(
       >- (qx_gen_tac `l` >> strip_tac >> qexists_tac `LENGTH l` >>
           simp[set_exp_def] >> metis_tac[listTheory.MEM_EL]) >>
       simp[FUN_EQ_THM, listTheory.LIST_EQ_REWRITE] >>
-      metis_tac[optionTheory.NOT_SOME_NONE,
-                DECIDE ``(x = y) <=> ~(x < y) /\ ~(y < x)``,
-                optionTheory.SOME_11]) >>
+      metis_tac[NOT_SOME_NONE, SOME_11,
+                DECIDE ``(x = y) <=> ~(x < y) /\ ~(y < x)``]) >>
   qexists_tac `\f. GENLIST (THE o f) (LEAST n. f n = NONE)` >>
   dsimp[INJ_DEF, set_exp_def] >> conj_tac
   >- (map_every qx_gen_tac [`f`, `n`] >> strip_tac >>
@@ -1109,8 +1108,7 @@ val list_BIGUNION_EXP = store_thm(
         by (numLib.LEAST_ELIM_TAC >> conj_tac
             >- (qexists_tac `n` >> simp[]) >>
             metis_tac[DECIDE ``(x = y) <=> ~(x < y) /\ ~(y < x)``,
-                      optionTheory.NOT_SOME_NONE,
-                      DECIDE ``~(x < x)``]) >>
+                      NOT_SOME_NONE, DECIDE ``~(x < x)``]) >>
       simp[] >> rpt strip_tac >> res_tac >> simp[]) >>
   map_every qx_gen_tac [`f`, `g`, `m`, `n`] >> rpt strip_tac >>
   `((LEAST n. f n = NONE) = m) /\ ((LEAST n. g n = NONE) = n)`
@@ -1121,8 +1119,7 @@ val list_BIGUNION_EXP = store_thm(
           all_tac
         ] >>
         metis_tac[DECIDE ``(x = y) <=> ~(x < y) /\ ~(y < x)``,
-                  optionTheory.NOT_SOME_NONE,
-                  DECIDE ``~(x < x)``]) >>
+                  NOT_SOME_NONE, DECIDE ``~(x < x)``]) >>
   ntac 2 (pop_assum SUBST_ALL_TAC) >>
   `m = n` by metis_tac[listTheory.LENGTH_GENLIST] >>
   pop_assum SUBST_ALL_TAC >> simp[FUN_EQ_THM] >> qx_gen_tac `i` >>
@@ -1143,7 +1140,7 @@ val INFINITE_A_list_BIJ_A = store_thm(
       qexists_tac `\e n. if n = 0 then SOME e else NONE` >>
       dsimp[INJ_DEF, set_exp_def] >> conj_tac
       >- (rpt strip_tac >> qexists_tac `1` >> simp[]) >>
-      simp[FUN_EQ_THM] >> metis_tac[optionTheory.SOME_11]) >>
+      simp[FUN_EQ_THM] >> metis_tac[SOME_11]) >>
   match_mp_tac CARD_BIGUNION >> dsimp[] >> conj_tac
   >- simp[IMAGE_cardleq_rwt, GSYM INFINITE_Unum] >>
   qx_gen_tac `n` >> Cases_on `0 < n` >> fs[]
@@ -1592,12 +1589,12 @@ val cardeq_bijns_cong = Q.store_thm(
   >- metis_tac[]
   >- (simp[EQ_IMP_THM, FUN_EQ_THM] >> rw[] >>
       rename [‘bf1 b = bf2 b’] >> reverse (Cases_on ‘b IN B’)
-      >- metis_tac[optionTheory.option_nchotomy] >>
+      >- metis_tac[option_nchotomy] >>
       ‘b = f (g b)’ by metis_tac[] >> pop_assum SUBST1_TAC >>
       ‘g b IN A’ by metis_tac[] >> first_x_assum (qspec_then ‘g b’ mp_tac) >>
       simp[] >>
       ‘(?b1'. bf1 b = SOME b1') /\ (?b2'. bf2 b = SOME b2')’ by metis_tac[] >>
-      simp[] >> ‘b1' IN B /\ b2' IN B’ by metis_tac[optionTheory.THE_DEF] >>
+      simp[] >> ‘b1' IN B /\ b2' IN B’ by metis_tac[THE_DEF] >>
       metis_tac[])
   >- metis_tac[]
   >- metis_tac[]
@@ -1605,10 +1602,10 @@ val cardeq_bijns_cong = Q.store_thm(
       rename [‘THE (ff _) = _’] >>
       qexists_tac ‘\b. if b IN B then SOME (f (THE (ff (g b)))) else NONE’ >>
       simp[] >> rpt strip_tac
-      >- metis_tac[optionTheory.THE_DEF]
-      >- metis_tac[optionTheory.THE_DEF] >>
+      >- metis_tac[THE_DEF]
+      >- metis_tac[THE_DEF] >>
       simp[FUN_EQ_THM] >>
-      metis_tac[optionTheory.THE_DEF, optionTheory.option_nchotomy]))
+      metis_tac[THE_DEF, option_nchotomy]))
 
 val bijections_cardeq = Q.store_thm(
   "bijections_cardeq",
@@ -1621,7 +1618,7 @@ val bijections_cardeq = Q.store_thm(
       simp[bijns_def, SUBSET_DEF, BIJ_DEF, INJ_IFF, set_exp_def] >>
       qx_gen_tac `f` >> rpt strip_tac
       >- (simp[] >> rename [‘f a = SOME b’] >> ‘a IN s’ by metis_tac[] >>
-          ‘b IN s’ by metis_tac[optionTheory.THE_DEF] >> metis_tac[]) >>
+          ‘b IN s’ by metis_tac[THE_DEF] >> metis_tac[]) >>
       qmatch_abbrev_tac ‘f x = NONE’ >> Cases_on ‘f x’ >> simp[] >> fs[]) >>
   ‘s =~ {T;F} CROSS s’ by simp[SET_SUM_CARDEQ_SET] >>
   ‘bijns s =~ bijns ({T;F} CROSS s)’ by metis_tac[cardeq_bijns_cong] >>
@@ -3334,13 +3331,6 @@ Definition BIGPRODi_def:
   }
 End
 
-Theorem option_imp_elim =
-        TypeBase.case_pred_imp_of “:'a option”
-          |> INST_TYPE [beta |-> bool]
-          |> Q.SPEC ‘I’
-          |> REWRITE_RULE [combinTheory.I_THM]
-
-
 (* A^0 = 1 *)
 Theorem BIGPRODi_KNONE[simp]:
   BIGPRODi (K NONE) = {K NONE}
@@ -3407,7 +3397,7 @@ Proof
   CCONTR_TAC >>
   qpat_x_assum ‘!x. _’ mp_tac >> simp[] >>
   qexists_tac ‘λj. OPTION_MAP CHOICE (Af j)’ >>
-  simp[SF DISJ_ss] >> gs[] >> metis_tac[CHOICE_DEF, optionTheory.SOME_11]
+  simp[SF DISJ_ss] >> gs[] >> metis_tac[CHOICE_DEF, SOME_11]
 QED
 
 Definition BIGPROD_def:
@@ -3482,7 +3472,7 @@ Proof
                    SOME (INR (THE (SND p (IMAGE OUTR s))))
                  else NONE’ >>
   rw[] >> simp[AllCaseEqs(), PULL_EXISTS]
-  >- (metis_tac[optionTheory.THE_DEF, MEMBER_NOT_EMPTY])
+  >- (metis_tac[THE_DEF, MEMBER_NOT_EMPTY])
   >- (rename [‘s = {}’, ‘s <> IMAGE INL A’] >>
       pop_assum mp_tac >> rw[]
       >- (qpat_x_assum ‘s <> IMAGE INL _’ mp_tac >>
@@ -3544,7 +3534,7 @@ Proof
   qexists_tac ‘tup0(| j |-> SOME e |)’ >>
   pop_assum mp_tac >> REWRITE_TAC [BIGPRODi_def] >>
   simp[combinTheory.APPLY_UPDATE_THM] >> rw[AllCaseEqs()] >>
-  metis_tac[optionTheory.SOME_11]
+  metis_tac[SOME_11]
 QED
 
 Theorem cardeq_addUnum:

--- a/src/pred_set/src/more_theories/hol4-set-unint.thy
+++ b/src/pred_set/src/more_theories/hol4-set-unint.thy
@@ -1,0 +1,28 @@
+name: hol-set-unint
+version: 1.0
+description: HOL set theories (before re-interpretation)
+author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
+license: MIT
+main {
+  import: cardinal
+  import: ordinal
+  import: topology
+  import: wellorder
+}
+cardinal {
+  import: wellorder
+  article: "cardinal.ot.art"
+}
+ordinal {
+  import: wellorder
+  import: cardinal
+  import: topology
+  article: "ordinal.ot.art"
+}
+topology {
+  import: cardinal
+  article: "topology.ot.art"
+}
+wellorder {
+  article: "wellorder.ot.art"
+}

--- a/src/pred_set/src/more_theories/hol4-set.thy
+++ b/src/pred_set/src/more_theories/hol4-set.thy
@@ -1,22 +1,22 @@
-name: hol-analysis
-version: 1.1
-description: HOL real analysis
+name: hol-set
+version: 1.0
+description: HOL set (and topology) theories
 author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
 license: MIT
 requires: base
 requires: hol-base
-requires: hol-set
-requires: hol-real
+requires: hol-quotient
 show: "HOL4"
 show: "Data.Bool"
 show: "Data.Option"
+show: "Data.Unit"
+show: "Data.Sum"
 show: "Data.Pair"
 show: "Data.List"
 show: "Function"
 show: "Relation"
 show: "Number.Natural"
-show: "Number.Real"
 main {
-  article: "hol4-analysis-unint.art"
-  interpretation: "../opentheory/hol4.int"
+  article: "hol4-set-unint.art"
+  interpretation: "../../../opentheory/hol4.int"
 }

--- a/src/pred_set/src/more_theories/ordinal.otd
+++ b/src/pred_set/src/more_theories/ordinal.otd
@@ -1,0 +1,3 @@
+skipthm ordDIVMOD
+skipthm ordDIV
+skipthm ordMOD

--- a/src/pred_set/src/more_theories/wellorderScript.sml
+++ b/src/pred_set/src/more_theories/wellorderScript.sml
@@ -2,7 +2,7 @@ open HolKernel Parse boolLib bossLib
 open boolSimps mesonLib numLib InductiveDefinition tautLib
 
 open relationTheory set_relationTheory pred_setTheory pairTheory
-     arithmeticTheory
+     arithmeticTheory optionTheory;
 
 val _ = new_theory "wellorder"
 
@@ -568,13 +568,13 @@ val wleast_IN_wo = store_thm(
   ``(wleast w s = SOME x) ==>
        x IN elsOf w /\ x NOTIN s /\
        !y. y IN elsOf w /\ y NOTIN s /\ x <> y ==> (x,y) WIN w``,
-  simp[wleast_def] >> DEEP_INTRO_TAC optionTheory.some_intro >>
+  simp[wleast_def] >> DEEP_INTRO_TAC some_intro >>
   simp[]);
 
 val wleast_EQ_NONE = store_thm(
   "wleast_EQ_NONE",
   ``(wleast w s = NONE) ==> elsOf w SUBSET s``,
-  simp[wleast_def] >> DEEP_INTRO_TAC optionTheory.some_intro >> rw[] >>
+  simp[wleast_def] >> DEEP_INTRO_TAC some_intro >> rw[] >>
   simp[SUBSET_DEF] >>
   qspec_then `w` ho_match_mp_tac WO_INDUCTION >>
   qx_gen_tac `x` >> rpt strip_tac >>
@@ -612,7 +612,7 @@ val wo2wo_EQ_SOME_downwards = store_thm(
   "wo2wo_EQ_SOME_downwards",
   ``!x y. (wo2wo w1 w2 x = SOME y) ==>
           !x0. (x0,x) WIN w1 ==> ?y0. wo2wo w1 w2 x0 = SOME y0``,
-  metis_tac [wo2wo_EQ_NONE, optionTheory.option_CASES]);
+  metis_tac [wo2wo_EQ_NONE, option_CASES]);
 
 val _ = overload_on (
   "woseg",
@@ -644,8 +644,8 @@ val wleast_SUBSET = store_thm(
   "wleast_SUBSET",
   ``(wleast w s1 = SOME x) /\ (wleast w s2 = SOME y) /\ s1 SUBSET s2 ==>
     (x = y) \/ (x,y) WIN w``,
-  simp[wleast_def] >> DEEP_INTRO_TAC optionTheory.some_intro >> simp[] >>
-  DEEP_INTRO_TAC optionTheory.some_intro >> simp[] >> metis_tac[SUBSET_DEF]);
+  simp[wleast_def] >> DEEP_INTRO_TAC some_intro >> simp[] >>
+  DEEP_INTRO_TAC some_intro >> simp[] >> metis_tac[SUBSET_DEF]);
 
 val wo2wo_mono = store_thm(
   "wo2wo_mono",
@@ -667,7 +667,7 @@ val wo2wo_ONTO = store_thm(
   `y0 NOTIN woseg w1 w2 x`
      by (asm_simp_tac (srw_ss() ++ DNF_ss) [] >> qx_gen_tac `a` >>
          `(wo2wo w1 w2 a = NONE) \/ ?y'. wo2wo w1 w2 a = SOME y'`
-            by metis_tac [optionTheory.option_CASES] >> simp[iseg_def] >>
+            by metis_tac [option_CASES] >> simp[iseg_def] >>
          metis_tac[WIN_elsOf]) >>
   `y0 <> y` by metis_tac [WIN_REFL] >>
   `y0 IN elsOf w2 /\ y IN elsOf w2` by metis_tac [WIN_elsOf] >>
@@ -680,7 +680,7 @@ val wo2wo_EQ_NONE_woseg = store_thm(
   spose_not_then strip_assume_tac >>
   last_x_assum mp_tac >> simp[] >>
   spose_not_then strip_assume_tac >>
-  fs[optionTheory.NOT_IS_SOME_EQ_NONE] >>
+  fs[NOT_IS_SOME_EQ_NONE] >>
   imp_res_tac wleast_EQ_NONE >>
   metis_tac[IMAGE_wo2wo_SUBSET,SUBSET_DEF,EXTENSION]);
 
@@ -704,18 +704,18 @@ val orderlt_trichotomy = store_thm(
     qexists_tac `THE o wo2wo w1 w2` >>
     `elsOf (wobound x0 w1) = { x | (x,x0) WIN w1 }` by rw[elsOf_wobound] >>
     simp[] >> rpt conj_tac >| [
-      metis_tac [wo2wo_IN_w2, optionTheory.THE_DEF],
-      metis_tac [wo2wo_11, optionTheory.THE_DEF, WIN_elsOf],
+      metis_tac [wo2wo_IN_w2, THE_DEF],
+      metis_tac [wo2wo_11, THE_DEF, WIN_elsOf],
       `elsOf w2 = woseg w1 w2 x0`
-        by metis_tac [wo2wo_EQ_NONE_woseg, optionTheory.option_CASES] >>
+        by metis_tac [wo2wo_EQ_NONE_woseg, option_CASES] >>
       asm_simp_tac (srw_ss() ++ DNF_ss) [iseg_def] >>
-      metis_tac [optionTheory.option_CASES],
-      simp[WIN_wobound] >> metis_tac [optionTheory.THE_DEF, wo2wo_mono]
+      metis_tac [option_CASES],
+      simp[WIN_wobound] >> metis_tac [THE_DEF, wo2wo_mono]
     ],
     ALL_TAC
   ] >>
   fs[METIS_PROVE []``(!x. ~P x \/ Q x) = (!x. P x ==> Q x)``,
-     METIS_PROVE [optionTheory.option_CASES, optionTheory.NOT_SOME_NONE]
+     METIS_PROVE [option_CASES, NOT_SOME_NONE]
                   ``(x <> NONE) <=> ?y. x = SOME y``] >>
   Cases_on `elsOf w2 = { y | ?x. x IN elsOf w1 /\ (wo2wo w1 w2 x = SOME y) }`
   >| [
@@ -723,11 +723,11 @@ val orderlt_trichotomy = store_thm(
     rw[orderiso_def] >> qexists_tac `THE o wo2wo w1 w2` >>
     pop_assum (strip_assume_tac o SIMP_RULE (srw_ss()) [EXTENSION]) >>
     simp[] >> rpt conj_tac >| [
-      metis_tac [optionTheory.THE_DEF, optionTheory.option_CASES],
-      metis_tac [wo2wo_11, optionTheory.THE_DEF, optionTheory.option_CASES],
-      metis_tac [optionTheory.THE_DEF],
-      metis_tac [optionTheory.THE_DEF, wo2wo_mono, WIN_elsOf,
-                 optionTheory.option_CASES]
+      metis_tac [THE_DEF, option_CASES],
+      metis_tac [wo2wo_11, THE_DEF, option_CASES],
+      metis_tac [THE_DEF],
+      metis_tac [THE_DEF, wo2wo_mono, WIN_elsOf,
+                 option_CASES]
     ],
     ALL_TAC
   ] >>
@@ -739,7 +739,7 @@ val orderlt_trichotomy = store_thm(
   `y0_opt <> NONE`
      by (qunabbrev_tac `y0_opt` >> strip_tac >>
          imp_res_tac wleast_EQ_NONE >> fs[SUBSET_DEF] >> metis_tac[]) >>
-  `?y0. y0_opt = SOME y0` by metis_tac [optionTheory.option_CASES] >>
+  `?y0. y0_opt = SOME y0` by metis_tac [option_CASES] >>
   qunabbrev_tac `y0_opt` >>
   pop_assum (strip_assume_tac o MATCH_MP wleast_IN_wo) >> fs[] >>
   qsuff_tac `orderlt w1 w2` >- rw[] >> simp[orderlt_def] >>
@@ -749,16 +749,14 @@ val orderlt_trichotomy = store_thm(
     by (rpt strip_tac >>
         `b <> y0` by metis_tac [] >>
         `~((y0,b) WIN w2)`
-           by metis_tac [wo2wo_ONTO, optionTheory.NOT_SOME_NONE] >>
+           by metis_tac [wo2wo_ONTO, NOT_SOME_NONE] >>
         metis_tac [WIN_trichotomy, wo2wo_IN_w2]) >>
   simp[elsOf_wobound] >> rpt conj_tac >| [
-    metis_tac [optionTheory.THE_DEF, optionTheory.option_CASES],
-    metis_tac [optionTheory.THE_DEF, wo2wo_11, optionTheory.option_CASES],
-    metis_tac [WIN_REFL, WIN_TRANS, WIN_elsOf, optionTheory.THE_DEF,
-               optionTheory.option_CASES],
+    metis_tac [THE_DEF, option_CASES],
+    metis_tac [THE_DEF, wo2wo_11, option_CASES],
+    metis_tac [WIN_REFL, WIN_TRANS, WIN_elsOf, THE_DEF, option_CASES],
     simp[WIN_wobound] >>
-    metis_tac [wo2wo_mono, optionTheory.THE_DEF, WIN_elsOf,
-               optionTheory.option_CASES]
+    metis_tac [wo2wo_mono, THE_DEF, WIN_elsOf, option_CASES]
   ]);
 
 val wZERO_def = Define`wZERO = wellorder_ABS {}`

--- a/src/probability/Holmakefile
+++ b/src/probability/Holmakefile
@@ -34,10 +34,11 @@ ifeq ($(KERNELID),otknl)
 
 ARTFILES = $(patsubst %Script.sml,%.ot.art,$(wildcard *Script.sml))
 
-all: hol4-analysis-unint.art hol4-probability-unint.art
-
-# This requires more than 32GB memory! ("-j 1" is recommended)
-heavy: hol4-analysis.art hol4-probability.art
+# This requires 32GB (-j 1) or 64GB (-j 2) memory on OpenTheory built by MLton.
+# Each "opentheory" process consumes about 25GB memory. (Using OpenTheory built
+# by PolyML, the memory consumption may be doubled to 50GB and thus only "-j 1"
+# is possible on a computer with 64GB memory.  -- Chun Tian, Apr 7, 2022
+all: hol4-analysis.art hol4-extreal.art hol4-probability.art
 
 hol4-analysis-unint.art: hol4-analysis-unint.thy $(ARTFILES)
 	opentheory info --article -o $@ $<
@@ -45,11 +46,24 @@ hol4-analysis-unint.art: hol4-analysis-unint.thy $(ARTFILES)
 hol4-analysis.art: hol4-analysis.thy hol4-analysis-unint.art ../opentheory/hol4.int
 	opentheory info --article -o $@ $<
 
+hol4-extreal-unint.art: hol4-extreal-unint.thy $(ARTFILES)
+	opentheory info --article -o $@ $<
+
+hol4-extreal.art: hol4-extreal.thy hol4-extreal-unint.art ../opentheory/hol4.int
+	opentheory info --article -o $@ $<
+
 hol4-probability-unint.art: hol4-probability-unint.thy $(ARTFILES)
 	opentheory info --article -o $@ $<
 
 hol4-probability.art: hol4-probability.thy hol4-probability-unint.art ../opentheory/hol4.int
 	opentheory info --article -o $@ $<
+
+install: hol4-extreal.thy hol4-extreal.art \
+		hol4-analysis.thy hol4-analysis.art \
+		hol4-probability.thy hol4-probability.art 
+	opentheory install --reinstall hol4-analysis.thy
+	opentheory install --reinstall hol4-extreal.thy
+	opentheory install --reinstall hol4-probability.thy
 
 real_topology.art: real_topology.otd
 extreal.art: extreal.otd

--- a/src/probability/hol4-analysis-unint.thy
+++ b/src/probability/hol4-analysis-unint.thy
@@ -1,5 +1,5 @@
 name: hol-analysis-unint
-version: 1.1
+version: 1.0
 description: HOL real analysis (before re-interpretation)
 author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
 license: MIT

--- a/src/probability/hol4-extreal-unint.thy
+++ b/src/probability/hol4-extreal-unint.thy
@@ -1,0 +1,16 @@
+name: hol-extreal-unint
+version: 1.0
+description: HOL4 extended reals (before re-interpretation)
+author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
+license: MIT
+main {
+  import: util-prob
+  import: extreal
+}
+util-prob {
+  article: "util_prob.ot.art"
+}
+extreal {
+  import: util-prob
+  article: "extreal.ot.art"
+}

--- a/src/probability/hol4-extreal.thy
+++ b/src/probability/hol4-extreal.thy
@@ -1,19 +1,14 @@
-name: hol-probability
-version: 1.1
-description: HOL probability theory
+name: hol-extreal
+version: 1.0
+description: HOL4 extended reals
 author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
 license: MIT
 requires: base
 requires: hol-base
 requires: hol-set
 requires: hol-real
-requires: hol-extreal
-requires: hol-words
-requires: hol-sort
-requires: hol-analysis
 show: "HOL4"
 show: "Data.Bool"
-show: "Data.Sum"
 show: "Data.Pair"
 show: "Data.List"
 show: "Function"
@@ -21,6 +16,6 @@ show: "Relation"
 show: "Number.Natural"
 show: "Number.Real"
 main {
-  article: "hol4-probability-unint.art"
+  article: "hol4-extreal-unint.art"
   interpretation: "../opentheory/hol4.int"
 }

--- a/src/probability/hol4-probability-unint.thy
+++ b/src/probability/hol4-probability-unint.thy
@@ -1,61 +1,41 @@
 name: hol-probability-unint
-version: 1.1
+version: 1.0
 description: HOL probability theory (before re-interpretation)
 author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
 license: MIT
 main {
-  import: util-prob
   import: sigma-algebra
   import: real-borel
-  import: extreal
   import: measure
   import: borel
   import: lebesgue
   import: martingale
   import: probability
 }
-util-prob {
-  article: "util_prob.ot.art"
-}
 sigma-algebra {
-  import: util-prob
   article: "sigma_algebra.ot.art"
 }
 real-borel {
-  import: util-prob
   import: sigma-algebra
   article: "real_borel.ot.art"
 }
-extreal {
-  import: util-prob
-  article: "extreal.ot.art"
-}
 measure {
-  import: util-prob
-  import: extreal
   import: sigma-algebra
   article: "measure.ot.art"
 }
 borel {
-  import: util-prob
-  import: extreal
   import: sigma-algebra
   import: real-borel
   import: measure
   article: "borel.ot.art"
 }
 lebesgue {
-  import: util-prob
-  import: extreal
   import: sigma-algebra
-  import: real-borel
   import: measure
   import: borel
   article: "lebesgue.ot.art"
 }
 martingale {
-  import: util-prob
-  import: extreal
   import: sigma-algebra
   import: real-borel
   import: measure
@@ -64,10 +44,7 @@ martingale {
   article: "martingale.ot.art"
 }
 probability {
-  import: util-prob
-  import: extreal
   import: sigma-algebra
-  import: real-borel
   import: measure
   import: borel
   import: lebesgue

--- a/src/quotient/src/Holmakefile
+++ b/src/quotient/src/Holmakefile
@@ -8,10 +8,18 @@ selftest.exe: selftest.uo quotient.uo
 
 ifeq ($(KERNELID),otknl)
 ARTFILES = $(patsubst %Script.sml,%.ot.art,$(wildcard *Script.sml))
-all: $(ARTFILES) hol4-quotient-unint.art
+
+all: $(ARTFILES) hol4-quotient.art
 
 hol4-quotient-unint.art: hol4-quotient-unint.thy $(ARTFILES)
 	opentheory info --article -o $@ $<
+
+hol4-quotient.art: hol4-quotient.thy hol4-quotient-unint.art ../../opentheory/hol4.int
+	opentheory info --article -o $@ $<
+
+install: hol4-quotient.thy hol4-quotient.art
+	opentheory install --reinstall $<
+
 endif
 
 EXTRA_CLEANS = selftest.exe quotient-selftest.log

--- a/src/quotient/src/hol4-quotient.thy
+++ b/src/quotient/src/hol4-quotient.thy
@@ -1,5 +1,5 @@
 name: hol-quotient
-version: 1.1
+version: 1.2
 description: HOL quotient theories
 author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
 license: MIT
@@ -13,7 +13,6 @@ show: "Data.Pair"
 show: "Data.Option"
 show: "Function"
 show: "Number.Natural"
-show: "Relation"
 main {
   article: "hol4-quotient-unint.art"
   interpretation: "../../opentheory/hol4.int"

--- a/src/real/Holmakefile
+++ b/src/real/Holmakefile
@@ -26,7 +26,7 @@ hol4-real-unint.art: hol4-real-unint.thy $(patsubst %,%.ot.art,$(BARE_THYS))
 hol4-real-unsat.art: hol4-real-unsat.thy hol4-real-unint.art ../opentheory/hol4.int
 	opentheory info --article -o $@ $<
 
-hol4-real-assums.art: hol4-real-unsat.thy hol4-real-unint.art ../opentheory/hol4.int
+hol4-real-assums.art: hol4-real-assums.thy hol4-real-unsat.art
 	opentheory info --skip-definitions --assumptions -o $@ $<
 	touch hol4-real-assums.ui
 	touch hol4-real-assums.uo
@@ -35,8 +35,13 @@ real.art: real.otd
 
 prove_real_assums.art: hol4-real-assums.art
 
-all: hol4-real-unint.art hol4-real-unsat.art
+hol4-real.art: hol4-real.thy hol4-real-unsat.art prove_real_assums.ot.art ../opentheory/hol4.int
+	opentheory info --article -o $@ $<
 
+install: hol4-real.thy hol4-real.art
+	opentheory install --reinstall $<
+
+all: hol4-real.art
 endif
 
 EXTRA_CLEANS = selftest.exe real-selftest.log

--- a/src/real/hol4-real-assums.thy
+++ b/src/real/hol4-real-assums.thy
@@ -3,39 +3,52 @@ version: 1.0
 description: Assumptions of the HOL real theories
 author: HOL4 people
 license: BSD
+main {
+  import: base
+  import: hol-base
+  import: hol-set
+  import: hol-integer
+  article: "hol4-real-unsat.art"
+}
 base {
-  package: base-1.200
+  package: base-1.221
 }
 hol-base {
   import: base
-  package: hol-base-1.0
+  article: "../boss/hol4-base.art"
+}
+hol-set {
+  import: base
+  import: hol-base
+  import: hol-quotient
+  article: "../pred_set/src/more_theories/hol4-set.art"
 }
 hol-string {
   import: base
   import: hol-base
-  package: hol-string-1.0
+  article: "../string/hol4-string.art"
 }
 hol-words {
   import: base
   import: hol-base
   import: hol-string
-  package: hol-words-1.0
+  article: "../n-bit/hol4-words.art"
 }
 hol-ring {
   import: base
   import: hol-base
-  package: hol-ring-1.0
+  article: "../ring/src/hol4-ring.art"
 }
 hol-res-quan {
   import: base
   import: hol-base
-  package: hol-res-quan-1.0
+  article: "../res_quan/src/hol4-res-quan.art"
 }
 hol-quotient {
   import: base
   import: hol-base
   import: hol-res-quan
-  package: hol-quotient-1.0
+  article: "../quotient/src/hol4-quotient.art"
 }
 hol-integer {
   import: base
@@ -44,11 +57,5 @@ hol-integer {
   import: hol-string
   import: hol-ring
   import: hol-quotient
-  package: hol-integer-1.0
-}
-main {
-  import: base
-  import: hol-base
-  import: hol-integer
-  article: "hol4-real-unsat.art"
+  article: "../integer/hol4-integer.art"
 }

--- a/src/real/hol4-real-unint.thy
+++ b/src/real/hol4-real-unint.thy
@@ -1,5 +1,5 @@
 name: hol-real-unint
-version: 1.1
+version: 1.0
 description: HOL real theories (before re-interpretation)
 author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
 license: MIT
@@ -26,8 +26,6 @@ intreal {
 }
 transc {
   import: real
-  import: metric
-  import: nets
   import: seq
   import: lim
   import: powser
@@ -68,12 +66,8 @@ seq {
   import: nets
   article: "seq.ot.art"
 }
-topology {
-  article: "../topology/topology.ot.art"
-}
 metric {
   import: real
-  import: topology
   article: "metric.ot.art"
 }
 lim {

--- a/src/real/hol4-real-unsat.thy
+++ b/src/real/hol4-real-unsat.thy
@@ -5,6 +5,7 @@ author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
 license: MIT
 requires: base
 requires: hol-base
+requires: hol-set
 requires: hol-integer
 show: "HOL4"
 show: "Data.Bool"

--- a/src/real/hol4-real.thy
+++ b/src/real/hol4-real.thy
@@ -1,10 +1,11 @@
 name: hol-real
-version: 1.1
+version: 1.2
 description: HOL real theories
 author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
 license: MIT
 requires: base
 requires: hol-base
+requires: hol-set
 requires: hol-integer
 show: "HOL4"
 show: "Data.Bool"

--- a/src/real/prove_real_assumsScript.sml
+++ b/src/real/prove_real_assumsScript.sml
@@ -71,7 +71,7 @@ local
       val P = rator(concl ax)
     in
       {abs_rep = mk_thm([],``(\a. ^abs (^rep a)) = (\a. a)``),
-       rep_abs = mk_thm([],``(\r. ^rep (^abs r) = r) <=> (\r. P r)``)}
+       rep_abs = mk_thm([],``(\r. ^rep (^abs r) = r) = (\r. P r)``)}
     end
 in
   val (reader:reader) = {
@@ -140,7 +140,9 @@ val REAL_MUL_LINV = mk_thm([],
 val real_div0 = mk_thm([],
   ``!x y. ~(y = 0) ==> (prove_real_assums$/ x y = x * prove_real_assums$inv y)``);
 
-val th1 = store_thm("th1",el 1 goals,
+(* |- !x y z. x < y /\ y < z ==> x < z *)
+val th1 = store_thm
+  ("th1", el 1 goals,
   rpt gen_tac
   \\ PURE_REWRITE_TAC[real_lt]
   \\ reverse(qspecl_then[`x`,`y`]strip_assume_tac REAL_LE_TOTAL)
@@ -150,7 +152,9 @@ val th1 = store_thm("th1",el 1 goals,
   \\ rpt strip_tac
   \\ imp_res_tac REAL_LE_TRANS);
 
-val th2 = store_thm("th2",el 2 goals,
+(* |- !x y z. y < z ==> x + y < x + z *)
+val th2 = store_thm
+  ("th2", el 2 goals,
   rpt gen_tac
   \\ PURE_REWRITE_TAC[real_lt]
   \\ reverse(qspecl_then[`y`,`z`]strip_assume_tac REAL_LE_TOTAL)
@@ -163,7 +167,7 @@ val th2 = store_thm("th2",el 2 goals,
   \\ metis_tac[REAL_LE_ANTISYM]);
 
 val REAL_ADD_LID_UNIQ = prove(
-  ``! x y. (x + y = y) = (x = 0)``,
+  ``!x y. (x + y = y) = (x = 0)``,
   metis_tac[REAL_ADD_LID,REAL_ADD_SYM,REAL_ADD_LINV,REAL_ADD_ASSOC]);
 
 val REAL_MUL_LZERO = prove(
@@ -174,7 +178,9 @@ val REAL_ENTIRE = prove(
   ``!x y. (x * y = 0) = (x = 0) \/ (y = 0)``,
   metis_tac[REAL_MUL_LINV,REAL_MUL_LID,REAL_MUL_ASSOC,REAL_MUL_LZERO,REAL_MUL_SYM]);
 
-val th3 = store_thm("th3",el 3 goals,
+(* |- !x y. real_0 < x /\ real_0 < y ==> real_0 < x * y *)
+val th3 = store_thm
+  ("th3", el 3 goals,
   rpt gen_tac
   \\ PURE_REWRITE_TAC[real_lt,REAL_0]
   \\ qspecl_then[`x`,`0`]strip_assume_tac REAL_LE_TOTAL >- asm_simp_tac bool_ss []
@@ -184,7 +190,9 @@ val th3 = store_thm("th3",el 3 goals,
   \\ `x * y = 0` by metis_tac[REAL_LE_ANTISYM]
   \\ metis_tac[REAL_ENTIRE,REAL_LE_REFL]);
 
-val th4 = store_thm("th4",el 4 goals,
+(* |- !x y. x = y \/ x < y \/ y < x *)
+val th4 = store_thm
+  ("th4", el 4 goals,
   metis_tac[real_lt,REAL_LE_TOTAL,REAL_LE_ANTISYM])
 
 val otax = mk_thm([],
@@ -192,10 +200,14 @@ val otax = mk_thm([],
         ?s. (!x. p x ==> x <= s) /\ !m. (!x. p x ==> x <= m) ==> s <= m``);
 
 val REAL_LE_LT = prove(
-  ``!x y. x <= y = x < y \/ (x = y)``,
+  ``!x y. x <= y <=> x < y \/ (x = y)``,
   metis_tac[real_lt,REAL_LE_TOTAL,REAL_LE_ANTISYM]);
 
-val th5 = store_thm("th5",el 5 goals,
+(* |- !P. (!x. P x ==> real_0 < x) /\ (?x. P x) /\ (?z. !x. P x ==> x < z) ==>
+          ?s. !y. (?x. P x /\ y < x) <=> y < s
+ *)
+val th5 = store_thm
+  ("th5", el 5 goals,
   rpt strip_tac
   \\ qspec_then`P`mp_tac otax
   \\ impl_tac >- metis_tac[REAL_LE_LT]
@@ -206,61 +218,95 @@ val th5 = store_thm("th5",el 5 goals,
   >- metis_tac[th1,REAL_LE_LT]
   \\ metis_tac[REAL_LE_TOTAL,REAL_LE_LT,real_lt]);
 
-val th6 = store_thm("th6",el 6 goals,
+(* |- !x. x <> real_0 ==> inv0 x * x = real_1 *)
+val th6 = store_thm
+  ("th6", el 6 goals,
   metis_tac[REAL_MUL_LINV,REAL_0,REAL_1,inv0_def]);
 
-val th7 = store_thm("th7",el 7 goals,
+(* |- !x. -x + x = real_0 *)
+val th7 = store_thm
+  ("th7", el 7 goals,
   metis_tac[realTheory.REAL_ADD_LINV,REAL_0]);
 
-val th8 = store_thm("th8",el 8 goals,
+(* |- !x. real_0 + x = x *)
+val th8 = store_thm
+  ("th8", el 8 goals,
   metis_tac[realTheory.REAL_ADD_LID,REAL_0]);
 
-val th9 = store_thm("th9",el 9 goals,
+(* |- !x. real_1 * x = x *)
+val th9 = store_thm
+  ("th9", el 9 goals,
   metis_tac[realTheory.REAL_MUL_LID,REAL_1]);
 
-val th10 = store_thm("th10",el 10 goals,
+(* |- !x. ~(x < x) *)
+val th10 = store_thm
+  ("th10", el 10 goals,
   simp_tac bool_ss [real_lt,REAL_LE_REFL]);
 
 val (pow0,powsuc) = CONJ_PAIR realTheory.pow;
 val () = Thm.delete_proof pow0
 val () = Thm.delete_proof powsuc
 
-val th11 = store_thm("th11",el 11 goals,
+(* |- (!x. x pow 0 = 1) /\ !x n. x pow SUC n = x * x pow n *)
+val th11 = store_thm
+  ("th11", el 11 goals,
   MATCH_ACCEPT_TAC(CONJ pow0 powsuc));
 
-val th12 = store_thm("th12",el 12 goals,
+(* |- 0 = real_0 /\ !n. &SUC n = &n + real_1 *)
+val th12 = store_thm
+  ("th12", el 12 goals,
   REWRITE_TAC[REAL_0,REAL_1,REAL_OF_NUM_ADD,arithmeticTheory.ADD1]);
 
-val th13 = store_thm("th13",el 13 goals,
+(* |- abs = (\x. if 0 <= x then x else -x) *)
+val th13 = store_thm
+  ("th13", el 13 goals,
   SIMP_TAC bool_ss [FUN_EQ_THM,abs]);
 
-val th14 = store_thm("th14",el 14 goals,
+(* |- abs = (\x. if 0 <= x then x else -x) *)
+val th14 = store_thm
+  ("th14", el 14 goals,
   SIMP_TAC bool_ss [FUN_EQ_THM,min_def]);
 
-val th15 = store_thm("th15",el 15 goals,
+(* |- min = (\x y. if x <= y then x else y) *)
+val th15 = store_thm
+  ("th15", el 15 goals,
   SIMP_TAC bool_ss [FUN_EQ_THM,max_def]);
 
-val th16 = store_thm("th16",el 16 goals,
+(* |- max = (\x y. if x <= y then y else x) *)
+val th16 = store_thm
+  ("th16", el 16 goals,
   SIMP_TAC bool_ss [FUN_EQ_THM,real_sub]);
 
-val th17 = store_thm("th17",el 17 goals,
+(* |- $- = (\x y. x + -y) *)
+val th17 = store_thm
+  ("th17", el 17 goals,
   SIMP_TAC bool_ss [FUN_EQ_THM,real_div_def,inv0_def]
   \\ metis_tac[real_div0,REAL_MUL_LZERO,REAL_MUL_SYM]);
 
-val th18 = store_thm("th18",el 18 goals,
+(* |- real_div = (\x y. x * inv0 y) *)
+val th18 = store_thm
+  ("th18", el 18 goals,
   SIMP_TAC bool_ss [FUN_EQ_THM]
   \\ metis_tac[real_lt]);
 
-val th19 = store_thm("th19",el 19 goals,
+(* |- $>= = (\x y. y <= x) *)
+val th19 = store_thm
+  ("th19", el 19 goals,
   SIMP_TAC bool_ss [FUN_EQ_THM,real_ge]);
 
-val th20 = store_thm("th20",el 20 goals,
+(* |- $> = (\x y. y < x) *)
+val th20 = store_thm
+  ("th20", el 20 goals,
   SIMP_TAC bool_ss [FUN_EQ_THM,real_gt]);
 
-val th21 = store_thm("th21",el 21 goals,
+(* |- inv0 real_0 = real_0 *)
+val th21 = store_thm
+  ("th21", el 21 goals,
   metis_tac[inv0_def,REAL_0]);
 
-val th22 = store_thm("th22",el 22 goals,
+(* |- real_1 <> real_0 *)
+val th22 = store_thm
+  ("th22", el 22 goals,
   PURE_REWRITE_TAC[REAL_0,REAL_1,REAL_OF_NUM_EQ,
     arithmeticTheory.ONE,prim_recTheory.SUC_ID]
   \\ strip_tac);

--- a/src/res_quan/src/Holmakefile
+++ b/src/res_quan/src/Holmakefile
@@ -2,10 +2,18 @@ ifdef POLY
 HOLHEAP = ../../num/termination/numheap
 endif
 
+all: $(DEFAULT_TARGETS)
+
 ifeq ($(KERNELID),otknl)
 ARTFILES = $(patsubst %Script.sml,%.ot.art,$(wildcard *Script.sml))
-all: $(ARTFILES) $(DEFAULT_TARGETS)
 
+all: $(ARTFILES) hol4-res-quan.art
+
+hol4-res-quan.art: hol4-res-quan.thy $(ARTFILES) ../../opentheory/hol4.int
+	opentheory info --article -o $@ $<
+
+install: hol4-res-quan.thy hol4-res-quan.art
+	opentheory install --reinstall $<
 endif
 
 ifdef HOLBUILD

--- a/src/res_quan/src/hol4-res-quan.thy
+++ b/src/res_quan/src/hol4-res-quan.thy
@@ -1,5 +1,5 @@
 name: hol-res-quan
-version: 1.1
+version: 1.2
 description: HOL theory about restricted quantifiers
 author: HOL OpenTheory Packager <opentheory-packager@hol-theorem-prover.org>
 license: MIT

--- a/src/ring/src/Holmakefile
+++ b/src/ring/src/Holmakefile
@@ -17,6 +17,9 @@ hol4-ring-unint.art: hol4-ring-unint.thy $(ARTFILES)
 
 hol4-ring.art: hol4-ring.thy hol4-ring-unint.art ../../opentheory/hol4.int
 	opentheory info --article -o $@ $<
+
+install: hol4-ring.thy hol4-ring.art
+	opentheory install --reinstall $<
 endif
 
 selftest.exe: selftest.uo numRingLib.uo

--- a/src/sort/Holmakefile
+++ b/src/sort/Holmakefile
@@ -22,6 +22,9 @@ hol4-sort-unint.art: hol4-sort-unint.thy $(ARTFILES)
 
 hol4-sort.art: hol4-sort.thy hol4-sort-unint.art ../opentheory/hol4.int
 	opentheory info --article -o $@ $<
+
+install: hol4-sort.thy hol4-sort.art
+	opentheory install --reinstall $<
 endif
 
 selftest.exe: selftest.uo

--- a/src/string/Holmakefile
+++ b/src/string/Holmakefile
@@ -15,13 +15,18 @@ selftest.exe: selftest.uo stringSyntax.uo stringLib.uo stringTheory.uo $(dprot $
 	$(HOLMOSMLC) -o $@ $<
 
 ifeq ($(KERNELID),otknl)
-all: string.ot.art string_num.ot.art ASCIInumbers.ot.art hol4-string.art
+ARTFILES = $(patsubst %Script.sml,%.ot.art,$(wildcard *Script.sml))
 
-hol4-string-unint.art: hol4-string-unint.thy string.ot.art string_num.ot.art ASCIInumbers.ot.art
+all: $(ARTFILES) hol4-string.art
+
+hol4-string-unint.art: hol4-string-unint.thy $(ARTFILES)
 	opentheory info --article -o $@ $<
 
 hol4-string.art: hol4-string.thy hol4-string-unint.art ../opentheory/hol4.int
 	opentheory info --article -o $@ $<
+
+install: hol4-string.thy hol4-string.art
+	opentheory install --reinstall $<
 
 string.art: string.otd
 


### PR DESCRIPTION
Hi,

HOL's OpenTheory support, at least the "export" part, represents a *hope* that the hard work (i.e. formal proofs) by HOL4 users can be exported into an intermediate format (OT articles) which can be either verified by third-party tools or translated into theorems of other theorem provers (not limited to HOL famility, in theory). The OT builds (`--otknl`) have been broken for quite some months, although previous fixes (#702, #803, #942, #958) were never complete.

The present PR throughly fixed all the remaining (well, not true: there are still some remaining issues mentioned in the comments) and accumulated issues (due to core theory changes) of HOL4's OpenTheory exporting support (NOTE: exporting only,  there are still issues with the OT importing support.)

As a result, in "examples/probability" I created a sample OT theory file to export everything from OpenTheory's own `base-1.221` (Boolean logic and other basic things) and `real-1.67` (construction of real numbers, originally from HOLLight, I think), almost all HOL4's core math theories, until my proofs of Law of Large Numbers of I.I.D. random variables in Probability Theory (#910, #938, #956). The resulting OT article has 856MB, can be downloaded [here](https://www.dropbox.com/s/uv0fxtdw5oyprvx/hol4-large-numbers.7z?dl=0).

To build HOL4 with `--otknl`, it will take about 6 hours on a very good (laptop) computers with 64GB memory, and at most `-j 2` should be used when calling `bin/build`.   (A simple math: each building process takes about 25GB peak memory, and `-j 3` will take 75GB and blow up your computer's memories and swap spaces.)  For a computer with 32GB memory, the total time should be doubled to 12 hours (with `-j 1` build option).

Another 6-7 hours are needed for generating the the sample OT article in "examples/probability" mentioned above. And this also requires manually installation of all the related OT packages by executing `Holmake -j1 install` in their directory, e.g. for `hol4-base.thy`, `hol4-real.thy`, etc.  The core building process has been modified by NOT installing any OT packages during the build, which saves a lot of time and prevent subtle dependency issues.

OpenTheory should be rebuilt by Mlton by adding `MLTON_OPTS += -default-type intinf` into its `Makefile`. But this is only for building the huge (sample) OT articles in `examples/probability`, not required for core theory builds.   Also note that OpenTheory built by PolyML usually has double memory consumptions, thus if you insist on using it, only `-j 1` is feasible even on computers with 64GB memory!

The code changes are many, across 63 files, and this is a very precise work. It's precise because the leaking of assumptions (which then become an unexpected axiom in the exported OT articles) can easily happen if there's any mistake made in the code. In fact, there were many such issues, and identifying them is not always easy. Below I will describe the code changes in details, classifying them in groups, each in form of a comment of this PR.

P. S. Ramana Kumar @xrchz has provided some helps in understanding some SML code. I believe some remaining issues here can only be fixed by him as the original author of many related code.

Chun Tian