### PR TITLE
Teach Holmake and Parse.sml about the tmux terminal

### DIFF
--- a/src/parse/Parse.sml
+++ b/src/parse/Parse.sml
@@ -79,7 +79,8 @@ fun interactive_ppbackend () = let
 in
   (* assumes interactive *)
   case getEnv "TERM" of
-    SOME s => if String.isPrefix "xterm" s then vt100_terminal
+    SOME s => if String.isPrefix "xterm" s orelse
+                 String.isPrefix "tmux" s then vt100_terminal
               else raw_terminal
   | _ => raw_terminal
 end

--- a/src/parse/testutils.sml
+++ b/src/parse/testutils.sml
@@ -92,7 +92,8 @@ fun checkterm pfx s =
   case OS.Process.getEnv "TERM" of
       NONE => s
     | SOME term =>
-      if String.isPrefix "xterm" term then
+      if String.isPrefix "xterm" term orelse
+         String.isPrefix "tmux" term then
         pfx ^ s ^ "\027[0m"
       else
         s

--- a/tools/Holmake/poly-terminal-prims.ML
+++ b/tools/Holmake/poly-terminal-prims.ML
@@ -20,6 +20,7 @@ fun TERM_isANSI () =
       | SOME t =>
           String.isPrefix "xterm" t orelse
           String.isPrefix "screen" t orelse
+          String.isPrefix "tmux" t orelse
           t = "eterm-color"
 
 end

--- a/tools/Holmake/terminal_primitives.sml
+++ b/tools/Holmake/terminal_primitives.sml
@@ -11,6 +11,7 @@ fun TERM_isANSI () =
       | SOME t =>
           String.isPrefix "xterm" t orelse
           String.isPrefix "screen" t orelse
+          String.isPrefix "tmux" t orelse
           t = "eterm-color"
 
 end


### PR DESCRIPTION
This makes Holmake and Parse.sml look for TERM-variable contents that start with "tmux" and use terminal colors if so.