### PR TITLE
Various updates to probablity scripts

### DIFF
--- a/Manual/Description/math.stex
+++ b/Manual/Description/math.stex
@@ -852,7 +852,7 @@ More precisely, we are interested in the sets:
 Or formally:
 \begin{hol}
 \begin{alltt}
-##thm function_space_alt_finite
+##thm lp_space_alt_finite
 \end{alltt}
 \end{hol}
 
@@ -871,7 +871,7 @@ Clearly, $u\in\mathcal{L}^p(\mu)$ if, and only if, $u\in\mathcal{M}(\mathscr{A})
 Furthermore, $\|u\|_p$ implies that $u(x) = 0$ for almost every $x$.
 \begin{hol}
 \begin{alltt}
-##thm function_space_alt_seminorm
+##thm lp_space_alt_seminorm
 
 ##thm seminorm_eq_0
 \end{alltt}

--- a/examples/probability/lebesgue_measureScript.sml
+++ b/examples/probability/lebesgue_measureScript.sml
@@ -64,7 +64,7 @@ QED
 val integral_indicator_UNIV = store_thm ("integral_indicator_UNIV",
   ``!s A. integral UNIV (indicator (s INTER A)) =
           integral A (indicator s)``,
-  REWRITE_TAC [integral] THEN REPEAT STRIP_TAC THEN AP_TERM_TAC THEN
+  REWRITE_TAC [integral_def] THEN REPEAT STRIP_TAC THEN AP_TERM_TAC THEN
   ABS_TAC THEN METIS_TAC [has_integral_indicator_UNIV]);
 
 val integrable_indicator_UNIV = store_thm ("integrable_indicator_UNIV",
@@ -463,7 +463,7 @@ Theorem lebesgue_of_negligible : (* was: lmeasure_eq_0 *)
 Proof
     RW_TAC std_ss [measure_lebesgue]
  >> Know `!n. integral (line n) (indicator s) = 0`
- >- (FULL_SIMP_TAC std_ss [integral, negligible, line, GSYM interval] \\
+ >- (FULL_SIMP_TAC std_ss [integral_def, negligible, line, GSYM interval] \\
      GEN_TAC >> MATCH_MP_TAC SELECT_UNIQUE \\
      GEN_TAC \\
      reverse EQ_TAC >- METIS_TAC [] \\

--- a/src/probability/Holmakefile
+++ b/src/probability/Holmakefile
@@ -1,4 +1,4 @@
-INCLUDES = ../real ../real/analysis ../sort ../res_quan/src ../n-bit \
+INCLUDES = ../real ../real/analysis ../res_quan/src ../n-bit \
            ../pred_set/src/more_theories ../quotient/src
 
 EXTRA_CLEANS = selftest.exe prob-selftest.log
@@ -9,11 +9,10 @@ EXTRA_CLEANS += $(HOLHEAP)
 
 REAL_OBJNAMES = realTheory realLib real_sigmaTheory RealArith iterateTheory
 
-OTHER_OBJNAMES = ../sort/sortingTheory ../res_quan/src/res_quanTools \
-	../res_quan/src/hurdUtils ../res_quan/src/jrhUtils \
-	../real/analysis/transcTheory
+OTHER_OBJNAMES = ../res_quan/src/res_quanTools ../res_quan/src/hurdUtils \
+	../res_quan/src/jrhUtils ../real/analysis/transcTheory
 
-SIGOBJ_OBJNAMES = pred_setLib numpairTheory logrootTheory
+SIGOBJ_OBJNAMES = pred_setLib logrootTheory
 
 OBJS = $(patsubst %,../real/%.uo,$(REAL_OBJNAMES)) \
        $(patsubst %,%.uo,$(OTHER_OBJNAMES)) \

--- a/src/probability/extrealScript.sml
+++ b/src/probability/extrealScript.sml
@@ -13,7 +13,7 @@ open metisLib combinTheory pred_setTheory res_quanTools pairTheory jrhUtils
      prim_recTheory arithmeticTheory tautLib pred_setLib hurdUtils;
 
 open realTheory realLib real_sigmaTheory RealArith seqTheory limTheory
-     transcTheory iterateTheory metricTheory;
+     transcTheory iterateTheory metricTheory listTheory rich_listTheory;
 
 open util_probTheory cardinalTheory;
 
@@ -9512,7 +9512,7 @@ QED
 (* ------------------------------------------------------------------------- *)
 
 Definition extreal_dist_def :
-    extreal_dist (Normal x) (Normal y) = dist (reduced_metric mr1) (x,y) /\
+    extreal_dist (Normal x) (Normal y) = dist (bounded_metric mr1) (x,y) /\
     extreal_dist  PosInf     PosInf    = 0 /\
     extreal_dist  NegInf     NegInf    = 0 /\
     extreal_dist  _          _         = 1
@@ -9524,23 +9524,23 @@ Theorem extreal_dist_ismet :
 Proof
     rw [ismet]
  >- (Cases_on ‘x’ >> Cases_on ‘y’ \\
-     rw [extreal_dist_def, reduced_metric_thm, MR1_DEF] \\
+     rw [extreal_dist_def, bounded_metric_thm, MR1_DEF] \\
      EQ_TAC >> rw [] \\
      fs [REAL_DIV_ZERO] \\
      rename1 ‘1 + abs (a - b)’ \\
      Suff ‘0 < 1 + abs (a - b)’ >- METIS_TAC [REAL_LT_IMP_NE] \\
      MATCH_MP_TAC REAL_LTE_TRANS \\
      Q.EXISTS_TAC ‘1’ >> rw [])
- >> Know ‘!a (b :real). dist (reduced_metric mr1) (a,b) <= 2’
+ >> Know ‘!a (b :real). dist (bounded_metric mr1) (a,b) <= 2’
  >- (rpt GEN_TAC \\
      MATCH_MP_TAC REAL_LE_TRANS >> Q.EXISTS_TAC ‘1’ >> rw [] \\
-     MATCH_MP_TAC REAL_LT_IMP_LE >> rw [reduced_metric_lt_1])
+     MATCH_MP_TAC REAL_LT_IMP_LE >> rw [bounded_metric_lt_1])
  >> DISCH_TAC
  >> Cases_on ‘x’ >> Cases_on ‘y’ >> Cases_on ‘z’
  >> rw [extreal_dist_def, METRIC_POS]
- >> rename1 ‘dist (reduced_metric mr1) (x,z) <=
-             dist (reduced_metric mr1) (y,x) + dist (reduced_metric mr1) (y,z)’
- >> ‘dist (reduced_metric mr1) (y,x) = dist (reduced_metric mr1) (x,y)’
+ >> rename1 ‘dist (bounded_metric mr1) (x,z) <=
+             dist (bounded_metric mr1) (y,x) + dist (bounded_metric mr1) (y,z)’
+ >> ‘dist (bounded_metric mr1) (y,x) = dist (bounded_metric mr1) (x,y)’
       by PROVE_TAC [METRIC_SYM]
  >> rw [METRIC_TRIANGLE]
 QED
@@ -9568,7 +9568,7 @@ Proof
  >> Cases_on ‘x’ >> Cases_on ‘y’
  >> rw [extreal_mr1_thm, extreal_dist_def]
  >> MATCH_MP_TAC REAL_LT_IMP_LE
- >> rw [reduced_metric_lt_1]
+ >> rw [bounded_metric_lt_1]
 QED
 
 (************************************************************************)
@@ -9663,15 +9663,16 @@ QED
 (*** EXTREAL_SUM_IMAGE Theorems ***)
 
 Theorem EXTREAL_SUM_IMAGE_ALT_FOLDR:
-    !f s. FINITE s ==> EXTREAL_SUM_IMAGE f s = FOLDR (λe acc. f e + acc) 0x (REVERSE (SET_TO_LIST s))
+    !f s. FINITE s ==>
+          EXTREAL_SUM_IMAGE f s = FOLDR (λe acc. f e + acc) 0x (REVERSE (SET_TO_LIST s))
 Proof
-    simp[EXTREAL_SUM_IMAGE_DEF,rich_listTheory.ITSET_TO_FOLDR]
+    simp[EXTREAL_SUM_IMAGE_DEF,ITSET_TO_FOLDR]
 QED
 
 Theorem EXTREAL_SUM_IMAGE_EQ':
     !f g s. FINITE s /\ (!x. x IN s ==> f x = g x) ==> EXTREAL_SUM_IMAGE f s = EXTREAL_SUM_IMAGE g s: extreal
 Proof
-    rw[] >> simp[EXTREAL_SUM_IMAGE_ALT_FOLDR] >> irule listTheory.FOLDR_CONG >> rw[]
+    rw[] >> simp[EXTREAL_SUM_IMAGE_ALT_FOLDR] >> irule FOLDR_CONG >> rw[]
 QED
 
 Theorem EXTREAL_SUM_IMAGE_MONO':
@@ -9680,7 +9681,7 @@ Proof
     ‘!f g l. (!e. MEM e l ==> f e <= g e) ==>
       (FOLDR (λe acc. f e + acc) 0x l <= FOLDR (λe acc. g e + acc) 0x l)’
         suffices_by rw[EXTREAL_SUM_IMAGE_ALT_FOLDR] >>
-    Induct_on ‘l’ >> rw[listTheory.FOLDR] >> irule le_add2 >> simp[]
+    Induct_on ‘l’ >> rw[FOLDR] >> irule le_add2 >> simp[]
 QED
 
 Theorem EXTREAL_SUM_IMAGE_COUNT_ZERO[simp]:

--- a/src/probability/hol4-probability.thy
+++ b/src/probability/hol4-probability.thy
@@ -9,7 +9,6 @@ requires: hol-set
 requires: hol-real
 requires: hol-extreal
 requires: hol-words
-requires: hol-sort
 requires: hol-analysis
 show: "HOL4"
 show: "Data.Bool"

--- a/src/probability/lebesgueScript.sml
+++ b/src/probability/lebesgueScript.sml
@@ -6247,26 +6247,6 @@ Proof
  >> MATCH_MP_TAC add2_sub2 >> art []
 QED
 
-(* in this theorem, the involved functions never take infinite values *)
-Theorem integral_add3 :
-    !m f g h. measure_space m /\
-              integrable m f /\ integrable m g /\ integrable m h /\
-             (!x. x IN m_space m ==> f x <> PosInf /\ f x <> NegInf) /\
-             (!x. x IN m_space m ==> g x <> PosInf /\ g x <> NegInf) /\
-             (!x. x IN m_space m ==> h x <> PosInf /\ h x <> NegInf)
-          ==> integral m (\x. f x + g x + h x) =
-              integral m f + integral m g + integral m h
-Proof
-    rpt STRIP_TAC
- >> Know ‘integral m (\x. f x + g x + h x) =
-          integral m (\x. f x + g x) + integral m h’
- >- (HO_MATCH_MP_TAC integral_add >> simp [] \\
-     MATCH_MP_TAC integrable_add >> rw [])
- >> Rewr'
- >> Suff ‘integral m (\x. f x + g x) = integral m f + integral m g’ >- rw []
- >> MATCH_MP_TAC integral_add >> rw []
-QED
-
 (* cf. real_lebesgueTheory.integral_times *)
 Theorem integral_cmul :
     !m f c. measure_space m /\ integrable m f ==>
@@ -11049,6 +11029,23 @@ Proof
         irule o SIMP_RULE (srw_ss ()) []) AE_INTER o SIMP_RULE (srw_ss ()) []) AE_subset >>
     fs[] >> rw[] >> NTAC 2 $ pop_assum SUBST1_TAC >>
     simp[extreal_add_def,extreal_sub_def,extreal_ainv_def,real_sub]
+QED
+
+(* An easy corollary of the new integral_add' and integrable_add' *)
+Theorem integral_add3 :
+    !m f g h. measure_space m /\
+              integrable m f /\ integrable m g /\ integrable m h
+          ==> integral m (\x. f x + g x + h x) =
+              integral m f + integral m g + integral m h
+Proof
+    rpt STRIP_TAC
+ >> Know ‘integral m (\x. f x + g x + h x) =
+          integral m (\x. f x + g x) + integral m h’
+ >- (HO_MATCH_MP_TAC integral_add' >> simp [] \\
+     MATCH_MP_TAC integrable_add' >> rw [])
+ >> Rewr'
+ >> Suff ‘integral m (\x. f x + g x) = integral m f + integral m g’ >- rw []
+ >> MATCH_MP_TAC integral_add' >> rw []
 QED
 
 val _ = export_theory ();

--- a/src/probability/martingaleScript.sml
+++ b/src/probability/martingaleScript.sml
@@ -6538,9 +6538,9 @@ QED
 (*  The Function Spaces L^p and Important Inequalities [1, Chapter 13]       *)
 (* ------------------------------------------------------------------------- *)
 
-(* The L^p function space (1 <= p) *)
-Definition function_space_def :
-    function_space p m =
+(* The L^p function space (1 <= p), was: ‘function_space’ *)
+Definition lp_space_def :
+    lp_space p m =
       {f | f IN measurable (m_space m,measurable_sets m) Borel /\
            if p = PosInf then
              ?c. 0 < c /\ measure m {x | x IN m_space m /\ c <= abs (f x)} = 0
@@ -6549,23 +6549,23 @@ Definition function_space_def :
 End
 
 (* The most common function spaces (L^1 and L^2) *)
-Overload L1_space = “function_space 1”
-Overload L2_space = “function_space 2”
+Overload L1_space = “lp_space 1”
+Overload L2_space = “lp_space 2”
 
-(* alternative definition of ‘function_space’ when p is finite *)
-Theorem function_space_alt_finite :
+(* alternative definition of ‘lp_space’ when p is finite *)
+Theorem lp_space_alt_finite :
     !p m f. 1 <= p /\ p <> PosInf ==>
-           (f IN function_space p m <=>
+           (f IN lp_space p m <=>
             f IN measurable (m_space m,measurable_sets m) Borel /\
             pos_fn_integral m (\x. (abs (f x)) powr p) <> PosInf)
 Proof
-    rw [function_space_def]
+    rw [lp_space_def]
 QED
 
-(* alternative definition of ‘function_space’ when p is infinite *)
-Theorem function_space_alt_infinite :
+(* alternative definition of ‘lp_space’ when p is infinite *)
+Theorem lp_space_alt_infinite :
     !m f. measure_space m ==>
-         (f IN function_space PosInf m <=>
+         (f IN lp_space PosInf m <=>
           f IN measurable (m_space m,measurable_sets m) Borel /\
           ?c. 0 < c /\ AE x::m. abs (f x) < c)
 Proof
@@ -6586,7 +6586,7 @@ Proof
      HO_MATCH_MP_TAC AE_iff_null \\
      rw [extreal_lt_def])
  >> RW_TAC std_ss [null_set_def, extreal_lt_def]
- >> EQ_TAC >> rw [function_space_def, GSYM extreal_lt_def]
+ >> EQ_TAC >> rw [lp_space_def, GSYM extreal_lt_def]
  >> Q.EXISTS_TAC ‘c’
  >> FULL_SIMP_TAC std_ss [GSYM extreal_lt_def]
  >> METIS_TAC []
@@ -6606,7 +6606,7 @@ Proof
  >> Know ‘f IN L2_space m <=>
           f IN measurable (m_space m,measurable_sets m) Borel /\
           pos_fn_integral m (\x. (abs (f x)) powr 2) <> PosInf’
- >- (MATCH_MP_TAC function_space_alt_finite \\
+ >- (MATCH_MP_TAC lp_space_alt_finite \\
      rw [extreal_of_num_def, extreal_le_eq])
  >> Rewr'
  >> EQ_TAC
@@ -6720,7 +6720,7 @@ Proof
 QED
 
 Theorem seminorm_not_infty :
-    !p m f. measure_space m /\ 1 <= p /\ p <> PosInf /\ f IN function_space p m ==>
+    !p m f. measure_space m /\ 1 <= p /\ p <> PosInf /\ f IN lp_space p m ==>
             seminorm p m f <> PosInf /\ seminorm p m f <> NegInf
 Proof
     rpt GEN_TAC >> STRIP_TAC
@@ -6729,7 +6729,7 @@ Proof
      MATCH_MP_TAC pos_not_neginf \\
      MATCH_MP_TAC seminorm_pos >> art [])
  >> RW_TAC std_ss [seminorm_normal]
- >> rfs [function_space_def]
+ >> rfs [lp_space_def]
  >> ‘0 < p’ by METIS_TAC [lte_trans, lt_01]
  >> ‘0 <= p’ by METIS_TAC [lt_imp_le]
  >> ‘p <> NegInf’ by PROVE_TAC [pos_not_neginf]
@@ -6757,19 +6757,19 @@ Proof
  >> rw [normal_powr]
 QED
 
-Theorem function_space_alt_seminorm :
+Theorem lp_space_alt_seminorm :
     !p m f. measure_space m /\ 1 <= p /\ p <> PosInf ==>
-           (f IN function_space p m <=>
+           (f IN lp_space p m <=>
             f IN Borel_measurable (m_space m,measurable_sets m) /\
             seminorm p m f < PosInf)
 Proof
     RW_TAC std_ss [GSYM lt_infty]
  >> EQ_TAC
  >| [ (* goal 1 (of 2) *)
-      rpt STRIP_TAC >- rfs [function_space_alt_finite] \\
+      rpt STRIP_TAC >- rfs [lp_space_alt_finite] \\
       METIS_TAC [seminorm_not_infty],
       (* goao 2 (of 2) *)
-      rw [function_space_alt_finite, seminorm_normal] \\
+      rw [lp_space_alt_finite, seminorm_normal] \\
       CCONTR_TAC \\
      ‘0 < p’ by PROVE_TAC [lte_trans, lt_01] \\
      ‘0 < inv p’ by PROVE_TAC [inv_pos'] \\
@@ -6783,7 +6783,7 @@ QED
 Theorem Hoelder_inequality :
     !m u v p q. measure_space m /\ 0 < p /\ 0 < q /\ inv(p) + inv(q) = 1 /\
                 p <> PosInf /\ q <> PosInf /\
-                u IN function_space p m /\ v IN function_space q m
+                u IN lp_space p m /\ v IN lp_space q m
             ==> integrable m (\x. u x * v x) /\
                 integral m (\x. abs (u x * v x)) <= seminorm p m u * seminorm q m v
 Proof
@@ -6797,7 +6797,7 @@ Proof
        by PROVE_TAC [seminorm_not_infty]
  >> ‘u IN measurable (m_space m,measurable_sets m) Borel /\
      v IN measurable (m_space m,measurable_sets m) Borel’
-       by gs [function_space_alt_finite]
+       by gs [lp_space_alt_finite]
  >> Suff ‘integral m (\x. abs (u x * v x)) <= seminorm p m u * seminorm q m v’
  >- (RW_TAC std_ss [] \\
      MATCH_MP_TAC integrable_from_abs >> ASM_SIMP_TAC std_ss [o_DEF] \\
@@ -7134,7 +7134,7 @@ Proof
       simp [] (* inv c * c = 1 *) \\
       MATCH_MP_TAC mul_linv_pos >> art [] \\
       Q.UNABBREV_TAC ‘c’ \\
-      METIS_TAC [function_space_alt_finite],
+      METIS_TAC [lp_space_alt_finite],
       (* goal 2 (of 2), symmetric with above *)
       Know ‘!x. abs (v x) / seminorm q m v = abs (v x) * inv (seminorm q m v)’
       >- (‘?r. 0 < r /\ seminorm q m v = Normal r’
@@ -7172,14 +7172,14 @@ Proof
       simp [] (* inv c * c = 1 *) \\
       MATCH_MP_TAC mul_linv_pos >> art [] \\
       Q.UNABBREV_TAC ‘c’ \\
-      METIS_TAC [function_space_alt_finite] ]
+      METIS_TAC [lp_space_alt_finite] ]
 QED
 
 (* A more convenient version (only the 2nd part) using ‘pos_fn_integral’ *)
 Theorem Hoelder_inequality' :
     !m u v p q. measure_space m /\ 0 < p /\ 0 < q /\ inv(p) + inv(q) = 1 /\
                 p <> PosInf /\ q <> PosInf /\
-                u IN function_space p m /\ v IN function_space q m
+                u IN lp_space p m /\ v IN lp_space q m
             ==> pos_fn_integral m (\x. abs (u x * v x)) <= seminorm p m u * seminorm q m v
 Proof
     rpt STRIP_TAC
@@ -7232,23 +7232,23 @@ QED
 (* This is the first part of Minkowski's inequality *)
 Theorem Minkowski_inequality_lemma[local] :
     !p m u v. measure_space m /\ 1 <= p /\ p <> PosInf /\
-              u IN function_space p m /\ v IN function_space p m
-          ==> (\x. u x + v x) IN function_space p m
+              u IN lp_space p m /\ v IN lp_space p m
+          ==> (\x. u x + v x) IN lp_space p m
 Proof
     rpt GEN_TAC >> STRIP_TAC
  >> ‘0 < p’ by PROVE_TAC [lte_trans, lt_01]
  >> ‘0 <= p’ by PROVE_TAC [lt_imp_le]
  >> ‘p <> NegInf’ by PROVE_TAC [pos_not_neginf]
- >> rw [function_space_alt_finite]
+ >> rw [lp_space_alt_finite]
  >- (MATCH_MP_TAC IN_MEASURABLE_BOREL_ADD' (* key result *) \\
      qexistsl_tac [‘u’, ‘v’] >> simp [] \\
-     rfs [function_space_alt_finite, measure_space_def])
+     rfs [lp_space_alt_finite, measure_space_def])
  >> REWRITE_TAC [lt_infty]
  >> MATCH_MP_TAC let_trans
  >> Q.EXISTS_TAC ‘pos_fn_integral m
                    (\x. 2 powr p * (abs (u x) powr p + abs (v x) powr p))’
  >> reverse CONJ_TAC (* easy goal first *)
- >- (rfs [function_space_alt_finite] \\
+ >- (rfs [lp_space_alt_finite] \\
      Know ‘?c. 0 <= c /\ 2 powr p = Normal c’
      >- (‘?r. 0 < r /\ p = Normal r’
             by METIS_TAC [extreal_cases, extreal_of_num_def, extreal_lt_eq] \\
@@ -7291,7 +7291,7 @@ Proof
  >> rw [powr_pos]
  >- (MATCH_MP_TAC le_mul >> art [powr_pos] \\
      MATCH_MP_TAC le_add >> art [powr_pos])
- >> rfs [function_space_alt_finite]
+ >> rfs [lp_space_alt_finite]
  >> Know ‘null_set m {x | x IN m_space m /\ abs (u x) powr p = PosInf} /\
           null_set m {x | x IN m_space m /\ abs (v x) powr p = PosInf}’
  >- (CONJ_TAC (* 2 subgoals, same tactics *) \\
@@ -7367,8 +7367,8 @@ QED
  *)
 Theorem Minkowski_inequality :
     !p m u v. measure_space m /\ 1 <= p /\ p <> PosInf /\
-              u IN function_space p m /\ v IN function_space p m
-          ==> (\x. u x + v x) IN function_space p m /\
+              u IN lp_space p m /\ v IN lp_space p m
+          ==> (\x. u x + v x) IN lp_space p m /\
               seminorm p m (\x. u x + v x) <= seminorm p m u + seminorm p m v
 Proof
     rpt GEN_TAC >> STRIP_TAC
@@ -7393,7 +7393,7 @@ Proof
  >- (POP_ORW \\
      MATCH_MP_TAC pos_fn_integral_mono_AE \\
      rw [le_mul, le_add, abs_pos, powr_pos] \\
-     rfs [function_space_alt_finite] \\
+     rfs [lp_space_alt_finite] \\
      Know ‘null_set m {x | x IN m_space m /\ abs (u x) powr p = PosInf} /\
            null_set m {x | x IN m_space m /\ abs (v x) powr p = PosInf}’
      >- (CONJ_TAC (* 2 subgoals, same tactics *) \\
@@ -7423,7 +7423,7 @@ Proof
           pos_fn_integral m (\x. abs (u x) * abs (u x + v x) powr (p - 1)) +
           pos_fn_integral m (\x. abs (v x) * abs (u x + v x) powr (p - 1))’
  >- (HO_MATCH_MP_TAC pos_fn_integral_add \\
-     rfs [function_space_alt_finite] \\
+     rfs [lp_space_alt_finite] \\
      rw [le_mul, abs_pos, powr_pos] >| (* 2 subgoals *)
      [ (* goal 1 (of 2) *)
        MATCH_MP_TAC IN_MEASURABLE_BOREL_TIMES \\
@@ -7488,8 +7488,8 @@ Proof
  >> ‘!x. 0 <= f x’ by rw [Abbr ‘f’, powr_pos]
  >> ‘!x. abs (f x) = f x’ by rw [abs_refl]
  >> RW_TAC std_ss []
- >> Know ‘f IN function_space q m’
- >- (rfs [function_space_alt_finite, Abbr ‘f’] \\
+ >> Know ‘f IN lp_space q m’
+ >- (rfs [lp_space_alt_finite, Abbr ‘f’] \\
      CONJ_TAC
      >- (HO_MATCH_MP_TAC IN_MEASURABLE_BOREL_ABS_POWR >> rw [sub_not_infty]) \\
     ‘!x. abs (abs (u x + v x) powr (p - 1)) = abs (u x + v x) powr (p - 1)’
@@ -7513,7 +7513,7 @@ Proof
  >> DISCH_TAC
  (* applying seminorm_eq_0 *)
  >> Cases_on ‘seminorm q m f = 0’
- >- (rfs [function_space_alt_finite, seminorm_eq_0] \\
+ >- (rfs [lp_space_alt_finite, seminorm_eq_0] \\
      Suff ‘seminorm p m (\x. u x + v x) = 0’
      >- (Rewr' >> MATCH_MP_TAC le_add >> rw [seminorm_pos]) \\
      Know ‘seminorm p m (\x. u x + v x) = 0 <=> AE x::m. u x + v x = 0’

--- a/src/probability/measureScript.sml
+++ b/src/probability/measureScript.sml
@@ -20,8 +20,8 @@
 
 open HolKernel Parse boolLib bossLib;
 
-open prim_recTheory arithmeticTheory optionTheory pairTheory
-     numpairTheory combinTheory pred_setTheory pred_setLib;
+open prim_recTheory arithmeticTheory optionTheory pairTheory combinTheory
+     pred_setTheory pred_setLib;
 
 open realTheory realLib metricTheory seqTheory transcTheory real_sigmaTheory
      real_topologyTheory;
@@ -2367,13 +2367,24 @@ val outer_measure_space_def = Define `
      {} IN (measurable_sets m) /\
      positive m /\ increasing m /\ countably_subadditive m`;
 
-(* Defition 18.1 of [1]: the family of countable S-covers
+(* Definition 18.1 [1, p.198] (countable S-covers with a diameter)
 
-   Notice that `BIGUNION (IMAGE f UNIV)` needs not be disjoint or in `sts`
+   Notice that `BIGUNION (IMAGE f UNIV)` needs not be disjoint or in `sts`.
  *)
-val countable_covers_def = Define
-   `countable_covers (sts :'a set set) =
-      \a. {f | f IN (univ(:num) -> sts) /\ a SUBSET (BIGUNION (IMAGE f UNIV))}`;
+Definition metric_countable_covers_def :
+    metric_countable_covers (d :'a metric) (e :extreal) (sts :'a set set) =
+      \a. {f | f IN (univ(:num) -> sts) /\ a SUBSET (BIGUNION (IMAGE f UNIV)) /\
+               !i. Normal (set_diameter d (f i)) <= e}
+End
+
+Overload countable_covers = “metric_countable_covers ARB PosInf”
+
+Theorem countable_covers_def :
+    !sts. countable_covers (sts :'a set set) =
+          \a. {f | f IN (univ(:num) -> sts) /\ a SUBSET (BIGUNION (IMAGE f UNIV))}
+Proof
+    RW_TAC std_ss [metric_countable_covers_def, le_infty]
+QED
 
 (* Defition 18.1 of [1]: outer measure of the set-function m for C (covering),
    which could be `coutable_covers sts`. *)
@@ -2958,10 +2969,11 @@ Theorem OUTER_MEASURE_CONSTRUCTION :
              !x. x SUBSET sp ==> v x <= u x
 Proof
     rpt GEN_TAC >> STRIP_TAC
- >> rename1 `positive (sp,sts,mu)` >> rename1 `m = _` (* m -> mu, u -> m *)
+ >> rename1 `positive (sp,sts,mu)`                       (* m -> mu *)
+ >> rename1 `m = outer_measure mu (countable_covers sts)` (* u -> m *)
  >> Q.ABBREV_TAC `C = countable_covers sts`
  >> Q.ABBREV_TAC `A = caratheodory_sets sp m`
- >> STRONG_CONJ_TAC
+ >> STRONG_CONJ_TAC (* outer_measure_space (sp,POW sp,m) *)
  >- (REWRITE_TAC [outer_measure_space_def, m_space_def, measurable_sets_def,
                   subset_class_POW, EMPTY_IN_POW] \\
      fs [countable_covers_def, outer_measure_def] \\
@@ -3148,20 +3160,22 @@ Proof
          PROVE_TAC [SUBSET_DEF]) >> DISCH_TAC \\
   (* merge two nesting BIGUNIONs into one BIGUNION *)
     `!i j. g i j IN sts` by PROVE_TAC [IN_FUNSET, IN_UNIV] \\
-     Q.ABBREV_TAC `ff = \n. g (nfst n) (nsnd n)` \\
-    `ff IN (univ(:num) -> sts)` by PROVE_TAC [IN_FUNSET, IN_UNIV] \\
+  (* UPDATE: new proof steps without using numpairTheory *)
+     Q.X_CHOOSE_THEN ‘h’ STRIP_ASSUME_TAC NUM_2D_BIJ_INV \\
+     Q.X_CHOOSE_THEN ‘h2’ STRIP_ASSUME_TAC
+       (SIMP_RULE (srw_ss()) []
+         (MATCH_MP BIJ_INV (ASSUME “BIJ h univ(:num) (univ(:num) CROSS univ(:num))”))) \\
+     Q.ABBREV_TAC ‘ff = (UNCURRY g) o h’ \\
+    `ff IN (univ(:num) -> sts)` by rw [Abbr ‘ff’, o_DEF, IN_FUNSET, UNCURRY] \\
      Know `BIGUNION (IMAGE (\n. BIGUNION (IMAGE (g n) univ(:num))) univ(:num)) =
            BIGUNION (IMAGE ff (univ(:num)))`
-     >- (RW_TAC std_ss [SET_EQ_SUBSET, SUBSET_DEF, IN_BIGUNION_IMAGE, IN_UNIV] >|
+     >- (rw [SET_EQ_SUBSET, SUBSET_DEF, IN_BIGUNION_IMAGE, Abbr ‘ff’, UNCURRY] >| (* 2 subgoals *)
          [ (* goal 1 (of 2) *)
-           Q.EXISTS_TAC `npair n x'` \\ (* numpairTheory is used here! *)
-           Q.UNABBREV_TAC `ff` >> BETA_TAC >> PROVE_TAC [nfst_npair, nsnd_npair],
+           rename1 ‘x IN g i j’ \\
+           Q.EXISTS_TAC ‘h2 (i,j)’ >> rw [],
            (* goal 2 (of 2) *)
-           Q.EXISTS_TAC `nfst x'` \\
-           Q.EXISTS_TAC `nsnd x'` \\
-           POP_ASSUM MP_TAC >> Q.UNABBREV_TAC `ff` >> BETA_TAC \\
-           REWRITE_TAC [] ]) \\
-     DISCH_TAC \\
+           rename1 ‘x IN g (FST (h n)) (SND (h n))’ (* last assum *) \\
+           qexistsl_tac [‘FST (h n)’, ‘SND (h n)’] >> art [] ]) >> DISCH_TAC \\
      Q.PAT_X_ASSUM `BIGUNION (IMAGE f UNIV) SUBSET X` MP_TAC \\
      POP_ORW >> DISCH_TAC \\
      Suff `suminf (\n. suminf (mu o g n)) = suminf (mu o ff)`
@@ -3169,19 +3183,14 @@ Proof
          FIRST_X_ASSUM MATCH_MP_TAC >> ASM_REWRITE_TAC []) \\
      Q.UNABBREV_TAC `ff` \\
   (* prepare for applying "ext_suminf_2d" *)
-     MATCH_MP_TAC EQ_SYM \\
-     Q.ABBREV_TAC `h = \n. (nfst n, nsnd n)` \\
+     ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
      Q.ABBREV_TAC `ff = \m n. mu (g m n)` \\
-     Know `(mu o (\n. g (nfst n) (nsnd n))) = UNCURRY ff o h`
-     >- (SIMP_TAC std_ss [o_DEF, FUN_EQ_THM, UNCURRY] \\
-         Q.UNABBREV_TAC `h` >> Q.UNABBREV_TAC `ff` \\
-         ASM_SIMP_TAC std_ss []) >> Rewr \\
+     Know `mu o UNCURRY g o h = UNCURRY ff o h`
+     >- (SIMP_TAC std_ss [o_DEF, FUN_EQ_THM, UNCURRY, Abbr ‘ff’]) >> Rewr \\
   (* finally, apply "ext_suminf_2d", cleaning up easy goals *)
      MATCH_MP_TAC ext_suminf_2d \\
      `!n. suminf (ff n) = (\n. suminf (mu o g n)) n` by METIS_TAC [o_DEF] \\
      POP_ASSUM ((ASM_SIMP_TAC std_ss) o wrap) \\
-     Know `BIJ h univ(:num) (univ(:num) CROSS univ(:num))`
-     >- (Q.UNABBREV_TAC `h` >> REWRITE_TAC [NUM_2D_BIJ_nfst_nsnd]) >> Rewr \\
   (* !m n. 0 <= ff m n *)
      Q.UNABBREV_TAC `ff` >> BETA_TAC \\
      PROVE_TAC [positive_def, measure_def, measurable_sets_def])

--- a/src/real/metricScript.sml
+++ b/src/real/metricScript.sml
@@ -163,11 +163,11 @@ val METRIC_NZ = store_thm("METRIC_NZ",
 
 val bmetric_tm = “(dist m)(x,y) / (1 + (dist m)(x,y))”;
 
-Definition reduced_metric_def :
-    reduced_metric (m :'a metric) = metric (\(x,y). ^bmetric_tm)
+Definition bounded_metric_def :
+    bounded_metric (m :'a metric) = metric (\(x,y). ^bmetric_tm)
 End
 
-Theorem reduced_metric_alt[local] :
+Theorem bounded_metric_alt[local] :
     !m x y. ^bmetric_tm = 1 - inv (1 + dist m (x,y))
 Proof
     rw [FUN_EQ_THM]
@@ -183,7 +183,7 @@ Proof
  >> rw [real_div, REAL_SUB_RDISTRIB, REAL_MUL_RINV]
 QED
 
-Theorem reduced_metric_ismet :
+Theorem bounded_metric_ismet :
     !m. ismet (\(x,y). ^bmetric_tm)
 Proof
     rw [ismet]
@@ -197,7 +197,7 @@ Proof
      MATCH_MP_TAC REAL_LTE_TRANS \\
      Q.EXISTS_TAC ‘1’ >> rw [METRIC_POS])
  >> DISCH_TAC
- >> REWRITE_TAC [reduced_metric_alt]
+ >> REWRITE_TAC [bounded_metric_alt]
  >> ‘1 - inv (1 + dist m (x,y)) + (1 - inv (1 + dist m (x,z))) =
      1 - (inv (1 + dist m (x,y)) + inv (1 + dist m (x,z)) - 1)’ by REAL_ARITH_TAC
  >> POP_ORW
@@ -247,19 +247,19 @@ Proof
  >> MATCH_MP_TAC REAL_LE_MUL >> rw [METRIC_POS]
 QED
 
-Theorem reduced_metric_thm :
-    !m x y. dist (reduced_metric m) (x,y) = ^bmetric_tm
+Theorem bounded_metric_thm :
+    !m x y. dist (bounded_metric m) (x,y) = ^bmetric_tm
 Proof
-    rw [reduced_metric_def]
+    rw [bounded_metric_def]
  >> ‘dist (metric (\(x,y). ^bmetric_tm)) = (\(x,y). ^bmetric_tm)’
-       by (rw [GSYM metric_tybij, reduced_metric_ismet])
+       by (rw [GSYM metric_tybij, bounded_metric_ismet])
  >> rw []
 QED
 
-Theorem reduced_metric_lt_1 :
-    !(m :'a metric) x y. dist (reduced_metric m) (x,y) < 1
+Theorem bounded_metric_lt_1 :
+    !(m :'a metric) x y. dist (bounded_metric m) (x,y) < 1
 Proof
-    rw [reduced_metric_thm]
+    rw [bounded_metric_thm]
  >> Know ‘0 < 1 + dist m (q,r)’
  >- (MATCH_MP_TAC REAL_LTE_TRANS \\
      Q.EXISTS_TAC ‘1’ >> rw [METRIC_POS])

--- a/src/res_quan/src/hurdUtils.sml
+++ b/src/res_quan/src/hurdUtils.sml
@@ -1007,6 +1007,7 @@ val Cond =
 
 val Rewr  = DISCH_THEN (REWRITE_TAC o wrap);
 val Rewr' = DISCH_THEN (ONCE_REWRITE_TAC o wrap);
+val POP_ORW = POP_ASSUM (ONCE_REWRITE_TAC o wrap);
 
 (* --------------------------------------------------------------------- *)
 (* EXACT_MP_TAC : thm -> tactic                                          *)
@@ -1046,6 +1047,8 @@ end;
 (*                                                                       *)
 (* By using ONCE_REWRITE_TAC[DISJ_COMM] first, a similar stronger tactic *)
 (* than DISJ1_TAC can be obtained.                                       *)
+(*                                                                       *)
+(* cf. LEFT_DISJ_TAC & RIGHT_DISJ_TAC (schneiderUtils)                   *)
 (* --------------------------------------------------------------------- *)
 
 val STRONG_DISJ_TAC :tactic =
@@ -1091,7 +1094,6 @@ fun FORWARD_TAC f (asms, g:term) =
 
 val Know = Q_TAC KNOW_TAC
 val Suff = Q_TAC SUFF_TAC
-val POP_ORW = POP_ASSUM (fn thm => ONCE_REWRITE_TAC [thm]);
 
 (* --------------------------------------------------------------------- *)
 (* A simple-minded CNF conversion.                                       *)


### PR DESCRIPTION
Hi,

Below are some various updates to probability scripts.

1. In `borelTheory`, during the construction of one-dimension Borel measure space (`lborel`), the proof of an intermediate theorem "lborel0_finite_additive" was using `sortingTheory.QSORT` to sort a list converted from a set. This dependency is a little weird, after all pure math proofs shouldn't depend on the correctness of quicksort algorithm.  Recent I found in `iterateTheory` there's the following topological sort theorem which can be used as alternative (`TOPOLOGICAL_SORT'` is an easy corollary added in #1033 using `count` instead of `numseg`):
```
   [TOPOLOGICAL_SORT]  Theorem (iterateTheory)
      ⊢ ∀ $<<.
          (∀x y. x << y ∧ y << x ⇒ x = y) ∧
          (∀x y z. x << y ∧ y << z ⇒ x << z) ⇒
          ∀n s.
            s HAS_SIZE n ⇒
            ∃f. s = IMAGE f {1 .. n} ∧
                ∀j k. j ∈ {1 .. n} ∧ k ∈ {1 .. n} ∧ j < k ⇒ ¬(f k << f j)
   
   [TOPOLOGICAL_SORT']  Theorem      
      ⊢ ∀R s n.
          transitive R ∧ antisymmetric R ∧ s HAS_SIZE n ⇒
          ∃f. s = IMAGE f (count n) ∧
              ∀j k. j < n ∧ k < n ∧ j < k ⇒ ¬R (f k) (f j)
```
With the above `TOPOLOGICAL_SORT'`, now probability proofs do not depend on `sortingTheory` any more.  NOTE: to apply the above theorem, the supplied relation must be both transivive and antisymmetric, the later property requires a more careful construction of sorting relation `R` than those needed by `sortingTheory.QSORT` (transitive + total).

2. In `measureTheory`, an intermediate theorem `OUTER_MEASURE_CONSTRUCTION` (needed by `CARATHEODORY_SEMIRING`) was using a concrete bijiection between one- and two-dimensional number sets (`npair`, `nfst`, `nsnd`) provided by `numpairTheory`.  But actually only the existence of such bijiections would be sufficient. When I was working on these proofs in 2018, I wasn't aware that, in `util_probTheory`, Hurd has already proved a number of such existence theorems, e.g. the following one:
```
   [NUM_2D_BIJ_INV]  Theorem (util_probTheory)      
      ⊢ ∃f. BIJ f 𝕌(:num) (𝕌(:num) × 𝕌(:num))
```
Now, with the above `NUM_2D_BIJ_INV` the proof of `OUTER_MEASURE_CONSTRUCTION` can also be done. Thus the need of `numpairTheory` gets removed from probability proofs.

(Below are other minor changes)

3. In `martingaleTheory`, the recently added `function_space` (#972) has been renamed to `lp_space`, to be aligned with Lean mathlib.  (I was thinking how to best name $L^p$ spaces in HOL, but never reached a satisfied one.)

4. In `metricTheory` and also `extrealTheory`, the recently added `reduced_metric` has been renamed to `bounded_metric`, an old (good) name but then changed in the last minute before sending the PR (#993).  There's no other formalization or textbook as references, but I personally think "bounded" is a better character than "reduced" which is a little ambiguous.

5. In `lebesgueTheory`, one existing theorem `integral_add3` has been improved with much less antecedents, after `integral_add'` added in #1017.
```
   [integral_add3]  Theorem (lebesgueTheory)      
      ⊢ ∀m f g h.
          measure_space m ∧ integrable m f ∧ integrable m g ∧
          integrable m h ⇒
          ∫ m (λx. f x + g x + h x) = ∫ m f + ∫ m g + ∫ m h   
```

6. In `hurdUtils`, I added some comments near `STRONG_DISJ_TAC`, with connections to `LEFT_DISJ_TAC` and `RIGHT_DISJ_TAC` provided by `schneiderUtils`.  All these tactics are sometimes more useful than the existing standard tactics.

--Chun
