### PR TITLE
Use relative paths in the generated "HOL Reference Page"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ tools/build-logs
 help/Docfiles/*.txt
 help/Docfiles/HTML/*
 help/HOLindex.html
+help/index.html
 help/HOL.Help
 help/src-sml/htmlsigs
 help/src-sml/index.tex
@@ -130,3 +131,4 @@ examples/l3-machine-code/**/*-heap
 
 *Script_ttt.sml
 *.tttsave
+/TAGS

--- a/help/src-sml/HOLPage.sml
+++ b/help/src-sml/HOLPage.sml
@@ -123,9 +123,11 @@ fun printHOLPage version bgcolor HOLpath idIndex TheoryIndex (dbfile, outfile)
         out "<P>";
 
         out"<DT><STRONG>";
-        href "IDENTIFIERS" idIndex;
+        href "IDENTIFIERS"
+             (normPath["src-sml","htmlsigs","idIndex.html"]); (* was: idIndex *)
         out "&nbsp;&nbsp;&nbsp;&nbsp;";
-        href "THEORY BINDINGS" TheoryIndex;
+        href "THEORY BINDINGS"
+             (normPath["src-sml","htmlsigs","TheoryIndex.html"]); (* was: TheoryIndex *)
         out "</STRONG>";
         out "<P>";
 	out "</DL>\n";

--- a/help/src-sml/HOLPage.sml
+++ b/help/src-sml/HOLPage.sml
@@ -50,12 +50,12 @@ fun printHOLPage version bgcolor HOLpath idIndex TheoryIndex (dbfile, outfile)
 	val os = TextIO.openOut outfile
 	fun out s = TextIO.output(os, s)
 	fun href anchor target =
-	    app out ["<A HREF=\"file://", target, "\">", anchor, "</A>"]
+	    app out ["<A HREF=\"", target, "\">", anchor, "</A>"]
 	fun idhref file line anchor =
 	    href anchor (concat [file, ".html#line", Int.toString line])
 	fun strhref file anchor = href anchor (file ^ ".html")
 	fun mkref line file = idhref file line file
-        val sigspath = normPath[HOLpath,"help","src-sml","htmlsigs"]
+        val sigspath = normPath["src-sml","htmlsigs"]
         fun path front file = normPath[front, file^".html"]
 
         fun class_of drop {comp=Str, file, line} =
@@ -105,7 +105,7 @@ fun printHOLPage version bgcolor HOLpath idIndex TheoryIndex (dbfile, outfile)
         out"<DT><STRONG>THEORIES</STRONG>\n";
         out "&nbsp;&nbsp;&nbsp;\n";
         href "(Theory Graph)"
-             (normPath [HOLpath,"help/theorygraph/theories.html"]);
+             (normPath ["theorygraph","theories.html"]);
         out "\n";
         out"<DD>"; prtree theory_of db;
         out "<P>";

--- a/help/src-sml/HOLPage.sml
+++ b/help/src-sml/HOLPage.sml
@@ -123,11 +123,9 @@ fun printHOLPage version bgcolor HOLpath idIndex TheoryIndex (dbfile, outfile)
         out "<P>";
 
         out"<DT><STRONG>";
-        href "IDENTIFIERS"
-             (normPath["src-sml","htmlsigs","idIndex.html"]); (* was: idIndex *)
+        href "IDENTIFIERS" idIndex;
         out "&nbsp;&nbsp;&nbsp;&nbsp;";
-        href "THEORY BINDINGS"
-             (normPath["src-sml","htmlsigs","TheoryIndex.html"]); (* was: TheoryIndex *)
+        href "THEORY BINDINGS" TheoryIndex;
         out "</STRONG>";
         out "<P>";
 	out "</DL>\n";

--- a/help/src-sml/makebase.sml
+++ b/help/src-sml/makebase.sml
@@ -58,7 +58,7 @@ val libdirDef = normPath[HOLpath,"sigobj"]
 val helpfileDef = normPath[HOLpath, "help","HOL.Help"]
 
 (* Default filename for the HOL reference page: *)
-val HOLpageDef = normPath[HOLpath, "help","HOLindex.html"]
+val HOLpageDef = normPath[HOLpath, "help","index.html"] (* was: HOLindex.html *)
 
 (* Default filename for the ASCII format database: *)
 val txtIndexDef = "index.txt"

--- a/help/src-sml/makebase.sml
+++ b/help/src-sml/makebase.sml
@@ -69,12 +69,11 @@ val texIndexDef = "index.tex"
 (* Default directory for signatures in HTML format: *)
 val htmlDirDef = "htmlsigs"
 
-(* Default filename for the HTML format database for identifiers: *)
-val htmlIndexDef = normPath[HOLpath,"help","src-sml",htmlDirDef,"idIndex.html"]
+(* Default (relative) filename for the HTML format database for identifiers: *)
+val htmlIndexDef = ["src-sml",htmlDirDef,"idIndex.html"]
 
-(* Default filename for the HTML format database for theories: *)
-val htmlTheoryIndexDef =
-   normPath[HOLpath,"help","src-sml",htmlDirDef,"TheoryIndex.html"]
+(* Default (relative) filename for the HTML format database for theories: *)
+val htmlTheoryIndexDef = ["src-sml",htmlDirDef,"TheoryIndex.html"]
 
 (* Default filename for the LaTeX signatures: *)
 val texSigs = "texsigsigs.tex"
@@ -226,7 +225,10 @@ val SRCFILES =
 fun process (libdir, helpfile, txtIndex,
              texIndex, htmldir, htmlIndex, htmlTheoryIndex, HOLpage)
  =
- (print ("Reading signatures in directory " ^ libdir ^
+ let val htmlIndexAbsolutePath       = normPath(concat[[HOLpath,"help"],htmlIndex]);
+     val htmlTheoryIndexAbsolutePath = normPath(concat[[HOLpath,"help"],htmlTheoryIndex]);
+ in
+   (print ("Reading signatures in directory " ^ libdir ^
         "\nand writing help database in file " ^ helpfile ^ "\n")
  ; dirToBase (libdir, docdirs, helpfile)
 
@@ -240,19 +242,21 @@ fun process (libdir, helpfile, txtIndex,
  ; Htmlsigs.sigsToHtml
      version bgcolor stoplist helpfile HOLpath SRCFILES (libdir, htmldir)
 
- ; print ("\nWriting HTML signature index in file " ^ htmlIndex ^ "\n")
+ ; print ("\nWriting HTML signature index in file " ^ htmlIndexAbsolutePath ^ "\n")
  ; Htmlsigs.printHTMLBase version bgcolor HOLpath
-         isSigId "HOL IDENTIFIER INDEX" (helpfile, htmlIndex)
+         isSigId "HOL IDENTIFIER INDEX" (helpfile, htmlIndexAbsolutePath)
 
  ; print ("\nWriting HTML theory signature index in file "
-          ^ htmlTheoryIndex ^ "\n")
+          ^ htmlTheoryIndexAbsolutePath ^ "\n")
  ; Htmlsigs.printHTMLBase version bgcolor HOLpath
-         isTheory "HOL THEORY BINDINGS" (helpfile, htmlTheoryIndex)
+         isTheory "HOL THEORY BINDINGS" (helpfile, htmlTheoryIndexAbsolutePath)
 
  ; print ("\nWriting HOLPage\n")
  ; HOLPage.printHOLPage version bgcolor HOLpath
-                        htmlIndex htmlTheoryIndex (helpfile, HOLpage)
- )
+                        normPath(htmlIndex)
+                        normPath(htmlTheoryIndex)
+                        (helpfile, HOLpage)
+ ) end; (* fun process *)
 
 in
     case CommandLine.arguments () of

--- a/help/src-sml/makebase.sml
+++ b/help/src-sml/makebase.sml
@@ -69,11 +69,12 @@ val texIndexDef = "index.tex"
 (* Default directory for signatures in HTML format: *)
 val htmlDirDef = "htmlsigs"
 
-(* Default (relative) filename for the HTML format database for identifiers: *)
-val htmlIndexDef = ["src-sml",htmlDirDef,"idIndex.html"]
+(* Default filename for the HTML format database for identifiers: *)
+val htmlIndexDef = normPath[HOLpath,"help","src-sml",htmlDirDef,"idIndex.html"]
 
-(* Default (relative) filename for the HTML format database for theories: *)
-val htmlTheoryIndexDef = ["src-sml",htmlDirDef,"TheoryIndex.html"]
+(* Default filename for the HTML format database for theories: *)
+val htmlTheoryIndexDef =
+   normPath[HOLpath,"help","src-sml",htmlDirDef,"TheoryIndex.html"]
 
 (* Default filename for the LaTeX signatures: *)
 val texSigs = "texsigsigs.tex"
@@ -225,10 +226,7 @@ val SRCFILES =
 fun process (libdir, helpfile, txtIndex,
              texIndex, htmldir, htmlIndex, htmlTheoryIndex, HOLpage)
  =
- let val htmlIndexAbsolutePath       = normPath(concat[[HOLpath,"help"],htmlIndex]);
-     val htmlTheoryIndexAbsolutePath = normPath(concat[[HOLpath,"help"],htmlTheoryIndex]);
- in
-   (print ("Reading signatures in directory " ^ libdir ^
+ (print ("Reading signatures in directory " ^ libdir ^
         "\nand writing help database in file " ^ helpfile ^ "\n")
  ; dirToBase (libdir, docdirs, helpfile)
 
@@ -242,21 +240,19 @@ fun process (libdir, helpfile, txtIndex,
  ; Htmlsigs.sigsToHtml
      version bgcolor stoplist helpfile HOLpath SRCFILES (libdir, htmldir)
 
- ; print ("\nWriting HTML signature index in file " ^ htmlIndexAbsolutePath ^ "\n")
+ ; print ("\nWriting HTML signature index in file " ^ htmlIndex ^ "\n")
  ; Htmlsigs.printHTMLBase version bgcolor HOLpath
-         isSigId "HOL IDENTIFIER INDEX" (helpfile, htmlIndexAbsolutePath)
+         isSigId "HOL IDENTIFIER INDEX" (helpfile, htmlIndex)
 
  ; print ("\nWriting HTML theory signature index in file "
-          ^ htmlTheoryIndexAbsolutePath ^ "\n")
+          ^ htmlTheoryIndex ^ "\n")
  ; Htmlsigs.printHTMLBase version bgcolor HOLpath
-         isTheory "HOL THEORY BINDINGS" (helpfile, htmlTheoryIndexAbsolutePath)
+         isTheory "HOL THEORY BINDINGS" (helpfile, htmlTheoryIndex)
 
  ; print ("\nWriting HOLPage\n")
  ; HOLPage.printHOLPage version bgcolor HOLpath
-                        normPath(htmlIndex)
-                        normPath(htmlTheoryIndex)
-                        (helpfile, HOLpage)
- ) end; (* fun process *)
+                        htmlIndex htmlTheoryIndex (helpfile, HOLpage)
+ )
 
 in
     case CommandLine.arguments () of


### PR DESCRIPTION
Hi,

This PR fixes a small but very annoying issue in the generated HTML "HOL Reference Page": previously all links in that page are `file://`-like absolute paths. As a (bad) result, HOL's "help" folder cannot be directly hosted by a Web server. Even not consider web hosting, if you pack the "help" folder as a zip and send to others, now they can just decompress it and click the entry HTML file to see the contents of each theories (previously this is impossible).

After the changes in this PR, now it's easy to create a soft link (by `ln -s`) from your local HOL working directory (the `help` sub-folder only) to the root directory of your local HTTP server (e.g. apache2) and view all HOL core theorems from a (remote) HTTP client, e.g. the Web browser of your tablet.  The HTML file name `HOLindex.html` has been also renamed to just `index.html`, which is the default entry HTML file name accepted by Apache and many other Web servers, so that there's no need to explicit type "HOLindex.html" as part of the URL.

Note that the links to proof scripts files (`*Script.sml`) are not touched. They are still in absolute paths.

P. S. The official online "HOL Reference Page" [1] (of the most recent HOL release) has already used relative paths. I was wondering how it was done, but now I think it should be manually modified after the HTML generation, by simply removing the absolute path prefix.

[1] https://hol-theorem-prover.org/kananaskis-14-helpdocs/help/HOLindex.html

Regards,

Chun Tian