### PR TITLE
HOL-Light's permutations.ml and vectors.ml (partial) ported to HOL4

### DIFF
--- a/examples/vector/permutationScript.sml
+++ b/examples/vector/permutationScript.sml
@@ -1,0 +1,1277 @@
+(* ========================================================================= *)
+(* Permutations, both general and specifically on finite sets.               *)
+(*    (HOL-Light's Library/permutations.ml)                                  *)
+(*                                                                           *)
+(*              (c) Copyright, John Harrison 2010                            *)
+(*              (c) Copyright, Liming Li 2011                                *)
+(* ========================================================================= *)
+
+open HolKernel Parse boolLib bossLib;
+
+open arithmeticTheory combinTheory pred_setTheory pairTheory PairedLambda
+     pred_setLib fcpTheory fcpLib tautLib numLib realTheory realLib;
+
+open hurdUtils cardinalTheory iterateTheory;
+
+val _ = new_theory "permutation";
+
+(* ========================================================================= *)
+(* HOL-Light compatibility layer                                             *)
+(* ========================================================================= *)
+
+(* |- CARD {} = 0 /\
+      !x s. FINITE s ==> CARD (x INSERT s) = if x IN s then CARD s else SUC (CARD s)
+ *)
+val CARD_CLAUSES = CONJ CARD_EMPTY (PROVE [CARD_INSERT]
+  ``!x s. FINITE s ==>
+           (CARD (x INSERT s) = (if x IN s then CARD s else SUC (CARD s)))``);
+
+(* |- (!f. IMAGE f {} = {}) /\ !f x s. IMAGE f (x INSERT s) = f x INSERT IMAGE f s *)
+val IMAGE_CLAUSES = CONJ IMAGE_EMPTY IMAGE_INSERT;
+
+(* |- FINITE {} /\ !x s. FINITE (x INSERT s) <=> FINITE s *)
+val FINITE_RULES = CONJ FINITE_EMPTY FINITE_INSERT;
+
+(* |- !n. SUC n <> 0 *)
+val NOT_SUC = numTheory.NOT_SUC;
+
+(* |- !m n. SUC m = SUC n <=> m = n *)
+val SUC_INJ = prim_recTheory.INV_SUC_EQ;
+
+(* |- (!m. ~(m < 0)) /\ !m n. m < SUC n <=> m = n \/ m < n *)
+val LT = CONJ (DECIDE ``!m:num. ~(m < 0)``) prim_recTheory.LESS_THM;
+
+(* |- !n. ~(n < n) *)
+val LT_REFL = prim_recTheory.LESS_REFL;
+
+(* ========================================================================= *)
+(* Permutations, both general and specifically on finite sets.               *)
+(* ========================================================================= *)
+
+(* NOTE: the old name `PERMUTES` is conflict with pred_setTheory:
+
+   val _ = overload_on("PERMUTES", ``\f s. BIJ f s s``);
+
+   but the two definitions are not equivalent, according to Michael Norrish.
+   So I've chosen to use lower-case name: permutes.
+                                           -- Chun Tian (binghe), May 28, 2018
+ *)
+val _ = set_fixity "permutes" (Infix(NONASSOC, 450)); (* same as relation *)
+
+Definition permutes :
+   p permutes s <=> (!x. ~(x IN s) ==> (p(x) = x)) /\ (!y. ?!x. p x = y)
+End
+
+(* connection to ‘pred_set$PERMUTES’, added by Chun Tian *)
+Theorem permutes_alt :
+    !f s. f permutes s <=> f PERMUTES s /\ !x. x NOTIN s ==> f(x) = x
+Proof
+    RW_TAC std_ss [permutes, BIJ_ALT, IN_FUNSET]
+ >> EQ_TAC >> RW_TAC bool_ss []
+ >| [ (* goal 1 (of 3) : f x IN s *)
+      CCONTR_TAC \\
+     ‘f x <> x’ by PROVE_TAC [] \\
+     ‘f (f x) = f x’ by PROVE_TAC [] \\
+      Q.PAT_X_ASSUM ‘!y. ?!x. f x = y’ (MP_TAC o (Q.SPEC ‘f (x:'a)’)) \\
+      RW_TAC std_ss [EXISTS_UNIQUE_THM] \\
+      DISJ2_TAC >> qexistsl_tac [‘f x’, ‘x’] >> art [],
+      (* goal 2 (of 3): ?!x. x IN s /\ y = f x *)
+      Q.PAT_X_ASSUM ‘!y. ?!x. f x = y’ (MP_TAC o (Q.SPEC ‘y’)) \\
+      RW_TAC pure_ss [EXISTS_UNIQUE_THM]
+      >- (Q.EXISTS_TAC ‘x’ >> METIS_TAC []) \\
+      rename1 ‘y = z’ \\
+      FIRST_X_ASSUM MATCH_MP_TAC >> art [],
+      (* goal 3 (of 3): f x = x *)
+      Cases_on ‘y IN s’
+      >- (Q.PAT_X_ASSUM ‘!y. y IN s ==> ?!x. x IN s /\ y = f x’
+            (MP_TAC o (Q.SPEC ‘y’)) \\
+          RW_TAC bool_ss [EXISTS_UNIQUE_THM] >- (Q.EXISTS_TAC ‘x’ >> rw []) \\
+          rename1 ‘y = z’ \\
+          FIRST_X_ASSUM MATCH_MP_TAC >> art [] \\
+          CONJ_TAC >> CCONTR_TAC >> METIS_TAC []) \\
+     ‘f y = y’ by PROVE_TAC [] \\
+      SIMP_TAC std_ss [EXISTS_UNIQUE_THM] \\
+      CONJ_TAC >- (Q.EXISTS_TAC ‘y’ >> rw []) \\
+      qx_genl_tac [‘x’, ‘z’] >> rpt STRIP_TAC \\
+     ‘x NOTIN s’ by METIS_TAC [] \\
+     ‘z NOTIN s’ by METIS_TAC [] \\
+     ‘f x = x /\ f z = z’ by PROVE_TAC [] \\
+      PROVE_TAC [] ]
+QED
+
+Theorem permutes_alt_univ :
+    !f. f permutes UNIV <=> f PERMUTES UNIV
+Proof
+    rw [permutes_alt]
+QED
+
+Theorem permutes_imp :
+    !f s. f permutes s ==> f PERMUTES s
+Proof
+    RW_TAC bool_ss [permutes_alt]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Inverse function (on whole universe).                                     *)
+(* ------------------------------------------------------------------------- *)
+
+Definition inverse :
+   inverse (f :'a->'b) = \y. @x. f x = y
+End
+
+(* This connection was suggested by Jeremy Dawson *)
+Theorem inverse_alt_LINV :
+    !f. (!y. ?x. f x = y) /\ (!x x'. (f x = f x') ==> (x = x')) ==>
+        inverse f = LINV f UNIV
+Proof
+    Q.X_GEN_TAC ‘f’ >> STRIP_TAC
+ >> simp [FUN_EQ_THM]
+ >> Q.X_GEN_TAC ‘y’ >> rw [inverse]
+ >> SELECT_ELIM_TAC >> rw []
+ >> ONCE_REWRITE_TAC [EQ_SYM_EQ]
+ >> irule LINV_DEF >> rw [INJ_DEF]
+ >> Q.EXISTS_TAC ‘UNIV’ >> rw []
+QED
+
+Theorem SURJECTIVE_INVERSE :
+   !f. (!y. ?x. f x = y) <=> !y. f (inverse f y) = y
+Proof
+  GEN_TAC THEN EQ_TAC THEN REPEAT STRIP_TAC THENL[
+REWRITE_TAC[inverse] THEN
+CONV_TAC (ONCE_DEPTH_CONV Thm.BETA_CONV) THEN CONV_TAC SELECT_CONV,
+Q.EXISTS_TAC(`inverse f y`)] THEN PROVE_TAC[]
+QED
+
+Theorem SURJECTIVE_INVERSE_o :
+   !f. (!y. ?x. f x = y) <=> (f o inverse f = I)
+Proof
+  REWRITE_TAC[FUN_EQ_THM, o_THM, I_THM, SURJECTIVE_INVERSE]
+QED
+
+Theorem INJECTIVE_INVERSE :
+   !f. (!x x'. (f x = f x') ==> (x = x')) = (!x. inverse f (f x) = x)
+Proof
+  GEN_TAC THEN EQ_TAC THENL[
+REPEAT STRIP_TAC THEN
+REWRITE_TAC[inverse] THEN
+CONV_TAC (ONCE_DEPTH_CONV Thm.BETA_CONV) THEN FIRST_ASSUM MATCH_MP_TAC THEN
+CONV_TAC SELECT_CONV THEN Q.EXISTS_TAC(`x`) THEN REFL_TAC,
+PROVE_TAC[]]
+QED
+
+Theorem INJECTIVE_INVERSE_o :
+   !f. (!x x'. (f x = f x') ==> (x = x')) = (inverse f o f = I)
+Proof
+  REWRITE_TAC[FUN_EQ_THM, o_THM, I_THM, INJECTIVE_INVERSE]
+QED
+
+Theorem INVERSE_UNIQUE_o :
+   !f g. (f o g = I) /\ (g o f = I) ==> (inverse f = g)
+Proof
+  REWRITE_TAC[FUN_EQ_THM, o_THM, I_THM] THEN
+  PROVE_TAC[INJECTIVE_INVERSE, SURJECTIVE_INVERSE]
+QED
+
+Theorem INVERSE_I :
+   inverse I = I
+Proof
+  MATCH_MP_TAC INVERSE_UNIQUE_o THEN REWRITE_TAC[I_o_ID]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Transpositions.                                                           *)
+(* ------------------------------------------------------------------------- *)
+
+(* cf. “pair$SWAP” (pairTheory.SWAP_def) *)
+Definition swap_def :
+   swap (i,j) k = if k = i then j else if k = j then i else k
+End
+
+Theorem SWAP_REFL :
+   !a. swap (a,a) = I
+Proof
+  REWRITE_TAC[FUN_EQ_THM, swap_def, I_THM] THEN PROVE_TAC[]
+QED
+
+Theorem SWAP_SYM :
+   !a b. swap(a,b) = swap(b,a)
+Proof
+  REWRITE_TAC[FUN_EQ_THM, swap_def, I_THM] THEN PROVE_TAC[]
+QED
+
+Theorem SWAP_IDEMPOTENT :
+   !a b. swap(a,b) o swap(a,b) = I
+Proof
+  REWRITE_TAC[FUN_EQ_THM, swap_def, o_THM, I_THM] THEN PROVE_TAC[]
+QED
+
+Theorem INVERSE_SWAP :
+   !a b. inverse(swap(a,b)) = swap(a,b)
+Proof
+  REPEAT GEN_TAC THEN MATCH_MP_TAC INVERSE_UNIQUE_o THEN
+  REWRITE_TAC[SWAP_IDEMPOTENT]
+QED
+
+Theorem SWAP_GALOIS :
+   !a b x y. (x = swap(a,b) y) = (y = swap(a,b) x)
+Proof
+  REWRITE_TAC[swap_def] THEN PROVE_TAC[]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Basic consequences of the definition.                                     *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem PERMUTES_IN_IMAGE :
+   !p s x. p permutes s ==> (p(x) IN s <=> x IN s)
+Proof
+  REWRITE_TAC[permutes] THEN PROVE_TAC[]
+QED
+
+Theorem PERMUTES_IMAGE :
+   !p s. p permutes s ==> (IMAGE p s = s)
+Proof
+  REWRITE_TAC[permutes, EXTENSION, IN_IMAGE] THEN PROVE_TAC[]
+QED
+
+Theorem PERMUTES_INJECTIVE :
+   !p s. p permutes s ==> !x y. (p(x) = p(y)) = (x = y)
+Proof
+  REWRITE_TAC[permutes] THEN PROVE_TAC[]
+QED
+
+Theorem PERMUTES_SURJECTIVE :
+   !p s. p permutes s ==> !y. ?x. p(x) = y
+Proof
+  REWRITE_TAC[permutes] THEN PROVE_TAC[]
+QED
+
+Theorem PERMUTES_INVERSES_o :
+   !p s. p permutes s ==> (p o inverse(p) = I) /\ (inverse(p) o p = I)
+Proof
+  REWRITE_TAC[GSYM INJECTIVE_INVERSE_o, GSYM SURJECTIVE_INVERSE_o] THEN
+  REWRITE_TAC[permutes] THEN PROVE_TAC[]
+QED
+
+Theorem PERMUTES_INVERSES :
+   !p s. p permutes s
+         ==> (!x. p(inverse(p) x) = x) /\ (!x. inverse(p) (p x) = x)
+Proof
+  REPEAT GEN_TAC THEN DISCH_THEN(MP_TAC o MATCH_MP PERMUTES_INVERSES_o) THEN
+  REWRITE_TAC[FUN_EQ_THM, o_THM, I_THM]
+QED
+
+Theorem PERMUTES_SUBSET :
+   !p s t. p permutes s /\ s SUBSET t ==> p permutes t
+Proof
+  REWRITE_TAC[permutes, SUBSET_DEF] THEN PROVE_TAC[]
+QED
+
+Theorem PERMUTES_EMPTY :
+   !p. p permutes {} <=> (p = I)
+Proof
+  REWRITE_TAC[FUN_EQ_THM, I_THM, permutes, NOT_IN_EMPTY] THEN PROVE_TAC[]
+QED
+
+Theorem PERMUTES_SING :
+   !p a. p permutes {a} <=> (p = I)
+Proof
+  REWRITE_TAC[FUN_EQ_THM, I_THM, permutes, IN_SING] THEN PROVE_TAC[]
+QED
+
+Theorem PERMUTES_UNIV :
+   !p. p permutes UNIV <=> !y. ?!x. p x = y
+Proof
+  REWRITE_TAC[permutes, IN_UNIV]
+QED
+
+Theorem PERMUTES_INVERSE_EQ :
+   !p s. p permutes s ==> !x y. (inverse(p) y = x) <=> (p x = y)
+Proof
+  REWRITE_TAC[permutes, inverse] THEN METIS_TAC[]
+QED
+
+Theorem PERMUTES_SWAP :
+   !a b s. a IN s /\ b IN s ==> swap(a,b) permutes s
+Proof
+  REWRITE_TAC[permutes, swap_def] THEN METIS_TAC[]
+QED
+
+Theorem PERMUTES_SUPERSET :
+   !p s t. p permutes s /\ (!x. x IN (s DIFF t) ==> (p(x) = x))
+           ==> p permutes t
+Proof
+  REWRITE_TAC[permutes, IN_DIFF] THEN PROVE_TAC[]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Group properties.                                                         *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem PERMUTES_I :
+   !s. I permutes s
+Proof
+  REWRITE_TAC[permutes, I_THM] THEN PROVE_TAC[]
+QED
+
+Theorem PERMUTES_COMPOSE :
+   !p q s x. p permutes s /\ q permutes s ==> (q o p) permutes s
+Proof
+  REWRITE_TAC[permutes, o_THM] THEN PROVE_TAC[]
+QED
+
+Theorem PERMUTES_INVERSE :
+   !p s. p permutes s ==> inverse(p) permutes s
+Proof
+  REPEAT STRIP_TAC THEN
+  FIRST_ASSUM(MP_TAC o MATCH_MP PERMUTES_INVERSE_EQ) THEN
+  POP_ASSUM MP_TAC THEN REWRITE_TAC[permutes] THEN PROVE_TAC[]
+QED
+
+Theorem PERMUTES_INVERSE_INVERSE :
+   !p s. p permutes s ==> (inverse(inverse(p)) = p)
+Proof
+  REWRITE_TAC [FUN_EQ_THM] THEN
+  PROVE_TAC[PERMUTES_INVERSE_EQ, PERMUTES_INVERSE]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* The number of permutations on a finite set.                               *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem PERMUTES_INSERT_LEMMA :
+   !p a s. p permutes (a INSERT s) ==> (swap(a,p(a)) o p) permutes s
+Proof
+  REPEAT STRIP_TAC THEN MATCH_MP_TAC PERMUTES_SUPERSET THEN
+  Q.EXISTS_TAC `a INSERT s` THEN CONJ_TAC THEN
+  METIS_TAC[PERMUTES_SWAP, PERMUTES_IN_IMAGE, IN_INSERT, PERMUTES_COMPOSE,
+            o_THM, swap_def, IN_DIFF]
+QED
+
+Theorem PERMUTES_INSERT :
+   {p | p permutes (a INSERT s)} =
+        IMAGE (\(b,p). swap(a,b) o p)
+              {(b,p) | b IN a INSERT s /\ p IN {p | p permutes s}}
+Proof
+  REWRITE_TAC[EXTENSION, IN_IMAGE] THEN Q.X_GEN_TAC `p: 'a -> 'a` THEN
+  CONV_TAC (DEPTH_CONV SET_SPEC_CONV) THEN
+  CONV_TAC(DEPTH_CONV GEN_BETA_CONV) THEN
+  SIMP_TAC std_ss[EXISTS_PROD]THEN EQ_TAC THENL
+   [DISCH_TAC THEN
+    qexistsl_tac [`(p: 'a -> 'a) a`, `swap(a,p a) o (p: 'a -> 'a)`]  THEN
+    ASM_REWRITE_TAC[SWAP_IDEMPOTENT, o_ASSOC, I_o_ID] THEN
+    PROVE_TAC[PERMUTES_IN_IMAGE, IN_INSERT, PERMUTES_INSERT_LEMMA],
+    SIMP_TAC std_ss[GSYM LEFT_FORALL_IMP_THM] THEN
+    qx_genl_tac [`b: 'a `, `q: 'a -> 'a `] THEN
+    STRIP_TAC THEN MATCH_MP_TAC PERMUTES_COMPOSE THEN
+    PROVE_TAC[PERMUTES_SUBSET, SUBSET_DEF, IN_INSERT, PERMUTES_SWAP]]
+QED
+
+Theorem HAS_SIZE_PERMUTATIONS :
+    !s:'a ->bool n: num. (s HAS_SIZE n) ==> ({p | p permutes s} HAS_SIZE (FACT n))
+Proof
+    SIMP_TAC std_ss [HAS_SIZE, GSYM AND_IMP_INTRO, RIGHT_FORALL_IMP_THM]
+ >> SET_INDUCT_TAC (* 2 sub-goals here *)
+ >> SIMP_TAC std_ss [PERMUTES_EMPTY, CARD_CLAUSES, GSPEC_EQ, FINITE_SING, CARD_SING, FACT]
+ >> REWRITE_TAC [GSYM HAS_SIZE, PERMUTES_INSERT]
+ >> MATCH_MP_TAC HAS_SIZE_IMAGE_INJ
+ >> CONJ_TAC (* still 2 sub-goals here *)
+ >| [ (* goal 1 (of 2) *)
+      SIMP_TAC std_ss [FORALL_PROD] \\
+      CONV_TAC (DEPTH_CONV SET_SPEC_CONV) \\
+      REWRITE_TAC[PAIR_EQ] \\
+      qx_genl_tac [`b: 'a`, `q: 'a -> 'a`, `c: 'a`, `r: 'a -> 'a`] \\
+      STRIP_TAC \\
+      Q.SUBGOAL_THEN `c: 'a = b` SUBST_ALL_TAC >| (* 2 sub-goals here *)
+      [ (* goal 1.1 (of 2) *)
+        FIRST_X_ASSUM (MP_TAC o C Q.AP_THM `e: 'a`) \\
+        REWRITE_TAC [o_THM, swap_def] \\
+        Q.SUBGOAL_THEN `((q: 'a -> 'a) e = e) /\ ((r: 'a -> 'a) e = e)`
+		(fn th => SIMP_TAC std_ss[th]) \\
+        PROVE_TAC [permutes],
+        (* goal 1.2 (of 2) *)
+        FIRST_X_ASSUM (MP_TAC o Q.AP_TERM `(\q:'a -> 'a. swap(e:'a,b) o q)`) \\
+        BETA_TAC \\
+        REWRITE_TAC [SWAP_IDEMPOTENT, o_ASSOC, I_o_ID] ],
+      (* goal 2 (of 2) *)
+      Know `{(b,p) | b IN e INSERT s /\ p IN {p | p permutes s}} =
+            (e INSERT s) CROSS {p | p permutes s}`
+      >- (REWRITE_TAC [EXTENSION, CROSS_DEF] \\
+          GEN_TAC >> REWRITE_TAC [GSPECIFICATION] >> BETA_TAC \\
+          REWRITE_TAC [PAIR_EQ] >> EQ_TAC >> STRIP_TAC >| (* 2 sub-goals here *)
+          [ (* goal 2.1 (of 2) *)
+            Cases_on `x'` >> FULL_SIMP_TAC std_ss [],
+            (* goal 2.2 (of 2) *)
+            Q.EXISTS_TAC `(FST x, SND x)` >> FULL_SIMP_TAC std_ss [] ] ) \\
+      DISCH_TAC >> ASM_REWRITE_TAC [] \\
+      ASM_SIMP_TAC std_ss [HAS_SIZE, FINITE_INSERT, CARD_CLAUSES, FINITE_CROSS,
+			   CARD_CROSS,FACT] ]
+QED
+
+Theorem FINITE_PERMUTATIONS :
+   !s. FINITE s ==> FINITE {p | p permutes s}
+Proof
+  METIS_TAC[HAS_SIZE_PERMUTATIONS, HAS_SIZE]
+QED
+
+Theorem CARD_PERMUTATIONS :
+   !s. FINITE s ==> (CARD {p | p permutes s} = FACT(CARD s))
+Proof
+  METIS_TAC[HAS_SIZE, HAS_SIZE_PERMUTATIONS]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Alternative characterizations of finite set.  (Be included in pred_set)   *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem FINITE_IMAGE_CARD :
+    !f s. FINITE s ==> CARD (IMAGE f s) <= CARD s
+Proof
+   GEN_TAC THEN HO_MATCH_MP_TAC FINITE_INDUCT THEN
+   RW_TAC std_ss[INJ_DEF, CARD_INSERT, NOT_IN_EMPTY, SUBSET_DEF, IN_IMAGE,
+                 IMAGE_EMPTY, CARD_EMPTY, IN_INSERT, IMAGE_INSERT,
+                 IMAGE_FINITE] THEN
+   RW_TAC arith_ss []
+QED
+
+Theorem SURJECTIVE_IFF_INJECTIVE_GEN :
+   !s t f: 'a -> 'b.
+        FINITE s /\ FINITE t /\ (CARD s = CARD t) /\ (IMAGE f s) SUBSET t
+        ==> ((!y. y IN t ==> ?x. x IN s /\ (f x = y)) <=>
+             (!x y. x IN s /\ y IN s /\ (f x = f y) ==> (x = y)))
+Proof
+  REPEAT STRIP_TAC THEN EQ_TAC THEN REPEAT STRIP_TAC THENL
+   [Q.ASM_CASES_TAC `x:'a = y` THEN ASM_REWRITE_TAC[] THEN
+    Q.SUBGOAL_THEN `CARD t <= CARD (IMAGE (f:'a -> 'b) (s DELETE y))` MP_TAC THENL
+     [MATCH_MP_TAC (SIMP_RULE std_ss[GSYM RIGHT_FORALL_IMP_THM,AND_IMP_INTRO] CARD_SUBSET) THEN
+      ASM_SIMP_TAC std_ss[IMAGE_FINITE, FINITE_DELETE] THEN
+      REWRITE_TAC[SUBSET_DEF, IN_IMAGE, IN_DELETE] THEN PROVE_TAC[],
+      REWRITE_TAC[GSYM NOT_LESS] THEN MATCH_MP_TAC LESS_EQ_LESS_TRANS THEN
+      Q.EXISTS_TAC `CARD(s DELETE (y:'a))` THEN
+      ASM_SIMP_TAC std_ss[FINITE_IMAGE_CARD, FINITE_DELETE, CARD_DELETE] THEN
+      PROVE_TAC[NOT_ZERO_LT_ZERO,CARD_EQ_0, MEMBER_NOT_EMPTY]],
+    Q.SUBGOAL_THEN `IMAGE (f:'a -> 'b) s = t` MP_TAC THENL
+     [PROVE_TAC [IMAGE_FINITE, CARD_IMAGE_INJ, SUBSET_EQ_CARD],
+      PROVE_TAC[EXTENSION, IN_IMAGE]]]
+QED
+
+Theorem SURJECTIVE_IFF_INJECTIVE :
+   !s f: 'a -> 'a.
+        FINITE s /\ (IMAGE f s) SUBSET s
+        ==> ((!y. y IN s ==> ?x. x IN s /\ (f x = y)) <=>
+             (!x y. x IN s /\ y IN s /\ (f x = f y) ==> (x = y)))
+Proof
+  SIMP_TAC std_ss[SURJECTIVE_IFF_INJECTIVE_GEN]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Alternative characterizations of permutation of finite set.               *)
+(* ------------------------------------------------------------------------- *)
+
+(* TODO: the following 2 theorem need long proof search of METIC_TAC *)
+Theorem PERMUTES_FINITE_INJECTIVE :
+   !s: 'a->bool p.
+        FINITE s
+        ==> (p permutes s <=>
+             (!x. ~(x IN s) ==> (p x = x)) /\
+             (!x. x IN s ==> p x IN s) /\
+             (!x y. x IN s /\ y IN s /\ (p x = p y) ==> (x = y)))
+Proof
+  REWRITE_TAC[permutes] THEN REPEAT STRIP_TAC THEN
+  MATCH_MP_TAC(TAUT `(p ==> (q <=> r)) ==> (p /\ q <=> p /\ r)`) THEN
+  DISCH_TAC THEN EQ_TAC THENL [PROVE_TAC[], ALL_TAC] THEN STRIP_TAC THEN
+  FIRST_ASSUM(MP_TAC o Q.SPEC `p: 'a -> 'a ` o MATCH_MP
+   (REWRITE_RULE[GSYM AND_IMP_INTRO] SURJECTIVE_IFF_INJECTIVE)) THEN
+  ASM_SIMP_TAC std_ss[SUBSET_DEF, FORALL_IN_IMAGE] THEN
+  STRIP_TAC THEN Q.X_GEN_TAC `y: 'a ` THEN
+  Q.ASM_CASES_TAC `(y: 'a) IN s` THEN METIS_TAC[]
+QED
+
+Theorem PERMUTES_FINITE_SURJECTIVE :
+   !s: 'a ->bool p.
+        FINITE s
+        ==> (p permutes s <=>
+             (!x. ~(x IN s) ==> (p x = x)) /\ (!x. x IN s ==> p x IN s) /\
+             (!y. y IN s ==> ?x. x IN s /\ (p x = y)))
+Proof
+  REWRITE_TAC[permutes] THEN REPEAT STRIP_TAC THEN
+  MATCH_MP_TAC(TAUT `(p ==> (q <=> r)) ==> (p /\ q <=> p /\ r)`) THEN
+  DISCH_TAC THEN EQ_TAC THENL [PROVE_TAC[], ALL_TAC] THEN STRIP_TAC THEN
+  FIRST_ASSUM(MP_TAC o Q.SPEC `p: 'a -> 'a ` o MATCH_MP
+   (REWRITE_RULE[GSYM AND_IMP_INTRO] SURJECTIVE_IFF_INJECTIVE)) THEN
+  ASM_SIMP_TAC std_ss[SUBSET_DEF, FORALL_IN_IMAGE] THEN
+  STRIP_TAC THEN Q.X_GEN_TAC `y: 'a ` THEN
+  Q.ASM_CASES_TAC `(y: 'a) IN s` THEN METIS_TAC[]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Permutations of index set for iterated operations.                        *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem ITERATE_PERMUTE :
+   !op. monoidal op ==>
+       !(f:'a -> 'b) p s. p permutes s ==> (iterate op s f = iterate op s (f o p))
+Proof
+  REPEAT STRIP_TAC THEN
+  FIRST_X_ASSUM(MATCH_MP_TAC o MATCH_MP ITERATE_BIJECTION) THEN
+  PROVE_TAC[permutes]
+QED
+
+Theorem NSUM_PERMUTE :
+   !f p s. p permutes s ==> (nsum s f = nsum s (f o p))
+Proof
+  REWRITE_TAC[nsum] THEN MATCH_MP_TAC ITERATE_PERMUTE THEN
+  REWRITE_TAC[MONOIDAL_ADD]
+QED
+
+Theorem NSUM_PERMUTE_COUNT :
+   !f p n. p permutes (count n) ==> (nsum (count n) f = nsum (count n) (f o p))
+Proof
+  PROVE_TAC[NSUM_PERMUTE, FINITE_COUNT]
+QED
+
+Theorem NSUM_PERMUTE_NUMSEG :
+   !f p m n.
+  p permutes (count n DIFF count m) ==>
+   (nsum (count n DIFF count m) f = nsum (count n DIFF count m) (f o p))
+Proof
+  PROVE_TAC[NSUM_PERMUTE, FINITE_COUNT, FINITE_DIFF]
+QED
+
+Theorem SUM_PERMUTE :
+   !f p s. p permutes s ==> (sum s f = sum s (f o p))
+Proof
+  REWRITE_TAC[sum_def] THEN MATCH_MP_TAC ITERATE_PERMUTE THEN
+  REWRITE_TAC[MONOIDAL_REAL_ADD]
+QED
+
+Theorem SUM_PERMUTE_COUNT :
+   !f p n. p permutes (count n) ==> (sum (count n) f = sum (count n) (f o p))
+Proof
+  PROVE_TAC[SUM_PERMUTE, FINITE_COUNT]
+QED
+
+Theorem SUM_PERMUTE_NUMSEG :
+   !f p m n.
+  p permutes (count n DIFF count m) ==>
+   (sum (count n DIFF count m) f = sum (count n DIFF count m) (f o p))
+Proof
+  PROVE_TAC[SUM_PERMUTE, FINITE_COUNT, FINITE_DIFF]
+QED
+
+Theorem PRODUCT_PERMUTE :
+   !f p s. p permutes s ==> (product s f = product s (f o p))
+Proof
+  REWRITE_TAC[product] THEN MATCH_MP_TAC ITERATE_PERMUTE THEN
+  REWRITE_TAC[MONOIDAL_REAL_MUL]
+QED
+
+Theorem PRODUCT_PERMUTE_COUNT :
+   !f p n.
+    p permutes (count n) ==> (product (count n) f = product (count n) (f o p))
+Proof
+  PROVE_TAC[PRODUCT_PERMUTE, FINITE_COUNT]
+QED
+
+Theorem PRODUCT_PERMUTE_NUMSEG :
+   !f p m n.
+     p permutes (count n DIFF count m) ==>
+       (product (count n DIFF count m) f = product (count n DIFF count m) (f o p))
+Proof
+  PROVE_TAC[PRODUCT_PERMUTE, FINITE_COUNT, FINITE_DIFF]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Various combinations of transpositions with 2, 1 and 0 common elements.   *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem SWAP_COMMON :
+   !a b c: 'a. ~(a = c) /\ ~(b = c)
+             ==> (swap(a,b) o swap(a,c) = swap(b,c) o swap(a,b))
+Proof
+  REPEAT GEN_TAC THEN REWRITE_TAC[FUN_EQ_THM, swap_def, o_THM] THEN
+  DISCH_TAC THEN GEN_TAC THEN
+  MAP_EVERY Q.ASM_CASES_TAC [`x: 'a = a`, `x: 'a = b`, `x: 'a = c`] THEN
+  REPEAT(FIRST_X_ASSUM SUBST_ALL_TAC) THEN ASM_REWRITE_TAC[] THEN
+  PROVE_TAC[]
+QED
+
+Theorem SWAP_COMMON' :
+   !a b c:'a. ~(a = b) /\ ~(a = c)
+             ==> (swap(a,c) o swap(b,c) = swap(b,c) o swap(a,b))
+Proof
+  REPEAT STRIP_TAC THEN
+  GEN_REWRITE_TAC (LAND_CONV o LAND_CONV) empty_rewrites [SWAP_SYM] THEN
+  ASM_SIMP_TAC std_ss[GSYM SWAP_COMMON] THEN
+  GEN_REWRITE_TAC (RAND_CONV o RAND_CONV) empty_rewrites [SWAP_SYM] THEN
+  REFL_TAC
+QED
+
+Theorem SWAP_INDEPENDENT :
+   !a b c d:'a. ~(a = c) /\ ~(a = d) /\ ~(b = c) /\ ~(b = d)
+               ==> (swap(a,b) o swap(c,d) = swap(c,d) o swap(a,b))
+Proof
+  REPEAT GEN_TAC THEN REWRITE_TAC[FUN_EQ_THM, swap_def, o_THM]  THEN
+  DISCH_TAC THEN GEN_TAC THEN
+  MAP_EVERY Q.ASM_CASES_TAC [`x: 'a = a`, `x: 'a = b`, `x: 'a = c`] THEN
+  REPEAT(FIRST_X_ASSUM SUBST_ALL_TAC) THEN ASM_REWRITE_TAC[] THEN
+  PROVE_TAC[]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Permutations as transposition sequences.                                  *)
+(* ------------------------------------------------------------------------- *)
+
+Inductive swapseq :
+   (swapseq 0 I) /\
+   (!a b p n. swapseq n p /\ ~(a = b) ==> swapseq (SUC n) (swap(a,b) o p))
+End
+
+Definition permutation :
+   permutation p = ?n. swapseq n p
+End
+
+(* ------------------------------------------------------------------------- *)
+(* Some closure properties of the set of permutations, with lengths.         *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem SWAPSEQ_I = CONJUNCT1 swapseq_rules
+
+Theorem PERMUTATION_I :
+   permutation I
+Proof
+  REWRITE_TAC[permutation] THEN PROVE_TAC[SWAPSEQ_I]
+QED
+
+Theorem SWAPSEQ_SWAP :
+   !a b. swapseq (if a = b then 0 else 1) (swap(a,b))
+Proof
+  REPEAT GEN_TAC THEN COND_CASES_TAC THEN ASM_REWRITE_TAC[num_CONV ``1:num``] THEN
+  PROVE_TAC[swapseq_rules, I_o_ID, SWAPSEQ_I, SWAP_REFL]
+QED
+
+Theorem PERMUTATION_SWAP :
+   !a b. permutation (swap(a,b))
+Proof
+  REWRITE_TAC[permutation] THEN PROVE_TAC[SWAPSEQ_SWAP]
+QED
+
+Theorem SWAPSEQ_COMPOSE :
+   !n p m q. swapseq n p /\ swapseq m q ==> swapseq (n + m) (p o q)
+Proof
+  SIMP_TAC std_ss[RIGHT_FORALL_IMP_THM, GSYM AND_IMP_INTRO] THEN
+  HO_MATCH_MP_TAC swapseq_ind THEN
+  REWRITE_TAC[ADD_CLAUSES, I_o_ID, GSYM o_ASSOC] THEN
+  PROVE_TAC[swapseq_rules]
+QED
+
+Theorem PERMUTATION_COMPOSE :
+   !p q. permutation p /\ permutation q ==> permutation (p o q)
+Proof
+  REWRITE_TAC[permutation] THEN PROVE_TAC[SWAPSEQ_COMPOSE]
+QED
+
+Theorem SWAPSEQ_ENDSWAP :
+   !n p a b:'a. swapseq n p /\ ~(a = b) ==> swapseq (SUC n) (p o swap(a,b))
+Proof
+  SIMP_TAC std_ss[RIGHT_FORALL_IMP_THM, GSYM AND_IMP_INTRO] THEN
+  HO_MATCH_MP_TAC swapseq_ind THEN REWRITE_TAC[I_o_ID, GSYM o_ASSOC] THEN
+  PROVE_TAC[o_ASSOC, swapseq_rules, I_o_ID]
+QED
+
+Theorem SWAPSEQ_INVERSE_EXISTS :
+   !n p:'a->'a. swapseq n p ==> ?q. swapseq n q /\ (p o q = I) /\ (q o p = I)
+Proof
+  HO_MATCH_MP_TAC swapseq_ind THEN CONJ_TAC THENL
+   [PROVE_TAC[I_o_ID, swapseq_rules], ALL_TAC] THEN
+  REPEAT STRIP_TAC THEN
+  MP_TAC(Q.SPECL [`n:num`, `q:'a->'a`, `a:'a`, `b:'a`] SWAPSEQ_ENDSWAP) THEN
+  ASM_REWRITE_TAC[] THEN DISCH_TAC THEN
+  Q.EXISTS_TAC `(q:'a->'a) o swap(a,b)` THEN
+  ASM_REWRITE_TAC[GSYM o_ASSOC] THEN
+  GEN_REWRITE_TAC (BINOP_CONV o LAND_CONV o RAND_CONV) empty_rewrites [o_ASSOC] THEN
+  ASM_REWRITE_TAC[SWAP_IDEMPOTENT, I_o_ID]
+QED
+
+Theorem SWAPSEQ_INVERSE :
+   !n p. swapseq n p ==> swapseq n (inverse p)
+Proof
+  PROVE_TAC[SWAPSEQ_INVERSE_EXISTS, INVERSE_UNIQUE_o]
+QED
+
+Theorem PERMUTATION_INVERSE :
+   !p. permutation p ==> permutation (inverse p)
+Proof
+  REWRITE_TAC[permutation] THEN PROVE_TAC[SWAPSEQ_INVERSE]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* The identity map only has even transposition sequences.                   *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem SYMMETRY_LEMMA[local] :
+   (!a b c d:'a. P a b c d ==> P a b d c) /\
+   (!a b c d. ~(a = b) /\ ~(c = d) /\
+             ((a = c) /\ (b = d) \/ (a = c) /\ ~(b = d) \/ ~(a = c) /\ (b = d) \/
+               ~(a = c) /\ ~(a = d) /\ ~(b = c) /\ ~(b = d))
+              ==> P a b c d)
+   ==> (!a b c d. ~(a = b) /\ ~(c = d) ==> P a b c d)
+Proof
+  REPEAT STRIP_TAC THEN MAP_EVERY Q.ASM_CASES_TAC
+   [`a:'a = c`, `a:'a = d`, `b:'a = c`, `b:'a = d`] THEN
+  PROVE_TAC[]
+QED
+
+Theorem SWAP_GENERAL :
+   !a b c d:'a.
+        ~(a = b) /\ ~(c = d)
+        ==> (swap(a,b) o swap(c,d) = I) \/
+            ?x y z. ~(x = a) /\ ~(y = a) /\ ~(z = a) /\ ~(x = y) /\
+                    (swap(a,b) o swap(c,d) = swap(x,y) o swap(a,z))
+Proof
+  HO_MATCH_MP_TAC SYMMETRY_LEMMA THEN CONJ_TAC THENL
+   [SIMP_TAC std_ss[SWAP_SYM], ALL_TAC] THEN
+  REPEAT STRIP_TAC THEN REPEAT(FIRST_X_ASSUM SUBST_ALL_TAC) THENL
+   [PROVE_TAC[SWAP_IDEMPOTENT],
+    DISJ2_TAC THEN qexistsl_tac [`b:'a`, `d:'a`, `b:'a`] THEN
+    PROVE_TAC[SWAP_COMMON],
+    DISJ2_TAC THEN qexistsl_tac [`c:'a`, `d:'a`, `c:'a`] THEN
+    PROVE_TAC[SWAP_COMMON'],
+    DISJ2_TAC THEN qexistsl_tac [`c:'a`, `d:'a`, `b:'a`] THEN
+  PROVE_TAC[SWAP_INDEPENDENT]]
+QED
+
+Theorem FIXING_SWAPSEQ_DECREASE :
+   !n p a b:'a.
+      swapseq n p /\ ~(a = b) /\ ((swap(a,b) o p) a = a)
+      ==> ~(n = 0) /\ swapseq (n - 1) (swap(a,b) o p)
+Proof
+  INDUCT_TAC THEN REPEAT GEN_TAC THEN
+  GEN_REWRITE_TAC (LAND_CONV o LAND_CONV) empty_rewrites [swapseq_cases] THEN
+  REWRITE_TAC[SUC_NOT, GSYM SUC_NOT] THENL
+   [DISCH_THEN(CONJUNCTS_THEN2 ASSUME_TAC MP_TAC) THEN
+    ASM_REWRITE_TAC[I_THM, o_THM, swap_def] THEN PROVE_TAC[],
+    ALL_TAC] THEN
+  SIMP_TAC bool_ss[GSYM LEFT_FORALL_IMP_THM, GSYM LEFT_EXISTS_AND_THM] THEN
+  qx_genl_tac [`c:'a`, `d:'a`, `q:'a->'a`, `m:num`] THEN
+  REWRITE_TAC[ADD1,EQ_ADD_RCANCEL, GSYM CONJ_ASSOC] THEN
+  DISCH_THEN(CONJUNCTS_THEN2 ASSUME_TAC MP_TAC) THEN
+  FIRST_X_ASSUM(SUBST_ALL_TAC o SYM) THEN
+  DISCH_THEN(CONJUNCTS_THEN2 ASSUME_TAC MP_TAC) THEN
+  FIRST_X_ASSUM SUBST_ALL_TAC THEN REWRITE_TAC[o_ASSOC] THEN STRIP_TAC THEN
+  MP_TAC(Q.SPECL [`a:'a`, `b:'a`, `c:'a`, `d:'a`] SWAP_GENERAL) THEN
+  ASM_REWRITE_TAC[] THEN
+  DISCH_THEN(DISJ_CASES_THEN2 SUBST_ALL_TAC MP_TAC) THEN
+  ASM_REWRITE_TAC[I_o_ID, ADD_SUB] THEN
+  SIMP_TAC bool_ss[GSYM LEFT_FORALL_IMP_THM] THEN
+  qx_genl_tac [`x:'a`, `y:'a`, `z:'a`] THEN
+  REPEAT(DISCH_THEN(CONJUNCTS_THEN2 ASSUME_TAC MP_TAC)) THEN
+  DISCH_THEN SUBST_ALL_TAC THEN FIRST_X_ASSUM(MP_TAC o Q.SPECL
+   [`q:'a->'a`, `a:'a`, `z:'a`]) THEN
+  GEN_REWRITE_TAC (LAND_CONV) empty_rewrites [IMP_DISJ_THM] THEN
+  REWRITE_TAC[DISJ_IMP_THM] THEN CONJ_TAC THENL
+   [GEN_REWRITE_TAC (RAND_CONV o LAND_CONV o ONCE_DEPTH_CONV)
+    empty_rewrites [EQ_SYM_EQ] THEN ASM_REWRITE_TAC[] THEN
+    Q.PAT_X_ASSUM `$= X Y` MP_TAC THEN
+    REWRITE_TAC[GSYM o_ASSOC] THEN
+    Q.ABBREV_TAC `r:'a->'a = swap(a:'a,z) o q` THEN
+    ASM_REWRITE_TAC[FUN_EQ_THM, o_THM, swap_def] THEN PROVE_TAC[],
+    qid_spec_tac `n:num` THEN INDUCT_TAC THEN
+    REWRITE_TAC[SUC_NOT, SUC_SUB1, GSYM o_ASSOC] THEN
+  PROVE_TAC[swapseq_rules]]
+QED
+
+Theorem SWAPSEQ_IDENTITY_EVEN :
+   !n. swapseq n (I:'a->'a) ==> EVEN n
+Proof
+  HO_MATCH_MP_TAC COMPLETE_INDUCTION THEN Q.X_GEN_TAC `n:num` THEN DISCH_TAC THEN
+  GEN_REWRITE_TAC LAND_CONV empty_rewrites [swapseq_cases] THEN
+  DISCH_THEN(DISJ_CASES_THEN2 (SUBST_ALL_TAC o CONJUNCT1) MP_TAC) THEN
+  REWRITE_TAC[EVEN] THEN SIMP_TAC bool_ss[GSYM LEFT_FORALL_IMP_THM] THEN
+  qx_genl_tac [`a:'a`, `b:'a`, `p:'a->'a`, `m:num`] THEN
+  DISCH_THEN(STRIP_ASSUME_TAC o GSYM) THEN
+  MP_TAC(Q.SPECL [`m:num`, `p:'a->'a`, `a:'a`, `b:'a`]
+    FIXING_SWAPSEQ_DECREASE) THEN
+  GEN_REWRITE_TAC (LAND_CONV o LAND_CONV o RAND_CONV o LAND_CONV o ONCE_DEPTH_CONV)
+    empty_rewrites [EQ_SYM_EQ] THEN ASM_REWRITE_TAC[I_THM] THEN STRIP_TAC THEN
+  FIRST_X_ASSUM(MP_TAC o SPEC ``(m - 1):num``) THEN
+  Q.UNDISCH_THEN `SUC m = n` (SUBST_ALL_TAC o SYM) THEN
+  ASM_REWRITE_TAC[DECIDE ``m - 1 < SUC m``] THEN Q.UNDISCH_TAC `~(m = 0)` THEN
+  qid_spec_tac `m:num` THEN INDUCT_TAC THEN
+  REWRITE_TAC[SUC_SUB1, EVEN]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Therefore we have a welldefined notion of parity.                         *)
+(* ------------------------------------------------------------------------- *)
+
+Definition evenperm :
+   evenperm p = EVEN(@n. swapseq n p)
+End
+
+Theorem SWAPSEQ_EVEN_EVEN :
+   !m n p:'a->'a. swapseq m p /\ swapseq n p ==> (EVEN m <=> EVEN n)
+Proof
+  REPEAT STRIP_TAC THEN
+  FIRST_X_ASSUM(MP_TAC o MATCH_MP SWAPSEQ_INVERSE_EXISTS) THEN
+  STRIP_TAC THEN
+  FIRST_X_ASSUM(MP_TAC o AP_TERM ``swapseq (n + m) :('a->'a)->bool``) THEN
+  ASM_SIMP_TAC bool_ss[SWAPSEQ_COMPOSE] THEN
+  DISCH_THEN(MP_TAC o MATCH_MP SWAPSEQ_IDENTITY_EVEN) THEN
+  SIMP_TAC bool_ss[EVEN_ADD]
+QED
+
+Theorem EVENPERM_UNIQUE :
+   !n p b. swapseq n p /\ (EVEN n = b) ==> (evenperm p = b)
+Proof
+  REWRITE_TAC[evenperm] THEN METIS_TAC[SWAPSEQ_EVEN_EVEN]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* And it has the expected composition properties.                           *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem EVENPERM_I :
+   evenperm I = T
+Proof
+  MATCH_MP_TAC EVENPERM_UNIQUE THEN PROVE_TAC[swapseq_rules, EVEN]
+QED
+
+Theorem EVENPERM_SWAP :
+   !a b:'a. evenperm (swap(a,b)) <=> (a = b)
+Proof
+  REPEAT GEN_TAC THEN MATCH_MP_TAC EVENPERM_UNIQUE THEN
+  METIS_TAC[SWAPSEQ_SWAP, EVEN, num_CONV ``1:num``]
+QED
+
+Theorem EVENPERM_COMPOSE :
+   !p q. permutation p /\ permutation q
+         ==> (evenperm (p o q) = (evenperm p = evenperm q))
+Proof
+  REWRITE_TAC[permutation] THEN
+  SIMP_TAC bool_ss[GSYM LEFT_EXISTS_AND_THM, GSYM RIGHT_EXISTS_AND_THM] THEN
+  SIMP_TAC bool_ss[GSYM LEFT_FORALL_IMP_THM] THEN REPEAT GEN_TAC THEN
+  DISCH_THEN(fn th => ASSUME_TAC th THEN
+               ASSUME_TAC(MATCH_MP SWAPSEQ_COMPOSE th)) THEN
+  METIS_TAC[EVENPERM_UNIQUE, SWAPSEQ_COMPOSE, EVEN_ADD]
+QED
+
+Theorem EVENPERM_INVERSE :
+   !p. permutation p ==> (evenperm (inverse p) = evenperm p)
+Proof
+  REWRITE_TAC[permutation] THEN REPEAT STRIP_TAC THEN
+  MATCH_MP_TAC EVENPERM_UNIQUE THEN
+  METIS_TAC[SWAPSEQ_INVERSE, EVENPERM_UNIQUE]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* A more abstract characterization of permutations.                         *)
+(* ------------------------------------------------------------------------- *)
+
+(* cf. pred_setTheory.BIJ_ALT *)
+Theorem PERMUTATION_BIJECTIVE :
+   !p. permutation p ==> !y. ?!x. p(x) = y
+Proof
+  REWRITE_TAC[permutation] THEN REPEAT STRIP_TAC THEN
+  FIRST_X_ASSUM(MP_TAC o MATCH_MP SWAPSEQ_INVERSE_EXISTS) THEN
+  SIMP_TAC bool_ss[FUN_EQ_THM, I_THM, o_THM, GSYM LEFT_FORALL_IMP_THM] THEN
+  METIS_TAC[]
+QED
+
+Theorem PERMUTATION_FINITE_SUPPORT :
+   !p. permutation p ==> FINITE {x:'a| ~(p x = x)}
+Proof
+  SIMP_TAC bool_ss[permutation, GSYM LEFT_FORALL_IMP_THM] THEN
+  CONV_TAC SWAP_VARS_CONV THEN HO_MATCH_MP_TAC swapseq_ind THEN
+  REWRITE_TAC[I_THM, FINITE_RULES,
+              Q.prove (`{x | F} = {}`,REWRITE_TAC[EXTENSION] THEN
+              CONV_TAC (DEPTH_CONV SET_SPEC_CONV) THEN
+              REWRITE_TAC[NOT_IN_EMPTY])] THEN
+  qx_genl_tac [`a:'a`, `b:'a`, `p:'a->'a`] THEN
+  STRIP_TAC THEN MATCH_MP_TAC SUBSET_FINITE_I THEN
+  Q.EXISTS_TAC `(a:'a) INSERT b INSERT {x | ~(p x = x)}` THEN
+  ASM_REWRITE_TAC[FINITE_INSERT, SUBSET_DEF, IN_INSERT] THEN
+  CONV_TAC (DEPTH_CONV SET_SPEC_CONV) THEN
+  REWRITE_TAC[o_THM, swap_def] THEN PROVE_TAC[]
+QED
+
+Theorem PERMUTATION_LEMMA :
+   !s p:'a->'a.
+       FINITE s /\
+       (!y. ?!x. p(x) = y) /\ (!x. ~(x IN s) ==> (p x = x))
+       ==> permutation p
+Proof
+  ONCE_REWRITE_TAC[GSYM AND_IMP_INTRO] THEN
+  SIMP_TAC bool_ss[RIGHT_FORALL_IMP_THM] THEN
+  HO_MATCH_MP_TAC FINITE_INDUCT THEN CONJ_TAC THENL
+   [REWRITE_TAC[NOT_IN_EMPTY] THEN REPEAT STRIP_TAC THEN
+    Q.SUBGOAL_THEN `p:'a->'a = I` (fn th => REWRITE_TAC[th, PERMUTATION_I]) THEN
+    ASM_REWRITE_TAC[FUN_EQ_THM, I_THM],
+    ALL_TAC] THEN
+  Q.X_GEN_TAC `s:'a->bool` THEN STRIP_TAC THEN Q.X_GEN_TAC `a:'a` THEN
+  REWRITE_TAC[IN_INSERT] THEN REPEAT STRIP_TAC THEN
+  Q.SUBGOAL_THEN `permutation ((swap(a,p(a)) o swap(a,p(a))) o (p:'a->'a))`
+  MP_TAC THENL [ALL_TAC, REWRITE_TAC[SWAP_IDEMPOTENT, I_o_ID]] THEN
+  REWRITE_TAC[GSYM o_ASSOC] THEN MATCH_MP_TAC PERMUTATION_COMPOSE THEN
+  REWRITE_TAC[PERMUTATION_SWAP] THEN FIRST_X_ASSUM MATCH_MP_TAC THEN
+  CONJ_TAC THENL
+   [Q.UNDISCH_TAC `!y. ?!x. (p:'a->'a) x = y` THEN
+    SIMP_TAC bool_ss[EXISTS_UNIQUE_THM, swap_def, o_THM] THEN
+    Q.ASM_CASES_TAC `(p:'a->'a) a = a` THEN ASM_REWRITE_TAC[] THENL
+     [PROVE_TAC[], ALL_TAC] THEN
+    REWRITE_TAC[Q.prove(
+     `((if p then x else y) = a) <=> if p then x = a else y = a`,PROVE_TAC[])] THEN
+    REWRITE_TAC[TAUT `(if p then x else y) <=> p /\ x \/ ~p /\ y`] THEN
+    PROVE_TAC[],
+    REWRITE_TAC[swap_def, o_THM] THEN
+    Q.ASM_CASES_TAC `(p:'a->'a) a = a` THEN ASM_REWRITE_TAC[] THEN
+    PROVE_TAC[]]
+QED
+
+Theorem PERMUTATION :
+   !p. permutation p <=> (!y. ?!x. p(x) = y) /\ FINITE {x:'a| ~(p(x) = x)}
+Proof
+  GEN_TAC THEN EQ_TAC THEN
+  SIMP_TAC bool_ss[PERMUTATION_BIJECTIVE, PERMUTATION_FINITE_SUPPORT] THEN
+  STRIP_TAC THEN MATCH_MP_TAC PERMUTATION_LEMMA THEN
+  Q.EXISTS_TAC `{x:'a| ~(p x = x)}` THEN
+  CONV_TAC (DEPTH_CONV SET_SPEC_CONV) THEN
+  ASM_REWRITE_TAC[]
+QED
+
+Theorem PERMUTATION_INVERSE_WORKS :
+   !p. permutation p ==> (inverse p o p = I) /\ (p o inverse p = I)
+Proof
+  PROVE_TAC[PERMUTATION_BIJECTIVE, SURJECTIVE_INVERSE_o,
+            INJECTIVE_INVERSE_o]
+QED
+
+Theorem PERMUTATION_INVERSE_COMPOSE :
+   !p q. permutation p /\ permutation q
+         ==> (inverse (p o q) = inverse q o inverse p)
+Proof
+  REPEAT STRIP_TAC THEN MATCH_MP_TAC INVERSE_UNIQUE_o THEN
+  REPEAT(FIRST_X_ASSUM(MP_TAC o MATCH_MP PERMUTATION_INVERSE_WORKS)) THEN
+  REWRITE_TAC[GSYM o_ASSOC] THEN REPEAT STRIP_TAC THEN
+  GEN_REWRITE_TAC (LAND_CONV o RAND_CONV) empty_rewrites [o_ASSOC] THEN
+  ASM_REWRITE_TAC[I_o_ID]
+QED
+
+val IMP_CONJ = CONJ_EQ_IMP;
+
+Theorem PERMUTATION_COMPOSE_EQ :
+   (!p q:'a->'a. permutation(p) ==> (permutation(p o q) <=> permutation q)) /\
+   (!p q:'a->'a. permutation(q) ==> (permutation(p o q) <=> permutation p))
+Proof
+  REPEAT STRIP_TAC THEN
+  FIRST_ASSUM(ASSUME_TAC o MATCH_MP PERMUTATION_INVERSE) THEN
+  EQ_TAC THEN ASM_SIMP_TAC std_ss [PERMUTATION_COMPOSE] THENL
+   [DISCH_THEN(MP_TAC o Q.SPEC `inverse(p:'a->'a)` o MATCH_MP
+     (REWRITE_RULE[IMP_CONJ_ALT] PERMUTATION_COMPOSE)),
+    DISCH_THEN(MP_TAC o Q.SPEC `inverse(q:'a->'a)` o MATCH_MP
+     (REWRITE_RULE[IMP_CONJ] PERMUTATION_COMPOSE))] THEN
+  ASM_SIMP_TAC std_ss [GSYM o_ASSOC, PERMUTATION_INVERSE_WORKS] THEN
+  ASM_SIMP_TAC bool_ss [o_ASSOC, PERMUTATION_INVERSE_WORKS] THEN
+  REWRITE_TAC[I_o_ID]
+QED
+
+Theorem PERMUTATION_COMPOSE_SWAP :
+   (!p a b:'a. permutation(swap(a,b) o p) <=> permutation p) /\
+   (!p a b:'a. permutation(p o swap(a,b)) <=> permutation p)
+Proof
+  SIMP_TAC bool_ss [PERMUTATION_COMPOSE_EQ, PERMUTATION_SWAP]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Relation to "permutes".                                                   *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem PERMUTATION_PERMUTES :
+   !p:'a->'a. permutation p <=> ?s. FINITE s /\ p permutes s
+Proof
+  GEN_TAC THEN REWRITE_TAC[PERMUTATION, permutes] THEN
+  EQ_TAC THEN STRIP_TAC THEN ASM_REWRITE_TAC[] THENL
+   [Q.EXISTS_TAC `{x:'a | ~(p x = x)}` THEN
+    CONV_TAC (DEPTH_CONV SET_SPEC_CONV) THEN
+    ASM_REWRITE_TAC[],
+    MATCH_MP_TAC SUBSET_FINITE_I THEN Q.EXISTS_TAC `s:'a->bool` THEN
+    ASM_REWRITE_TAC[SUBSET_DEF] THEN
+    CONV_TAC (DEPTH_CONV SET_SPEC_CONV) THEN PROVE_TAC[]]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Hence a sort of induction principle composing by swaps.                   *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem PERMUTES_INDUCT :
+   !P s. FINITE s /\
+         P I /\
+         (!a b:'a p. a IN s /\ b IN s /\ P p /\ permutation p
+                    ==> P (swap(a,b) o p))
+         ==> (!p. p permutes s ==> P p)
+Proof
+  ONCE_REWRITE_TAC[TAUT `a /\ b /\ c ==> d <=> b ==> a ==> c ==> d`] THEN
+  SIMP_TAC std_ss[RIGHT_FORALL_IMP_THM] THEN GEN_TAC THEN DISCH_TAC THEN
+  HO_MATCH_MP_TAC FINITE_INDUCT THEN
+  ASM_REWRITE_TAC[PERMUTES_EMPTY, IN_INSERT] THEN REPEAT STRIP_TAC THEN
+  ASM_REWRITE_TAC[] THEN
+  Q.SUBGOAL_THEN `p = swap(e,p e) o swap(e,p e) o (p:'a->'a)` SUBST1_TAC THENL
+   [REWRITE_TAC[o_ASSOC, SWAP_IDEMPOTENT, I_o_ID], ALL_TAC] THEN
+  Q.PAT_X_ASSUM `$==> X Y` MP_TAC THEN
+  GEN_REWRITE_TAC (LAND_CONV) empty_rewrites [IMP_DISJ_THM] THEN
+  REWRITE_TAC[DISJ_IMP_THM] THEN CONJ_TAC THENL [PROVE_TAC[], ALL_TAC] THEN
+  DISCH_THEN(fn th => FIRST_X_ASSUM MATCH_MP_TAC THEN ASSUME_TAC th) THEN
+  PROVE_TAC[PERMUTES_IN_IMAGE, IN_INSERT, PERMUTES_INSERT_LEMMA,
+                PERMUTATION_PERMUTES, FINITE_INSERT, PERMUTATION_COMPOSE,
+                PERMUTATION_SWAP]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Sign of a permutation as a real number.                                   *)
+(* ------------------------------------------------------------------------- *)
+
+Definition sign_def :
+   (sign p):real = if evenperm p then &1 else - &1
+End
+
+Theorem SIGN_NZ :
+   !p. ~(sign p = &0)
+Proof
+  REWRITE_TAC[sign_def] THEN GEN_TAC THEN COND_CASES_TAC THEN REAL_ARITH_TAC
+QED
+
+Theorem SIGN_I :
+   sign I = &1
+Proof
+  REWRITE_TAC[sign_def, EVENPERM_I]
+QED
+
+Theorem SIGN_INVERSE :
+   !p. permutation p ==> (sign (inverse p) = sign p)
+Proof
+  SIMP_TAC bool_ss[sign_def, EVENPERM_INVERSE]
+QED
+
+Theorem SIGN_COMPOSE :
+   !p q. permutation p /\ permutation q ==> (sign (p o q) = sign (p) * sign (q))
+Proof
+  SIMP_TAC bool_ss[sign_def, EVENPERM_COMPOSE] THEN REPEAT STRIP_TAC THEN
+  MAP_EVERY Q.ASM_CASES_TAC [`evenperm p`, `evenperm q`] THEN
+  ASM_REWRITE_TAC[] THEN REAL_ARITH_TAC
+QED
+
+Theorem SIGN_SWAP :
+   !a b. sign (swap(a,b)) = if a = b then &1 else - &1
+Proof
+  REWRITE_TAC[sign_def, EVENPERM_SWAP]
+QED
+
+Theorem SIGN_IDEMPOTENT :
+   !p. sign (p) * sign (p) = &1
+Proof
+  GEN_TAC THEN REWRITE_TAC[sign_def] THEN
+  COND_CASES_TAC THEN REAL_ARITH_TAC
+QED
+
+Theorem REAL_ABS_SIGN :
+   !p. abs(sign p) = &1
+Proof
+  GEN_TAC THEN REWRITE_TAC[sign_def] THEN
+  COND_CASES_TAC THEN REAL_ARITH_TAC
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* More lemmas about permutations.                                           *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem PERMUTES_NUMSET_LE :
+   !p s:num->bool. p permutes s /\ (!i. i IN s ==> p(i) <= i) ==> (p = I)
+Proof
+  REPEAT GEN_TAC THEN REWRITE_TAC[FUN_EQ_THM, I_THM] THEN STRIP_TAC THEN
+  HO_MATCH_MP_TAC COMPLETE_INDUCTION THEN Q.X_GEN_TAC `n:num` THEN DISCH_TAC THEN
+  Q.ASM_CASES_TAC `(n:num) IN s` THENL [ALL_TAC, PROVE_TAC[permutes]] THEN
+  ASM_SIMP_TAC bool_ss[EQ_LESS_EQ] THEN REWRITE_TAC[GSYM NOT_LESS] THEN
+  PROVE_TAC[PERMUTES_INJECTIVE, LESS_EQ_REFL,NOT_LESS]
+QED
+
+Theorem PERMUTES_NUMSET_GE :
+   !p s:num->bool. p permutes s /\ (!i. i IN s ==> i <= p(i)) ==> (p = I)
+Proof
+  REPEAT STRIP_TAC THEN
+  MP_TAC(Q.SPECL [`inverse(p:num->num)`, `s:num->bool`] PERMUTES_NUMSET_LE) THEN
+  GEN_REWRITE_TAC (LAND_CONV) empty_rewrites [IMP_DISJ_THM] THEN
+  REWRITE_TAC[DISJ_IMP_THM] THEN CONJ_TAC THENL
+   [PROVE_TAC[PERMUTES_INVERSE, PERMUTES_INVERSES, PERMUTES_IN_IMAGE],
+    PROVE_TAC[PERMUTES_INVERSE_INVERSE, INVERSE_I]]
+QED
+
+Theorem IMAGE_INVERSE_PERMUTATIONS :
+   !s:'a->bool. {inverse p | p permutes s} = {p | p permutes s}
+Proof
+  REWRITE_TAC[EXTENSION] THEN CONV_TAC (ONCE_DEPTH_CONV SET_SPEC_CONV) THEN
+  PROVE_TAC[PERMUTES_INVERSE_INVERSE, PERMUTES_INVERSE]
+QED
+
+Theorem IMAGE_COMPOSE_PERMUTATIONS_L :
+   !s q:'a->'a. q permutes s ==> ({q o p | p permutes s} = {p | p permutes s})
+Proof
+  REWRITE_TAC[EXTENSION] THEN CONV_TAC (ONCE_DEPTH_CONV SET_SPEC_CONV) THEN
+  REPEAT GEN_TAC THEN STRIP_TAC THEN
+  Q.X_GEN_TAC `p:'a->'a` THEN EQ_TAC THENL
+   [PROVE_TAC[PERMUTES_COMPOSE],
+    DISCH_TAC THEN Q.EXISTS_TAC `inverse (q:'a->'a) o (p:'a->'a)` THEN
+    ASM_SIMP_TAC bool_ss[o_ASSOC, PERMUTES_INVERSE, PERMUTES_COMPOSE] THEN
+    PROVE_TAC [PERMUTES_INVERSES_o, I_o_ID]]
+QED
+
+Theorem IMAGE_COMPOSE_PERMUTATIONS_R :
+   !s q:'a->'a. q permutes s ==> ({p o q | p permutes s} = {p | p permutes s})
+Proof
+  REWRITE_TAC[EXTENSION] THEN CONV_TAC (ONCE_DEPTH_CONV SET_SPEC_CONV) THEN
+  REPEAT GEN_TAC THEN STRIP_TAC THEN
+  Q.X_GEN_TAC `p:'a->'a` THEN EQ_TAC THENL
+   [PROVE_TAC[PERMUTES_COMPOSE],
+    DISCH_TAC THEN Q.EXISTS_TAC `(p:'a->'a) o inverse (q:'a->'a)` THEN
+    ASM_SIMP_TAC bool_ss[GSYM o_ASSOC, PERMUTES_INVERSE, PERMUTES_COMPOSE] THEN
+    PROVE_TAC [PERMUTES_INVERSES_o, I_o_ID]]
+QED
+
+Theorem PERMUTES_IN_COUNT :
+   !p n i. p permutes count n /\ i IN count n ==>  p(i) < n
+Proof
+  REWRITE_TAC[permutes, IN_COUNT] THEN PROVE_TAC[]
+QED
+
+Theorem PERMUTES_IN_NUMSEG :
+   !p n i. p permutes {1 .. n} /\ i IN {1 .. n} ==> 1 <= p(i) /\ p(i) <= n
+Proof
+  REWRITE_TAC[permutes, IN_NUMSEG] THEN PROVE_TAC[]
+QED
+
+Theorem SUM_PERMUTATIONS_INVERSE :
+   !f m n. sum {p | p permutes count n } f =
+           sum {p | p permutes count n } (\p. f(inverse p))
+Proof
+  REPEAT GEN_TAC THEN
+  GEN_REWRITE_TAC (funpow 2 LAND_CONV) empty_rewrites
+   [GSYM IMAGE_INVERSE_PERMUTATIONS] THEN
+  SIMP_TAC bool_ss
+   [Once (Q.prove(`{f x | p x} = IMAGE f {x | p x}`,
+     REWRITE_TAC[EXTENSION, IN_IMAGE] THEN
+     CONV_TAC (DEPTH_CONV SET_SPEC_CONV) THEN REWRITE_TAC[]))] THEN
+  GEN_REWRITE_TAC (RAND_CONV o RAND_CONV o ONCE_DEPTH_CONV) empty_rewrites [GSYM o_DEF] THEN
+  MATCH_MP_TAC SUM_IMAGE THEN
+  CONV_TAC (DEPTH_CONV SET_SPEC_CONV) THEN
+  PROVE_TAC[PERMUTES_INVERSE_INVERSE]
+QED
+
+Theorem SUM_PERMUTATIONS_COMPOSE_L :
+   !f s q. q permutes s ==>
+           sum {p | p permutes s} f =
+           sum {p | p permutes s} (\p. f(q o p))
+Proof
+  REPEAT STRIP_TAC THEN
+  FIRST_ASSUM(fn th => GEN_REWRITE_TAC (funpow 2 LAND_CONV) empty_rewrites
+   [GSYM(MATCH_MP IMAGE_COMPOSE_PERMUTATIONS_L th)]) THEN
+  SIMP_TAC bool_ss
+   [Once (Q.prove(`{f x | p x} = IMAGE f {x | p x}`,
+     REWRITE_TAC[EXTENSION, IN_IMAGE] THEN
+     CONV_TAC (DEPTH_CONV SET_SPEC_CONV) THEN REWRITE_TAC[]))] THEN
+  REWRITE_TAC[GSYM o_DEF, ETA_THM] THEN
+  MATCH_MP_TAC SUM_IMAGE THEN
+  CONV_TAC (DEPTH_CONV SET_SPEC_CONV) THEN
+  REPEAT STRIP_TAC THEN
+  FIRST_X_ASSUM(MP_TAC o AP_TERM ``\p:'a-> 'a. inverse(q:'a-> 'a) o p``) THEN
+  BETA_TAC THEN REWRITE_TAC[o_ASSOC] THEN
+  EVERY_ASSUM(CONJUNCTS_THEN SUBST1_TAC o MATCH_MP PERMUTES_INVERSES_o) THEN
+  REWRITE_TAC[I_o_ID]
+QED
+
+Theorem SUM_PERMUTATIONS_COMPOSE_L_COUNT :
+   !f n q. q permutes count n ==>
+           sum {p | p permutes count n} f =
+           sum {p | p permutes count n} (\p. f(q o p))
+Proof
+  REWRITE_TAC[SUM_PERMUTATIONS_COMPOSE_L]
+QED
+
+Theorem SUM_PERMUTATIONS_COMPOSE_L_NUMSEG :
+   !f m n q.
+        q permutes (count n DIFF count m)
+        ==> sum {p | p permutes (count n DIFF count m)} f =
+            sum {p | p permutes (count n DIFF count m)} (\p. f(q o p))
+Proof
+  REPEAT STRIP_TAC THEN
+  FIRST_ASSUM(fn th => GEN_REWRITE_TAC (funpow 2 LAND_CONV) empty_rewrites
+   [GSYM(MATCH_MP IMAGE_COMPOSE_PERMUTATIONS_L th)]) THEN
+  SIMP_TAC bool_ss
+   [Once (Q.prove(`{f x | p x} = IMAGE f {x | p x}`,
+     REWRITE_TAC[EXTENSION, IN_IMAGE] THEN
+     CONV_TAC (DEPTH_CONV SET_SPEC_CONV) THEN REWRITE_TAC[]))] THEN
+  REWRITE_TAC[GSYM o_DEF, ETA_THM] THEN
+  MATCH_MP_TAC SUM_IMAGE THEN
+  CONV_TAC (DEPTH_CONV SET_SPEC_CONV) THEN
+  REPEAT STRIP_TAC THEN
+  FIRST_X_ASSUM(MP_TAC o AP_TERM ``\p:num-> num. inverse(q:num-> num) o p``) THEN
+  BETA_TAC THEN REWRITE_TAC[o_ASSOC] THEN
+  EVERY_ASSUM(CONJUNCTS_THEN SUBST1_TAC o MATCH_MP PERMUTES_INVERSES_o) THEN
+  REWRITE_TAC[I_o_ID]
+QED
+
+Theorem SUM_PERMUTATIONS_COMPOSE_R :
+   !f s q.
+        q permutes s
+        ==> sum {p | p permutes s} f =
+            sum {p | p permutes s} (\p. f(p o q))
+Proof
+  REPEAT STRIP_TAC THEN
+  FIRST_ASSUM(fn th => GEN_REWRITE_TAC (funpow 2 LAND_CONV) empty_rewrites
+   [GSYM(MATCH_MP IMAGE_COMPOSE_PERMUTATIONS_R th)]) THEN
+  SIMP_TAC bool_ss
+   [Once (Q.prove(`{f x | p x} = IMAGE f {x | p x}`,
+     REWRITE_TAC[EXTENSION, IN_IMAGE] THEN
+     CONV_TAC (DEPTH_CONV SET_SPEC_CONV) THEN REWRITE_TAC[]))] THEN
+  SIMP_TAC bool_ss[GSYM o_ABS_R] THEN
+  MATCH_MP_TAC SUM_IMAGE THEN
+  CONV_TAC (DEPTH_CONV SET_SPEC_CONV) THEN
+  REPEAT STRIP_TAC THEN
+  FIRST_X_ASSUM(MP_TAC o AP_TERM ``\p:'a-> 'a. p o inverse(q:'a-> 'a)``) THEN
+  BETA_TAC THEN REWRITE_TAC[GSYM o_ASSOC] THEN
+  EVERY_ASSUM(CONJUNCTS_THEN SUBST1_TAC o MATCH_MP PERMUTES_INVERSES_o) THEN
+  REWRITE_TAC[I_o_ID]
+QED
+
+Theorem SUM_PERMUTATIONS_COMPOSE_R_COUNT :
+   !f n q.
+        q permutes count n
+        ==> sum {p | p permutes count n} f =
+            sum {p | p permutes count n} (\p. f(p o q))
+Proof
+  REWRITE_TAC[SUM_PERMUTATIONS_COMPOSE_R]
+QED
+
+Theorem SUM_PERMUTATIONS_COMPOSE_R_NUMSEG :
+   !f m n q.
+        q permutes (count n DIFF count m)
+        ==> sum {p | p permutes (count n DIFF count m)} f =
+            sum {p | p permutes (count n DIFF count m)} (\p. f(p o q))
+Proof
+  REPEAT STRIP_TAC THEN
+  FIRST_ASSUM(fn th => GEN_REWRITE_TAC (funpow 2 LAND_CONV) empty_rewrites
+   [GSYM(MATCH_MP IMAGE_COMPOSE_PERMUTATIONS_R th)]) THEN
+  SIMP_TAC bool_ss
+   [Once (Q.prove(`{f x | p x} = IMAGE f {x | p x}`,
+     REWRITE_TAC[EXTENSION, IN_IMAGE] THEN
+     CONV_TAC (DEPTH_CONV SET_SPEC_CONV) THEN REWRITE_TAC[]))] THEN
+  SIMP_TAC bool_ss[GSYM o_ABS_R] THEN
+  MATCH_MP_TAC SUM_IMAGE THEN
+  CONV_TAC (DEPTH_CONV SET_SPEC_CONV) THEN
+  REPEAT STRIP_TAC THEN
+  FIRST_X_ASSUM(MP_TAC o AP_TERM ``\p:num-> num. p o inverse(q:num-> num)``) THEN
+  BETA_TAC THEN REWRITE_TAC[GSYM o_ASSOC] THEN
+  EVERY_ASSUM(CONJUNCTS_THEN SUBST1_TAC o MATCH_MP PERMUTES_INVERSES_o) THEN
+  REWRITE_TAC[I_o_ID]
+QED
+
+val _ = export_theory ();
+val _ = html_theory "permutation";

--- a/examples/vector/vectorScript.sml
+++ b/examples/vector/vectorScript.sml
@@ -1,0 +1,1282 @@
+(* ========================================================================= *)
+(* Real vectors in Euclidean space, and elementary linear algebra.           *)
+(*     (HOL-Light's Multivariate/vectors.ml)                                 *)
+(*                                                                           *)
+(*              (c) Copyright, John Harrison 1998-2008                       *)
+(*       (c) Copyright, Liming Li, Yong Guan and Zhiping Shi 2011            *)
+(*               (c) Copyright, Marco Maggesi 2014                           *)
+(*       (c) Copyright, Andrea Gabrielli, Marco Maggesi 2016-2017            *)
+(* ========================================================================= *)
+
+open HolKernel Parse boolLib bossLib;
+
+open arithmeticTheory combinTheory pred_setTheory pairTheory PairedLambda
+     pred_setLib fcpTheory fcpLib tautLib numLib listTheory rich_listTheory;
+
+open realTheory realLib iterateTheory real_sigmaTheory RealArith mesonLib;
+
+open hurdUtils permutationTheory;
+
+val _ = new_theory "vector";
+
+(* ------------------------------------------------------------------------- *)
+(* Basic componentwise operations on vectors.                                *)
+(* ------------------------------------------------------------------------- *)
+
+Definition vector_add_def :
+   (vector_add :real['N]->real['N]->real['N]) x y = FCP i. x ' i + y ' i
+End
+
+Definition vector_sub_def :
+   (vector_sub :real['N]->real['N]->real['N]) x y = FCP i. x ' i - y ' i
+End
+
+Definition vector_neg_def :
+   (vector_neg :real['N]->real['N]) x = FCP i. ~(x ' i)
+End
+
+Overload "+"  = “vector_add :real['N] -> real['N] -> real['N]”
+Overload "-"  = “vector_sub :real['N] -> real['N] -> real['N]”
+Overload "~"              = “vector_neg :real['N] -> real['N]”
+Overload "numeric_negate" = “vector_neg :real['N] -> real['N]”
+
+(* Below are equivalent definitions using advanced concepts in fcpTheory *)
+Definition FCP_MAP2 :
+   FCP_MAP2 f (x :'a['N]) (y :'b['N]) = FCP_MAP (UNCURRY f) (FCP_ZIP x y)
+End
+
+Theorem FCP_MAP2_def : (* was: vector_map2_def *)
+   !f x y. FCP_MAP2 f (x :'a['N]) (y :'b['N]) = (FCP i. f (x ' i) (y ' i))
+Proof
+   SRW_TAC [FCP_ss] [FCP_MAP2, FCP_MAP_def, FCP_ZIP_def, UNCURRY_DEF]
+QED
+
+Theorem vector_add_alt :
+   !x y. (vector_add :real['N]->real['N]->real['N]) x y = FCP_MAP2 (+) x y
+Proof
+   rw [FCP_MAP2_def, vector_add_def]
+QED
+
+Theorem vector_sub_alt :
+   !x y. (vector_sub :real['N]->real['N]->real['N]) x y = FCP_MAP2 (-) x y
+Proof
+   rw [FCP_MAP2_def, vector_sub_def]
+QED
+
+Theorem vector_neg_alt :
+   !x. (vector_neg :real['N]->real['N]) x = FCP_MAP (~) x
+Proof
+   rw [FCP_MAP_def, vector_neg_def]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Also the scalar-vector multiplication.                                    *)
+(* ------------------------------------------------------------------------- *)
+
+Definition vector_mul_def :
+   (vector_mul :real -> real['N] -> real['N]) c x = FCP i. c * x ' i
+End
+
+Overload "*" = “vector_mul :real -> real['N] -> real['N]”
+
+Theorem vector_mul_alt :
+    !c x. (vector_mul :real -> real['N] -> real['N]) c x = FCP_MAP ($* c) x
+Proof
+    rw [FCP_MAP_def, vector_mul_def]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Vectors corresponding to small naturals. Perhaps should overload "&"?     *)
+(* ------------------------------------------------------------------------- *)
+
+Definition vec_def :
+   (vec :num -> real['N]) n = FCP i. &n
+End
+
+(* this is experimental, for user code only (not used in the rest of file) *)
+val _ = add_numeral_form (#"v", SOME "vec");
+
+(* prioritize_real() *)
+val _ = prefer_real();
+
+(* ------------------------------------------------------------------------- *)
+(* Dot products.                                                             *)
+(* ------------------------------------------------------------------------- *)
+
+(* Infixl 600 is the same as "*", "INTER" and "*_c", etc. *)
+val _ = set_fixity "dot"  (Infixl 600); (* was: Infixr 20 (HOL-Light) *)
+
+(* This definition is based on ‘iterate$sum’ (iterateTheory.sum_def).
+
+   NOTE: The original definition of ‘dot’ in HOL-Light is
+
+     sum(1..dimindex(:N)) (\i. x$i * y$i)
+
+   It seems that in HOL-Light FCP indexes start from 1 (instead of 0 in HOL4),
+   and whenever the original proofs use DIMINDEX_GE_1, in the ported proofs we
+   should use DIMINDEX_GT_0 instead. (See, e.g., the proof of VEC_EQ below.)
+ *)
+Definition dot_def :
+   ((x:real['N]) dot (y:real['N])) =
+     sum (count(dimindex(:'N))) (\i. (x ' i) * (y ' i))
+End
+
+(* alternative definition using ‘real_sigma$SIGMA’ (REAL_SUM_IMAGE_DEF) *)
+Theorem dot_alt :
+    !x y. ((x:real['N]) dot (y:real['N])) =
+          SIGMA (\i. (x ' i) * (y ' i)) (count (dimindex(:'N)))
+Proof
+    rw [dot_def, GSYM REAL_SUM_IMAGE_sum]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* A naive proof procedure to lift really trivial arithmetic stuff from R.   *)
+(* ------------------------------------------------------------------------- *)
+
+val VECTOR_ARITH_TAC =
+    rpt GEN_TAC
+ >> SIMP_TAC std_ss [dot_def, GSYM SUM_ADD', GSYM SUM_SUB', FINITE_COUNT,
+                     GSYM SUM_LMUL, GSYM SUM_RMUL, GSYM SUM_NEG']
+ >> (MATCH_MP_TAC SUM_EQ' ORELSE MATCH_MP_TAC SUM_EQ_0' ORELSE
+     GEN_REWRITE_TAC ONCE_DEPTH_CONV empty_rewrites [CART_EQ])
+ >> SIMP_TAC bool_ss[GSYM FORALL_AND_THM] >> TRY EQ_TAC
+ >> TRY(HO_MATCH_MP_TAC MONO_ALL) >> TRY GEN_TAC
+ >> REWRITE_TAC[TAUT `(a ==> b) /\ (a ==> c) <=> a ==> b /\ c`,
+                TAUT `(a ==> b) \/ (a ==> c) <=> a ==> b \/ c`]
+ >> TRY (MATCH_MP_TAC(TAUT `(a ==> b ==> c) ==> (a ==> b) ==> (a ==> c)`))
+ >> SRW_TAC[FCP_ss][vector_add_def, vector_sub_def, vector_neg_def,
+                    vector_mul_def, vec_def]
+ >> TRY (POP_ASSUM MP_TAC)
+ >> REAL_ARITH_TAC;
+
+fun VECTOR_ARITH tm = prove(tm,VECTOR_ARITH_TAC);
+
+(* ------------------------------------------------------------------------- *)
+(* Obvious "component-pushing".                                              *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem VEC_COMPONENT :
+   !k i. i < dimindex(:'N) ==> (((vec k):real['N]) ' i = &k)
+Proof
+   SRW_TAC [FCP_ss][vec_def]
+QED
+
+Theorem VECTOR_ADD_COMPONENT :
+   !x:real['N] y i. i < dimindex (:'N) ==> ((x + y) ' i = (x ' i) + (y ' i))
+Proof
+   SRW_TAC [FCP_ss][vector_add_def]
+QED
+
+Theorem VECTOR_NEG_COMPONENT :
+   !x:real['N] i. i < dimindex (:'N) ==> ((~x) ' i = -(x ' i))
+Proof
+   SRW_TAC [FCP_ss][vector_neg_def]
+QED
+
+Theorem VECTOR_SUB_COMPONENT :
+   !x:real['N] y i. i < dimindex (:'N) ==> ((x - y) ' i = (x ' i) - (y ' i))
+Proof
+   SRW_TAC [FCP_ss][vector_sub_def]
+QED
+
+Theorem VECTOR_MUL_COMPONENT :
+   !x:real['N] c i. i < dimindex (:'N) ==> ((c * x) ' i = c * (x ' i))
+Proof
+   SRW_TAC [FCP_ss][vector_mul_def]
+QED
+
+Theorem COND_COMPONENT[local] :
+   (if b then x else y) ' i = if b then x ' i else y ' i
+Proof
+   PROVE_TAC[]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Some frequently useful arithmetic lemmas over vectors.                    *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem VECTOR_ADD_SYM = VECTOR_ARITH ``!x y:real['N]. x + y = y + x``
+
+Theorem VECTOR_ADD_LID = VECTOR_ARITH ``!x:real['N]. (vec 0) + x = x``
+
+Theorem VECTOR_ADD_RID = VECTOR_ARITH ``!x:real['N]. x + (vec 0) = x``
+
+Theorem VECTOR_SUB_REFL = VECTOR_ARITH ``!x:real['N]. x - x = (vec 0)``
+
+Theorem VECTOR_ADD_LINV = VECTOR_ARITH ``!x:real['N]. ~x + x = (vec 0)``
+
+Theorem VECTOR_ADD_RINV = VECTOR_ARITH ``!x:real['N]. x + ~x = (vec 0)``
+
+Theorem VECTOR_SUB_RADD = VECTOR_ARITH ``!x y. x - (x + y) = ~y:real['N]``
+
+Theorem VECTOR_NEG_SUB = VECTOR_ARITH ``!x:real['N] y. ~(x - y) = y - x``
+
+Theorem VECTOR_SUB_EQ = VECTOR_ARITH ``!x y:real['N]. (x - y = (vec 0)) <=> (x = y)``
+
+Theorem VECTOR_MUL_ASSOC = VECTOR_ARITH ``!a b x:real['N]. a * (b * x) = (a * b) * x``
+
+Theorem VECTOR_MUL_LID = VECTOR_ARITH ``!x:real['N]. &1 * x = x``
+
+Theorem VECTOR_MUL_LZERO = VECTOR_ARITH ``!x:real['N]. &0 * x = (vec 0)``
+
+Theorem VECTOR_SUB_ADD = VECTOR_ARITH ``(x - y) + y = x:real['N]``
+
+Theorem VECTOR_SUB_ADD2 = VECTOR_ARITH ``y + (x - y) = x:real['N]``
+
+Theorem VECTOR_ADD_LDISTRIB = VECTOR_ARITH ``c * (x + y:real['N]) = c * x + c * y``
+
+Theorem VECTOR_SUB_LDISTRIB = VECTOR_ARITH ``c * (x - y:real['N]) = c * x - c * y``
+
+Theorem VECTOR_ADD_RDISTRIB = VECTOR_ARITH ``(a + b) * x:real['N] = a * x + b * x``
+
+Theorem VECTOR_SUB_RDISTRIB = VECTOR_ARITH ``(a - b) * x:real['N] = a * x - b * x``
+
+Theorem VECTOR_ADD_SUB = VECTOR_ARITH ``(x + y:real['N]) - x = y``
+
+Theorem VECTOR_EQ_ADDR = VECTOR_ARITH ``(x + y = x:real['N]) <=> (y = (vec 0))``
+
+Theorem VECTOR_EQ_ADDL = VECTOR_ARITH ``(x + y = y:real['N]) <=> (x = (vec 0))``
+
+Theorem VECTOR_SUB = VECTOR_ARITH ``x - y = x + ~(y:real['N])``
+
+Theorem VECTOR_SUB_RZERO = VECTOR_ARITH ``x - (vec 0) = x:real['N]``
+
+Theorem VECTOR_MUL_RZERO = VECTOR_ARITH ``c * (vec 0) = (vec 0):real['N]``
+
+Theorem VECTOR_NEG_MINUS1 = VECTOR_ARITH ``~x = (-(&1)) * x:real['N]``
+
+Theorem VECTOR_ADD_ASSOC = VECTOR_ARITH ``(x:real['N]) + (y + z) = x + y + z``
+
+Theorem VECTOR_SUB_LZERO = VECTOR_ARITH ``(vec 0):real['N] - x = ~x``
+
+Theorem VECTOR_NEG_NEG = VECTOR_ARITH ``~(~(x:real['N])) = x``
+
+Theorem VECTOR_MUL_LNEG = VECTOR_ARITH ``~c * x:real['N] = ~(c * x)``
+
+Theorem VECTOR_MUL_RNEG = VECTOR_ARITH ``c * ~x:real['N] = ~(c * x)``
+
+Theorem VECTOR_NEG_0 = VECTOR_ARITH ``~((vec 0)) = (vec 0):real['N]``
+
+(* new *)
+Theorem VECTOR_NEG_EQ_0 = VECTOR_ARITH ``~~x = vec 0 <=> x = (vec 0):real['N]``
+
+(* new *)
+Theorem VECTOR_EQ_NEG2 = VECTOR_ARITH ``!x y:real['N]. ~~x = ~~y <=> x = y``
+
+Theorem VECTOR_ADD_AC = VECTOR_ARITH
+  ``(m + n = n + m:real['N]) /\
+    ((m + n) + p = m + n + p) /\
+    (m + n + p = n + m + p)``
+
+val LE_REFL = LESS_EQ_REFL;
+
+(* new *)
+Theorem VEC_EQ :
+    !m n. (vec m = (vec n):real['N]) <=> (m = n)
+Proof
+    RW_TAC real_ss [CART_EQ, VEC_COMPONENT]
+ >> MESON_TAC[DIMINDEX_GT_0] (* was: DIMINDEX_GE_1 here, see dot_def's NOTES *)
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Properties of the dot product.                                            *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem DOT_SYM = VECTOR_ARITH ``!x y:real['N]. (x dot y) = (y dot x)``
+
+Theorem DOT_LADD = VECTOR_ARITH ``!x y z:real['N]. ((x + y) dot z) = (x dot z) + (y dot z)``
+
+Theorem DOT_RADD = VECTOR_ARITH ``!x y z:real['N]. (x dot (y + z)) = (x dot y) + (x dot z)``
+
+Theorem DOT_LSUB = VECTOR_ARITH ``!x y z:real['N]. ((x - y) dot z) = (x dot z) - (y dot z)``
+
+Theorem DOT_RSUB = VECTOR_ARITH ``!x y z:real['N]. (x dot (y - z)) = (x dot y) - (x dot z)``
+
+Theorem DOT_LMUL = VECTOR_ARITH ``!c x y:real['N]. ((c * x) dot y) = c * (x dot y)``
+
+Theorem DOT_RMUL = VECTOR_ARITH ``!c x y:real['N]. (x dot (c * y)) = c * (x dot y)``
+
+Theorem DOT_LNEG = VECTOR_ARITH ``!x y:real['N]. ((~x) dot y) = ~(x dot y)``
+
+Theorem DOT_RNEG = VECTOR_ARITH ``!x y:real['N]. (x dot (~y)) = ~(x dot y)``
+
+Theorem DOT_LZERO = VECTOR_ARITH ``!x:real['N]. ((vec 0) dot x) = &0``
+
+Theorem DOT_RZERO = VECTOR_ARITH ``!x:real['N]. (x dot (vec 0)) = &0``
+
+(* ------------------------------------------------------------------------- *)
+(* Sums of vectors (per-index summation).                                    *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem NEUTRAL_VECTOR_ADD :
+    neutral(+) = (vec 0):real['N]
+Proof
+  REWRITE_TAC[neutral] THEN MATCH_MP_TAC SELECT_UNIQUE THEN
+  BETA_TAC THEN REWRITE_TAC[VECTOR_EQ_ADDR,VECTOR_EQ_ADDL]
+QED
+
+Theorem MONOIDAL_VECTOR_ADD :
+    monoidal ((+):real['N]->real['N]->real['N])
+Proof
+  REWRITE_TAC[monoidal, NEUTRAL_VECTOR_ADD] THEN
+  REPEAT CONJ_TAC THEN VECTOR_ARITH_TAC
+QED
+
+(* NOTE: previously there was a porting mistake (by wrongly written 'a to 'N).
+
+   Here ‘s’ is an index set ('a), ‘f’ is a set of real['N] vectors indexed by ‘s’.
+ *)
+Definition vsum_def :
+   (vsum:('a->bool)->('a->real['N])->real['N]) s f = FCP i. sum s (\x. f(x) ' i)
+End
+
+Theorem vsum_alt :
+    !s f. FINITE s ==>
+         (vsum:('a->bool)->('a->real['N])->real['N]) s f =
+          FCP i. SIGMA (\x. f(x) ' i) s
+Proof
+    rw [vsum_def, GSYM REAL_SUM_IMAGE_sum]
+QED
+
+Theorem VSUM_CLAUSES :
+   (!(f:'a->real['N]). vsum {} f = (vec 0)) /\
+   (!x (f:'a->real['N]) s. FINITE s
+            ==> vsum (x INSERT s) f =
+                if x IN s then vsum s f else f(x) + vsum s f)
+Proof
+  SRW_TAC[FCP_ss][vsum_def, VECTOR_ADD_COMPONENT, SUM_CLAUSES, VEC_COMPONENT]
+QED
+
+Theorem VSUM :
+   !(f:'a->real['N]) s. FINITE s ==> vsum s f = iterate (+) s f
+Proof
+  GEN_TAC THEN HO_MATCH_MP_TAC FINITE_INDUCT THEN
+  ASM_SIMP_TAC bool_ss[VSUM_CLAUSES, ITERATE_CLAUSES, MONOIDAL_VECTOR_ADD] THEN
+  REWRITE_TAC[NEUTRAL_VECTOR_ADD]
+QED
+
+Theorem VSUM_EQ_0 :
+   !(f:'a->real['N]) s. (!x:'a. x IN s ==> (f(x) = (vec 0))) ==> (vsum s f = (vec 0))
+Proof
+  SRW_TAC[FCP_ss][vsum_def, vec_def, SUM_EQ_0']
+QED
+
+Theorem VSUM_0 :
+   (vsum:('a->bool)->('a->real['N])->real['N]) s (\x. (vec 0)) = (vec 0)
+Proof
+  SIMP_TAC bool_ss[VSUM_EQ_0]
+QED
+
+Theorem VSUM_LMUL :
+   !(f:'a->real['N]) c s.  vsum s (\x. c * f(x)) = c * vsum s f
+Proof
+  SRW_TAC[FCP_ss][vsum_def, VECTOR_MUL_COMPONENT, SUM_LMUL]
+QED
+
+Theorem VSUM_RMUL :
+   !(c :'a->real) s (v :real['N]). vsum s (\x. c x * v) = (sum s c) * v
+Proof
+  SRW_TAC[FCP_ss][vsum_def, VECTOR_MUL_COMPONENT, SUM_RMUL]
+QED
+
+Theorem VSUM_ADD :
+   !(f:'a->real['N]) g s. FINITE s ==> (vsum s (\x. f x + g x) = vsum s f + vsum s g)
+Proof
+  SRW_TAC[FCP_ss][vsum_def, VECTOR_ADD_COMPONENT, SUM_ADD']
+QED
+
+Theorem VSUM_SUB :
+   !(f:'a->real['N]) g s. FINITE s ==> (vsum s (\x. f x - g x) = vsum s f - vsum s g)
+Proof
+  SRW_TAC[FCP_ss][vsum_def, VECTOR_SUB_COMPONENT, SUM_SUB']
+QED
+
+(* NOTE: there's no ‘i < dimindex(:'N)’ part in HOL-Light *)
+Theorem VSUM_COMPONENT :
+   !s f i. i < dimindex(:'N) ==> (vsum s (f:'a->real['N])) ' i = sum s (\x. f(x) ' i)
+Proof
+  SRW_TAC[FCP_ss][vsum_def]
+QED
+
+Theorem VSUM_IMAGE :
+   !(f :'a->'b) (g :'b->real['N]) s.
+        FINITE s /\ (!x y. x IN s /\ y IN s /\ (f x = f y) ==> (x = y))
+           ==> (vsum (IMAGE f s) g = vsum s (g o f))
+Proof
+  SRW_TAC[FCP_ss][vsum_def] THEN REPEAT STRIP_TAC THEN
+  W(MP_TAC o PART_MATCH (lhs o rand) SUM_IMAGE o lhs o snd) THEN
+  ASM_SIMP_TAC bool_ss[o_DEF]
+QED
+
+Theorem VSUM_DELETE :
+   !(f:'a->real['N]) s a. FINITE s /\ a IN s
+           ==> (vsum (s DELETE a) f = vsum s f - f a)
+Proof
+  SRW_TAC[FCP_ss][vsum_def, SUM_DELETE, VECTOR_SUB_COMPONENT]
+QED
+
+Theorem VSUM_NEG :
+   !(f:'a->real['N]) s. vsum s (\x. ~f x) = ~vsum s f
+Proof
+  SRW_TAC[FCP_ss][vsum_def, SUM_NEG', VECTOR_NEG_COMPONENT]
+QED
+
+Theorem VSUM_EQ :
+   !(f:'a->real['N]) g s. (!x. x IN s ==> (f x = g x)) ==> (vsum s f = vsum s g)
+Proof
+  SRW_TAC[FCP_ss][vsum_def] THEN
+  MATCH_MP_TAC SUM_EQ' THEN ASM_SIMP_TAC bool_ss[]
+QED
+
+Theorem VSUM_DELETE_CASES :
+   !x (f:'a->real['N]) s.
+        FINITE(s:'a->bool)
+        ==> (vsum (s DELETE x) f = if x IN s then vsum s f - f x else vsum s f)
+Proof
+  REPEAT STRIP_TAC THEN COND_CASES_TAC THEN
+  ASM_SIMP_TAC bool_ss[Q.prove(`~(x IN s) ==> (s DELETE x = s)`,
+                               REWRITE_TAC[DELETE_NON_ELEMENT])] THEN
+  FIRST_ASSUM(fn th => GEN_REWRITE_TAC (RAND_CONV o ONCE_DEPTH_CONV) empty_rewrites
+   [MATCH_MP (Q.prove(`x IN s ==> (s = x INSERT (s DELETE x))`,
+                      PROVE_TAC[INSERT_DELETE])) th]) THEN
+  ASM_SIMP_TAC bool_ss[VSUM_CLAUSES, FINITE_DELETE, IN_DELETE] THEN VECTOR_ARITH_TAC
+QED
+
+Theorem VSUM_RESTRICT_SET :
+   !P s (f:'a->real['N]).
+           vsum {x | x IN s /\ P x} f =
+           vsum s (\x. if P x then f x else (vec 0))
+Proof
+  SRW_TAC[FCP_ss][vsum_def, VEC_COMPONENT, SUM_RESTRICT_SET, COND_COMPONENT]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Basis vectors in coordinate directions.                                   *)
+(* ------------------------------------------------------------------------- *)
+
+Definition basis_def :
+   basis k = ((FCP i. if i = k then &1 else &0):real['N])
+End
+
+Theorem BASIS_INJ :
+   !i j. i < dimindex(:'N) /\ j < dimindex(:'N) /\ (basis i :real['N] = basis j)
+     ==> i = j
+Proof
+  SRW_TAC[FCP_ss][basis_def] THEN
+  FIRST_X_ASSUM(MP_TAC o SPEC ``i:num``) THEN
+  CONV_TAC CONTRAPOS_CONV THEN ASM_SIMP_TAC bool_ss[REAL_10]
+QED
+
+Theorem BASIS_NE :
+   !i j. i < dimindex(:'N) /\ j < dimindex(:'N) /\ ~(i = j)
+     ==> ~(basis i :real['N] = basis j)
+Proof
+  PROVE_TAC[BASIS_INJ]
+QED
+
+Theorem BASIS_COMPONENT :
+   !k i. i < dimindex(:'N)
+         ==> ((basis k :real['N]) ' i = if i = k then &1 else &0)
+Proof
+  SRW_TAC[FCP_ss][basis_def]
+QED
+
+Theorem BASIS_EXPANSION :
+   !(x:real['N]). vsum (count(dimindex(:'N))) (\i. x ' i * basis i) = x
+Proof
+  SRW_TAC[FCP_ss][VSUM_COMPONENT, VECTOR_MUL_COMPONENT, BASIS_COMPONENT] THEN
+  ONCE_REWRITE_TAC[COND_RAND] THEN REWRITE_TAC[REAL_MUL_RZERO] THEN
+  GEN_REWRITE_TAC (LAND_CONV o ONCE_DEPTH_CONV) empty_rewrites [EQ_SYM_EQ] THEN
+  ASM_SIMP_TAC bool_ss[SUM_DELTA, IN_COUNT, REAL_MUL_RID]
+QED
+
+Theorem BASIS_EXPANSION_UNIQUE :
+   !u (x:real['N]).
+        (vsum (count(dimindex(:'N))) (\i. f(i) * basis i) = x) <=>
+        (!i. i < dimindex(:'N) ==> (f(i) = x ' i))
+Proof
+  SRW_TAC[FCP_ss][VSUM_COMPONENT, VECTOR_MUL_COMPONENT, BASIS_COMPONENT] THEN
+  REWRITE_TAC[COND_RAND, REAL_MUL_RZERO, REAL_MUL_RID] THEN
+  GEN_REWRITE_TAC (LAND_CONV o BINDER_CONV o RAND_CONV o LAND_CONV o
+                   ONCE_DEPTH_CONV) empty_rewrites[EQ_SYM_EQ] THEN
+  SIMP_TAC bool_ss[SUM_DELTA, IN_COUNT]
+QED
+
+Theorem DOT_BASIS :
+   !x:real['N] i. i < dimindex(:'N) ==> (((basis i) dot x) = x ' i) /\
+                                        ((x dot (basis i)) = x ' i)
+Proof
+  REWRITE_TAC[dot_def, basis_def] THEN REPEAT STRIP_TAC THEN
+  MATCH_MP_TAC EQ_TRANS THEN
+  Q.EXISTS_TAC `sum (count (dimindex (:'N))) (\i'. (if i' = i then 1 else 0) * x ' i')` THEN
+  CONJ_TAC THENL
+  [MATCH_MP_TAC SUM_EQ' THEN SRW_TAC[FCP_ss][], ALL_TAC,
+   MATCH_MP_TAC SUM_EQ' THEN SRW_TAC[FCP_ss][], ALL_TAC] THEN
+  REWRITE_TAC[COND_RATOR, COND_RAND, REAL_MUL_LZERO] THEN
+  ASM_SIMP_TAC bool_ss[SUM_DELTA, IN_COUNT, REAL_MUL_LID]
+QED
+
+Theorem VECTOR_EQ_LDOT :
+   !y z:real['N]. (!x. (x dot y) = (x dot z)) <=> (y = z)
+Proof
+  REPEAT GEN_TAC THEN EQ_TAC THEN SIMP_TAC bool_ss[] THEN
+  REWRITE_TAC[CART_EQ] THEN PROVE_TAC[DOT_BASIS]
+QED
+
+Theorem VECTOR_EQ_RDOT :
+   !x y:real['N]. (!z. (x dot z) = (y dot z)) <=> (x = y)
+Proof
+  REPEAT GEN_TAC THEN EQ_TAC THEN SIMP_TAC bool_ss[] THEN
+  REWRITE_TAC[CART_EQ] THEN PROVE_TAC[DOT_BASIS]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Linear functions.                                                         *)
+(* ------------------------------------------------------------------------- *)
+
+(* cf. ‘real_topology$linear’ (real_topologyTheory.linear) *)
+Definition linear_def :
+   vec_linear (f:real['M]->real['N]) =
+       ((!x y. f(x + y) = f(x) + f(y)) /\
+        (!c x. f(c * x) = c * f(x)))
+End
+
+Overload "linear" = “vec_linear :(real['M]->real['N])->bool”
+
+Theorem LINEAR_COMPOSE_CMUL :
+   !(f:real['M]->real['N]) c. linear f ==> linear (\x. c * f(x))
+Proof
+  SIMP_TAC bool_ss[linear_def] THEN REPEAT STRIP_TAC THEN VECTOR_ARITH_TAC
+QED
+
+Theorem LINEAR_COMPOSE_NEG :
+   !(f:real['M]->real['N]). linear f ==> linear (\x. ~(f(x)))
+Proof
+  SIMP_TAC bool_ss[linear_def] THEN REPEAT STRIP_TAC THEN VECTOR_ARITH_TAC
+QED
+
+Theorem LINEAR_COMPOSE_ADD :
+   !(f:real['M]->real['N]) g. linear f /\ linear g ==> linear (\x. f(x) + g(x))
+Proof
+  SIMP_TAC bool_ss[linear_def] THEN REPEAT STRIP_TAC THEN VECTOR_ARITH_TAC
+QED
+
+Theorem LINEAR_COMPOSE_SUB :
+   !(f:real['M]->real['N]) g. linear f /\ linear g ==> linear (\x. f(x) - g(x))
+Proof
+  SIMP_TAC bool_ss[linear_def] THEN REPEAT STRIP_TAC THEN VECTOR_ARITH_TAC
+QED
+
+Theorem LINEAR_COMPOSE :
+   !(f:real['M]->real['N]) g. linear f /\ linear g ==> linear (g o f)
+Proof
+  SIMP_TAC bool_ss[linear_def, o_THM]
+QED
+
+Theorem LINEAR_ID :
+   linear (\x. x:real['N])
+Proof
+  REWRITE_TAC[linear_def] THEN BETA_TAC THEN REWRITE_TAC[]
+QED
+
+Theorem LINEAR_I :
+   linear (I :real['N]->real['N])
+Proof
+  REWRITE_TAC[I_DEF, K_DEF, S_DEF] THEN BETA_TAC THEN BETA_TAC THEN
+  REWRITE_TAC[LINEAR_ID]
+QED
+
+Theorem LINEAR_ZERO :
+   linear ((\x. (vec 0)):real['M]->real['N])
+Proof
+  REWRITE_TAC[linear_def] THEN CONJ_TAC THEN VECTOR_ARITH_TAC
+QED
+
+Theorem LINEAR_NEGATION :
+   linear ((~) :real['N]->real['N])
+Proof
+  REWRITE_TAC[linear_def] THEN VECTOR_ARITH_TAC
+QED
+
+Theorem LINEAR_COMPOSE_VSUM :
+   !(f :'a->real['M]->real['N]) s.
+         FINITE s /\ (!a. a IN s ==> linear(f a))
+         ==> linear(\x. vsum s (\a. f a x))
+Proof
+  GEN_TAC THEN REWRITE_TAC[GSYM AND_IMP_INTRO] THEN
+  HO_MATCH_MP_TAC FINITE_INDUCT THEN
+  SIMP_TAC bool_ss[VSUM_CLAUSES,LINEAR_ZERO] THEN
+  REWRITE_TAC[IN_INSERT] THEN REPEAT STRIP_TAC THEN
+  HO_MATCH_MP_TAC LINEAR_COMPOSE_ADD THEN
+  REWRITE_TAC [ETA_AX] THEN PROVE_TAC[]
+QED
+
+Theorem LINEAR_VMUL_COMPONENT :
+   !(f:real['M]->real['N]) v k.
+     linear f /\ k < dimindex(:'N)
+     ==> linear (\x. f(x) ' k * v)
+Proof
+  SIMP_TAC bool_ss[linear_def, VECTOR_ADD_COMPONENT, VECTOR_MUL_COMPONENT] THEN
+  REPEAT STRIP_TAC THEN VECTOR_ARITH_TAC
+QED
+
+Theorem LINEAR_0 :
+   !(f:real['M]->real['N]). linear f ==> (f((vec 0)) = (vec 0))
+Proof
+  PROVE_TAC[VECTOR_MUL_LZERO, linear_def]
+QED
+
+Theorem LINEAR_CMUL :
+   !(f:real['M]->real['N]) c x. linear f ==> (f(c * x) = c * f(x))
+Proof
+  SIMP_TAC bool_ss[linear_def]
+QED
+
+Theorem LINEAR_NEG :
+   !(f:real['M]->real['N]) x. linear f ==> (f(~x) = ~(f x))
+Proof
+  ONCE_REWRITE_TAC[VECTOR_NEG_MINUS1] THEN SIMP_TAC bool_ss[LINEAR_CMUL]
+QED
+
+Theorem LINEAR_ADD :
+   !(f:real['M]->real['N]) x y. linear f ==> (f(x + y) = f(x) + f(y))
+Proof
+  SIMP_TAC bool_ss[linear_def]
+QED
+
+Theorem LINEAR_SUB :
+   !(f:real['M]->real['N]) x y. linear f ==> (f(x - y) = f(x) - f(y))
+Proof
+  SIMP_TAC bool_ss[VECTOR_SUB, LINEAR_ADD, LINEAR_NEG]
+QED
+
+Theorem LINEAR_VSUM :
+   !(f:real['M]->real['N]) g s. linear f /\ FINITE s ==> (f(vsum s g) = vsum s (f o g))
+Proof
+  GEN_TAC THEN GEN_TAC THEN
+  SIMP_TAC bool_ss[GSYM AND_IMP_INTRO, RIGHT_FORALL_IMP_THM] THEN
+  DISCH_TAC THEN HO_MATCH_MP_TAC FINITE_INDUCT THEN
+  SIMP_TAC bool_ss[VSUM_CLAUSES] THEN
+  FIRST_ASSUM(fn th =>
+    SIMP_TAC bool_ss[MATCH_MP LINEAR_0 th, MATCH_MP LINEAR_ADD th, o_THM])
+QED
+
+Theorem LINEAR_VSUM_MUL :
+   !(f:real['M]->real['N]) s c v.
+        linear f /\ FINITE s
+        ==> (f(vsum s (\i. c i * v i)) = vsum s (\i. c(i) * f(v i)))
+Proof
+  SIMP_TAC bool_ss[LINEAR_VSUM, o_DEF, LINEAR_CMUL]
+QED
+
+Theorem LINEAR_INJECTIVE_0 :
+   !(f:real['M]->real['N]). linear f
+       ==> ((!x y. (f(x) = f(y)) ==> (x = y)) <=>
+            (!x. (f(x) = (vec 0)) ==> (x = (vec 0))))
+Proof
+  REPEAT STRIP_TAC THEN
+  GEN_REWRITE_TAC (LAND_CONV o ONCE_DEPTH_CONV) empty_rewrites [GSYM VECTOR_SUB_EQ] THEN
+  ASM_SIMP_TAC bool_ss[GSYM LINEAR_SUB] THEN PROVE_TAC[VECTOR_SUB_RZERO]
+QED
+
+Theorem SYMMETRIC_LINEAR_IMAGE :
+   !(f:real['M]->real['N]) s. (!x. x IN s ==> ~x IN s) /\ linear f
+          ==> !x. x IN (IMAGE f s) ==> ~x IN (IMAGE f s)
+Proof
+  SIMP_TAC bool_ss[FORALL_IN_IMAGE, GSYM LINEAR_NEG] THEN
+  PROVE_TAC[IN_IMAGE]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Bilinear functions.                                                       *)
+(* ------------------------------------------------------------------------- *)
+
+(* cf. real_topologyTheory.bilinear *)
+Definition bilinear_def :
+   vec_bilinear (h:real['M]->real['N]->real['P]) =
+     ((!x. linear(\y. h x y)) /\ (!y. linear (\x. h x y)))
+End
+
+Overload "bilinear" = “vec_bilinear :(real['M]->real['N]->real['P])->bool”
+
+(* Below are simple bilinear properties directly ported from HOL-Light *)
+Theorem BILINEAR_SWAP :
+   !(h:real['M]->real['N]->real['P]).
+        bilinear(\x y. h y x) <=> bilinear h
+Proof
+  SIMP_TAC bool_ss[bilinear_def, ETA_AX] THEN METIS_TAC []
+QED
+
+Theorem BILINEAR_LADD :
+   !(h:real['M]->real['N]->real['P]) x y z.
+      bilinear h ==> h (x + y) z = (h x z) + (h y z)
+Proof
+  SIMP_TAC bool_ss[bilinear_def, linear_def]
+QED
+
+Theorem BILINEAR_RADD :
+   !(h:real['M]->real['N]->real['P]) x y z.
+      bilinear h ==> h x (y + z) = (h x y) + (h x z)
+Proof
+  SIMP_TAC bool_ss[bilinear_def, linear_def]
+QED
+
+Theorem BILINEAR_LMUL :
+   !(h:real['M]->real['N]->real['P]) c x y.
+      bilinear h ==> h (c * x) y = c * (h x y)
+Proof
+  SIMP_TAC bool_ss[bilinear_def, linear_def]
+QED
+
+Theorem BILINEAR_RMUL :
+   !(h:real['M]->real['N]->real['P]) c x y.
+      bilinear h ==> h x (c * y) = c * (h x y)
+Proof
+  SIMP_TAC bool_ss[bilinear_def, linear_def]
+QED
+
+Theorem BILINEAR_LNEG :
+   !(h:real['M]->real['N]->real['P]) x y. bilinear h ==> h (~x) y = ~(h x y)
+Proof
+  ONCE_REWRITE_TAC[VECTOR_NEG_MINUS1] THEN SIMP_TAC bool_ss[BILINEAR_LMUL]
+QED
+
+Theorem BILINEAR_RNEG :
+   !(h:real['M]->real['N]->real['P]) x y. bilinear h ==> h x (~y) = ~(h x y)
+Proof
+  ONCE_REWRITE_TAC[VECTOR_NEG_MINUS1] THEN SIMP_TAC bool_ss[BILINEAR_RMUL]
+QED
+
+Theorem BILINEAR_LZERO :
+   !(h:real['M]->real['N]->real['P]) x. bilinear h ==> h (vec 0) x = vec 0
+Proof
+  ONCE_REWRITE_TAC[VECTOR_ARITH ``(x:real['M]) = vec 0 <=> x + x = x``] THEN
+  SIMP_TAC bool_ss[GSYM BILINEAR_LADD, VECTOR_ADD_LID]
+QED
+
+Theorem BILINEAR_RZERO :
+   !(h:real['M]->real['N]->real['P]) x. bilinear h ==> h x (vec 0) = vec 0
+Proof
+  ONCE_REWRITE_TAC[VECTOR_ARITH ``(x:real['M]) = vec 0 <=> x + x = x``] THEN
+  SIMP_TAC bool_ss[GSYM BILINEAR_RADD, VECTOR_ADD_LID]
+QED
+
+Theorem BILINEAR_LSUB :
+   !(h:real['M]->real['N]->real['P]) x y z.
+      bilinear h ==> h (x - y) z = (h x z) - (h y z)
+Proof
+  SIMP_TAC bool_ss[VECTOR_SUB, BILINEAR_LNEG, BILINEAR_LADD]
+QED
+
+Theorem BILINEAR_RSUB :
+   !(h:real['M]->real['N]->real['P]) x y z.
+      bilinear h ==> h x (y - z) = (h x y) - (h x z)
+Proof
+  SIMP_TAC bool_ss[VECTOR_SUB, BILINEAR_RNEG, BILINEAR_RADD]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Adjoints.                                                                 *)
+(* ------------------------------------------------------------------------- *)
+
+Definition adjoint_def :
+   adjoint(f:real['M]->real['N]) = @f'. !x y. (f(x) dot y) = (x dot f'(y))
+End
+
+Theorem ADJOINT_WORKS :
+   !f:real['M]->real['N]. linear f ==> !x y. (f(x) dot y) = (x dot (adjoint f)(y))
+Proof
+  GEN_TAC THEN DISCH_TAC THEN REWRITE_TAC[adjoint_def] THEN CONV_TAC SELECT_CONV THEN
+  SIMP_TAC bool_ss[Once SWAP_FORALL_THM, Once (GSYM SKOLEM_THM)] THEN
+  GEN_TAC THEN
+  Q.EXISTS_TAC `(FCP i. (f:real['M]->real['N]) (basis i) dot y):real['M]` THEN
+  GEN_TAC THEN
+  GEN_REWRITE_TAC (funpow 2 LAND_CONV o RAND_CONV) empty_rewrites[GSYM BASIS_EXPANSION] THEN
+  ASM_SIMP_TAC bool_ss[LINEAR_VSUM, FINITE_COUNT] THEN
+  REWRITE_TAC[dot_def] THEN MATCH_MP_TAC EQ_TRANS THEN
+  Q.EXISTS_TAC
+   `sum (count (dimindex (:'N)))
+        (\i. sum (count (dimindex (:'M))) (\i'.f (x ' i' * basis i') ' i *  y ' i))` THEN
+  CONJ_TAC
+  >- (MATCH_MP_TAC SUM_EQ' THEN SRW_TAC[FCP_ss][VSUM_COMPONENT, GSYM SUM_RMUL]) THEN
+  MATCH_MP_TAC EQ_TRANS THEN
+  Q.EXISTS_TAC
+   `sum (count (dimindex (:'M)))
+        (\i. x ' i * sum (count (dimindex (:'N))) (\i'. f (basis i) ' i' * y ' i'))` THEN
+  CONJ_TAC
+  >- (REWRITE_TAC[GSYM SUM_LMUL] THEN
+      SIMP_TAC bool_ss[Once SUM_SWAP, FINITE_COUNT] THEN
+      MATCH_MP_TAC SUM_EQ' THEN SRW_TAC[][] THEN MATCH_MP_TAC SUM_EQ' THEN
+      SRW_TAC[FCP_ss][VECTOR_MUL_COMPONENT, LINEAR_CMUL, REAL_MUL_ASSOC]) THEN
+  MATCH_MP_TAC SUM_EQ' THEN SRW_TAC[FCP_ss][]
+QED
+
+Theorem ADJOINT_LINEAR :
+   !f:real['M]->real['N]. linear f ==> linear(adjoint f)
+Proof
+  REPEAT STRIP_TAC THEN REWRITE_TAC[linear_def, GSYM VECTOR_EQ_LDOT] THEN
+  ASM_SIMP_TAC bool_ss[DOT_RMUL, DOT_RADD, GSYM ADJOINT_WORKS]
+QED
+
+Theorem ADJOINT_CLAUSES :
+   !f:real['M]->real['N].
+     linear f ==> (!x y. (x dot (adjoint f)(y)) = (f(x) dot y)) /\
+                  (!x y. ((adjoint f)(y) dot x) = (y dot f(x)))
+Proof
+  PROVE_TAC[ADJOINT_WORKS, DOT_SYM]
+QED
+
+Theorem ADJOINT_ADJOINT :
+   !f:real['M]->real['N]. linear f ==> (adjoint(adjoint f) = f)
+Proof
+  SIMP_TAC bool_ss[FUN_EQ_THM, GSYM VECTOR_EQ_LDOT, ADJOINT_CLAUSES, ADJOINT_LINEAR]
+QED
+
+Theorem ADJOINT_UNIQUE :
+   !(f:real['M]->real['N]) f'. linear f /\ (!x y. (f'(x) dot y) = (x dot f(y)))
+          ==> (f' = adjoint f)
+Proof
+  SIMP_TAC bool_ss[FUN_EQ_THM, GSYM VECTOR_EQ_RDOT, ADJOINT_CLAUSES]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Matrix notation. NB: an MxN matrix is of type real^N^M, not real^M^N.     *)
+(* We could define a special type if we're going to use them a lot.          *)
+(* ------------------------------------------------------------------------- *)
+
+Definition matrix_cmul_def :
+   matrix_cmul:real->real['N]['M]->real['N]['M] c A = FCP i j. c * A ' i ' j
+End
+
+Definition matrix_neg_def :
+   matrix_neg:real['N]['M]->real['N]['M] A = FCP i j. -(A ' i ' j)
+End
+
+Definition matrix_add_def :
+   matrix_add:real['N]['M]->real['N]['M]->real['N]['M] A B =
+     FCP i j. A ' i ' j + B ' i ' j
+End
+
+Definition matrix_sub_def :
+   matrix_sub:real['N]['M]->real['N]['M]->real['N]['M] A B =
+     FCP i j. A ' i ' j - B ' i ' j
+End
+
+(* MxP * PxN = MxN *)
+Definition matrix_mul_def :
+   matrix_mul:real['P]['M]->real['N]['P]->real['N]['M] A B =
+     FCP i j. sum (count(dimindex(:'P))) (\k. A ' i ' k * B ' k ' j)
+End
+
+(* MxN * Nx1 = Mx1 *)
+Definition matrix_vector_mul_def :
+   matrix_vector_mul:real['N]['M]->real['N]->real['M] A x =
+     FCP i. sum (count(dimindex(:'N))) (\j. A ' i ' j * x ' j)
+End
+
+(* 1xM * MxN = 1xN *)
+Definition vector_matrix_mul_def :
+   vector_matrix_mul:real['M]->real['N]['M]->real['N] x A =
+     FCP j. sum (count(dimindex(:'M))) (\i. A ' i ' j * x ' i)
+End
+
+Overload "~"  = “matrix_neg       :real['N]['M]->real['N]['M]”
+Overload "+"  = “matrix_add       :real['N]['M]->real['N]['M]->real['N]['M]”
+Overload "-"  = “matrix_sub       :real['N]['M]->real['N]['M]->real['N]['M]”
+Overload "**" = “matrix_mul       :real['P]['M]->real['N]['P]->real['N]['M]”
+Overload "**" = “matrix_vector_mul:real['N]['M]->real['N]->real['M]”
+Overload "**" = “vector_matrix_mul:real['M]->real['N]['M]->real['N]”
+Overload "*"  = “matrix_cmul      :real->real['N]['M]->real['N]['M]”
+
+(* The ith row of a MxN matrix is a 1xN vector *)
+Definition row_def :
+   (row:num->real['N]['M]->real['N]) i A = (FCP j. A ' i ' j ):real['N]
+End
+
+(* The jth column of a MxN matrix is a Mx1 vector *)
+Definition column_def :
+   (column:num->real['N]['M]->real['M]) j A = (FCP i. A ' i ' j):real['M]
+End
+
+(* transpose operation: MxN -> NxM *)
+Definition transp_def :
+   (transp:real['N]['M]->real['M]['N]) A = (FCP i j. (A ' j ' i)):real['M]['N]
+End
+
+(* MxN diagonal matrix of the same elements. This serves as "matrix constant" *)
+Definition mat_def :
+   (mat:num->real['N]['M]) k = FCP i j. if i = j then &k else &0
+End
+
+(* this is experimental, for user code only (not used in the rest of file) *)
+val _ = add_numeral_form (#"m", SOME "mat");
+
+(* The set of all 1xN rows of an MxN matrix *)
+Definition rows_def :
+   rows (A:real['N]['M]) = {row i A | i < dimindex(:'M)}
+End
+
+Definition columns_def :
+   columns (A:real['N]['M]) = {column i A | i < dimindex(:'N)}
+End
+
+Theorem ROW_FCP :
+   !f k. k < dimindex(:'M) ==>
+        (row k ((FCP i j. f i j):real['N]['M]) = FCP j. f k j)
+Proof
+    SRW_TAC [FCP_ss][row_def]
+QED
+
+Theorem COLUMN_FCP :
+   !f k. k < dimindex (:'N) ==>
+        (column k ((FCP i j. f i j):real['N]['M]) = FCP i. f i k)
+Proof
+    SRW_TAC [FCP_ss][column_def]
+QED
+
+Theorem MATRIX_CMUL_COMPONENT :
+   !c A:real['N]['M] i j. i < dimindex(:'M) /\ j < dimindex(:'N) ==>
+                         ((c * A) ' i ' j = c * A ' i ' j)
+Proof
+  SRW_TAC[FCP_ss][matrix_cmul_def]
+QED
+
+Theorem MATRIX_ADD_COMPONENT :
+   !A B:real['N]['M] i j. i < dimindex(:'M) /\ j < dimindex(:'N) ==>
+                         ((A + B) ' i ' j = A ' i ' j + B ' i ' j)
+Proof
+  SRW_TAC[FCP_ss][matrix_add_def]
+QED
+
+Theorem MATRIX_SUB_COMPONENT :
+   !A B:real['N]['M] i j. i < dimindex(:'M) /\ j < dimindex(:'N) ==>
+                         ((A - B) ' i ' j = A ' i ' j - B ' i ' j)
+Proof
+  SRW_TAC[FCP_ss][matrix_sub_def]
+QED
+
+Theorem MATRIX_NEG_COMPONENT :
+   !A:real['N]['M] i j. i < dimindex(:'M) /\ j < dimindex(:'N) ==>
+                       ((~A) ' i ' j = -A ' i ' j)
+Proof
+  SRW_TAC[FCP_ss][matrix_neg_def]
+QED
+
+Theorem MAT_COMPONENT :
+   !n i j. i < dimindex(:'M) /\ j < dimindex(:'N) ==>
+          ((mat n:real['N]['M]) ' i ' j = if i = j then &n else &0)
+Proof
+  SRW_TAC[FCP_ss][mat_def]
+QED
+
+Theorem MATRIX_CMUL_ASSOC :
+   !a b X:real['N]['M]. a * (b * X) = (a * b) * X
+Proof
+  SRW_TAC[FCP_ss][matrix_cmul_def, REAL_MUL_ASSOC]
+QED
+
+Theorem MATRIX_CMUL_LID :
+   !X:real['N]['M]. &1 * X = X
+Proof
+  SRW_TAC[FCP_ss][matrix_cmul_def, REAL_MUL_LID]
+QED
+
+Theorem MATRIX_ADD_SYM :
+   !A:real['N]['M] B. A + B = B + A
+Proof
+  SRW_TAC[FCP_ss][matrix_add_def, REAL_ADD_SYM]
+QED
+
+Theorem MATRIX_ADD_ASSOC :
+   !A:real['N]['M] B C. A + (B + C) = (A + B) + C
+Proof
+  SRW_TAC[FCP_ss][matrix_add_def, REAL_ADD_ASSOC]
+QED
+
+Theorem MATRIX_ADD_LID :
+   !A:real['N]['M]. mat 0 + A = A
+Proof
+  SRW_TAC[FCP_ss][matrix_add_def, mat_def, COND_ID, REAL_ADD_LID]
+QED
+
+Theorem MATRIX_ADD_RID :
+   !A:real['N]['M]. A + mat 0 = A
+Proof
+  SRW_TAC[FCP_ss][matrix_add_def, mat_def, COND_ID, REAL_ADD_LID]
+QED
+
+Theorem MATRIX_ADD_LNEG :
+   !A:real['N]['M]. ~A + A = mat 0
+Proof
+  SRW_TAC[FCP_ss][matrix_neg_def, matrix_add_def, mat_def, COND_ID, REAL_ADD_LINV]
+QED
+
+Theorem MATRIX_ADD_RNEG :
+   !A:real['N]['M]. A + ~A = mat 0
+Proof
+  SRW_TAC[FCP_ss][matrix_neg_def, matrix_add_def, mat_def, COND_ID, REAL_ADD_RINV]
+QED
+
+Theorem MATRIX_SUB :
+   !A:real['N]['M] B. A - B = A + ~B
+Proof
+  SRW_TAC[FCP_ss][matrix_neg_def, matrix_add_def, matrix_sub_def, real_sub]
+QED
+
+Theorem MATRIX_SUB_REFL :
+   !A:real['N]['M]. A - A = mat 0
+Proof
+  REWRITE_TAC[MATRIX_SUB, MATRIX_ADD_RNEG]
+QED
+
+Theorem MATRIX_ADD_LDISTRIB :
+   !A:real['P]['M] B:real['N]['P] C. A ** (B + C) = A ** B + A ** C
+Proof
+  SRW_TAC[FCP_ss][matrix_mul_def, matrix_add_def, GSYM SUM_ADD'] THEN
+  MATCH_MP_TAC SUM_EQ' THEN
+  SRW_TAC[FCP_ss][REAL_ADD_LDISTRIB]
+QED
+
+Theorem VECTOR_DOT_FCP2 :
+  !f u v. (($FCP f :real['N]) dot v) =
+           sum (count (dimindex(:'N))) (\i. f i * (v ' i)) /\
+          (u dot ($FCP f :real['N])) =
+           sum (count (dimindex(:'N))) (\i. (u ' i) * f i)
+Proof
+    SRW_TAC [FCP_ss] [dot_def, SUM_EQ']
+QED
+
+Theorem MATRIX_MUL_EQ :
+    !A:real['P]['M] B:real['N]['P] k:real.
+        (FCP i j. sum (count(dimindex(:'P))) (\k. A ' i ' k * B ' k ' j)) =
+        (FCP i j. (row i A) dot (column j B)): real['N]['M]
+Proof
+    SRW_TAC[FCP_ss][dot_def, row_def, column_def] THEN
+    MATCH_MP_TAC SUM_EQ' THEN SRW_TAC[FCP_ss][]
+QED
+
+Theorem MATRIX_MUL_ASSOC :
+    !(A:real['N]['M]) (B:real['P]['N]) (C:real['Q]['P]).
+      (A ** B) ** C = A ** (B ** C)
+Proof
+    SRW_TAC [FCP_ss][matrix_mul_def, MATRIX_MUL_EQ, ROW_FCP, COLUMN_FCP, VECTOR_DOT_FCP2] THEN
+    rename1 ‘j < dimindex(:'Q)’ \\
+    SRW_TAC [][dot_def, GSYM SUM_LMUL, GSYM SUM_RMUL] THEN
+    SRW_TAC [][Once SUM_SWAP] THEN
+    MATCH_MP_TAC SUM_EQ' THEN
+    Q.X_GEN_TAC ‘k’ >> SRW_TAC [][] THEN
+    MATCH_MP_TAC SUM_EQ' THEN
+    Q.X_GEN_TAC ‘l’ >> SRW_TAC [][] THEN
+    SRW_TAC [FCP_ss][row_def, column_def]
+QED
+
+Theorem MATRIX_MUL_LMUL :
+   !A:real['N]['M] B:real['P]['N] c. (c * A) ** B = c * (A ** B)
+Proof
+  SRW_TAC[FCP_ss][matrix_mul_def, matrix_vector_mul_def, MATRIX_CMUL_COMPONENT] THEN
+  rename1 ‘j < dimindex(:'P)’ \\
+  MATCH_MP_TAC EQ_TRANS THEN
+  Q.EXISTS_TAC
+   `sum (count (dimindex (:'N))) (\k. c * (A ' i ' k * B ' k ' j))` THEN
+  CONJ_TAC
+  >- (MATCH_MP_TAC SUM_EQ' THEN
+      SRW_TAC[FCP_ss][MATRIX_CMUL_COMPONENT, REAL_MUL_ASSOC]) THEN
+  SIMP_TAC bool_ss[SUM_LMUL]
+QED
+
+Theorem MATRIX_MUL_RMUL :
+   !A:real['N]['M] B:real['P]['N] c. A ** (c * B) = c * (A ** B)
+Proof
+  SRW_TAC[FCP_ss][matrix_mul_def, matrix_vector_mul_def, MATRIX_CMUL_COMPONENT] THEN
+  rename1 ‘j < dimindex(:'P)’ \\
+  MATCH_MP_TAC EQ_TRANS THEN
+  Q.EXISTS_TAC
+   `sum (count (dimindex (:'N))) (\k. c * (A ' i ' k * B ' k ' j))` THEN
+  CONJ_TAC
+  >- (MATCH_MP_TAC SUM_EQ' THEN
+      SRW_TAC[FCP_ss][MATRIX_CMUL_COMPONENT]) THEN
+  SIMP_TAC bool_ss[SUM_LMUL]
+QED
+
+Theorem MATRIX_VECTOR_MUL_ASSOC :
+   !A:real['N]['M] B:real['P]['N] x:real['P]. A ** B ** x = (A ** B) ** x
+Proof
+  REPEAT GEN_TAC THEN
+  SRW_TAC[FCP_ss][matrix_mul_def, matrix_vector_mul_def] THEN
+  MATCH_MP_TAC EQ_TRANS THEN
+  Q.EXISTS_TAC
+   `sum (count (dimindex (:'N)))
+    (\j. A ' i ' j *
+         sum (count (dimindex (:'P))) (\k. B ' j ' k * x ' k))` THEN
+  CONJ_TAC >- (MATCH_MP_TAC SUM_EQ' THEN SRW_TAC[FCP_ss][]) THEN
+  MATCH_MP_TAC EQ_TRANS THEN
+  Q.EXISTS_TAC
+   `sum (count (dimindex (:'P)))
+    (\j. sum (count (dimindex (:'N))) (\k. A ' i ' k * B ' k ' j) * x ' j)` THEN
+  reverse CONJ_TAC >- (MATCH_MP_TAC SUM_EQ' THEN SRW_TAC[FCP_ss][]) THEN
+  REWRITE_TAC[GSYM SUM_LMUL, GSYM SUM_RMUL] THEN BETA_TAC THEN
+  REWRITE_TAC[REAL_MUL_ASSOC] THEN
+  SIMP_TAC bool_ss[Once SUM_SWAP, FINITE_COUNT]
+QED
+
+(* NOTE: here ‘mat 1’ must be a NxN square matrix *)
+Theorem MATRIX_VECTOR_MUL_LID :
+   !x:real['N]. (mat 1 :real['N]['N]) ** x = x
+Proof
+  REWRITE_TAC[matrix_vector_mul_def,
+   GEN_REWRITE_RULE (RAND_CONV o ONCE_DEPTH_CONV) empty_rewrites[EQ_SYM_EQ]
+    (SPEC_ALL mat_def)] THEN
+  SRW_TAC[FCP_ss][] THEN MATCH_MP_TAC EQ_TRANS THEN
+  Q.EXISTS_TAC `sum (count (dimindex (:'N)))(\j. (if j = i then 1 else 0) * x ' j)` THEN
+  CONJ_TAC >- (MATCH_MP_TAC SUM_EQ' THEN SRW_TAC[FCP_ss][]) \\
+  REWRITE_TAC[COND_RATOR, COND_RAND] THEN
+  ASM_SIMP_TAC bool_ss[SUM_DELTA, REAL_MUL_LZERO, IN_COUNT, REAL_MUL_LID]
+QED
+
+Theorem MATRIX_VECTOR_MUL_LZERO :
+   !x:real['N]. (mat 0 :real['N]['M]) ** x = vec 0
+Proof
+  SRW_TAC[FCP_ss][mat_def, matrix_vector_mul_def, VEC_COMPONENT] THEN
+  MATCH_MP_TAC EQ_TRANS THEN
+  Q.EXISTS_TAC `sum (count (dimindex (:'N))) (\j. 0 * x ' j)` THEN
+  CONJ_TAC >- (MATCH_MP_TAC SUM_EQ' THEN SRW_TAC[FCP_ss][]) \\
+  REWRITE_TAC[REAL_MUL_LZERO, SUM_0']
+QED
+
+Theorem MATRIX_VECTOR_MUL_RZERO :
+   !A:real['N]['M]. A ** (vec 0) = (vec 0)
+Proof
+  SRW_TAC[FCP_ss][matrix_vector_mul_def, VEC_COMPONENT] THEN
+  MATCH_MP_TAC EQ_TRANS THEN
+  Q.EXISTS_TAC `sum (count (dimindex (:'N))) (\j. 0)` THEN
+  reverse CONJ_TAC >- REWRITE_TAC[SUM_0'] \\
+  MATCH_MP_TAC SUM_EQ' THEN SRW_TAC[FCP_ss][VEC_COMPONENT]
+QED
+
+Theorem MATRIX_TRANSP_MUL :
+   !A:real['N]['M] B. transp(A ** B) = transp(B) ** transp(A)
+Proof
+  SRW_TAC[FCP_ss][matrix_mul_def, transp_def] THEN
+  MATCH_MP_TAC SUM_EQ' THEN
+  SRW_TAC[FCP_ss][Once REAL_MUL_SYM]
+QED
+
+Theorem MATRIX_EQ :
+   !A:real['N]['M] B. (A = B) <=> !x:real['N]. A ** x = B ** x
+Proof
+  REPEAT GEN_TAC THEN EQ_TAC >- PROVE_TAC[] THEN
+  DISCH_THEN(MP_TAC o GEN ``i:num`` o SPEC ``(basis i):real['N]``) THEN
+  SIMP_TAC (bool_ss ++ FCP_ss) [CART_EQ, matrix_vector_mul_def, basis_def] THEN
+  Q.SUBGOAL_THEN `!i i'.
+   (sum (count (dimindex (:'N)))
+   (\j. A:real['N]['M] ' i' ' j * (FCP i'. if i' = i then 1 else 0):real['N] ' j) =
+        sum (count (dimindex (:'N)))
+   (\j. A ' i' ' j * if j = i then 1 else 0))` ASSUME_TAC
+   >- (REPEAT GEN_TAC THEN MATCH_MP_TAC SUM_EQ' THEN SRW_TAC[FCP_ss][]) THEN
+  Q.SUBGOAL_THEN `!i i'.
+   (sum (count (dimindex (:'N)))
+   (\j. B:real['N]['M] ' i' ' j * (FCP i'. if i' = i then 1 else 0):real['N] ' j) =
+        sum (count (dimindex (:'N)))
+   (\j. B ' i' ' j * if j = i then 1 else 0))` ASSUME_TAC
+   >- (REPEAT GEN_TAC THEN MATCH_MP_TAC SUM_EQ' THEN SRW_TAC[FCP_ss][]) THEN
+  ASM_REWRITE_TAC[] THEN
+  SIMP_TAC bool_ss[SUM_DELTA, COND_RAND, REAL_MUL_RZERO, REAL_MUL_RID, IN_COUNT]
+QED
+
+Theorem TRANSP_MAT :
+   !n. transp(mat n) = mat n :real['M]['N]
+Proof
+  SRW_TAC[FCP_ss][transp_def, mat_def, EQ_SYM_EQ]
+QED
+
+Theorem TRANSP_TRANSP :
+   !A:real['N]['M]. transp(transp A) = A
+Proof
+  SRW_TAC[FCP_ss][transp_def]
+QED
+
+Theorem TRANSP_EQ :
+   !A B:real['N]['M]. (transp A = transp B) <=> (A = B)
+Proof
+  PROVE_TAC[TRANSP_TRANSP]
+QED
+
+Theorem ROW_TRANSP :
+   !A:real['N]['M] i.
+        i < dimindex(:'N) ==> (row i (transp A) = column i A)
+Proof
+  SRW_TAC[FCP_ss][row_def, column_def, transp_def]
+QED
+
+Theorem COLUMN_TRANSP :
+   !A:real['N]['M] i.
+        i < dimindex(:'M) ==> (column i (transp A) = row i A)
+Proof
+  SRW_TAC[FCP_ss][row_def, column_def, transp_def]
+QED
+
+Theorem ROWS_TRANSP :
+   !A:real['N]['M]. rows(transp A) = columns A
+Proof
+  REWRITE_TAC[rows_def, columns_def, EXTENSION] THEN
+  CONV_TAC (DEPTH_CONV SET_SPEC_CONV) THEN PROVE_TAC[ROW_TRANSP]
+QED
+
+Theorem COLUMNS_TRANSP :
+   !A:real['N]['M]. columns(transp A) = rows A
+Proof
+  PROVE_TAC[TRANSP_TRANSP, ROWS_TRANSP]
+QED
+
+Theorem VECTOR_MATRIX_MUL_TRANSP :
+   !A:real['N]['M] x:real['M]. x ** A = transp A ** x
+Proof
+  REWRITE_TAC[matrix_vector_mul_def, vector_matrix_mul_def, transp_def] THEN
+  SRW_TAC[FCP_ss][] THEN MATCH_MP_TAC SUM_EQ' THEN BETA_TAC THEN SRW_TAC[FCP_ss][]
+QED
+
+Theorem MATRIX_VECTOR_MUL_TRANSP :
+   !A:real['N]['M] x:real['N]. A ** x = x ** transp A
+Proof
+  REWRITE_TAC[VECTOR_MATRIX_MUL_TRANSP, TRANSP_TRANSP]
+QED
+
+Theorem MATRIX_MUL_LID :
+   !A:real['N]['M]. mat 1 ** A = A
+Proof
+   REPEAT GEN_TAC THEN SRW_TAC [FCP_ss][matrix_mul_def, mat_def]
+   THEN MATCH_MP_TAC EQ_TRANS
+   THEN Q.EXISTS_TAC `sum (count (dimindex (:'M)))(\k. if k = i then A ' k ' i' else 0)`
+   THEN CONJ_TAC THENL
+   [MATCH_MP_TAC SUM_EQ' THEN SRW_TAC [][] THEN SRW_TAC [FCP_ss][],
+    ASM_SIMP_TAC bool_ss[SUM_DELTA, IN_COUNT]]
+QED
+
+Theorem MATRIX_MUL_RID :
+   !A:real['N]['M]. A ** mat 1 = A
+Proof
+   REPEAT STRIP_TAC THEN ONCE_REWRITE_TAC [GSYM TRANSP_EQ]
+   THEN ONCE_REWRITE_TAC[MATRIX_TRANSP_MUL]
+   THEN REWRITE_TAC[TRANSP_MAT]
+   THEN MATCH_ACCEPT_TAC MATRIX_MUL_LID
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Two sometimes fruitful ways of looking at matrix-vector multiplication.   *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem MATRIX_MUL_DOT :
+   !A:real['N]['M] x. A ** x = FCP i. A ' i dot x
+Proof
+  REWRITE_TAC[matrix_vector_mul_def, dot_def] THEN SRW_TAC[FCP_ss][]
+QED
+
+Theorem MATRIX_MUL_VSUM :
+   !A:real['N]['M] x. A ** x = vsum(count(dimindex(:'N))) (\i. x ' i * column i A)
+Proof
+  SRW_TAC[FCP_ss][matrix_vector_mul_def, VSUM_COMPONENT, VECTOR_MUL_COMPONENT,
+                  column_def, Once REAL_MUL_SYM]
+QED
+
+val _ = export_theory ();
+val _ = html_theory "vector";

--- a/src/parallel_builds/core/Holmakefile
+++ b/src/parallel_builds/core/Holmakefile
@@ -76,7 +76,7 @@ EX2DIRS = AKS algebra algorithms/boyer_moore \
             logic/ltl logic/ltl-transformations \
             l3-machine-code/decompilers \
           miller \
-	  probability \
+	  probability vector \
           separationLogic/src separationLogic/src/holfoot simple_complexity \
           temporal_deep
 

--- a/src/pred_set/src/more_theories/cardinalScript.sml
+++ b/src/pred_set/src/more_theories/cardinalScript.sml
@@ -1862,28 +1862,6 @@ val CARD_LE_INJ = store_thm ("CARD_LE_INJ",
   SIMP_TAC std_ss [IN_INSERT, SUBSET_DEF, IN_IMAGE] THEN
   METIS_TAC[SUBSET_DEF, IN_IMAGE]);
 
-Theorem CARD_IMAGE_INJ:
-   !(f:'a->'b) s. (!x y. x IN s /\ y IN s /\ (f(x) = f(y)) ==> (x = y)) /\
-                  FINITE s ==> (CARD (IMAGE f s) = CARD s)
-Proof
-  GEN_TAC THEN ONCE_REWRITE_TAC [CONJ_SYM] THEN
-  REWRITE_TAC[GSYM AND_IMP_INTRO] THEN GEN_TAC THEN
-  KNOW_TAC “
-    (!(x :'a) (y :'a).
-       x IN s ==> y IN s ==> ((f :'a -> 'b) x = f y) ==> (x = y)) ==>
-       (CARD (IMAGE f s) = CARD s) <=>
-    (\s. (!(x :'a) (y :'a).
-       x IN s ==> y IN s ==> ((f :'a -> 'b) x = f y) ==> (x = y)) ==>
-      (CARD (IMAGE f s) = CARD s)) (s:'a->bool)” THENL
-  [FULL_SIMP_TAC std_ss[], DISCH_TAC THEN ONCE_ASM_REWRITE_TAC []
-  THEN MATCH_MP_TAC FINITE_INDUCT THEN BETA_TAC THEN
-  REWRITE_TAC[NOT_IN_EMPTY, IMAGE_EMPTY, IMAGE_INSERT] THEN
-  REPEAT STRIP_TAC THENL
-  [ASM_SIMP_TAC std_ss [CARD_DEF, IMAGE_FINITE, IN_IMAGE],
-  ASM_SIMP_TAC std_ss [CARD_DEF, IMAGE_FINITE, IN_IMAGE] THEN
-  COND_CASES_TAC THENL [ASM_MESON_TAC[IN_INSERT], ASM_MESON_TAC[IN_INSERT]]]]
-QED
-
 Theorem CARD_IMAGE_LE:
    !(f:'a->'b) s. FINITE s ==> CARD(IMAGE f s) <= CARD s
 Proof
@@ -2035,35 +2013,6 @@ val CARD_SUBSET_EQ = store_thm ("CARD_SUBSET_EQ",
    [REWRITE_TAC[GSYM HAS_SIZE_0] THEN
     FULL_SIMP_TAC std_ss [HAS_SIZE, CARD_EMPTY],
     UNDISCH_TAC ``a:'a->bool SUBSET b`` THEN SET_TAC[]]);
-
-val HAS_SIZE_INDEX = store_thm ("HAS_SIZE_INDEX",
- ``!s n. s HAS_SIZE n
-   ==> ?f:num->'a. (!m. m < n ==> f(m) IN s) /\
-   (!x. x IN s ==> ?!m. m < n /\ (f m = x))``,
-
-  KNOW_TAC ``(!(s:'a->bool) (n:num). s HAS_SIZE n ==>
-       ?f. (!m. m < n ==> f m IN s) /\ !x. x IN s ==> ?!m. m < n /\ (f m = x)) =
-             (!(n:num) (s:'a->bool). s HAS_SIZE n ==>
-       ?f. (!m. m < n ==> f m IN s) /\ !x. x IN s ==> ?!m. m < n /\ (f m = x))``
-  THENL [EQ_TAC THENL [FULL_SIMP_TAC std_ss [], FULL_SIMP_TAC std_ss []], ALL_TAC]
-  THEN DISCH_TAC THEN ONCE_ASM_REWRITE_TAC [] THEN
-  INDUCT_TAC THEN SIMP_TAC std_ss [HAS_SIZE_0, HAS_SIZE_SUC, NOT_IN_EMPTY,
-  ARITH_PROVE ``(!m. m < 0:num <=> F) /\ (!m n. m < SUC n <=> (m = n) \/ m < n)``] THEN
-  X_GEN_TAC ``s:'a->bool`` THEN REWRITE_TAC[EXTENSION, NOT_IN_EMPTY] THEN
-  SIMP_TAC std_ss [NOT_FORALL_THM] THEN
-  DISCH_THEN(CONJUNCTS_THEN2 (X_CHOOSE_TAC ``a:'a``) (MP_TAC o SPEC ``a:'a``)) THEN
-  ASM_REWRITE_TAC[] THEN DISCH_TAC THEN
-  FIRST_X_ASSUM(MP_TAC o SPEC ``s DELETE (a:'a)``) THEN ASM_REWRITE_TAC[] THEN
-  DISCH_THEN(X_CHOOSE_THEN ``f:num->'a`` STRIP_ASSUME_TAC) THEN
-  EXISTS_TAC ``\m:num. if m < n then f(m) else a:'a`` THEN BETA_TAC THEN CONJ_TAC THENL
-  [GEN_TAC THEN REWRITE_TAC[] THEN COND_CASES_TAC THEN
-  ASM_MESON_TAC[IN_DELETE], ALL_TAC] THEN
-  X_GEN_TAC ``x:'a`` THEN DISCH_TAC THEN ASM_REWRITE_TAC[] THEN
-  FIRST_X_ASSUM(MP_TAC o SPEC ``x:'a``) THEN
-  ASM_REWRITE_TAC[IN_DELETE] THEN
-  DISCH_TAC THEN
-  Cases_on `x <> a` THEN1 METIS_TAC [] THEN
-  METIS_TAC [LESS_REFL, IN_DELETE]);
 
 Theorem CARD_BIGUNION_LE:
  !s t:'a->'b->bool m n.

--- a/src/real/iterateScript.sml
+++ b/src/real/iterateScript.sml
@@ -2096,7 +2096,9 @@ val ITERATE_PAIR = store_thm ("ITERATE_PAIR",
 (* Sums of natural numbers.                                                  *)
 (* ------------------------------------------------------------------------- *)
 
-val nsum = Define `(nsum :('a->bool)->('a->num)->num) = iterate (+)`;
+Definition nsum :
+   (nsum :('a->bool)->('a->num)->num) = iterate (+)
+End
 
 val NEUTRAL_ADD = store_thm ("NEUTRAL_ADD",
   ``neutral((+):num->num->num) = 0``,
@@ -4021,8 +4023,9 @@ QED
 (* Products over natural numbers.                                            *)
 (* ------------------------------------------------------------------------- *)
 
-val nproduct = new_definition ("nproduct",
-  ``nproduct = iterate(( * ):num->num->num)``);
+Definition nproduct :
+   nproduct = iterate(( * ):num->num->num)
+End
 
 val NPRODUCT_CLAUSES = store_thm ("NPRODUCT_CLAUSES",
  ``(!f. nproduct {} f = 1) /\


### PR DESCRIPTION
Hi,

more than 4 years ago (Jan 2018), a Chinese author @LiLiming ever sent a PR (#513) here about their porting work of HOL-Light's vector and matrix theories. The PR was closed due to missing necessary preliminary work, but actually there are many small mistakes in the code to be fixed, it definitely cannot run Kananaskis-6 although it may be "developed" there.

However, I was considering this work important, because HOL-Light's real-valued vector formalization is the basis of its `Multivariate` calculus, and matrices may have applications in discrete-time Markov Chains (DTMC) that one day I may also touch. Thus I saved their code in a branch of my fork of HOL repository, and recently I started to fix issues in these old code.

There were four ML scripts:

1. `permutation.sml` is a port of HOL-Light's `Library/permutations.ml`, a theory of permutations of set elements. I will explain soon the difference between HOL-Light's permutation and HOL4's existing `PERMUTES` (in `pred_setTheory`, as an overload of `BIJ f s s`, i.e. bijections between the same set)
2. `iterate.sml` is another port of `iterateTheory`. I checked this file and found no theorems beyond what we already have in src/real/iterateScript.sml`. Thus this file can be just thrown away.
3. `Vectors.ml` is a port of HOL-Lights' `Multivariate/vectors.ml` (up to at most 2018). It is this theory containing the formalization of vector and matrix arithmetics.
4. `Determinant.sml`, a theory of "determinants" (special application of square matrix) of Linear Algebra.

In this PR, I fully fixed `permutation.sml` (now `permutationTheory`) and partially (~50%) fixed `Vectors.ml` (now `vectorScript.sml`).   I didn't continue the work and stopped here (for now), because I found it's more urgent to improve HOL4's `REAL_ARITH_TAC` (see some comments in #1035).

# `permutationTheory`

In `permutationTheory` we have HOL-Light's version of permutations defined in this way:
```
permutes
⊢ ∀p s. p permutes s ⇔ (∀x. x ∉ s ⇒ p x = x) ∧ ∀y. ∃!x. p x = y
```
I added the following new theorem to show the relationship between this `permutes` and HOL4's existing `PERMUTES` in `pred_setTheory`:
```
permutes_alt
⊢ ∀f s. f permutes s ⇔ f PERMUTES s ∧ ∀x. x ∉ s ⇒ f x = x

permutes_alt_univ
⊢ ∀f. f permutes 𝕌(:α) ⇔ f PERMUTES 𝕌(:α)
```
In other words, HOL-Light's `f permutes s` asserts a total function `f`, and for all elements outside of the set `s`, the function simply returns the input value.  In particular, for permutations on universal sets, the two definitions are equivalent. 

Unlike other cases (like division-by-zero), this time I think HOL-Light's `permutes` is more general and useful: if one  considers a superset of `s`, say `s SUBSET t`, obviously `f` is also a permutation of `t`, while in the case of HOL4's existing `f PERMUTES s` the function `f` is unspecified outside of `s`. 

For instance, in the applications of matrix theory, sometimes one may need to only swap two rows or columns, and such "swapping" operator can be formalized as a permutation of only two indexes, which by HOL-Light's `permutes` definition is also a valid permutation of all indexes of the matrix.

`permutes` over finite sets is called `permutation` of particular importance:
```
PERMUTATION_PERMUTES
⊢ ∀p. permutation p ⇔ ∃s. FINITE s ∧ p permutes s
```
`permutation` over finite sets can be defined by finite number of swapping actions, each time only two elements are swapped. Actually the original definitions are the following:
```
Definition swap_def :
   swap (i,j) k = if k = i then j else if k = j then i else k
End

Inductive swapseq :
   (swapseq 0 I) /\
   (!a b p n. swapseq n p /\ ~(a = b) ==> swapseq (SUC n) (swap(a,b) o p))
End

Definition permutation :
   permutation p = ?n. swapseq n p
End
```
Many interesting properties about this finite permutation are proven, while there are still more in HOL-Light's latest version.

# Vectors in `vectorTheory`

The so-called "vector" are nothing but FCP of type `:real['N]`. By defining their add, sub, neg and mul operators (and overloaded to `+`, `-`, `~` and `*`), e.g.,
```
vector_add_def
⊢ ∀x y. x + y = FCP i. x ' i + y ' i
```
Their algebra laws can be easily proven (by a single, internal tactic function), e.g.
```
VECTOR_ADD_LID
⊢ ∀x. 0 + x = x
VECTOR_ADD_LINV
⊢ ∀x. -x + x = 0
VECTOR_ADD_RDISTRIB
⊢ (a + b) * x = a * x + b * x
VECTOR_ADD_RID
⊢ ∀x. x + 0 = x
VECTOR_ADD_RINV
⊢ ∀x. x + -x = 0
VECTOR_ADD_SUB
⊢ x + y − x = y
VECTOR_ADD_SYM
⊢ ∀x y. x + y = y + x
...
```
For vectors, the most complicated binary operator is their "dot" multiplication:
```
dot_def
⊢ ∀x y. x dot y = sum (count (dimindex (:'N))) (λi. x ' i * y ' i)
```
Many textbook properties about "dot" are provided, of course.

P. S. In Harrison's 2005 ITP paper [1], he ever mentioned a sophisticated quantifier elimination procedure of vector arithmetics, provided by mathematician Robert Solovay. I will investigate the possibility of porting this decision procedure to HOL4.

[1] Harrison, J.: A HOL Theory of Euclidean Space. In: Hurd, J. and Melham, T.F. (eds.) LNCS 3693 - Theorem Proving in Higher Order Logics (TPHOLs 2005). pp. 114–129. Springer, Berlin, Heidelberg (2005).

# Matrices in `vectorTheory`

Matrix is nothing but FCP of type `:real['N]['M]`, but NOTE that MxN matrix is of type `:real['N]['M]`, not `:real['M]['N]`.
Among other matrix operators, the following 3 multiplication operators (overloaded to "**") between matrix (or vector) and another matrix (or vector) is important: (vector * vector is "dot", already there)
```
(* MxP * PxN = MxN *)
Definition matrix_mul_def :
   matrix_mul:real['P]['M]->real['N]['P]->real['N]['M] A B =
     FCP i j. sum (count(dimindex(:'P))) (\k. A ' i ' k * B ' k ' j)
End

(* MxN * Nx1 = Mx1 *)
Definition matrix_vector_mul_def :
   matrix_vector_mul:real['N]['M]->real['N]->real['M] A x =
     FCP i. sum (count(dimindex(:'N))) (\j. A ' i ' j * x ' j)
End

(* 1xM * MxN = 1xN *)
Definition vector_matrix_mul_def :
   vector_matrix_mul:real['M]->real['N]['M]->real['N] x A =
     FCP j. sum (count(dimindex(:'M))) (\i. A ' i ' j * x ' i)
End
```
Again, many common algebra laws are provided. So far there's no killer theorems ported.

--Chun
