### PR TITLE
Sync type sizes in DataSize and TypeBasePure

### DIFF
--- a/src/1/TypeBasePure.sig
+++ b/src/1/TypeBasePure.sig
@@ -121,6 +121,7 @@ sig
                          (hol_type -> term option) *
                          (hol_type -> term) -> hol_type -> term
 
+   val type_size_pre   : (hol_type -> term option) -> typeBase -> hol_type -> term
    val type_size       : typeBase -> hol_type -> term
    val type_encode     : typeBase -> hol_type -> term
    val type_lift       : typeBase -> hol_type -> term

--- a/src/1/TypeBasePure.sml
+++ b/src/1/TypeBasePure.sml
@@ -789,14 +789,19 @@ fun Zero() = mk_thy_const{Name="0",Thy="num", Ty=num()}
              handle HOL_ERR _ =>
              raise ERR "type_size.Zero()" "Numbers not declared"
 
-fun type_size db ty =
+fun type_size_pre theta db ty =
  let fun K0 ty = mk_abs(mk_var("v",ty),Zero())
-     fun theta ty = if is_vartype ty then SOME (K0 ty) else NONE
+     fun theta2 ty = case theta ty of
+         NONE => if is_vartype ty then SOME (K0 ty) else NONE
+       | SOME sz => if type_of sz = (ty --> num()) then SOME sz
+         else raise (ERR "type_size_pre" "pre-supplied size has wrong type")
      val gamma = Option.map fst o
                  Option.composePartial (size_of,fetch db)
   in
     typeValue (theta,gamma,K0) ty
   end
+
+val type_size = type_size_pre (fn _ => NONE)
 
 (*---------------------------------------------------------------------------
     Encoding: map a HOL type (ty) into a term having type :ty -> bool list

--- a/src/datatype/DataSize.sml
+++ b/src/datatype/DataSize.sml
@@ -242,6 +242,10 @@ fun define_size {induction, recursion} db = case define_size_rec recursion db of
     NONE => NONE
   | SOME r => if ! prove_size_eqs then let
     val comb_eqs = size_def_to_comb db (SOME induction) (#def r)
+      handle HOL_ERR err =>
+        let in
+        print "Error proving size_eqs, consider DataSize.prove_size_eqs := false\n\n";
+        raise (HOL_ERR err) end
     val dtys = Prim_rec.doms_of_tyaxiom recursion
     val def_name = fst(dest_type(hd dtys))
     val _ = save_thm (def_name ^ "_size_eq", comb_eqs)

--- a/src/datatype/DataSize.sml
+++ b/src/datatype/DataSize.sml
@@ -183,9 +183,8 @@ fun size_def_to_comb (db : TypeBasePure.typeBase) opt_ind_rec size_def =
         val eq = mk_eq (mk_comb (lhs_m, x), mk_comb (rhs_m, x))
       in (mk_forall (x, eq), mk_eq (lhs_m, rhs_m)) end
     val eqs = map (fst o eq) ind_tys |> list_mk_conj
-    fun size_rule ty = TypeBasePure.fetch db ty |> valOf |> TypeBasePure.size_of
-            |> valOf |> snd
-    val aux_size_rules = aux_ms |> map (size_rule o arg_ty)
+    fun size_of_rcd ty = TypeBasePure.fetch db ty |> valOf |> TypeBasePure.size_of
+    val aux_size_rules = aux_ms |> map (size_of_rcd o arg_ty) |> mapfilter (snd o valOf)
     val aux_size_eqs = aux_size_rules |> HOLset.fromList thm_compare |> HOLset.listItems
         |> mapfilter (valOf o size_def_to_comb db NONE)
     val size_def' = REWRITE_RULE [boolTheory.ITSELF_EQN_RWT] size_def

--- a/src/datatype/selftest.sml
+++ b/src/datatype/selftest.sml
@@ -464,6 +464,9 @@ val _ = tprint "Testing indirect recursion size eqs with basic types";
 val _ = quiet_warnings (fn () =>
            (Datatype `v_rec = V (v_rec + num) | W`)
            ) () handle _ => die "FAILED!"
+(* it's awkward to load this at this point. however, some of the previous tests
+   are interesting precisely because it isn't loaded. FIXME later *)
+val _ = load "basicSize"
 val _ = quiet_warnings (fn () =>
            (Datatype`a_rec = A ((a_rec # unit # num option # (unit + num)) list) | B unit`)
            ) () handle _ => die "FAILED!"

--- a/src/datatype/selftest.sml
+++ b/src/datatype/selftest.sml
@@ -460,18 +460,13 @@ val _ = quiet_warnings (fn () =>
           handle _ => die "FAILED!"
 val _ = OK()
 
-val _ = tprint "Testing indirect recursion size eqs with basic types";
+val _ = tprint "Initial test of indirect datatype recursion with basic types";
+(* there are more thorough tests of this in the datatypes_basic_test theory *)
 val _ = quiet_warnings (fn () =>
            (Datatype `v_rec = V (v_rec + num) | W`)
            ) () handle _ => die "FAILED!"
-(* it's awkward to load this at this point. however, some of the previous tests
-   are interesting precisely because it isn't loaded. FIXME later *)
-val _ = load "basicSize"
 val _ = quiet_warnings (fn () =>
            (Datatype`a_rec = A ((a_rec # unit # num option # (unit + num)) list) | B unit`)
            ) () handle _ => die "FAILED!"
-fun is_ls t = is_const t andalso fst (dest_const t) = "list_size"
-val ls = DB.theorem "a_rec_size_eq" |> concl |> can (find_term is_ls)
-val _ = if ls then OK () else die "FAILED: size_eq does not contain list_size"
 
 val _ = Process.exit Process.success;

--- a/src/datatype/theory_tests/datatypes_basic_testScript.sml
+++ b/src/datatype/theory_tests/datatypes_basic_testScript.sml
@@ -1,0 +1,74 @@
+(* Tests of datatypes with indirect recursion, especially involving basic
+   types. Some of these were moved here from selftest to ensure that
+   basicSize is loaded and the tests make sense. *)
+
+open HolKernel Parse Datatype
+local open testutils basicSize in end
+
+val _ = new_theory "datatypes_basic_test" ;
+
+val ERR = mk_HOL_ERR "datatype_basic_test"
+
+
+(* these are a subset of the tests in datatype selftest.sml, which
+   are interesting because they involve the basic types, which are
+   installed but missing their size functions in this context *)
+
+fun check_size_eq ty nms = let
+    val _ = testutils.tprint ("Checking size_eq in " ^ type_to_string ty)
+    val szs_etc = TypeBase.size_of ty |> snd |> CONJUNCTS
+      |> map (lhs o snd o strip_forall o concl)
+      |> map (find_terms is_const) |> List.concat
+    val eq_rhss = mapfilter (Conv.TOP_SWEEP_CONV TotalDefn.size_eq_conv) szs_etc
+      |> map (rhs o concl)
+    fun is_nm nm t = total (fst o dest_const) t = SOME nm
+    fun check nm = if List.exists (can (find_term (is_nm nm))) eq_rhss then ()
+      else raise ERR "check_size_eq" ("no term named " ^ nm)
+    val _ = List.map check nms
+  in testutils.OK () end
+
+(* Tom Ridge's example from 2009/04/23 *)
+val _ = Hol_datatype `
+  command2 =
+     Skip2
+   | Seq2 of bool # command2 # command2
+   | IfThenElse2 of bool # num # command2 # command2
+   | While2 of (num # num) # bool # command2
+`;
+
+val _ = check_size_eq ``: command2`` ["pair_size", "bool_size"]
+
+(* this version raises a different error *)
+val _ = Hol_datatype `
+  tr20090423 =
+     trSkip2
+   | trSeq2 of bool # tr20090423 # tr20090423
+   | trIfThenElse2 of bool # num # tr20090423 # tr20090423
+   | trWhile2 of (num # num) # bool # tr20090423
+`;
+
+val _ = check_size_eq ``: tr20090423`` ["pair_size", "bool_size"]
+
+(* Ramana Kumar's examples from 2010/08/25 *)
+val _ = Hol_datatype `t1 = c1 of 'a => t1 itself `;
+val _ = Hol_datatype `t2 = c2 of t2 t1 itself ` ;
+
+val _ = Hol_datatype `u1 = d1 of 'a itself`;
+val _ = Hol_datatype `u2 = d2 of 'a u1 `;
+val _ = Hol_datatype `u3 = d3 of u4 u2 u1 ;
+                      u4 = d4 of u3 u1 `;
+
+val _ = check_size_eq ``: u3`` ["u1_size", "u2_size"];
+
+val _ = Hol_datatype `list = NIL | :: of 'a => list`;
+
+val _ = Datatype `v_rec = V (v_rec + num) | W`
+
+val _ = check_size_eq ``: v_rec`` ["full_sum_size"];
+
+val _ = Datatype`a_rec = A ((a_rec # unit # num option # (unit + num)) list) | B unit`
+
+val _ = check_size_eq ``: a_rec`` ["option_size", "list_size", "one_size"];
+
+val _ = save_theory ();
+

--- a/src/datatype/theory_tests/with_basic_sizesScript.sml
+++ b/src/datatype/theory_tests/with_basic_sizesScript.sml
@@ -2,12 +2,12 @@
    types. Some of these were moved here from selftest to ensure that
    basicSize is loaded and the tests make sense. *)
 
-open HolKernel Parse Datatype
+open HolKernel Parse Datatype boolSyntax
 local open testutils basicSize in end
 
-val _ = new_theory "datatypes_basic_test" ;
+val _ = new_theory "with_basic_sizes" ;
 
-val ERR = mk_HOL_ERR "datatype_basic_test"
+val ERR = mk_HOL_ERR "with_basic_sizes"
 
 
 (* these are a subset of the tests in datatype selftest.sml, which
@@ -16,8 +16,8 @@ val ERR = mk_HOL_ERR "datatype_basic_test"
 
 fun check_size_eq ty nms = let
     val _ = testutils.tprint ("Checking size_eq in " ^ type_to_string ty)
-    val szs_etc = TypeBase.size_of ty |> snd |> CONJUNCTS
-      |> map (lhs o snd o strip_forall o concl)
+    val szs_etc = TypeBase.size_of ty |> snd |> concl |> strip_conj
+      |> map (lhs o snd o strip_forall)
       |> map (find_terms is_const) |> List.concat
     val eq_rhss = mapfilter (Conv.TOP_SWEEP_CONV TotalDefn.size_eq_conv) szs_etc
       |> map (rhs o concl)
@@ -49,16 +49,17 @@ val _ = Hol_datatype `
 
 val _ = check_size_eq ``: tr20090423`` ["pair_size", "bool_size"]
 
-(* Ramana Kumar's examples from 2010/08/25 *)
-val _ = Hol_datatype `t1 = c1 of 'a => t1 itself `;
-val _ = Hol_datatype `t2 = c2 of t2 t1 itself ` ;
+(* Ramana Kumar's examples from 2010/08/25
+   with itself replaced by option to avoid a particular silly issue *)
+val _ = Hol_datatype `t1 = c1 of 'a => t1 option `;
+val _ = Hol_datatype `t2 = c2 of t2 t1 option ` ;
 
-val _ = Hol_datatype `u1 = d1 of 'a itself`;
+val _ = Hol_datatype `u1 = d1 of 'a option`;
 val _ = Hol_datatype `u2 = d2 of 'a u1 `;
 val _ = Hol_datatype `u3 = d3 of u4 u2 u1 ;
                       u4 = d4 of u3 u1 `;
 
-val _ = check_size_eq ``: u3`` ["u1_size", "u2_size"];
+val _ = check_size_eq ``: u3`` ["u1_size", "u2_size", "option_size"];
 
 val _ = Hol_datatype `list = NIL | :: of 'a => list`;
 

--- a/src/datatype/theory_tests/with_basic_sizesScript.sml
+++ b/src/datatype/theory_tests/with_basic_sizesScript.sml
@@ -71,5 +71,5 @@ val _ = Datatype`a_rec = A ((a_rec # unit # num option # (unit + num)) list) | B
 
 val _ = check_size_eq ``: a_rec`` ["option_size", "list_size", "one_size"];
 
-val _ = save_theory ();
+val _ = export_theory ();
 

--- a/src/num/termination/TotalDefn.sml
+++ b/src/num/termination/TotalDefn.sml
@@ -480,7 +480,9 @@ fun size_eq_conv tm = let
           then ty_rec (HOLset.add (ty_s, ty)) (snd (dest_type ty) @ tys)
           else ty_rec ty_s tys
     val all_tys = ty_rec (HOLset.empty Type.compare) tys
-    val size_eqs = mapfilter TypeBase.size_of all_tys
+    val size_eqs = mapfilter TypeBase.axiom_of all_tys
+      |> map Prim_rec.doms_of_tyaxiom |> List.concat
+      |> mapfilter TypeBase.size_of
       |> map fst |> mapfilter dest_thy_const
       |> mapfilter (fn xs => fetch (#Thy xs) (#Name xs ^ "_eq"))
   in simpLib.SIMP_CONV boolSimps.bool_ss size_eqs tm end


### PR DESCRIPTION
This patch generalises the type-size builder in TypeBasePure so that code in
DataSize can share it rather than (as previously) defining its own.

The previous situation was observed by @agomezl to result in problems when
a datatype contained the word type. The two implementations (in DataSize and
TypeBasePure) query the type database differently and so see the word type
(which is a specialised pun of the cartesian product type) differently and assign
it different sizes. This new version should pick the standard size.

One of the goals of earlier work on size_eqs was to avoid silly situations where
TypeBasePure.type_size was the wrong choice of size. This happened, for instance
multiple names for a size existed (e.g. tree1_size vs list_size tree_size), and so
the system proves they are equal. It would be good to remove further discrepancies.

I expect that tests will fail, I'm putting this up anyway in case it attracts discussion.