### PR TITLE
Fix hol-toggle-trace() when other integer libraries like Arbint is currently open

### DIFF
--- a/tools/hol-mode.src
+++ b/tools/hol-mode.src
@@ -1040,7 +1040,8 @@ argument N, sets the trace to that value in particular."
       (progn
         (message (concat "Toggling " s))
         (send-raw-string-to-hol
-         (format "val _ = let val nm = \"%s\"
+         (format "local open Int in
+                  val _ = let val nm = \"%s\"
                       fun findfn r = #name r = nm
                       val old =
                             #trace_level (valOf (List.find findfn (traces())))
@@ -1049,8 +1050,8 @@ argument N, sets the trace to that value in particular."
                       if 0 < old then (set_trace nm 0; print \"off\\n\")
                       else (set_trace nm 1; print \"on\\n\")
                   end handle Option =>
-                        print \"** No such trace var: \\\"%s\\\"\\n\""
-                 s s)
+                        print \"** No such trace var: \\\"%s\\\"\\n\"
+                  end" s s)
          nil))
     (let ((n (prefix-numeric-value arg)))
       (message (format "Setting %s to %d" s n))
@@ -1065,7 +1066,6 @@ argument N, sets the trace to that value in particular."
   "Toggles the \"Unicode\" trace."
   (interactive)
   (hol-toggle-trace "Unicode"))
-
 
 (defun hol-toggle-emacs-tooltips ()
   "Toggles whether HOL produces tooltip information while pretty-printing."


### PR DESCRIPTION
Hi,

In `hol-model.el`, the Lisp code of `hol-toggle-trace()` sends some SML code involved integer operations, which implicitly assume the current open integer library is the default one (either `Int` or `IntInf`, depending on PolyML builds.)  But in some HOL files the `Arbint` is open as the default (e.g. in `src/real/RealArith.sml`). And in this case if I try to toggle, e.g., the Unicode trace, it will fail with the following type mismatch errors:
```
> # # # # # # # # # # poly: : error: Type error in function application.
   Function: < : int * int -> bool
   Argument: (0, old) : IntInf.int * IntInf.int
   Reason:
      Can't unify IntInf.int (*In Basis*) with int (*Created from opaque signature*)
         (Different type constructors)
Found near if 0 < old then (set_trace nm 0; print "off\n") else (set_trace nm 1; print "on\n")
Static Errors
> 
```

A simple solution is to put `local open Int in ... end` as a wrapper of these code. (Let's not argue why `Arbint` should be open by default, it just happened sometimes.)

Chun Tian