### PR TITLE
Add a size for the "itself" type in basicSize

### DIFF
--- a/src/num/theories/basicSize.sml
+++ b/src/num/theories/basicSize.sml
@@ -52,6 +52,14 @@ local
                      (TypeBasePure.put_size one_size_info one_info)
 
   (*----------------------------------------------------------------------*)
+  (* "Itself" type                                                        *)
+  (*----------------------------------------------------------------------*)
+
+  val itself_info = Option.valOf (TypeBase.read {Tyop="itself",Thy="bool"})
+  val itself_size_info = (itself_size_tm,TypeBasePure.ORIG itself_size_def)
+  val itself_info' = TypeBasePure.put_size itself_size_info itself_info
+
+  (*----------------------------------------------------------------------*)
   (* Options                                                              *)
   (*----------------------------------------------------------------------*)
 
@@ -64,6 +72,7 @@ in
    val _ = TypeBase.write [prod_info']
    val _ = TypeBase.write [sum_info']
    val _ = TypeBase.write [one_info']
+   val _ = TypeBase.write [itself_info']
    val _ = TypeBase.write [option_info']
 end
 

--- a/src/num/theories/basicSizeScript.sml
+++ b/src/num/theories/basicSizeScript.sml
@@ -16,6 +16,9 @@ val pair_size_def = new_definition
 val one_size_def = new_definition
   ("one_size_def", ``one_size (x:one) = 0``);
 
+val itself_size_def = new_definition
+  ("itself_size_def", ``itself_size (x : 'a itself) = 0``);
+
 val sum_size_def =
  new_recursive_definition
    {def = ``(sum_size (f:'a->num) g (INL x) = f x) /\

--- a/src/num/theories/basicSizeSyntax.sig
+++ b/src/num/theories/basicSizeSyntax.sig
@@ -9,24 +9,28 @@ sig
   val sum_size_tm : term
   val full_sum_size_tm : term
   val one_size_tm : term
+  val itself_size_tm : term
   val option_size_tm : term
 
   val mk_bool_size : term -> term
   val mk_pair_size : term * term * term -> term
   val mk_sum_size : term * term * term -> term
   val mk_one_size : term -> term
+  val mk_itself_size : term -> term
   val mk_option_size : term * term -> term
 
   val dest_bool_size : term -> term
   val dest_pair_size : term -> term * term * term
   val dest_sum_size : term -> term * term * term
   val dest_one_size : term -> term
+  val dest_itself_size : term -> term
   val dest_option_size : term -> term * term
 
   val is_bool_size : term -> bool
   val is_pair_size : term -> bool
   val is_sum_size : term -> bool
   val is_one_size : term -> bool
+  val is_itself_size : term -> bool
   val is_option_size : term -> bool
 
 end

--- a/src/num/theories/basicSizeSyntax.sml
+++ b/src/num/theories/basicSizeSyntax.sml
@@ -11,12 +11,14 @@ val pair_size_tm = prim_mk_const {Thy = "basicSize", Name = "pair_size"};
 val sum_size_tm = prim_mk_const {Thy = "basicSize", Name = "sum_size"};
 val full_sum_size_tm = prim_mk_const {Thy = "basicSize", Name = "full_sum_size"};
 val one_size_tm = prim_mk_const {Thy = "basicSize", Name = "one_size"};
+val itself_size_tm = prim_mk_const {Thy = "basicSize", Name = "itself_size"};
 val option_size_tm = prim_mk_const {Thy = "basicSize", Name = "option_size"};
 
 fun dom tm = fst(dom_rng(type_of tm));
 
 fun mk_bool_size tm = mk_comb(bool_size_tm,tm);
 fun mk_one_size tm = mk_comb(one_size_tm,tm);
+fun mk_itself_size tm = mk_icomb(itself_size_tm,tm);
 fun mk_pair_size (f,g,p) =
  list_mk_comb(inst[alpha |-> dom f, beta |-> dom g] pair_size_tm,[f,g,p]);
 fun mk_sum_size (f,g,s) =
@@ -26,6 +28,7 @@ fun mk_option_size (f,tm) =
 
 val dest_bool_size = dest_monop bool_size_tm  (ERR "dest_bool_size" "");
 val dest_one_size = dest_monop one_size_tm    (ERR "dest_one_size" "");
+val dest_itself_size = dest_monop itself_size_tm (ERR "dest_itself_size" "");
 val dest_pair_size = dest_triop pair_size_tm  (ERR "dest_pair_size" "");
 val dest_sum_size = dest_triop pair_size_tm   (ERR "dest_sum_size" "");
 val dest_option_size = dest_binop option_size_tm (ERR "dest_option_size" "");
@@ -34,6 +37,7 @@ val is_bool_size = can dest_bool_size;
 val is_pair_size = can dest_pair_size;
 val is_sum_size = can dest_sum_size;
 val is_one_size = can dest_one_size;
+val is_itself_size = can dest_itself_size;
 val is_option_size = can dest_option_size;
 
 end


### PR DESCRIPTION
Add "itself" to the collection of types with manual size setup
in basicSize. This doesn't seem to cause any problems. I don't
have any examples to point at where it solves any problems
either.