### PR TITLE
Vimhol bugfixes and multiple stacked hol sessions

### DIFF
--- a/tools/vim/README.md
+++ b/tools/vim/README.md
@@ -52,7 +52,7 @@ are using a custom fifo path).
 ## HOL interactive session inside the vim editor
 
 Neovim and some versions of vim can run the interactive HOL session (HOL repl) in a terminal buffer within the editor, right next to a file buffer.
-Vim supports this feature if `:echo has('terminal')` prints `1`.
+Vim supports this feature if `:echo has('terminal')` prints `1`, neovim if `:echo exists(':terminal')` prints a non-zero value.
 For the supported versions, this plugin offers additional keyboard mappings to open and close a HOL session, as documented below in the section *key mappings for the HOL repl buffer*.
 Whenever a HOL session is started, a new unique fifo is created.
 

--- a/tools/vim/hol.src
+++ b/tools/vim/hol.src
@@ -250,6 +250,7 @@ nn <buffer><silent> <LocalLeader>n :call HOLCall(function("HOLF"),["Feedback.set
 no <buffer><LocalLeader>h h
 
 if ! exists('$HOLDIR') || (!has('terminal') && ! has('nvim'))
+      \ || (has('nvim') && !exists(':terminal'))
   let b:did_hol = 1
   " skip terminal feature
   finish

--- a/tools/vim/hol.src
+++ b/tools/vim/hol.src
@@ -263,7 +263,7 @@ else
 endif
 
 function! HOLREPLnew()
-  let l:cmd = getenv('HOLDIR') . '/bin/hol'
+  let l:cmd = $HOLDIR . '/bin/hol'
   if ! executable(l:cmd)
     echoerr 'hol command not found: ' . l:cmd
     return 0

--- a/tools/vim/hol.src
+++ b/tools/vim/hol.src
@@ -262,6 +262,11 @@ else
   let s:rlwrap_str = ''
 endif
 
+" initialise
+if ! has_key(g:,'hol_repl')
+  let g:hol_repl = []
+endif
+
 function! HOLREPLnew()
   let l:cmd = $HOLDIR . '/bin/hol'
   if ! executable(l:cmd)
@@ -277,35 +282,63 @@ function! HOLREPLnew()
   \  "env": {
   \    "VIMHOL_FIFO": s:holpipe
   \  }}
+  let altname = expand("%:r:t") " alternate name for terminal buffer
   echom 'holrepl cmd: ' . s:rlwrap_str . l:cmd
   if has('nvim') " neovim terminal
     let options.stdin = "null"
     vsplit | enew
     let l:terminal_job_id = termopen(s:rlwrap_str . l:cmd, options)
-    let g:hol_repl = {'buf': bufnr(''), 'job': l:terminal_job_id}
+    call add(g:hol_repl, {'buf': bufnr(''), 'job': l:terminal_job_id, 'pipe': s:holpipe})
     " scroll to end of terminal buffer
     silent! normal G
   else " vim terminal
-    rightbelow let g:hol_repl = term_start(s:rlwrap_str . l:cmd, options)
-    call term_setkill(g:hol_repl, 'term')
+    rightbelow let s:replbuf = term_start(s:rlwrap_str . l:cmd, options)
+    call add(g:hol_repl, {'buf': s:replbuf, 'pipe': s:holpipe})
+    call term_setkill(g:hol_repl[-1].buf, 'term')
   endif
+  " set (unique) buffer name containing the origin
+  let g:hol_repl[-1].altname = 'hol ('. g:hol_repl[-1].buf . '): ' . altname
+  exec 'file ' . g:hol_repl[-1].altname
   wincmd p
 endfunction
 
 if has('nvim')
   function! HOLREPLsend(text)
-    call chansend(g:hol_repl.job, a:text)
+    " only send commands if a terminal buffer exists
+    if has_key(g:,'hol_repl') && len(g:hol_repl) > 0
+      call chansend(g:hol_repl[-1].job, a:text)
+    else
+      echoerr "vimhol: no active hol repl found"
+    endif
   endfunction
 else
   function! HOLREPLsend(text)
-    call term_sendkeys(g:hol_repl, a:text)
+    " only send commands if a terminal buffer exists
+    if has_key(g:,'hol_repl') && len(g:hol_repl) > 0
+      call term_sendkeys(g:hol_repl[-1].buf, a:text)
+    else
+      echoerr "vimhol: no active hol repl found"
+    endif
   endfunction
 endif
 
+" close terminal
+function! HOLREPLclose()
+  if has_key(g:,'hol_repl') && len(g:hol_repl) > 0
+    call HOLREPLsend("\<C-D>")
+    call remove(g:hol_repl, -1)
+    " (re)set the current holpipe
+    if len(g:hol_repl) > 0
+      let s:holpipe = g:hol_repl[-1].pipe
+    else
+      unlet s:holpipe
+    endif
+  endif
+endfunction
 " open a new hol terminal
 nn <buffer><silent> <LocalLeader>x :call HOLREPLnew()<CR>
 " close a hol_repl buffer
-nn <buffer><silent> <LocalLeader>X :call HOLREPLsend("\<C-D>")<CR>
+nn <buffer><silent> <LocalLeader>X :call HOLREPLclose()<CR>
 " send current line (or highlighted section) to terminal
 vn <buffer><silent> <LocalLeader>w "0y:call HOLREPLsend(getreg('0',1) . ";\n")<CR>
 nm <buffer><silent><expr> <LocalLeader>w "V".maplocalleader."w"

--- a/tools/vim/vimhol.sh
+++ b/tools/vim/vimhol.sh
@@ -65,7 +65,7 @@ WD="$(echo "$@" | xargs dirname 2>/dev/null \
       | cat - <(pwd) | head -n 1)"
 
 # create new fifo pipe
-VIMHOL_FIFO="$(mktemp -u -p "${XDG_RUNTIME_DIR:-/tmp}" "hol-XXXXXXXXXX")"
+VIMHOL_FIFO="$(env TMPDIR="${XDG_RUNTIME_DIR:-/tmp}" mktemp -t "hol-XXXXXXXXXX")"
 test -p "$VIMHOL_FIFO" || mkfifo "$VIMHOL_FIFO"
 
 # For $HOLDIR/bin/hol, set $HOL_CONFIG to use $HOLDIR/tools/vim/hol-config.sml


### PR DESCRIPTION
This PR fixes two bugs: It makes `vimhol.sh` work on macOS, and allows vim
prior version 8.2 to host a hol terminal.

In addition multiple hol sessions are supported for vim with the terminal feature.

Some of the general behaviour of the vim plugin as well as multiple hol
sessions are demonstrated in an ascii video:
https://asciinema.org/a/mH7mXu047txZvZk21jd9qSYSI