### PR TITLE
Add definition for float_unordered

### DIFF
--- a/src/floating-point/binary_ieeeScript.sml
+++ b/src/floating-point/binary_ieeeScript.sml
@@ -737,6 +737,10 @@ val float_equal_def = Define`
    float_equal (x: ('t, 'w) float) y =
       (float_compare x y = EQ)`
 
+val float_unordered_def = Define`
+   float_unordered (x: ('t, 'w) float) y =
+      (float_compare x y = UN)`
+
 val exponent_boundary_def = Define`
    exponent_boundary (y: ('t, 'w) float) (x: ('t, 'w) float) =
       (x.Sign = y.Sign) /\ (w2n x.Exponent = w2n y.Exponent + 1) /\


### PR DESCRIPTION
This patch add a definition for the "unordered" floating point comparison operation.

Rationale for including it:

a) It's part of the IEEE 754 standard
b) Programs often use it for checking for error conditions: if unordered(a, b) then handle_error else if a < b then do_stuff endif
c) CPU's often have a hardware instruction for it (so it's useful to have in the library when modelling hardware)
d) It's part of the Standard ML basis library (so we might want to include it in CakeML).

Things missing from this patch:

This patch just adds the definition. Ideally, we would also want stuff in machine_ieee that instantiates this operator for a particular size of floating point etc. I am not sure how that part of  the HOL4 libraries work, so I haven't attempted to do that.

A further question: do we want to have float_unorderedEqual as well. That's used much less often, but would complete the set of having all possible floating point comparison operators (every possible mapping {EQ, LT, GT, UN} -> bool.