### PR TITLE
Fix --otknl build due to neater filtering of Holmake artifacts (#1020)

### DIFF
--- a/src/boss/Holmakefile
+++ b/src/boss/Holmakefile
@@ -64,11 +64,11 @@ hol4-base-unint.art: hol4-base-unint.thy $(ARTS)
 
 base-theorems.art:
 	opentheory info --theorems -o $@ base
-	touch base-theorems.ui base-theorems.uo
+	touch $(HOLOBJDIR)/base-theorems.ui $(HOLOBJDIR)/base-theorems.uo
 
 hol4-assums.art: hol4-base-unsat.thy hol4-base-unint.art ../opentheory/hol4.int
 	opentheory info --skip-definitions --assumptions -o $@ $<
-	touch hol4-assums.ui hol4-assums.uo
+	touch $(HOLOBJDIR)/hol4-assums.ui $(HOLOBJDIR)/hol4-assums.uo
 
 prove_base_assums.art: prove_base_assums.otd base-theorems.art hol4-assums.art
 
@@ -86,6 +86,7 @@ endif
 ifdef HOLSELFTESTLEVEL
 all: boss-selftest.log
 
-boss-selftest.log: ./selftest.exe
-	$(tee ./selftest.exe,$@)
+boss-selftest.log: selftest.exe
+	$(tee ./$<, $@)
+
 endif

--- a/src/real/Holmakefile
+++ b/src/real/Holmakefile
@@ -24,7 +24,7 @@ BARE_THYS = realax real intreal real_sigma metric nets iterate
 
 base-theorems.art:
 	opentheory info --theorems -o $@ real-1.61
-	touch base-theorems.ui base-theorems.uo
+	touch $(HOLOBJDIR)/base-theorems.ui $(HOLOBJDIR)/base-theorems.uo
 
 hol4-real-unint.art: hol4-real-unint.thy $(patsubst %,%.ot.art,$(BARE_THYS))
 	opentheory info --article -o $@ $<
@@ -34,8 +34,8 @@ hol4-real-unsat.art: hol4-real-unsat.thy hol4-real-unint.art ../opentheory/hol4.
 
 hol4-real-assums.art: hol4-real-assums.thy hol4-real-unsat.art
 	opentheory info --skip-definitions --assumptions -o $@ $<
-	touch hol4-real-assums.ui
-	touch hol4-real-assums.uo
+	touch $(HOLOBJDIR)/hol4-real-assums.ui
+	touch $(HOLOBJDIR)/hol4-real-assums.uo
 
 prove_real_assums.art: hol4-real-assums.art base-theorems.art
 


### PR DESCRIPTION
This small patch further fixed OpenTheory building (`--otknl`) due to movements of `Holmake` artifacts (`.ui`, `.uo` files).