### PR TITLE
Fix Moscow ML builds

### DIFF
--- a/src/floating-point/Holmakefile
+++ b/src/floating-point/Holmakefile
@@ -29,7 +29,7 @@ fp32Syntax.uo: fp-functor.uo fp32Syntax.sml $(WORDS_SYNTAX)
 fp64Syntax.uo: fp-functor.uo fp64Syntax.sml $(WORDS_SYNTAX)
 	$(HOLMOSMLC) -c -toplevel Overlay.ui fp-sig.ui fp-functor.ui fp64Syntax.sml
 
-selftest.exe: selftest.uo
+selftest.exe: selftest.uo fp16Syntax.uo fp64Syntax.uo
 	$(HOLMOSMLC) -o $@ $<
 
 ifdef HOLSELFTESTLEVEL

--- a/src/floating-point/selftest.sml
+++ b/src/floating-point/selftest.sml
@@ -6,7 +6,7 @@ open fp16Syntax
 val _ = tprint "mk_fp_isZero(16) has correct rator"
 val _ = require_msg (check_result (same_const “machine_ieee$fp16_isZero”))
                     term_to_string
-                    (rator o mk_fp_isZero) (mk_var("x", “:word16”))
+                    (rator o fp16Syntax.mk_fp_isZero) (mk_var("x", “:word16”))
 
 val f14 =
   “<| Sign := 0w; Exponent := 130w; Significand := 0x600000w |> : (23,8)float”

--- a/src/real/bitArithLib.sig
+++ b/src/real/bitArithLib.sig
@@ -1,6 +1,12 @@
+(**
+  Library implementing Karatsuba multiplication for the HOL4 evaluator
+  based on the theorems in bitArithScript.sml
+**)
 signature bitArithLib =
 sig
-  include Abbrev Arbnum
+  include Abbrev
+  type num = Arbnum.num
+
   (* Make definitions *)
   val karatsuba_lim : num ref
 

--- a/src/real/bitArithLib.sml
+++ b/src/real/bitArithLib.sml
@@ -2,7 +2,7 @@
   Library implementing Karatsuba multiplication for the HOL4 evaluator
   based on the theorems in bitArithScript.sml
 **)
-structure bitArithLib =
+structure bitArithLib :> bitArithLib =
 struct
   open HolKernel Parse Theory arithmeticTheory realTheory
         boolLib bossLib; (* HOL4 dependencies *)


### PR DESCRIPTION
The `bitArithLib` addition (#1056) has caused the following compilation issue by Moscow ML:

```
Theory "bitArith" took 27.6s to build
Holmake: Compiling bitArithTheory.sig
Holmake: Compiling bitArithTheory.sml
Holmake: Compiling bitArithLib.sml
! File bitArithLib.sig exists, but there is no signature constraint in bitArithLib.sml
*** FATAL: Build failed in directory /Users/binghe/ML/HOL.mosml/src/parallel_builds/core
```

After fixing the first code line of `bitArithTheory.sml`, the next error is about `bitArithTheory.sig` where the `include Arbum` is now replaced by `type num = Arbnum.num` (It seems that `include` is for inherit other signatures in SML, but this is not the purpose here):

```
Holmake: Compiling bitArithLib.sml
! Interface mismatch: the implementation of unit bitArithLib
! does not match its interface, because ... 
! Missing declaration: value bitArithLib.zero in the unit bitArithLib
! is specified in the interface as 
!   val zero : num
! but not declared in the implementation
*** FATAL: Build failed in directory /Users/binghe/ML/HOL.mosml/src/parallel_builds/core
```

The last issue is at `src/floating-point/selftest.sml`, which lacks necessary dependencies on `fp64Syntax` and `fp16Syntax`. But then it's strange that the code `open fp16Syntax` doesn't work: to fix the compilation issue I still have to change `mk_fp_isZero` to `fp16Syntax .mk_fp_isZero`. I don't understand why, perhaps it's because `fp16Syntax` is defined by a functor:

```
File "selftest.sml", line 3, characters 11-21:
! local open fp64Syntax in end
!            ^^^^^^^^^^
! Warning: this unit was compiled as a sequence of toplevel declarations,
! but is being used as if it had been compiled as a structure.
File "selftest.sml", line 4, characters 5-15:
! open fp16Syntax
!      ^^^^^^^^^^
! Warning: this unit was compiled as a sequence of toplevel declarations,
! but is being used as if it had been compiled as a structure.
File "selftest.sml", line 9, characters 29-41:
!                     (rator o mk_fp_isZero) (mk_var("x", (Parse.Type [QUOTE " (*#loc 9 60*):word16"])))
!                              ^^^^^^^^^^^^
! Unbound value identifier: mk_fp_isZero
*** FATAL: Build failed in directory /Users/binghe/ML/HOL.mosml/src/parallel_builds/core
```

--Chun
