### PR TITLE
Generalized definition of measurable mappings in measure theory

### DIFF
--- a/doc/next-release.md
+++ b/doc/next-release.md
@@ -138,6 +138,14 @@ Incompatibilities:
     This change makes the naming consistent across all of HOL’s fragments.
     These names are used when referring to fragments in calls to `diminish_srw_ss`, when using `ExclSF` (see above), and in printing the values in the REPL.
 
+*   In `sigma_algebraTheory`, the definition of `measurable` has been generalized without
+    requiring that the involved systems of sets must be σ-algebras. This change allows the user to
+    express measurable mappings over generators of σ-algebras. (cf. `MEASURABLE_LIFT` for a related
+    important lemma.)  Existing proofs may break in two ways (both are easy to fix): 1. The need of
+    extra antecedents (usually easily available) when applying some existing measure and probability
+    theorems. 2. When proving `f IN measurable a b`, some proof branches regarding σ-algebras no
+    longer exists (thus the related proof scripts must be eliminated).
+
 * * * * *
 
 <div class="footer">

--- a/examples/diningcryptos/leakageScript.sml
+++ b/examples/diningcryptos/leakageScript.sml
@@ -298,10 +298,8 @@ val unif_prog_space_highlowrandom_distribution = store_thm
    >> POP_ORW
    >> RW_TAC std_ss [CARD_CROSS, CARD_SING]);
 
-
-val unif_prog_space_leakage_reduce = store_thm
-  ("unif_prog_space_leakage_reduce",
-   ``!high low random f. FINITE high /\ FINITE low /\ FINITE random /\
+Theorem unif_prog_space_leakage_reduce :
+    !high low random f. FINITE high /\ FINITE low /\ FINITE random /\
            ~((high CROSS low) CROSS random={}) ==>
            (leakage (unif_prog_space high low random) f =
             SIGMA (\x. (\(x,y,z).
@@ -313,7 +311,8 @@ val unif_prog_space_leakage_reduce = store_thm
                   joint_distribution (unif_prog_space high low random) f L {(x,z)} *
                   lg (joint_distribution (unif_prog_space high low random) f L {(x,z)} *
                       & (CARD low))) x)
-                  (IMAGE (\s. (f s,SND (FST s))) (high CROSS low CROSS random)))``,
+                  (IMAGE (\s. (f s,SND (FST s))) (high CROSS low CROSS random)))
+Proof
    RW_TAC std_ss [leakage_def]
    >> Q.ABBREV_TAC `foo =
                   SIGMA (\x. (\(x,y,z).
@@ -354,6 +353,8 @@ val unif_prog_space_leakage_reduce = store_thm
       by RW_TAC std_ss [unif_prog_space_def, FINITE_CROSS, PSPACE]
    >> `POW (p_space (unif_prog_space high low random)) = events (unif_prog_space high low random)`
       by RW_TAC std_ss [unif_prog_space_def, PSPACE, EVENTS]
+ (* stage work *)
+   >> ‘prob_space (unif_prog_space high low random)’ by PROVE_TAC [prob_space_unif_prog_space]
    >> RW_TAC std_ss [finite_conditional_mutual_information_reduce]
    >> `p_space (unif_prog_space high low random) =
        (high CROSS low CROSS random)`
@@ -514,7 +515,8 @@ val unif_prog_space_leakage_reduce = store_thm
               >> RW_TAC std_ss [joint_distribution_def]
               >> Suff `PREIMAGE (\x. (f x,H x,L x)) {(f x',SND x)} INTER (high CROSS low CROSS random) = {}`
               >- METIS_TAC [prob_space_unif_prog_space, PROB_EMPTY]
-              >> ONCE_REWRITE_TAC [EXTENSION] >> RW_TAC std_ss [NOT_IN_EMPTY, IN_INTER, IN_PREIMAGE, IN_SING, IN_CROSS,
+              >> ONCE_REWRITE_TAC [EXTENSION]
+              >> RW_TAC std_ss [NOT_IN_EMPTY, IN_INTER, IN_PREIMAGE, IN_SING, IN_CROSS,
                                 low_state_def, high_state_def, PAIR]
               >> Q.PAT_X_ASSUM `FST x = f x'` (MP_TAC o GSYM) >> RW_TAC std_ss []
               >> POP_ASSUM (K ALL_TAC) >> POP_ASSUM (MP_TAC o Q.SPEC `x''`)
@@ -561,11 +563,11 @@ val unif_prog_space_leakage_reduce = store_thm
    >> Rewr'
    >> ASM_SIMP_TAC std_ss [GSYM REAL_SUM_IMAGE_IN_IF]
    >> ONCE_REWRITE_TAC [REAL_ADD_COMM] >> RW_TAC std_ss [GSYM real_sub]
-   >> Q.UNABBREV_TAC `foo` >> RW_TAC std_ss []);
+   >> Q.UNABBREV_TAC `foo` >> RW_TAC std_ss []
+QED
 
-val unif_prog_space_visible_leakage_reduce = store_thm
-  ("unif_prog_space_visible_leakage_reduce",
-   ``!high low random f. FINITE high /\ FINITE low /\ FINITE random /\
+Theorem unif_prog_space_visible_leakage_reduce :
+    !high low random f. FINITE high /\ FINITE low /\ FINITE random /\
            ~((high CROSS low) CROSS random={}) ==>
            (visible_leakage (unif_prog_space high low random) f =
             SIGMA
@@ -587,7 +589,8 @@ SIGMA
         lg
           (joint_distribution (unif_prog_space high low random) f (\s. (L s,R s))
              {(x,z)} * & (CARD low * CARD random))) x)
-  (IMAGE (\s. (f s,SND (FST s),SND s)) (high CROSS low CROSS random)))``,
+  (IMAGE (\s. (f s,SND (FST s),SND s)) (high CROSS low CROSS random)))
+Proof
    RW_TAC std_ss [visible_leakage_def]
    >> Q.ABBREV_TAC `foo = SIGMA
   (\x.
@@ -643,6 +646,8 @@ SIGMA
       by RW_TAC std_ss [unif_prog_space_def, FINITE_CROSS, PSPACE]
    >> `POW (p_space (unif_prog_space high low random)) = events (unif_prog_space high low random)`
       by RW_TAC std_ss [unif_prog_space_def, PSPACE, EVENTS]
+ (* stage work *)
+   >> ‘prob_space (unif_prog_space high low random)’ by PROVE_TAC [prob_space_unif_prog_space]
    >> RW_TAC std_ss [finite_conditional_mutual_information_reduce]
    >> `p_space (unif_prog_space high low random) =
        (high CROSS low CROSS random)`
@@ -855,7 +860,8 @@ SIGMA
    >> POP_ORW
    >> ASM_SIMP_TAC std_ss [GSYM REAL_SUM_IMAGE_IN_IF]
    >> ONCE_REWRITE_TAC [REAL_ADD_COMM] >> RW_TAC std_ss [GSYM real_sub]
-   >> Q.UNABBREV_TAC `foo` >> RW_TAC std_ss []);
+   >> Q.UNABBREV_TAC `foo` >> RW_TAC std_ss []
+QED
 
 val unif_prog_space_leakage_lemma1 = store_thm
   ("unif_prog_space_leakage_lemma1",
@@ -1332,8 +1338,9 @@ val unif_prog_space_leakage_lemma2 = store_thm
         (high CROSS low CROSS
          IMAGE SND ({FST (FST s')} CROSS {SND (FST s')} CROSS random)) then
             1 else 0))`
-        by (ONCE_REWRITE_TAC [FUN_EQ_THM] >> RW_TAC std_ss [IN_INTER, IN_SING, IN_CROSS, IN_PREIMAGE,
-                           IN_IMAGE, SND, high_state_def, low_state_def]
+        by (ONCE_REWRITE_TAC [FUN_EQ_THM]
+            >> RW_TAC std_ss [IN_INTER, IN_SING, IN_CROSS, IN_PREIMAGE,
+                              IN_IMAGE, SND, high_state_def, low_state_def]
             >> RW_TAC std_ss []
             >> METIS_TAC [PAIR])
    >> POP_ORW
@@ -1418,7 +1425,8 @@ val unif_prog_space_visible_leakage_lemma2 = store_thm
    >> RW_TAC std_ss []
    >> `(PREIMAGE f {f s'} INTER PREIMAGE (\s. (H s,L s,R s)) {(FST (FST s'),SND (FST s'),SND s')} INTER
         (high CROSS low CROSS random)) = {s'}`
-        by (ONCE_REWRITE_TAC [EXTENSION] >> RW_TAC std_ss [IN_INTER, IN_SING, IN_PREIMAGE, high_state_def,
+        by (ONCE_REWRITE_TAC [EXTENSION]
+            >> RW_TAC std_ss [IN_INTER, IN_SING, IN_PREIMAGE, high_state_def,
                            low_state_def, random_state_def, IN_CROSS]
             >> METIS_TAC [PAIR, FST, SND])
    >> RW_TAC std_ss [REAL_SUM_IMAGE_SING, IN_CROSS]);

--- a/examples/miller/prob/probScript.sml
+++ b/examples/miller/prob/probScript.sml
@@ -1351,10 +1351,9 @@ val PREFIX_COVER_APPEND = store_thm
                      image_countable, o_THM]
    >> RW_TAC std_ss [EVENTS_BERN_PREFIX_SET]);
 
-val INDEP_FN_BIND = store_thm
-  ("INDEP_FN_BIND",
-   ``!f g.
-       f IN indep_fn /\ (!x. g x IN indep_fn) ==> BIND f g IN indep_fn``,
+Theorem INDEP_FN_BIND :
+    !f g. f IN indep_fn /\ (!x. g x IN indep_fn) ==> BIND f g IN indep_fn
+Proof
   RW_TAC std_ss [indep_fn_def, GSPECIFICATION] >| (* 4 goals here *)
   [ (* goal 1 (of 4) *)
     MATCH_MP_TAC COUNTABLE_SUBSET
@@ -1379,7 +1378,7 @@ val INDEP_FN_BIND = store_thm
                             MEASURABLE_PROD_SIGMA) \\
          POP_ASSUM (ASSUME_TAC o (REWRITE_RULE [space_def, subsets_def])) \\
          POP_ASSUM MATCH_MP_TAC \\
-         RW_TAC std_ss [SIGMA_ALGEBRA_BERN] )
+         rw [SIGMA_ALGEBRA_BERN, subset_class_def, SPACE_BERN_UNIV] )
     >> REWRITE_TAC [UNIV_SIGMA_ALGEBRA]
     >> CONJ_TAC
     >- RW_TAC std_ss [SUBSET_DEF, IN_CROSS, IN_UNIV, range_def, IN_IMAGE, o_THM,
@@ -1430,7 +1429,7 @@ val INDEP_FN_BIND = store_thm
                             MEASURABLE_PROD_SIGMA) \\
          POP_ASSUM (ASSUME_TAC o (REWRITE_RULE [space_def, subsets_def])) \\
          POP_ASSUM MATCH_MP_TAC \\
-         RW_TAC std_ss [SIGMA_ALGEBRA_BERN] )
+         rw [SIGMA_ALGEBRA_BERN, subset_class_def, SPACE_BERN_UNIV] )
     >> REWRITE_TAC [SIGMA_ALGEBRA_BERN]
     >> CONJ_TAC
     >- ( RW_TAC std_ss [SUBSET_DEF, IN_CROSS, IN_UNIV, range_def, IN_IMAGE, o_THM,
@@ -1519,7 +1518,8 @@ val INDEP_FN_BIND = store_thm
     >> RW_TAC std_ss [sdrop_def, LENGTH, APPEND, I_THM, o_THM]
     >> SEQ_CASES_TAC `s`
     >> POP_ASSUM MP_TAC
-    >> RW_TAC std_ss [PREFIX_SET_SCONS, STL_SCONS] ]);
+    >> RW_TAC std_ss [PREFIX_SET_SCONS, STL_SCONS] ]
+QED
 
 val INDEP_FN_PROB = store_thm
   ("INDEP_FN_PROB",

--- a/examples/miller/prob/prob_algebraScript.sml
+++ b/examples/miller/prob/prob_algebraScript.sml
@@ -48,6 +48,12 @@ val prob_measure_def = Define
    `prob_measure s =
         inf {r | ?c. (s = prob_embed c) /\ (prob_premeasure c = r)}`;
 
+(* NOTE: in sigma_algebraTheory, the definition of ‘measurable’ has been
+   modified by removing all sigma-algebra requirements. The following
+   definition of ‘premeasurable’ is not changed accordingly, as it's only
+   used in the ‘miller’ example, but some related theorems may have to
+   add sigma_algebra antecedents.  -- Chun Tian, 24/10/2022
+ *)
 val premeasurable_def = Define
    `premeasurable a b = {f | algebra a /\ algebra b /\
                              f IN (space a -> space b) /\
@@ -61,11 +67,17 @@ val IN_PREMEASURABLE = store_thm
                 (!s. s IN subsets b ==> (PREIMAGE f s) INTER (space a) IN subsets a)``,
    RW_TAC std_ss [premeasurable_def, GSPECIFICATION]);
 
-val MEASURABLE_IMP_PREMEASURABLE = store_thm
-  ("MEASURABLE_IMP_PREMEASURABLE", ``!f a b. f IN measurable a b ==> f IN premeasurable a b``,
+(* NOTE: added ‘sigma_algebra a /\ sigma_algebra b’ into antecedents,
+         due to changes of ‘measurable’
+ *)
+Theorem MEASURABLE_IMP_PREMEASURABLE :
+    !f a b. sigma_algebra a /\ sigma_algebra b /\ f IN measurable a b ==>
+            f IN premeasurable a b
+Proof
    rpt GEN_TAC
    >> RW_TAC std_ss [measurable_def, premeasurable_def, GSPECIFICATION,
-                     SIGMA_ALGEBRA_ALGEBRA]);
+                     SIGMA_ALGEBRA_ALGEBRA]
+QED
 
 val MEASURABLE_IS_PREMEASURABLE = store_thm
   ("MEASURABLE_IS_PREMEASURABLE",
@@ -75,15 +87,17 @@ val MEASURABLE_IS_PREMEASURABLE = store_thm
    >> IMP_RES_TAC SIGMA_ALGEBRA_ALGEBRA
    >> METIS_TAC []);
 
-val PREMEASURABLE_SIGMA = store_thm
-  ("PREMEASURABLE_SIGMA",
-   ``!f a b sp.
+Theorem PREMEASURABLE_SIGMA :
+    !f a b sp.
        sigma_algebra a /\ subset_class sp b /\ f IN (space a -> sp) /\
        (!s. s IN b ==> (PREIMAGE f s) INTER (space a) IN subsets a) ==>
-       f IN premeasurable a (sigma sp b)``,
-   rpt STRIP_TAC
-   >> MATCH_MP_TAC MEASURABLE_IMP_PREMEASURABLE
-   >> RW_TAC std_ss [MEASURABLE_SIGMA]);
+       f IN premeasurable a (sigma sp b)
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC MEASURABLE_IMP_PREMEASURABLE
+ >> RW_TAC std_ss [SIGMA_ALGEBRA_SIGMA]
+ >> MATCH_MP_TAC MEASURABLE_SIGMA >> art []
+QED
 
 val PREMEASURABLE_SUBSET = store_thm
   ("PREMEASURABLE_SUBSET",
@@ -123,6 +137,7 @@ val PREMEASURABLE_COMP = store_thm
         by (RW_TAC std_ss [Once EXTENSION, IN_INTER, IN_PREIMAGE] >> METIS_TAC [])
    >> METIS_TAC []);
 
+(* NOTE: there's also prob_preserving_def in real_probabilityTheory *)
 val prob_preserving_def = Define
    `prob_preserving m1 m2 =
    {f |

--- a/examples/probability/large_numberScript.sml
+++ b/examples/probability/large_numberScript.sml
@@ -651,6 +651,8 @@ Theorem SLLN_uncorrelated :
 Proof
     PRINT_TAC "proving SLLN_uncorrelated (Strong Law of Large Numbers for uncorrelated r.v.'s) ..."
  >> RW_TAC std_ss [LLN_def]
+ >> ‘sigma_algebra (measurable_space p)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA, prob_space_def]
  (* without loss of generality *)
  >> MP_TAC (Q.SPECL [`p`, `X`, `Z`, `\n. expectation p (Z n)`, `c`]
                     SLLN_uncorrelated_wlog)
@@ -1789,6 +1791,8 @@ Theorem equivalent_events :
             !n. {x | x IN p_space p /\ X n x <> Y n x} IN events p
 Proof
     RW_TAC std_ss [events_def, p_space_def, prob_space_def]
+ >> ‘sigma_algebra (measurable_space p)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA, prob_space_def]
  >> `{x | x IN m_space p /\ X n x <> Y n x} =
      {x | X n x <> Y n x} INTER m_space p` by SET_TAC []
  >> POP_ORW
@@ -3079,6 +3083,8 @@ Theorem WLLN_IID :
 Proof
     PRINT_TAC "proving WLLN_IID (Weak Law of Large Numbers for I.I.D. r.v.'s) ..."
  >> RW_TAC std_ss [LLN_alt_converge_PR_IID]
+ >> ‘sigma_algebra (measurable_space p)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA, prob_space_def]
  (* define Y = truncated X, Z = SIGMA Y and prove their properties *)
  >> LLN_IID_shared_tactics
  (* stage work *)
@@ -4388,6 +4394,8 @@ Theorem SLLN_IID_lemma :
 Proof
     PRINT_TAC "proving SLLN_IID (Strong Law of Large Numbers for I.I.D. r.v.'s) ..."
  >> rpt GEN_TAC >> STRIP_TAC
+ >> ‘sigma_algebra (measurable_space p)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA, prob_space_def]
  (* define Y = truncated X, Z = SIGMA Y and prove their properties *)
  >> LLN_IID_shared_tactics
  (* additional properties of Z (n = 0 is included as a trivial case) *)
@@ -5151,6 +5159,8 @@ Theorem SLLN_IID_zero[local] :
       ==> LLN p X almost_everywhere
 Proof
     rw [LLN_alt_converge_AE_IID, converge_AE_def, AE_DEF]
+ >> ‘sigma_algebra (measurable_space p)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA, prob_space_def]
  >> Know ‘!n. expectation p (X n) = 0’
  >- (Q.PAT_X_ASSUM ‘expectation p (X 0) = 0’ (ONCE_REWRITE_TAC o wrap o SYM) \\
      MATCH_MP_TAC identical_distribution_expectation >> rw [] \\
@@ -5984,6 +5994,8 @@ Theorem SLLN_IID_diverge :
       ==> AE x::p. limsup (\n. abs (SIGMA (\i. X i x) (count (SUC n))) / &SUC n) = PosInf
 Proof
     rpt STRIP_TAC
+ >> ‘sigma_algebra (measurable_space p)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA, prob_space_def]
  >> Know ‘!a. 0 < a ==> expectation p (\x. abs (X 0 x) / Normal a) = PosInf’
  >- (rpt STRIP_TAC >> CCONTR_TAC \\
      Q.ABBREV_TAC ‘Y = \x. abs (X 0 x) / Normal a’ \\

--- a/examples/probability/lebesgue_measureScript.sml
+++ b/examples/probability/lebesgue_measureScript.sml
@@ -433,8 +433,7 @@ Theorem borel_imp_lebesgue_measurable : (* was: borel_measurable_lebesgueI *)
         f IN borel_measurable (m_space lebesgue, measurable_sets lebesgue)
 Proof
     RW_TAC std_ss [measurable_def, GSPECIFICATION]
- >| [ SIMP_TAC std_ss [sigma_algebra_lebesgue, sets_lebesgue, space_lebesgue],
-      FULL_SIMP_TAC std_ss [space_lebesgue, space_borel, space_def],
+ >| [ FULL_SIMP_TAC std_ss [space_lebesgue, space_borel, space_def],
       FULL_SIMP_TAC std_ss [space_def, subsets_def] ]
  >> FULL_SIMP_TAC std_ss [space_borel, space_lebesgue, INTER_UNIV]
  >> MATCH_MP_TAC lebesgueI_borel >> ASM_SET_TAC []

--- a/examples/probability/normal_rvScript.sml
+++ b/examples/probability/normal_rvScript.sml
@@ -37,7 +37,8 @@ Theorem PDF_LE_POS :
 Proof
     rpt STRIP_TAC
  >> `measure_space (space borel, subsets borel, distribution p X)`
-       by PROVE_TAC [distribution_prob_space, prob_space_def]
+       by PROVE_TAC [distribution_prob_space, prob_space_def,
+                     sigma_algebra_borel]
  >> ASSUME_TAC sigma_finite_lborel
  >> ASSUME_TAC measure_space_lborel
  >> MP_TAC (ISPECL [(* m *) ``lborel``,
@@ -56,7 +57,7 @@ Theorem EXPECTATION_PDF_1 : (* was: INTEGRAL_PDF_1 *)
 Proof
     rpt STRIP_TAC
  >> `prob_space (space borel, subsets borel, distribution p X)`
-       by PROVE_TAC [distribution_prob_space]
+       by PROVE_TAC [distribution_prob_space, sigma_algebra_borel]
  >> NTAC 2 (POP_ASSUM MP_TAC) >> KILL_TAC
  >> RW_TAC std_ss [prob_space_def, p_space_def, m_space_def, measure_def,
                    expectation_def]

--- a/src/probability/borelScript.sml
+++ b/src/probability/borelScript.sml
@@ -8867,22 +8867,23 @@ Theorem IN_MEASURABLE_BOREL_PROD':
     !a f g s. FINITE s /\ sigma_algebra a /\ (!i. i IN s ==> f i IN Borel_measurable a) /\
         (!x. x IN space a ==> g x = EXTREAL_PROD_IMAGE (λi. f i x) s) ==> g IN Borel_measurable a
 Proof
-    NTAC 2 gen_tac >> simp[Once SWAP_FORALL_THM,Once $ GSYM AND_IMP_INTRO,RIGHT_FORALL_IMP_THM] >>
-    Induct_on ‘s’ >> rw[]
-    >- (fs[EXTREAL_PROD_IMAGE_EMPTY] >> irule IN_MEASURABLE_BOREL_CONST >>
-        simp[] >> qexists_tac ‘1’ >> simp[]) >>
-    rfs[EXTREAL_PROD_IMAGE_PROPERTY,DELETE_NON_ELEMENT_RWT] >>
-    irule IN_MEASURABLE_BOREL_MUL' >> simp[] >> qexistsl_tac [‘f e’,‘λx. EXTREAL_PROD_IMAGE (λi. f i x) s’] >> simp[]
+    NTAC 2 gen_tac >> simp[Once SWAP_FORALL_THM,Once $ GSYM AND_IMP_INTRO,RIGHT_FORALL_IMP_THM]
+ >> Induct_on ‘s’ >> rw[]
+ >- (fs[EXTREAL_PROD_IMAGE_EMPTY] >> irule IN_MEASURABLE_BOREL_CONST >>
+     simp[] >> qexists_tac ‘1’ >> simp[])
+ >> rfs[EXTREAL_PROD_IMAGE_PROPERTY,DELETE_NON_ELEMENT_RWT]
+ >> irule IN_MEASURABLE_BOREL_MUL' >> simp[]
+ >> qexistsl_tac [‘f e’,‘λx. EXTREAL_PROD_IMAGE (λi. f i x) s’] >> simp[]
 QED
 
-(*
 Theorem IN_MEASURABLE_BOREL_INV:
     !a f g. sigma_algebra a /\ f IN Borel_measurable a /\
         (!x. x IN space a ==> g x = extreal_inv (f x) * indicator_fn {y | f y <> 0} x) ==>
         g IN Borel_measurable a
 Proof
-    rw[] >> simp[IN_MEASURABLE_BOREL,FUNSET] >>
-    ‘(!c. c <= 0 ==> {x | g x < Normal c} INTER space a IN subsets a) /\
+    rw[]
+ >> simp[IN_MEASURABLE_BOREL,FUNSET]
+ >> ‘(!c. c <= 0 ==> {x | g x < Normal c} INTER space a IN subsets a) /\
       {x | g x = 0} INTER space a IN subsets a /\
       (!c. 0 < c ==> {x | 0 < g x /\ g x < Normal c} INTER space a IN subsets a)’ suffices_by (
         rw[] >> Cases_on ‘c <= 0’ >> simp[] >> fs[REAL_NOT_LE] >>
@@ -8890,24 +8891,26 @@ Proof
         fs[normal_0] >> drule_then (fn th => NTAC 2 $ dxrule_all_then assume_tac th) SIGMA_ALGEBRA_UNION >>
         pop_assum mp_tac >> qmatch_abbrev_tac ‘s IN _ ==> t IN _’ >> ‘s = t’ suffices_by simp[] >>
         UNABBREV_ALL_TAC >> rw[EXTENSION] >> qpat_x_assum ‘!x. _’ kall_tac >>
-        Cases_on ‘x IN space a’ >> simp[] >> Cases_on ‘g x’ >> simp[]) >>
-    rw[]
-    >- (drule_then (qspecl_then [‘if c = 0 then NegInf else Normal (inv c)’,‘0’] mp_tac) IN_MEASURABLE_BOREL_OO >>
-        qmatch_abbrev_tac ‘s IN _ ==> t IN _’ >> ‘s = t’ suffices_by simp[] >> UNABBREV_ALL_TAC >>
-        simp[EXTENSION] >> strip_tac >> Cases_on ‘x IN space a’ >> simp[indicator_fn_def] >>
-        Cases_on ‘f x’ >> rw[extreal_inv_def] >> eq_tac >> strip_tac >> simp[] >>
-        drule_all_then assume_tac REAL_LTE_TRANS >> fs[])
-    >- (drule_all_then assume_tac IN_MEASURABLE_BOREL_SING >>
-        pop_assum (fn th => map_every (fn tm => qspec_then tm assume_tac th) [‘NegInf’,‘0’,‘PosInf’]) >>
-        drule_then (fn th => NTAC 2 $ dxrule_all_then assume_tac th) SIGMA_ALGEBRA_UNION >>
-        pop_assum mp_tac >> qmatch_abbrev_tac ‘s IN _ ==> t IN _’ >> ‘s = t’ suffices_by simp[] >>
-        UNABBREV_ALL_TAC >> rw[EXTENSION] >> Cases_on ‘x IN space a’ >> simp[indicator_fn_def] >>
-        Cases_on ‘f x’ >> rw[extreal_inv_def])
-    >- (drule_then (qspecl_then [‘Normal (inv c)’,‘PosInf’] mp_tac) IN_MEASURABLE_BOREL_OO >>
-        qmatch_abbrev_tac ‘s IN _ ==> t IN _’ >> ‘s = t’ suffices_by simp[] >> UNABBREV_ALL_TAC >>
-        rw[EXTENSION] >> Cases_on ‘x IN space a’ >> simp[indicator_fn_def] >>
-        Cases_on ‘f x’ >> rw[extreal_inv_def] >> simp[] >> eq_tac >> strip_tac >> rfs[] >>
-        REVERSE CONJ_ASM1_TAC >- simp[] >> ‘0 <= c * r’ by simp[] >> rfs[REAL_MUL_SIGN])
+        Cases_on ‘x IN space a’ >> simp[] >> Cases_on ‘g x’ >> simp[])
+ >> rw[]
+ >- (MP_TAC (Q.SPECL [‘f’, ‘a’] IN_MEASURABLE_BOREL_OO) >> RW_TAC std_ss [] \\
+     POP_ASSUM (qspecl_then [‘if c = 0 then NegInf else Normal (inv c)’,‘0’] mp_tac) \\
+     qmatch_abbrev_tac ‘s IN _ ==> t IN _’ >> ‘s = t’ suffices_by simp[] >> UNABBREV_ALL_TAC >>
+     simp[EXTENSION] >> strip_tac >> Cases_on ‘x IN space a’ >> simp[indicator_fn_def] >>
+     Cases_on ‘f x’ >> rw[extreal_inv_def] >> eq_tac >> strip_tac >> simp[] >>
+     drule_all_then assume_tac REAL_LTE_TRANS >> fs[])
+ >- (drule_all_then assume_tac IN_MEASURABLE_BOREL_SING >>
+     pop_assum (fn th => map_every (fn tm => qspec_then tm assume_tac th) [‘NegInf’,‘0’,‘PosInf’]) >>
+     drule_then (fn th => NTAC 2 $ dxrule_all_then assume_tac th) SIGMA_ALGEBRA_UNION >>
+     pop_assum mp_tac >> qmatch_abbrev_tac ‘s IN _ ==> t IN _’ >> ‘s = t’ suffices_by simp[] >>
+     UNABBREV_ALL_TAC >> rw[EXTENSION] >> Cases_on ‘x IN space a’ >> simp[indicator_fn_def] >>
+     Cases_on ‘f x’ >> rw[extreal_inv_def])
+ >- (MP_TAC (Q.SPECL [‘f’, ‘a’] IN_MEASURABLE_BOREL_OO) >> RW_TAC std_ss [] \\
+     POP_ASSUM (qspecl_then [‘Normal (inv c)’,‘PosInf’] mp_tac) \\
+     qmatch_abbrev_tac ‘s IN _ ==> t IN _’ >> ‘s = t’ suffices_by simp[] >> UNABBREV_ALL_TAC >>
+     rw[EXTENSION] >> Cases_on ‘x IN space a’ >> simp[indicator_fn_def] >>
+     Cases_on ‘f x’ >> rw[extreal_inv_def] >> simp[] >> eq_tac >> strip_tac >> rfs[] >>
+     REVERSE CONJ_ASM1_TAC >- simp[] >> ‘0 <= c * r’ by simp[] >> rfs[REAL_MUL_SIGN])
 QED
 
 Theorem IN_MEASURABLE_BOREL_MUL_INV:
@@ -8995,14 +8998,17 @@ Proof
     >- (rfs[EVEN_ODD,ODD])
 QED
 
+(* NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’
+
+         Here ‘Normal o real’ is actually used as a "filter" to remove all infinities from
+         the domain of a function f.
+ *)
 Theorem IN_MEASURABLE_BOREL_NORMAL_REAL:
-    !sa f. f IN Borel_measurable sa ==>
-       Normal o real o f IN Borel_measurable sa
+    !a f. sigma_algebra a /\ f IN Borel_measurable a ==> Normal o real o f IN Borel_measurable a
 Proof
-    rw[] >> irule IN_MEASURABLE_BOREL_IMP_BOREL' >> irule_at Any in_borel_measurable_from_Borel >>
-    simp[] >> fs[IN_MEASURABLE]
+    rw[] >> irule IN_MEASURABLE_BOREL_IMP_BOREL' >> art []
+ >> irule_at Any in_borel_measurable_from_Borel >> art []
 QED
-*)
 
 (*** AE Theorems ***)
 

--- a/src/probability/borelScript.sml
+++ b/src/probability/borelScript.sml
@@ -876,11 +876,13 @@ Proof
  >> final_tactics
 QED
 
-val MEASURABLE_BOREL = store_thm
-  ("MEASURABLE_BOREL",
-  ``!f a. f IN measurable a Borel <=>
-          sigma_algebra a /\ f IN (space a -> UNIV) /\
-          !c. ((PREIMAGE f {x| x < Normal c}) INTER (space a)) IN subsets a``,
+(* NOTE: moved ‘sigma_algebra a’ to antecedents due to changes of ‘measurable’ *)
+Theorem MEASURABLE_BOREL :
+    !f a. sigma_algebra a ==>
+         (f IN measurable a Borel <=>
+          f IN (space a -> UNIV) /\
+          !c. ((PREIMAGE f {x| x < Normal c}) INTER (space a)) IN subsets a)
+Proof
     RW_TAC std_ss []
  >> `sigma_algebra Borel` by RW_TAC std_ss [SIGMA_ALGEBRA_BOREL]
  >> `space Borel = UNIV` by RW_TAC std_ss [Borel_def, space_def, SPACE_SIGMA]
@@ -893,23 +895,28 @@ val MEASURABLE_BOREL = store_thm
  >> RW_TAC std_ss [Borel_def]
  >> MATCH_MP_TAC MEASURABLE_SIGMA
  >> RW_TAC std_ss [subset_class_def,SUBSET_UNIV,IN_IMAGE,IN_UNIV]
- >> METIS_TAC []);
+ >> METIS_TAC []
+QED
 
-val IN_MEASURABLE_BOREL = store_thm
-  ("IN_MEASURABLE_BOREL",
-  ``!f a. f IN measurable a Borel <=>
-          sigma_algebra a /\ f IN (space a -> UNIV) /\
-          !c. ({x | f x < Normal c} INTER space a) IN subsets a``,
+Theorem IN_MEASURABLE_BOREL :
+    !f a. sigma_algebra a ==>
+         (f IN measurable a Borel <=>
+          f IN (space a -> UNIV) /\
+          !c. ({x | f x < Normal c} INTER space a) IN subsets a)
+Proof
   RW_TAC std_ss []
   >> `!c. {x | f x < Normal c} = PREIMAGE f {x| x < Normal c}`
        by RW_TAC std_ss [EXTENSION,IN_PREIMAGE,GSPECIFICATION]
-  >> RW_TAC std_ss [MEASURABLE_BOREL]);
+  >> RW_TAC std_ss [MEASURABLE_BOREL]
+QED
 
-val IN_MEASURABLE_BOREL_NEGINF = store_thm
-  ("IN_MEASURABLE_BOREL_NEGINF",
-  ``!f a. f IN measurable a Borel ==>
-          ({x | f x = NegInf} INTER space a) IN subsets a``,
-    RW_TAC std_ss [IN_MEASURABLE_BOREL, GSPECIFICATION, IN_FUNSET, IN_UNIV]
+(* NOTE: added ‘sigma_algebra a’ due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_NEGINF :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          ({x | f x = NegInf} INTER space a) IN subsets a
+Proof
+    rpt STRIP_TAC
+ >> rfs [IN_MEASURABLE_BOREL, GSPECIFICATION, IN_FUNSET]
  >> Know `{x | f x = NegInf} INTER space a =
           BIGINTER (IMAGE (\n. {x | f x < -(&n)} INTER space a) UNIV)`
  >- (RW_TAC std_ss [EXTENSION, IN_BIGINTER_IMAGE, IN_UNIV, GSPECIFICATION, IN_INTER] \\
@@ -922,13 +929,16 @@ val IN_MEASURABLE_BOREL_NEGINF = store_thm
  >> POP_ASSUM MATCH_MP_TAC
  >> RW_TAC std_ss [IN_FUNSET, IN_UNIV]
  >> `- &n = Normal (- &n)` by PROVE_TAC [extreal_ainv_def, extreal_of_num_def]
- >> METIS_TAC []);
+ >> METIS_TAC []
+QED
 
-val IN_MEASURABLE_BOREL_NOT_POSINF = store_thm (* new *)
-  ("IN_MEASURABLE_BOREL_NOT_POSINF",
-  ``!f a. f IN measurable a Borel ==>
-          ({x | f x <> PosInf} INTER space a) IN subsets a``,
-    RW_TAC std_ss [IN_MEASURABLE_BOREL, GSPECIFICATION, IN_FUNSET, IN_UNIV]
+(* NOTE: added ‘sigma_algebra a’ due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_NOT_POSINF :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          ({x | f x <> PosInf} INTER space a) IN subsets a
+Proof
+    rpt STRIP_TAC
+ >> rfs [IN_MEASURABLE_BOREL, GSPECIFICATION, IN_FUNSET]
  >> Know `{x | f x <> PosInf} INTER space a =
           BIGUNION (IMAGE (\n. {x | f x < &n} INTER space a) UNIV)`
  >- (RW_TAC std_ss [EXTENSION, IN_BIGUNION_IMAGE, IN_UNIV, GSPECIFICATION, IN_INTER] \\
@@ -945,30 +955,38 @@ val IN_MEASURABLE_BOREL_NOT_POSINF = store_thm (* new *)
  >> FIRST_X_ASSUM MATCH_MP_TAC
  >> RW_TAC std_ss [IN_FUNSET, IN_UNIV]
  >> `&n = Normal (&n)` by PROVE_TAC [extreal_of_num_def]
- >> METIS_TAC []);
+ >> METIS_TAC []
+QED
 
-val IN_MEASURABLE_BOREL_IMP = store_thm (* new *)
-  ("IN_MEASURABLE_BOREL_IMP",
-  ``!f a. f IN measurable a Borel ==>
-          !c. ({x | f x < c} INTER space a) IN subsets a``,
+(* NOTE: added ‘sigma_algebra a’ due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_IMP :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !c. ({x | f x < c} INTER space a) IN subsets a
+Proof
     rpt STRIP_TAC
  >> Cases_on `c`
  >- (REWRITE_TAC [lt_infty, GSPEC_F, INTER_EMPTY] \\
-     fs [IN_MEASURABLE_BOREL, sigma_algebra_def, ALGEBRA_EMPTY])
+     rw [SIGMA_ALGEBRA_EMPTY])
  >- (REWRITE_TAC [GSYM lt_infty] \\
      MATCH_MP_TAC IN_MEASURABLE_BOREL_NOT_POSINF >> art [])
- >> fs [IN_MEASURABLE_BOREL]);
+ >> rfs [IN_MEASURABLE_BOREL]
+QED
 
-(* the same theorems with more meaningful names, new *)
-val IN_MEASURABLE_BOREL_RO = save_thm
-  ("IN_MEASURABLE_BOREL_RO", IN_MEASURABLE_BOREL_IMP);
+(* |- !f a.
+        sigma_algebra a /\ f IN Borel_measurable a ==>
+        !c. {x | f x < c} INTER space a IN subsets a
+ *)
+Theorem IN_MEASURABLE_BOREL_RO = IN_MEASURABLE_BOREL_IMP
 
-val IN_MEASURABLE_BOREL_ALT1 = store_thm
-  ("IN_MEASURABLE_BOREL_ALT1",
-  ``!f a. f IN measurable a Borel <=>
-          sigma_algebra a /\ f IN (space a -> UNIV) /\
-          !c. ({x | Normal c <= f x} INTER space a) IN subsets a``,
-    RW_TAC std_ss [IN_MEASURABLE_BOREL, GSPECIFICATION, IN_FUNSET, IN_UNIV]
+(* NOTE: moved ‘sigma_algebra a’ to antecedents due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_ALT1 :
+    !f a. sigma_algebra a ==>
+         (f IN measurable a Borel <=>
+          f IN (space a -> UNIV) /\
+          !c. ({x | Normal c <= f x} INTER space a) IN subsets a)
+Proof
+    rpt STRIP_TAC
+ >> RW_TAC std_ss [IN_MEASURABLE_BOREL, GSPECIFICATION, IN_FUNSET, IN_UNIV]
  >> EQ_TAC
  >- (RW_TAC std_ss []
      >> `{x | Normal c <= f x} = PREIMAGE f {x | Normal c <= x}`
@@ -995,17 +1013,21 @@ val IN_MEASURABLE_BOREL_ALT1 = store_thm
      by METIS_TAC [GSYM PREIMAGE_COMPL_INTER]
  >> `!c. COMPL {x | Normal c <= x} = {x | x < Normal c}`
      by RW_TAC std_ss [EXTENSION, IN_COMPL, IN_UNIV, IN_DIFF, GSPECIFICATION, extreal_lt_def]
- >> METIS_TAC []);
+ >> METIS_TAC []
+QED
 
-val IN_MEASURABLE_BOREL_ALT2 = store_thm
-  ("IN_MEASURABLE_BOREL_ALT2",
-  ``!f a. f IN measurable a Borel <=>
-          sigma_algebra a /\ f IN (space a -> UNIV) /\
-          !c. ({x | f x <= Normal c} INTER space a) IN subsets a``,
-    RW_TAC std_ss []
+(* NOTE: moved ‘sigma_algebra a’ to antecedents due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_ALT2 :
+    !f a. sigma_algebra a ==>
+         (f IN measurable a Borel <=>
+          f IN (space a -> UNIV) /\
+          !c. ({x | f x <= Normal c} INTER space a) IN subsets a)
+Proof
+    rpt STRIP_TAC
+ >> RW_TAC std_ss [IN_MEASURABLE_BOREL]
  >> EQ_TAC
- >- (RW_TAC std_ss [IN_MEASURABLE_BOREL]
-     >> `!c. {x | f x <= Normal c} INTER (space a) =
+ >- (RW_TAC std_ss [] \\
+     `!c. {x | f x <= Normal c} INTER (space a) =
              BIGINTER (IMAGE (\n:num. {x | f x < Normal (c + (1/2) pow n)} INTER space a) UNIV)`
         by (RW_TAC std_ss [EXTENSION, IN_BIGINTER_IMAGE, IN_UNIV,IN_INTER]
             >> EQ_TAC
@@ -1016,9 +1038,12 @@ val IN_MEASURABLE_BOREL_ALT2 = store_thm
                 >> METIS_TAC [let_add2,extreal_of_num_def,extreal_not_infty,add_rzero,le_infty])
              >> RW_TAC std_ss [GSPECIFICATION]
              >> `!n. f x < Normal (c + (1 / 2) pow n)` by METIS_TAC []
-             >> `(\n. c + (1 / 2) pow n) = (\n. (\n. c) n + (\n. (1 / 2) pow n) n) ` by RW_TAC real_ss [FUN_EQ_THM]
+             >> `(\n. c + (1 / 2) pow n) = (\n. (\n. c) n + (\n. (1 / 2) pow n) n)`
+                    by RW_TAC real_ss [FUN_EQ_THM]
              >> `(\n. (1 / 2) pow n) --> 0` by RW_TAC real_ss [SEQ_POWER]
-             >> `(\n. c + (1 / 2) pow n) --> c` by METIS_TAC [SEQ_CONST, Q.SPECL [`(\n:num. c)`,`c`,`(\n. (1/2) pow n)`,`0`] SEQ_ADD,REAL_ADD_RID]
+             >> `(\n. c + (1 / 2) pow n) --> c`
+                    by METIS_TAC [SEQ_CONST,
+                         Q.SPECL [`(\n:num. c)`,`c`,`(\n. (1/2) pow n)`,`0`] SEQ_ADD,REAL_ADD_RID]
              >> Cases_on `f x = NegInf` >- METIS_TAC [le_infty]
              >> `f x <> PosInf` by METIS_TAC [lt_infty]
              >> `?r. f x = Normal r` by METIS_TAC [extreal_cases]
@@ -1034,7 +1059,7 @@ val IN_MEASURABLE_BOREL_ALT2 = store_thm
                  by (RW_TAC std_ss [IN_FUNSET])
              >> METIS_TAC [])
      >> METIS_TAC [])
- >> RW_TAC std_ss [IN_MEASURABLE_BOREL]
+ >> RW_TAC std_ss []
  >> `!c. {x | f x < Normal c} INTER (space a) =
          BIGUNION (IMAGE (\n:num. {x | f x <= Normal (c - (1/2) pow n)} INTER space a) UNIV)`
      by (RW_TAC std_ss [EXTENSION, IN_BIGUNION_IMAGE, IN_UNIV,IN_INTER,GSPECIFICATION]
@@ -1071,28 +1096,39 @@ val IN_MEASURABLE_BOREL_ALT2 = store_thm
          >> METIS_TAC [])
  >> FULL_SIMP_TAC std_ss []
  >> MATCH_MP_TAC SIGMA_ALGEBRA_ENUM
- >> RW_TAC std_ss [IN_FUNSET]);
+ >> RW_TAC std_ss [IN_FUNSET]
+QED
 
-val IN_MEASURABLE_BOREL_ALT2_IMP = store_thm (* new *)
-  ("IN_MEASURABLE_BOREL_ALT2_IMP",
-  ``!f a. f IN measurable a Borel ==> !c. ({x | f x <= c} INTER space a) IN subsets a``,
+(* NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_ALT2_IMP :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !c. ({x | f x <= c} INTER space a) IN subsets a
+Proof
     rpt STRIP_TAC
  >> Cases_on `c`
  >- (REWRITE_TAC [le_infty] \\
      MATCH_MP_TAC IN_MEASURABLE_BOREL_NEGINF >> art [])
  >- (REWRITE_TAC [le_infty, GSPEC_T, INTER_UNIV] \\
      fs [IN_MEASURABLE_BOREL, sigma_algebra_def, ALGEBRA_SPACE])
- >> fs [IN_MEASURABLE_BOREL_ALT2]);
+ >> rfs [IN_MEASURABLE_BOREL_ALT2]
+QED
 
-val IN_MEASURABLE_BOREL_RC = save_thm
-  ("IN_MEASURABLE_BOREL_RC", IN_MEASURABLE_BOREL_ALT2_IMP);
+(* |- !f a.
+        sigma_algebra a /\ f IN Borel_measurable a ==>
+        !c. {x | f x <= c} INTER space a IN subsets a
 
-val IN_MEASURABLE_BOREL_ALT3 = store_thm
-  ("IN_MEASURABLE_BOREL_ALT3",
-  ``!f a. f IN measurable a Borel <=>
-          sigma_algebra a /\ f IN (space a -> UNIV) /\
-          !c. ({x | Normal c < f x} INTER space a) IN subsets a``,
- RW_TAC std_ss [IN_MEASURABLE_BOREL_ALT2,GSPECIFICATION]
+   NOTE: "RC" ("C" is at right of "R") means a right-closed (C) half-interval (R).
+ *)
+Theorem IN_MEASURABLE_BOREL_RC = IN_MEASURABLE_BOREL_ALT2_IMP
+
+(* NOTE: moved ‘sigma_algebra a’ to antecedents due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_ALT3 :
+    !f a. sigma_algebra a ==>
+         (f IN measurable a Borel <=>
+          f IN (space a -> UNIV) /\
+          !c. ({x | Normal c < f x} INTER space a) IN subsets a)
+Proof
+    RW_TAC std_ss [IN_MEASURABLE_BOREL_ALT2,GSPECIFICATION]
  >> EQ_TAC
  >- (RW_TAC std_ss []
      >> `{x|Normal c < f x} = PREIMAGE f {x | Normal c < x}` by RW_TAC std_ss[PREIMAGE_def,GSPECIFICATION]
@@ -1109,13 +1145,16 @@ val IN_MEASURABLE_BOREL_ALT3 = store_thm
  >> `!c. space a DIFF (PREIMAGE f {x | Normal c < x}) IN subsets a` by METIS_TAC [DIFF_INTER2]
  >> `!c. (PREIMAGE f (COMPL {x | Normal c < x}) INTER space a) IN subsets a` by METIS_TAC [GSYM PREIMAGE_COMPL_INTER]
  >> `COMPL {x | Normal c < x} = {x | x <= Normal c}` by RW_TAC std_ss [EXTENSION,GSPECIFICATION,IN_COMPL,extreal_lt_def]
- >> METIS_TAC []);
+ >> METIS_TAC []
+QED
 
-val IN_MEASURABLE_BOREL_POSINF = store_thm (* new *)
-  ("IN_MEASURABLE_BOREL_POSINF",
-  ``!f a. f IN measurable a Borel ==>
-          ({x | f x = PosInf} INTER space a) IN subsets a``,
-    RW_TAC std_ss [IN_MEASURABLE_BOREL_ALT3, GSPECIFICATION, IN_FUNSET, IN_UNIV]
+(* NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_POSINF :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          ({x | f x = PosInf} INTER space a) IN subsets a
+Proof
+    rpt STRIP_TAC
+ >> rfs [IN_MEASURABLE_BOREL_ALT3, GSPECIFICATION, IN_FUNSET]
  >> Know `{x | f x = PosInf} INTER space a =
           BIGINTER (IMAGE (\n. {x | &n < f x} INTER space a) UNIV)`
  >- (RW_TAC std_ss [EXTENSION, IN_BIGINTER_IMAGE, IN_UNIV, GSPECIFICATION, IN_INTER] \\
@@ -1128,13 +1167,16 @@ val IN_MEASURABLE_BOREL_POSINF = store_thm (* new *)
  >> POP_ASSUM MATCH_MP_TAC
  >> RW_TAC std_ss [IN_FUNSET, IN_UNIV]
  >> `&n = Normal (&n)` by PROVE_TAC [extreal_of_num_def]
- >> METIS_TAC []);
+ >> METIS_TAC []
+QED
 
-val IN_MEASURABLE_BOREL_NOT_NEGINF = store_thm (* new *)
-  ("IN_MEASURABLE_BOREL_NOT_NEGINF",
-  ``!f a. f IN measurable a Borel ==>
-          ({x | f x <> NegInf} INTER space a) IN subsets a``,
-    RW_TAC std_ss [IN_MEASURABLE_BOREL_ALT3, GSPECIFICATION, IN_FUNSET, IN_UNIV]
+(* NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_NOT_NEGINF :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          ({x | f x <> NegInf} INTER space a) IN subsets a
+Proof
+    rpt STRIP_TAC
+ >> rfs [IN_MEASURABLE_BOREL_ALT3, GSPECIFICATION, IN_FUNSET]
  >> Know `{x | f x <> NegInf} INTER space a =
           BIGUNION (IMAGE (\n. {x | -(&n) < f x} INTER space a) UNIV)`
  >- (RW_TAC std_ss [EXTENSION, IN_BIGUNION_IMAGE, IN_UNIV, GSPECIFICATION, IN_INTER] \\
@@ -1151,65 +1193,80 @@ val IN_MEASURABLE_BOREL_NOT_NEGINF = store_thm (* new *)
  >> FIRST_X_ASSUM MATCH_MP_TAC
  >> RW_TAC std_ss [IN_FUNSET, IN_UNIV]
  >> `-&n = Normal (-&n)` by PROVE_TAC [extreal_ainv_def, extreal_of_num_def]
- >> METIS_TAC []);
+ >> METIS_TAC []
+QED
 
-val IN_MEASURABLE_BOREL_ALT1_IMP = store_thm (* new *)
-  ("IN_MEASURABLE_BOREL_ALT1_IMP",
-  ``!f a. f IN measurable a Borel ==>
-          !c. ({x | c <= f x} INTER space a) IN subsets a``,
+(* NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_ALT1_IMP :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !c. ({x | c <= f x} INTER space a) IN subsets a
+Proof
     rpt STRIP_TAC
  >> Cases_on `c`
  >- (REWRITE_TAC [le_infty, GSPEC_T, INTER_UNIV] \\
      fs [IN_MEASURABLE_BOREL, sigma_algebra_def, ALGEBRA_SPACE])
  >- (REWRITE_TAC [le_infty] \\
      MATCH_MP_TAC IN_MEASURABLE_BOREL_POSINF >> art [])
- >> fs [IN_MEASURABLE_BOREL_ALT1]);
+ >> rfs [IN_MEASURABLE_BOREL_ALT1]
+QED
 
-val IN_MEASURABLE_BOREL_CR = save_thm
-  ("IN_MEASURABLE_BOREL_CR", IN_MEASURABLE_BOREL_ALT1_IMP);
+(* |- !f a.
+        sigma_algebra a /\ f IN Borel_measurable a ==>
+        !c. {x | c <= f x} INTER space a IN subsets a
 
-val IN_MEASURABLE_BOREL_ALT3_IMP = store_thm (* new *)
-  ("IN_MEASURABLE_BOREL_ALT3_IMP",
-  ``!f a. f IN measurable a Borel ==>
-          !c. ({x | c < f x} INTER space a) IN subsets a``,
+   NOTE: "CR" ("C" is at left of "R") means a left-closed (C) half-interval (R).
+ *)
+Theorem IN_MEASURABLE_BOREL_CR = IN_MEASURABLE_BOREL_ALT1_IMP
+
+(* NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_ALT3_IMP :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !c. ({x | c < f x} INTER space a) IN subsets a
+Proof
     rpt STRIP_TAC
  >> Cases_on `c`
  >- (REWRITE_TAC [GSYM lt_infty] \\
      MATCH_MP_TAC IN_MEASURABLE_BOREL_NOT_NEGINF >> art [])
  >- (REWRITE_TAC [lt_infty, GSPEC_F, INTER_EMPTY] \\
      fs [IN_MEASURABLE_BOREL, sigma_algebra_def, ALGEBRA_EMPTY])
- >> fs [IN_MEASURABLE_BOREL_ALT3]);
+ >> rfs [IN_MEASURABLE_BOREL_ALT3]
+QED
 
-val IN_MEASURABLE_BOREL_OR = save_thm
-  ("IN_MEASURABLE_BOREL_OR", IN_MEASURABLE_BOREL_ALT3_IMP);
+(*  |- !f a.
+        sigma_algebra a /\ f IN Borel_measurable a ==>
+        !c. {x | c < f x} INTER space a IN subsets a
 
-(* changed ‘!x. f x <> NegInf’ to ‘!x. x IN space a ==> f x <> NegInf’ *)
+   NOTE: "OR" ("O" is at left of "R") means a left-open (O) half-interval (R).
+ *)
+Theorem IN_MEASURABLE_BOREL_OR = IN_MEASURABLE_BOREL_ALT3_IMP
+
+(* changed ‘!x. f x <> NegInf’ to ‘!x. x IN space a ==> f x <> NegInf’
+
+   NOTE: moved ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’
+ *)
 Theorem IN_MEASURABLE_BOREL_ALT4 :
-    !f a. (!x. x IN space a ==> f x <> NegInf) ==>
-          (f IN measurable a Borel <=>
-           sigma_algebra a /\ f IN (space a -> UNIV) /\
-           !c d. ({x | Normal c <= f x /\ f x < Normal d} INTER space a) IN subsets a)
+    !f a. sigma_algebra a /\ (!x. x IN space a ==> f x <> NegInf) ==>
+         (f IN measurable a Borel <=>
+          f IN (space a -> UNIV) /\
+          !c d. ({x | Normal c <= f x /\ f x < Normal d} INTER space a) IN subsets a)
 Proof
     RW_TAC std_ss []
  >> EQ_TAC
- >- (STRIP_TAC \\
-     CONJ_TAC >- METIS_TAC [IN_MEASURABLE_BOREL] \\
-     CONJ_TAC >- METIS_TAC [IN_MEASURABLE_BOREL] \\
-     RW_TAC std_ss [] \\
-    `!d. {x | f x < Normal d} INTER space a IN subsets a`
+ >- (rpt STRIP_TAC >- rfs [IN_MEASURABLE_BOREL] \\
+    `{x | f x < Normal d} INTER space a IN subsets a`
         by METIS_TAC [IN_MEASURABLE_BOREL] \\
-    `!c. {x | Normal c <= f x} INTER space a IN subsets a`
+    `{x | Normal c <= f x} INTER space a IN subsets a`
         by METIS_TAC [IN_MEASURABLE_BOREL_ALT1] \\
-     FULL_SIMP_TAC std_ss [IN_MEASURABLE_BOREL] \\
-    `!c d. (({x | Normal c <= f x} INTER space a) INTER
-            ({x | f x < Normal d} INTER space a)) IN subsets a`
+     rfs [IN_MEASURABLE_BOREL] \\
+    `(({x | Normal c <= f x} INTER space a) INTER
+      ({x | f x < Normal d} INTER space a)) IN subsets a`
         by METIS_TAC [sigma_algebra_def, ALGEBRA_INTER] \\
-    `!c d. ({x | Normal c <= f x} INTER space a) INTER ({x | f x < Normal d} INTER space a) =
-           ({x | Normal c <= f x} INTER {x | f x < Normal d} INTER space a)`
+    `({x | Normal c <= f x} INTER space a) INTER ({x | f x < Normal d} INTER space a) =
+     ({x | Normal c <= f x} INTER {x | f x < Normal d} INTER space a)`
         by METIS_TAC [INTER_ASSOC, INTER_COMM, INTER_IDEMPOT] \\
     `{x | Normal c <= f x} INTER {x | f x < Normal d} = {x | Normal c <= f x /\ f x < Normal d}`
         by RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER] \\
-     METIS_TAC [])
+     METIS_TAC [SIGMA_ALGEBRA_INTER])
  >> RW_TAC std_ss [IN_MEASURABLE_BOREL]
  >> `!c. {x | f x < Normal c} INTER (space a) =
          BIGUNION
@@ -1234,29 +1291,30 @@ Proof
  >> METIS_TAC []
 QED
 
-(* changed ‘!x. f x <> NegInf’ to ‘!x. x IN space a ==> f x <> NegInf’ *)
+(* changed ‘!x. f x <> NegInf’ to ‘!x. x IN space a ==> f x <> NegInf’
+
+   NOTE: moved ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’
+ *)
 Theorem IN_MEASURABLE_BOREL_ALT5 :
-    !f a. (!x. x IN space a ==> f x <> NegInf) ==>
-          (f IN measurable a Borel <=>
-           sigma_algebra a /\ f IN (space a -> UNIV) /\
-           !c d. ({x | Normal c < f x /\ f x <= Normal d} INTER space a) IN subsets a)
+    !f a. sigma_algebra a /\ (!x. x IN space a ==> f x <> NegInf) ==>
+         (f IN measurable a Borel <=>
+          f IN (space a -> UNIV) /\
+          !c d. ({x | Normal c < f x /\ f x <= Normal d} INTER space a) IN subsets a)
 Proof
     RW_TAC std_ss []
  >> EQ_TAC
- >- ((RW_TAC std_ss [] >| [METIS_TAC [IN_MEASURABLE_BOREL], METIS_TAC [IN_MEASURABLE_BOREL], ALL_TAC])
-     >> `(!d. {x | f x <= Normal d} INTER space a IN subsets a)` by METIS_TAC [IN_MEASURABLE_BOREL_ALT2]
-     >> `(!c. {x | Normal c < f x} INTER space a IN subsets a)` by METIS_TAC [IN_MEASURABLE_BOREL_ALT3]
-     >> FULL_SIMP_TAC std_ss [IN_MEASURABLE_BOREL]
-     >> `!c d. (({x | Normal c < f x} INTER space a) INTER ({x | f x <= Normal d} INTER space a)) IN subsets a`
+ >- (rpt STRIP_TAC >- rfs [IN_MEASURABLE_BOREL]
+     >> `{x | f x <= Normal d} INTER space a IN subsets a` by METIS_TAC [IN_MEASURABLE_BOREL_ALT2]
+     >> `{x | Normal c < f x} INTER space a IN subsets a` by METIS_TAC [IN_MEASURABLE_BOREL_ALT3]
+     >> rfs [IN_MEASURABLE_BOREL]
+     >> `({x | Normal c < f x} INTER space a) INTER ({x | f x <= Normal d} INTER space a) IN subsets a`
           by METIS_TAC [sigma_algebra_def,ALGEBRA_INTER]
-     >> `!c d. (({x | Normal c < f x} INTER space a) INTER ({x | f x <=  Normal d} INTER space a)) =
-                ({x | Normal c < f x} INTER {x | f x <= Normal d} INTER space a)`
+     >> `({x | Normal c < f x} INTER space a) INTER ({x | f x <=  Normal d} INTER space a) =
+          {x | Normal c < f x} INTER {x | f x <= Normal d} INTER space a`
           by (RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER] >> METIS_TAC [])
      >> `{x | Normal c < f x} INTER {x | f x <= Normal d} = {x | Normal c < f x /\ f x <= Normal d}`
           by RW_TAC std_ss [EXTENSION ,GSPECIFICATION, IN_INTER]
-     >> `{x | Normal c < f x} INTER {x | f x <= Normal d} = {x | Normal c < f x /\ f x <= Normal d}`
-          by RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER]
-     >> METIS_TAC [])
+     >> METIS_TAC [SIGMA_ALGEBRA_INTER])
  >> RW_TAC std_ss [IN_MEASURABLE_BOREL_ALT2]
  >> `!c. {x | f x <= Normal c} INTER (space a) =
           BIGUNION (IMAGE (\n:num. {x | Normal (- &n) < f x /\ f x <= Normal c } INTER space a) UNIV)`
@@ -1272,7 +1330,7 @@ Proof
                 >> ONCE_REWRITE_TAC [GSYM REAL_ADD]
                 >> RW_TAC real_ss [REAL_NEG_ADD, REAL_LT_ADD_SUB,REAL_LT_ADD1])
             >> RW_TAC std_ss [GSPECIFICATION] >> METIS_TAC [lt_infty])
- >> `BIGUNION (IMAGE (\n:num. {x | Normal (- &n) < f x /\ f x <= Normal c } INTER space a) UNIV) IN subsets a`
+ >> `BIGUNION (IMAGE (\n:num. {x | Normal (- &n) < f x /\ f x <= Normal c} INTER space a) UNIV) IN subsets a`
      by (RW_TAC std_ss []
          >> (MP_TAC o Q.SPEC `a`) SIGMA_ALGEBRA_FN
          >> RW_TAC std_ss []
@@ -1283,34 +1341,39 @@ Proof
  >> METIS_TAC []
 QED
 
-(* changed ‘!x. f x <> NegInf’ to ‘!x. x IN space a ==> f x <> NegInf’ *)
+(* changed ‘!x. f x <> NegInf’ to ‘!x. x IN space a ==> f x <> NegInf’
+
+   NOTE: ‘sigma_algebra a’ is moved to antecedents due to changes of ‘measurable’
+ *)
 Theorem IN_MEASURABLE_BOREL_ALT6 :
-    !f a. (!x. x IN space a ==> f x <> NegInf) ==>
-          (f IN measurable a Borel <=>
-           sigma_algebra a /\ f IN (space a -> UNIV) /\
-           !c d. ({x| Normal c <= f x /\ f x <= Normal d} INTER space a) IN subsets a)
+    !f a. sigma_algebra a /\ (!x. x IN space a ==> f x <> NegInf) ==>
+         (f IN measurable a Borel <=>
+          f IN (space a -> UNIV) /\
+          !c d. ({x | Normal c <= f x /\ f x <= Normal d} INTER space a) IN subsets a)
 Proof
-  RW_TAC std_ss []
+     RW_TAC std_ss []
   >> EQ_TAC
-  >- ((RW_TAC std_ss [] >| [METIS_TAC [IN_MEASURABLE_BOREL], METIS_TAC [IN_MEASURABLE_BOREL], ALL_TAC])
-      >> `(!d. {x | f x <= Normal d} INTER space a IN subsets a)` by METIS_TAC [IN_MEASURABLE_BOREL_ALT2]
-      >> `(!c. {x | Normal c <= f x} INTER space a IN subsets a)` by METIS_TAC [IN_MEASURABLE_BOREL_ALT1]
-      >> FULL_SIMP_TAC std_ss [IN_MEASURABLE_BOREL]
-      >> `!c d. (({x | Normal c <= f x} INTER space a) INTER ({x | f x <= Normal d} INTER space a)) IN subsets a`
+  >- (rpt STRIP_TAC >- rfs [IN_MEASURABLE_BOREL]
+      >> `{x | f x <= Normal d} INTER space a IN subsets a` by METIS_TAC [IN_MEASURABLE_BOREL_ALT2]
+      >> `{x | Normal c <= f x} INTER space a IN subsets a` by METIS_TAC [IN_MEASURABLE_BOREL_ALT1]
+      >> rfs [IN_MEASURABLE_BOREL]
+      >> `({x | Normal c <= f x} INTER space a) INTER ({x | f x <= Normal d} INTER space a) IN subsets a`
          by METIS_TAC [sigma_algebra_def, ALGEBRA_INTER]
-      >> `!c d. (({x | Normal c <= f x} INTER space a) INTER ({x | f x <= Normal d} INTER space a)) =
-                ({x | Normal c <= f x} INTER {x | f x <= Normal d} INTER space a)`
+      >> `({x | Normal c <= f x} INTER space a) INTER ({x | f x <= Normal d} INTER space a) =
+          ({x | Normal c <= f x} INTER {x | f x <= Normal d} INTER space a)`
          by (RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER] >> METIS_TAC [])
       >> `{x | Normal c <= f x} INTER {x | f x <= Normal d} = {x | Normal c <= f x /\ f x <= Normal d}`
          by RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER]
       >> `{x | Normal c <= f x} INTER {x | f x <= Normal d} = {x | Normal c <= f x /\ f x <= Normal d}`
          by RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER]
-      >> METIS_TAC [])
+      >> METIS_TAC [SIGMA_ALGEBRA_INTER])
   >> RW_TAC std_ss [IN_MEASURABLE_BOREL_ALT4]
   >> `!c. {x | Normal c <= f x /\ f x < Normal d} INTER (space a) =
-          BIGUNION (IMAGE (\n:num. {x | Normal c <= f x /\ f x <= Normal (d - (1/2) pow n)} INTER space a) UNIV)`
+          BIGUNION (IMAGE (\n:num. {x | Normal c <= f x /\
+                                        f x <= Normal (d - (1/2) pow n)} INTER space a) UNIV)`
       by (RW_TAC std_ss [EXTENSION, IN_BIGUNION_IMAGE, IN_UNIV, IN_INTER, GSPECIFICATION]
-          >> `(\n. c - (1 / 2) pow n) = (\n. (\n. c) n - (\n. (1 / 2) pow n) n) ` by RW_TAC real_ss [FUN_EQ_THM]
+          >> `(\n. c - (1 / 2) pow n) = (\n. (\n. c) n - (\n. (1 / 2) pow n) n)`
+             by RW_TAC real_ss [FUN_EQ_THM]
           >> `(\n. c) --> c` by RW_TAC std_ss [SEQ_CONST]
           >> `(\n. (1 / 2) pow n) --> 0` by RW_TAC real_ss [SEQ_POWER]
           >> `(\n. c - (1 / 2) pow n) --> c`
@@ -1330,36 +1393,42 @@ Proof
               >> FULL_SIMP_TAC real_ss [GSYM REAL_LT_ADD_SUB, REAL_ADD_COMM, REAL_LT_IMP_LE])
           >> RW_TAC std_ss [] >|
              [ METIS_TAC[],
-               `!n. - ((1 / 2) pow n) < 0:real` by METIS_TAC [REAL_POW_LT, REAL_NEG_0, REAL_LT_NEG, EVAL ``0:real < 1/2``]
+               `!n. - ((1 / 2) pow n) < 0:real`
+                 by METIS_TAC [REAL_POW_LT, REAL_NEG_0, REAL_LT_NEG, EVAL ``0:real < 1/2``]
                >> `!n. d - (1 / 2) pow n < d` by METIS_TAC [REAL_LT_IADD, REAL_ADD_RID, real_sub]
                >> `f x <> PosInf` by METIS_TAC [le_infty,extreal_not_infty]
                >> `?r. f x = Normal r` by METIS_TAC [extreal_cases]
                >> FULL_SIMP_TAC std_ss [extreal_le_def,extreal_lt_eq]
                >> METIS_TAC [REAL_LET_TRANS],
                METIS_TAC [] ])
-  >> `BIGUNION (IMAGE (\n:num. {x | Normal c <= f x /\ f x <= Normal (d - ((1 / 2) pow n))} INTER space a) UNIV)
-      IN subsets a`
+  >> `BIGUNION (IMAGE (\n:num. {x | Normal c <= f x /\
+                                    f x <= Normal (d - ((1 / 2) pow n))} INTER space a) UNIV)
+        IN subsets a`
       by (RW_TAC std_ss []
           >> (MP_TAC o Q.SPEC `a`) SIGMA_ALGEBRA_FN
           >> RW_TAC std_ss []
-          >> `(\n. {x | Normal c <= f x /\ f x <= Normal (d - ((1 / 2) pow n))} INTER space a) IN (UNIV -> subsets a)`
+          >> `(\n. {x | Normal c <= f x /\ f x <= Normal (d - ((1 / 2) pow n))} INTER space a)
+                IN (UNIV -> subsets a)`
              by FULL_SIMP_TAC real_ss [IN_FUNSET, GSPECIFICATION, IN_INTER]
-          >> `{x | Normal c <= f x /\ f x <= Normal (d - ((1/2) pow n))} INTER space a IN subsets a` by METIS_TAC []
+          >> `{x | Normal c <= f x /\ f x <= Normal (d - ((1/2) pow n))} INTER space a IN subsets a`
+             by METIS_TAC []
           >> METIS_TAC [])
   >> METIS_TAC []
 QED
 
-(* changed ‘!x. f x <> NegInf’ to ‘!x. x IN space a ==> f x <> NegInf’ *)
+(* changed ‘!x. f x <> NegInf’ to ‘!x. x IN space a ==> f x <> NegInf’
+
+   NOTE: ‘sigma_algebra a’ is moved to antecedents due to changes of ‘measurable’
+ *)
 Theorem IN_MEASURABLE_BOREL_ALT7 :
-    !f a. (!x. x IN space a ==> f x <> NegInf) ==>
-          (f IN measurable a Borel <=>
-           sigma_algebra a /\ f IN (space a -> UNIV) /\
-           !c d. ({x | Normal c < f x /\ f x < Normal d } INTER space a) IN subsets a)
+    !f a. sigma_algebra a /\ (!x. x IN space a ==> f x <> NegInf) ==>
+         (f IN measurable a Borel <=>
+          f IN (space a -> UNIV) /\
+          !c d. ({x | Normal c < f x /\ f x < Normal d } INTER space a) IN subsets a)
 Proof
   RW_TAC std_ss []
   >> EQ_TAC
-  >- (RW_TAC std_ss [IN_FUNSET,IN_UNIV]
-      >- METIS_TAC [IN_MEASURABLE_BOREL]
+  >- (rpt STRIP_TAC >- rfs [IN_MEASURABLE_BOREL]
       >> `(!d. {x | f x < Normal d} INTER space a IN subsets a)` by METIS_TAC [IN_MEASURABLE_BOREL]
       >> `(!c. {x | Normal c < f x} INTER space a IN subsets a)` by METIS_TAC [IN_MEASURABLE_BOREL_ALT3]
       >> FULL_SIMP_TAC std_ss [IN_MEASURABLE_BOREL]
@@ -1394,9 +1463,10 @@ Proof
   >> METIS_TAC []
 QED
 
-val IN_MEASURABLE_BOREL_ALT4_IMP_r = prove (
-  ``!f a. f IN measurable a Borel ==>
-          !c d. ({x | Normal c <= f x /\ f x < Normal d} INTER space a) IN subsets a``,
+Theorem IN_MEASURABLE_BOREL_ALT4_IMP_r[local] :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !c d. ({x | Normal c <= f x /\ f x < Normal d} INTER space a) IN subsets a
+Proof
     RW_TAC std_ss [IN_FUNSET, IN_UNIV]
  >> `!d. {x | f x < Normal d} INTER space a IN subsets a` by METIS_TAC [IN_MEASURABLE_BOREL]
  >> `!c. {x | Normal c <= f x} INTER space a IN subsets a` by METIS_TAC [IN_MEASURABLE_BOREL_ALT1]
@@ -1408,11 +1478,13 @@ val IN_MEASURABLE_BOREL_ALT4_IMP_r = prove (
     by METIS_TAC [INTER_ASSOC, INTER_COMM, INTER_IDEMPOT]
  >> `{x | Normal c <= f x} INTER {x | f x < Normal d} = {x | Normal c <= f x /\ f x < Normal d}`
     by RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER]
- >> METIS_TAC []);
+ >> METIS_TAC []
+QED
 
-val IN_MEASURABLE_BOREL_ALT4_IMP_p = prove (
-  ``!f a. f IN measurable a Borel ==>
-          !c. ({x | Normal c <= f x /\ f x < PosInf} INTER space a) IN subsets a``,
+Theorem IN_MEASURABLE_BOREL_ALT4_IMP_p[local] :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !c. ({x | Normal c <= f x /\ f x < PosInf} INTER space a) IN subsets a
+Proof
     RW_TAC std_ss [IN_FUNSET, IN_UNIV]
  >> Know `{x | f x < PosInf} INTER space a IN subsets a`
  >- (REWRITE_TAC [GSYM lt_infty] \\
@@ -1426,17 +1498,19 @@ val IN_MEASURABLE_BOREL_ALT4_IMP_p = prove (
     by METIS_TAC [INTER_ASSOC, INTER_COMM, INTER_IDEMPOT]
  >> `{x | Normal c <= f x} INTER {x | f x < PosInf} = {x | Normal c <= f x /\ f x < PosInf}`
     by RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER]
- >> METIS_TAC []);
+ >> METIS_TAC []
+QED
 
-val IN_MEASURABLE_BOREL_ALT4_IMP = store_thm (* new *)
-  ("IN_MEASURABLE_BOREL_ALT4_IMP",
-  ``!f a. f IN measurable a Borel ==>
-          !c d. ({x | c <= f x /\ f x < d} INTER space a) IN subsets a``,
+(* NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_ALT4_IMP :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !c d. ({x | c <= f x /\ f x < d} INTER space a) IN subsets a
+Proof
     rpt STRIP_TAC
  >> Cases_on `c` >> Cases_on `d` (* 9 subgoals *)
  >- ((* goal 1 (of 9) *)
      REWRITE_TAC [lt_infty, le_infty, GSPEC_F, INTER_EMPTY] \\
-     fs [IN_MEASURABLE_BOREL, sigma_algebra_def, ALGEBRA_EMPTY])
+     rfs [IN_MEASURABLE_BOREL, sigma_algebra_def, ALGEBRA_EMPTY])
  >- ((* goal 2 (of 9) *)
      REWRITE_TAC [GSYM lt_infty, le_infty] \\
      MATCH_MP_TAC IN_MEASURABLE_BOREL_NOT_POSINF >> art [])
@@ -1460,14 +1534,21 @@ val IN_MEASURABLE_BOREL_ALT4_IMP = store_thm (* new *)
  >- ((* goal 8 (of 9) *)
      MATCH_MP_TAC IN_MEASURABLE_BOREL_ALT4_IMP_p >> art [])
  (* goal 9 (of 9) *)
- >> MATCH_MP_TAC IN_MEASURABLE_BOREL_ALT4_IMP_r >> art []);
+ >> MATCH_MP_TAC IN_MEASURABLE_BOREL_ALT4_IMP_r >> art []
+QED
 
-val IN_MEASURABLE_BOREL_CO = save_thm
-  ("IN_MEASURABLE_BOREL_CO", IN_MEASURABLE_BOREL_ALT4_IMP);
+(* |- !f a.
+        sigma_algebra a /\ f IN Borel_measurable a ==>
+        !c d. {x | c <= f x /\ f x < d} INTER space a IN subsets a
 
-val IN_MEASURABLE_BOREL_ALT5_IMP_r = prove (
-  ``!f a. f IN measurable a Borel ==>
-          !c d. ({x | Normal c < f x /\ f x <= Normal d} INTER space a) IN subsets a``,
+   NOTE: "CO" means left-closed (C) and right-open (O) intervals.
+ *)
+Theorem IN_MEASURABLE_BOREL_CO = IN_MEASURABLE_BOREL_ALT4_IMP
+
+Theorem IN_MEASURABLE_BOREL_ALT5_IMP_r[local] :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !c d. ({x | Normal c < f x /\ f x <= Normal d} INTER space a) IN subsets a
+Proof
     RW_TAC std_ss [IN_FUNSET, IN_UNIV]
  >> `(!d. {x | f x <= Normal d} INTER space a IN subsets a)` by METIS_TAC [IN_MEASURABLE_BOREL_ALT2]
  >> `(!c. {x | Normal c < f x} INTER space a IN subsets a)` by METIS_TAC [IN_MEASURABLE_BOREL_ALT3]
@@ -1479,11 +1560,13 @@ val IN_MEASURABLE_BOREL_ALT5_IMP_r = prove (
     by (RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER] >> METIS_TAC [])
  >> `{x | Normal c < f x} INTER {x | f x <= Normal d} =
      {x | Normal c < f x /\ f x <= Normal d}` by RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER]
- >> METIS_TAC []);
+ >> METIS_TAC []
+QED
 
-val IN_MEASURABLE_BOREL_ALT5_IMP_n = prove (
-  ``!f a. f IN measurable a Borel ==>
-          !d. ({x | NegInf < f x /\ f x <= Normal d} INTER space a) IN subsets a``,
+Theorem IN_MEASURABLE_BOREL_ALT5_IMP_n[local] :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !d. ({x | NegInf < f x /\ f x <= Normal d} INTER space a) IN subsets a
+Proof
     RW_TAC std_ss [IN_FUNSET, IN_UNIV]
  >> `!d. {x | f x <= Normal d} INTER space a IN subsets a` by METIS_TAC [IN_MEASURABLE_BOREL_ALT2]
  >> Know `{x | NegInf < f x} INTER space a IN subsets a`
@@ -1498,12 +1581,14 @@ val IN_MEASURABLE_BOREL_ALT5_IMP_n = prove (
     by (RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER] >> METIS_TAC [])
  >> `{x | NegInf < f x} INTER {x | f x <= Normal d} =
      {x | NegInf < f x /\ f x <= Normal d}` by RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER]
- >> METIS_TAC []);
+ >> METIS_TAC []
+QED
 
-val IN_MEASURABLE_BOREL_ALT5_IMP = store_thm (* new *)
-  ("IN_MEASURABLE_BOREL_ALT5_IMP",
-  ``!f a. f IN measurable a Borel ==>
-          !c d. ({x | c < f x /\ f x <= d} INTER space a) IN subsets a``,
+(* NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_ALT5_IMP :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !c d. ({x | c < f x /\ f x <= d} INTER space a) IN subsets a
+Proof
     rpt STRIP_TAC
  >> Cases_on `c` >> Cases_on `d` (* 9 subgoals *)
  >- ((* goal 1 (of 9) *)
@@ -1534,33 +1619,40 @@ val IN_MEASURABLE_BOREL_ALT5_IMP = store_thm (* new *)
      REWRITE_TAC [le_infty] \\
      MATCH_MP_TAC IN_MEASURABLE_BOREL_ALT3_IMP >> art [])
  (* goal 9 (of 9) *)
- >> MATCH_MP_TAC IN_MEASURABLE_BOREL_ALT5_IMP_r >> art []);
+ >> MATCH_MP_TAC IN_MEASURABLE_BOREL_ALT5_IMP_r >> art []
+QED
 
-val IN_MEASURABLE_BOREL_OC = save_thm
-  ("IN_MEASURABLE_BOREL_OC", IN_MEASURABLE_BOREL_ALT5_IMP);
+(* |- !f a.
+        sigma_algebra a /\ f IN Borel_measurable a ==>
+        !c d. {x | c < f x /\ f x <= d} INTER space a IN subsets a
+ *)
+Theorem IN_MEASURABLE_BOREL_OC = IN_MEASURABLE_BOREL_ALT5_IMP
 
-val IN_MEASURABLE_BOREL_ALT6_IMP_r = prove (
-  ``!f a. f IN measurable a Borel ==>
-          !c d. ({x| Normal c <= f x /\ f x <= Normal d} INTER space a) IN subsets a``,
+Theorem IN_MEASURABLE_BOREL_ALT6_IMP_r[local] :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !c d. ({x| Normal c <= f x /\ f x <= Normal d} INTER space a) IN subsets a
+Proof
     RW_TAC std_ss [IN_FUNSET,IN_UNIV]
  >> `(!d. {x | f x <= Normal d} INTER space a IN subsets a)` by METIS_TAC [IN_MEASURABLE_BOREL_ALT2]
  >> `(!c. {x | Normal c <= f x} INTER space a IN subsets a)` by METIS_TAC [IN_MEASURABLE_BOREL_ALT1]
- >> FULL_SIMP_TAC std_ss [IN_MEASURABLE_BOREL]
+ >> rfs [IN_MEASURABLE_BOREL]
  >> `!c d. (({x | Normal c <= f x} INTER space a) INTER ({x | f x <= Normal d} INTER space a)) IN subsets a`
     by METIS_TAC [sigma_algebra_def,ALGEBRA_INTER]
  >> `!c d. (({x | Normal c <= f x} INTER space a) INTER ({x | f x <= Normal d} INTER space a)) =
            ({x | Normal c <= f x} INTER {x | f x <= Normal d} INTER space a)`
     by (RW_TAC std_ss [EXTENSION,GSPECIFICATION,IN_INTER] >> METIS_TAC [])
-  >> `{x | Normal c <= f x} INTER {x | f x <= Normal d} = {x | Normal c <= f x /\ f x <= Normal d}`
+ >> `{x | Normal c <= f x} INTER {x | f x <= Normal d} = {x | Normal c <= f x /\ f x <= Normal d}`
     by RW_TAC std_ss [EXTENSION,GSPECIFICATION,IN_INTER]
-  >> `{x | Normal c <= f x} INTER {x | f x <= Normal d} = {x | Normal c <= f x /\ f x <= Normal d}`
+ >> `{x | Normal c <= f x} INTER {x | f x <= Normal d} = {x | Normal c <= f x /\ f x <= Normal d}`
     by RW_TAC std_ss [EXTENSION,GSPECIFICATION,IN_INTER]
-  >> METIS_TAC []);
+ >> METIS_TAC []
+QED
 
-val IN_MEASURABLE_BOREL_ALT6_IMP  = store_thm (* new *)
-  ("IN_MEASURABLE_BOREL_ALT6_IMP",
-  ``!f a. f IN measurable a Borel ==>
-          !c d. ({x| c <= f x /\ f x <= d} INTER space a) IN subsets a``,
+(* NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_ALT6_IMP :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !c d. ({x| c <= f x /\ f x <= d} INTER space a) IN subsets a
+Proof
     rpt STRIP_TAC
  >> Cases_on `c` >> Cases_on `d` (* 9 subgoals *)
  >- ((* goal 1 (of 9) *)
@@ -1594,18 +1686,23 @@ val IN_MEASURABLE_BOREL_ALT6_IMP  = store_thm (* new *)
      REWRITE_TAC [le_infty] \\
      MATCH_MP_TAC IN_MEASURABLE_BOREL_ALT1_IMP >> art [])
  (* goal 9 (of 9) *)
- >> MATCH_MP_TAC IN_MEASURABLE_BOREL_ALT6_IMP_r >> art []);
+ >> MATCH_MP_TAC IN_MEASURABLE_BOREL_ALT6_IMP_r >> art []
+QED
 
-val IN_MEASURABLE_BOREL_CC = save_thm
-  ("IN_MEASURABLE_BOREL_CC", IN_MEASURABLE_BOREL_ALT6_IMP);
+(* |- !f a.
+        sigma_algebra a /\ f IN Borel_measurable a ==>
+        !c d. {x | c <= f x /\ f x <= d} INTER space a IN subsets a: thm
+ *)
+Theorem IN_MEASURABLE_BOREL_CC = IN_MEASURABLE_BOREL_ALT6_IMP
 
-val IN_MEASURABLE_BOREL_ALT7_IMP_r = prove (
-  ``!f a. f IN measurable a Borel ==>
-          !c d. ({x | Normal c < f x /\ f x < Normal d} INTER space a) IN subsets a``,
+Theorem IN_MEASURABLE_BOREL_ALT7_IMP_r[local] :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !c d. ({x | Normal c < f x /\ f x < Normal d} INTER space a) IN subsets a
+Proof
     RW_TAC std_ss [IN_FUNSET, IN_UNIV]
  >> `(!d. {x | f x < Normal d} INTER space a IN subsets a)` by METIS_TAC [IN_MEASURABLE_BOREL]
  >> `(!c. {x | Normal c < f x} INTER space a IN subsets a)` by METIS_TAC [IN_MEASURABLE_BOREL_ALT3]
- >> FULL_SIMP_TAC std_ss [IN_MEASURABLE_BOREL]
+ >> rfs [IN_MEASURABLE_BOREL]
  >> `!c d. (({x | Normal c < f x} INTER space a) INTER ({x | f x < Normal d} INTER space a)) IN subsets a`
     by METIS_TAC [sigma_algebra_def, ALGEBRA_INTER]
  >> `!c d. ({x | Normal c < f x} INTER space a) INTER ({x | f x < Normal d} INTER space a) =
@@ -1615,14 +1712,16 @@ val IN_MEASURABLE_BOREL_ALT7_IMP_r = prove (
     by RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER]
  >> `{x | Normal c < f x} INTER {x | f x < Normal d} = {x | Normal c < f x /\ f x < Normal d}`
     by RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER]
- >> METIS_TAC []);
+ >> METIS_TAC []
+QED
 
-val IN_MEASURABLE_BOREL_ALT7_IMP_np = prove ((* new *)
-  ``!f a. f IN measurable a Borel ==>
-          ({x | NegInf < f x /\ f x < PosInf} INTER space a) IN subsets a``,
+Theorem IN_MEASURABLE_BOREL_ALT7_IMP_np[local] :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          ({x | NegInf < f x /\ f x < PosInf} INTER space a) IN subsets a
+Proof
     rpt STRIP_TAC
  >> IMP_RES_TAC IN_MEASURABLE_BOREL_ALT7_IMP_r
- >> fs [IN_MEASURABLE_BOREL, IN_FUNSET, IN_UNIV]
+ >> rfs [IN_MEASURABLE_BOREL, IN_FUNSET, IN_UNIV]
  >> Know `{x | NegInf < f x /\ f x < PosInf} INTER space a =
           BIGUNION (IMAGE (\n. {x | -&n < f x /\ f x < &n} INTER space a) UNIV)`
  >- (RW_TAC std_ss [EXTENSION, IN_BIGUNION_IMAGE, IN_UNIV, GSPECIFICATION, IN_INTER] \\
@@ -1649,14 +1748,16 @@ val IN_MEASURABLE_BOREL_ALT7_IMP_np = prove ((* new *)
  >> RW_TAC std_ss [IN_FUNSET, IN_UNIV]
  >> `&n = Normal (&n)` by PROVE_TAC [extreal_of_num_def]
  >> `-&n = Normal (-&n)` by PROVE_TAC [extreal_ainv_def, extreal_of_num_def]
- >> METIS_TAC []);
+ >> METIS_TAC []
+QED
 
-val IN_MEASURABLE_BOREL_ALT7_IMP_n = prove ((* new *)
-  ``!f a. f IN measurable a Borel ==>
-          !d. ({x | NegInf < f x /\ f x < Normal d} INTER space a) IN subsets a``,
+Theorem IN_MEASURABLE_BOREL_ALT7_IMP_n[local] :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !d. ({x | NegInf < f x /\ f x < Normal d} INTER space a) IN subsets a
+Proof
     rpt STRIP_TAC
  >> IMP_RES_TAC IN_MEASURABLE_BOREL_ALT7_IMP_r
- >> fs [IN_MEASURABLE_BOREL, IN_FUNSET, IN_UNIV]
+ >> rfs [IN_MEASURABLE_BOREL, IN_FUNSET, IN_UNIV]
  >> Know `{x | NegInf < f x /\ f x < Normal d} INTER space a =
           BIGUNION (IMAGE (\n. {x | -&n < f x /\ f x < Normal d} INTER space a) UNIV)`
  >- (RW_TAC std_ss [EXTENSION, IN_BIGUNION_IMAGE, IN_UNIV, GSPECIFICATION, IN_INTER] \\
@@ -1675,14 +1776,16 @@ val IN_MEASURABLE_BOREL_ALT7_IMP_n = prove ((* new *)
  >> FIRST_X_ASSUM MATCH_MP_TAC
  >> RW_TAC std_ss [IN_FUNSET, IN_UNIV]
  >> `-&n = Normal (-&n)` by PROVE_TAC [extreal_ainv_def, extreal_of_num_def]
- >> METIS_TAC []);
+ >> METIS_TAC []
+QED
 
-val IN_MEASURABLE_BOREL_ALT7_IMP_p = prove ((* new *)
-  ``!f a. f IN measurable a Borel ==>
-          !c. ({x | Normal c < f x /\ f x < PosInf} INTER space a) IN subsets a``,
+Theorem IN_MEASURABLE_BOREL_ALT7_IMP_p[local] :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !c. ({x | Normal c < f x /\ f x < PosInf} INTER space a) IN subsets a
+Proof
     rpt STRIP_TAC
  >> IMP_RES_TAC IN_MEASURABLE_BOREL_ALT7_IMP_r
- >> fs [IN_MEASURABLE_BOREL, IN_FUNSET, IN_UNIV]
+ >> rfs [IN_MEASURABLE_BOREL, IN_FUNSET, IN_UNIV]
  >> Know `{x | Normal c < f x /\ f x < PosInf} INTER space a =
           BIGUNION (IMAGE (\n. {x | Normal c < f x /\ f x < &n} INTER space a) UNIV)`
  >- (RW_TAC std_ss [EXTENSION, IN_BIGUNION_IMAGE, IN_UNIV, GSPECIFICATION, IN_INTER] \\
@@ -1701,12 +1804,14 @@ val IN_MEASURABLE_BOREL_ALT7_IMP_p = prove ((* new *)
  >> FIRST_X_ASSUM MATCH_MP_TAC
  >> RW_TAC std_ss [IN_FUNSET, IN_UNIV]
  >> `&n = Normal (&n)` by PROVE_TAC [extreal_of_num_def]
- >> METIS_TAC []);
+ >> METIS_TAC []
+QED
 
-val IN_MEASURABLE_BOREL_ALT7_IMP = store_thm
-  ("IN_MEASURABLE_BOREL_ALT7_IMP",
-  ``!f a. f IN measurable a Borel ==>
-          !c d. ({x | c < f x /\ f x < d} INTER space a) IN subsets a``,
+(* NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_ALT7_IMP :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !c d. ({x | c < f x /\ f x < d} INTER space a) IN subsets a
+Proof
     rpt STRIP_TAC
  >> Cases_on `c` >> Cases_on `d` (* 9 subgoals *)
  >- ((* goal 1 (of 9) *)
@@ -1731,14 +1836,19 @@ val IN_MEASURABLE_BOREL_ALT7_IMP = store_thm
  >- ((* goal 8 (of 9) *)
      MATCH_MP_TAC IN_MEASURABLE_BOREL_ALT7_IMP_p >> art [])
  (* goal 9 (of 9) *)
- >> MATCH_MP_TAC IN_MEASURABLE_BOREL_ALT7_IMP_r >> art []);
+ >> MATCH_MP_TAC IN_MEASURABLE_BOREL_ALT7_IMP_r >> art []
+QED
 
-val IN_MEASURABLE_BOREL_OO = save_thm (* not "00" *)
-  ("IN_MEASURABLE_BOREL_OO", IN_MEASURABLE_BOREL_ALT7_IMP);
+(* |- !f a.
+        sigma_algebra a /\ f IN Borel_measurable a ==>
+        !c d. {x | c < f x /\ f x < d} INTER space a IN subsets a
+ *)
+Theorem IN_MEASURABLE_BOREL_OO = IN_MEASURABLE_BOREL_ALT7_IMP
 
-val IN_MEASURABLE_BOREL_ALT8_r = prove (
-  ``!f a. f IN measurable a Borel ==>
-          !c. ({x | f x = Normal c} INTER space a) IN subsets a``,
+Theorem IN_MEASURABLE_BOREL_ALT8_r[local] :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !c. ({x | f x = Normal c} INTER space a) IN subsets a
+Proof
     RW_TAC std_ss [IN_FUNSET, IN_UNIV]
  >> MP_TAC IN_MEASURABLE_BOREL_ALT4_IMP_r
  >> RW_TAC std_ss []
@@ -1775,12 +1885,14 @@ val IN_MEASURABLE_BOREL_ALT8_r = prove (
  >> `(\n. {x | Normal (c - ((1/2) pow n)) <= f x /\
                f x < Normal (c + ((1/2) pow n))} INTER space a) IN (UNIV -> subsets a)`
         by (RW_TAC std_ss [IN_FUNSET])
- >> METIS_TAC [IN_MEASURABLE_BOREL]);
+ >> METIS_TAC [IN_MEASURABLE_BOREL]
+QED
 
-val IN_MEASURABLE_BOREL_ALT8 = store_thm (* new *)
-  ("IN_MEASURABLE_BOREL_ALT8",
-  ``!f a. f IN measurable a Borel ==>
-          !c. ({x | f x = c} INTER space a) IN subsets a``,
+(* NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_ALT8 :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !c. ({x | f x = c} INTER space a) IN subsets a
+Proof
     rpt STRIP_TAC
  >> Cases_on `c` (* 3 subgoals *)
  >| [ (* goal 1 (of 3) *)
@@ -1790,15 +1902,20 @@ val IN_MEASURABLE_BOREL_ALT8 = store_thm (* new *)
       RW_TAC std_ss [IN_MEASURABLE_BOREL_ALT3] \\
       MATCH_MP_TAC IN_MEASURABLE_BOREL_POSINF >> art [IN_MEASURABLE_BOREL_ALT3],
       (* goal 3 (of 3) *)
-      IMP_RES_TAC IN_MEASURABLE_BOREL_ALT8_r >> art [] ]);
+      IMP_RES_TAC IN_MEASURABLE_BOREL_ALT8_r >> art [] ]
+QED
 
-val IN_MEASURABLE_BOREL_SING = save_thm
-  ("IN_MEASURABLE_BOREL_SING", IN_MEASURABLE_BOREL_ALT8);
+(* |- !f a.
+        sigma_algebra a /\ f IN Borel_measurable a ==>
+        !c. {x | f x = c} INTER space a IN subsets a
+ *)
+Theorem IN_MEASURABLE_BOREL_SING = IN_MEASURABLE_BOREL_ALT8
 
-val IN_MEASURABLE_BOREL_ALT9 = store_thm
-  ("IN_MEASURABLE_BOREL_ALT9",
-  ``!f a. f IN measurable a Borel ==>
-          !c. ({x | f x <> c} INTER space a) IN subsets a``,
+(* NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_ALT9 :
+    !f a. sigma_algebra a /\ f IN measurable a Borel ==>
+          !c. ({x | f x <> c} INTER space a) IN subsets a
+Proof
     rpt STRIP_TAC
  >> IMP_RES_TAC IN_MEASURABLE_BOREL_SING
  >> Know `!c. {x | f x <> c} INTER (space a) =
@@ -1806,20 +1923,23 @@ val IN_MEASURABLE_BOREL_ALT9 = store_thm
  >- (RW_TAC std_ss [EXTENSION, IN_UNIV, IN_DIFF, IN_INTER, GSPECIFICATION] \\
      EQ_TAC >- (rpt STRIP_TAC >> art []) \\
      METIS_TAC []) >> Rewr
- >> fs [IN_MEASURABLE_BOREL]
- >> MATCH_MP_TAC ALGEBRA_COMPL
- >> CONJ_TAC
- >- IMP_RES_TAC SIGMA_ALGEBRA_ALGEBRA
- >> ASM_REWRITE_TAC []);
+ >> rfs [IN_MEASURABLE_BOREL]
+ >> MATCH_MP_TAC SIGMA_ALGEBRA_COMPL >> art []
+QED
 
-val IN_MEASURABLE_BOREL_NOT_SING = save_thm
-  ("IN_MEASURABLE_BOREL_NOT_SING", IN_MEASURABLE_BOREL_ALT9);
+(* |- !f a.
+        sigma_algebra a /\ f IN Borel_measurable a ==>
+        !c. {x | f x <> c} INTER space a IN subsets a
+ *)
+Theorem IN_MEASURABLE_BOREL_NOT_SING = IN_MEASURABLE_BOREL_ALT9
 
-(* all IMP versions of IN_MEASURABLE_BOREL_ALTs *)
-val IN_MEASURABLE_BOREL_ALL = store_thm
-  ("IN_MEASURABLE_BOREL_ALL",
-  ``!f a.
-        f IN measurable a Borel ==>
+(* All IMP versions of IN_MEASURABLE_BOREL_ALTs
+
+   NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’
+ *)
+Theorem IN_MEASURABLE_BOREL_ALL :
+    !f a.
+        sigma_algebra a /\ f IN measurable a Borel ==>
         (!c. {x | f x < c} INTER space a IN subsets a) /\
         (!c. {x | c <= f x} INTER space a IN subsets a) /\
         (!c. {x | f x <= c} INTER space a IN subsets a) /\
@@ -1829,7 +1949,8 @@ val IN_MEASURABLE_BOREL_ALL = store_thm
         (!c d. {x | c <= f x /\ f x <= d} INTER space a IN subsets a) /\
         (!c d. {x | c < f x /\ f x < d} INTER space a IN subsets a) /\
         (!c. {x | f x = c} INTER space a IN subsets a) /\
-        (!c. {x | f x <> c} INTER space a IN subsets a)``,
+        (!c. {x | f x <> c} INTER space a IN subsets a)
+Proof
     METIS_TAC [IN_MEASURABLE_BOREL_RO,         (* f x < c *)
                IN_MEASURABLE_BOREL_CR,         (* c <= f x *)
                IN_MEASURABLE_BOREL_RC,         (* f x <= c *)
@@ -1839,31 +1960,32 @@ val IN_MEASURABLE_BOREL_ALL = store_thm
                IN_MEASURABLE_BOREL_CC,         (* c <= f x /\ f x <= d *)
                IN_MEASURABLE_BOREL_OO,         (* c < f x /\ f x < d *)
                IN_MEASURABLE_BOREL_SING,       (* f x = c *)
-               IN_MEASURABLE_BOREL_NOT_SING]); (* f x <> c *)
+               IN_MEASURABLE_BOREL_NOT_SING]   (* f x <> c *)
+QED
 
 (* |- !f m.
-         f IN measurable (m_space m,measurable_sets m) Borel ==>
-         (!c. {x | f x < c} INTER m_space m IN measurable_sets m) /\
-         (!c. {x | c <= f x} INTER m_space m IN measurable_sets m) /\
-         (!c. {x | f x <= c} INTER m_space m IN measurable_sets m) /\
-         (!c. {x | c < f x} INTER m_space m IN measurable_sets m) /\
-         (!c d. {x | c <= f x /\ f x < d} INTER m_space m IN measurable_sets m) /\
-         (!c d. {x | c < f x /\ f x <= d} INTER m_space m IN measurable_sets m) /\
-         (!c d. {x | c <= f x /\ f x <= d} INTER m_space m IN measurable_sets m) /\
-         (!c d. {x | c < f x /\ f x < d} INTER m_space m IN measurable_sets m) /\
-         !c. {x | f x = c} INTER m_space m IN measurable_sets m /\
-         !c. {x | f x <> c} INTER m_space m IN measurable_sets m
+        sigma_algebra (measurable_space m) /\ f IN Borel_measurable (measurable_space m) ==>
+        (!c. {x | f x < c} INTER m_space m IN measurable_sets m) /\
+        (!c. {x | c <= f x} INTER m_space m IN measurable_sets m) /\
+        (!c. {x | f x <= c} INTER m_space m IN measurable_sets m) /\
+        (!c. {x | c < f x} INTER m_space m IN measurable_sets m) /\
+        (!c d. {x | c <= f x /\ f x < d} INTER m_space m IN measurable_sets m) /\
+        (!c d. {x | c < f x /\ f x <= d} INTER m_space m IN measurable_sets m) /\
+        (!c d. {x | c <= f x /\ f x <= d} INTER m_space m IN measurable_sets m) /\
+        (!c d. {x | c < f x /\ f x < d} INTER m_space m IN measurable_sets m) /\
+        (!c. {x | f x = c} INTER m_space m IN measurable_sets m) /\
+        !c. {x | f x <> c} INTER m_space m IN measurable_sets m: thm
  *)
-val IN_MEASURABLE_BOREL_ALL_MEASURE = save_thm
-  ("IN_MEASURABLE_BOREL_ALL_MEASURE",
+Theorem IN_MEASURABLE_BOREL_ALL_MEASURE =
   ((Q.GENL [`f`, `m`]) o
    (REWRITE_RULE [space_def, subsets_def]) o
-   (Q.SPECL [`f`, `(m_space m,measurable_sets m)`])) IN_MEASURABLE_BOREL_ALL);
+   (Q.SPECL [`f`, `(m_space m,measurable_sets m)`])) IN_MEASURABLE_BOREL_ALL
 
-val IN_MEASURABLE_BOREL_LT = store_thm
-  ("IN_MEASURABLE_BOREL_LT",
-  ``!f g a. f IN measurable a Borel /\ g IN measurable a Borel ==>
-            ({x | f x < g x} INTER space a) IN subsets a``,
+(* NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_LT :
+    !f g a. sigma_algebra a /\ f IN measurable a Borel /\ g IN measurable a Borel ==>
+            ({x | f x < g x} INTER space a) IN subsets a
+Proof
   RW_TAC std_ss []
   >> `{x | f x < g x} INTER space a =
       BIGUNION (IMAGE (\r. {x | f x < r /\ r < g x} INTER space a) Q_set)`
@@ -1872,23 +1994,22 @@ val IN_MEASURABLE_BOREL_LT = store_thm
             >- RW_TAC std_ss [Q_DENSE_IN_R]
             >> METIS_TAC [lt_trans])
   >> POP_ORW
-  >> MATCH_MP_TAC BIGUNION_IMAGE_Q
-  >> CONJ_TAC
-  >- FULL_SIMP_TAC std_ss [IN_MEASURABLE_BOREL]
+  >> MATCH_MP_TAC BIGUNION_IMAGE_Q >> art []
   >> RW_TAC std_ss [IN_FUNSET]
   >> `{x | f x < r /\ r < g x} INTER space a =
      ({x | f x < r} INTER space a) INTER ({x | r < g x} INTER space a)`
        by (RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER] >> METIS_TAC [])
   >> POP_ORW
-  >> MATCH_MP_TAC ALGEBRA_INTER
-  >> CONJ_TAC
-  >- FULL_SIMP_TAC std_ss [IN_MEASURABLE_BOREL, sigma_algebra_def]
-  >> `?c. r = Normal c` by METIS_TAC [rat_not_infty, extreal_cases]
-  >> METIS_TAC [IN_MEASURABLE_BOREL_ALL]);
+  >> MATCH_MP_TAC SIGMA_ALGEBRA_INTER >> art []
+  >> METIS_TAC [IN_MEASURABLE_BOREL_ALL]
+QED
 
-(* changed quantifier orders (was: f g a) *)
+(* changed quantifier orders (was: f g a)
+
+   NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’
+ *)
 Theorem IN_MEASURABLE_BOREL_LE :
-    !a f g. f IN measurable a Borel /\ g IN measurable a Borel ==>
+    !a f g. sigma_algebra a /\ f IN measurable a Borel /\ g IN measurable a Borel ==>
             ({x | f x <= g x} INTER space a) IN subsets a
 Proof
     RW_TAC std_ss []
@@ -1899,33 +2020,30 @@ Proof
  >> METIS_TAC [algebra_def, IN_MEASURABLE_BOREL, sigma_algebra_def]
 QED
 
+Theorem IN_MEASURABLE_BOREL_EQ' :
+    !a f g. (!x. x IN space a ==> (f x = g x)) /\
+            g IN measurable a Borel ==> f IN measurable a Borel
+Proof
+    rw [measurable_def, IN_FUNSET]
+ >> Know ‘PREIMAGE f s INTER space a = PREIMAGE g s INTER space a’
+ >- (rw [Once EXTENSION, PREIMAGE_def] \\
+     METIS_TAC [])
+ >> Rewr'
+ >> FIRST_X_ASSUM MATCH_MP_TAC >> art []
+QED
+
 (* changed quantifier orders (was: f g m) for applications in martingaleTheory *)
 Theorem IN_MEASURABLE_BOREL_EQ :
     !m f g. (!x. x IN m_space m ==> (f x = g x)) /\
             g IN measurable (m_space m,measurable_sets m) Borel ==>
             f IN measurable (m_space m,measurable_sets m) Borel
 Proof
-    RW_TAC std_ss []
- >> FULL_SIMP_TAC std_ss [IN_MEASURABLE_BOREL]
- >> CONJ_TAC
- >- (EVAL_TAC THEN SRW_TAC[] [IN_DEF, space_def, IN_FUNSET])
- >> GEN_TAC
- >> POP_ASSUM (MP_TAC o Q.SPEC `c`)
- >> MATCH_MP_TAC EQ_IMPLIES >> AP_THM_TAC >> AP_TERM_TAC
- >> ASM_SET_TAC [space_def]
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC IN_MEASURABLE_BOREL_EQ'
+ >> Q.EXISTS_TAC ‘g’ >> rw []
 QED
 
-Theorem IN_MEASURABLE_BOREL_EQ' :
-    !a f g. (!x. x IN space a ==> (f x = g x)) /\
-            g IN measurable a Borel ==> f IN measurable a Borel
-Proof
-    rw [IN_MEASURABLE_BOREL, IN_FUNSET]
- >> POP_ASSUM (MP_TAC o Q.SPEC `c`)
- >> Suff ‘{x | g x < Normal c} INTER space a =
-          {x | f x < Normal c} INTER space a’ >- rw []
- >> ASM_SET_TAC []
-QED
-
+(* cf. IN_MEASURABLE_CONG (sigma_algebraTheory) for a more general version *)
 Theorem IN_MEASURABLE_BOREL_CONG :
     !m f g. (!x. x IN m_space m ==> (f x = g x)) ==>
             (f IN measurable (m_space m,measurable_sets m) Borel <=>
@@ -2898,11 +3016,13 @@ val IN_MEASURABLE_BOREL_CMUL_INDICATOR = store_thm
  >> MATCH_MP_TAC IN_MEASURABLE_BOREL_INDICATOR
  >> METIS_TAC []);
 
-val IN_MEASURABLE_BOREL_MUL_INDICATOR = store_thm
-  ("IN_MEASURABLE_BOREL_MUL_INDICATOR",
-  ``!a f s. sigma_algebra a /\ f IN measurable a Borel /\ s IN subsets a ==>
-            (\x. f x * indicator_fn s x) IN measurable a Borel``,
-    RW_TAC std_ss [IN_MEASURABLE_BOREL_ALT2, IN_FUNSET, IN_UNIV]
+Theorem IN_MEASURABLE_BOREL_MUL_INDICATOR :
+    !a f s. sigma_algebra a /\ f IN measurable a Borel /\ s IN subsets a ==>
+            (\x. f x * indicator_fn s x) IN measurable a Borel
+Proof
+    rpt STRIP_TAC
+ >> rfs [IN_MEASURABLE_BOREL_ALT2, IN_FUNSET]
+ >> Q.X_GEN_TAC ‘c’
  >> Cases_on `0 <= Normal c`
  >- (`{x | f x * indicator_fn s x <= Normal c} INTER space a =
       (({x | f x <= Normal c} INTER space a) INTER s) UNION (space a DIFF s)`
@@ -2910,18 +3030,16 @@ val IN_MEASURABLE_BOREL_MUL_INDICATOR = store_thm
                             IN_UNION, IN_DIFF] \\
              Cases_on `x IN s` >- RW_TAC std_ss [mul_rone, mul_rzero] \\
              RW_TAC std_ss [mul_rone, mul_rzero]) >> POP_ORW \\
-     MATCH_MP_TAC ALGEBRA_UNION \\
-     CONJ_TAC >- FULL_SIMP_TAC std_ss [sigma_algebra_def] \\
-     reverse CONJ_TAC >- FULL_SIMP_TAC std_ss [sigma_algebra_def, algebra_def] \\
-     MATCH_MP_TAC ALGEBRA_INTER \\
-     FULL_SIMP_TAC std_ss [sigma_algebra_def])
+     MATCH_MP_TAC SIGMA_ALGEBRA_UNION >> art [] \\
+     CONJ_TAC >- (MATCH_MP_TAC SIGMA_ALGEBRA_INTER >> art []) \\
+     MATCH_MP_TAC SIGMA_ALGEBRA_COMPL >> art [])
  >> `{x | f x * indicator_fn s x <= Normal c} INTER space a =
      (({x | f x <= Normal c} INTER space a) INTER s)`
          by (RW_TAC std_ss [indicator_fn_def, EXTENSION, GSPECIFICATION, IN_INTER] \\
              Cases_on `x IN s` >- RW_TAC std_ss [mul_rone, mul_rzero] \\
              RW_TAC std_ss [mul_rone, mul_rzero]) >> POP_ORW
- >> MATCH_MP_TAC ALGEBRA_INTER
- >> FULL_SIMP_TAC std_ss [sigma_algebra_def]);
+ >> MATCH_MP_TAC SIGMA_ALGEBRA_INTER >> art []
+QED
 
 Theorem IN_MEASURABLE_BOREL_CMUL_INDICATOR' :
     !a c s. sigma_algebra a /\ s IN subsets a ==>
@@ -2951,7 +3069,8 @@ Theorem IN_MEASURABLE_BOREL_MAX :
     !a f g. sigma_algebra a /\ f IN measurable a Borel /\ g IN measurable a Borel
         ==> (\x. max (f x) (g x)) IN measurable a Borel
 Proof
-    RW_TAC std_ss [IN_MEASURABLE_BOREL, extreal_max_def, IN_FUNSET, IN_UNIV]
+    RW_TAC std_ss [extreal_max_def]
+ >> rfs [IN_MEASURABLE_BOREL, IN_FUNSET]
  >> `!c. {x | (if f x <= g x then g x else f x) < c} = {x | f x < c} INTER {x | g x < c}`
         by (RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER] \\
             EQ_TAC
@@ -2968,7 +3087,8 @@ Theorem IN_MEASURABLE_BOREL_MIN :
     !a f g. sigma_algebra a /\ f IN measurable a Borel /\ g IN measurable a Borel
         ==> (\x. min (f x) (g x)) IN measurable a Borel
 Proof
-    RW_TAC std_ss [IN_MEASURABLE_BOREL, extreal_min_def, IN_FUNSET, IN_UNIV]
+    RW_TAC std_ss [extreal_min_def]
+ >> rfs [IN_MEASURABLE_BOREL, IN_FUNSET]
  >> Know `!c. {x | (if f x <= g x then f x else g x) < c} =
               {x | f x < c} UNION {x | g x < c}`
  >- (RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_UNION] \\
@@ -3001,7 +3121,9 @@ Theorem IN_MEASURABLE_BOREL_MONO_SUP :
             (!x. x IN space a ==> (f x = sup (IMAGE (\n. fi n x) UNIV)))
          ==> f IN measurable a Borel
 Proof
-    RW_TAC std_ss [IN_MEASURABLE_BOREL_ALT2, IN_FUNSET, IN_UNIV]
+    rpt STRIP_TAC
+ >> rfs [IN_MEASURABLE_BOREL_ALT2, IN_FUNSET]
+ >> Q.X_GEN_TAC ‘c’
  >> Know ‘{x | sup (IMAGE (\n. fi n x) UNIV) <= Normal c} INTER space a =
            BIGINTER (IMAGE (\n. {x | fi n x <= Normal c} INTER space a) UNIV)’
  >- (RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_BIGINTER_IMAGE, IN_UNIV, IN_INTER, sup_le'] \\
@@ -3033,7 +3155,8 @@ Theorem IN_MEASURABLE_BOREL_SUP :
            ==> f IN measurable a Borel
 Proof
     rpt STRIP_TAC
- >> RW_TAC std_ss [IN_MEASURABLE_BOREL_ALT2, IN_FUNSET, IN_UNIV]
+ >> rfs [IN_MEASURABLE_BOREL_ALT2, IN_FUNSET]
+ >> Q.X_GEN_TAC ‘c’
  >> Know ‘{x | sup (IMAGE (\n. fi n x) X) <= Normal c} INTER space a =
            BIGINTER (IMAGE (\n. {x | fi n x <= Normal c} INTER space a) X)’
  >- (RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_BIGINTER_IMAGE, IN_UNIV, IN_INTER, sup_le'] \\
@@ -3059,7 +3182,7 @@ Proof
  >> ‘IMAGE A X = {A i | i IN X}’ by SET_TAC [] >> POP_ORW
  >> MATCH_MP_TAC (Q.SPECL [‘space a’, ‘subsets a’] SIGMA_ALGEBRA_COUNTABLE_INT)
  >> rw [IN_FUNSET, space_def, subsets_def, SPACE, SUBSET_DEF, Abbr ‘A’]
- >> MATCH_MP_TAC IN_MEASURABLE_BOREL_RC >> rw []
+ >> FIRST_X_ASSUM MATCH_MP_TAC >> art []
 QED
 
 Theorem IN_MEASURABLE_BOREL_MONO_INF :
@@ -3067,7 +3190,9 @@ Theorem IN_MEASURABLE_BOREL_MONO_INF :
             (!x. x IN space a ==> (f x = inf (IMAGE (\n. fi n x) UNIV)))
          ==> f IN measurable a Borel
 Proof
-    RW_TAC std_ss [IN_MEASURABLE_BOREL_ALT1, IN_FUNSET, IN_UNIV]
+    rpt STRIP_TAC
+ >> rfs [IN_MEASURABLE_BOREL_ALT1, IN_FUNSET]
+ >> Q.X_GEN_TAC ‘c’
  >> Know ‘{x | Normal c <= inf (IMAGE (\n. fi n x) UNIV)} INTER space a =
            BIGINTER (IMAGE (\n. {x | Normal c <= fi n x} INTER space a) UNIV)’
  >- (RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_BIGINTER_IMAGE, IN_UNIV, IN_INTER, le_inf'] \\
@@ -3098,7 +3223,8 @@ Theorem IN_MEASURABLE_BOREL_INF :
            ==> f IN measurable a Borel
 Proof
     rpt STRIP_TAC
- >> RW_TAC std_ss [IN_MEASURABLE_BOREL_ALT1, IN_FUNSET, IN_UNIV]
+ >> rfs [IN_MEASURABLE_BOREL_ALT1, IN_FUNSET]
+ >> Q.X_GEN_TAC ‘c’
  >> Know ‘{x | Normal c <= inf (IMAGE (\n. fi n x) X)} INTER space a =
            BIGINTER (IMAGE (\n. {x | Normal c <= fi n x} INTER space a) X)’
  >- (RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_BIGINTER_IMAGE, IN_UNIV, IN_INTER, le_inf'] \\
@@ -3124,7 +3250,7 @@ Proof
  >> ‘IMAGE A X = {A i | i IN X}’ by SET_TAC [] >> POP_ORW
  >> MATCH_MP_TAC (Q.SPECL [‘space a’, ‘subsets a’] SIGMA_ALGEBRA_COUNTABLE_INT)
  >> rw [IN_FUNSET, space_def, subsets_def, SPACE, SUBSET_DEF, Abbr ‘A’]
- >> MATCH_MP_TAC IN_MEASURABLE_BOREL_CR >> rw []
+ >> FIRST_X_ASSUM MATCH_MP_TAC >> art []
 QED
 
 (* a generalized version of IN_MEASURABLE_BOREL_MAX, cf. sup_maximal *)
@@ -3228,10 +3354,13 @@ Proof
       RW_TAC arith_ss [COUNT_SUC, SUBSET_DEF, FINITE_COUNT, IN_COUNT] ]
 QED
 
-val IN_MEASURABLE_BOREL_FN_PLUS = store_thm
-  ("IN_MEASURABLE_BOREL_FN_PLUS",
-  ``!a f. f IN measurable a Borel ==> fn_plus f IN measurable a Borel``,
-    RW_TAC std_ss [IN_MEASURABLE_BOREL, IN_FUNSET, IN_UNIV, fn_plus_def]
+(* NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_FN_PLUS :
+    !a f. sigma_algebra a /\ f IN measurable a Borel ==> fn_plus f IN measurable a Borel
+Proof
+    rpt STRIP_TAC
+ >> rfs [IN_MEASURABLE_BOREL, IN_FUNSET, fn_plus_def]
+ >> Q.X_GEN_TAC ‘c’
  >> Cases_on `c <= 0`
  >- (`{x | (if 0 < f x then f x else 0) < Normal c} = {}`
        by (RW_TAC std_ss [EXTENSION, GSPECIFICATION, NOT_IN_EMPTY] \\
@@ -3244,14 +3373,15 @@ val IN_MEASURABLE_BOREL_FN_PLUS = store_thm
            >- (RW_TAC real_ss [] >> METIS_TAC [extreal_lt_def, let_trans]) \\
            RW_TAC real_ss [] \\
            METIS_TAC [extreal_lt_eq, extreal_of_num_def, real_lte])
- >> METIS_TAC []);
+ >> METIS_TAC []
+QED
 
-val IN_MEASURABLE_BOREL_FN_MINUS = store_thm
-  ("IN_MEASURABLE_BOREL_FN_MINUS",
-  ``!a f. f IN measurable a Borel ==> fn_minus f IN measurable a Borel``,
+(* NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’ *)
+Theorem IN_MEASURABLE_BOREL_FN_MINUS :
+    !a f. sigma_algebra a /\ f IN measurable a Borel ==> fn_minus f IN measurable a Borel
+Proof
     RW_TAC std_ss [fn_minus_def]
- >> RW_TAC std_ss [IN_MEASURABLE_BOREL, IN_FUNSET, IN_UNIV, fn_minus_def]
- >- METIS_TAC [IN_MEASURABLE_BOREL]
+ >> rw [IN_MEASURABLE_BOREL, IN_FUNSET]
  >> Cases_on `c <= 0`
  >- (`{x | (if f x < 0 then -f x else 0) < Normal c} = {}`
         by (RW_TAC std_ss [EXTENSION, GSPECIFICATION, NOT_IN_EMPTY] \\
@@ -3268,12 +3398,17 @@ val IN_MEASURABLE_BOREL_FN_MINUS = store_thm
                            extreal_ainv_def]) \\
             RW_TAC std_ss [] >- METIS_TAC [lt_neg, neg_neg, extreal_ainv_def] \\
             METIS_TAC [real_lte, extreal_lt_eq, extreal_of_num_def, extreal_ainv_def])
- >> METIS_TAC [IN_MEASURABLE_BOREL_ALL]);
+ >> METIS_TAC [IN_MEASURABLE_BOREL_ALL]
+QED
 
-(* used in martingaleTheory.FUBINI *)
+(* NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’
+
+   This theorem is used in martingaleTheory.FUBINI.
+ *)
 Theorem IN_MEASURABLE_BOREL_PLUS_MINUS :
-    !a f. f IN measurable a Borel <=>
-          fn_plus f IN measurable a Borel /\ fn_minus f IN measurable a Borel
+    !a f. sigma_algebra a ==>
+         (f IN measurable a Borel <=>
+          fn_plus f IN measurable a Borel /\ fn_minus f IN measurable a Borel)
 Proof
     rpt STRIP_TAC
  >> EQ_TAC
@@ -3282,9 +3417,7 @@ Proof
  >> MATCH_MP_TAC IN_MEASURABLE_BOREL_SUB
  >> qexistsl_tac [`fn_plus f`, `fn_minus f`]
  >> RW_TAC std_ss [fn_plus_def, fn_minus_def, sub_rzero, lt_antisym, sub_rzero, add_lzero]
- >| [ (* goal 1 (of 8) *)
-      METIS_TAC [IN_MEASURABLE_BOREL],
-      (* goal 2 (of 8) *)
+ >| [ (* goal 2 (of 8) *)
       METIS_TAC [lt_antisym],
       (* goal 3 (of 8) *)
       DISJ1_TAC >> REWRITE_TAC [extreal_not_infty, extreal_of_num_def] \\
@@ -3305,16 +3438,15 @@ Proof
       METIS_TAC [le_antisym, extreal_lt_def] ]
 QED
 
-(* The reverse version of IN_MEASURABLE_BOREL_IMP_BOREL *)
+(* The reverse version of IN_MEASURABLE_BOREL_IMP_BOREL
+
+   NOTE: added ‘sigma_algebra a’ into antecedents due to changes of ‘measurable’
+ *)
 Theorem in_borel_measurable_from_Borel :
-    !a f. f IN measurable a Borel ==> (real o f) IN measurable a borel
+    !a f. sigma_algebra a /\ f IN measurable a Borel ==> (real o f) IN measurable a borel
 Proof
-    rpt GEN_TAC >> DISCH_TAC
+    rpt GEN_TAC >> STRIP_TAC
  >> simp [IN_MEASURABLE, sigma_algebra_borel, IN_FUNSET, space_borel]
- (* sigma_algebra a *)
- >> STRONG_CONJ_TAC
- >- (fs [IN_MEASURABLE, SIGMA_ALGEBRA_BOREL, SPACE_BOREL])
- >> DISCH_TAC
  >> Q.X_GEN_TAC ‘B’ >> STRIP_TAC
  >> rw [PREIMAGE_def]
  >> Know ‘{x | real (f x) IN B} INTER space a =
@@ -5344,8 +5476,7 @@ Proof
  (* complete_measure_space is used here indirectly *)
  >> ‘{x | x IN m_space m /\ (f x = g x)} IN measurable_sets m’
       by METIS_TAC [AE_IMP_MEASURABLE_SETS]
- >> fs [complete_measure_space_def,
-        AE_ALT, IN_MEASURABLE_BOREL, IN_FUNSET, IN_UNIV]
+ >> fs [complete_measure_space_def, AE_ALT, IN_MEASURABLE_BOREL, IN_FUNSET]
  >> ‘N IN measurable_sets m’ by PROVE_TAC [null_set_def]
  >> GEN_TAC
  >> ‘{x | g x < Normal c} = {x | g x < Normal c /\ (f x = g x)} UNION
@@ -5369,6 +5500,8 @@ Proof
      ({x | f x < Normal c} INTER m_space m) INTER {x | x IN m_space m /\ (f x = g x)}’
       by SET_TAC [] >> POP_ORW
  >> MATCH_MP_TAC MEASURE_SPACE_INTER >> art []
+ >> ‘sigma_algebra (measurable_space m)’ by PROVE_TAC [measure_space_def]
+ >> fs [IN_MEASURABLE_BOREL]
 QED
 
 (* ------------------------------------------------------------------------- *)
@@ -8200,8 +8333,7 @@ Proof
     rpt STRIP_TAC
  >> Q.ABBREV_TAC ‘g = \x. (X x,Y x)’
  >> simp [IN_MEASURABLE, IN_FUNSET, SPACE_PROD_SIGMA, SPACE_BOREL]
- >> STRONG_CONJ_TAC >- REWRITE_TAC [SIGMA_ALGEBRA_BOREL_2D]
- >> DISCH_TAC
+ >> ‘sigma_algebra (Borel CROSS Borel)’ by PROVE_TAC [SIGMA_ALGEBRA_BOREL_2D]
  (* stage work *)
  >> Suff ‘IMAGE (\s. PREIMAGE g s INTER space a)
                 (subsets (Borel CROSS Borel)) SUBSET subsets a’
@@ -8743,6 +8875,8 @@ Proof
     irule IN_MEASURABLE_BOREL_MUL' >> simp[] >> qexistsl_tac [‘f e’,‘λx. EXTREAL_PROD_IMAGE (λi. f i x) s’] >> simp[]
 QED
 
+(*
+
 Theorem IN_MEASURABLE_BOREL_INV:
     !a f g. sigma_algebra a /\ f IN Borel_measurable a /\
         (!x. x IN space a ==> g x = extreal_inv (f x) * indicator_fn {y | f y <> 0} x) ==>
@@ -8945,6 +9079,8 @@ Proof
         (irule o SIMP_RULE (srw_ss ()) []) AE_subset >>
     rw[] >> irule EXTREAL_SUM_IMAGE_EQ' >> rw[combinTheory.C_DEF]
 QED
+
+*)
 
 val _ = export_theory ();
 

--- a/src/probability/borelScript.sml
+++ b/src/probability/borelScript.sml
@@ -8876,7 +8876,6 @@ Proof
 QED
 
 (*
-
 Theorem IN_MEASURABLE_BOREL_INV:
     !a f g. sigma_algebra a /\ f IN Borel_measurable a /\
         (!x. x IN space a ==> g x = extreal_inv (f x) * indicator_fn {y | f y <> 0} x) ==>
@@ -9003,6 +9002,7 @@ Proof
     rw[] >> irule IN_MEASURABLE_BOREL_IMP_BOREL' >> irule_at Any in_borel_measurable_from_Borel >>
     simp[] >> fs[IN_MEASURABLE]
 QED
+*)
 
 (*** AE Theorems ***)
 
@@ -9074,13 +9074,12 @@ Theorem AE_eq_sum:
     !m f fae s. FINITE s /\ measure_space m /\ (!n. n IN s ==> AE x::m. (f n x):extreal = fae n x) ==>
         AE x::m. SIGMA (C f x) s = SIGMA (C fae x) s
 Proof
-    rw[] >> qspecl_then [‘m’,‘λn x. f n x = fae n x’,‘s’] assume_tac AE_BIGINTER >> rfs[finite_countable] >>
-    qspecl_then [‘m’,‘λx. !n. n IN s ==> f n x = fae n x’,‘λx. SIGMA (C f x) s = SIGMA (C fae x) s’]
-        (irule o SIMP_RULE (srw_ss ()) []) AE_subset >>
-    rw[] >> irule EXTREAL_SUM_IMAGE_EQ' >> rw[combinTheory.C_DEF]
+    rw[] >> qspecl_then [‘m’,‘λn x. f n x = fae n x’,‘s’] assume_tac AE_BIGINTER
+ >> rfs[finite_countable]
+ >> qspecl_then [‘m’,‘λx. !n. n IN s ==> f n x = fae n x’,‘λx. SIGMA (C f x) s = SIGMA (C fae x) s’]
+        (irule o SIMP_RULE (srw_ss ()) []) AE_subset
+ >> rw[] >> irule EXTREAL_SUM_IMAGE_EQ' >> rw[combinTheory.C_DEF]
 QED
-
-*)
 
 val _ = export_theory ();
 

--- a/src/probability/lebesgueScript.sml
+++ b/src/probability/lebesgueScript.sml
@@ -10981,7 +10981,6 @@ Proof
     >- (irule lte_trans >> qexists_tac ‘f x’ >> simp[])
 QED
 
-(*
 Theorem integral_add':
     !m f g. measure_space m /\ integrable m f /\ integrable m g ==>
         integral m (λx. f x + g x) = integral m f + integral m g
@@ -11108,7 +11107,6 @@ Proof
  >> Suff ‘integral m (\x. f x + g x) = integral m f + integral m g’ >- rw []
  >> MATCH_MP_TAC integral_add' >> rw []
 QED
- *)
 
 val _ = export_theory ();
 

--- a/src/probability/lebesgueScript.sml
+++ b/src/probability/lebesgueScript.sml
@@ -5580,13 +5580,12 @@ Proof
  >> METIS_TAC []
 QED
 
-
-(* TODO *)
-
-val integrable_cmul = store_thm
-  ("integrable_cmul",
-  ``!m f c. measure_space m /\ integrable m f ==> integrable m (\x. Normal c * f x)``,
-    RW_TAC std_ss []
+Theorem integrable_cmul :
+    !m f c. measure_space m /\ integrable m f ==> integrable m (\x. Normal c * f x)
+Proof
+    rpt STRIP_TAC
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
  >> Cases_on `c = 0`
  >- RW_TAC std_ss [integrable_zero, mul_lzero, GSYM extreal_of_num_def]
  >> `(\x. Normal c * f x) IN measurable (m_space m,measurable_sets m) Borel`
@@ -5623,7 +5622,8 @@ val integrable_cmul = store_thm
  >> RW_TAC std_ss [extreal_ainv_def]
  >> `0 <= -c` by METIS_TAC [REAL_LT_IMP_LE, REAL_LE_NEG, REAL_NEG_0]
  >> RW_TAC std_ss [pos_fn_integral_cmul, FN_PLUS_POS]
- >> METIS_TAC [mul_not_infty, integrable_def]);
+ >> METIS_TAC [mul_not_infty, integrable_def]
+QED
 
 (* NOTE: added `!x. x IN m_space m ==> f x <> NegInf /\ g x <> PosInf`, one way
    to make sure that `f - g` is defined (i.e. f/g cannot be the same infinites *)
@@ -5701,14 +5701,15 @@ Theorem integrable_not_infty_lemma[local] :
              (integral m f = integral m g)
 Proof
     RW_TAC std_ss [integral_pos_fn, integrable_def]
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
  >> Q.ABBREV_TAC `g = (\x. if f x = PosInf then 0 else f x)`
  >> Q.EXISTS_TAC `g`
  >> `!x. x IN m_space m ==> 0 <= g x` by METIS_TAC [le_refl]
  >> `!x. x IN m_space m ==> g x <= f x` by METIS_TAC [le_refl,le_infty]
  >> `!x. x IN m_space m ==> g x <> PosInf` by METIS_TAC [num_not_infty]
  >> Know `g IN measurable (m_space m,measurable_sets m) Borel`
- >- (RW_TAC std_ss [IN_MEASURABLE_BOREL, space_def, subsets_def, IN_FUNSET, IN_UNIV]
-     >- METIS_TAC [measure_space_def] \\
+ >- (RW_TAC std_ss [IN_MEASURABLE_BOREL, space_def, subsets_def, IN_FUNSET, IN_UNIV] \\
      Cases_on `Normal c <= 0`
      >- (`{x | g x < Normal c} INTER m_space m = {}`
             by (RW_TAC std_ss [EXTENSION, GSPECIFICATION, NOT_IN_EMPTY, IN_INTER] \\
@@ -5724,7 +5725,8 @@ Proof
      RW_TAC std_ss [] \\ (* 2 subgoals *)
      METIS_TAC [(REWRITE_RULE [space_def, subsets_def] o
                  Q.SPECL [`f`,`(m_space m, measurable_sets m)`])
-                    IN_MEASURABLE_BOREL_ALL, integrable_def, INTER_COMM]) >> DISCH_TAC
+                    IN_MEASURABLE_BOREL_ALL, integrable_def, INTER_COMM])
+ >> DISCH_TAC
  >> CONJ_TAC
  >- (RW_TAC std_ss []
      >- (FULL_SIMP_TAC std_ss [lt_infty] \\
@@ -5855,6 +5857,8 @@ Theorem integrable_not_infty_alt :
          (integral m f = integral m (\x. if f x = PosInf then 0 else f x))
 Proof
     rpt GEN_TAC >> STRIP_TAC
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
  >> Q.ABBREV_TAC `g = (\x. if f x = PosInf then 0 else f x)`
  >> `!x. x IN m_space m ==> 0 <= g x` by METIS_TAC [le_refl]
  >> `!x. x IN m_space m ==> g x <= f x` by METIS_TAC [le_refl, le_infty]
@@ -5862,8 +5866,7 @@ Proof
  >> `!x. x IN m_space m ==> g x <> NegInf` by METIS_TAC [lt_infty, lte_trans, num_not_infty]
  >> `!x. x IN m_space m ==> f x <> NegInf` by METIS_TAC [lt_infty, lte_trans, num_not_infty]
  >> Know `g IN measurable (m_space m,measurable_sets m) Borel`
- >- (RW_TAC std_ss [IN_MEASURABLE_BOREL, space_def, subsets_def, IN_FUNSET, IN_UNIV]
-     >- METIS_TAC [measure_space_def] \\
+ >- (RW_TAC std_ss [IN_MEASURABLE_BOREL, space_def, subsets_def, IN_FUNSET, IN_UNIV] \\
      Cases_on `Normal c <= 0`
      >- (`{x | g x < Normal c} INTER m_space m = {}`
             by (RW_TAC std_ss [EXTENSION, GSPECIFICATION, NOT_IN_EMPTY, IN_INTER] \\
@@ -6037,6 +6040,8 @@ Theorem integral_add_lemma :
       (integral m f = pos_fn_integral m f1 - pos_fn_integral m f2)
 Proof
     rpt STRIP_TAC
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
  >> REWRITE_TAC [integral_def]
  >> `!x. x IN m_space m ==> f1 x <> NegInf` by METIS_TAC [pos_not_neginf]
  >> `!x. x IN m_space m ==> f2 x <> NegInf` by METIS_TAC [pos_not_neginf]
@@ -6156,6 +6161,8 @@ Theorem integral_add :
            (integral m (\x. f x + g x) = integral m f + integral m g)
 Proof
     RW_TAC std_ss []
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
  >> Know `integral m (\x. f x + g x) =
           pos_fn_integral m (\x. fn_plus f x + fn_plus g x) -
           pos_fn_integral m (\x. fn_minus f x + fn_minus g x)`
@@ -6641,14 +6648,16 @@ QED
    added `integrable m f` into antecedents, otherwise `integral m f` is not defined;
    added `measure m (m_space m) < PosInf` into antecedents
  *)
-val finite_support_integral_reduce = store_thm
-  ("finite_support_integral_reduce",
-  ``!m f. measure_space m /\ f IN measurable (m_space m,measurable_sets m) Borel /\
+Theorem finite_support_integral_reduce :
+    !m f. measure_space m /\ f IN measurable (m_space m,measurable_sets m) Borel /\
          (!x. x IN m_space m ==> f x <> NegInf /\ f x <> PosInf) /\
           FINITE (IMAGE f (m_space m)) /\
           integrable m f /\ measure m (m_space m) < PosInf ==>
-         (integral m f = finite_space_integral m f)``,
+         (integral m f = finite_space_integral m f)
+Proof
     rpt STRIP_TAC
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
  >> `?c1 n. BIJ c1 (count n) (IMAGE f (m_space m))`
        by RW_TAC std_ss [GSYM FINITE_BIJ_COUNT_EQ]
  >> `?c. !i. (i IN count n ==> (c1 i = Normal (c i)))`
@@ -6914,7 +6923,8 @@ val finite_support_integral_reduce = store_thm
  >- METIS_TAC [mul_not_infty]
  >> MATCH_MP_TAC pos_not_neginf
  >> IMP_RES_TAC MEASURE_SPACE_POSITIVE
- >> METIS_TAC [positive_def]);
+ >> METIS_TAC [positive_def]
+QED
 
 (* special case of "finite_support_integral_reduce": (m_space m) is finite.
 
@@ -6944,9 +6954,10 @@ Theorem finite_space_POW_integral_reduce :
          (integral m f = SIGMA (\x. f x * (measure m {x})) (m_space m))
 Proof
     RW_TAC std_ss []
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
  >> `f IN measurable (m_space m, measurable_sets m) Borel`
         by (RW_TAC std_ss [IN_MEASURABLE_BOREL,IN_FUNSET,IN_UNIV,space_def,subsets_def]
-            >- FULL_SIMP_TAC std_ss [measure_space_def]
             >> METIS_TAC [INTER_SUBSET,IN_POW])
  >> `?c n. BIJ c (count n) (m_space m)` by RW_TAC std_ss [GSYM FINITE_BIJ_COUNT_EQ]
  >> `FINITE (count n)` by RW_TAC std_ss [FINITE_COUNT]
@@ -7259,6 +7270,8 @@ Theorem measure_space_density :
          (!x. x IN m_space m ==> 0 <= f x) ==> measure_space (density m f)
 Proof
     Q.X_GEN_TAC ‘M’ >> rpt STRIP_TAC
+ >> ‘sigma_algebra (measurable_space M)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
  >> SIMP_TAC std_ss [measure_space_def, density_measure_def, density_def,
                      m_space_def, measurable_sets_def]
  >> Q.PAT_ASSUM `measure_space M`
@@ -7318,7 +7331,8 @@ Theorem measure_space_density' :
 Proof
     rpt STRIP_TAC
  >> MATCH_MP_TAC measure_space_density >> art [FN_PLUS_POS]
- >> MATCH_MP_TAC IN_MEASURABLE_BOREL_FN_PLUS >> art []
+ >> MATCH_MP_TAC IN_MEASURABLE_BOREL_FN_PLUS
+ >> rw [MEASURE_SPACE_SIGMA_ALGEBRA]
 QED
 
 val suminf_measure = prove (
@@ -7708,6 +7722,8 @@ Theorem integral_abs_eq_0 :
         ((AE x::m. (abs o f) x = 0) <=> (measure m {x | x IN m_space m /\ f x <> 0} = 0))
 Proof
     rpt GEN_TAC >> STRIP_TAC
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
  >> Know `{x | x IN m_space m /\ f x <> 0} IN measurable_sets m`
  >- (`{x | x IN m_space m /\ f x <> 0} = {x | f x <> 0} INTER m_space m` by SET_TAC [] \\
      POP_ORW >> METIS_TAC [IN_MEASURABLE_BOREL_ALL_MEASURE]) >> DISCH_TAC
@@ -7727,7 +7743,6 @@ Proof
          ((GEN_REWRITE_TAC (RAND_CONV o ONCE_DEPTH_CONV) empty_rewrites) o wrap o SYM) \\
        IMP_RES_TAC MEASURE_SPACE_INCREASING \\
        MATCH_MP_TAC INCREASING >> fs [abs_eq_0] ]) >> DISCH_TAC
- >> `sigma_algebra (m_space m,measurable_sets m)` by PROVE_TAC [measure_space_def]
  (* RHS ==> LHS, by AE and integral_null_set *)
  >> reverse EQ_TAC
  >- (SIMP_TAC bool_ss [AE_ALT, GSYM IN_NULL_SET] >> STRIP_TAC \\
@@ -8395,12 +8410,15 @@ val RADON_F_def = Define
 val RADON_F_integrals_def = Define
    `RADON_F_integrals m v = {r | ?f. (r = pos_fn_integral m f) /\ f IN RADON_F m v}`;
 
-val lemma_radon_max_in_F = Q.prove (
-   `!f g m v. measure_space m /\ measure_space v /\
+Theorem lemma_radon_max_in_F[local] :
+    !f g m v. measure_space m /\ measure_space v /\
               (m_space v = m_space m) /\ (measurable_sets v = measurable_sets m) /\
               f IN RADON_F m v /\ g IN RADON_F m v
-          ==> (\x. max (f x) (g x)) IN RADON_F m v`,
+          ==> (\x. max (f x) (g x)) IN RADON_F m v
+Proof
     RW_TAC real_ss [RADON_F_def, GSPECIFICATION, max_le, le_max]
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
  >- FULL_SIMP_TAC std_ss [IN_MEASURABLE_BOREL_MAX, measure_space_def]
  >> Q.ABBREV_TAC `A1 = {x | x IN A /\ g x < f x}`
  >> Q.ABBREV_TAC `A2 = {x | x IN A /\ f x <= g x}`
@@ -10028,11 +10046,14 @@ Proof
    FIRST_X_ASSUM (ASSUME_TAC o ONCE_REWRITE_RULE [SPECIFICATION]) THEN
    POP_ASSUM (fn th => ONCE_REWRITE_TAC [th]) THEN
    ONCE_REWRITE_TAC [METIS [] ``PosInf = (\x. PosInf) x``] THEN
-   MATCH_MP_TAC MEASURABLE_IF THEN REPEAT CONJ_TAC THENL
-   [SIMP_TAC std_ss [SPACE, m_space_def, measurable_sets_def] THEN
+   MATCH_MP_TAC MEASURABLE_IF >> rpt STRIP_TAC >| (* 5 subgoals *)
+   [(* goal 1 (of 5) *)
+    SIMP_TAC std_ss [SPACE, m_space_def, measurable_sets_def] THEN
     MATCH_MP_TAC IN_MEASURABLE_BOREL_CONST THEN Q.EXISTS_TAC `PosInf` THEN
     METIS_TAC [measure_space_def],
+    (* goal 2 (of 5) *)
     ALL_TAC,
+    (* goal 3 (of 5) *)
     ONCE_REWRITE_TAC [prove (``{x | x IN m_space M /\ Q0 x} = {x | x IN m_space M /\ x IN Q0}``,
      SIMP_TAC std_ss [SPECIFICATION])] THEN SIMP_TAC std_ss [GSYM INTER_DEF] THEN
     ONCE_REWRITE_TAC [METIS [subsets_def]
@@ -10040,7 +10061,10 @@ Proof
     MATCH_MP_TAC ALGEBRA_INTER THEN SIMP_TAC std_ss [subsets_def] THEN
     CONJ_TAC THENL [METIS_TAC [measure_space_def, sigma_algebra_def], ALL_TAC] THEN
     METIS_TAC [MEASURE_SPACE_MSPACE_MEASURABLE],
-    ASM_REWRITE_TAC []] THEN
+    (* goal 4 (of 5) *)
+    ASM_REWRITE_TAC [],
+    (* goal 5 (of 5) *)
+    rw [SIGMA_ALGEBRA_BOREL] ] THEN
    Know `!x. suminf (\i. f i x * indicator_fn (Q i) x) =
              sup (IMAGE (\n. SIGMA (\i. f i x * indicator_fn (Q i) x)
                              (count n)) univ(:num))`
@@ -10621,6 +10645,8 @@ Theorem Radon_Nikodym_sigma_finite : (* was: RADON_NIKODYM *)
              (pos_fn_integral M (\x. f x * indicator_fn A x) = measure N A)
 Proof
     rpt STRIP_TAC
+ >> ‘sigma_algebra (measurable_space M) /\ sigma_algebra (measurable_space N)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
  >> Q.PAT_X_ASSUM `m_space M = m_space N` (ASSUME_TAC o SYM)
  >> Q.PAT_X_ASSUM `measurable_sets M = measurable_sets N` (ASSUME_TAC o SYM)
  >> ASM_REWRITE_TAC []
@@ -10697,10 +10723,9 @@ Proof
      reverse CONJ_TAC
      >- (MATCH_MP_TAC pos_fn_integral_zero \\
          METIS_TAC [measure_space_def, positive_def]) \\
-     SIMP_TAC std_ss [IN_MEASURABLE_BOREL] THEN ASM_SIMP_TAC std_ss [] \\
+     ASM_SIMP_TAC std_ss [IN_MEASURABLE_BOREL] \\
      ASM_SIMP_TAC std_ss [space_def, INTER_EMPTY, subsets_def] \\
-     CONJ_TAC >- (EVAL_TAC >> SRW_TAC [] [IN_DEF, IN_FUNSET]) \\
-     METIS_TAC [IN_SING])
+     SRW_TAC [] [IN_DEF, IN_FUNSET])
  >> Suff `measure_absolutely_continuous (measure N) mt`
  >- (STRIP_TAC \\
      MP_TAC (Q.SPECL [`mt`, `N`] Radon_Nikodym_finite_arbitrary) \\
@@ -10956,6 +10981,7 @@ Proof
     >- (irule lte_trans >> qexists_tac ‘f x’ >> simp[])
 QED
 
+(*
 Theorem integral_add':
     !m f g. measure_space m /\ integrable m f /\ integrable m g ==>
         integral m (λx. f x + g x) = integral m f + integral m g
@@ -11082,6 +11108,7 @@ Proof
  >> Suff ‘integral m (\x. f x + g x) = integral m f + integral m g’ >- rw []
  >> MATCH_MP_TAC integral_add' >> rw []
 QED
+ *)
 
 val _ = export_theory ();
 

--- a/src/probability/lebesgueScript.sml
+++ b/src/probability/lebesgueScript.sml
@@ -3022,24 +3022,27 @@ Theorem lemma_fn_seq_in_psfis[local] :
             (fn_seq_integral m f n IN psfis m (fn_seq m f n))
 Proof
     RW_TAC std_ss [IN_psfis_eq, pos_simple_fn_def]
- >> Q.EXISTS_TAC `count (4 ** n + 1)`
- >> Q.EXISTS_TAC `(\k. if k IN count (4 ** n) then
+ >> qexistsl_tac [`count (4 ** n + 1)`,
+                  `(\k. if k IN count (4 ** n) then
                           {x | x IN m_space m /\ &k / 2 pow n <= f x /\
                                f x < (&k + 1) / 2 pow n}
-                       else {x | x IN m_space m /\ 2 pow n <= f x} )`
- >> Q.EXISTS_TAC `(\k. if k IN count (4 ** n) then &k / 2 pow n else 2 pow n )`
- >> `FINITE (count (4 ** n))` by RW_TAC std_ss [FINITE_COUNT]
- >> `FINITE (count (4 ** n + 1))` by RW_TAC std_ss [FINITE_COUNT]
+                        else {x | x IN m_space m /\ 2 pow n <= f x})`,
+                  `(\k. if k IN count (4 ** n) then &k / 2 pow n else 2 pow n)`]
+ >> `FINITE (count (4 ** n)) /\
+     FINITE (count (4 ** n + 1))` by RW_TAC std_ss [FINITE_COUNT]
  >> `!n. 0:real < 2 pow n` by RW_TAC real_ss [REAL_POW_LT]
  >> `!n. 0:real <> 2 pow n` by RW_TAC real_ss [REAL_LT_IMP_NE]
  >> `!n k. &k / 2 pow n = Normal (&k / 2 pow n)`
       by METIS_TAC [extreal_of_num_def,extreal_pow_def,extreal_div_eq]
  >> `!n z. Normal z / 2 pow n = Normal (z / 2 pow n)`
       by METIS_TAC [extreal_pow_def,extreal_div_eq,extreal_of_num_def]
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
+ (* flatten all CONJ *)
+ >> ASM_SIMP_TAC std_ss [GSYM CONJ_ASSOC]
+ >> CONJ_TAC >- RW_TAC std_ss [lemma_fn_seq_positive]
  >> CONJ_TAC
- >- (CONJ_TAC >- RW_TAC std_ss [lemma_fn_seq_positive] \\
-     CONJ_TAC
-     >- (RW_TAC real_ss [fn_seq_def, IN_COUNT, GSYM ADD1, COUNT_SUC] \\
+ >- (RW_TAC real_ss [fn_seq_def, IN_COUNT, GSYM ADD1, COUNT_SUC] \\
         `(\i. Normal (if i < 4 ** n then &i / 2 pow n else 2 pow n) *
               indicator_fn (if i < 4 ** n then
                    {x | x IN m_space m /\ Normal (&i / 2 pow n) <= f x /\
@@ -3087,28 +3090,27 @@ Proof
           reverse CONJ_TAC
           >- (RW_TAC std_ss [indicator_fn_def,mul_rone,mul_rzero,num_not_infty] \\
               METIS_TAC [extreal_of_num_def,extreal_pow_def,extreal_not_infty]) \\
-          FULL_SIMP_TAC std_ss [EXTREAL_SUM_IMAGE_NOT_INFTY]) \\
-     CONJ_TAC
-     >- (RW_TAC real_ss []
+          FULL_SIMP_TAC std_ss [EXTREAL_SUM_IMAGE_NOT_INFTY])
+ >> CONJ_TAC
+ >- (RW_TAC real_ss []
          >- (`{x | x IN m_space m /\ Normal (&i / 2 pow n) <= f x /\ f x < (&i + 1) / 2 pow n} =
               {x | Normal (&i / 2 pow n) <= f x /\ f x < Normal (&(i + 1) / 2 pow n)} INTER m_space m`
                  by (RW_TAC std_ss [EXTENSION,GSPECIFICATION,IN_INTER,CONJ_COMM] \\
                     `(&i + 1:extreal) = &(i + 1)`
                        by RW_TAC std_ss [extreal_add_def,extreal_of_num_def,REAL_ADD] \\
-                     METIS_TAC []) \\
+                     METIS_TAC []) >> POP_ORW \\
              METIS_TAC [IN_MEASURABLE_BOREL_ALL, m_space_def, measurable_sets_def,
                         space_def, subsets_def]) \\
         `{x | x IN m_space m /\ 2 pow n <= f x} = {x | Normal (2 pow n) <= f x} INTER m_space m`
             by RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INTER, CONJ_COMM,
-                              extreal_of_num_def, extreal_pow_def] \\
+                              extreal_of_num_def, extreal_pow_def] >> POP_ORW \\
          METIS_TAC [IN_MEASURABLE_BOREL_ALL, m_space_def, measurable_sets_def,
-                    space_def, subsets_def]) \\
-     CONJ_TAC >- RW_TAC std_ss [] \\
-     CONJ_TAC
-     >- RW_TAC real_ss [extreal_of_num_def,extreal_pow_def,extreal_le_def,
-                        REAL_LT_IMP_LE,POW_POS,REAL_LE_DIV] \\
-     CONJ_TAC
-     >- (RW_TAC real_ss [DISJOINT_DEF,IN_COUNT,IN_INTER,EXTENSION,GSPECIFICATION] >|
+                    space_def, subsets_def])
+ >> CONJ_TAC
+ >- RW_TAC real_ss [extreal_of_num_def,extreal_pow_def,extreal_le_def,
+                    REAL_LT_IMP_LE,POW_POS,REAL_LE_DIV]
+ >> CONJ_TAC
+ >- (RW_TAC real_ss [DISJOINT_DEF,IN_COUNT,IN_INTER,EXTENSION,GSPECIFICATION] >|
          [ reverse EQ_TAC >- RW_TAC std_ss [NOT_IN_EMPTY] \\
            RW_TAC real_ss [] \\
            RW_TAC std_ss [NOT_IN_EMPTY] \\
@@ -3150,8 +3152,10 @@ Proof
               >> `&(j + 1) / 2 pow n <= 2 pow n` by RW_TAC std_ss [extreal_of_num_def,extreal_add_def,extreal_pow_def,extreal_div_eq,extreal_lt_eq,extreal_le_def]
              >> `(&j + 1) = &(j + 1)` by METIS_TAC [extreal_of_num_def,extreal_add_def,REAL_ADD]
              >> METIS_TAC [lte_trans,extreal_lt_def]])
-     >> RW_TAC std_ss [EXTENSION,IN_BIGUNION_IMAGE,GSPECIFICATION]
-     >> EQ_TAC
+ (* BIGUNION (IMAGE ... = m_space m *)
+ >> CONJ_TAC
+ >- (RW_TAC std_ss [EXTENSION,IN_BIGUNION_IMAGE,GSPECIFICATION] \\
+     EQ_TAC
      >- (RW_TAC std_ss []
          >> Cases_on `k IN count (4 ** n)`
          >- FULL_SIMP_TAC std_ss [GSPECIFICATION,lemma_fn_3]
@@ -3163,6 +3167,7 @@ Proof
      >> Q.EXISTS_TAC `k`
      >> FULL_SIMP_TAC real_ss [IN_COUNT,GSPECIFICATION]
      >> METIS_TAC [])
+ (* fn_seq_integral m f n = pos_simple_fn_integral m (count (4 ** n + 1)) _ _ *)
   >> RW_TAC real_ss [pos_simple_fn_integral_def,fn_seq_integral_def]
   >> `4 ** n + 1 = SUC (4 ** n)` by RW_TAC real_ss []
   >> ASM_SIMP_TAC std_ss []
@@ -3232,10 +3237,8 @@ Proof
   >> FULL_SIMP_TAC std_ss [EXTREAL_SUM_IMAGE_NOT_INFTY]
 QED
 
-(* This huge theorem (from HVG) cannot be put in borelTheory as it depends on
-   several lemmas here.
-
-   NOTE: IN_MEASURABLE_BOREL_TIMES is not included in this result.
+(* This huge theorem (from HVG Concordia) cannot be put into borelTheory as it
+   depends on several lemmas here.
  *)
 Theorem BOREL_INDUCT : (* was: Induct_on_Borel_functions *)
   !f m P.
@@ -3255,10 +3258,13 @@ Theorem BOREL_INDUCT : (* was: Induct_on_Borel_functions *)
           (!i x. 0 <= u i x) /\ (!x. mono_increasing (\i. u i x)) /\
           (!i. P (u i)) ==> P (\x. sup (IMAGE (\i. u i x) UNIV))) ==> P f
 Proof
-  RW_TAC std_ss [] THEN FIRST_ASSUM MATCH_MP_TAC THEN
-  Q.EXISTS_TAC `(\x. sup (IMAGE (\i. fn_seq m f i x) univ(:num)))` THEN
-  ASM_SIMP_TAC std_ss [lemma_fn_seq_sup] THEN
-
+    RW_TAC std_ss []
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
+ >> FIRST_ASSUM MATCH_MP_TAC
+ >> Q.EXISTS_TAC `(\x. sup (IMAGE (\i. fn_seq m f i x) univ(:num)))`
+ >> ASM_SIMP_TAC std_ss [lemma_fn_seq_sup]
+ THEN
   Know `!i. (\x. SIGMA
           (\k. &k / 2 pow i *
              indicator_fn {x |
@@ -3834,7 +3840,10 @@ Theorem measurable_sequence :
                   (pos_fn_integral m (fn_minus f) =
                    sup (IMAGE (\i. pos_fn_integral m (gi i)) UNIV)))
 Proof
-    rpt STRIP_TAC
+    rpt GEN_TAC >> STRIP_TAC
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
+ >> CONJ_TAC
  >- (Q.EXISTS_TAC `(\n. fn_seq m (fn_plus f) n)` \\
      Q.EXISTS_TAC `(\n. fn_seq_integral m (fn_plus f) n)` \\
      CONJ_TAC >- RW_TAC std_ss [FN_PLUS_POS, lemma_fn_seq_mono_increasing] \\
@@ -4848,6 +4857,8 @@ Theorem lebesgue_monotone_convergence_AE :
          sup (IMAGE (\i. pos_fn_integral m (fn_plus (fi i))) univ(:num)))
 Proof
     RW_TAC std_ss [FN_PLUS_ALT']
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
  >> FULL_SIMP_TAC std_ss [AE_ALT, GSPECIFICATION]
  >> Q.ABBREV_TAC `ff = (\i x. if x IN m_space m DIFF N then fi i x else 0)`
  >> Know `AE x::m. !i. ff i x = fi i x`
@@ -4897,9 +4908,10 @@ Proof
          ONCE_REWRITE_TAC [METIS [subsets_def]
            ``measurable_sets m = subsets (m_space m, measurable_sets m)``] \\
         `{x | x IN m_space m /\ x IN m_space m DIFF N} = m_space m DIFF N` by SET_TAC [] \\
-         POP_ASSUM (fn th => REWRITE_TAC [th]) >> MATCH_MP_TAC ALGEBRA_DIFF \\
+         POP_ASSUM (fn th => REWRITE_TAC [th, SIGMA_ALGEBRA_BOREL]) \\
+         MATCH_MP_TAC SIGMA_ALGEBRA_DIFF \\
          FULL_SIMP_TAC std_ss [subsets_def, GSYM IN_NULL_SET, null_sets, GSPECIFICATION] \\
-         METIS_TAC [MEASURE_SPACE_MSPACE_MEASURABLE, measure_space_def, sigma_algebra_def]) \\
+         METIS_TAC [MEASURE_SPACE_MSPACE_MEASURABLE, measure_space_def]) \\
      CONJ_TAC
      >- (rpt STRIP_TAC \\
          Q.UNABBREV_TAC `ff` >> SIMP_TAC std_ss [ext_mono_increasing_def] \\
@@ -5033,6 +5045,8 @@ Theorem integral_split' :
 Proof
     RW_TAC std_ss [integrable_def, integral_def,
                    fn_plus_mul_indicator, fn_minus_mul_indicator]
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
  >> Know ‘pos_fn_integral m (fn_plus f) =
           pos_fn_integral m (\x. fn_plus f x * indicator_fn s x) +
           pos_fn_integral m (\x. fn_plus f x * indicator_fn (m_space m DIFF s) x)’
@@ -5177,6 +5191,8 @@ val integrable_infty = store_thm
   ``!m f s. measure_space m /\ integrable m f /\ s IN measurable_sets m /\
            (!x. x IN s ==> (f x = PosInf)) ==> (measure m s = 0)``,
   RW_TAC std_ss [integrable_def]
+  >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
   >> (MP_TAC o Q.SPECL [`m`,`fn_plus f`,`s`]) pos_fn_integral_split
   >> RW_TAC std_ss [IN_MEASURABLE_BOREL_FN_PLUS,DISJOINT_DIFF,FN_PLUS_POS]
   >> `(\x. fn_plus f x * indicator_fn s x) = (\x. PosInf * indicator_fn s x)`
@@ -5194,29 +5210,30 @@ val integrable_infty = store_thm
       by METIS_TAC [lt_infty,lte_trans,num_not_infty]
   >> FULL_SIMP_TAC std_ss [mul_lposinf, lt_imp_ne, add_infty]);
 
-val integrable_infty_null = store_thm
-  ("integrable_infty_null",
-  ``!m f. measure_space m /\ integrable m f ==>
-          null_set m {x | x IN m_space m /\ (f x = PosInf)}``,
-  RW_TAC std_ss []
-  >> Q.ABBREV_TAC `s = {x | x IN m_space m /\ (f x = PosInf)} `
-  >> Suff `s IN measurable_sets m`
-  >- (RW_TAC std_ss [null_set_def]
+Theorem integrable_infty_null :
+    !m f. measure_space m /\ integrable m f ==>
+          null_set m {x | x IN m_space m /\ (f x = PosInf)}
+Proof
+    RW_TAC std_ss []
+ >> Q.ABBREV_TAC `s = {x | x IN m_space m /\ (f x = PosInf)} `
+ >> Suff `s IN measurable_sets m`
+ >- (RW_TAC std_ss [null_set_def]
       >> MATCH_MP_TAC integrable_infty
       >> Q.EXISTS_TAC `f`
       >> RW_TAC std_ss []
       >> Q.UNABBREV_TAC `s`
       >> FULL_SIMP_TAC std_ss [GSPECIFICATION])
-  >> `f IN measurable (m_space m, measurable_sets m) Borel`
+ >> `f IN measurable (m_space m, measurable_sets m) Borel`
       by FULL_SIMP_TAC std_ss [integrable_def]
-  >> (MP_TAC o Q.SPEC `PosInf` o UNDISCH)
-      (REWRITE_RULE [subsets_def, space_def, IN_FUNSET, IN_UNIV]
-                    (Q.SPECL [`f`,`(m_space m, measurable_sets m)`] IN_MEASURABLE_BOREL_ALT8))
-  >> Suff `s = {x | f x = PosInf} INTER m_space m`
-  >- METIS_TAC []
-  >> Q.UNABBREV_TAC `s`
-  >> RW_TAC std_ss [EXTENSION,IN_INTER,GSPECIFICATION]
-  >> METIS_TAC []);
+ >> MP_TAC (Q.SPECL [`f`,`(m_space m, measurable_sets m)`] IN_MEASURABLE_BOREL_ALT8)
+ >> rw [MEASURE_SPACE_SIGMA_ALGEBRA]
+ >> POP_ASSUM (MP_TAC o (Q.SPEC `PosInf`))
+ >> Suff `s = {x | f x = PosInf} INTER m_space m`
+ >- METIS_TAC []
+ >> Q.UNABBREV_TAC `s`
+ >> RW_TAC std_ss [EXTENSION,IN_INTER,GSPECIFICATION]
+ >> METIS_TAC []
+QED
 
 Theorem pos_fn_integral_infty_null :
     !m f. measure_space m /\ (!x. x IN m_space m ==> 0 <= f x) /\
@@ -5308,21 +5325,27 @@ Proof
  >> METIS_TAC [pos_fn_integral_mono, FN_PLUS_POS, FN_MINUS_POS, lt_infty, let_trans]
 QED
 
-val integrable_fn_plus = store_thm
-  ("integrable_fn_plus",
-  ``!m f. measure_space m /\ integrable m f ==> integrable m (fn_plus f)``,
-    RW_TAC std_ss [integrable_def, GSYM fn_plus_def, FN_PLUS_POS, FN_PLUS_POS_ID,
+Theorem integrable_fn_plus :
+    !m f. measure_space m /\ integrable m f ==> integrable m (fn_plus f)
+Proof
+    rpt STRIP_TAC >> POP_ASSUM MP_TAC
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
+ >> RW_TAC std_ss [integrable_def, GSYM fn_plus_def, FN_PLUS_POS, FN_PLUS_POS_ID,
                    IN_MEASURABLE_BOREL_FN_PLUS, GSYM fn_minus_def, FN_MINUS_POS_ZERO,
                    pos_fn_integral_zero, num_not_infty]
- >> METIS_TAC []);
+QED
 
-val integrable_fn_minus = store_thm
-  ("integrable_fn_minus",
-  ``!m f. measure_space m /\ integrable m f ==> integrable m (fn_minus f)``,
-    RW_TAC std_ss [integrable_def, GSYM fn_minus_def, FN_MINUS_POS, FN_PLUS_POS_ID,
+Theorem integrable_fn_minus :
+    !m f. measure_space m /\ integrable m f ==> integrable m (fn_minus f)
+Proof
+    rpt STRIP_TAC >> POP_ASSUM MP_TAC
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
+ >> RW_TAC std_ss [integrable_def, GSYM fn_minus_def, FN_MINUS_POS, FN_PLUS_POS_ID,
                    IN_MEASURABLE_BOREL_FN_MINUS, GSYM fn_plus_def, FN_MINUS_POS_ZERO,
                    pos_fn_integral_zero, num_not_infty]
- >> METIS_TAC []);
+QED
 
 (* added `measure m (m_space m) < PosInf` into antecedents, otherwise not true *)
 val integrable_const = store_thm
@@ -5369,12 +5392,15 @@ val integrable_zero = store_thm
                     pos_fn_integral_zero, num_not_infty]);
 
 (* Theorem 10.3 (i) <-> (ii) [1, p.84] *)
-val integrable_plus_minus = store_thm
-  ("integrable_plus_minus",
-  ``!m f. measure_space m ==>
+Theorem integrable_plus_minus :
+    !m f. measure_space m ==>
          (integrable m f <=> f IN measurable (m_space m, measurable_sets m) Borel /\
-                             integrable m (fn_plus f) /\ integrable m (fn_minus f))``,
-    RW_TAC std_ss [integrable_def, GSYM fn_plus_def, GSYM fn_minus_def]
+                             integrable m (fn_plus f) /\ integrable m (fn_minus f))
+Proof
+    rpt STRIP_TAC
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
+ >> RW_TAC std_ss [integrable_def, GSYM fn_plus_def, GSYM fn_minus_def]
  >> `fn_plus (fn_minus f) = fn_minus f` by METIS_TAC [FN_MINUS_POS, FN_PLUS_POS_ID]
  >> `fn_minus (fn_minus f) = (\x. 0)` by METIS_TAC [FN_MINUS_POS, FN_MINUS_POS_ZERO]
  >> `fn_plus (fn_plus f) = fn_plus f` by METIS_TAC [FN_PLUS_POS, FN_PLUS_POS_ID]
@@ -5383,7 +5409,8 @@ val integrable_plus_minus = store_thm
  >> `(\x. fn_plus f x) = fn_plus f` by METIS_TAC []
  >> EQ_TAC
  >> RW_TAC std_ss [IN_MEASURABLE_BOREL_FN_PLUS, IN_MEASURABLE_BOREL_FN_MINUS,
-                   pos_fn_integral_zero, num_not_infty]);
+                   pos_fn_integral_zero, num_not_infty]
+QED
 
 (* added ‘x IN m_space m’ *)
 Theorem integrable_add_pos :
@@ -5391,7 +5418,10 @@ Theorem integrable_add_pos :
            (!x. x IN m_space m ==> 0 <= f x) /\
            (!x. x IN m_space m ==> 0 <= g x) ==> integrable m (\x. f x + g x)
 Proof
-    RW_TAC std_ss []
+    rpt STRIP_TAC
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
+ >> RW_TAC std_ss []
  >> `!x. x IN m_space m ==> 0 <= (\x. f x + g x) x` by RW_TAC real_ss [le_add]
  >> `f IN measurable (m_space m,measurable_sets m) Borel` by METIS_TAC [integrable_def]
  >> `g IN measurable (m_space m,measurable_sets m) Borel` by METIS_TAC [integrable_def]
@@ -5529,6 +5559,8 @@ Theorem integrable_add :
         ==> integrable m (\x. f x + g x)
 Proof
     RW_TAC std_ss []
+ >> ‘sigma_algebra (measurable_space m)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
  >> Know `(\x. f x + g x) IN measurable (m_space m, measurable_sets m) Borel`
  >- (MATCH_MP_TAC IN_MEASURABLE_BOREL_ADD \\
      qexistsl_tac [`f`, `g`] >> simp [] \\
@@ -5547,6 +5579,9 @@ Proof
  >> MATCH_MP_TAC FN_MINUS_ADD_LE
  >> METIS_TAC []
 QED
+
+
+(* TODO *)
 
 val integrable_cmul = store_thm
   ("integrable_cmul",

--- a/src/probability/probabilityScript.sml
+++ b/src/probability/probabilityScript.sml
@@ -5211,10 +5211,6 @@ Theorem converge_LP_alt_pow =
         SIMP_RULE std_ss [absolute_moment_def, sub_rzero]
                   converge_LP_alt_absolute_moment;
 
-
-(* TODO *)
-
-
 (* Theorem 4.1.1 [1, p.69] (2) *)
 Theorem converge_AE_alt_sup :
     !p X Y. prob_space p /\ (!n. real_random_variable (X n) p) /\
@@ -5239,6 +5235,8 @@ Proof
      EQ_TAC >> RW_TAC std_ss [] \\
      POP_ASSUM (STRIP_ASSUME_TAC o
                  (REWRITE_RULE [LESS_EQ_REFL]) o (Q.SPEC `m`))) >> Rewr'
+ >> ‘sigma_algebra (measurable_space p)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA, prob_space_def]
  >> Know `!e n. {x | x IN p_space p /\ abs (X n x - Y x) <= e} IN events p`
  >- (RW_TAC std_ss [abs_bounds] \\
      Q.ABBREV_TAC `f = \x. X n x - Y x` \\
@@ -5456,6 +5454,8 @@ Proof
      EQ_TAC >> RW_TAC std_ss [] \\
      POP_ASSUM (STRIP_ASSUME_TAC o
                  (REWRITE_RULE [LESS_EQ_REFL]) o (Q.SPEC `m`))) >> Rewr'
+ >> ‘sigma_algebra (measurable_space p)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA, prob_space_def]
  >> fs [real_random_variable_def]
  >> Know `!e n. {x | x IN p_space p /\ abs (X n x - Y x) <= e} IN events p`
  >- (RW_TAC std_ss [abs_bounds] \\
@@ -5567,6 +5567,8 @@ Proof
  >> Know `!n. D n SUBSET B n`
  >- (RW_TAC set_ss [Abbr `D`, Abbr `B`, SUBSET_DEF] \\
      Q.EXISTS_TAC `n` >> art [LESS_EQ_REFL]) >> DISCH_TAC
+ >> ‘sigma_algebra (measurable_space p)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA, prob_space_def]
  >> Q.ABBREV_TAC `f = \n x. X n x - Y x`
  >> Know `!n. (f n) IN measurable (m_space p,measurable_sets p) Borel`
  >- (GEN_TAC >> Q.UNABBREV_TAC `f` >> BETA_TAC \\
@@ -5675,6 +5677,8 @@ Proof
  >> rpt STRIP_TAC
  >> fs [real_random_variable_def]
  >> Q.ABBREV_TAC `f = \n x. X n x - Y x`
+ >> ‘sigma_algebra (measurable_space p)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA, prob_space_def]
  >> Know `!n. (f n) IN measurable (m_space p,measurable_sets p) Borel`
  >- (GEN_TAC >> Q.UNABBREV_TAC `f` >> BETA_TAC \\
      MATCH_MP_TAC IN_MEASURABLE_BOREL_SUB \\
@@ -5725,6 +5729,8 @@ Proof
              (prob p (limsup (\n. {x | x IN p_space p /\ e < abs (X n x - Y x)})) = 0))`
  >- METIS_TAC []
  >> rpt STRIP_TAC
+ >> ‘sigma_algebra (measurable_space p)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA, prob_space_def]
  >> fs [real_random_variable_def]
  >> Q.ABBREV_TAC `f = \n x. X n x - Y x`
  >> Know `!n. (f n) IN measurable (m_space p,measurable_sets p) Borel`
@@ -5824,6 +5830,8 @@ Proof
  >> `real_random_variable (\x. 0) p` by PROVE_TAC [real_random_variable_zero]
  >> RW_TAC real_ss [converge_LP_alt_pow, converge_PR_def, LIM_SEQUENTIALLY,
                     dist, expectation_def, sub_rzero, REAL_SUB_RZERO]
+ >> ‘sigma_algebra (measurable_space p)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA, prob_space_def]
  >> fs [real_random_variable_def]
  >> rename1 `0 < d` (* the last assumption *)
  >> Know `!n. {x | x IN p_space p /\ e < abs (X n x)} IN events p`
@@ -5935,8 +5943,7 @@ Proof
      {x | Normal (E pow k) <= (\x. abs (X n x) pow k) x} INTER m_space p`
         by SET_TAC [] >> POP_ORW \\
      Suff `(\x. abs (X n x) pow k) IN measurable (m_space p,measurable_sets p) Borel`
-     >- (DISCH_THEN (REWRITE_TAC o wrap o
-                     (MATCH_MP IN_MEASURABLE_BOREL_ALL_MEASURE))) \\
+     >- rw [IN_MEASURABLE_BOREL_ALL_MEASURE] \\
     `!x. abs (X n x) = (\x. abs (X n x)) x` by METIS_TAC [] >> POP_ORW \\
      MATCH_MP_TAC IN_MEASURABLE_BOREL_POW \\
      MATCH_MP_TAC IN_MEASURABLE_BOREL_ABS >> Q.EXISTS_TAC `X n` \\
@@ -6248,6 +6255,8 @@ Proof
  >> rw [MAX_LE]
  >> NTAC 2 (Q.PAT_X_ASSUM ‘!n. _ <= n ==> P’ (MP_TAC o (Q.SPEC ‘n’)))
  >> RW_TAC std_ss []
+ >> ‘sigma_algebra (measurable_space p)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA, prob_space_def]
  (* stage work *)
  >> Know `!Z b. real_random_variable Z p ==>
                 {x | x IN p_space p /\ b < abs (Z x)} IN events p`
@@ -6839,6 +6848,8 @@ Theorem expectation_bounds :
           suminf (\n. prob p {x | x IN p_space p /\ &SUC n <= abs (X x)})
 Proof
     rpt GEN_TAC >> STRIP_TAC
+ >> ‘sigma_algebra (measurable_space p)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA, prob_space_def]
  >> Q.ABBREV_TAC ‘A = \n. {x | x IN p_space p /\ &n <= abs (X x) /\ abs (X x) < &SUC n}’
  >> Know ‘!n. A n IN events p’
  >- (RW_TAC std_ss [Abbr ‘A’] \\
@@ -7400,6 +7411,8 @@ Proof
  >> MATCH_MP_TAC let_trans
  >> Q.EXISTS_TAC ‘1 + suminf (\n. prob p {x | x IN p_space p /\ &SUC n <= abs (X x)})’
  >> FULL_SIMP_TAC std_ss [GSYM lt_infty]
+ >> ‘sigma_algebra (measurable_space p)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA, prob_space_def]
  >> Know ‘suminf (\n. prob p {x | x IN p_space p /\ &SUC n <= abs (X x)}) <> NegInf’
  >- (MATCH_MP_TAC pos_not_neginf \\
      MATCH_MP_TAC ext_suminf_pos >> rw [] \\
@@ -7588,7 +7601,7 @@ Proof
  (* applying integral_cong_measure *)
  >> ‘prob_space (space Borel,subsets Borel,distribution p (X i)) /\
      prob_space (space Borel,subsets Borel,distribution p (X n))’
-       by METIS_TAC [distribution_prob_space]
+       by METIS_TAC [distribution_prob_space, SIGMA_ALGEBRA_BOREL]
  >> MATCH_MP_TAC integrable_cong_measure
  >> fs [prob_space_def]
 QED
@@ -7642,7 +7655,7 @@ Proof
  (* applying integral_cong_measure *)
  >> ‘prob_space (space Borel,subsets Borel,distribution p (X i)) /\
      prob_space (space Borel,subsets Borel,distribution p (X n))’
-       by METIS_TAC [distribution_prob_space]
+       by METIS_TAC [distribution_prob_space, SIGMA_ALGEBRA_BOREL]
  >> MATCH_MP_TAC integral_cong_measure
  >> fs [prob_space_def]
 QED
@@ -7771,11 +7784,13 @@ Proof
  >> Q.ABBREV_TAC ‘f = \x. (X x,Y x)’
  >> Q.ABBREV_TAC ‘u = \(x,y). x * (y :extreal)’
  >> ‘(\x. X x * Y x) = u o f’ by rw [Abbr ‘u’, Abbr ‘f’, o_DEF] >> POP_ORW
+ >> ‘sigma_algebra (measurable_space p)’
+      by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA, prob_space_def]
  (* applying MEASURABLE_PROD_SIGMA' *)
  >> Know ‘f IN measurable (m_space p,measurable_sets p) (Borel CROSS Borel)’
  >- (MATCH_MP_TAC MEASURABLE_PROD_SIGMA' \\
-     STRONG_CONJ_TAC >- fs [measure_space_def] >> DISCH_TAC \\
-     rw [Abbr ‘f’, o_DEF, ETA_AX])
+     simp [Abbr ‘f’, o_DEF, ETA_AX] \\
+     MP_TAC SIGMA_ALGEBRA_BOREL >> rw [sigma_algebra_def, algebra_def])
  >> DISCH_TAC
  >> Know ‘u IN measurable (Borel CROSS Borel) Borel’
  >- (Q.UNABBREV_TAC ‘u’ \\
@@ -7892,8 +7907,7 @@ Proof
  >> Q.PAT_X_ASSUM ‘f IN measurable (m_space p,measurable_sets p) (Borel CROSS Borel)’ K_TAC
  >> Q.UNABBREV_TAC ‘f’
  (* applying Fubini; finiteness / integrability is needed here. *)
- >> Know ‘integral (m1 CROSS m2) u =
-          integral m2 (\y. integral m1 (\x. u (x,y)))’
+ >> Know ‘integral (m1 CROSS m2) u = integral m2 (\y. integral m1 (\x. u (x,y)))’
  >- (MP_TAC (ISPECL [“m1 :extreal m_space”, “m2 :extreal m_space”,
                      “u :extreal # extreal -> extreal”] Fubini) \\
      Know ‘((m_space m1,measurable_sets m1) CROSS
@@ -7986,7 +8000,7 @@ Proof
        >- (MATCH_MP_TAC pos_fn_integral_distr \\
            rw [FN_PLUS_POS, SIGMA_ALGEBRA_BOREL] \\
            MATCH_MP_TAC IN_MEASURABLE_BOREL_FN_PLUS \\
-           REWRITE_TAC [IN_MEASURABLE_BOREL_BOREL_I]) >> Rewr' \\
+           REWRITE_TAC [IN_MEASURABLE_BOREL_BOREL_I, SIGMA_ALGEBRA_BOREL]) >> Rewr' \\
       ‘(fn_plus (\x. x) o X) = fn_plus X’ by rw [fn_plus_def, o_DEF] >> POP_ORW \\
        fs [integrable_def],
        (* goal 2 (of 2) *)
@@ -7995,7 +8009,7 @@ Proof
        >- (MATCH_MP_TAC pos_fn_integral_distr \\
            rw [FN_MINUS_POS, SIGMA_ALGEBRA_BOREL] \\
            MATCH_MP_TAC IN_MEASURABLE_BOREL_FN_MINUS \\
-           REWRITE_TAC [IN_MEASURABLE_BOREL_BOREL_I]) >> Rewr' \\
+           REWRITE_TAC [IN_MEASURABLE_BOREL_BOREL_I, SIGMA_ALGEBRA_BOREL]) >> Rewr' \\
       ‘(fn_minus (\x. x) o X) = fn_minus X’ by rw [fn_minus_def, o_DEF] >> POP_ORW \\
        fs [integrable_def] ])
  >> Rewr'
@@ -8597,7 +8611,7 @@ Theorem pdf_le_pos :
 Proof
     rpt STRIP_TAC
  >> `measure_space (space Borel, subsets Borel, distribution p X)`
-       by PROVE_TAC [distribution_prob_space, prob_space_def]
+       by PROVE_TAC [distribution_prob_space, prob_space_def, SIGMA_ALGEBRA_BOREL]
  >> ASSUME_TAC SIGMA_FINITE_LBOREL
  >> ASSUME_TAC MEASURE_SPACE_LBOREL
  >> MP_TAC (ISPECL [(* m *) ``ext_lborel``,
@@ -8616,7 +8630,7 @@ Theorem expectation_pdf_1 :
 Proof
     rpt STRIP_TAC
  >> `prob_space (space Borel, subsets Borel, distribution p X)`
-       by PROVE_TAC [distribution_prob_space]
+       by PROVE_TAC [distribution_prob_space, SIGMA_ALGEBRA_BOREL]
  >> NTAC 2 (POP_ASSUM MP_TAC) >> KILL_TAC
  >> RW_TAC std_ss [prob_space_def, p_space_def, m_space_def, measure_def,
                    expectation_def]

--- a/src/probability/real_borelScript.sml
+++ b/src/probability/real_borelScript.sml
@@ -16,7 +16,6 @@
 (*            Contact:  <m_qasi@ece.concordia.ca>                            *)
 (*                                                                           *)
 (* Note: This theory is inspired by Isabelle/HOL                             *)
-(*                                                                           *)
 (* ------------------------------------------------------------------------- *)
 
 open HolKernel Parse boolLib bossLib;
@@ -81,17 +80,16 @@ val sigma_algebra_borel = store_thm
    >> MATCH_MP_TAC SIGMA_ALGEBRA_SIGMA
    >> RW_TAC std_ss [subset_class_def, IN_UNIV, IN_IMAGE, SUBSET_DEF]);
 
-val in_borel_measurable_open = store_thm
-  ("in_borel_measurable_open",
-  ``!f M. f IN borel_measurable M <=>
-          (sigma_algebra M) /\
+(* NOTE: removed ‘sigma_algebra M’ due to changes of ‘measurable’ *)
+Theorem in_borel_measurable_open :
+    !f M. f IN borel_measurable M <=>
           (!s. s IN subsets (sigma UNIV {s | open s}) ==>
-           (PREIMAGE f s) INTER (space M) IN subsets M)``,
+           (PREIMAGE f s) INTER (space M) IN subsets M)
+Proof
   REPEAT GEN_TAC THEN RW_TAC std_ss [measurable_def] THEN
   SIMP_TAC std_ss [GSPECIFICATION] THEN EQ_TAC THEN REPEAT STRIP_TAC THEN
   FULL_SIMP_TAC std_ss [] THENL
   [FIRST_X_ASSUM MATCH_MP_TAC THEN ASM_SIMP_TAC std_ss [borel],
-   SIMP_TAC std_ss [sigma_algebra_borel],
    EVAL_TAC THEN SIMP_TAC std_ss [borel, sigma_def, space_def] THEN
    SIMP_TAC std_ss [IN_UNIV] THEN SIMP_TAC std_ss [IN_DEF] THEN rw[IN_FUNSET],
    FIRST_X_ASSUM MATCH_MP_TAC THEN POP_ASSUM MP_TAC THEN
@@ -99,12 +97,13 @@ val in_borel_measurable_open = store_thm
    SIMP_TAC std_ss [GSPECIFICATION] THEN REPEAT STRIP_TAC THEN
    FIRST_X_ASSUM MATCH_MP_TAC THEN REWRITE_TAC [SUBSET_DEF, sigma_sets_basic] THEN
    MATCH_MP_TAC sigma_algebra_sigma_sets THEN REWRITE_TAC [POW_DEF] THEN
-   SET_TAC []]);
+   SET_TAC []]
+QED
 
+(* NOTE: removed ‘sigma_algebra M’ due to changes of ‘measurable’ *)
 val in_borel_measurable_borel = store_thm
   ("in_borel_measurable_borel",
   ``!f M. f IN borel_measurable M <=>
-          (sigma_algebra M) /\
           (!s. s IN subsets borel ==> (PREIMAGE f s) INTER (space M) IN subsets M)``,
   SIMP_TAC std_ss [in_borel_measurable_open, borel]);
 
@@ -717,10 +716,10 @@ Proof
       rw [] >> Q.EXISTS_TAC ‘i’ >> REWRITE_TAC [] ]
 QED
 
+(* NOTE: removed ‘sigma_algebra s’ due to changes in ‘measurable’ *)
 val in_borel_measurable = store_thm
   ("in_borel_measurable",
    ``!f s. f IN borel_measurable s <=>
-           sigma_algebra s /\
            (!s'. s' IN subsets (sigma UNIV (IMAGE (\a. {x | x <= a}) UNIV)) ==>
                  PREIMAGE f s' INTER space s IN subsets s)``,
    RW_TAC std_ss [IN_MEASURABLE, borel_def,
@@ -756,11 +755,15 @@ val borel_measurable_indicator = store_thm
         by (RW_TAC std_ss [Once EXTENSION, IN_INTER, IN_PREIMAGE, NOT_IN_EMPTY] >> METIS_TAC [])
    >> POP_ORW >> FULL_SIMP_TAC std_ss [SIGMA_ALGEBRA, algebra_def]);
 
-(* cf. IN_MEASURABLE_BOREL_RC in borelTheory *)
+(* NOTE: moved ‘sigma_algebra m’ to antecedents due to changes of ‘measurable’
+
+   cf. IN_MEASURABLE_BOREL_RC in borelTheory
+ *)
 Theorem in_borel_measurable_le :
-    !f m. f IN borel_measurable m <=>
-          sigma_algebra m /\ f IN (space m -> UNIV) /\
-          !a. {w | w IN space m /\ f w <= a} IN subsets m
+    !f m. sigma_algebra m ==>
+         (f IN borel_measurable m <=>
+          f IN (space m -> UNIV) /\
+          !a. {w | w IN space m /\ f w <= a} IN subsets m)
 Proof
    rpt STRIP_TAC >> EQ_TAC
    >- (RW_TAC std_ss [in_borel_measurable, subsets_def, space_def,
@@ -802,8 +805,10 @@ val sigma_le_less = store_thm
             >> POP_ORW
             >> RW_TAC std_ss [GSPECIFICATION]
             >> EQ_TAC
-            >- (RW_TAC std_ss [] >- METIS_TAC [] >> MATCH_MP_TAC REAL_LET_TRANS >> Q.EXISTS_TAC `a - inv (& (SUC n))`
-                >> RW_TAC real_ss [REAL_LT_SUB_RADD, REAL_LT_ADDR, REAL_LT_INV_EQ] >> METIS_TAC [])
+            >- (RW_TAC std_ss [] >- METIS_TAC []
+                >> MATCH_MP_TAC REAL_LET_TRANS >> Q.EXISTS_TAC `a - inv (& (SUC n))`
+                >> RW_TAC real_ss [REAL_LT_SUB_RADD, REAL_LT_ADDR, REAL_LT_INV_EQ]
+                >> METIS_TAC [])
             >> RW_TAC std_ss []
             >> `(\n. inv (($& o SUC) n)) --> 0`
                 by (MATCH_MP_TAC SEQ_INV0
@@ -852,7 +857,8 @@ val sigma_ge_gr = store_thm
             >> POP_ORW
             >> RW_TAC std_ss [GSPECIFICATION]
             >> EQ_TAC
-            >- (RW_TAC std_ss [] >- ASM_REWRITE_TAC [] >> MATCH_MP_TAC REAL_LET_TRANS >> Q.EXISTS_TAC `f x - inv (& (SUC n))`
+            >- (RW_TAC std_ss [] >- ASM_REWRITE_TAC []
+                >> MATCH_MP_TAC REAL_LET_TRANS >> Q.EXISTS_TAC `f x - inv (& (SUC n))`
                 >> RW_TAC real_ss [REAL_LT_SUB_RADD, REAL_LT_ADDR, REAL_LT_INV_EQ])
             >> RW_TAC std_ss []
             >> `(\n. inv (($& o SUC) n)) --> 0`
@@ -887,10 +893,12 @@ val sigma_gr_le = store_thm
    >> POP_ORW
    >> METIS_TAC [SIGMA_ALGEBRA]);
 
+(* NOTE: moved ‘sigma_algebra m’ to antecedents due to changes of ‘measurable’ *)
 Theorem in_borel_measurable_gr :
-    !f m. f IN borel_measurable m <=>
-          sigma_algebra m /\ f IN (space m -> UNIV) /\
-          !a. {w | w IN space m /\ a < f w} IN subsets m
+    !f m. sigma_algebra m  ==>
+         (f IN borel_measurable m <=>
+          f IN (space m -> UNIV) /\
+          !a. {w | w IN space m /\ a < f w} IN subsets m)
 Proof
    RW_TAC std_ss [in_borel_measurable_le]
    >> EQ_TAC
@@ -905,10 +913,12 @@ Proof
    >> METIS_TAC [sigma_gr_le, SPACE, subsets_def, space_def]
 QED
 
+(* NOTE: moved ‘sigma_algebra m’ to antecedents due to changes of ‘measurable’ *)
 Theorem in_borel_measurable_less :
-    !f m. f IN borel_measurable m <=>
-          sigma_algebra m /\ f IN (space m -> UNIV) /\
-          !a. {w | w IN space m /\ f w < a} IN subsets m
+    !f m. sigma_algebra m ==>
+         (f IN borel_measurable m <=>
+          f IN (space m -> UNIV) /\
+          !a. {w | w IN space m /\ f w < a} IN subsets m)
 Proof
    RW_TAC std_ss [in_borel_measurable_le, IN_FUNSET, IN_UNIV]
    >> EQ_TAC
@@ -964,10 +974,12 @@ Proof
    >> METIS_TAC []
 QED
 
+(* NOTE: moved ‘sigma_algebra m’ to antecedents due to changes of ‘measurable’ *)
 Theorem in_borel_measurable_ge :
-    !f m. f IN borel_measurable m <=>
-          sigma_algebra m /\ f IN (space m -> UNIV) /\
-          !a. {w | w IN space m /\ a <= f w} IN subsets m
+    !f m. sigma_algebra m ==>
+         (f IN borel_measurable m <=>
+          f IN (space m -> UNIV) /\
+          !a. {w | w IN space m /\ a <= f w} IN subsets m)
 Proof
    RW_TAC std_ss [in_borel_measurable_less, IN_FUNSET, IN_UNIV]
    >> EQ_TAC
@@ -1245,18 +1257,18 @@ Proof
       REWRITE_TAC [real_sub] ]
 QED
 
-Theorem in_borel_measurable_sqr :
+Theorem in_borel_measurable_pow2 : (* was: in_borel_measurable_sqr *)
     !a f g. sigma_algebra a /\ f IN measurable a borel /\
             (!x. x IN space a ==> (g x = (f x) pow 2)) ==> g IN measurable a borel
 Proof
     rpt STRIP_TAC
  >> Know `!c. {x | f x <= c} INTER space a IN subsets a`
- >- (GEN_TAC >> fs [in_borel_measurable_le, IN_FUNSET, IN_UNIV] \\
+ >- (GEN_TAC >> rfs [in_borel_measurable_le, IN_FUNSET, IN_UNIV] \\
     ‘{x | f x <= c} INTER space a = {x | x IN space a /\ f x <= c}’ by SET_TAC [] \\
      POP_ORW >> art [])
  >> DISCH_TAC
  >> Know `!c. {x | c <= f x} INTER space a IN subsets a`
- >- (GEN_TAC >> fs [in_borel_measurable_ge, IN_FUNSET, IN_UNIV] \\
+ >- (GEN_TAC >> rfs [in_borel_measurable_ge, IN_FUNSET, IN_UNIV] \\
     ‘{x | c <= f x} INTER space a = {x | x IN space a /\ c <= f x}’ by SET_TAC [] \\
      POP_ORW >> art [])
  >> DISCH_TAC
@@ -1334,24 +1346,28 @@ Proof
       Q.EXISTS_TAC `(\x. f x pow 2)` \\
       RW_TAC std_ss [] >| (* 2 subgoals *)
       [ (* goal 1.1 (of 2) *)
-        MATCH_MP_TAC in_borel_measurable_sqr \\
+        MATCH_MP_TAC in_borel_measurable_pow2 \\
         Q.EXISTS_TAC `(\x. f x + g x)` \\
         RW_TAC std_ss [] \\
         MATCH_MP_TAC in_borel_measurable_add \\
         qexistsl_tac [`f`, `g`] \\
         RW_TAC std_ss [],
         (* goal 1.2 (of 2) *)
-        MATCH_MP_TAC in_borel_measurable_sqr >> METIS_TAC [] ],
+        MATCH_MP_TAC in_borel_measurable_pow2 >> METIS_TAC [] ],
       (* goal 2 (of 2) *)
-      MATCH_MP_TAC in_borel_measurable_sqr >> METIS_TAC [] ]
+      MATCH_MP_TAC in_borel_measurable_pow2 >> METIS_TAC [] ]
 QED
 
-(* cf. borelTheory.IN_MEASURABLE_BOREL_MAX *)
+(* NOTE: added ‘sigma_algebra a’ due to changes in ‘measurable’
+
+   cf. borelTheory.IN_MEASURABLE_BOREL_MAX
+ *)
 Theorem in_borel_measurable_max :
-    !a f g. f IN measurable a borel /\ g IN measurable a borel
+    !a f g. sigma_algebra a /\ f IN measurable a borel /\ g IN measurable a borel
         ==> (\x. max (f x) (g x)) IN measurable a borel
 Proof
     RW_TAC std_ss [in_borel_measurable_less, max_def, IN_FUNSET, IN_UNIV]
+ >> rfs [in_borel_measurable_less]
  >> `!c. {x | x IN space a /\ (if f x <= g x then g x else f x) < c} =
          {x | x IN space a /\ f x < c} INTER
          {x | x IN space a /\ g x < c}`
@@ -1362,12 +1378,16 @@ Proof
  >> MATCH_MP_TAC SIGMA_ALGEBRA_INTER >> art []
 QED
 
-(* cf. borelTheory.IN_MEASURABLE_BOREL_MIN *)
+(* NOTE: added ‘sigma_algebra a’ due to changes in ‘measurable’
+
+   cf. borelTheory.IN_MEASURABLE_BOREL_MIN
+ *)
 Theorem in_borel_measurable_min :
-    !a f g. f IN measurable a borel /\ g IN measurable a borel
+    !a f g. sigma_algebra a /\ f IN measurable a borel /\ g IN measurable a borel
         ==> (\x. min (f x) (g x)) IN measurable a borel
 Proof
     RW_TAC std_ss [in_borel_measurable_less, min_def, IN_FUNSET, IN_UNIV]
+ >> rfs [in_borel_measurable_less]
  >> `!c. {x | x IN space a /\ (if f x <= g x then f x else g x) < c} =
          {x | x IN space a /\ f x < c} UNION
          {x | x IN space a /\ g x < c}`
@@ -1378,13 +1398,15 @@ Proof
  >> MATCH_MP_TAC SIGMA_ALGEBRA_UNION >> art []
 QED
 
-(* cf. borelTheory.IN_MEASURABLE_BOREL_LT *)
+(* NOTE: added ‘sigma_algebra a’ due to changes in ‘measurable’
+
+   cf. borelTheory.IN_MEASURABLE_BOREL_LT
+ *)
 Theorem in_borel_measurable_lt2 :
-    !a f g. f IN measurable a borel /\ g IN measurable a borel ==>
+    !a f g. sigma_algebra a /\ f IN measurable a borel /\ g IN measurable a borel ==>
             {x | x IN space a /\ f x < g x} IN subsets a
 Proof
     RW_TAC std_ss []
- >> ‘sigma_algebra a’ by PROVE_TAC [in_borel_measurable]
  >> `{x | x IN space a /\ f x < g x} =
       BIGUNION (IMAGE (\r. {x | f x < r /\ r < g x} INTER space a) q_set)`
         by (RW_TAC std_ss [EXTENSION, GSPECIFICATION, IN_BIGUNION_IMAGE, IN_INTER] \\
@@ -1401,18 +1423,19 @@ Proof
  >> MATCH_MP_TAC SIGMA_ALGEBRA_INTER >> art []
  >> CONJ_TAC
  >| [ (* goal 1 (of 2) *)
-      Q.PAT_X_ASSUM ‘f IN borel_measurable a’
-         (MP_TAC o (SIMP_RULE (srw_ss()) [in_borel_measurable_less, IN_FUNSET])) \\
-      RW_TAC std_ss [],
+      Q.PAT_X_ASSUM ‘f IN borel_measurable a’ MP_TAC \\
+      rw [in_borel_measurable_less, IN_FUNSET],
       (* goal 2 (of 2) *)
-      Q.PAT_X_ASSUM ‘g IN borel_measurable a’
-         (MP_TAC o (SIMP_RULE (srw_ss()) [in_borel_measurable_gr, IN_FUNSET])) \\
-      RW_TAC std_ss [] ]
+      Q.PAT_X_ASSUM ‘g IN borel_measurable a’ MP_TAC \\
+      rw [in_borel_measurable_gr, IN_FUNSET] ]
 QED
 
-(* cf. borelTheory.IN_MEASURABLE_BOREL_LE *)
+(* NOTE: added ‘sigma_algebra a’ due to changes in ‘measurable’
+
+   cf. borelTheory.IN_MEASURABLE_BOREL_LE
+ *)
 Theorem in_borel_measurable_le2 :
-    !a f g. f IN measurable a borel /\ g IN measurable a borel ==>
+    !a f g. sigma_algebra a /\ f IN measurable a borel /\ g IN measurable a borel ==>
             {x | x IN space a /\ f x <= g x} IN subsets a
 Proof
     RW_TAC std_ss []
@@ -1425,13 +1448,17 @@ Proof
  >> fs [in_borel_measurable]
 QED
 
-(* cf. borelTheory.IN_MEASURABLE_BOREL_MUL_INDICATOR *)
+(* NOTE: added ‘sigma_algebra a’ due to changes in ‘measurable’
+
+   cf. borelTheory.IN_MEASURABLE_BOREL_MUL_INDICATOR
+ *)
 Theorem in_borel_measurable_mul_indicator :
-    !a f s. f IN measurable a borel /\ s IN subsets a ==>
+    !a f s. sigma_algebra a /\ f IN measurable a borel /\ s IN subsets a ==>
             (\x. f x * indicator_fn s x) IN measurable a borel
 Proof
-    RW_TAC std_ss [in_borel_measurable_le, IN_FUNSET, IN_UNIV]
- >> rename1 ‘{x | x IN space a /\ f x * indicator_fn s x <= c} IN subsets a’
+    rpt STRIP_TAC
+ >> rfs [in_borel_measurable_le, IN_FUNSET]
+ >> Q.X_GEN_TAC ‘c’
  >> Cases_on `0 <= c`
  >- (`{x | x IN space a /\ f x * indicator_fn s x <= c} =
       ({x | x IN space a /\ f x <= c} INTER s) UNION (space a DIFF s)`

--- a/src/probability/real_probabilityScript.sml
+++ b/src/probability/real_probabilityScript.sml
@@ -231,40 +231,44 @@ val PROB_INDEP = store_thm
   ``!p s t u. indep p s t /\ (u = s INTER t) ==> (prob p u = prob p s * prob p t)``,
     RW_TAC std_ss [indep_def]);
 
+(* removed ‘measure_space p1 /\ measure_space p2’ due to changes of ‘measure_preserving’ *)
 val PROB_PRESERVING = store_thm
   ("PROB_PRESERVING",
   ``!p1 p2.
        prob_preserving p1 p2 =
        {f | f IN measurable (p_space p1, events p1) (p_space p2, events p2) /\
-             measure_space p1 /\ measure_space p2 /\
         !s. s IN events p2 ==> (prob p1 ((PREIMAGE f s)INTER(p_space p1)) = prob p2 s)}``,
     RW_TAC std_ss [prob_preserving_def, measure_preserving_def, events_def,
                    prob_def, p_space_def]);
 
+(* NOTE: added ‘measure_space (m_space p2,a,measure p2)’ due to changes of ‘measurable’ *)
 val PROB_PRESERVING_SUBSET = store_thm
   ("PROB_PRESERVING_SUBSET",
   ``!p1 p2 a.
        prob_space p1 /\ prob_space p2 /\
+       measure_space (m_space p2,a,measure p2) /\
        (events p2 = subsets (sigma (p_space p2) a)) ==>
        prob_preserving p1 (p_space p2, a, prob p2) SUBSET
        prob_preserving p1 p2``,
     RW_TAC std_ss [prob_space_def, prob_preserving_def, prob_def, events_def, p_space_def]
- >> PROVE_TAC [MEASURE_PRESERVING_SUBSET]);
+ >> MATCH_MP_TAC MEASURE_PRESERVING_SUBSET >> art []);
 
+(* NOTE: added ‘measure_space (m_space p2,a,measure p2)’ due to changes of ‘measurable’ *)
 val PROB_PRESERVING_LIFT = store_thm
   ("PROB_PRESERVING_LIFT",
   ``!p1 p2 a f.
        prob_space p1 /\ prob_space p2 /\
+       measure_space (m_space p2,a,measure p2) /\
        (events p2 = subsets (sigma (m_space p2) a)) /\
        f IN prob_preserving p1 (m_space p2, a, prob p2) ==>
        f IN prob_preserving p1 p2``,
     RW_TAC std_ss [prob_space_def, prob_preserving_def, prob_def, events_def, p_space_def]
  >> PROVE_TAC [MEASURE_PRESERVING_LIFT]);
 
+(* NOTE: removed unnecessary antecedent ‘prob_space p1’ *)
 val PROB_PRESERVING_UP_LIFT = store_thm
   ("PROB_PRESERVING_UP_LIFT",
   ``!p1 p2 f.
-       prob_space p1 /\
        f IN prob_preserving (p_space p1, a, prob p1) p2 /\
        sigma_algebra (p_space p1, events p1) /\
        a SUBSET events p1 ==>
@@ -272,20 +276,22 @@ val PROB_PRESERVING_UP_LIFT = store_thm
     RW_TAC std_ss [prob_preserving_def, prob_def, events_def, p_space_def, prob_space_def]
  >> PROVE_TAC [MEASURE_PRESERVING_UP_LIFT]);
 
+(* NOTE: removed unnecessary antecedent ‘prob_space p1’ *)
 val PROB_PRESERVING_UP_SUBSET = store_thm
   ("PROB_PRESERVING_UP_SUBSET",
-  ``!p1 p2.
-       prob_space p1 /\
+  ``!p1 p2 a.
        a SUBSET events p1 /\
        sigma_algebra (p_space p1, events p1) ==>
        prob_preserving (p_space p1, a, prob p1) p2 SUBSET prob_preserving p1 p2``,
     RW_TAC std_ss [prob_preserving_def, prob_def, events_def, p_space_def, prob_space_def]
  >> PROVE_TAC [MEASURE_PRESERVING_UP_SUBSET]);
 
+(* NOTE: removed unnecessary antecedent ‘prob_space p1’
+         added ‘subset_class (m_space m1) a’ into antecedents due to changes of ‘measurable’
+ *)
 val PROB_PRESERVING_UP_SIGMA = store_thm
   ("PROB_PRESERVING_UP_SIGMA",
-  ``!p1 p2 a.
-        prob_space p1 /\
+  ``!p1 p2 a. subset_class (p_space p1) a /\
        (events p1 = subsets (sigma (p_space p1) a)) ==>
        prob_preserving (p_space p1, a, prob p1) p2 SUBSET prob_preserving p1 p2``,
     RW_TAC std_ss [prob_preserving_def, prob_def, events_def, p_space_def, prob_space_def]
@@ -907,9 +913,10 @@ val marginal_joint_zero3 = store_thm
            by METIS_TAC [PROB_INCREASING,INTER_SUBSET,IN_POW]
        >> METIS_TAC [PROB_POSITIVE,INTER_SUBSET,IN_POW,REAL_LE_ANTISYM]]);
 
+(* NOTE: added ‘prob_space p /\ sigma_algebra s’ due to changes of ‘measurable’ *)
 val distribution_prob_space = store_thm
   ("distribution_prob_space",
-  ``!p X s. random_variable X p s ==>
+  ``!p X s. prob_space p /\ sigma_algebra s /\ random_variable X p s ==>
                 prob_space (space s, subsets s, distribution p X)``,
    RW_TAC std_ss [random_variable_def, distribution_def, prob_space_def, measure_def, PSPACE,
                   measure_space_def, m_space_def, measurable_sets_def, IN_MEASURABLE,
@@ -946,9 +953,11 @@ val distribution_prob_space = store_thm
    >> FULL_SIMP_TAC std_ss [IN_FUNSET, EXTENSION, IN_PREIMAGE, IN_INTER]
    >> METIS_TAC []);
 
+(* NOTE: added ‘prob_space p /\ sigma_algebra s’ due to changes of ‘measurable’ *)
 val uniform_distribution_prob_space = store_thm
   ("uniform_distribution_prob_space",
-  ``!X p s. FINITE (p_space p) /\ FINITE (space s) /\ random_variable X p s ==>
+  ``!X p s. prob_space p /\ sigma_algebra s /\
+            FINITE (p_space p) /\ FINITE (space s) /\ random_variable X p s ==>
         prob_space (space s, subsets s, uniform_distribution p X s)``,
   RW_TAC std_ss []
   >> `prob_space p` by FULL_SIMP_TAC std_ss [random_variable_def]
@@ -976,28 +985,35 @@ val uniform_distribution_prob_space = store_thm
   >> `CARD (s' UNION t) = CARD s' + CARD t`  by METIS_TAC [CARD_UNION, ADD_0, SUBSET_FINITE]
   >> RW_TAC std_ss [GSYM REAL_ADD, REAL_ADD_RDISTRIB]);
 
+(* NOTE: added ‘prob_space p /\ sigma_algebra s’ due to changes of ‘measurable’ *)
 val distribution_lebesgue_thm1 = store_thm
   ("distribution_lebesgue_thm1",
-  ``!X p s A. random_variable X p s /\ A IN subsets s ==>
+  ``!X p s A. prob_space p /\ sigma_algebra s /\
+              random_variable X p s /\ A IN subsets s ==>
              (distribution p X A = integral p (indicator_fn (PREIMAGE X A INTER p_space p)))``,
-   RW_TAC std_ss [random_variable_def, prob_space_def, distribution_def, events_def, IN_MEASURABLE, p_space_def, prob_def,
+   RW_TAC std_ss [random_variable_def, prob_space_def, distribution_def, events_def,
+		  IN_MEASURABLE, p_space_def, prob_def,
                   subsets_def, space_def, GSYM integral_indicator_fn]);
 
+(* NOTE: added ‘prob_space p /\ sigma_algebra s’ due to changes of ‘measurable’ *)
 val distribution_lebesgue_thm2 = store_thm
   ("distribution_lebesgue_thm2",
-  ``!X p s A. random_variable X p s /\ A IN subsets s ==>
+  ``!X p s A. prob_space p /\ sigma_algebra s /\
+              random_variable X p s /\ A IN subsets s ==>
              (distribution p X A = integral (space s, subsets s, distribution p X) (indicator_fn A))``,
    rpt STRIP_TAC
    >> `prob_space (space s,subsets s,distribution p X)`
         by RW_TAC std_ss [distribution_prob_space]
    >> Q.PAT_X_ASSUM `random_variable X p s` MP_TAC
-   >> RW_TAC std_ss [random_variable_def, prob_space_def, distribution_def, events_def, IN_MEASURABLE, p_space_def, prob_def,
+   >> RW_TAC std_ss [random_variable_def, prob_space_def, distribution_def, events_def,
+		     IN_MEASURABLE, p_space_def, prob_def,
                   subsets_def, space_def]
    >> `measure p (PREIMAGE X A INTER m_space p) =
        measure (space s,subsets s,(\A. measure p (PREIMAGE X A INTER m_space p))) A`
         by RW_TAC std_ss [measure_def]
    >> POP_ORW
-   >> (MP_TAC o Q.SPECL [`(space s,subsets s,(\A. measure p (PREIMAGE X A INTER m_space p)))`,`A`] o INST_TYPE [``:'a``|->``:'b``])
+   >> (MP_TAC o Q.SPECL [`(space s,subsets s,(\A. measure p (PREIMAGE X A INTER m_space p)))`,`A`]
+              o INST_TYPE [``:'a``|->``:'b``])
         integral_indicator_fn
    >> FULL_SIMP_TAC std_ss [measurable_sets_def, prob_space_def, distribution_def, prob_def, p_space_def]);
 
@@ -1127,15 +1143,17 @@ val prob_x_eq_1_imp_prob_y_eq_0 = store_thm
    >- RW_TAC std_ss [Once EXTENSION, NOT_IN_EMPTY, IN_INTER, IN_SING]
    >> METIS_TAC [PROB_EMPTY]);
 
+(* NOTE: added ‘prob_space p’ due to changes of ‘measurable’ *)
 val distribution_x_eq_1_imp_distribution_y_eq_0 = store_thm
   ("distribution_x_eq_1_imp_distribution_y_eq_0",
-  ``!X p x. random_variable X p (IMAGE X (p_space p),POW (IMAGE X (p_space p))) /\
+  ``!X p x. prob_space p /\
+            random_variable X p (IMAGE X (p_space p),POW (IMAGE X (p_space p))) /\
            (distribution p X {x} = 1) ==>
            (!y. y <> x ==> (distribution p X {y} = 0))``,
    rpt STRIP_TAC
    >> (MP_TAC o Q.SPECL [`p`, `X`, `(IMAGE X (p_space p),POW (IMAGE X (p_space p)))`])
               distribution_prob_space
-   >> RW_TAC std_ss [space_def, subsets_def]
+   >> RW_TAC std_ss [space_def, subsets_def, POW_SIGMA_ALGEBRA]
    >> (MP_TAC o Q.ISPECL [`(IMAGE (X :'a -> 'b)
            (p_space
               (p :
@@ -1199,7 +1217,6 @@ val joint_distribution_le2 = store_thm
   >> MATCH_MP_TAC PROB_INCREASING
   >> RW_TAC std_ss [IN_POW,INTER_SUBSET]
   >> RW_TAC std_ss [SUBSET_DEF,IN_PREIMAGE,IN_CROSS,IN_INTER]);
-
 
 val joint_conditional = store_thm
  ("joint_conditional",``!p X Y a b. prob_space p /\ (events p = POW (p_space p)) ==>
@@ -1316,7 +1333,8 @@ Proof
                          space_def, subsets_def, IN_POW, INTER_SUBSET, IN_IMAGE]
           >> METIS_TAC [IN_IMAGE])
  >> Q.ABBREV_TAC `p1 = (IMAGE X (p_space p), POW (IMAGE X (p_space p)), distribution p X)`
- >> `prob_space p1` by METIS_TAC [distribution_prob_space, space_def, subsets_def]
+ >> `prob_space p1` by METIS_TAC [distribution_prob_space, space_def, subsets_def,
+				  POW_SIGMA_ALGEBRA]
  >> (MP_TAC o Q.SPEC `p1` o INST_TYPE [``:'a`` |-> ``:'b``]) PROB_REAL_SUM_IMAGE_SPACE
  >> `FINITE (p_space p1)` by METIS_TAC [PSPACE, IMAGE_FINITE]
  >> `!x. x IN p_space p1 ==> {x} IN events p1`


### PR DESCRIPTION
Hi,

Measurable functions or mappings is a fundamental concept in Measure Theory. In particular, random variables are nothing but measurable mappings from a probability space to a σ-algebra (usually Borel σ-algebra).

But currently its definition (`sigma_algebra$measurable`) is not very flexible:
```
   [measurable_def]  Definition
      ⊢ ∀a b.
          measurable a b =
          {f |
           sigma_algebra a ∧ sigma_algebra b ∧ f ∈ (space a → space b) ∧
           ∀s. s ∈ subsets b ⇒ PREIMAGE f s ∩ space a ∈ subsets a}
```
The problem is at the parts `sigma_algebra a ∧ sigma_algebra b` which requires that, when stating `measurable a b` (the set of measurable mappings from a to b), both `a` and `b` must be σ-algebras.  But sometimes one must work on generators of these σ-algebras, and a very useful lemma says "measurable over generators is equivalent to measurable over the σ-algebra generated". (This σ-algebra is the smallest one containing that generator as a system of sets.)  The hard part of this lemma is supposed to be provided by an existing theorem with correct proof:
```
   [MEASURABLE_LIFT]  Theorem      
      ⊢ ∀f a b.
          f ∈ measurable a b ⇒
          f ∈ measurable a (sigma (space b) (subsets b))
```
But if `measurable a b` implicitly requires that `sigma_algebra b`, we can see that `(sigma (space b) (subsets b))` will be nothing but `b` itself (cf. `SIGMA_STABLE`), then this theorem becomes meaningless (a set is subset of itself).

On the other hand, when `f ∈ measurable a b` occurs as a proof goal, for all the existing cases found in core HOL theories, the proofs (and their textbook versions) only focus on showing `∀s. s ∈ subsets b ⇒ PREIMAGE f s ∩ space a ∈ subsets a`. For the part `sigma_algebra a ∧ sigma_algebra b`, it's either directly provided as antecedents of the related theorem, or is trivial to prove.

In this PR, I have modified the above definition of `measurable` by removing the σ-algebra requirements:
```
   [measurable_def]  Definition      
      ⊢ ∀a b.
          measurable a b =
          {f |
           f ∈ (space a → space b) ∧
           ∀s. s ∈ subsets b ⇒ PREIMAGE f s ∩ space a ∈ subsets a}
```
With this changes, now the above `MEASURABLE_LIFT` is meaningful, by adding just one easy antecedent (making sure that `b` is indeed a system of sets satisfying the `subset_class` relation):
```
   [MEASURABLE_LIFT]  Theorem      
      ⊢ ∀f a b.
          sigma_algebra a ∧ subset_class (space b) (subsets b) ∧
          f ∈ measurable a b ⇒
          f ∈ measurable a (sigma (space b) (subsets b))
```

Many other theorems must be fixed (not hard) due to the above changes. Sometimes they require more antecedents (of σ-algebras), other times some trivial proof branches (after expanding `measurable_def`) cease to exist.  In particular, many theorems in `miller` and `diningcryptos` examples, previous no requirements of `prob_space p` when a probability space `p` is involved, now `prob_space p` must be added. But eventually the final toplevel theorems in these examples have no change in their statements at all. In other words, changed theorem statements only happen at intermediate levels.

Only with this PR, certain more advanced probability theorems can be proved. For example, to show a (finite) sequence of mutually independent random variables, after dividing into two disjoint sets, the functional composition of each sets as new random variables, are still independent.  This independent proof must be done on measurable mappings of carefully chosen  generators, which themselves are not σ-algebras.

Regards,

Chun Tian