### PR TITLE
Updated MiniSAT for HOL-Omega

### DIFF
--- a/src/HolSat/sat_solvers/minisat/File.C
+++ b/src/HolSat/sat_solvers/minisat/File.C
@@ -118,8 +118,11 @@ void putUInt(File& out, uint64 val)
 }
 
 
-uint64 getUInt(File& in)
-    throw(Exception_EOF)
+#if __cplusplus >= 201703L
+uint64 getUInt (File& in) noexcept(false)
+#else
+uint64 getUInt (File& in) throw(Exception_EOF)
+#endif
 {
     uint byte0, byte1, byte2, byte3, byte4, byte5, byte6, byte7;
     byte0 = in.getChar();

--- a/src/HolSat/sat_solvers/minisat/File.h
+++ b/src/HolSat/sat_solvers/minisat/File.h
@@ -15,6 +15,9 @@
 #endif
 
 
+
+
+
 //=================================================================================================
 // A buffered file abstraction with only 'putChar()' and 'getChar()'.
 
@@ -131,7 +134,11 @@ public:
 
 
 void                 putUInt (File& out, uint64 val);
+#if __cplusplus >= 201703L
+uint64               getUInt (File& in) noexcept(false);
+#else
 uint64               getUInt (File& in) throw(Exception_EOF);
+#endif
 static inline uint64 encode64(int64  val)           { return (val >= 0) ? (uint64)val << 1 : (((uint64)(~val) << 1) | 1); }
 static inline int64  decode64(uint64 val)           { return ((val & 1) == 0) ? (int64)(val >> 1) : ~(int64)(val >> 1); }
 static inline void   putInt  (File& out, int64 val) { putUInt(out, encode64(val)); }

--- a/src/HolSat/sat_solvers/minisat/Global.h
+++ b/src/HolSat/sat_solvers/minisat/Global.h
@@ -53,10 +53,6 @@ typedef const char    cchar;
 template<class T> static inline T min(T x, T y) { return (x < y) ? x : y; }
 template<class T> static inline T max(T x, T y) { return (x > y) ? x : y; }
 
-template <bool> struct STATIC_ASSERTION_FAILURE;
-template <> struct STATIC_ASSERTION_FAILURE<true>{};
-#define TEMPLATE_FAIL STATIC_ASSERTION_FAILURE<false>()
-
 
 //=================================================================================================
 // 'malloc()'-style memory allocation -- never returns NULL; aborts instead:
@@ -190,6 +186,10 @@ public:
     // Vector interface:
     const T& operator [] (int index) const  { return data[index]; }
     T&       operator [] (int index)        { return data[index]; }
+
+template <bool> struct STATIC_ASSERTION_FAILURE;
+// template <> struct STATIC_ASSERTION_FAILURE<true>{};
+#define TEMPLATE_FAIL STATIC_ASSERTION_FAILURE<false>()
 
     // Don't allow copying (error prone):
     vec<T>&  operator = (vec<T>& other) { TEMPLATE_FAIL; }

--- a/src/HolSat/sat_solvers/minisat/Main.C
+++ b/src/HolSat/sat_solvers/minisat/Main.C
@@ -72,11 +72,11 @@ void printStats(SolverStats& stats, double& cpu_time, int64& mem_used)
 {
     cpu_time = cpuTime();
     mem_used = memUsed();
-    reportf("restarts              : %"I64_fmt"\n", stats.starts);
-    reportf("conflicts             : %-12"I64_fmt"   (%.0f /sec)\n", stats.conflicts   , stats.conflicts   /cpu_time);
-    reportf("decisions             : %-12"I64_fmt"   (%.0f /sec)\n", stats.decisions   , stats.decisions   /cpu_time);
-    reportf("propagations          : %-12"I64_fmt"   (%.0f /sec)\n", stats.propagations, stats.propagations/cpu_time);
-    reportf("conflict literals     : %-12"I64_fmt"   (%4.2f %% deleted)\n", stats.tot_literals, (stats.max_literals - stats.tot_literals)*100 / (double)stats.max_literals);
+    reportf("restarts              : %" I64_fmt "\n", stats.starts);
+    reportf("conflicts             : %-12" I64_fmt "   (%.0f /sec)\n", stats.conflicts   , stats.conflicts   /cpu_time);
+    reportf("decisions             : %-12" I64_fmt "   (%.0f /sec)\n", stats.decisions   , stats.decisions   /cpu_time);
+    reportf("propagations          : %-12" I64_fmt "   (%.0f /sec)\n", stats.propagations, stats.propagations/cpu_time);
+    reportf("conflict literals     : %-12" I64_fmt "   (%4.2f %% deleted)\n", stats.tot_literals, (stats.max_literals - stats.tot_literals)*100 / (double)stats.max_literals);
     if (mem_used != 0) reportf("Memory used           : %.2f MB\n", mem_used / 1048576.0);
     reportf("CPU time              : %g s\n", cpu_time);
 }

--- a/src/HolSat/sat_solvers/minisat/Makefile
+++ b/src/HolSat/sat_solvers/minisat/Makefile
@@ -15,12 +15,12 @@ RCOBJS    = $(addsuffix r,  $(COBJS))
 
 EXEC      = minisat
 
-CXX       = g++
+CXX       = $(or $(MINISAT_CXX),c++)
 CFLAGS    = -Wall -ffloat-store -fno-strict-aliasing
 COPTIMIZE = -O3
 
 
-.PHONY : s p d r build clean depend
+.PHONY : s p d r build clean
 
 r:	WAY=release
 s:	WAY=standard
@@ -45,7 +45,7 @@ build:
 
 clean:
 	@rm -f $(EXEC)_standard $(EXEC)_profile $(EXEC)_debug $(EXEC) $(EXEC)_static \
-	  $(COBJS) $(PCOBJS) $(DCOBJS) $(RCOBJS) depend.mak
+	  $(COBJS) $(PCOBJS) $(DCOBJS) $(RCOBJS)
 
 ## Build rule
 %.o %.op %.od %.or:	%.C
@@ -74,15 +74,43 @@ $(EXEC)_static: $(RCOBJS)
 	@$(CXX) --static $(RCOBJS)  -Wall -o $@
 
 
-## Make dependencies
-depend:	depend.mak
-depend.mak: $(CSRCS) $(CHDRS)
-	@echo Making dependencies ...
-	@$(CXX) -MM $(CSRCS) > depend.mak
-	@cp depend.mak /tmp/depend.mak.tmp
-	@sed "s/o:/op:/" /tmp/depend.mak.tmp >> depend.mak
-	@sed "s/o:/od:/" /tmp/depend.mak.tmp >> depend.mak
-	@sed "s/o:/or:/" /tmp/depend.mak.tmp >> depend.mak
-	@rm /tmp/depend.mak.tmp
 
-include depend.mak
+File.o: File.C File.h Global.h
+
+Main.o: Main.C Solver.h SolverTypes.h Global.h VarOrder.h Heap.h Proof.h \
+  File.h Sort.h
+
+Proof.o: Proof.C Proof.h SolverTypes.h Global.h File.h Sort.h
+
+Solver.o: Solver.C Solver.h SolverTypes.h Global.h VarOrder.h Heap.h \
+  Proof.h File.h Sort.h
+
+File.op: File.C File.h Global.h
+
+Main.op: Main.C Solver.h SolverTypes.h Global.h VarOrder.h Heap.h Proof.h \
+  File.h Sort.h
+
+Proof.op: Proof.C Proof.h SolverTypes.h Global.h File.h Sort.h
+
+Solver.op: Solver.C Solver.h SolverTypes.h Global.h VarOrder.h Heap.h \
+  Proof.h File.h Sort.h
+
+File.od: File.C File.h Global.h
+
+Main.od: Main.C Solver.h SolverTypes.h Global.h VarOrder.h Heap.h Proof.h \
+  File.h Sort.h
+
+Proof.od: Proof.C Proof.h SolverTypes.h Global.h File.h Sort.h
+
+Solver.od: Solver.C Solver.h SolverTypes.h Global.h VarOrder.h Heap.h \
+  Proof.h File.h Sort.h
+
+File.or: File.C File.h Global.h
+
+Main.or: Main.C Solver.h SolverTypes.h Global.h VarOrder.h Heap.h Proof.h \
+  File.h Sort.h
+
+Proof.or: Proof.C Proof.h SolverTypes.h Global.h File.h Sort.h
+
+Solver.or: Solver.C Solver.h SolverTypes.h Global.h VarOrder.h Heap.h \
+  Proof.h File.h Sort.h

--- a/src/HolSat/sat_solvers/minisat/Solver.C
+++ b/src/HolSat/sat_solvers/minisat/Solver.C
@@ -253,7 +253,7 @@ public:
 
 void Solver::analyze(Clause* confl, vec<Lit>& out_learnt, int& out_btlevel)
 {
-    vec<char>&     seen  = analyze_seen;
+    vec<int8_t>&   seen  = analyze_seen;
     int            pathC = 0;
     Lit            p     = lit_Undef;
     bool           sconfl;
@@ -418,7 +418,7 @@ void Solver::analyzeFinal(Clause* confl, bool skip_first)
         if (proof != NULL) conflict_id = proof->last();
         return; }
 
-    vec<char>&     seen  = analyze_seen;
+    vec<int8_t>& seen = analyze_seen;
     if (proof != NULL) proof->beginChain(confl->id());
     for (int i = skip_first ? 1 : 0; i < confl->size(); i++){
         Var     x = var((*confl)[i]);
@@ -832,7 +832,7 @@ bool Solver::solve(const vec<Lit>& assumps)
         if (var(conflict[i]) >= 100){
             Lit p = conflict[i];
             Var x = var(p);
-            printf("confl[%d] = "L_LIT"\n", i, L_lit(p));
+            printf("confl[%d] = " L_LIT "\n", i, L_lit(p));
             printf("level     = %d\n", level[x]);
             printf("reason    = %p\n", reason[x]);
             printf("unit_id   = %d\n", unit_id[x]);

--- a/src/HolSat/sat_solvers/minisat/Solver.h
+++ b/src/HolSat/sat_solvers/minisat/Solver.h
@@ -63,7 +63,7 @@ protected:
     VarOrder            order;            // Keeps track of the decision variable order.
 
     vec<vec<Clause*> >  watches;          // 'watches[lit]' is a list of constraints watching 'lit' (will go there if literal becomes true).
-    vec<char>           assigns;          // The current assignments (lbool:s stored as char:s).
+    vec<int8_t>         assigns;          // The current assignments (lbool:s stored as int8_t:s).
     vec<Lit>            trail;            // Assignment stack; stores all assigments made in the order they were made.
     vec<int>            trail_lim;        // Separator indices for different decision levels in 'trail[]'.
     vec<Clause*>        reason;           // 'reason[var]' is the clause that implied the variables current value, or 'NULL' if none.
@@ -77,7 +77,7 @@ protected:
 
     // Temporaries (to reduce allocation overhead). Each variable is prefixed by the method in which is used:
     //
-    vec<char>           analyze_seen;
+    vec<int8_t>         analyze_seen;
     vec<Lit>            analyze_stack;
     vec<Lit>            analyze_toclear;
     Clause*             propagate_tmpbin;

--- a/src/HolSat/sat_solvers/minisat/SolverTypes.h
+++ b/src/HolSat/sat_solvers/minisat/SolverTypes.h
@@ -107,7 +107,7 @@ inline Clause* Clause_new(bool learnt, const vec<Lit>& ps, ClauseId id = ClauseI
     assert(sizeof(Lit)      == sizeof(uint));
     assert(sizeof(float)    == sizeof(uint));
     assert(sizeof(ClauseId) == sizeof(uint));
-    void*   mem = xmalloc<char>(sizeof(Clause) + sizeof(uint)*(ps.size() + (int)learnt + (int)(id != ClauseId_NULL)));
+    void*   mem = xmalloc<int8_t>(sizeof(Clause) + sizeof(uint)*(ps.size() + (int)learnt + (int)(id != ClauseId_NULL)));
     return new (mem) Clause(learnt, ps, id); }
 
 

--- a/src/HolSat/sat_solvers/minisat/VarOrder.h
+++ b/src/HolSat/sat_solvers/minisat/VarOrder.h
@@ -34,13 +34,13 @@ struct VarOrder_lt {
 };
 
 class VarOrder {
-    const vec<char>&    assigns;     // var->val. Pointer to external assignment table.
+    const vec<int8_t>&  assigns;     // var->val. Pointer to external assignment table.
     const vec<double>&  activity;    // var->act. Pointer to external activity table.
     Heap<VarOrder_lt>   heap;
     double              random_seed; // For the internal random number generator
 
 public:
-    VarOrder(const vec<char>& ass, const vec<double>& act) :
+    VarOrder(const vec<int8_t>& ass, const vec<double>& act) :
         assigns(ass), activity(act), heap(VarOrder_lt(act)), random_seed(91648253)
         { }
 


### PR DESCRIPTION
Hi,

this PR applies to the old `HOL-Omega` branch, for the compilation issues of MiniSAT (on modern C compilers), whose source code is updated from recent branches.

With only this fix and an old version of working PolyML, e.g. v5.4.1, one should be able to build the latest HOL-Omega (based on HOL Kananaskis-8) and play with it (for both `-stdknl` and `-expk` kernels).

Regards,

Chun Tian