### PR TITLE
Add `Q.LIST_REFINE_EXISTS_TAC`

### DIFF
--- a/Manual/Cheatsheet/cheatsheet.md
+++ b/Manual/Cheatsheet/cheatsheet.md
@@ -115,7 +115,7 @@ If these are still too blunt, we can use *conversions* to carry out surgical rew
 Conversions are functions of type `term -> thm`, such that applying a conversion to a term `t` produces a theorem `⊢ t = t'`.
 These can be converted into tactics using <code>CONV_TAC <i>conversion</i></code>.
 There are many conversions and conversion combinators - an exhaustive list can be found in the HOL4 documentation, mostly listed under the `Conv` structure.
-Good starting points are `REWRITE_CONV`, `THENC`, `RAND_CONV`, `RATOR_CONV`, `LHS_CONV`, `RHS_CONV`, `QCHANGED_CONV`, `DEPTH_CONV`, `PAT_CONV`, and `PATH_CONV`.
+Good starting points are `SCONV`, `REWRITE_CONV`, `THENC`, `RAND_CONV`, `RATOR_CONV`, `LHS_CONV`, `RHS_CONV`, `QCHANGED_CONV`, `DEPTH_CONV`, `PAT_CONV`, and `PATH_CONV`.
 
 
 ### Rewrite modifiers
@@ -149,8 +149,18 @@ Also commonly used when rewriting are:
 <code>iff{LR,RL} <i>theorem</i></code>
 : Turns a bi-implication into an implication, going left-to-right or right-to-left respectively.
 
+<code>SRULE [<i>rewrites</i>] <i>theorem</i></code>
+: Uses the stateful simpset and supplied rewrites to rewrite the theorem.
+
+<code>Cong <i>theorem</i></code>
+: Uses the supplied theorem as a *congruence rule* instead of a rewrite.
+  Congruence rules tell the simplifier how to traverse terms, so they can be useful for rewriting within subterms.
+  For example,
+    using `Cong AND_CONG` allows use of each conjunct in a conjunction to rewrite the others; and
+    the goal `(∀ e. MEM e l ==> f e = g e) ==> h (MAP f l) = h (MAP g l)` is solved by `simp[Cong MAP_CONG]`.
+
 <br>
-Note that `GSYM` and `iff{LR,RL}` are termed *rules* - these transform theorems to other theorems, allowing the above to be combined (e.g. `simp[Once $ GSYM thm]`).
+Note that the above are termed *rules* - these transform theorems to other theorems, allowing the above to be combined (e.g. `simp[Once $ GSYM thm]`).
 There are many other useful rules - see the HOL4 documentation for more details.
 
 In some cases we may wish to use a set of rewrites for simplification.
@@ -327,16 +337,27 @@ In many cases, we may want to state exactly how the goal should be taken apart (
 `AP_THM_TAC`
 : Reduces a goal of the form `f x = g x` to `f = g`.
 
+`MK_COMB_TAC`
+: Reduces a goal of the form `f x = g y` to two subgoals, `f = g` and `x = y`.
+
 `impl_tac`
 : For a goal of the form `(A ==> B) ==> C`, splits into the two subgoals `A` and `B ==> C`.
   `impl_keep_tac` is a variant which keeps `A` as an assumption in the `B ==> C` subgoal.
 
 <code>qexists &grave;<i>term</i>&grave;</code>
-: Instantiates a top-level `∃` quantifer with the supplied term.
+: Instantiates a top-level `∃` quantifier with the supplied term.
+
+<code>qexistsl &grave;<i>terms</i>&grave;</code>
+: Like `qexists`, but accepts a list of terms to instantiate multiple `∃` quantifiers.
 
 <code>qrefine &grave;<i>term</i>&grave;</code>
-: Refines a top-level `∃` quantifer using the supplied term - any free variables in the term become`∃`-quantified.
+: Refines a top-level `∃` quantifier using the supplied term - any free variables in the term become`∃`-quantified.
   For example, for a goal `∃ n : num. if n = 0 then P n else Q n`, applying ``qrefine `SUC k` >> simp[]`` produces the goal `∃ k : num. Q (SUC k)` (where `SUC` is the successor function).
+
+<code>qrefinel &grave;<i>terms</i>&grave;</code>
+: Like `qrefine`, but accepts a list of terms to instantiate multiple `∃` quantifiers.
+  Also can be passed underscores, to avoid refining selected `∃` quantifiers.
+  For example, for a goal `n = 2 /\ c = 5 ==> ∃ a b c d. a + b = c + d`, the tactic <code>strip_tac >> qrefinel [&grave;_&grave;,&grave;SUC c&grave;,&grave;_&grave;,&grave;n + m&grave;]</code> produces the new goal `∃ a c' m. a + SUC c = c' + (n + m)` .
 
 <code>goal_assum $ drule_at Any</code>
 : For a goal of the form `∃ vars . P1 /\ ... /\ Pn` (where the `vars` may be free in the `Pi`), attempts to match the `Pi` against the assumptions.
@@ -383,6 +404,19 @@ The latter usually have a `"_x_"` in their names.
 <code>spose_not_then <i>thm_tactic</i></code>
 : Like `goal_assum`, but geared towards proof-by-contradiction: negates the goal **and** pushes the negation inwards, before applying the given theorem-tactic to the result.
   A common usage is `spose_not_then assume_tac`.
+
+<code>ASSUME_NAMED_TAC "<i>label</i>" <i>theorem</i></code>
+: Found in `markerLib`.
+  Add the theorem as an labelled assumption: `label :- theorem`.
+  E.g. `pop_assum $ ASSUME_NAMED_TAC "..."`.
+
+<code>LABEL_ASSUM "<i>label</i>" <i>thm_tactic</i></code><br><code>LABEL_X_ASSUM "<i>label</i>" <i>thm_tactic</i></code>
+: Found in `markerLib`.
+  Select the labelled assumption `label :- assumption` and apply <code><i>thm_tactic</i> assumption</code>.
+
+<code>L "<i>label</i>"</code>
+: Found in `markerLib`.
+  When used in a stateful simplifier, produces the theorem `assumption` from labelled assumption `label :- assumption`.
 
 
 ## Instantiations and generalisations
@@ -491,7 +525,7 @@ Instead, we can rename variables appropriately, and abbreviate large terms.
 : Unabbreviates all existing abbreviations.
 
 <code>Abbr &grave;<i>var</i>&grave;</code>
-: Produces a rewrite theorem which unabbreviates the supplied variable.
+: When used in a stateful simplifier, produces a rewrite theorem which unabbreviates the supplied variable.
   For example, if `x` is an abbreviation in the goal-state, using ``simp[Abbr `x`]`` will unabbreviate `x` in the goal.
 
 <code>qx_gen_tac &grave;<i>var</i>&grave;</code>

--- a/help/Docfiles/Q.LIST_REFINE_EXISTS_TAC.doc
+++ b/help/Docfiles/Q.LIST_REFINE_EXISTS_TAC.doc
@@ -1,0 +1,50 @@
+\DOC LIST_REFINE_EXISTS_TAC
+
+\TYPE {Q.LIST_REFINE_EXISTS_TAC : term quotation list -> tactic}
+
+\SYNOPSIS
+Attacks existential goals, making existential variables more concrete.
+
+\KEYWORDS
+
+
+\LIBRARY
+Q
+
+\DESCRIBE
+{Q.LIST_REFINE_EXISTS_TAC} is similar to {Q.REFINE_EXISTS_TAC}, except it
+accepts a list of quotations rather than a single one. It further skips
+quotations of a single variable beginning with an underscore, permitting
+straightforward refinement of nested existentials.
+
+Note that quotations are parsed right-to-left, so earlier quotations are parsed
+in the context of later ones.
+
+\FAILURE
+Fails if passed too many quotations for the current goal.
+Otherwise fails similarly to {Q.REFINE_EXISTS_TAC}.
+
+\EXAMPLE
+
+{
+  - Q.LIST_REFINE_EXISTS_TAC [`_`,`SUC c`,`_`,`n + m`]
+      ([``n = 2``,``c = 5``], ``∃a b c d. a + b = c + d``);
+  > val it =
+       ([([``n = 2``, ``c = 5``], ``∃a c' m. a + SUC c = c' + (n + m)``)], fn)
+       : goal list * validation
+}
+
+\USES
+Like {Q.REFINE_EXISTS_TAC}, {Q.LIST_REFINE_EXISTS_TAC} is useful if it is clear
+that an existential goal can be solved by a term of particular form, but it is
+not yet clear exactly what this term will be.
+
+It is particularly useful when refining deeply-nested existentials, or many
+existentials at once.
+
+\COMMENTS
+This tactic is also available under the alias {bossLib.qrefinel}.
+
+\SEEALSO
+Q.REFINE_EXISTS_TAC, Tactic.EXISTS_TAC.
+\ENDDOC

--- a/help/Docfiles/Q.REFINE_EXISTS_TAC.doc
+++ b/help/Docfiles/Q.REFINE_EXISTS_TAC.doc
@@ -51,5 +51,5 @@ able to exploit the additional structure that has appeared in the
 place of the existential variable.
 
 \SEEALSO
-Tactic.EXISTS_TAC.
+Q.LIST_REFINE_EXISTS_TAC, Tactic.EXISTS_TAC.
 \ENDDOC

--- a/src/boss/bossLib.sig
+++ b/src/boss/bossLib.sig
@@ -211,6 +211,7 @@ sig
   val qexists : term quotation -> tactic
   val qexistsl : term quotation list -> tactic
   val qrefine : term quotation -> tactic
+  val qrefinel : term quotation list -> tactic
   val qsuff_tac : term quotation -> tactic
   val qid_spec_tac : term quotation -> tactic
   val qspec_tac : term quotation * term quotation -> tactic

--- a/src/boss/bossLib.sml
+++ b/src/boss/bossLib.sml
@@ -294,6 +294,7 @@ val wlog_then = wlog_then
   val qexists = qexists_tac
   val qexistsl = qexistsl_tac
   val qrefine = Q.REFINE_EXISTS_TAC
+  val qrefinel = Q.LIST_REFINE_EXISTS_TAC
   val qsuff_tac : term quotation -> tactic = Q_TAC SUFF_TAC
   val qspec_tac = Q.SPEC_TAC
   val qid_spec_tac : term quotation -> tactic = Q.ID_SPEC_TAC

--- a/src/q/Q.sig
+++ b/src/q/Q.sig
@@ -18,6 +18,7 @@ sig
   val EXISTS_TAC             : tmquote -> tactic
   val LIST_EXISTS_TAC        : tmquote list -> tactic
   val REFINE_EXISTS_TAC      : tmquote -> tactic
+  val LIST_REFINE_EXISTS_TAC : tmquote list -> tactic
   val GEN                    : tmquote -> thm -> thm
   val GENL                   : tmquote list -> thm -> thm
   val SPEC                   : tmquote -> thm -> thm


### PR DESCRIPTION
And `bossLib` shorthand, `qrefinel`. Fixes #1021.

There are quite a few potential variable shadowing problems with this kind of tactic - hopefully I've accounted for all of them...

Also update the cheatsheet - fix some typos and add:
- `qrefinel` / `qexistsl`
- `SCONV` / `SRULE`
- `Cong`
- `MK_COMB_TAC`
- `ASSUME_NAMED_TAC` / `LABEL_{,X_}ASSUM`