### PR TITLE
Improved `LLN` definition, fixing some related proofs

### DIFF
--- a/src/probability/measureScript.sml
+++ b/src/probability/measureScript.sml
@@ -3600,7 +3600,7 @@ Proof
          MATCH_MP_TAC INJ_IMAGE \\
          Q.EXISTS_TAC `c'` >> REWRITE_TAC [INJ_DEF, IN_COUNT] >> BETA_TAC \\
          METIS_TAC []) >> Rewr' \\
-     SIMP_TAC std_ss [BIGUNION_IMAGE_OVER_INTER_R, o_DEF] \\
+     SIMP_TAC std_ss [BIGUNION_OVER_INTER_R, o_DEF] \\
   (* applying FINITE_ADDITIVE and EXTREAL_SUM_IMAGE_EQ *)
      Know `SIGMA (\i. mu (BIGUNION (IMAGE (\i'. f i INTER f' i') (count n')))) (count n) =
            SIGMA (\i. SIGMA (mu o (\i'. f i INTER f' i')) (count n')) (count n)`
@@ -3613,7 +3613,7 @@ Proof
              >- (MATCH_MP_TAC pos_not_neginf \\
                  fs [positive_def, measure_def, measurable_sets_def] \\
                  Q.PAT_ASSUM `!s. s IN sts ==> 0 <= mu s` MATCH_MP_TAC \\
-                 REWRITE_TAC [GSYM BIGUNION_IMAGE_OVER_INTER_R] \\
+                 REWRITE_TAC [GSYM BIGUNION_OVER_INTER_R] \\
                 `f x INTER BIGUNION (IMAGE f' (count n')) = f x` by PROVE_TAC [] \\
                  POP_ORW >> METIS_TAC [SUBSET_DEF, IN_IMAGE, IN_COUNT]) \\
              (* SIGMA (\i'. mu (f x' INTER f' i')) (count n') <> NegInf *)
@@ -3638,7 +3638,7 @@ Proof
          CONJ_TAC >- (rpt STRIP_TAC \\
                       MATCH_MP_TAC DISJOINT_RESTRICT_R >> PROVE_TAC []) \\
          (* `BIGUNION (IMAGE (\i'. f x' INTER f' i') (count n')) IN sts` *)
-         REWRITE_TAC [GSYM BIGUNION_IMAGE_OVER_INTER_R] \\
+         REWRITE_TAC [GSYM BIGUNION_OVER_INTER_R] \\
         `f x INTER BIGUNION (IMAGE f' (count n')) = f x` by PROVE_TAC [] \\
          POP_ORW >> METIS_TAC [SUBSET_DEF, IN_IMAGE, IN_COUNT]) >> Rewr' \\
      (* symmetric with previous known *)
@@ -3654,7 +3654,7 @@ Proof
                  fs [positive_def, measure_def, measurable_sets_def] \\
                  Q.PAT_ASSUM `!s. s IN sts ==> 0 <= mu s` MATCH_MP_TAC \\
                  (* BIGUNION (IMAGE (\i'. f' x' INTER f i') (count n)) IN sts *)
-                 REWRITE_TAC [GSYM BIGUNION_IMAGE_OVER_INTER_R] \\
+                 REWRITE_TAC [GSYM BIGUNION_OVER_INTER_R] \\
                 `f' x INTER BIGUNION (IMAGE f (count n)) = f' x` by PROVE_TAC [] \\
                  POP_ORW >> METIS_TAC [SUBSET_DEF, IN_IMAGE, IN_COUNT]) \\
              (* SIGMA (\i'. mu (f' x' INTER f i')) (count n) <> NegInf *)
@@ -3679,7 +3679,7 @@ Proof
          CONJ_TAC >- (rpt STRIP_TAC \\
                       MATCH_MP_TAC DISJOINT_RESTRICT_R >> PROVE_TAC []) \\
       (* `BIGUNION (IMAGE (\i'. f' x' INTER f i') (count n)) IN sts` *)
-         REWRITE_TAC [GSYM BIGUNION_IMAGE_OVER_INTER_R] \\
+         REWRITE_TAC [GSYM BIGUNION_OVER_INTER_R] \\
         `f' x INTER BIGUNION (IMAGE f (count n)) = f' x` by PROVE_TAC [] \\
          POP_ORW >> METIS_TAC [SUBSET_DEF, IN_IMAGE, IN_COUNT]) >> Rewr' \\
      SIMP_TAC std_ss [o_DEF] \\
@@ -4149,7 +4149,7 @@ Proof
      RW_TAC std_ss [disjoint_def, IN_IMAGE, IN_COUNT] \\
      Cases_on `i = i'` >- METIS_TAC [] \\
      MATCH_MP_TAC DISJOINT_RESTRICT_L >> PROVE_TAC []) >> Rewr'
- >> REWRITE_TAC [GSYM BIGUNION_IMAGE_OVER_INTER_L]
+ >> REWRITE_TAC [GSYM BIGUNION_OVER_INTER_L]
  >> `BIGUNION (IMAGE f' (count n)) = BIGUNION (IMAGE z univ(:num))` by PROVE_TAC []
  >> POP_ORW
  >> Know `!x. BIGUNION (IMAGE z univ(:num)) INTER z x = z x`

--- a/src/probability/util_probScript.sml
+++ b/src/probability/util_probScript.sml
@@ -1198,103 +1198,70 @@ val BIGUNION_IMAGE_COUNT_IMP_UNIV = store_thm
  >> FULL_SIMP_TAC std_ss [IN_BIGUNION, IN_IMAGE, PULL_EXISTS, IN_UNIV]
  >> METIS_TAC []);
 
-val BIGUNION_OVER_INTER_L = store_thm
-  ("BIGUNION_OVER_INTER_L",
-  ``!f d. BIGUNION (IMAGE f univ(:num)) INTER d =
-          BIGUNION (IMAGE (\i. f i INTER d) univ(:num))``,
-    rpt GEN_TAC
- >> REWRITE_TAC [EXTENSION]
- >> GEN_TAC >> EQ_TAC
- >| [ (* goal 1 (of 2) *)
-      RW_TAC std_ss [IN_BIGUNION, IN_INTER, IN_IMAGE] \\
-      `x IN (f x' INTER d)` by PROVE_TAC [IN_INTER] \\
-      Q.EXISTS_TAC `f x' INTER d` >> art [] \\
-      Q.EXISTS_TAC `x'` >> art [],
-      (* goal 2 (of 2) *)
-      RW_TAC std_ss [IN_BIGUNION, IN_INTER, IN_IMAGE] >|
-      [ fs [IN_INTER] >> Q.EXISTS_TAC `f i` >> ASM_REWRITE_TAC [] \\
-        Q.EXISTS_TAC `i` >> REWRITE_TAC [],
-        PROVE_TAC [IN_INTER] ] ]);
+Theorem BIGUNION_OVER_INTER_L :
+    !f s d. BIGUNION (IMAGE f s) INTER d = BIGUNION (IMAGE (\i. f i INTER d) s)
+Proof
+    rw [Once EXTENSION]
+ >> EQ_TAC >> rw []
+ >| [ (* goal 1 (of 3) *)
+      rename1 ‘y IN s’ \\
+      Q.EXISTS_TAC ‘f y INTER d’ >> rw [] \\
+      Q.EXISTS_TAC ‘y’ >> rw [],
+      (* goal 2 (of 3) *)
+      fs [] \\
+      Q.EXISTS_TAC ‘f i’ >> rw [] \\
+      Q.EXISTS_TAC ‘i’ >> rw [],
+      (* goal 3 (of 3) *)
+      fs [] ]
+QED
 
-val BIGUNION_OVER_INTER_R = store_thm
-  ("BIGUNION_OVER_INTER_R",
-  ``!f d. d INTER BIGUNION (IMAGE f univ(:num)) =
-          BIGUNION (IMAGE (\i. d INTER f i) univ(:num))``,
-    rpt GEN_TAC
- >> REWRITE_TAC [EXTENSION]
- >> GEN_TAC >> EQ_TAC
- >| [ (* goal 1 (of 2) *)
-      RW_TAC std_ss [IN_BIGUNION, IN_INTER, IN_IMAGE, IN_UNIV] \\
-      `x IN (d INTER f x')` by PROVE_TAC [IN_INTER] \\
-      Q.EXISTS_TAC `d INTER f x'` >> art [] \\
-      Q.EXISTS_TAC `x'` >> art [],
-      (* goal 2 (of 2) *)
-      RW_TAC std_ss [IN_BIGUNION, IN_INTER, IN_IMAGE, IN_UNIV] >|
-      [ fs [IN_INTER] >> Q.EXISTS_TAC `f i` >> ASM_REWRITE_TAC [] \\
-        Q.EXISTS_TAC `i` >> REWRITE_TAC [],
-        PROVE_TAC [IN_INTER] ] ]);
+(* |- !f s d. d INTER BIGUNION (IMAGE f s) = BIGUNION (IMAGE (\i. d INTER f i) s) *)
+Theorem BIGUNION_OVER_INTER_R = ONCE_REWRITE_RULE [INTER_COMM] BIGUNION_OVER_INTER_L
 
-val BIGUNION_OVER_DIFF = store_thm
-  ("BIGUNION_OVER_DIFF",
-  ``!f d. BIGUNION (IMAGE f univ(:num)) DIFF d =
-          BIGUNION (IMAGE (\i. f i DIFF d) univ(:num))``,
-    rpt GEN_TAC
- >> REWRITE_TAC [EXTENSION]
- >> GEN_TAC >> EQ_TAC
- >| [ (* goal 1 (of 2) *)
-      RW_TAC std_ss [IN_BIGUNION, IN_DIFF, IN_IMAGE, IN_UNIV] \\
-      `x IN (f x' DIFF d)` by PROVE_TAC [IN_DIFF] \\
-      Q.EXISTS_TAC `f x' DIFF d` >> art [] \\
-      Q.EXISTS_TAC `x'` >> art [],
-      (* goal 2 (of 2) *)
-      RW_TAC std_ss [IN_BIGUNION, IN_DIFF, IN_IMAGE, IN_UNIV] >|
-      [ fs [IN_DIFF] >> Q.EXISTS_TAC `f i` >> art [] \\
-        Q.EXISTS_TAC `i` >> REWRITE_TAC [],
-        PROVE_TAC [IN_DIFF] ] ]);
+Theorem BIGUNION_OVER_DIFF :
+    !f s d. BIGUNION (IMAGE f s) DIFF d = BIGUNION (IMAGE (\i. f i DIFF d) s)
+Proof
+    rw [Once EXTENSION]
+ >> EQ_TAC >> rw []
+ >| [ (* goal 1 (of 3) *)
+      rename1 ‘y IN s’ \\
+      Q.EXISTS_TAC ‘f y DIFF d’ >> rw [] \\
+      Q.EXISTS_TAC ‘y’ >> rw [],
+      (* goal 2 (of 3) *)
+      fs [] \\
+      Q.EXISTS_TAC ‘f i’ >> art [] \\
+      Q.EXISTS_TAC ‘i’ >> art [],
+      (* goal 3 (of 3) *)
+      fs [] ]
+QED
 
-val BIGUNION_IMAGE_OVER_INTER_L = store_thm
-  ("BIGUNION_IMAGE_OVER_INTER_L",
-  ``!f n d. BIGUNION (IMAGE f (count n)) INTER d =
-            BIGUNION (IMAGE (\i. f i INTER d) (count n))``,
-    rpt GEN_TAC
- >> REWRITE_TAC [EXTENSION]
- >> GEN_TAC >> EQ_TAC
- >| [ RW_TAC std_ss [IN_BIGUNION, IN_INTER, IN_IMAGE] \\
-      `x IN (f x' INTER d)` by PROVE_TAC [IN_INTER] \\
-      Q.EXISTS_TAC `f x' INTER d` >> art [] \\
-      Q.EXISTS_TAC `x'` >> art [],
-      RW_TAC std_ss [IN_BIGUNION, IN_INTER, IN_IMAGE] >|
-      [ fs [IN_INTER] >> Q.EXISTS_TAC `f i` >> art [] \\
-        Q.EXISTS_TAC `i` >> art [],
-        PROVE_TAC [IN_INTER] ] ]);
-
-val BIGUNION_IMAGE_OVER_INTER_R = store_thm
-  ("BIGUNION_IMAGE_OVER_INTER_R",
-  ``!f n d. d INTER BIGUNION (IMAGE f (count n)) =
-            BIGUNION (IMAGE (\i. d INTER f i) (count n))``,
-    rpt GEN_TAC
- >> ONCE_REWRITE_TAC [INTER_COMM]
- >> REWRITE_TAC [BIGUNION_IMAGE_OVER_INTER_L]);
-
-val BIGINTER_IMAGE_OVER_INTER_L = store_thm
-  ("BIGINTER_IMAGE_OVER_INTER_L",
-  ``!f n d. 0 < n ==>
-           (BIGINTER (IMAGE f (count n)) INTER d =
-            BIGINTER (IMAGE (\i. f i INTER d) (count n)))``,
+Theorem BIGINTER_OVER_INTER_L :
+    !f s d. s <> {} ==> (BIGINTER (IMAGE f s) INTER d =
+                         BIGINTER (IMAGE (\i. f i INTER d) s))
+Proof
     rpt STRIP_TAC
- >> REWRITE_TAC [EXTENSION]
- >> GEN_TAC >> EQ_TAC
- >| [ RW_TAC std_ss [IN_BIGINTER_IMAGE, IN_INTER, IN_COUNT],
-      RW_TAC std_ss [IN_BIGINTER_IMAGE, IN_INTER, IN_COUNT] >> RES_TAC ]);
+ >> rw [Once EXTENSION]
+ >> EQ_TAC >> rw []
+ >| [ (* goal 1 (of 3) *)
+      rw [] >> FIRST_X_ASSUM MATCH_MP_TAC \\
+      Q.EXISTS_TAC ‘i’ >> rw [],
+      (* goal 2 (of 3) *)
+      rename1 ‘y IN s’ \\
+      Suff ‘x IN (f y INTER d)’ >- rw [] \\
+      FIRST_X_ASSUM MATCH_MP_TAC \\
+      Q.EXISTS_TAC ‘y’ >> rw [],
+      (* goal 3 (of 3) *)
+      fs [GSYM MEMBER_NOT_EMPTY] \\
+      rename1 ‘i IN s’ \\
+      Suff ‘x IN f i INTER d’ >- rw [] \\
+      FIRST_X_ASSUM MATCH_MP_TAC \\
+      Q.EXISTS_TAC ‘i’ >> rw [] ]
+QED
 
-val BIGINTER_IMAGE_OVER_INTER_R = store_thm
-  ("BIGINTER_IMAGE_OVER_INTER_R",
-  ``!f n d. 0 < n ==>
-           (d INTER BIGINTER (IMAGE f (count n)) =
-            BIGINTER (IMAGE (\i. d INTER f i) (count n)))``,
-    rpt STRIP_TAC
- >> ONCE_REWRITE_TAC [INTER_COMM]
- >> MATCH_MP_TAC BIGINTER_IMAGE_OVER_INTER_L >> art []);
+(* |- !f s d. s <> {} ==>
+              d INTER BIGINTER (IMAGE f s) = BIGINTER (IMAGE (\i. d INTER f i) s)
+ *)
+Theorem BIGINTER_OVER_INTER_R = ONCE_REWRITE_RULE [INTER_COMM] BIGINTER_OVER_INTER_L
 
 (* any finite set can be decomposed into a finite sequence of sets *)
 val finite_decomposition_simple = store_thm (* new *)
@@ -1740,8 +1707,24 @@ val disjoint_family_on = new_definition ("disjoint_family_on",
   ``disjoint_family_on a s =
       (!m n. m IN s /\ n IN s /\ (m <> n) ==> (a m INTER a n = {}))``);
 
+(* A new, equivalent definition based on DISJOINT *)
+Theorem disjoint_family_on_def :
+    !A J. disjoint_family_on A (J :'index set) <=>
+         (!i j. i IN J /\ j IN J /\ (i <> j) ==> DISJOINT (A i) (A j))
+Proof
+    rw [DISJOINT_DEF, disjoint_family_on]
+QED
+
 val disjoint_family = new_definition ("disjoint_family",
   ``disjoint_family A = disjoint_family_on A UNIV``);
+
+(* A new, equivalent definition based on DISJOINT *)
+Theorem disjoint_family_def :
+    !A. disjoint_family (A :'index -> 'a set) <=>
+        !i j. i <> j ==> DISJOINT (A i) (A j)
+Proof
+    rw [disjoint_family, disjoint_family_on_def]
+QED
 
 (* This is the way to convert a family of sets into a disjoint family *)
 (* of sets, cf. SETS_TO_DISJOINT_SETS -- Chun Tian *)


### PR DESCRIPTION
Hi,

For the statements of various version of the "Law of Large Numbers", I ever introduced the constant `LLN` whose definition was:
```
Definition LLN_def :
    LLN p X convergence_mode =
    let Z n x = SIGMA (\i. X i x) (count n) in
      ((\n x. (Z (SUC n) x - expectation p (Z (SUC n))) / &SUC n) --> (\x. 0))
       (convergence_mode p)
End
```
In some actual LLN proofs, the above `let Z n x` will become an abbreviation `Z` representing the partial sums of random variable X. Usually one expects the "first" of such partial sum should be X itself, but unfortunately this is not true: `Z 0 x` is always zero, since `SIGMA (\i. X i x) (count 0) = SIGMA (\i. X i x) {} = 0`, and I found this fact has caused some mis-alignments between textbook proofs and their formalizations.

In this PR, I changed above definition of `LLN` into the following equivalence form:
```
Definition LLN_def :
    LLN p X convergence_mode =
    let Z n x = SIGMA (\i. X i x) (count (SUC n)) in
      ((\n x. (Z n x - expectation p (Z n)) / &SUC n) --> (\x. 0))
       (convergence_mode p)
End
```
One can see that, after expanding `Z` the two definitions are literally the same. However, in the actual proofs one now have `Z` as the "correct" partial sums: `Z(0) = X(0)`, `Z(1) = X(0) + X(1)` and so on.    I took the hard way to go over all LLN proofs again and fixed them. At the end, I found the overall proof size shrunk a little after this change, and some previously hard constant estimations when doing `Q.EXISTS_TAC`, now becomes more reasonable and straightforward (see the ending part of `SLLN_uncorrelated`.)

I also did some minor cleanups at various places `src/probability`. In particular, some lemmas in `util_probTheory` are generalized and merged with each other.   In `extrealTheory`, I added several new extreal lemmas (not all of them are immediately used), e.g. `pow_pow: |- !x m n. (x pow m) pow n = x pow (m * n)`.

--Chun


