### PR TITLE
Docker-based CI for GitHub Actions

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -41,3 +41,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            SML=poly
+            # NOTE: the arg-value cannot be quoted here:
+            BUILDOPTS=--expk -j2

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,0 +1,43 @@
+name: docker-ci
+
+on:
+  pull_request:
+    branches: [ develop ]
+  push:
+    branches:
+      - "master"
+      - "develop"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ secrets.DOCKER_HUB_USERNAME }}/hol-dev
+          tags: |
+            # dynamically set the branch name as a prefix
+            type=sha,prefix={{branch}}-
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: developers/docker-ci/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -9,7 +9,7 @@ on:
       - "develop"
 
 jobs:
-  build:
+  build-stdknl:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -22,7 +22,7 @@ jobs:
           images: ${{ secrets.DOCKER_HUB_USERNAME }}/hol-dev
           tags: |
             # dynamically set the branch name as a prefix
-            type=sha,prefix={{branch}}-
+            type=sha,prefix={{branch}}-,suffix=-stdknl
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -39,9 +39,46 @@ jobs:
           context: .
           file: developers/docker-ci/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             SML=poly
-            # NOTE: the arg-value cannot be quoted here:
+            # NOTE: the arg value cannot be quoted here:
+            BUILDOPTS=--stdknl -j2
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-expk:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ secrets.DOCKER_HUB_USERNAME }}/hol-dev
+          tags: |
+            # dynamically set the branch name as a prefix
+            type=sha,prefix={{branch}}-,suffix=-expk
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: developers/docker-ci/Dockerfile
+          push: true
+          build-args: |
+            SML=poly
+            # NOTE: the arg value cannot be quoted here:
             BUILDOPTS=--expk -j2
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/self-runner.yml
+++ b/.github/workflows/self-runner.yml
@@ -1,0 +1,70 @@
+name: self-runner
+
+env:
+  default_kernel: 'expk'
+  default_concurrency: '2'
+  default_dockerfile: 'Dockerfile'
+
+on:
+  workflow_dispatch:
+    inputs:
+      kernel:
+        description: 'HOL kernel'
+        required: true
+        default: 'stdknl'
+        type: choice
+        options:
+        - stdknl
+        - expk
+        - otknl
+      concurrency:
+        description: 'Concurrency'
+        required: true
+        default: '2'
+        type: number
+      more-options:
+        description: 'More options'
+        required: false
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ secrets.DOCKER_HUB_USERNAME }}/hol-dev
+          tags: |
+            # dynamically set the branch name as a prefix
+            type=sha,prefix={{branch}}-,suffix=-self
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: developers/docker-ci/${{ env.default_dockerfile }}
+          push: true
+          build-args: |
+            SML=poly
+            # NOTE: the arg value cannot be quoted here:
+            BUILDOPTS=--${{ github.event.inputs.kernel || env.default_kernel }} -j${{ github.event.inputs.concurrency || env.default_concurrency }} ${{ github.event.inputs.more-options }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/developers/docker-ci/Dockerfile
+++ b/developers/docker-ci/Dockerfile
@@ -6,18 +6,18 @@
 # This "base" image is described in "base/Dockerfile"
 FROM binghelisp/hol-dev:latest
 
-# Hardware specification for Windows and Linux virtual machines: 2-core CPU (x86_64)
-ARG BUILD_OPT="--expk -j4"
-ARG ML_PROG=poly
+# GitHub Actions' hardware specification for Linux virtual machines: 2-core CPU (x86_64)
+ARG SML=poly
+ARG BUILDOPTS="--expk -j2"
 
 WORKDIR /ML/HOL
 
-# copy all files to the docker image
+# fast copy all files to the docker image
 COPY --link . .
 
 # build HOL
-RUN ${ML_PROG} < tools/smart-configure.sml 
-RUN bin/build ${BUILD_OPT}
+RUN ${SML} < tools/smart-configure.sml 
+RUN bin/build ${BUILDOPTS}
 
 ENV PATH=/ML/HOL/bin:$PATH
 

--- a/developers/docker-ci/Dockerfile
+++ b/developers/docker-ci/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+#
+# HOL4 building environment (Docker), the CI image
+#
+
+# This "base" image is described in "base/Dockerfile"
+FROM binghelisp/hol-dev:latest
+
+# Hardware specification for Windows and Linux virtual machines: 2-core CPU (x86_64)
+ARG BUILD_OPT="--expk -j2"
+
+WORKDIR /ML/HOL
+
+# copy all files to the docker image
+COPY --link . .
+
+# build HOL
+RUN poly < tools/smart-configure.sml 
+RUN bin/build ${BUILD_OPT}
+
+ENV PATH=/ML/HOL/bin:$PATH
+
+# default entrypoint
+ENTRYPOINT /ML/HOL/bin/hol

--- a/developers/docker-ci/Dockerfile
+++ b/developers/docker-ci/Dockerfile
@@ -7,19 +7,18 @@
 FROM binghelisp/hol-dev:latest
 
 # GitHub Actions' hardware specification for Linux virtual machines: 2-core CPU (x86_64)
+# By default we use 4 cores in other building environments (e.g. Docker Hub autobuilds)
+ARG BUILDOPTS="--expk -j4"
 ARG SML=poly
-ARG BUILDOPTS="--expk -j2"
 
 WORKDIR /ML/HOL
 
 # fast copy all files to the docker image
 COPY --link . .
 
-# build HOL
+# building HOL
 RUN ${SML} < tools/smart-configure.sml 
 RUN bin/build ${BUILDOPTS}
-
-ENV PATH=/ML/HOL/bin:$PATH
 
 # default entrypoint
 ENTRYPOINT /ML/HOL/bin/hol

--- a/developers/docker-ci/Dockerfile
+++ b/developers/docker-ci/Dockerfile
@@ -20,5 +20,5 @@ COPY --link . .
 RUN ${SML} < tools/smart-configure.sml 
 RUN bin/build ${BUILDOPTS}
 
-# default entrypoint
-ENTRYPOINT /ML/HOL/bin/hol
+# This can be overrided by "docker run <command>"
+CMD ["/ML/HOL/bin/hol"]

--- a/developers/docker-ci/Dockerfile
+++ b/developers/docker-ci/Dockerfile
@@ -7,7 +7,8 @@
 FROM binghelisp/hol-dev:latest
 
 # Hardware specification for Windows and Linux virtual machines: 2-core CPU (x86_64)
-ARG BUILD_OPT="--expk -j2"
+ARG BUILD_OPT="--expk -j4"
+ARG ML_PROG=poly
 
 WORKDIR /ML/HOL
 
@@ -15,7 +16,7 @@ WORKDIR /ML/HOL
 COPY --link . .
 
 # build HOL
-RUN poly < tools/smart-configure.sml 
+RUN ${ML_PROG} < tools/smart-configure.sml 
 RUN bin/build ${BUILD_OPT}
 
 ENV PATH=/ML/HOL/bin:$PATH

--- a/developers/docker-ci/base/.emacs
+++ b/developers/docker-ci/base/.emacs
@@ -1,6 +1,7 @@
 (load "/ML/HOL/tools/hol-input.el")
 (load "/ML/HOL/tools/holscript-mode.el")
 (load "/ML/HOL/tools/hol-unicode.el")
+(load "/ML/HOL/tools/hol-mode.el")
 
 (setq hol-executable     "/ML/HOL/bin/hol")
 (setq holmake-executable "/ML/HOL/bin/Holmake")

--- a/developers/docker-ci/base/.emacs
+++ b/developers/docker-ci/base/.emacs
@@ -4,4 +4,4 @@
 
 (setq hol-executable     "/ML/HOL/bin/hol")
 (setq holmake-executable "/ML/HOL/bin/Holmake")
-(setq indent-tabs-mode   nil)
+(setq indent-tabs-mode nil)

--- a/developers/docker-ci/base/.emacs
+++ b/developers/docker-ci/base/.emacs
@@ -1,0 +1,7 @@
+(load "/ML/HOL/tools/hol-input.el")
+(load "/ML/HOL/tools/holscript-mode.el")
+(load "/ML/HOL/tools/hol-unicode.el")
+
+(setq hol-executable     "/ML/HOL/bin/hol")
+(setq holmake-executable "/ML/HOL/bin/Holmake")
+(setq indent-tabs-mode   nil)

--- a/developers/docker-ci/base/Dockerfile
+++ b/developers/docker-ci/base/Dockerfile
@@ -4,7 +4,7 @@
 #
 # e.g. docker build --push -t binghelisp/hol-dev .
 
-# GitHub Action recommends Debian-based systems as base images
+# GitHub Actions recommends Debian-based systems as base images
 FROM debian:stable
 
 WORKDIR /ML
@@ -18,8 +18,8 @@ ENV LD_LIBRARY_PATH=/usr/local/lib
 RUN apt-get update -qy
 RUN apt-get install -qy build-essential graphviz git libgmp-dev curl wget
 
-# optional packages (IDE)
-RUN apt-get install -qy emacs-nox vim automake
+# optional packages (IDE and others)
+RUN apt-get install -qy emacs-nox vim automake procps
 RUN apt-get clean
 
 # install MLton (https://github.com/MLton/mlton.git)
@@ -33,6 +33,7 @@ RUN wget -q -O polyml-5.9.tar.gz https://github.com/polyml/polyml/archive/refs/t
 RUN tar xzf polyml-5.9.tar.gz
 RUN cd polyml-5.9 && ./configure --enable-intinf-as-int
 RUN make -C polyml-5.9 -j4
+RUN make -C polyml-5.9 compiler
 RUN make -C polyml-5.9 install
 
 # install mosml (https://github.com/kfl/mosml.git)
@@ -53,6 +54,6 @@ RUN cp opentheory-1.5/bin/mlton/opentheory /usr/local/bin
 COPY .emacs /root
 
 # [optional] delete building directories for smaller image sizes
-RUN rm -rf polyml-5.9*
-RUN rm -rf mosml-ver-2.10.1*
-RUN rm -rf opentheory-1.5*
+RUN rm -rf polyml*
+RUN rm -rf mosml*
+RUN rm -rf opentheory*

--- a/developers/docker-ci/base/Dockerfile
+++ b/developers/docker-ci/base/Dockerfile
@@ -57,3 +57,6 @@ COPY .emacs /root
 RUN rm -rf polyml*
 RUN rm -rf mosml*
 RUN rm -rf opentheory*
+
+# for developments using this base image with attached /ML volumes
+ENV PATH=/ML/HOL/bin:$PATH

--- a/developers/docker-ci/base/Dockerfile
+++ b/developers/docker-ci/base/Dockerfile
@@ -8,6 +8,7 @@
 FROM debian:stable
 
 WORKDIR /ML
+VOLUME /ML
 
 # Use this mode when you need zero interaction while installing or upgrading the system via apt
 ENV DEBIAN_FRONTEND=noninteractive
@@ -17,15 +18,15 @@ ENV LD_LIBRARY_PATH=/usr/local/lib
 RUN apt-get update -qy
 RUN apt-get install -qy build-essential graphviz git libgmp-dev curl wget
 
-# optional packages
+# optional packages (IDE)
 RUN apt-get install -qy emacs-nox vim automake
 RUN apt-get clean
 
-# install Mlton (https://github.com/MLton/mlton.git)
-RUN wget -q https://github.com/MLton/mlton/releases/download/on-20201002-release/mlton-20201002-1.amd64-linux.tgz
-RUN tar xzf mlton-20201002-1.amd64-linux.tgz
-RUN make -C mlton-20201002-1.amd64-linux
-RUN rm -rf mlton-20201002-1.amd64-linux*
+# install MLton (https://github.com/MLton/mlton.git)
+RUN wget -q https://github.com/MLton/mlton/releases/download/on-20210117-release/mlton-20210117-1.amd64-linux-glibc2.31.tgz
+RUN tar xzf mlton-20210117-1.amd64-linux-glibc2.31.tgz
+RUN make -C mlton-20210117-1.amd64-linux-glibc2.31
+RUN rm -rf mlton-20210117-1.amd64-linux-glibc2.31*
 
 # install polyml (https://github.com/polyml/polyml.git)
 RUN wget -q -O polyml-5.9.tar.gz https://github.com/polyml/polyml/archive/refs/tags/v5.9.tar.gz
@@ -40,9 +41,18 @@ RUN tar xzf mosml-ver-2.10.1.tar.gz
 RUN make -C mosml-ver-2.10.1/src world
 RUN make -C mosml-ver-2.10.1/src install
 
+# install OpenTheory
+RUN wget -q -O /root/opentheory-local.tar.gz https://github.com/binghe/opentheory/releases/download/v1.5/opentheory-local.tar.gz
+RUN cd /root && tar xzf opentheory-local.tar.gz
+RUN wget -q -O opentheory-1.5.tar.gz https://github.com/binghe/opentheory/archive/refs/tags/v1.5.tar.gz
+RUN tar xzf opentheory-1.5.tar.gz
+RUN make -C opentheory-1.5 mlton
+RUN cp opentheory-1.5/bin/mlton/opentheory /usr/local/bin
+
 # for Emacs
-COPY .emacs /root/
+COPY .emacs /root
 
 # [optional] delete building directories for smaller image sizes
 RUN rm -rf polyml-5.9*
 RUN rm -rf mosml-ver-2.10.1*
+RUN rm -rf opentheory-1.5*

--- a/developers/docker-ci/base/Dockerfile
+++ b/developers/docker-ci/base/Dockerfile
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1
+#
+# HOL4 building environment (Docker), base image
+#
+# e.g. docker build --push -t binghelisp/hol-dev .
+
+# GitHub Action recommends Debian-based systems as base images
+FROM debian:stable
+
+WORKDIR /ML
+
+# Use this mode when you need zero interaction while installing or upgrading the system via apt
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LD_LIBRARY_PATH=/usr/local/lib
+
+# necessary packages
+RUN apt-get update -qy
+RUN apt-get install -qy build-essential graphviz git libgmp-dev curl wget
+
+# optional packages
+RUN apt-get install -qy emacs-nox vim automake
+RUN apt-get clean
+
+# install Mlton (https://github.com/MLton/mlton.git)
+RUN wget -q https://github.com/MLton/mlton/releases/download/on-20201002-release/mlton-20201002-1.amd64-linux.tgz
+RUN tar xzf mlton-20201002-1.amd64-linux.tgz
+RUN make -C mlton-20201002-1.amd64-linux
+RUN rm -rf mlton-20201002-1.amd64-linux*
+
+# install polyml (https://github.com/polyml/polyml.git)
+RUN wget -q -O polyml-5.9.tar.gz https://github.com/polyml/polyml/archive/refs/tags/v5.9.tar.gz
+RUN tar xzf polyml-5.9.tar.gz
+RUN cd polyml-5.9 && ./configure --enable-intinf-as-int
+RUN make -C polyml-5.9 -j4
+RUN make -C polyml-5.9 install
+
+# install mosml (https://github.com/kfl/mosml.git)
+RUN wget -q -O mosml-ver-2.10.1.tar.gz https://github.com/kfl/mosml/archive/refs/tags/ver-2.10.1.tar.gz
+RUN tar xzf mosml-ver-2.10.1.tar.gz
+RUN make -C mosml-ver-2.10.1/src world
+RUN make -C mosml-ver-2.10.1/src install
+
+# for Emacs
+COPY .emacs /root/
+
+# [optional] delete building directories for smaller image sizes
+RUN rm -rf polyml-5.9*
+RUN rm -rf mosml-ver-2.10.1*


### PR DESCRIPTION
Hi,

This PR proposes a possible CI solution, which added a GitHub Action workflow called `docker-ci.yml` (under `.github/workflows/`). First of all, please note that, if other persons propose other CI solutions, there's no conflict, as long as they put their workflow as a different file name under `.github/workflows/`.

After some investigations, I found the Docker-based workflow has some advantages:

1. To build HOL in a cloud-based environment (usually a Linux virtual machine), beside basic packages, the PolyML (optionally with Mlton) or Moscow ML must also be installed.   Mlton has officially downloadable Linux packages, while PolyML and Moscow ML should be built from the official source code.   Using docker, we can first build a "base" image which contains all necessary packages and these ML installations.  This base image is defined in `developers/docker-ci/base/Dockerfile` and can be pulled to any user's Docker Hub repository.

2. Using docker, the workflow definition itself (for GitHub Actions) is basically some boilerplate code: all application-specific building details are provided by another docker image which actually build HOL, possibly with various options. This docker image is defined in `developers/docker-ci/Dockerfile` whose `FROM` is based on the above "base" docker image, currently at my personal Docker Hub repository [`binghelisp/hol-dev:latest`](https://hub.docker.com/repository/docker/binghelisp/hol-dev) but can be easily switched to any other.

3. Using docker, after the CI build, all the artifacts are packed into a new docker image and uploaded to the above mentioned Docker Hub repository, tagged with Git branch name + commit hash. User can easily pull the docker image into their local machine and run it or check the artifact files.

Some sample CI build can be found here: https://github.com/binghe/HOL/actions

To fully setup the CI and see it working from the "Actions" tab, after merging the code, HOL maintainer (@mn200) should create (if not having already) a (free) Docker account and create a new public Docker Hub repository, named `hol-dev` (in this way minimal changes are need). Then do the following steps:

1. In Docker Hub, create a new "Access Tokens" (from User Settings -> Security). What's being created is a password-like string, which must be copied and later pasted into GitHub. The name of the token is not important, can be "hol", for instance.

2. In GitHub, go to "Settings" of HOL, then "Security -> Secrets -> Actions", then click "New repository secrets" twice, to create the following named secrets: 1) `DOCKER_HUB_USERNAME`, whose value is your docker ID.  2) `DOCKER_HUB_ACCESS_TOKEN`, whose value is the token string given by the previous step in Docker Hub.

This should be enough for getting the CI working up.  If the Docker base image is changed, then there's no need to depend on my personal image, and the line "FROM binghelisp/hol-dev:latest" in one of the `Dockerfile` can be updated to HOL maintainer's own docker images.

Hope this helps,

Chun Tian
