### PR TITLE
Fixed `docker-ci.yml` for auto-building on pull requests

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -2,7 +2,9 @@ name: docker-ci
 
 on:
   pull_request:
-    branches: [ develop ]
+    branches:
+      - "develop"
+
   push:
     branches:
       - "master"
@@ -21,8 +23,7 @@ jobs:
         with:
           images: ${{ secrets.DOCKER_HUB_USERNAME }}/hol-dev
           tags: |
-            # dynamically set the branch name as a prefix
-            type=sha,prefix={{branch}}-,suffix=-stdknl
+            type=sha,suffix=-stdknl
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -42,7 +43,7 @@ jobs:
           build-args: |
             SML=poly
             # NOTE: the arg value cannot be quoted here:
-            BUILDOPTS=--stdknl -j2
+            BUILDOPTS=--stdknl -j2 -t
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -58,8 +59,7 @@ jobs:
         with:
           images: ${{ secrets.DOCKER_HUB_USERNAME }}/hol-dev
           tags: |
-            # dynamically set the branch name as a prefix
-            type=sha,prefix={{branch}}-,suffix=-expk
+            type=sha,suffix=-expk
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -79,6 +79,6 @@ jobs:
           build-args: |
             SML=poly
             # NOTE: the arg value cannot be quoted here:
-            BUILDOPTS=--expk -j2
+            BUILDOPTS=--expk -j2 -t
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - "master"
       - "develop"
+env:
+  USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+  PASSWORD: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
 jobs:
   build-stdknl:
@@ -28,8 +31,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          username: ${{ env.USERNAME }}
+          password: ${{ env.PASSWORD }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -24,7 +24,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ secrets.DOCKER_HUB_USERNAME }}/hol-dev
+          images: ${{ env.USERNAME }}/hol-dev
           tags: |
             type=sha,suffix=-stdknl
 
@@ -60,15 +60,15 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ secrets.DOCKER_HUB_USERNAME }}/hol-dev
+          images: ${{ env.USERNAME }}/hol-dev
           tags: |
             type=sha,suffix=-expk
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          username: ${{ env.USERNAME }}
+          password: ${{ env.PASSWORD }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
There're two bugs in the GitHub Action workflow `docker-ci.yml`.

# When building HOL on pull requests

When uploading the building artifacts to Docker Hub (or any other Docker-compatible container registry), previously I try to set the branch name as part of the docker image tags.  Unfortunately, the GitHub-provided `{{branch}}` variable previously used as the tag prefix is empty on pull requests, because in this case the building branch is from a remote repository. What I actually use as the prefix is `{{branch}}-`, and if `{{branch}}` is empty, the actual tag will have a leading `-`, which is invalid.

What I'm trying to do here is to use a single, unified workflow for CI purposes of both push and pull requests. The simplest solution I have now is to fallback to the default prefix (`sha-`). This works for all known cases, but from the docker image tags you won't easily know the building branch, just the commit id (SHA) is left, plus `stdknl` or `expk`.

I've tested the above changes by sending a PR [1] to myself in my personal HOL repository, and now it seems worked:

By the way, I added `-t` in the default building options. This will trigger some (if not all) `selftest.sml` tests.

[1] https://github.com/binghe/HOL/pull/5

# The existing CI failures: "unauthorized: incorrect username or password"

I found one solution from [2].

[2] https://stackoverflow.com/questions/74167604/authorization-failure-at-docker-login-step-in-github-actions?rq=1