### PR TITLE
Updated Docker-based CI workflow for more platforms

### DIFF
--- a/.github/workflows/docker-ci-for-pr.yml
+++ b/.github/workflows/docker-ci-for-pr.yml
@@ -1,0 +1,46 @@
+# A dedicated workflow for building pull requests
+name: docker-ci-pull_request
+
+on:
+  pull_request:
+    branches:
+      - "develop"
+
+jobs:
+  build-stdknl:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: developers/docker-ci/Dockerfile
+          push: false
+          build-args: |
+            SML=poly
+            BUILDOPTS=--stdknl -j2 -t
+
+  build-expk:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: developers/docker-ci/Dockerfile
+          push: false
+          build-args: |
+            SML=poly
+            BUILDOPTS=--expk -j2 -t

--- a/.github/workflows/docker-ci-for-pr.yml
+++ b/.github/workflows/docker-ci-for-pr.yml
@@ -1,5 +1,5 @@
 # A dedicated workflow for building pull requests
-name: docker-ci-pull_request
+name: docker-ci-for-pr
 
 on:
   pull_request:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,10 +1,6 @@
 name: docker-ci
 
 on:
-  pull_request:
-    branches:
-      - "develop"
-
   push:
     branches:
       - "master"

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - "master"
       - "develop"
+
 env:
   USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
   PASSWORD: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -26,7 +27,7 @@ jobs:
         with:
           images: ${{ env.USERNAME }}/hol-dev
           tags: |
-            type=sha,suffix=-stdknl
+            type=sha,prefix=ci-,suffix=-stdknl
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -62,7 +63,7 @@ jobs:
         with:
           images: ${{ env.USERNAME }}/hol-dev
           tags: |
-            type=sha,suffix=-expk
+            type=sha,prefix=ci-,suffix=-expk
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/self-runner.yml
+++ b/.github/workflows/self-runner.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   build:
-    runs-on: [ self-runner, ubuntu-latest ]
+    runs-on: ubuntu-latest
     steps:
       -
         name: Checkout

--- a/.github/workflows/self-runner.yml
+++ b/.github/workflows/self-runner.yml
@@ -4,6 +4,7 @@ env:
   default_kernel: 'expk'
   default_concurrency: '2'
   default_dockerfile: 'Dockerfile'
+  default_platform: 'linux/amd64'
 
 on:
   workflow_dispatch:
@@ -17,6 +18,15 @@ on:
         - stdknl
         - expk
         - otknl
+      platform:
+        description: 'Platform'
+        required: true
+        default: 'linux/amd64'
+        type: choice
+        options:
+        - linux/386
+        - linux/amd64
+        - linux/arm64
       concurrency:
         description: 'Concurrency'
         required: true
@@ -29,7 +39,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [ self-runner, ubuntu-latest ]
     steps:
       -
         name: Checkout
@@ -63,6 +73,8 @@ jobs:
           file: developers/docker-ci/${{ env.default_dockerfile }}
           push: true
           build-args: |
+            TARGETPLATFORM=${{ github.event.inputs.platform || env.default_platform }}
+            # NOTE: mosml is too slow to be chosen here
             SML=poly
             # NOTE: the arg value cannot be quoted here:
             BUILDOPTS=--${{ github.event.inputs.kernel || env.default_kernel }} -j${{ github.event.inputs.concurrency || env.default_concurrency }} ${{ github.event.inputs.more-options }}

--- a/developers/docker-ci/Dockerfile
+++ b/developers/docker-ci/Dockerfile
@@ -4,7 +4,11 @@
 #
 
 # This "base" image is described in "base/Dockerfile"
-FROM binghelisp/hol-dev:latest
+FROM --platform=$TARGETPLATFORM binghelisp/hol-dev:latest
+
+# The following two arguments are supported by "docker buildx" commands
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
 
 # GitHub Actions' hardware specification for Linux virtual machines: 2-core CPU (x86_64)
 # By default we use 4 cores in other building environments (e.g. Docker Hub autobuilds)

--- a/developers/docker-ci/base/Dockerfile
+++ b/developers/docker-ci/base/Dockerfile
@@ -2,10 +2,16 @@
 #
 # HOL4 building environment (Docker), base image
 #
-# e.g. docker build --push -t binghelisp/hol-dev .
+# e.g. docker buildx build --platform linux/386,linux/amd64,linux/arm64 .
 
 # GitHub Actions recommends Debian-based systems as base images
-FROM debian:stable
+FROM --platform=$TARGETPLATFORM debian:stable
+
+# The following two arguments are supported by "docker buildx"
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+RUN echo "I was running on $BUILDPLATFORM, building for $TARGETPLATFORM" > /tmp/log
 
 WORKDIR /ML
 VOLUME /ML
@@ -13,50 +19,51 @@ VOLUME /ML
 # Use this mode when you need zero interaction while installing or upgrading the system via apt
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LD_LIBRARY_PATH=/usr/local/lib
+ENV PATH=/ML/HOL/bin:$PATH
 
-# necessary packages
+# some necessary Debian packages
 RUN apt-get update -qy
-RUN apt-get install -qy build-essential graphviz git libgmp-dev curl wget
-
-# optional packages (IDE and others)
-RUN apt-get install -qy emacs-nox vim automake procps
+RUN apt-get install -qy build-essential graphviz git libgmp-dev wget curl procps file
 RUN apt-get clean
 
-# install MLton (https://github.com/MLton/mlton.git)
-RUN wget -q https://github.com/MLton/mlton/releases/download/on-20210117-release/mlton-20210117-1.amd64-linux-glibc2.31.tgz
-RUN tar xzf mlton-20210117-1.amd64-linux-glibc2.31.tgz
-RUN make -C mlton-20210117-1.amd64-linux-glibc2.31
-RUN rm -rf mlton-20210117-1.amd64-linux-glibc2.31*
+# 1. install Moscow ML (https://github.com/kfl/mosml.git)
+RUN wget -q -O - https://github.com/kfl/mosml/archive/refs/tags/ver-2.10.1.tar.gz | tar xzf -
+RUN make -C mosml-ver-2.10.1/src world install
+RUN rm -rf mosml-ver-2.10.1
 
-# install polyml (https://github.com/polyml/polyml.git)
-RUN wget -q -O polyml-5.9.tar.gz https://github.com/polyml/polyml/archive/refs/tags/v5.9.tar.gz
-RUN tar xzf polyml-5.9.tar.gz
-RUN cd polyml-5.9 && ./configure --enable-intinf-as-int
+# 2. install polyml (https://github.com/polyml/polyml.git)
+RUN wget -q -O - https://github.com/polyml/polyml/archive/refs/tags/v5.9.tar.gz | tar xzf -
+RUN if [ "linux/386" = "$TARGETPLATFORM" ]; then \
+       cd polyml-5.9 && ./configure --build=i686-pc-linux-gnu --enable-intinf-as-int; \
+    else \
+       cd polyml-5.9 && ./configure --enable-intinf-as-int; \
+    fi
 RUN make -C polyml-5.9 -j4
-RUN make -C polyml-5.9 compiler
-RUN make -C polyml-5.9 install
+RUN make -C polyml-5.9 compiler install
+RUN rm -rf polyml-5.9
 
-# install mosml (https://github.com/kfl/mosml.git)
-RUN wget -q -O mosml-ver-2.10.1.tar.gz https://github.com/kfl/mosml/archive/refs/tags/ver-2.10.1.tar.gz
-RUN tar xzf mosml-ver-2.10.1.tar.gz
-RUN make -C mosml-ver-2.10.1/src world
-RUN make -C mosml-ver-2.10.1/src install
+# 3. install MLton binary (https://github.com/MLton/mlton.git) for linux/amd64 only
+RUN if [ "linux/amd64" = "$TARGETPLATFORM" ]; then \
+    wget -q -O - https://github.com/MLton/mlton/releases/download/on-20210117-release/mlton-20210117-1.amd64-linux-glibc2.31.tgz | tar xzf -; fi
+RUN if [ "linux/amd64" = "$TARGETPLATFORM" ]; then make -C mlton-20210117-1.amd64-linux-glibc2.31; fi
+RUN rm -rf mlton-20210117-1.amd64-linux-glibc2.31
 
-# install OpenTheory
-RUN wget -q -O /root/opentheory-local.tar.gz https://github.com/binghe/opentheory/releases/download/v1.5/opentheory-local.tar.gz
-RUN cd /root && tar xzf opentheory-local.tar.gz
-RUN wget -q -O opentheory-1.5.tar.gz https://github.com/binghe/opentheory/archive/refs/tags/v1.5.tar.gz
-RUN tar xzf opentheory-1.5.tar.gz
-RUN make -C opentheory-1.5 mlton
-RUN cp opentheory-1.5/bin/mlton/opentheory /usr/local/bin
+# 4. install OpenTheory with local packages
+RUN wget -q -O - https://github.com/binghe/opentheory/archive/refs/tags/v1.5.tar.gz | tar xzf -
+RUN if [ "linux/amd64" = "$TARGETPLATFORM" ]; then \
+        make -C opentheory-1.5 mlton; \
+    else \
+        make -C opentheory-1.5 polyml; \
+    fi
+RUN if [ "linux/amd64" = "$TARGETPLATFORM" ]; then \
+        cp opentheory-1.5/bin/mlton/opentheory /usr/local/bin; \
+    else \
+        cp opentheory-1.5/bin/polyml/opentheory /usr/local/bin; \
+    fi
+RUN rm -rf opentheory-1.5
+RUN wget -q -O /root/opentheory-local.tar.gz \
+    https://github.com/binghe/opentheory/releases/download/v1.5/opentheory-local.tar.gz
+RUN cd /root && tar xzf opentheory-local.tar.gz && rm opentheory-local.tar.gz
 
-# for Emacs
+# for HOL Emacs mode (Emacs is not installed by default, however)
 COPY .emacs /root
-
-# [optional] delete building directories for smaller image sizes
-RUN rm -rf polyml*
-RUN rm -rf mosml*
-RUN rm -rf opentheory*
-
-# for developments using this base image with attached /ML volumes
-ENV PATH=/ML/HOL/bin:$PATH


### PR DESCRIPTION
First of all, I updated my docker base image `binghelisp/hol-dev` with more platforms (`linux/386` and `linux/arm64`) supported.  This is based on Docker's `buildx` technology: a single tag with multiple platforms behind it.

Then, the `self-runner` workflow can be manually triggered with platform options: `linux/386`, `linux/amd64` and `linux/arm64`.   HOL building on Linux/ARM64 is relatively slow on GitHub Actions' x86-based hardware, it took about 3 hours 33 minutes (without `-t`) [1].

[1] https://github.com/binghe/HOL/actions/runs/3881807957

As a side effect, on M1 Mac with Docker Desktop installed, now HOL users may pull the above docker image to obtain a HOL building environment with Moscow ML, PolyML and OpenTheory installed.