### PR TITLE
Change slash to `fn` to make emacs happy in hol-input.el

### DIFF
--- a/tools/hol-input.el
+++ b/tools/hol-input.el
@@ -58,12 +58,12 @@ removing all space and newline characters."
 ;; lexical-let is used since Elisp lacks lexical scoping.
 
 (defun hol-input-compose (f g)
-  "\x -> concatMap F (G x)"
+  "fn x -> concatMap F (G x)"
   (lexical-let ((f1 f) (g1 g))
     (lambda (x) (hol-input-concat-map f1 (funcall g1 x)))))
 
 (defun hol-input-or (f g)
-  "\x -> F x ++ G x"
+  "fn x -> F x ++ G x"
   (lexical-let ((f1 f) (g1 g))
     (lambda (x) (append (funcall f1 x) (funcall g1 x)))))
 


### PR DESCRIPTION
I am running emacs 30.0.50. Apparently emacs all of a sudden is not so happy about having a slash in the docstring. This is replicable on my build of emacs 30.0.50 (built on commit `640fd9b594fa`):
```
(defun angry-emacs ()
  "not so happy about the slash! \x -> x"
  nil)
```
This will get the following error:
```
Debugger entered--Lisp error: (error "Invalid escape character syntax")
  #<subr elisp--preceding-sexp>()
  apply(#<subr elisp--preceding-sexp> nil)
  evil--preceding-sexp(#<subr elisp--preceding-sexp>)
  apply(evil--preceding-sexp #<subr elisp--preceding-sexp> nil)
  elisp--preceding-sexp()
  elisp--eval-last-sexp(nil)
  eval-last-sexp(nil)
  funcall-interactively(eval-last-sexp nil)
  command-execute(eval-last-sexp)
```
As long as you get rid of the slash, emacs is happy:
```
(defun angry-emacs ()
  "not so happy about the slash! fn x -> x"
  nil)
```
So I just changed all the `#"\\"` to `fn`.