### PR TITLE
Vimhol respect `lastmaker`

### DIFF
--- a/tools/vim/README.md
+++ b/tools/vim/README.md
@@ -32,9 +32,10 @@ All files are located under tools/vim
 
 1. Add the contents of `hol-config.sml` to your `~/.hol-config.sml` file
 2. Add the contents of `filetype.vim` to your `~/.vim/filetype.vim`
-3. Run hol to start the HOL session
+3. Run hol to start the HOL session (only necessary when using vim without
+   support for terminal buffers)
 4. Run vim and open a HOL script
-5. Select some SML value or declaration and type hs to send it to the HOL
+5. Select some SML value or declaration and type `hs` to send it to the HOL
    session. See below for more key mappings
 
 If you don't have `filetype on` in vim, then this won't work. In that case, you
@@ -53,8 +54,13 @@ are using a custom fifo path).
 
 Neovim and some versions of vim can run the interactive HOL session (HOL repl) in a terminal buffer within the editor, right next to a file buffer.
 Vim supports this feature if `:echo has('terminal')` prints `1`, neovim if `:echo exists(':terminal')` prints a non-zero value.
-For the supported versions, this plugin offers additional keyboard mappings to open and close a HOL session, as documented below in the section *key mappings for the HOL repl buffer*.
-Whenever a HOL session is started, a new unique fifo is created.
+For the supported versions, this plugin offers additional keyboard mappings to open and close a terminal buffer running hol, as documented below in the section *key mappings for the HOL repl buffer*.
+Whenever a new HOL interactive session is started, a new unique fifo is created.
+
+The `hol` executable that is run in the interactive session is determined in the following order:
+1. If `Holmake` was previously run in the current working directory of the loaded theory file before (and thus the file `.HOLMK/lastmaker` exists) the plugin attempts to run the `hol` that is relative to the previously used `Holmake`.
+2. Otherwise, if the `$HOLDIR` environment variable is set the plugin attempts to run `$HOLDIR/bin/hol`.
+3. Otherwise, simply `hol` will be run (expecting `hol` to be in the `$PATH` environment variable).
 
 Read more in the documentation on [vim terminal buffers](https://vimhelp.org/terminal.txt.html) (or [neovim terminal buffers](https://neovim.io/doc/user/nvim_terminal_emulator.html)).
 
@@ -99,7 +105,7 @@ Command     | Description
 `hy`        | Toggle HOL's show types trace.
 `hn`        | Toggle HOL's `PP.avoid_unicode` trace.
 
-## Key mappings for the HOL repl buffer
+## Key mappings for the hol terminal buffer
 
 For the HOL repl hosted by vim the following commands work in normal mode of
 any `*Script.sml` file:

--- a/tools/vim/hol.src
+++ b/tools/vim/hol.src
@@ -249,19 +249,41 @@ nn <buffer><silent> <LocalLeader>y :call HOLCall(function("HOLF"),["Globals.show
 nn <buffer><silent> <LocalLeader>n :call HOLCall(function("HOLF"),["Feedback.set_trace \"PP.avoid_unicode\" (1 - Feedback.current_trace \"PP.avoid_unicode\")"])<CR>
 no <buffer><LocalLeader>h h
 
-if ! exists('$HOLDIR') || (!has('terminal') && ! has('nvim'))
-      \ || (has('nvim') && !exists(':terminal'))
-  let b:did_hol = 1
+if (!has('terminal') && ! has('nvim'))
+    \ || (has('nvim') && !exists(':terminal'))
   " skip terminal feature
+  let b:did_hol = 1
+  echomsg "vimhol: no support for (n)vim terminal feature"
   finish
 endif
 
-" if exists use readline wrapper
-if executable('rlwrap')
-  let s:rlwrap_str = 'rlwrap '
-else
-  let s:rlwrap_str = ''
-endif
+" finds hol located next Holmake (the lastmaker)
+function! LastmakerHOL()
+  let lastmakerfile = ".HOLMK/lastmaker"
+  if filereadable(lastmakerfile)
+    let lm = readfile(lastmakerfile,"",1)
+    if 0 < len(lm)
+      " assumes only one Holmake string in lastmaker path
+      return fnamemodify(lm[0],":s?Holmake?hol?")
+    endif
+  endif
+  return ""
+endfunction
+
+" finds a HOL executable
+function! WhichHOL()
+  let lm = LastmakerHOL()
+  let holdir = $HOLDIR . '/bin/hol'
+  " honouring 'hol' next to lastmaker
+  if executable(lm)
+    return lm
+  elseif executable(holdir)
+    return holdir
+  elseif executable('hol')
+    return 'hol'
+  endif
+  return ""
+endfunction
 
 " initialise
 if ! has_key(g:,'hol_repl')
@@ -269,14 +291,14 @@ if ! has_key(g:,'hol_repl')
 endif
 
 function! HOLREPLnew()
-  let l:cmd = $HOLDIR . '/bin/hol'
-  if ! executable(l:cmd)
-    echoerr 'hol command not found: ' . l:cmd
+  let l:cmd = WhichHOL()
+  if ! (0 < len(l:cmd) && executable(l:cmd))
+    echoerr 'vimhol: hol command not found ' . l:cmd . ' Set HOLDIR environment variable'
     return 0
   endif
   let s:holpipe = tempname()
   call system('mkfifo '. s:holpipe)
-  "echom "holrepl pipe " . s:holpipe
+  "echomsg "holrepl pipe " . s:holpipe
   let options = {
   \  "cwd": expand('%:p:h'),
   \  "vertical": 1,
@@ -284,16 +306,20 @@ function! HOLREPLnew()
   \    "VIMHOL_FIFO": s:holpipe
   \  }}
   let altname = expand("%:r:t") " alternate name for terminal buffer
-  echom 'holrepl cmd: ' . s:rlwrap_str . l:cmd
+  echomsg 'vimhol repl cmd: ' . l:cmd
   if has('nvim') " neovim terminal
     let options.stdin = "null"
     vsplit | enew
-    let l:terminal_job_id = termopen(s:rlwrap_str . l:cmd, options)
+    let l:terminal_job_id = termopen(l:cmd, options)
     call add(g:hol_repl, {'buf': bufnr(''), 'job': l:terminal_job_id, 'pipe': s:holpipe})
     " scroll to end of terminal buffer
     silent! normal G
   else " vim terminal
-    rightbelow let s:replbuf = term_start(s:rlwrap_str . l:cmd, options)
+    " Uncomment the next vimscript let-assignment to automatically close any
+    " terminated terminal buffer window. This is encouraged for advanced users
+    " only, because also any buffer with a failing hol command will be closed.
+    "let options.term_finish = "close"
+    rightbelow let s:replbuf = term_start(l:cmd, options)
     call add(g:hol_repl, {'buf': s:replbuf, 'pipe': s:holpipe})
     call term_setkill(g:hol_repl[-1].buf, 'term')
   endif


### PR DESCRIPTION
The vimhol plugin (with (n)vim terminal feature) now dynamically chooses
the first `hol` executable in the following order, when starting a new
interactive hol session:

1. hol relative to the lastmaker
  If `Holmake` was run on the edited theory before, its path resides in
  `.HOLMK/lastmaker`. vimhol probes that path with `hol` substituted for
  `Holmake`.
2. `$HOLDIR` environment variable
3. `hol` if in scope, e.g. from `PATH`

This feature removes the earlier requirement of setting a `$HOLDIR`
environment variable.

The path of the chosen hol is printed as a message for the user (via
`echomsg`), which is as well accessible through `:messages`. The message
has the shape `hol repl cmd(<id>): <cmd>` containing the related
terminal buffer id and the hol command.

Hope this is a reasonable somewhat analogous behaviour to [`hol-mode.el`](https://github.com/HOL-Theorem-Prover/HOL/blob/59508de8d4c907351c9ffa2bc4a7c5acc8a54088/tools/hol-mode.src#L844-L884)
