### PR TITLE
Fix ASL equivalence proofs

### DIFF
--- a/examples/l3-machine-code/arm8/asl-equiv/l3_equivalence_lemmasScript.sml
+++ b/examples/l3-machine-code/arm8/asl-equiv/l3_equivalence_lemmasScript.sml
@@ -124,7 +124,7 @@ Proof
     >- (
       rw[bool_list_eq, v2n_APPEND, v2n_add, LENGTH_add_MAX] >>
       `MAX (LENGTH a) 1 = LENGTH a ∧ MAX (LENGTH a + 1) 1 = LENGTH a + 1` by (
-        rw[MAX_DEF] >> Cases_on `a` >> gvs[]) >>
+        rw[MAX_DEF] >> gvs[]) >>
       rw[] >> simp[LENGTH_n2v] >>
       `LOG 2 (2 * v2n a + 2) = SUC $ LOG 2 (v2n a + 1)` by
         simp[GSYM logrootTheory.LOG_MULT] >>
@@ -134,7 +134,7 @@ Proof
       rw[bool_list_eq] >- rw[v2n_APPEND, v2n_add] >>
       simp[LENGTH_add_MAX] >>
       `MAX (LENGTH a + 1) 1 = LENGTH a + 1` by (
-        rw[MAX_DEF] >> Cases_on `a` >> gvs[]) >>
+        rw[MAX_DEF] >> gvs[]) >>
       `v2n (a ++ [F]) + 1 = v2n (a ++ [T])` by simp[v2n_APPEND] >> simp[] >>
       qspec_then `a ++ [T]` assume_tac LENGTH_n2v_v2n_LESS >> gvs[MAX_DEF]
       )
@@ -145,7 +145,7 @@ Proof
     rw[bool_list_eq] >- rw[v2n_APPEND, v2n_add] >>
     simp[LENGTH_add_MAX] >>
     `MAX (LENGTH a + 1) 1 = LENGTH a + 1` by (
-      rw[MAX_DEF] >> Cases_on `a` >> gvs[]) >>
+      rw[MAX_DEF] >> gvs[]) >>
     `v2n (a ++ [F]) + 1 = v2n (a ++ [T])` by simp[v2n_APPEND] >> simp[] >>
     qspec_then `a ++ [T]` assume_tac LENGTH_n2v_v2n_LESS >> gvs[MAX_DEF]
     )
@@ -359,7 +359,8 @@ Proof
     qmatch_goalsub_abbrev_tac `add neg` >>
     `EXISTS $¬ neg` by (unabbrev_all_tac >> gvs[EXISTS_MEM, MEM_MAP]) >>
     simp[LENGTH_add_MAX] >>
-    `MAX (LENGTH neg) 1 = LENGTH neg` by (unabbrev_all_tac >> simp[MAX_DEF]) >>
+    `MAX (LENGTH neg) 1 = LENGTH neg` by (
+      unabbrev_all_tac >> simp[MAX_DEF] >> rw[] >> gvs[]) >>
     pop_assum SUBST_ALL_TAC >> simp[MAX_DEF, LENGTH_n2v] >>
     reverse IF_CASES_TAC >> gvs[] >- (unabbrev_all_tac >> simp[]) >>
     Cases_on `v2n neg = 0` >- (unabbrev_all_tac >> gvs[]) >>

--- a/examples/l3-machine-code/arm8/asl-equiv/l3_equivalence_miscScript.sml
+++ b/examples/l3-machine-code/arm8/asl-equiv/l3_equivalence_miscScript.sml
@@ -356,7 +356,7 @@ Theorem extract_bit:
 Proof
   rw[] >> bitstringLib.Cases_on_v2w `w` >>
   simp[word_extract_v2w] >>
-  irule $ iffLR WORD_EQ >> rw[] >> Cases_on `x` >> gvs[] >>
+  irule $ iffLR WORD_EQ >> rw[] >>
   simp[bit_v2w, testbit_el, word_bits_v2w, field_def, shiftr_def, fixwidth] >>
   simp[DROP_TAKE, TAKE1, HD_DROP] >>
   Cases_on `EL (dimindex (:α) - (i + 1)) v` >> gvs[] >> WORD_DECIDE_TAC
@@ -557,7 +557,7 @@ Theorem LENGTH_add:
 Proof
   rw[] >> gvs[]
   >- (
-    gvs[LENGTH_add_MAX] >> reverse $ rw[MAX_DEF] >- (Cases_on `ys` >> gvs[]) >>
+    gvs[LENGTH_add_MAX] >> reverse $ rw[MAX_DEF] >- gvs[] >>
     qpat_x_assum `LENGTH _ < _` mp_tac >>
     simp[LENGTH_n2v, NOT_LESS, LE_LT1, ADD1] >>
     irule LOG_LT >> simp[v2n_add_less_limit]


### PR DESCRIPTION
These proofs broke due to changes in automatic rewrites, causing CakeML regression to fail in turn (https://cakeml.org/regression.cgi/job/2152). This commit should fix them.