### PR TITLE
Avoid issues with evaluation of `n2l` and `l2n`.

### DIFF
--- a/src/finite_maps/patricia_castsScript.sml
+++ b/src/finite_maps/patricia_castsScript.sml
@@ -238,7 +238,7 @@ val s2n_STRING_STRING = prove(
   `!f b c1 c2 s.
        1 < b /\ 0 < (f c1 MOD b) ==>
        b <= s2n b f (STRING c1 (STRING c2 s))`,
-  SRW_TAC [ARITH_ss] [EXP_ADD, s2n_def, EVAL ``l2n b [c]``, Once l2n_APPEND]
+  SRW_TAC [ARITH_ss] [EXP_ADD, s2n_def, l2n_def, Once l2n_APPEND]
     \\ MATCH_MP_TAC (DECIDE ``a <= b ==> a <= b + c``)
     \\ REWRITE_TAC [GSYM MULT_ASSOC]
     \\ SRW_TAC [ARITH_ss] [ZERO_LESS_MULT, ZERO_LT_EXP]);

--- a/src/list/src/numposrepLib.sml
+++ b/src/list/src/numposrepLib.sml
@@ -13,19 +13,36 @@ open Parse
 (* ------------------------------------------------------------------------- *)
 
 local
-   val thm = Thm.CONJUNCT2 l2n_pow2_compute
-   val rule = simpLib.SIMP_RULE numLib.std_ss []
-   val f = numSyntax.mk_numeral o Arbnum.log2 o Arbnum.fromInt
-   fun l2n_pow2 i = rule (Thm.SPEC (f i) thm)
-   fun n2l_pow2 i = rule (Thm.SPEC (f i) n2l_pow2_compute)
-   val sizes = [2, 8, 16, 256]
+   val srule = simpLib.SIMP_RULE numLib.std_ss
+   val rule = srule []
+   val rule0 = srule [bitTheory.DIVMOD_2EXP_def, boolTheory.LET_THM]
+   val n_tm =
+     Term.mk_comb (numSyntax.numeral_tm, Term.mk_var ("n", numSyntax.num))
+   fun zero_num_rule th =
+     CONJ (rule0 (Q.SPEC `0n` th)) (rule (Thm.SPEC n_tm th))
+   fun log_spec (th1, th2) i =
+     let
+       val a = Arbnum.fromInt i
+       val lga = Arbnum.log2 a
+     in
+       if Arbnum.pow (Arbnum.two, lga) = a then
+         Thm.SPEC (numSyntax.mk_numeral lga) th1
+       else
+         Thm.SPEC (numSyntax.mk_numeral a) th2
+     end
+   val l2n_rule =
+     rule o log_spec (Thm.CONJUNCT2 l2n_pow2_compute, Thm.CONJUNCT2 l2n_def)
+   val n2l_rule =
+     zero_num_rule o
+     log_spec (n2l_pow2_compute, Conv.CONV_RULE Conv.SWAP_FORALL_CONV n2l_def)
+   val sizes = [2, 8, 10, 16, 256]
    val thms =
-      [numLib.SUC_RULE BOOLIFY_def, l2n_def, n2l_def, l2n_2_thms,
+      [numLib.SUC_RULE BOOLIFY_def, Thm.CONJUNCT1 l2n_def, l2n_2_thms,
        num_from_bin_list_def, num_from_oct_list_def, num_from_dec_list_def,
        num_from_hex_list_def,
        num_to_bin_list_def, num_to_oct_list_def, num_to_dec_list_def,
        num_to_hex_list_def] @
-      List.map l2n_pow2 (tl sizes) @ List.map n2l_pow2 sizes
+      List.map l2n_rule (tl sizes) @ List.map n2l_rule sizes
 in
    fun add_numposrep_compset cmp = computeLib.add_thms thms cmp
 end


### PR DESCRIPTION
For example, restricts evaluation of `n2l` to terms with standard base sizes and `NUMERAL` values. Previously, EVAL ``n2l 10 a`` and EVAL ``n2l a 10` would both loop.