### PR TITLE
Equivalence between ‘lim$differentiable’ and ‘derivative$differentiable’

### DIFF
--- a/src/real/analysis/limScript.sml
+++ b/src/real/analysis/limScript.sml
@@ -278,6 +278,20 @@ Proof
     rw [differentiable, diffl_has_vector_derivative]
 QED
 
+(* The equivalence between ‘differentiable’ and ‘derivative$differentiable’ *)
+Theorem differentiable_alt :
+    !f x. f differentiable x <=> derivative$differentiable f (at x)
+Proof
+    rw [differentiable, diffl_has_derivative, derivativeTheory.differentiable]
+ >> EQ_TAC
+ >- (STRIP_TAC \\
+     Q.EXISTS_TAC ‘\x. l * x’ >> rw [])
+ >> DISCH_THEN (Q.X_CHOOSE_THEN ‘g’ ASSUME_TAC)
+ >> ‘linear g’ by PROVE_TAC [has_derivative]
+ >> ‘?l. g = \x. l * x’ by METIS_TAC [linear_repr]
+ >> Q.EXISTS_TAC ‘l’ >> rw []
+QED
+
 (*---------------------------------------------------------------------------*)
 (* Derivative is unique                                                      *)
 (*---------------------------------------------------------------------------*)

--- a/src/real/analysis/real_topologyScript.sml
+++ b/src/real/analysis/real_topologyScript.sml
@@ -240,6 +240,49 @@ val linear = new_definition ("linear",
         (!x y. f(x + y) = f(x) + f(y)) /\
         (!c x. f(c * x) = c * f(x))``);
 
+(* Courtesy to Thomas Sewell for providing this proof (first) on Slack
+
+   NOTE: The explicit-form of linear functions (linear_repr and linear_alt) does
+         NOT hold in higher dimensional spaces, e.g. (f:real['M]->real['N]), cf.
+         vec_linear_def in examples/vectorScript.sml (ported from HOL-Light).
+
+         However, the theorem linear_repr is necessary in limTheory to show the
+         equivalence between the old and new definitions of "differentiable":
+
+         |- !f x. f differentiable_at x <=> f differentiable (at x)
+ *)
+Theorem linear_lemma[local]:
+  (!c x. f(c * x) = c * f(x)) ==> ?l. f = (\x. l * x)
+Proof
+  rw []
+  \\ qexists_tac `f 1`
+  \\ rw [FUN_EQ_THM]
+  \\ metis_tac [linear, REAL_MUL_RID]
+QED
+
+Theorem linear_repr :
+    !f. linear f <=> ?l. f = \x. l * x
+Proof
+    Q.X_GEN_TAC ‘f’
+ >> EQ_TAC
+ >> rw [linear, linear_lemma]
+ >> REAL_ARITH_TAC
+QED
+
+(* In fact, only the part ‘!c x. f(c * x) = c * f(x))’ is primitive.
+
+   This theorem may simplify some theorems below, but it only holds for
+   one-dimensional linear functions (I believe). --Chun Tian, 11 nov 2022.
+ *)
+Theorem linear_alt_cmul :
+    !f. linear f <=> !c x. f(c * x) = c * f(x)
+Proof
+    Q.X_GEN_TAC ‘f’
+ >> EQ_TAC >- rw [linear]
+ >> rw [linear_repr]
+ >> MATCH_MP_TAC linear_lemma >> art []
+QED
+
 val LINEAR_SCALING = store_thm ("LINEAR_SCALING",
  ``!c. linear(\x:real. c * x)``,
  SIMP_TAC std_ss [linear] THEN REAL_ARITH_TAC);


### PR DESCRIPTION
Hi,

This small PR continues #1033 bridging the old and new derivative theories of the calculus. The concept of differentiable functions in `limTheory` and the more general version from `real_topologyTheory` (when focusing on single point `at x`) are actually equivalent:
```
   [differentiable_alt]  Theorem (limTheory)      
      ⊢ ∀f x. f differentiable x ⇔ derivative$differentiable f (at x)
```

This proof wasn't obvious to me, until the following theorem is proven (after some discussions on Slack), which shows that any one-dimension linear function has an explicit form (NOTE: this result doesn't hold in higher dimensions, i.e. vector functions):
```
   [linear_repr]  Theorem (real_topologyTheory)
      ⊢ ∀f. linear f ⇔ ∃l. f = (λx. l * x)

   [linear_alt_cmul]  Theorem      
      ⊢ ∀f. linear f ⇔ ∀c x. f (c * x) = c * f x
```
Where `linear` is defined in this way:
```
   [linear]  Definition
      ⊢ ∀f. linear f ⇔
            (∀x y. f (x + y) = f x + f y) ∧ ∀c x. f (c * x) = c * f x
```

# Future directions

The possible next step in this direction is to update «HOL Description», expanding the part related to calculus. I'm near the end of this documentation work.

But what's more important is to prove the equivalence between Lebesgue Integral and Gauge Integral for functions integrable in both integrals. Otherwise it's almost impossible to calculate any concrete Lebesgue integrals (over intervals) involving higher-order polynomials, and transcendental functions. In other words, under certain "integrable" conditions [2], something like the following theorem should be proven:
```
|- !f a b. f absolutely_integrable_on (interval[a,b]) ==>
          (lebesgue$integral lebesgue (\x. Normal (f x) * indicator_fn (interval[a,b]) x) =
           Normal (integration$integral (interval (a,b)) f))
```
where `lebesgue` is the measure space of all (real-valued) Lebesgue measurable sets defined in `examples/probability/lebesgue_measureScript.sml`.  This proof is not easy but I know a version of this proof in a book [1]

[1] R. G. Bartle, A Modern Theory of Integration. American Mathematical Soc., 2001.
[2] "A function is Lebesgue integrable if and only if the function and its absolute value are Henstock–Kurzweil integrable." somewhere from [1]