### PR TITLE
Updated Dockerfile for CI builds

### DIFF
--- a/developers/docker-ci/base-5.4/Dockerfile
+++ b/developers/docker-ci/base-5.4/Dockerfile
@@ -1,0 +1,50 @@
+# syntax=docker/dockerfile:1
+#
+# HOL4 building environment (Docker), base image for HOL-Omega
+#
+# e.g. docker buildx build --platform linux/386,linux/amd64 -t binghelisp/hol-dev:polyml-5.4 .
+
+# GitHub Actions recommends Debian-based systems as base images
+FROM ubuntu:16.04
+
+# The following two arguments are supported by "docker buildx"
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+RUN echo "I was running on $BUILDPLATFORM, building for $TARGETPLATFORM" > /tmp/log
+
+WORKDIR /ML
+VOLUME /ML
+
+# Use this mode when you need zero interaction while installing or upgrading the system via apt
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LD_LIBRARY_PATH=/usr/local/lib
+ENV PATH=/ML/HOL-Omega/bin:/ML/HOL/bin:$PATH
+
+# some necessary Debian packages
+RUN apt-get update -qy
+RUN apt-get install -qy build-essential graphviz git libgmp-dev wget curl procps file
+
+# for Unicode display, learnt from Magnus Myreen
+RUN apt-get install -qy locales-all man aptitude
+RUN apt-get clean
+
+# 1. install Moscow ML (https://github.com/kfl/mosml.git)
+RUN wget -q -O - https://github.com/kfl/mosml/archive/refs/tags/ver-2.10.1.tar.gz | tar xzf -
+RUN make -C mosml-ver-2.10.1/src world install
+RUN rm -rf mosml-ver-2.10.1
+
+# 2. install polyml-5.4.1 (https://github.com/binghe/polyml)
+RUN wget -q -O - https://github.com/binghe/polyml/archive/refs/tags/v5.4.1.tar.gz | tar xzf -
+RUN if [ "linux/386" = "$TARGETPLATFORM" ]; then \
+       cd polyml-5.4.1 && ./configure --build=i686-pc-linux-gnu --enable-intinf-as-int; \
+    else \
+       cd polyml-5.4.1 && ./configure --enable-intinf-as-int; \
+    fi
+RUN make -C polyml-5.4.1 -j4
+RUN make -C polyml-5.4.1 compiler install
+RUN rm -rf polyml-5.4.1
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8

--- a/developers/docker-ci/base-5.4/Makefile
+++ b/developers/docker-ci/base-5.4/Makefile
@@ -1,0 +1,12 @@
+IMAGE=binghelisp/hol-dev:polyml-5.4
+
+build:
+	docker buildx build --platform linux/386 .
+	docker buildx build --platform linux/amd64 .
+	docker buildx build --platform linux/386,linux/amd64 -t $(IMAGE) .
+
+push: build
+	docker push $(IMAGE)
+
+run:
+	docker run --rm -ti $(IMAGE)

--- a/developers/docker-ci/base/Dockerfile
+++ b/developers/docker-ci/base/Dockerfile
@@ -23,8 +23,14 @@ ENV PATH=/ML/HOL/bin:$PATH
 
 # some necessary Debian packages
 RUN apt-get update -qy
-RUN apt-get install -qy build-essential graphviz git libgmp-dev wget curl procps file
+RUN apt-get install -qy build-essential graphviz git libgmp-dev wget curl procps file unzip
+
+# for Unicode display, learnt from Magnus Myreen
+RUN apt-get install -qy locales-all terminfo man aptitude
 RUN apt-get clean
+
+# IDE
+RUN apt-get install -qy emacs-nox
 
 # 1. install Moscow ML (https://github.com/kfl/mosml.git)
 RUN wget -q -O - https://github.com/kfl/mosml/archive/refs/tags/ver-2.10.1.tar.gz | tar xzf -
@@ -32,15 +38,16 @@ RUN make -C mosml-ver-2.10.1/src world install
 RUN rm -rf mosml-ver-2.10.1
 
 # 2. install polyml (https://github.com/polyml/polyml.git)
-RUN wget -q -O - https://github.com/polyml/polyml/archive/refs/tags/v5.9.tar.gz | tar xzf -
+RUN wget -q -O polyml-master.zip https://github.com/polyml/polyml/archive/refs/heads/master.zip
+RUN unzip polyml-master.zip
 RUN if [ "linux/386" = "$TARGETPLATFORM" ]; then \
-       cd polyml-5.9 && ./configure --build=i686-pc-linux-gnu --enable-intinf-as-int; \
+       cd polyml-master && ./configure --build=i686-pc-linux-gnu --enable-intinf-as-int; \
     else \
-       cd polyml-5.9 && ./configure --enable-intinf-as-int; \
+       cd polyml-master && ./configure --enable-intinf-as-int; \
     fi
-RUN make -C polyml-5.9 -j4
-RUN make -C polyml-5.9 compiler install
-RUN rm -rf polyml-5.9
+RUN make -C polyml-master -j4
+RUN make -C polyml-master compiler install
+RUN rm -rf polyml-master polyml-master.zip
 
 # 3. install MLton binary (https://github.com/MLton/mlton.git) for linux/amd64 only
 RUN if [ "linux/amd64" = "$TARGETPLATFORM" ]; then \
@@ -67,3 +74,7 @@ RUN cd /root && tar xzf opentheory-local.tar.gz && rm opentheory-local.tar.gz
 
 # for HOL Emacs mode (Emacs is not installed by default, however)
 COPY .emacs /root
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8

--- a/developers/docker-ci/base/Makefile
+++ b/developers/docker-ci/base/Makefile
@@ -1,0 +1,26 @@
+# NOTE: If you meet "ERROR: failed to solve: no match for platform in manifest",
+#       your error should be related to this open issue [1] that enter into
+#       Docker Desktop 4.20.  As a workaround, you should disable the flag
+#      'Use containerd' for pulling and storing images within the feature of
+#       Docker Desktop to solve it [2].  -- Chun Tian (binghe), July 17, 2023
+#
+# [1] https://github.com/moby/moby/issues/44578
+# [2] https://stackoverflow.com/questions/76355896
+
+DOCKER_IMAGE=binghelisp/hol-dev
+
+build:
+	docker buildx build --platform linux/386 .
+	docker buildx build --platform linux/amd64 .
+	docker buildx build --platform linux/arm64 .
+	docker buildx build --platform linux/386,linux/amd64,linux/arm64 \
+		-t $(DOCKER_IMAGE) .
+
+# This will reuse the images built locally by the "build" target
+push:
+	docker buildx build --platform linux/386,linux/amd64,linux/arm64 \
+		-t $(DOCKER_IMAGE) --push .
+
+# This runs the docker image in your native platform
+run:
+	docker run -ti --rm $(DOCKER_IMAGE)


### PR DESCRIPTION
Thanks for the hints. It seems that the remaining issue in #1110 is the PolyML itself - the latest release (5.9) has some issues at exception handling. After switching to latest PolyML `master` code for Docker-based CI builds, so far I haven't observed another building failure.

This PR contains the definition of the current version of Docker Hub image `binghelisp/hol-dev:latest` [1]. (NOTE: it's based on Debian "stable", which got updated to version 12 recently at June 10 as a major Debian release [2].)

There's also a Dockerfile for PolyML-5.4 (useful for very old builds such as HOL-Omega).

NOTE: The docker image here also contains the Unicode fixes ever discussed on Slack when running Emacs IDE in it, thus is also suitable as a "reference development environment" to some HOL users (In this case, the volume `ML` must be created and attached as a persistent personal data store, when running the docker image (`docker run -v ML:/ML ...`)

[1] https://hub.docker.com/r/binghelisp/hol-dev
[2] https://www.debian.org/News/2023/20230610