### PR TITLE
More properties of INT_FLOOR and INT_CEILING

### DIFF
--- a/src/real/intrealScript.sml
+++ b/src/real/intrealScript.sml
@@ -549,7 +549,7 @@ Proof
  >> METIS_TAC [REAL_LT_IMP_NE, INT_FLOOR_BOUNDS, real_of_int_add]
 QED
 
-Theorem is_int_thm :
+Theorem is_int_thm_lemma[local] :
     !x. is_int x <=> real_of_int (INT_FLOOR x) = real_of_int (INT_CEILING x)
 Proof
     Q.X_GEN_TAC ‘x’
@@ -560,6 +560,12 @@ Proof
  >> fs [INT_CEILING_INT_FLOOR]
  >> Suff ‘INT_FLOOR x < INT_FLOOR x + 1’ >- PROVE_TAC [INT_LT_IMP_NE]
  >> rw [INT_LT_ADDR]
+QED
+
+Theorem is_int_thm :
+    !x. is_int x <=> INT_FLOOR x = INT_CEILING x
+Proof
+    rw [is_int_thm_lemma, real_of_int_11]
 QED
 
 Theorem INT_CEILING_ADD_NUM :

--- a/src/real/intrealScript.sml
+++ b/src/real/intrealScript.sml
@@ -2,8 +2,9 @@
    A bridging theory between integers and reals
    ------------------------------------------------------------------------- *)
 
-open HolKernel Parse boolLib bossLib
-open intLib RealArith
+open HolKernel Parse boolLib bossLib;
+
+open arithmeticTheory integerTheory intLib realTheory RealArith hurdUtils;
 
 local open realSimps in end
 
@@ -64,30 +65,30 @@ End
 
 val real_of_int_monotonic = Q.store_thm("real_of_int_monotonic",
   `!i j. i < j ==> real_of_int i < real_of_int j`,
-  Cases \\ Cases \\ srw_tac[][real_of_int] \\ intLib.ARITH_TAC)
+  Cases \\ Cases \\ srw_tac[][real_of_int] \\ ARITH_TAC)
 
 val real_arch_least1 =
-  realTheory.REAL_ARCH_LEAST
+  REAL_ARCH_LEAST
   |> Q.SPEC `1r`
   |> SIMP_RULE (srw_ss()) []
 
-val Num_suc1 = intLib.ARITH_PROVE ``Num (&n + 1) = n + 1``
+val Num_suc1 = ARITH_PROVE ``Num (&n + 1) = n + 1``
 
-val lem = Q.prove( `!n. -&n <= 0r`, simp [realTheory.REAL_NEG_LE0])
+val lem = Q.prove( `!n. -&n <= 0r`, simp [REAL_NEG_LE0])
 
 val lem2 = Q.prove(
   `!n. -&(n + 1n) = -&n - 1r`,
-  once_rewrite_tac [GSYM realTheory.add_ints]
-  \\ simp [realTheory.real_sub]
+  once_rewrite_tac [GSYM add_ints]
+  \\ simp [real_sub]
   )
 
-val lem3 = intLib.ARITH_PROVE ``-&n + 1 < 0i ==> (Num (&n + -1i) = (n - 1))``
+val lem3 = ARITH_PROVE ``-&n + 1 < 0i ==> (Num (&n + -1i) = (n - 1))``
 
 val lem4 = Q.prove(
   `!n. n <> 0 ==> (-&(n - 1n) = -&n + 1r)`,
   strip_tac
   \\ Cases_on `n = 1` >- simp []
-  \\ metis_tac [realTheory.REAL_SUB, realTheory.REAL_NEG_SUB,
+  \\ metis_tac [REAL_SUB, REAL_NEG_SUB,
                 REAL_ARITH ``-a + b = b - a: real``,
                 DECIDE ``n <> 0 /\ n <> 1 ==> (n - 1 <> 0n)``]
   )
@@ -95,68 +96,72 @@ val lem4 = Q.prove(
 val lem5 = Q.prove(
   `!m n. n + 1 < m ==> -&m + 1 <= -&n - 1r`,
   REPEAT strip_tac
-  \\ once_rewrite_tac [GSYM realTheory.REAL_LE_NEG]
-  \\ rewrite_tac [realTheory.REAL_NEG_SUB, realTheory.REAL_NEG_ADD,
-                  realTheory.REAL_SUB_RNEG]
+  \\ once_rewrite_tac [GSYM REAL_LE_NEG]
+  \\ rewrite_tac [REAL_NEG_SUB, REAL_NEG_ADD,
+                  REAL_SUB_RNEG]
   \\ Cases_on `m`
   \\ full_simp_tac(srw_ss())[arithmeticTheory.ADD1]
-  \\ REWRITE_TAC [GSYM realTheory.REAL_ADD,
+  \\ REWRITE_TAC [GSYM REAL_ADD,
                   REAL_ARITH ``a + b + -b = a: real``]
   \\ simp []
   )
 
-val INT_FLOOR_BOUNDS = Q.store_thm("INT_FLOOR_BOUNDS",
-  `!r. real_of_int (INT_FLOOR r) <= r /\ r < real_of_int (INT_FLOOR r + 1)`,
-  srw_tac[][INT_FLOOR_def, integerTheory.LEAST_INT_DEF] \\ SELECT_ELIM_TAC \\ (
+(* cf. INT_FLOOR_BOUNDS' for another form where ‘real_of_int (INT_FLOOR r)’
+       stays in the middle.
+ *)
+Theorem INT_FLOOR_BOUNDS :
+    !r. real_of_int (INT_FLOOR r) <= r /\ r < real_of_int (INT_FLOOR r + 1)
+Proof
+  srw_tac[][INT_FLOOR_def, LEAST_INT_DEF] \\ SELECT_ELIM_TAC \\ (
   REVERSE conj_tac
-  >- (srw_tac[][realTheory.REAL_NOT_LT]
+  >- (srw_tac[][REAL_NOT_LT]
       \\ pop_assum (qspec_then `x - 1` assume_tac)
-      \\ full_simp_tac(srw_ss())[intLib.ARITH_PROVE ``a - 1 < a: int``])
+      \\ full_simp_tac(srw_ss())[ARITH_PROVE ``a - 1 < a: int``])
   \\ Cases_on `0 <= r`
   >- (imp_res_tac real_arch_least1
       \\ qexists_tac `&n`
-      \\ srw_tac[][real_of_int, realTheory.REAL_NOT_LT,
+      \\ srw_tac[][real_of_int, REAL_NOT_LT,
              REWRITE_RULE [GSYM arithmeticTheory.ADD1] Num_suc1,
-             intLib.ARITH_PROVE ``~(&n + 1i < 0)``]
-      >- metis_tac [lem, realTheory.REAL_LE_TRANS]
+             ARITH_PROVE ``~(&n + 1i < 0)``]
+      >- metis_tac [lem, REAL_LE_TRANS]
       \\ Cases_on `i'`
       \\ full_simp_tac(srw_ss())[Num_suc1]
       >| [`n' + 1 <= n` by decide_tac
-          \\ metis_tac [realTheory.REAL_LE, realTheory.REAL_LE_TRANS],
+          \\ metis_tac [REAL_LE, REAL_LE_TRANS],
           imp_res_tac
-            (intLib.ARITH_PROVE ``n <> 0 /\ ~(-&n + 1i < 0) ==> (n = 1)``)
+            (ARITH_PROVE ``n <> 0 /\ ~(-&n + 1i < 0) ==> (n = 1)``)
           \\ full_simp_tac(srw_ss())[],
           `1 <= n` by decide_tac
-          \\ metis_tac [realTheory.REAL_LE, realTheory.REAL_LE_TRANS]
+          \\ metis_tac [REAL_LE, REAL_LE_TRANS]
       ]
   )
   \\ imp_res_tac (REAL_ARITH ``~(0r <= r) ==> 0 <= -r /\ r <> 0``)
   \\ imp_res_tac real_arch_least1
-  \\ rev_full_simp_tac(srw_ss())[arithmeticTheory.ADD1, integerTheory.INT_NEG_ADD,
+  \\ rev_full_simp_tac(srw_ss())[arithmeticTheory.ADD1, INT_NEG_ADD,
           REAL_ARITH ``r <= 0r ==> (&(n: num) <= -r <=> r <= -&n)``,
           REAL_ARITH ``r <= 0r ==> (-r < &n <=> -&n < r)``]
   \\ Cases_on `r = -&n`
   >| [qexists_tac `~&n`, qexists_tac `~&(SUC n)`]
-  \\ rev_full_simp_tac(srw_ss())[real_of_int, integerTheory.INT_NEG_ADD]
+  \\ rev_full_simp_tac(srw_ss())[real_of_int, INT_NEG_ADD]
   \\ (conj_tac
       >- (srw_tac[][lem3]
           \\ Cases_on `n`
           \\ full_simp_tac(srw_ss())[arithmeticTheory.ADD1,
                  REAL_ARITH ``r <= 0r /\ r <> 0 ==> r < 0``,
                  REAL_ARITH ``a <= b - 1 ==> a < b: real``,
-                 intLib.ARITH_PROVE ``-&(n + 1) + 1 < 0i <=> n <> 0``,
+                 ARITH_PROVE ``-&(n + 1) + 1 < 0i <=> n <> 0``,
                  REAL_ARITH ``r <= -1r ==> r < 0``,
                  REAL_ARITH ``a <= b /\ a <> b ==> a < b: real``])
-      \\ srw_tac[][realTheory.REAL_NOT_LT]
+      \\ srw_tac[][REAL_NOT_LT]
       \\ Cases_on `i'`
       \\ rev_full_simp_tac(srw_ss())[lem2, lem3, lem4, arithmeticTheory.ADD1]
-      \\ (intLib.ARITH_TAC ORELSE
-          imp_res_tac (intLib.ARITH_PROVE ``n + 1 < m ==> (-&m + 1 < 0i)``)
+      \\ (ARITH_TAC ORELSE
+          imp_res_tac (ARITH_PROVE ``n + 1 < m ==> (-&m + 1 < 0i)``)
           \\ metis_tac
-               [realTheory.REAL_LET_TRANS, realTheory.REAL_LT_IMP_LE, lem5])
+               [REAL_LET_TRANS, REAL_LT_IMP_LE, lem5])
      )
   )
-  )
+QED
 
 Theorem INT_FLOOR:
   !r i. (INT_FLOOR r = i) <=> real_of_int i <= r /\ r < real_of_int (i + 1)
@@ -164,7 +169,7 @@ Proof
   REPEAT strip_tac
   \\ eq_tac
   >- metis_tac [INT_FLOOR_BOUNDS]
-  \\ srw_tac[][INT_FLOOR_def, integerTheory.LEAST_INT_DEF]
+  \\ srw_tac[][INT_FLOOR_def, LEAST_INT_DEF]
   \\ SELECT_ELIM_TAC
   \\ conj_tac
   >- (
@@ -172,7 +177,7 @@ Proof
     \\ res_tac
     \\ Cases_on `i`
     \\ Cases_on `i'`
-    \\ full_simp_tac(srw_ss())[real_of_int, intLib.ARITH_PROVE ``~(&n + 1i < 0)``]
+    \\ full_simp_tac(srw_ss())[real_of_int, ARITH_PROVE ``~(&n + 1i < 0)``]
     >| [
       all_tac,
       Cases_on `-&n' + 1 < 0i`,
@@ -181,16 +186,16 @@ Proof
       Cases_on `-&n + 1 < 0i`
     ]
     \\ full_simp_tac(srw_ss())[Num_suc1]
-    \\ imp_res_tac realTheory.REAL_LET_TRANS
-    \\ full_simp_tac(srw_ss())[integerTheory.INT_NOT_LT]
-    \\ intLib.ARITH_TAC
+    \\ imp_res_tac REAL_LET_TRANS
+    \\ full_simp_tac(srw_ss())[INT_NOT_LT]
+    \\ ARITH_TAC
   )
   \\ srw_tac[][]
   \\ Cases_on `i < x`
   >- res_tac
   \\ Cases_on `i = x`
   >- asm_rewrite_tac []
-  \\ `x < i` by intLib.ARITH_TAC
+  \\ `x < i` by ARITH_TAC
   \\ Cases_on `i`
   \\ Cases_on `x`
   \\ full_simp_tac(srw_ss())[real_of_int]
@@ -205,14 +210,14 @@ Proof
     Cases_on `-&n + 1 < 0i`
   ]
   \\ full_simp_tac(srw_ss())[]
-  \\ imp_res_tac realTheory.REAL_LET_TRANS
-  \\ full_simp_tac(srw_ss())[integerTheory.INT_NOT_LT]
-  \\ intLib.ARITH_TAC
+  \\ imp_res_tac REAL_LET_TRANS
+  \\ full_simp_tac(srw_ss())[INT_NOT_LT]
+  \\ ARITH_TAC
 QED
 
 val int_floor_1 = Q.prove(
   `(INT_FLOOR &n = &n) /\ (INT_FLOOR (-&n) = -&n)`,
-  srw_tac[][INT_FLOOR, real_of_int] \\ intLib.ARITH_TAC)
+  srw_tac[][INT_FLOOR, real_of_int] \\ ARITH_TAC)
 
 val tac =
   imp_res_tac arithmeticTheory.DIVISION
@@ -224,30 +229,30 @@ val int_floor_2 = Q.prove(
   `0 < m ==> (INT_FLOOR (&n / &m) = &n / &m)`,
   strip_tac
   \\ rewrite_tac [INT_FLOOR]
-  \\ srw_tac[][real_of_int, realTheory.le_ratr, realTheory.lt_ratl, Num_suc1]
+  \\ srw_tac[][real_of_int, le_ratr, lt_ratl, Num_suc1]
   \\ TRY decide_tac
   >- tac
-  >- intLib.ARITH_TAC
+  >- ARITH_TAC
   \\ tac
   )
 
 val lem1 =
   metisLib.METIS_PROVE
-    [realTheory.REAL_POS_NZ, realTheory.REAL_DIV_REFL, realTheory.neg_rat]
+    [REAL_POS_NZ, REAL_DIV_REFL, neg_rat]
     ``!a. 0r < a ==> (-a / a = -1)``
 
 val lem2 = Q.prove(
   `!n. 0n < n ==> (-&n / &n = -1i)`,
   REPEAT strip_tac
-  \\ `0i < &n` by intLib.ARITH_TAC
-  \\ simp [integerTheory.int_div]
+  \\ `0i < &n` by ARITH_TAC
+  \\ simp [int_div]
   )
 
 val lem3 = Q.prove(
   `!n m. 0n < n /\ n < m ==> (-&n / &m = -1i)`,
   REPEAT strip_tac
-  \\ `0i < &n` by intLib.ARITH_TAC
-  \\ simp [integerTheory.int_div, arithmeticTheory.LESS_DIV_EQ_ZERO]
+  \\ `0i < &n` by ARITH_TAC
+  \\ simp [int_div, arithmeticTheory.LESS_DIV_EQ_ZERO]
   )
 
 val tac2 =
@@ -256,9 +261,9 @@ val tac2 =
 val lem4 = Q.prove(
   `!n m. 0 < m /\ m < n ==> -&n / &m < -1i`,
   NTAC 3 strip_tac
-  \\ `&m <> 0i` by intLib.ARITH_TAC
-  \\ simp [integerTheory.int_div]
-  \\ srw_tac[][intLib.ARITH_PROVE ``a + -1 < -1 <=> a < 0i``]
+  \\ `&m <> 0i` by ARITH_TAC
+  \\ simp [int_div]
+  \\ srw_tac[][ARITH_PROVE ``a + -1 < -1 <=> a < 0i``]
   \\ tac
   >- (SPOSE_NOT_THEN strip_assume_tac
       \\ `(n DIV m = 0) \/ (n DIV m = 1)` by decide_tac
@@ -290,20 +295,20 @@ val int_floor_3 = Q.prove(
   \\ Cases_on `n = m`
   >- simp [lem1, lem2, real_of_int]
   \\ Cases_on `n < m`
-  >- simp [lem3, real_of_int, realTheory.le_ratr, realTheory.lt_ratl]
+  >- simp [lem3, real_of_int, le_ratr, lt_ratl]
   \\ `m < n` by decide_tac
-  \\ simp [lem4, real_of_int, realTheory.le_ratr, realTheory.lt_ratl,
-           intLib.ARITH_PROVE ``a < -1i ==> a < 0 /\ a + 1 < 0``]
-  \\ simp [integerTheory.int_div]
-  \\ srw_tac[][integerTheory.INT_NEG_ADD, lem5, Num_suc1,
-         intLib.ARITH_PROVE ``a + 1 + -1 = a: int``,
-         intLib.ARITH_PROVE ``1n < a ==> (Num (&a + -1) = a - 1)``]
+  \\ simp [lem4, real_of_int, le_ratr, lt_ratl,
+           ARITH_PROVE ``a < -1i ==> a < 0 /\ a + 1 < 0``]
+  \\ simp [int_div]
+  \\ srw_tac[][INT_NEG_ADD, lem5, Num_suc1,
+         ARITH_PROVE ``a + 1 + -1 = a: int``,
+         ARITH_PROVE ``1n < a ==> (Num (&a + -1) = a - 1)``]
   \\ tac
   )
 
 val INT_CEILING_IMP = Q.prove (
   `!r i. real_of_int (i - 1) < r /\ r <= real_of_int i ==> (INT_CEILING r = i)`,
-  srw_tac[][INT_CEILING_def, integerTheory.LEAST_INT_DEF]
+  srw_tac[][INT_CEILING_def, LEAST_INT_DEF]
   \\ SELECT_ELIM_TAC
   \\ conj_tac
   >- (
@@ -320,16 +325,16 @@ val INT_CEILING_IMP = Q.prove (
       all_tac
     ]
     \\ full_simp_tac(srw_ss())[]
-    \\ imp_res_tac realTheory.REAL_LTE_TRANS
+    \\ imp_res_tac REAL_LTE_TRANS
     \\ full_simp_tac(srw_ss())[]
-    \\ intLib.ARITH_TAC
+    \\ ARITH_TAC
   )
   \\ srw_tac[][]
   \\ Cases_on `i < x`
   >- res_tac
   \\ Cases_on `i = x`
   >- asm_rewrite_tac []
-  \\ `x < i` by intLib.ARITH_TAC
+  \\ `x < i` by ARITH_TAC
   \\ Cases_on `i`
   \\ Cases_on `x`
   \\ full_simp_tac(srw_ss())[real_of_int]
@@ -341,9 +346,9 @@ val INT_CEILING_IMP = Q.prove (
     all_tac
   ]
   \\ full_simp_tac(srw_ss())[]
-  \\ imp_res_tac realTheory.REAL_LTE_TRANS
+  \\ imp_res_tac REAL_LTE_TRANS
   \\ full_simp_tac(srw_ss())[]
-  \\ intLib.ARITH_TAC
+  \\ ARITH_TAC
   )
 
 val INT_CEILING_INT_FLOOR = Q.store_thm("INT_CEILING_INT_FLOOR",
@@ -351,24 +356,28 @@ val INT_CEILING_INT_FLOOR = Q.store_thm("INT_CEILING_INT_FLOOR",
        let i = INT_FLOOR r in if real_of_int i = r then i else i + 1`,
   lrw []
   \\ match_mp_tac INT_CEILING_IMP
-  >- (`INT_FLOOR r - 1 < INT_FLOOR r` by intLib.ARITH_TAC
+  >- (`INT_FLOOR r - 1 < INT_FLOOR r` by ARITH_TAC
       \\ imp_res_tac real_of_int_monotonic
       \\ simp []
-      \\ metis_tac [INT_FLOOR_BOUNDS, realTheory.REAL_LTE_TRANS])
-  \\ simp [intLib.ARITH_PROVE ``a + 1 -1i = a``,
+      \\ metis_tac [INT_FLOOR_BOUNDS, REAL_LTE_TRANS])
+  \\ simp [ARITH_PROVE ``a + 1 -1i = a``,
            REAL_ARITH ``a <= b /\ a <> b ==> a < b: real``,
-           INT_FLOOR_BOUNDS, realTheory.REAL_LT_IMP_LE]
+           INT_FLOOR_BOUNDS, REAL_LT_IMP_LE]
   )
 
-val INT_CEILING_BOUNDS = Q.store_thm("INT_CEILING_BOUNDS",
-  `!r. real_of_int (INT_CEILING r - 1) < r /\ r <= real_of_int (INT_CEILING r)`,
-  lrw [INT_CEILING_INT_FLOOR, INT_FLOOR_BOUNDS, realTheory.REAL_LT_IMP_LE,
-       intLib.ARITH_PROVE ``a + 1i - 1 = a``,
+(* cf. INT_CEILING_BOUNDS' for another form where ‘real_of_int (INT_CEILING r)’
+       stays in the middle.
+ *)
+Theorem INT_CEILING_BOUNDS :
+    !r. real_of_int (INT_CEILING r - 1) < r /\ r <= real_of_int (INT_CEILING r)
+Proof
+  lrw [INT_CEILING_INT_FLOOR, INT_FLOOR_BOUNDS, REAL_LT_IMP_LE,
+       ARITH_PROVE ``a + 1i - 1 = a``,
        REAL_ARITH ``a <= b /\ a <> b ==> a < b: real``]
   \\ pop_assum (fn th => CONV_TAC (RAND_CONV (ONCE_REWRITE_CONV [SYM th])))
   \\ match_mp_tac real_of_int_monotonic
-  \\ intLib.ARITH_TAC
-  )
+  \\ ARITH_TAC
+QED
 
 Theorem INT_CEILING:
   !r i. (INT_CEILING r = i) <=> real_of_int (i - 1) < r /\ r <= real_of_int i
@@ -392,7 +401,6 @@ in
              ["INT_FLOOR_compute", "INT_CEILING_INT_FLOOR"]
 end
 
-open arithmeticTheory
 val real_of_int_num = store_thm("real_of_int_num[simp]",
   ``real_of_int (& n) = &n``,
   rewrite_tac[real_of_int_def]
@@ -402,8 +410,8 @@ val real_of_int_num = store_thm("real_of_int_num[simp]",
 val real_of_int_add = store_thm("real_of_int_add[simp]",
   ``real_of_int (m + n) = real_of_int m + real_of_int n``,
   Cases_on `m` \\ Cases_on `n` \\ fs [real_of_int_def] \\ rw []
-  \\ fs [integerTheory.INT_ADD_CALCULATE]
-  \\ rw [] \\ fs [] \\ fs [GSYM NOT_LESS,realTheory.add_ints]);
+  \\ fs [INT_ADD_CALCULATE]
+  \\ rw [] \\ fs [] \\ fs [GSYM NOT_LESS,add_ints]);
 
 val real_of_int_neg = store_thm("real_of_int_neg[simp]",
   ``real_of_int (-m) = -real_of_int m``,
@@ -411,12 +419,12 @@ val real_of_int_neg = store_thm("real_of_int_neg[simp]",
 
 val real_of_int_sub = store_thm("real_of_int_sub[simp]",
   ``real_of_int (m - n) = real_of_int m - real_of_int n``,
-  fs [integerTheory.int_sub,realTheory.real_sub]);
+  fs [int_sub,real_sub]);
 
 val real_of_int_mul = store_thm("real_of_int_mul[simp]",
   ``real_of_int (m * n) = real_of_int m * real_of_int n``,
   Cases_on `m` \\ Cases_on `n` \\ fs [real_of_int_def] \\ rw []
-  \\ fs [integerTheory.INT_MUL_CALCULATE]);
+  \\ fs [INT_MUL_CALCULATE]);
 
 val real_of_int_lt = store_thm("real_of_int_lt[simp]",
   “real_of_int m < real_of_int n <=> m < n”,
@@ -430,58 +438,58 @@ val real_of_int_11 = store_thm("real_of_int_11[simp]",
 
 val real_of_int_le = store_thm("real_of_int_le[simp]",
   “real_of_int m <= real_of_int n <=> m <= n”,
-  simp[realTheory.REAL_LE_LT, integerTheory.INT_LE_LT]);
+  simp[REAL_LE_LT, INT_LE_LT]);
 
 Theorem INT_FLOOR_MONO:
   x < y ==> INT_FLOOR x <= INT_FLOOR y
 Proof
-  CCONTR_TAC >> gs[integerTheory.INT_NOT_LE] >>
-  ‘flr y + 1i <= flr x’ by simp[GSYM integerTheory.INT_LT_LE1] >>
+  CCONTR_TAC >> gs[INT_NOT_LE] >>
+  ‘flr y + 1i <= flr x’ by simp[GSYM INT_LT_LE1] >>
   ‘y < real_of_int (flr y + 1)’ by simp[INT_FLOOR_BOUNDS] >>
   ‘real_of_int (flr x) <= x’ by simp[INT_FLOOR_BOUNDS] >>
-  metis_tac[realTheory.REAL_LET_TRANS, realTheory.REAL_LTE_TRANS,
-            realTheory.REAL_LT_TRANS,
-            real_of_int_le, realTheory.REAL_LT_REFL]
+  metis_tac[REAL_LET_TRANS, REAL_LTE_TRANS,
+            REAL_LT_TRANS,
+            real_of_int_le, REAL_LT_REFL]
 QED
 
 Theorem INT_FLOOR_SUCa[local]:
   INT_FLOOR r + 1 <= INT_FLOOR (r + 1)
 Proof
-  CCONTR_TAC >> gs[integerTheory.INT_NOT_LE] >>
-  ‘INT_FLOOR (r + 1) + 1 <= INT_FLOOR r + 1’ by gs[integerTheory.INT_LT_LE1] >>
+  CCONTR_TAC >> gs[INT_NOT_LE] >>
+  ‘INT_FLOOR (r + 1) + 1 <= INT_FLOOR r + 1’ by gs[INT_LT_LE1] >>
   ‘real_of_int (flr r) + 1 <= r + 1’ by simp[INT_FLOOR_BOUNDS] >>
   ‘r + 1 < real_of_int (flr (r + 1) + 1)’ by simp[INT_FLOOR_BOUNDS] >>
   ‘real_of_int(flr (r + 1) + 1) <= real_of_int (flr r + 1)’ by simp[] >>
-  ‘r + 1 < real_of_int (flr r + 1)’ by metis_tac[realTheory.REAL_LTE_TRANS] >>
-  metis_tac[real_of_int_num, realTheory.REAL_LTE_TRANS, realTheory.REAL_LT_REFL,
+  ‘r + 1 < real_of_int (flr r + 1)’ by metis_tac[REAL_LTE_TRANS] >>
+  metis_tac[real_of_int_num, REAL_LTE_TRANS, REAL_LT_REFL,
             real_of_int_add]
 QED
 
 Theorem INT_FLOOR_SUCb[local]:
   INT_FLOOR (r + 1) <= INT_FLOOR r + 1
 Proof
-  CCONTR_TAC >> gs[integerTheory.INT_NOT_LE] >>
+  CCONTR_TAC >> gs[INT_NOT_LE] >>
   qabbrev_tac ‘i = (flr r:int) + 1’ >> qabbrev_tac ‘j:int = flr (r + 1)’ >>
-  ‘i + 1 <= j’ by gs[integerTheory.INT_LT_LE1] >>
+  ‘i + 1 <= j’ by gs[INT_LT_LE1] >>
   ‘r < real_of_int i’ by simp[INT_FLOOR_BOUNDS, Abbr‘i’] >>
   ‘real_of_int j <= r + 1’ by simp[INT_FLOOR_BOUNDS, Abbr‘j’] >>
   ‘r + 1 < real_of_int j’
-    by (irule realTheory.REAL_LTE_TRANS >>
+    by (irule REAL_LTE_TRANS >>
         irule_at Any (iffRL real_of_int_le) >> first_assum $ irule_at Any >>
         simp[]) >>
-  metis_tac[realTheory.REAL_LTE_TRANS, realTheory.REAL_LT_REFL]
+  metis_tac[REAL_LTE_TRANS, REAL_LT_REFL]
 QED
 
 Theorem INT_FLOOR_SUC:
   INT_FLOOR (x + 1) = INT_FLOOR x + 1
 Proof
-  simp[GSYM integerTheory.INT_LE_ANTISYM, INT_FLOOR_SUCb, INT_FLOOR_SUCa]
+  simp[GSYM INT_LE_ANTISYM, INT_FLOOR_SUCb, INT_FLOOR_SUCa]
 QED
 
 Theorem INT_FLOOR_SUB1:
   INT_FLOOR (x - 1) = INT_FLOOR x - 1
 Proof
-  simp[integerTheory.INT_EQ_SUB_LADD, GSYM INT_FLOOR_SUC,
+  simp[INT_EQ_SUB_LADD, GSYM INT_FLOOR_SUC,
        REAL_ARITH “x - 1r + 1 = x”]
 QED
 
@@ -489,40 +497,181 @@ Theorem INT_FLOOR_SUM_NUM[simp]:
   INT_FLOOR (x + &n) = INT_FLOOR x + &n /\
   INT_FLOOR (&n + x) = INT_FLOOR x + &n
 Proof
-  csimp[realTheory.REAL_ADD_COMM] >>
+  csimp[REAL_ADD_COMM] >>
   Induct_on‘n’>>
-  simp[realTheory.REAL, GSYM realTheory.REAL_ADD, Excl "REAL_ADD",
-       integerTheory.INT, realTheory.REAL_ADD_ASSOC, INT_FLOOR_SUC,
-       integerTheory.INT_ADD_ASSOC
+  simp[REAL, GSYM REAL_ADD, Excl "REAL_ADD",
+       INT, REAL_ADD_ASSOC, INT_FLOOR_SUC,
+       INT_ADD_ASSOC
       ]
 QED
+
+(* Add an alias for better naming *)
+Theorem INT_FLOOR_ADD_NUM = INT_FLOOR_SUM_NUM
 
 Theorem INT_FLOOR_SUB_NUM[simp]:
   INT_FLOOR (x - &n) = INT_FLOOR x - &n /\
   INT_FLOOR (&n - x) = INT_FLOOR (-x) + &n
 Proof
-  reverse conj_tac >- simp[realTheory.real_sub] >>
+  reverse conj_tac >- simp[real_sub] >>
   Induct_on ‘n’ >>
-  simp[realTheory.REAL, Excl "REAL_ADD", GSYM realTheory.REAL_ADD,
+  simp[REAL, Excl "REAL_ADD", GSYM REAL_ADD,
        REAL_ARITH “x - (y + z) = x - y - z:real”, INT_FLOOR_SUB1,
-       integerTheory.INT] >>
-  intLib.ARITH_TAC
+       INT] >>
+  ARITH_TAC
 QED
 
 Theorem INT_FLOOR_SUM[simp]:
   INT_FLOOR (x + real_of_int y) = INT_FLOOR x + y /\
   INT_FLOOR (real_of_int y + x) = INT_FLOOR x + y
 Proof
-  csimp[realTheory.REAL_ADD_COMM] >>
-  Cases_on ‘y’ >> simp[GSYM realTheory.real_sub, GSYM integerTheory.int_sub]
+  csimp[REAL_ADD_COMM] >>
+  Cases_on ‘y’ >> simp[GSYM real_sub, GSYM int_sub]
 QED
 
 Theorem ints_exist_in_gaps:
   !a b. a + 1 < b ==> ?i. a < real_of_int i /\ real_of_int i < b
 Proof
   rpt strip_tac >> irule_at Any (cj 2 INT_FLOOR_BOUNDS) >> simp[] >>
-  irule realTheory.REAL_LET_TRANS >> first_assum $ irule_at Any >>
+  irule REAL_LET_TRANS >> first_assum $ irule_at Any >>
   simp[INT_FLOOR_BOUNDS]
 QED
 
+(* Alternative definition of is_int by INT_CEILING *)
+Theorem is_int_alt :
+    !x. is_int x <=> x = real_of_int (INT_CEILING x)
+Proof
+    rw [is_int_def]
+ >> EQ_TAC >- rw [INT_CEILING_INT_FLOOR]
+ >> DISCH_TAC
+ >> CCONTR_TAC
+ >> fs [INT_CEILING_INT_FLOOR]
+ >> ‘1 = real_of_int 1’ by rw [real_of_int_num, real_of_num]
+ >> METIS_TAC [REAL_LT_IMP_NE, INT_FLOOR_BOUNDS, real_of_int_add]
+QED
+
+Theorem is_int_thm :
+    !x. is_int x <=> real_of_int (INT_FLOOR x) = real_of_int (INT_CEILING x)
+Proof
+    Q.X_GEN_TAC ‘x’
+ >> EQ_TAC >- METIS_TAC [is_int_def, is_int_alt]
+ >> DISCH_TAC
+ >> Suff ‘real_of_int (INT_FLOOR x) = x’ >- rw [GSYM is_int_def]
+ >> CCONTR_TAC
+ >> fs [INT_CEILING_INT_FLOOR]
+ >> Suff ‘INT_FLOOR x < INT_FLOOR x + 1’ >- PROVE_TAC [INT_LT_IMP_NE]
+ >> rw [INT_LT_ADDR]
+QED
+
+Theorem INT_CEILING_ADD_NUM :
+    INT_CEILING (x + &n) = INT_CEILING x + &n /\
+    INT_CEILING (&n + x) = INT_CEILING x + &n
+Proof
+    CONJ_TAC >> simp [INT_CEILING_INT_FLOOR]
+ >| [ (* goal 1 (of 2) *)
+      Cases_on ‘real_of_int (INT_FLOOR x) = x’ >> simp [] \\
+      ARITH_TAC,
+      (* goal 2 (of 2) *)
+      Cases_on ‘real_of_int (INT_FLOOR x) = x’ >> simp []
+      >- PROVE_TAC [REAL_ADD_COMM] \\
+     ‘&n + x = x + &n’ by PROVE_TAC [REAL_ADD_COMM] >> POP_ORW \\
+      simp [] >> ARITH_TAC ]
+QED
+
+Theorem INT_CEILING_SUB_NUM :
+    INT_CEILING (x - &n) = INT_CEILING x - &n /\
+    INT_CEILING (&n - x) = INT_CEILING (-x) + &n
+Proof
+    CONJ_TAC >> simp [INT_CEILING_INT_FLOOR]
+ >| [ (* goal 1 (of 2) *)
+      Cases_on ‘real_of_int (INT_FLOOR x) = x’ >> simp [real_sub] \\
+      ARITH_TAC,
+      (* goal 2 (of 2) *)
+      Cases_on ‘real_of_int (INT_FLOOR ~x) = ~x’ >> simp [real_sub]
+      >- PROVE_TAC [REAL_ADD_COMM] \\
+     ‘&n + -x = -x + &n’ by PROVE_TAC [REAL_ADD_COMM] >> POP_ORW \\
+      simp [] >> ARITH_TAC ]
+QED
+
+Theorem INT_CEILING_BOUNDS' :
+    !r. r <= real_of_int (INT_CEILING r) /\ real_of_int (INT_CEILING r) < r + 1
+Proof
+    rw [INT_CEILING_BOUNDS]
+ >> Suff ‘real_of_int (INT_CEILING r) - 1 < r’ >- rw [REAL_LT_SUB_RADD]
+ >> Suff ‘real_of_int (INT_CEILING r) - 1 = real_of_int (INT_CEILING r - 1)’
+ >- (Rewr' >> REWRITE_TAC [INT_CEILING_BOUNDS])
+ >> rw [real_of_num, INT_CEILING_SUB_NUM]
+QED
+
+Theorem INT_FLOOR_BOUNDS' :
+    !r. r - 1 < real_of_int (INT_FLOOR r) /\ real_of_int (INT_FLOOR r) <= r
+Proof
+    rw [INT_FLOOR_BOUNDS]
+ >> Suff ‘r < real_of_int (INT_FLOOR r) + 1’ >- rw [REAL_LT_SUB_RADD]
+ >> Suff ‘real_of_int (INT_FLOOR r) + 1 = real_of_int (INT_FLOOR r + 1)’
+ >- (Rewr' >> REWRITE_TAC [INT_FLOOR_BOUNDS])
+ >> rw [real_of_num, INT_CEILING_ADD_NUM]
+QED
+
+Theorem INT_FLOOR':
+    !r i. (INT_FLOOR r = i) <=> r - 1 < real_of_int i /\ real_of_int i <= r
+Proof
+    rw [INT_FLOOR]
+ >> Suff ‘r < real_of_int i + 1 <=> r - 1 < real_of_int i’ >- METIS_TAC []
+ >> simp [REAL_LT_SUB_RADD]
+QED
+
+Theorem INT_CEILING':
+    !r i. (INT_CEILING r = i) <=> r <= real_of_int i /\ real_of_int i < r + 1
+Proof
+    rw [INT_CEILING]
+ >> Suff ‘real_of_int i - 1 < r <=> real_of_int i < r + 1’ >- METIS_TAC []
+ >> simp [REAL_LT_SUB_RADD]
+QED
+
+(* https://proofwiki.org/wiki/Floor_of_Negative_equals_Negative_of_Ceiling *)
+Theorem INT_FLOOR_NEG :
+    !x. INT_FLOOR (~x) = ~INT_CEILING x
+Proof
+    Q.X_GEN_TAC ‘x’
+ >> simp [INT_FLOOR', INT_CEILING_BOUNDS']
+ >> ‘-x - 1 = ~(x + 1)’ by REAL_ARITH_TAC >> POP_ORW
+ >> simp [REAL_LT_NEG, INT_CEILING_BOUNDS']
+QED
+
+Theorem INT_CEILING_NEG :
+    !x. INT_CEILING (~x) = ~INT_FLOOR x
+Proof
+    Q.X_GEN_TAC ‘x’
+ >> simp [INT_CEILING', INT_FLOOR_BOUNDS']
+ >> ‘-x + 1 = ~(x - 1)’ by REAL_ARITH_TAC >> POP_ORW
+ >> simp [REAL_LT_NEG, INT_FLOOR_BOUNDS']
+QED
+
+(*---------------------------------------------------------------------------*
+ *  Fractional part                                                          *
+ *---------------------------------------------------------------------------*)
+
+ (* ‘frac x’ to mean x mod 1 or ‘x - flr x’, the fractional part of x [1]
+
+   NOTE: For the negative numbers, here it is defined in the same way as for
+   positive numbers [2] (thus ‘frac 3.6 = 0.6’ but ‘frac ~3.6 = 0.4’.)
+ *)
+Definition frac_def :
+    frac x = x - real_of_int (INT_FLOOR x)
+End
+
+Theorem is_int_eq_frac_0 :
+    !x. is_int x <=> frac x = 0
+Proof
+    rw [frac_def, is_int_def, REAL_SUB_0]
+QED
+
 val _ = export_theory ()
+
+(* References:
+
+   [1] Graham, R.L., Knuth, D.E., Patashnik, O.: Concrete Mathematics. 2nd Eds.
+       Addison-Wesley Publishing Company (1994).
+   [2] https://en.wikipedia.org/wiki/Floor_and_ceiling_functions
+   [3] https://en.wikipedia.org/wiki/Fractional_part
+ *)


### PR DESCRIPTION
Hi,

Recently I started needing `INT_FLOOR` and `INT_CEILING` of `intrealTheory` and immediately found that the existing set of theorems are missing some notable (and nice) ones, e.g. the following two "negated properties" (proof is from [1]) at the end of a chain of newly added theorems:
```
   [INT_CEILING_NEG]  Theorem (intrealTheory)      
      ⊢ ∀x. ⌈-x⌉ = -⌊x⌋

   [INT_FLOOR_NEG]  Theorem      
      ⊢ ∀x. ⌊-x⌋ = -⌈x⌉
```
However, I must say that all new proofs are quite simple, because the existing theorems (some proofs are hard) have indeed provided an axiomatic system where all the remaining properties of `INT_FLOOR` and `INT_CEILING` can be derived from just the existing ones without going into their original definition by `LEAST` bindings.

Besides, I also added a new definition for the "Fractional part" [2] of real numbers. Although there's no much supporting theorems for it, I believe this definition is famous and sometimes occurs in other definitions:
```
   [frac_def]  Definition      
      ⊢ ∀x. frac x = x − real_of_int ⌊x⌋
```

Furthermore, for the `is_int` predicate,  I added the following alternative definitions:
```
   [is_int_alt]  Theorem      
      ⊢ ∀x. is_int x ⇔ x = real_of_int ⌈x⌉
   
   [is_int_eq_frac_0]  Theorem      
      ⊢ ∀x. is_int x ⇔ frac x = 0
   
   [is_int_thm]  Theorem      
      ⊢ ∀x. is_int x ⇔ ⌊x⌋ = ⌈x⌉
```

I also cleaned up the script by explicitly opening `arithmeticTheory`, `realTheory` and `intLib` and then removed all functions calls with their prefixes. I think this is in the right direction causing no other issues.

Regards,

Chun Tian

[1] https://proofwiki.org/wiki/Floor_of_Negative_equals_Negative_of_Ceiling
[2] https://en.wikipedia.org/wiki/Fractional_part