### PR TITLE
Fix ODD_CONV and prevent cv_compute from returning NUMERAL 0

### DIFF
--- a/src/num/reduce/src/Arithconv.sml
+++ b/src/num/reduce/src/Arithconv.sml
@@ -150,7 +150,7 @@ ODD_CONV “ODD 7000000001”
 *)
 val ODD_CONV =
   REWR_CONV cvTheory.ODD_to_cv
-  THENC RAND_CONV (RAND_CONV cv_eval)
+  THENC RAND_CONV cv_eval
   THENC REWRITE_CONV [c2b_thm]
 
 val _ = Parse.temp_set_grammars ambient_grammars

--- a/src/thm/Compute.sml
+++ b/src/thm/Compute.sml
@@ -328,10 +328,19 @@ fun mk_num ({cv_num_tm, numeral_tm, ...} : ctsyntax) t =
 fun mk_pair ({cv_pair_tm, ...} : ctsyntax) s t =
   mk_comb (mk_comb (cv_pair_tm, s), t);
 
-fun mk_cval_term ct cv =
-  case cv of
-    Num n => mk_num ct (mk_numeral ct n)
-  | Pair (p, q) => mk_pair ct (mk_cval_term ct p) (mk_cval_term ct q);
+local
+  fun mk_cv_zero ({cv_num_tm, zero_tm, ...} : ctsyntax) =
+    mk_comb (cv_num_tm, zero_tm)
+in
+  fun mk_cval_term ct cv =
+    case cv of
+      Num n =>
+        if n = Arbnum.zero then
+          mk_cv_zero ct
+        else
+          mk_num ct (mk_numeral ct n)
+    | Pair (p, q) => mk_pair ct (mk_cval_term ct p) (mk_cval_term ct q);
+end (* local *)
 
 (* -------------------------------------------------------------------------
  * [dest_code_eqn] takes apart a code equation and performs a type check at the


### PR DESCRIPTION
This PR fixes the following:
* It makes the new `Arithconv.ODD_CONV` work
* It prevents `Thm.compute` from returning terms containing `NUMERAL 0`: it now returns `0` instead