### PR TITLE
Promote `examples/vector/permutationTheory` to the core library

### DIFF
--- a/doc/next-release.md
+++ b/doc/next-release.md
@@ -60,6 +60,9 @@ New theories:
   variable length arrays. The soundness of a parameterized matcher is
   proved.
 
+- `permutes`: The theory of permutations for general and finite sets, originally
+  ported from HOL-Light's `Library/permutations.ml`.
+
 New tools:
 ----------
 

--- a/examples/probability/Holmakefile
+++ b/examples/probability/Holmakefile
@@ -13,12 +13,11 @@ HOLHEAP = heap
 OBJS = real/realLib n-bit/fcpLib res_quan/src/hurdUtils probability/probabilityTheory
 FULL_OBJPATHS = $(patsubst %,$(HOLDIR)/src/%.uo,$(OBJS)) \
                 $(HOLDIR)/sigobj/posetTheory.uo
-HEAP0 = $(HOLDIR)/src/probability/probheap
 
 all: $(HOLHEAP)
 
-$(HOLHEAP): $(FULL_OBJPATHS) $(HOLDIR)/bin/hol.state $(HEAP0)
-	$(protect $(HOLDIR)/bin/buildheap) -b $(HEAP0) -o $@ $(FULL_OBJPATHS)
+$(HOLHEAP): $(FULL_OBJPATHS) $(HOLDIR)/bin/hol.state
+	$(protect $(HOLDIR)/bin/buildheap) -o $@ $(FULL_OBJPATHS)
 endif
 
 all: $(DEFAULT_TARGETS)

--- a/examples/vector/matrixScript.sml
+++ b/examples/vector/matrixScript.sml
@@ -15,7 +15,7 @@ open arithmeticTheory combinTheory pred_setTheory pairTheory PairedLambda
      topologyTheory InductiveDefinition;
 
 open realTheory realLib iterateTheory real_sigmaTheory RealArith mesonLib;
-open hurdUtils permutationTheory vectorTheory;
+open hurdUtils permutesTheory vectorTheory;
 
 val _ = new_theory "matrix";
 

--- a/examples/vector/vectorScript.sml
+++ b/examples/vector/vectorScript.sml
@@ -17,7 +17,7 @@ open arithmeticTheory combinTheory pred_setTheory pairTheory PairedLambda
      topologyTheory InductiveDefinition;
 
 open realTheory realLib iterateTheory real_sigmaTheory RealArith mesonLib;
-open hurdUtils cardinalTheory permutationTheory;
+open hurdUtils cardinalTheory permutesTheory;
 
 val _ = new_theory "vector";
 

--- a/src/pred_set/src/more_theories/cardinalScript.sml
+++ b/src/pred_set/src/more_theories/cardinalScript.sml
@@ -1867,8 +1867,6 @@ val CARD_LE_INJ = store_thm ("CARD_LE_INJ",
   SIMP_TAC std_ss [IN_INSERT, SUBSET_DEF, IN_IMAGE] THEN
   METIS_TAC[SUBSET_DEF, IN_IMAGE]);
 
-Theorem CARD_IMAGE_LE = pred_setTheory.CARD_IMAGE
-
 val SURJECTIVE_IFF_INJECTIVE_GEN = store_thm ("SURJECTIVE_IFF_INJECTIVE_GEN",
  ``!s t f:'a->'b.
         FINITE s /\ FINITE t /\ (CARD s = CARD t) /\ (IMAGE f s) SUBSET t

--- a/src/probability/Holmakefile
+++ b/src/probability/Holmakefile
@@ -3,28 +3,6 @@ INCLUDES = ../real ../real/analysis ../sort ../res_quan/src ../n-bit \
 
 EXTRA_CLEANS = selftest.exe prob-selftest.log
 
-ifdef POLY
-HOLHEAP = probheap
-EXTRA_CLEANS += $(HOLHEAP)
-
-REAL_OBJNAMES = Diff transcTheory
-
-OTHER_OBJNAMES = ../res_quan/src/res_quanTools ../res_quan/src/hurdUtils \
-	../res_quan/src/jrhUtils
-
-SIGOBJ_OBJNAMES = pred_setLib logrootTheory
-
-OBJS = $(patsubst %,../real/analysis/%.uo,$(REAL_OBJNAMES)) \
-       $(patsubst %,%.uo,$(OTHER_OBJNAMES)) \
-       $(patsubst %,$(dprot $(SIGOBJ)/%.uo),$(SIGOBJ_OBJNAMES))
-
-all: $(HOLHEAP)
-
-$(HOLHEAP): $(OBJS) $(dprot $(HOLDIR)/src/real/analysis/realheap)
-	$(protect $(HOLDIR)/bin/buildheap) -o $@ \
-		-b $(protect $(HOLDIR)/src/real/analysis/realheap) $(OBJS)
-endif
-
 all: $(DEFAULT_TARGETS) selftest.exe
 
 selftest.exe: selftest.uo

--- a/src/real/analysis/real_topologyScript.sml
+++ b/src/real/analysis/real_topologyScript.sml
@@ -18,13 +18,13 @@
 
 open HolKernel Parse boolLib bossLib;
 
-open numTheory numLib unwindLib tautLib Arith prim_recTheory
-     combinTheory quotientTheory arithmeticTheory realTheory real_sigmaTheory
+open numTheory numLib unwindLib tautLib prim_recTheory
+     combinTheory quotientTheory arithmeticTheory realTheory
      jrhUtils pairTheory boolTheory pred_setTheory optionTheory
-     sumTheory InductiveDefinition ind_typeTheory listTheory mesonLib
+     sumTheory InductiveDefinition listTheory mesonLib
      realLib topologyTheory metricTheory netsTheory;
 
-open wellorderTheory cardinalTheory iterateTheory hurdUtils;
+open wellorderTheory cardinalTheory permutesTheory iterateTheory hurdUtils;
 
 val _ = new_theory "real_topology";
 
@@ -57,22 +57,6 @@ Overload uncountable           = “\s. ~countable s”
 Overload UNCOUNTABLE[inferior] = “uncountable”
 
 (* ------------------------------------------------------------------------- *)
-(* Permutes                                                                  *)
-(* ------------------------------------------------------------------------- *)
-
-val _ = set_fixity "permutes" (Infix(NONASSOC, 450));
-
-(* This is different with pred_setTheory.PERMUTES *)
-val permutes = new_definition ("permutes",
- ``p permutes s <=> (!x. ~(x IN s) ==> (p(x) = x)) /\ (!y. ?!x. (p x = y))``);
-
-val PERMUTES_IMAGE = store_thm ("PERMUTES_IMAGE",
- ``!p s. p permutes s ==> (IMAGE p s = s)``,
-  REWRITE_TAC[permutes, EXTENSION, IN_IMAGE] THEN MESON_TAC[]);
-
-val PERMUTES_INJECTIVE = store_thm ("PERMUTES_INJECTIVE",
- ``!p s. p permutes s ==> !x y. (p(x) = p(y)) <=> (x = y)``,
-  REWRITE_TAC[permutes] THEN MESON_TAC[]);
 
 val EXISTS_IN_INSERT = store_thm ("EXISTS_IN_INSERT",
  ``!P a s. (?x. x IN (a INSERT s) /\ P x) <=> P a \/ ?x. x IN s /\ P x``,
@@ -1428,7 +1412,7 @@ val EXCHANGE_LEMMA = store_thm ("EXCHANGE_LEMMA",
       FINITE t /\ independent s /\ s SUBSET span t ==>
       ?t'. t' HAS_SIZE CARD t /\ s SUBSET t' /\ t' SUBSET s UNION t /\
         s SUBSET span t') ==>
-    (!t'':real->bool s':real->bool'. (CARD (t'' DIFF s') < CARD (t DIFF s)) ==>
+    (!t'':real->bool s':real->bool. (CARD (t'' DIFF s') < CARD (t DIFF s)) ==>
       FINITE t'' /\ independent s' /\ s' SUBSET span t'' ==>
       ?t'. t' HAS_SIZE CARD t'' /\ s' SUBSET t' /\ t' SUBSET s' UNION t'' /\
         s' SUBSET span t')`` THENL


### PR DESCRIPTION
Hi,

I propose we promote the theory of permutation (from HOL-Light) in `examples/vector/permutationScript.sml` to the core library. This theory is more advanced than the `PERMUTES` (a simple overload to `BIJ`) and in practice it's easy to satisfy the extra total-function requirements of it.

The issue was that the the core definition `permutes` is actually already defined in `real_topologyTheory` (and is also used there), and to solve it we shall move the entire theory of permutation to somewhere before `real_topology`.
```
   [permutes]  Definition (real_topologyTheory, old)      
      ⊢ ∀p s. p permutes s ⇔ (∀x. x ∉ s ⇒ p x = x) ∧ ∀y. ∃!x. p x = y
```
Since the entire concept is irrelevant with real numbers but for general sets.  I propose we move this `permutationTheory` into `pred_set/src/more_theories`, just after `cardinalTheory` (where several set-theoretic lemmas are needed).  But the name `permutation` is not very good: it's already used in another file in the examples and is perhaps also used in many unknown user scripts. So I renamed it a little, to `permutes`.   Then, the duplication in `real_topologyTheory` gets removed (and it now opens the new `permutesTheory`). For the previous theory parts involving real numbers and iterations, I appended them at the end of `iterateTheory`.

Other changes: for the building parallelism, I also removed the heap in `src/probability` so that theories like `util_prob` can be built much earlier (than `transcTheory`). I remember this heap was added before the multi-directory build system was introduced.

Chun