### PR TITLE
[fsgraph] Edge induction principle (fsg_edge_induction)

### DIFF
--- a/examples/generic_finite_graphs/fsgraphScript.sml
+++ b/examples/generic_finite_graphs/fsgraphScript.sml
@@ -313,15 +313,7 @@ Theorem fsgedges_members :
 Proof
     rpt GEN_TAC >> STRIP_TAC
  >> POP_ASSUM (STRIP_ASSUME_TAC o (MATCH_MP alledges_valid))
- >> Cases_on ‘x = a’
- >- (Q.PAT_X_ASSUM ‘{x;y} = {a;b}’ MP_TAC \\
-     rw [Once EXTENSION] >> METIS_TAC [])
- >> Cases_on ‘x = b’
- >- (Q.PAT_X_ASSUM ‘{x;y} = {a;b}’ MP_TAC \\
-     rw [Once EXTENSION] >> METIS_TAC [])
- >> Q.PAT_X_ASSUM ‘{x;y} = {a;b}’ MP_TAC
- >> rw [Once EXTENSION]
- >> METIS_TAC []
+ >> fs [INSERT2_lemma]
 QED
 
 Theorem fsgedges_fsgAddEdge[simp] :


### PR DESCRIPTION
This PR enriches the `fsgraphTheory` of finite simple graphs.

Currently there's already the following induction theroem for `fsgraph`. The idea is to start from empty graph, and then each time adds one node (vertex), together with all new edges connected to it, until the final target graph is constructed:
```
fsg_induction
⊢ ∀P. P emptyG ∧
      (∀n es g0.
         P g0 ∧ FINITE es ∧ n ∉ nodes g0 ∧
         valid_edges es (n INSERT nodes g0) ∧ (∀e. e ∈ es ⇒ n ∈ e) ⇒
         P (fsgAddEdges es (addNode n () g0))) ⇒
      ∀g. P g
```

But some graph theory proofs require "edge induction": given a target graph, the induction starts from a graph with the same set of nodes but no edges at all, and each time it adds one edge to the graph, until reaching the final target graph:
```
fsg_edge_induction
⊢ ∀g P.
    P (fsgAddNodes (nodes g) emptyG) ∧
    (∀g0 x y.
       nodes g0 = nodes g ∧ x ≠ y ∧ {x; y} ⊆ nodes g ∧ {x; y} ∉ fsgedges g0 ∧
       P g0 ⇒
       P (fsgAddEdge x y g0)) ⇒
    P g
```
where the graph operation for adding just one edge `fsgAddEdge` is defined (with some supporting theorems):
```
fsgAddEdge_def
⊢ ∀x y g. fsgAddEdge x y g = addUDEdge x y () g
```
and the graph operations for adding one node `fsgAddNode` and a set of nodes `fsgAddNodes:
```
fsgAddNode_def
⊢ ∀n g. fsgAddNode n g = addNode n () g
fsgAddNodes_def
⊢ ∀N g. fsgAddNodes N g = ITSET fsgAddNode N g
```

--Chun