### PR TITLE
more results of terms having head normal forms (`has_hnf`)

### DIFF
--- a/examples/lambda/barendregt/chap2Script.sml
+++ b/examples/lambda/barendregt/chap2Script.sml
@@ -80,15 +80,17 @@ val one_hole_is_normal = store_thm(
                                   MP_TAC (MATCH_MP imp (CONJ cth th))))) THEN
   SIMP_TAC std_ss []);
 
-val (lameq_rules, lameq_indn, lameq_cases) = (* p. 13 *)
-  IndDefLib.xHol_reln "lameq"
-    `(!x M N. (LAM x M) @@ N == [N/x]M) /\
+Inductive lameq :
+     (!x M N. (LAM x M) @@ N == [N/x]M) /\
      (!M. M == M) /\
+[~SYM:]
      (!M N. M == N ==> N == M) /\
+[~TRANS:]
      (!M N L. M == N /\ N == L ==> M == L) /\
      (!M N Z. M == N ==> M @@ Z == N @@ Z) /\
      (!M N Z. M == N ==> Z @@ M == Z @@ N) /\
-     (!M N x. M == N ==> LAM x M == LAM x N)`;
+     (!M N x. M == N ==> LAM x M == LAM x N)
+End
 
 val lameq_refl = Store_thm(
   "lameq_refl",
@@ -104,9 +106,6 @@ val lameq_weaken_cong = store_thm(
   "lameq_weaken_cong",
   ``(M1:term) == M2 ==> N1 == N2 ==> (M1 == N1 <=> M2 == N2)``,
   METIS_TAC [lameq_rules]);
-
-Theorem lameq_SYM = List.nth(CONJUNCTS lameq_rules, 2)
-Theorem lameq_TRANS = List.nth(CONJUNCTS lameq_rules, 3)
 
 val fixed_point_thm = store_thm(  (* p. 14 *)
   "fixed_point_thm",
@@ -309,7 +308,7 @@ val SUB_LAM_RWT = store_thm(
 val lameq_asmlam = store_thm(
   "lameq_asmlam",
   ``!M N. M == N ==> asmlam eqns M N``,
-  HO_MATCH_MP_TAC lameq_indn THEN METIS_TAC [asmlam_rules]);
+  HO_MATCH_MP_TAC lameq_ind THEN METIS_TAC [asmlam_rules]);
 
 fun betafy ss =
     simpLib.add_relsimp {refl = GEN_ALL lameq_refl,

--- a/examples/lambda/barendregt/chap2Script.sml
+++ b/examples/lambda/barendregt/chap2Script.sml
@@ -106,6 +106,7 @@ val lameq_weaken_cong = store_thm(
   METIS_TAC [lameq_rules]);
 
 Theorem lameq_SYM = List.nth(CONJUNCTS lameq_rules, 2)
+Theorem lameq_TRANS = List.nth(CONJUNCTS lameq_rules, 3)
 
 val fixed_point_thm = store_thm(  (* p. 14 *)
   "fixed_point_thm",
@@ -537,6 +538,15 @@ val is_abs_vsubst_invariant = Store_thm(
   HO_MATCH_MP_TAC nc_INDUCTION2 THEN Q.EXISTS_TAC `{u;v}` THEN
   SRW_TAC [][SUB_THM, SUB_VAR]);
 
+Theorem is_abs_cases :
+    !t. is_abs t <=> ?v t0. t = LAM v t0
+Proof
+    Q.X_GEN_TAC ‘t’
+ >> Q.SPEC_THEN ‘t’ STRUCT_CASES_TAC term_CASES
+ >> SRW_TAC [][]
+ >> qexistsl_tac [‘v’, ‘t0’] >> REWRITE_TAC []
+QED
+
 val (is_comb_thm, _) = define_recursive_term_function
   `(is_comb (VAR s) = F) /\
    (is_comb (t1 @@ t2) = T) /\
@@ -560,6 +570,22 @@ val is_var_vsubst_invariant = Store_thm(
   ``!t. is_var ([VAR v/u] t) = is_var t``,
   HO_MATCH_MP_TAC nc_INDUCTION2 THEN Q.EXISTS_TAC `{u;v}` THEN
   SRW_TAC [][SUB_THM, SUB_VAR]);
+
+Theorem is_var_cases :
+    !t. is_var t <=> ?y. t = VAR y
+Proof
+    Q.X_GEN_TAC ‘t’
+ >> Q.SPEC_THEN ‘t’ STRUCT_CASES_TAC term_CASES
+ >> SRW_TAC [][]
+QED
+
+Theorem term_cases :
+    !t. is_var t \/ is_comb t \/ is_abs t
+Proof
+    Q.X_GEN_TAC ‘t’
+ >> Q.SPEC_THEN ‘t’ STRUCT_CASES_TAC term_CASES
+ >> SRW_TAC [][]
+QED
 
 val (bnf_thm, _) = define_recursive_term_function
   `(bnf (VAR s) <=> T) /\
@@ -706,6 +732,7 @@ QED
 val _ = remove_ovl_mapping "Y" {Thy = "chap2", Name = "Y"}
 
 val _ = export_theory()
+val _ = html_theory "chap2";
 
 (* References:
 

--- a/examples/lambda/barendregt/chap3Script.sml
+++ b/examples/lambda/barendregt/chap3Script.sml
@@ -925,9 +925,11 @@ Proof
  >> MATCH_MP_TAC grandbeta_imp_betastar >> art []
 QED
 
-(* cf. abs_grandbeta, added by Chun Tian *)
+(* |- !R x y z. R^+ x y /\ R^+ y z ==> R^+ x z *)
+Theorem TC_TRANS[local] = REWRITE_RULE [transitive_def] TC_TRANSITIVE
+
 Theorem abs_betastar :
-    !x M Z. LAM x M -b->* Z ==> ?N'. (Z = LAM x N') /\ M == N'
+    !x M Z. LAM x M -b->* Z ==> ?N'. (Z = LAM x N') /\ M -b->* N'
 Proof
     rpt GEN_TAC
  >> REWRITE_TAC [SYM theorem3_17]
@@ -936,13 +938,13 @@ Proof
  >> rpt STRIP_TAC
  >- (FULL_SIMP_TAC std_ss [abs_grandbeta] \\
      Q.EXISTS_TAC ‘N0’ >> art [] \\
-     MATCH_MP_TAC grandbeta_imp_lameq >> art [])
+     MATCH_MP_TAC TC_SUBSET >> art [])
  >> Q.PAT_X_ASSUM ‘Z = LAM x N'’ (FULL_SIMP_TAC std_ss o wrap)
  >> FULL_SIMP_TAC std_ss [abs_grandbeta]
  >> Q.EXISTS_TAC ‘N0’ >> art []
- >> MATCH_MP_TAC lameq_TRANS
+ >> MATCH_MP_TAC TC_TRANS
  >> Q.EXISTS_TAC ‘N'’ >> art []
- >> MATCH_MP_TAC grandbeta_imp_lameq >> art []
+ >> MATCH_MP_TAC TC_SUBSET >> art []
 QED
 
 val lameq_consistent = store_thm(

--- a/examples/lambda/barendregt/chap3Script.sml
+++ b/examples/lambda/barendregt/chap3Script.sml
@@ -929,9 +929,12 @@ QED
 Theorem TC_TRANS[local] = REWRITE_RULE [transitive_def] TC_TRANSITIVE
 
 Theorem abs_betastar :
-    !x M Z. LAM x M -b->* Z ==> ?N'. (Z = LAM x N') /\ M -b->* N'
+    !x M Z. LAM x M -b->* Z <=> ?N'. (Z = LAM x N') /\ M -b->* N'
 Proof
     rpt GEN_TAC
+ >> reverse EQ_TAC
+ >- (rw [] >> PROVE_TAC [reduction_rules])
+ (* stage work *)
  >> REWRITE_TAC [SYM theorem3_17]
  >> Q.ID_SPEC_TAC ‘Z’
  >> HO_MATCH_MP_TAC (Q.ISPEC ‘grandbeta’ TC_INDUCT_ALT_RIGHT)

--- a/examples/lambda/barendregt/head_reductionScript.sml
+++ b/examples/lambda/barendregt/head_reductionScript.sml
@@ -1,7 +1,8 @@
 open HolKernel Parse boolLib bossLib
 
-open chap3Theory pred_setTheory termTheory boolSimps
-open nomsetTheory binderLib
+open pred_setTheory boolSimps;
+
+open termTheory chap2Theory chap3Theory nomsetTheory binderLib;
 
 val _ = new_theory "head_reduction"
 
@@ -350,5 +351,15 @@ val head_reductions_have_weak_prefixes = store_thm(
    ho_match_mp_tac relationTheory.RTC_STRONG_INDUCT >> conj_tac
      >- metis_tac [hnf_whnf, relationTheory.RTC_RULES] >>
    metis_tac [relationTheory.RTC_RULES, hreduce_weak_or_strong]);
+
+(* ----------------------------------------------------------------------
+    HNF and Combinators
+   ---------------------------------------------------------------------- *)
+
+Theorem hnf_I :
+    hnf I
+Proof
+    RW_TAC std_ss [hnf_thm, I_def]
+QED
 
 val _ = export_theory()

--- a/examples/lambda/barendregt/normal_orderScript.sml
+++ b/examples/lambda/barendregt/normal_orderScript.sml
@@ -1057,3 +1057,4 @@ val normstar_to_vheadbinary_wstar = save_thm(
                  [leneq2, DECIDE ``x < 2 ⇔ (x = 0) ∨ (x = 1)``]);
 
 val _ = export_theory()
+val _ = html_theory "normal_order";

--- a/examples/lambda/barendregt/solvableScript.sml
+++ b/examples/lambda/barendregt/solvableScript.sml
@@ -9,7 +9,8 @@ open arithmeticTheory pred_setTheory listTheory sortingTheory finite_mapTheory
      hurdUtils;
 
 (* lambda theories *)
-open termTheory appFOLDLTheory chap2Theory standardisationTheory reductionEval;
+open termTheory appFOLDLTheory chap2Theory chap3Theory standardisationTheory
+     reductionEval;
 
 val _ = new_theory "solvable";
 
@@ -104,9 +105,6 @@ Proof
  >> rw [lameq_K]
 QED
 
-Theorem lameq_symm[local]  = List.nth(CONJUNCTS lameq_rules, 2)
-Theorem lameq_trans[local] = List.nth(CONJUNCTS lameq_rules, 3)
-
 Theorem solvable_xIO :
     solvable (VAR x @@ I @@ Omega)
 Proof
@@ -186,7 +184,7 @@ Proof
      MATCH_MP_TAC FV_ssub \\
      rw [Abbr ‘fm’, FUN_FMAP_DEF, FAPPLY_FUPDATE_THM])
  (* stage work *)
- >> MATCH_MP_TAC lameq_trans
+ >> MATCH_MP_TAC lameq_TRANS
  >> Q.EXISTS_TAC ‘fm ' (M @* Ns)’
  >> reverse CONJ_TAC
  >- (ONCE_REWRITE_TAC [SYM ssub_I] \\
@@ -243,7 +241,7 @@ Proof
      MATCH_MP_TAC LAMl_appstar >> rw [])
  >> DISCH_TAC
  >> ‘LAMl vs M @* Ns0 @* Ns1 == fm ' M @* Ns1’ by PROVE_TAC [lameq_appstar_cong]
- >> ‘fm ' M @* Ns1 == I’ by PROVE_TAC [lameq_trans, lameq_symm]
+ >> ‘fm ' M @* Ns1 == I’ by PROVE_TAC [lameq_TRANS, lameq_SYM]
  >> qexistsl_tac [‘fm ' M’, ‘Ns1’]
  >> rw [closed_substitution_instances_def]
  >> Q.EXISTS_TAC ‘fm’ >> rw [Abbr ‘fm’]
@@ -281,7 +279,7 @@ Proof
      FULL_SIMP_TAC std_ss [GSYM appstar_APPEND] \\
      Q.ABBREV_TAC ‘Ns' = Ns ++ Is’ \\
     ‘LENGTH Ns' = n’ by (rw [Abbr ‘Ns'’, Abbr ‘Is’]) \\
-    ‘LAMl vs M @* Ns' == I’ by PROVE_TAC [lameq_trans] \\
+    ‘LAMl vs M @* Ns' == I’ by PROVE_TAC [lameq_TRANS] \\
      Know ‘EVERY closed Ns'’
      >- (rw [EVERY_APPEND, Abbr ‘Ns'’] \\
          rw [EVERY_MEM, Abbr ‘Is’, closed_def, MEM_GENLIST] \\
@@ -327,7 +325,7 @@ Proof
  >> Know ‘LAMl vs M @* Ps @* Ns == (FEMPTY |++ ZIP (vs,Ps)) ' M @* Ns’
  >- (MATCH_MP_TAC lameq_appstar_cong >> art [])
  >> DISCH_TAC
- >> ‘LAMl vs M @* Ps @* Ns == I’ by PROVE_TAC [lameq_trans]
+ >> ‘LAMl vs M @* Ps @* Ns == I’ by PROVE_TAC [lameq_TRANS]
  >> qexistsl_tac [‘LAMl vs M’, ‘Ps ++ Ns’]
  >> rw [appstar_APPEND, closures_def]
  >> Q.EXISTS_TAC ‘vs’ >> art []
@@ -369,7 +367,7 @@ Proof
      MATCH_MP_TAC LAMl_appstar >> rw [])
  >> DISCH_TAC
  >> ‘LAMl vs M @* Ns0 @* Ns1 == fm ' M @* Ns1’ by PROVE_TAC [lameq_appstar_cong]
- >> ‘fm ' M @* Ns1 == I’ by PROVE_TAC [lameq_trans, lameq_symm]
+ >> ‘fm ' M @* Ns1 == I’ by PROVE_TAC [lameq_TRANS, lameq_SYM]
  (* Ns0' is the permuted version of Ns0 *)
  >> Q.ABBREV_TAC ‘Ns0' = GENLIST (\i. EL (f i) Ns0) n’
  >> ‘LENGTH Ns0' = n’ by rw [Abbr ‘Ns0'’, LENGTH_GENLIST]
@@ -392,9 +390,9 @@ Proof
      MATCH_MP_TAC LAMl_appstar >> rw [])
  >> DISCH_TAC
  >> ‘LAMl vs' M @* Ns0' @* Ns1 == fm' ' M @* Ns1’ by PROVE_TAC [lameq_appstar_cong]
- >> MATCH_MP_TAC lameq_trans
+ >> MATCH_MP_TAC lameq_TRANS
  >> Q.EXISTS_TAC ‘fm' ' M @* Ns1’ >> art []
- >> MATCH_MP_TAC lameq_trans
+ >> MATCH_MP_TAC lameq_TRANS
  >> Q.EXISTS_TAC ‘fm ' M @* Ns1’ >> art []
  >> Suff ‘fm = fm'’ >- rw []
  (* cleanup uncessary assumptions *)
@@ -476,7 +474,7 @@ Proof
  >> ‘LAMl vs M @* (Ns ++ Is) == I @* Is’ by rw [appstar_APPEND]
  >> Q.ABBREV_TAC ‘Ns' = Ns ++ Is’
  >> ‘LENGTH Ns' = n’ by (rw [Abbr ‘Ns'’, Abbr ‘Is’])
- >> ‘LAMl vs M @* Ns' == I’ by PROVE_TAC [lameq_trans]
+ >> ‘LAMl vs M @* Ns' == I’ by PROVE_TAC [lameq_TRANS]
  >> Know ‘EVERY closed Ns'’
  >- (rw [EVERY_APPEND, Abbr ‘Ns'’] \\
      rw [EVERY_MEM, Abbr ‘Is’, closed_def, MEM_GENLIST] \\
@@ -489,8 +487,8 @@ QED
 Theorem ssub_LAM[local] = List.nth(CONJUNCTS ssub_thm, 2)
 
 (* Lemma 8.3.3 (ii) *)
-Theorem solvable_iff_solvable_LAM[simp] :
-    !M x. solvable (LAM x M) <=> solvable M
+Theorem solvable_iff_LAM[simp] :
+    !x M. solvable (LAM x M) <=> solvable M
 Proof
     rpt STRIP_TAC
  >> reverse EQ_TAC
@@ -509,7 +507,7 @@ Proof
             rw [Abbr ‘fm0’, Abbr ‘N’, DOMSUB_FAPPLY_THM, closed_def]) >> Rewr' \\
         DISCH_TAC \\
         Know ‘fm0 ' (LAM x M @@ N) @* Ns == I’
-        >- (MATCH_MP_TAC lameq_trans \\
+        >- (MATCH_MP_TAC lameq_TRANS \\
             Q.EXISTS_TAC ‘fm0 ' ([N/x] M) @* Ns’ \\
             POP_ASSUM (REWRITE_TAC o wrap) \\
             MATCH_MP_TAC lameq_appstar_cong \\
@@ -525,7 +523,7 @@ Proof
         Q.EXISTS_TAC ‘fm0’ >> rw [Abbr ‘fm0’, DOMSUB_FAPPLY_THM],
         (* goal 1.2 (of 2) *)
         Know ‘fm ' (LAM x M @@ I) @* Ns == I’
-        >- (MATCH_MP_TAC lameq_trans \\
+        >- (MATCH_MP_TAC lameq_TRANS \\
             Q.EXISTS_TAC ‘fm ' M @* Ns’ >> art [] \\
             MATCH_MP_TAC lameq_appstar_cong \\
             MATCH_MP_TAC lameq_ssub_cong >> art [] \\
@@ -561,7 +559,7 @@ Proof
         simp [appstar_APPEND] \\
         DISCH_TAC \\
         Know ‘[h/x] (fm ' M) @* t == I’
-        >- (MATCH_MP_TAC lameq_trans \\
+        >- (MATCH_MP_TAC lameq_TRANS \\
             Q.EXISTS_TAC ‘LAM x (fm ' M) @@ h @* t’ >> art [] \\
             MATCH_MP_TAC lameq_appstar_cong \\
             rw [lameq_rules]) \\
@@ -596,7 +594,7 @@ Proof
         simp [appstar_APPEND] \\
         DISCH_TAC \\
         Know ‘[h/x] (fm ' M) @* t == I’
-        >- (MATCH_MP_TAC lameq_trans \\
+        >- (MATCH_MP_TAC lameq_TRANS \\
             Q.EXISTS_TAC ‘LAM x (fm ' M) @@ h @* t’ >> art [] \\
             MATCH_MP_TAC lameq_appstar_cong \\
             rw [lameq_rules]) \\

--- a/examples/lambda/barendregt/standardisationScript.sml
+++ b/examples/lambda/barendregt/standardisationScript.sml
@@ -2500,12 +2500,22 @@ Proof
 QED
 
 Theorem hnf_appstar :
-    !M Ns. hnf (M @* Ns) /\ Ns <> [] ==> hnf M /\ ~is_abs M
+    !M Ns. Ns <> [] ==> (hnf (M @* Ns) <=> hnf M /\ ~is_abs M)
 Proof
-    Q.X_GEN_TAC ‘M’
+    rpt STRIP_TAC
+ >> EQ_TAC
+ >- (POP_ASSUM MP_TAC \\
+     Q.ID_SPEC_TAC ‘Ns’ >> HO_MATCH_MP_TAC SNOC_INDUCT \\
+     rw [SNOC_APPEND, SYM appstar_SNOC] \\
+     Cases_on ‘Ns = []’ >> fs [])
+ >> STRIP_TAC
+ >> Q.ID_SPEC_TAC ‘Ns’
  >> HO_MATCH_MP_TAC SNOC_INDUCT
  >> rw [SNOC_APPEND, SYM appstar_SNOC]
- >> Cases_on ‘Ns = []’ >> fs []
+ >> Q.PAT_X_ASSUM ‘~is_abs M’ MP_TAC >> KILL_TAC >> DISCH_TAC
+ >> Q.SPEC_TAC (‘Ns'’, ‘Ns’)
+ >> HO_MATCH_MP_TAC SNOC_INDUCT
+ >> rw [SNOC_APPEND, SYM appstar_SNOC]
 QED
 
 Theorem hnf_cases :
@@ -2536,9 +2546,7 @@ Proof
      rw [hnf_cases])
  (* stage work *)
  >> ‘?Z. LAM x M -b->* Z /\ N -b->* Z’ by METIS_TAC [lameq_CR]
- >> Know ‘?N'. (Z = LAM x N') /\ M -b->* N'’
- >- (MATCH_MP_TAC abs_betastar >> art [])
- >> STRIP_TAC
+ >> ‘?N'. (Z = LAM x N') /\ M -b->* N'’ by rw [GSYM abs_betastar]
  >> Q.EXISTS_TAC ‘N'’
  >> ‘hnf Z’ by PROVE_TAC [hnf_preserved]
  >> gs [hnf_thm]

--- a/examples/lambda/barendregt/standardisationScript.sml
+++ b/examples/lambda/barendregt/standardisationScript.sml
@@ -2523,7 +2523,7 @@ Proof
  >> qexistsl_tac [‘vs’, ‘args’, ‘y’] >> art []
 QED
 
-(* Proposition 8.3.13 (i) *)
+(* Proposition 8.3.13 (i) [1, p.174] *)
 Theorem has_hnf_iff_LAM[simp] :
     !x M. has_hnf (LAM x M) <=> has_hnf M
 Proof
@@ -2536,11 +2536,13 @@ Proof
      rw [hnf_cases])
  (* stage work *)
  >> ‘?Z. LAM x M -b->* Z /\ N -b->* Z’ by METIS_TAC [lameq_CR]
- >> Suff ‘?N'. (Z = LAM x N') /\ M == N'’
- >- (STRIP_TAC \\
-    ‘hnf Z’ by PROVE_TAC [hnf_preserved] \\
-     Q.EXISTS_TAC ‘N'’ >> gs [hnf_thm])
- >> MATCH_MP_TAC abs_betastar >> art []
+ >> Know ‘?N'. (Z = LAM x N') /\ M -b->* N'’
+ >- (MATCH_MP_TAC abs_betastar >> art [])
+ >> STRIP_TAC
+ >> Q.EXISTS_TAC ‘N'’
+ >> ‘hnf Z’ by PROVE_TAC [hnf_preserved]
+ >> gs [hnf_thm]
+ >> MATCH_MP_TAC betastar_lameq >> art []
 QED
 
 val _ = export_theory()

--- a/examples/lambda/basics/termScript.sml
+++ b/examples/lambda/basics/termScript.sml
@@ -1,6 +1,6 @@
 open HolKernel boolLib Parse bossLib generic_termsTheory
 
-open boolSimps
+open boolSimps arithmeticTheory;
 
 open nomsetTheory
 open pred_setTheory finite_mapTheory hurdUtils
@@ -558,6 +558,24 @@ val size_def = new_specification("size_def", ["size"], size_exists)
 Theorem size_thm[simp] = CONJUNCT1 size_def
 
 Theorem size_tpm[simp] = GSYM (CONJUNCT2 size_def)
+
+Theorem size_nonzero :
+    !t:term. 0 < size t
+Proof
+    HO_MATCH_MP_TAC simple_induction
+ >> SRW_TAC [ARITH_ss][]
+QED
+
+(* |- !t. size t <> 0 *)
+Theorem size_nz =
+    REWRITE_RULE [GSYM arithmeticTheory.NOT_ZERO_LT_ZERO] size_nonzero
+
+Theorem size_1 :
+    (size M = 1) <=> ?y. (M = VAR y)
+Proof
+    Q.SPEC_THEN `M` STRUCT_CASES_TAC term_CASES
+ >> SRW_TAC [][size_thm, size_nz]
+QED
 
 (* ----------------------------------------------------------------------
     iterated substitutions (ugh)


### PR DESCRIPTION
Hi,

This is a stage work proving more results of terms having head normal forms (`has_hnf`), independent with solvable terms. The end of the chain of proved theorems is the following theorems with `[simp]` (Proposition 8.3.13 (i) of [1, p.174]):
```
[has_hnf_iff_LAM] (standardisationTheory)
    ⊢ ∀x M. has_hnf (LAM x M) ⇔ has_hnf M
```

Now I have to use `chap3Theory`, i.e. using theorems about (beta) reductions (`beta` and `grandbeta`) to prove results about beta conversions (`lameq`). The following important lemmas are proved:
```
lameq_CR (chap3Theory)
    ⊢ ∀M N. M == N ⇒ ∃Z. M -β->* Z ∧ N -β->* Z

grandbeta_imp_betastar (chap3Theory)
    ⊢ ∀M N. M =β=> N ⇒ M -β->* N

grandbeta_imp_lameq (chap3Theory)
    ⊢ ∀M N. M =β=> N ⇒ M == N

abs_betastar (chap3Theory, statements modified in 2nd commit)
    ⊢ ∀x M Z. LAM x M -β->* Z ⇒ ∃N'. Z = LAM x N' ∧ M -β->* N'
```

P.S. With the above theorem "has_hnf_iff_LAM" and the following theorem (slightly renamed) added by previous PR #1148:
```
solvable_iff_LAM (solvableTheory)
    ⊢ ∀x M. solvable (LAM x M) ⇔ solvable M
```
we are now ready to show `|- solvable M <=> has_hnf M` (a term is solvable iff has head normal forms) by first reducing all involved terms to closed terms (by closing the terms with `LAM`s of free variables.), i.e. `|- closed M ==> solvable M <=> has_hnf M`.

[1] Barendregt, H.P.: The Lambda Calculus, Its Syntax and Semantics. College Publications, London (1984).