### PR TITLE
Lambda term is solvable iff it has hnf (head normal form)

### DIFF
--- a/examples/lambda/barendregt/chap2Script.sml
+++ b/examples/lambda/barendregt/chap2Script.sml
@@ -267,8 +267,8 @@ Proof
     Q.X_GEN_TAC ‘x’
  >> REWRITE_TAC [I_def, Once EQ_SYM_EQ]
  >> Cases_on ‘x = "x"’ >- rw []
- >> NewQ.ABBREV_TAC ‘u :term = VAR x’
- >> NewQ.ABBREV_TAC ‘y = "x"’
+ >> qabbrev_tac ‘u :term = VAR x’
+ >> qabbrev_tac ‘y = "x"’
  >> ‘y NOTIN FV u’ by rw [Abbr ‘u’]
  >> Know ‘LAM x u = LAM y ([VAR y/x] u)’
  >- (MATCH_MP_TAC SIMPLE_ALPHA >> art [])
@@ -354,7 +354,7 @@ QED
 Theorem I_appstar :
     I @* (GENLIST (\i. I) n) == I
 Proof
-    NewQ.ABBREV_TAC ‘Is = GENLIST (\i. I) n’
+    qabbrev_tac ‘Is = GENLIST (\i. I) n’
  >> MATCH_MP_TAC I_appstar'
  >> rw [Abbr ‘Is’, MEM_GENLIST]
 QED
@@ -799,7 +799,7 @@ Theorem lameq_LAMl_appstar :
               LAMl vs M @* Ns == (FEMPTY |++ ZIP (vs,Ns)) ' M
 Proof
     rpt STRIP_TAC
- >> NewQ.ABBREV_TAC ‘L = ZIP (vs,Ns)’
+ >> qabbrev_tac ‘L = ZIP (vs,Ns)’
  >> ‘(Ns = MAP SND L) /\ (vs = MAP FST L)’ by rw [Abbr ‘L’, MAP_ZIP]
  >> FULL_SIMP_TAC std_ss []
  >> Q.PAT_X_ASSUM ‘EVERY closed (MAP SND L)’ MP_TAC
@@ -809,10 +809,10 @@ Proof
  >> Induct_on ‘L’ >> rw []
  >- (Suff ‘FEMPTY |++ [] = FEMPTY :string |-> term’ >- rw [] \\
      rw [FUPDATE_LIST_EQ_FEMPTY])
- >> NewQ.ABBREV_TAC ‘v = FST h’
- >> NewQ.ABBREV_TAC ‘vs = MAP FST L’
- >> NewQ.ABBREV_TAC ‘N = SND h’
- >> NewQ.ABBREV_TAC ‘Ns = MAP SND L’
+ >> qabbrev_tac ‘v = FST h’
+ >> qabbrev_tac ‘vs = MAP FST L’
+ >> qabbrev_tac ‘N = SND h’
+ >> qabbrev_tac ‘Ns = MAP SND L’
  (* RHS rewriting *)
  >> ‘h :: L = [h] ++ L’ by rw [] >> POP_ORW
  >> rw [FUPDATE_LIST_APPEND]
@@ -821,7 +821,7 @@ Proof
      rw [DISJOINT_ALT])
  >> Rewr'
  >> rw [GSYM FUPDATE_EQ_FUPDATE_LIST]
- >> NewQ.ABBREV_TAC ‘fm = FEMPTY |++ L’
+ >> qabbrev_tac ‘fm = FEMPTY |++ L’
  >> FULL_SIMP_TAC std_ss []
  >> ‘h = (v,N)’ by rw [Abbr ‘v’, Abbr ‘N’] >> POP_ORW
  >> Know ‘(fm |+ (v,N)) ' M = fm ' ([N/v] M)’

--- a/examples/lambda/barendregt/finite_developmentsScript.sml
+++ b/examples/lambda/barendregt/finite_developmentsScript.sml
@@ -4090,4 +4090,3 @@ val corollary11_2_29 = store_thm(
              relationTheory.diamond_TC_diamond]);
 
 val _ = export_theory();
-val _ = html_theory "finite_developments";

--- a/examples/lambda/barendregt/finite_developmentsScript.sml
+++ b/examples/lambda/barendregt/finite_developmentsScript.sml
@@ -4090,3 +4090,4 @@ val corollary11_2_29 = store_thm(
              relationTheory.diamond_TC_diamond]);
 
 val _ = export_theory();
+val _ = html_theory "finite_developments";

--- a/examples/lambda/barendregt/head_reductionScript.sml
+++ b/examples/lambda/barendregt/head_reductionScript.sml
@@ -1,18 +1,16 @@
-open HolKernel Parse boolLib bossLib
+open HolKernel Parse boolLib bossLib BasicProvers;
 
 open boolSimps relationTheory pred_setTheory listTheory finite_mapTheory
-     hurdUtils;
+     arithmeticTheory llistTheory pathTheory optionTheory hurdUtils;
 
 open termTheory appFOLDLTheory chap2Theory chap3Theory nomsetTheory binderLib
-     term_posnsTheory;
+     term_posnsTheory finite_developmentsTheory;
 
 val _ = new_theory "head_reduction"
 
 val _ = ParseExtras.temp_loose_equality()
 
 fun Store_thm(trip as (n,t,tac)) = store_thm trip before export_rewrites [n]
-
-val _ = set_trace "Unicode" 1
 
 Inductive hreduce1 :
   (∀v M N. hreduce1 (LAM v M @@ N) ([N/v]M)) ∧
@@ -39,6 +37,12 @@ val hreduce1_FV = store_thm(
   ``∀M N. M -h-> N ⇒ ∀v. v ∈ FV N ⇒ v ∈ FV M``,
   METIS_TAC [SUBSET_DEF, hreduce_ccbeta, cc_beta_FV_SUBSET]);
 
+Theorem hreduces_FV :
+    ∀M N. M -h->* N ⇒ v ∈ FV N ⇒ v ∈ FV M
+Proof
+    HO_MATCH_MP_TAC relationTheory.RTC_INDUCT
+ >> METIS_TAC [relationTheory.RTC_RULES, hreduce1_FV]
+QED
 
 val _ = temp_add_rule {block_style = (AroundEachPhrase, (PP.INCONSISTENT,2)),
                        fixity = Infix(NONASSOC, 950),
@@ -211,12 +215,55 @@ val hnf_ccbeta_preserved = store_thm(
     SRW_TAC [][] THEN FULL_SIMP_TAC (srw_ss()) []
   ]);
 
+Theorem hnf_I :
+    hnf I
+Proof
+    RW_TAC std_ss [hnf_thm, I_def]
+QED
+
+Theorem hnf_LAMl[simp] :
+    hnf (LAMl vs M) <=> hnf M
+Proof
+    Induct_on ‘vs’ >> rw []
+QED
+
+Theorem hnf_appstar :
+    !M Ns. hnf (M @* Ns) <=> hnf M /\ (is_abs M ⇒ (Ns = []))
+Proof
+  Induct_on ‘Ns’ using SNOC_INDUCT >> simp[appstar_SNOC] >>
+  dsimp[SF CONJ_ss] >> metis_tac[]
+QED
+
+(* NOTE: ‘ALL_DISTINCT vs’ has been added to RHS. *)
+Theorem hnf_cases :
+    !M : term. hnf M <=> ?vs args y. ALL_DISTINCT vs /\ (M = LAMl vs (VAR y @* args))
+Proof
+    simp [FORALL_AND_THM, EQ_IMP_THM]
+ (* this direction is proved by Michael Norrish *)
+ >> reverse conj_tac
+ >- simp [PULL_EXISTS, hnf_appstar]
+ (* below is learnt from bnf_characterisation *)
+ >> ho_match_mp_tac nc_INDUCTION2
+ >> qexists_tac ‘{}’ >> rw [] >~ [‘VAR _ @* _ = M1 @@ M2’]
+ >- (gs [app_eq_appstar] \\
+     qexists_tac ‘args ++ [M2]’ >> rw [GSYM SNOC_APPEND])
+ >> gs [app_eq_appstar] >~ [‘VAR z @* Ms’]
+ >> reverse (Cases_on ‘MEM y vs’)
+ >- (qexistsl_tac [‘y::vs’, ‘Ms’, ‘z’] >> simp [])
+ >> ‘y # LAMl vs (VAR z @* Ms)’ by simp [FV_LAMl]
+ >> Q_TAC (NEW_TAC "x") ‘y INSERT (set vs) UNION (FV (VAR z @* Ms))’
+ >> ‘x # LAMl vs (VAR z @* Ms)’ by simp [FV_LAMl]
+ >> dxrule_then (qspec_then ‘y’ mp_tac) tpm_ALPHA
+ >> simp [tpm_fresh, FV_LAMl]
+ >> strip_tac >> qexists ‘x::vs’ >> simp []
+QED
+
 (* ----------------------------------------------------------------------
     Weak head reductions (weak_head or -w->)
    ---------------------------------------------------------------------- *)
 
 Inductive weak_head :
-  (∀v M N. weak_head (LAM v M @@ N) ([N/v]M)) ∧
+  (∀v M N :term. weak_head (LAM v M @@ N) ([N/v]M)) ∧
   (∀M₁ M₂ N. weak_head M₁ M₂ ⇒ weak_head (M₁ @@ N) (M₂ @@ N))
 End
 
@@ -540,44 +587,535 @@ val is_head_redex_vsubst_invariant = store_thm(
   HO_MATCH_MP_TAC nc_INDUCTION2 THEN Q.EXISTS_TAC `{x;v}` THEN
   SRW_TAC [][is_head_redex_thm, SUB_THM, SUB_VAR]);
 
-(* ----------------------------------------------------------------------
-    More results about head normal forms (hnf)
-   ---------------------------------------------------------------------- *)
+val head_redex_preserved = store_thm(
+  "head_redex_preserved",
+  ``!M p N.
+      labelled_redn beta M p N ==>
+      !h. h is_head_redex M /\ ~(h = p) ==> h is_head_redex N``,
+  HO_MATCH_MP_TAC strong_labelled_redn_ind THEN
+  SRW_TAC [][is_head_redex_thm, beta_def] THENL [
+    FULL_SIMP_TAC (srw_ss()) [is_head_redex_thm],
+    `?v t. M = LAM v t` by PROVE_TAC [is_abs_thm, term_CASES] THEN
+    FULL_SIMP_TAC (srw_ss()) [labelled_redn_lam],
+    `?f x. M = f @@ x` by PROVE_TAC [is_comb_APP_EXISTS] THEN
+    SRW_TAC [][] THEN
+    Q.PAT_X_ASSUM `labelled_redn beta _ _ _` MP_TAC THEN
+    ONCE_REWRITE_TAC [labelled_redn_cases] THEN
+    FULL_SIMP_TAC (srw_ss()) [is_head_redex_thm, beta_def] THEN
+    PROVE_TAC [is_comb_thm]
+  ]);
 
-Theorem hnf_I :
-    hnf I
+Definition is_head_reduction_def :
+  is_head_reduction s = okpath (labelled_redn beta) s /\
+                        !i. i + 1 IN PL s ==>
+                            nth_label i s is_head_redex el i s
+End
+
+Theorem is_head_reduction_thm[simp] :
+    (is_head_reduction (stopped_at x) = T) /\
+    (is_head_reduction (pcons x r p) =
+       labelled_redn beta x r (first p) /\ r is_head_redex x /\
+       is_head_reduction p)
 Proof
-    RW_TAC std_ss [hnf_thm, I_def]
+  SRW_TAC [][is_head_reduction_def, GSYM ADD1,
+             EQ_IMP_THM]
+  THENL [
+    POP_ASSUM (Q.SPEC_THEN `0` MP_TAC) THEN SRW_TAC [][],
+    RES_TAC THEN FULL_SIMP_TAC (srw_ss()) [],
+    Cases_on `i` THEN SRW_TAC [][]
+  ]
 QED
 
-Theorem hnf_LAMl[simp] :
-    hnf (LAMl vs M) <=> hnf M
+val _ = add_infix ("head_reduces", 760, NONASSOC)
+Definition head_reduces_def :
+  M head_reduces N = ?s. finite s /\ (first s = M) /\ (last s = N) /\
+                         is_head_reduction s
+End
+
+val head_reduce1_def = store_thm(
+  "head_reduce1_def",
+  ``M -h-> N = (?r. r is_head_redex M /\ labelled_redn beta M r N)``,
+  EQ_TAC THENL [
+    Q_TAC SUFF_TAC `!M N. M -h-> N ==>
+                          ?r. r is_head_redex M /\ labelled_redn beta M r N`
+          THEN1 METIS_TAC [] THEN
+    HO_MATCH_MP_TAC hreduce1_ind THEN SRW_TAC [][] THENL [
+      METIS_TAC [beta_def, is_head_redex_rules, labelled_redn_rules],
+      METIS_TAC [is_head_redex_rules, labelled_redn_rules],
+      Q.SPEC_THEN `M` FULL_STRUCT_CASES_TAC term_CASES THENL [
+        FULL_SIMP_TAC (srw_ss()) [Once labelled_redn_cases, beta_def],
+        METIS_TAC [is_head_redex_rules, labelled_redn_rules],
+        FULL_SIMP_TAC (srw_ss()) []
+      ]
+    ],
+    Q_TAC SUFF_TAC `!M r N. labelled_redn beta M r N ==>
+                            r is_head_redex M ==> M -h-> N`
+          THEN1 METIS_TAC [] THEN
+    HO_MATCH_MP_TAC labelled_redn_ind THEN
+    SIMP_TAC (srw_ss() ++ DNF_ss) [beta_def, is_head_redex_thm,
+                                   Once is_comb_APP_EXISTS, hreduce1_rwts]
+  ]);
+
+val head_reduces_RTC_hreduce1 = store_thm(
+  "head_reduces_RTC_hreduce1",
+  ``(head_reduces) = RTC (-h->)``,
+  SIMP_TAC (srw_ss()) [head_reduces_def, FUN_EQ_THM, GSYM LEFT_FORALL_IMP_THM,
+                       FORALL_AND_THM, EQ_IMP_THM] THEN
+  CONJ_TAC THENL [
+    Q_TAC SUFF_TAC `!s. finite s ==>
+                        is_head_reduction s ==>
+                        RTC (-h->) (first s) (last s)` THEN1
+          PROVE_TAC [] THEN
+    HO_MATCH_MP_TAC pathTheory.finite_path_ind THEN
+    SIMP_TAC (srw_ss()) [relationTheory.RTC_RULES] THEN
+    MAP_EVERY Q.X_GEN_TAC [`x`,`r`,`p`] THEN REPEAT STRIP_TAC THEN
+    MATCH_MP_TAC (CONJUNCT2 (SPEC_ALL relationTheory.RTC_RULES)) THEN
+    Q.EXISTS_TAC `first p` THEN SRW_TAC [][head_reduce1_def] THEN
+    PROVE_TAC [],
+    HO_MATCH_MP_TAC relationTheory.RTC_INDUCT THEN
+    SRW_TAC [][head_reduce1_def] THENL [
+      Q.EXISTS_TAC `stopped_at x` THEN SRW_TAC [][],
+      Q.EXISTS_TAC `pcons x r s` THEN SRW_TAC [][]
+    ]
+  ]);
+
+val head_reduces_reduction_beta = store_thm(
+  "head_reduces_reduction_beta",
+  ``!M N. M head_reduces N ==> reduction beta M N``,
+  SIMP_TAC (srw_ss()) [head_reduces_RTC_hreduce1] THEN
+  MATCH_MP_TAC relationTheory.RTC_MONOTONE THEN
+  METIS_TAC [head_reduce1_def, labelled_redn_cc]);
+
+Theorem hreduces_lameq :
+    M -h->* N ==> M == N
 Proof
-    Induct_on ‘vs’ >> rw []
+    rw [SYM head_reduces_RTC_hreduce1]
+ >> MATCH_MP_TAC betastar_lameq
+ >> MATCH_MP_TAC head_reduces_reduction_beta >> art []
 QED
 
-Theorem hnf_appstar :
-    !M Ns. hnf (M @* Ns) <=> hnf M /\ (is_abs M ⇒ (Ns = []))
+val head_reduces_TRANS = store_thm(
+  "head_reduces_TRANS",
+  ``!M N P. M head_reduces N /\ N head_reduces P ==> M head_reduces P``,
+  METIS_TAC [relationTheory.RTC_RTC, head_reduces_RTC_hreduce1]);
+
+val has_hnf_def = Define`
+  has_hnf M = ?N. M == N /\ hnf N
+`;
+
+val has_bnf_hnf = store_thm(
+  "has_bnf_hnf",
+  ``has_bnf M ⇒ has_hnf M``,
+  SRW_TAC [][has_hnf_def, chap2Theory.has_bnf_def] THEN
+  METIS_TAC [bnf_hnf]);
+
+val head_reduct_def = Define`
+  head_reduct M = if ?r. r is_head_redex M then
+                    SOME (@N. M -h-> N)
+                  else NONE
+`;
+
+val head_reduct_unique = store_thm(
+  "head_reduct_unique",
+  ``!M N. M -h-> N ==> (head_reduct M = SOME N)``,
+  SRW_TAC [][head_reduce1_def, head_reduct_def] THEN1 METIS_TAC [] THEN
+  SELECT_ELIM_TAC THEN METIS_TAC [is_head_redex_unique, labelled_redn_det]);
+
+val head_reduct_NONE = store_thm(
+  "head_reduct_NONE",
+  ``(head_reduct M = NONE) = !N. ~(M -h-> N)``,
+  SRW_TAC [][head_reduct_def, head_reduce1_def] THEN
+  METIS_TAC [head_redex_is_redex, IN_term_IN_redex_posns,
+             is_redex_occurrence_def]);
+
+val head_reduct_SOME = store_thm(
+  "head_reduct_SOME",
+  ``(head_reduct M = SOME N) = M -h-> N``,
+  SIMP_TAC (srw_ss()) [EQ_IMP_THM, head_reduct_unique] THEN
+  SRW_TAC [][head_reduct_def] THEN SELECT_ELIM_TAC THEN
+  SRW_TAC [][head_reduce1_def] THEN
+  METIS_TAC [head_redex_is_redex, IN_term_IN_redex_posns,
+             is_redex_occurrence_def]);
+
+val is_head_reduction_coind = store_thm(
+  "is_head_reduction_coind",
+  ``(!x r q. P (pcons x r q) ==>
+             labelled_redn beta x r (first q) /\
+             r is_head_redex x /\ P q) ==>
+    !p. P p ==> is_head_reduction p``,
+  SIMP_TAC (srw_ss()) [is_head_reduction_def, IMP_CONJ_THM,
+                       FORALL_AND_THM] THEN CONJ_TAC
+  THENL [
+    STRIP_TAC THEN HO_MATCH_MP_TAC okpath_co_ind THEN METIS_TAC [],
+    STRIP_TAC THEN GEN_TAC THEN STRIP_TAC THEN
+    Q_TAC SUFF_TAC `!i. i + 1 IN PL p ==> nth_label i p is_head_redex el i p /\
+                                          P (drop (i + 1) p)` THEN1
+          METIS_TAC [] THEN
+    Induct THEN FULL_SIMP_TAC (srw_ss()) [GSYM ADD1] THENL [
+      Q.ISPEC_THEN `p` FULL_STRUCT_CASES_TAC path_cases THEN
+      FULL_SIMP_TAC (srw_ss()) [] THEN METIS_TAC [],
+      STRIP_TAC THEN
+      `SUC i IN PL p`
+         by METIS_TAC [PL_downward_closed, DECIDE ``x < SUC x``] THEN
+      FULL_SIMP_TAC (srw_ss()) [] THEN
+      Q.ISPEC_THEN `p` FULL_STRUCT_CASES_TAC path_cases THEN
+      FULL_SIMP_TAC (srw_ss()) [] THEN
+      `?y s q'. drop i q = pcons y s q'` by METIS_TAC [drop_not_stopped] THEN
+      `labelled_redn beta y s (first q') /\ s is_head_redex y /\ P q'`
+          by METIS_TAC [stopped_at_not_pcons, pcons_11] THEN
+      `el 0 (drop i q) = el i q` by SRW_TAC [][] THEN
+      `el i q = y` by METIS_TAC [el_def, first_thm] THEN
+      `nth_label 0 (drop i q) = nth_label i q` by SRW_TAC [][] THEN
+      `nth_label i q = s` by METIS_TAC [nth_label_def, first_label_def] THEN
+      SRW_TAC [][drop_tail_commute]
+    ]
+  ]);
+
+val head_reduction_path_uexists = prove(
+  ``!M. ?!p. (first p = M) /\ is_head_reduction p /\
+             (finite p ==> hnf (last p))``,
+  GEN_TAC THEN
+  Q.ISPEC_THEN `\M. (M, OPTION_MAP (\N. ((@r. r is_head_redex M), N))
+                                  (head_reduct M))`
+               STRIP_ASSUME_TAC path_Axiom THEN
+  `!M. first (g M) = M`
+      by (POP_ASSUM (fn th => SRW_TAC [][Once th]) THEN
+          Cases_on `head_reduct M` THEN SRW_TAC [][]) THEN
+  `!M. is_head_reduction (g M)`
+      by (Q_TAC SUFF_TAC
+                `!p. (?M. p = g M) ==> is_head_reduction p` THEN1
+                METIS_TAC [] THEN
+          HO_MATCH_MP_TAC is_head_reduction_coind THEN
+          Q.PAT_X_ASSUM `!x:term. g x = Z`
+                          (fn th => SIMP_TAC (srw_ss())
+                                             [Once th, SimpL ``(==>)``]) THEN
+          REPEAT GEN_TAC THEN STRIP_TAC THEN
+          Cases_on `head_reduct M` THEN
+          FULL_SIMP_TAC (srw_ss()) [head_reduct_SOME, head_reduce1_def] THEN
+          REPEAT VAR_EQ_TAC THEN SELECT_ELIM_TAC THEN
+          METIS_TAC [is_head_redex_unique]) THEN
+  `!p. finite p ==> !M. (p = g M) ==> hnf (last p)`
+      by (HO_MATCH_MP_TAC finite_path_ind THEN
+          SIMP_TAC (srw_ss()) [] THEN CONJ_TAC THEN REPEAT GEN_TAC THENL [
+            Q.PAT_X_ASSUM `!x:term. g x = Z`
+                        (fn th => ONCE_REWRITE_TAC [th]) THEN
+            Cases_on `head_reduct M` THEN SRW_TAC [][] THEN
+            FULL_SIMP_TAC (srw_ss()) [hnf_no_head_redex, head_reduct_NONE,
+                                      head_reduce1_def] THEN
+            METIS_TAC [head_redex_is_redex, IN_term_IN_redex_posns,
+                       is_redex_occurrence_def],
+            STRIP_TAC THEN GEN_TAC THEN
+            Q.PAT_X_ASSUM `!x:term. g x = Z`
+                        (fn th => ONCE_REWRITE_TAC [th]) THEN
+            Cases_on `head_reduct M` THEN SRW_TAC [][]
+          ]) THEN
+  SIMP_TAC (srw_ss()) [EXISTS_UNIQUE_THM] THEN CONJ_TAC THENL [
+    Q.EXISTS_TAC `g M` THEN
+    Q.PAT_X_ASSUM `!x:term. g x = Z` (K ALL_TAC) THEN METIS_TAC [],
+    REPEAT (POP_ASSUM (K ALL_TAC)) THEN
+    REPEAT STRIP_TAC THEN
+    ONCE_REWRITE_TAC [path_bisimulation] THEN
+    Q.EXISTS_TAC `\p1 p2. is_head_reduction p1 /\ is_head_reduction p2 /\
+                          (first p1 = first p2) /\
+                          (finite p1 ==> hnf (last p1)) /\
+                          (finite p2 ==> hnf (last p2))` THEN
+    SRW_TAC [][] THEN
+    Q.ISPEC_THEN `q1` (REPEAT_TCL STRIP_THM_THEN SUBST_ALL_TAC)
+                 path_cases THEN
+    Q.ISPEC_THEN `q2` (REPEAT_TCL STRIP_THM_THEN SUBST_ALL_TAC)
+                 path_cases THEN FULL_SIMP_TAC (srw_ss()) []
+    THENL [
+      METIS_TAC [hnf_no_head_redex],
+      METIS_TAC [hnf_no_head_redex],
+      METIS_TAC [is_head_redex_unique, labelled_redn_det]
+    ]
+  ]);
+
+val head_reduction_path_def = new_specification(
+  "head_reduction_path_def",
+  ["head_reduction_path"],
+  CONJUNCT1 ((SIMP_RULE bool_ss [EXISTS_UNIQUE_THM] o
+              SIMP_RULE bool_ss [UNIQUE_SKOLEM_THM])
+             head_reduction_path_uexists));
+
+val head_reduction_path_unique = store_thm(
+  "head_reduction_path_unique",
+  ``!M p. (first p = M) /\ is_head_reduction p /\
+          (finite p ==> hnf (last p)) ==>
+          (head_reduction_path M = p)``,
+  REPEAT STRIP_TAC THEN
+  Q.SPEC_THEN `M` (ASSUME_TAC o CONJUNCT2 o
+                   SIMP_RULE bool_ss [EXISTS_UNIQUE_THM])
+              head_reduction_path_uexists THEN
+  METIS_TAC [head_reduction_path_def]);
+
+Theorem infinite_is_head_reduction_drop :
+    !p. infinite p /\ is_head_reduction p ==> !n. is_head_reduction (drop n p)
 Proof
-  Induct_on ‘Ns’ using SNOC_INDUCT >> simp[appstar_SNOC] >>
-  dsimp[SF CONJ_ss] >> metis_tac[]
+    NTAC 2 STRIP_TAC
+ >> Induct_on ‘n’ >> rw []
+ >> ‘!i. i IN PL p’ by PROVE_TAC [infinite_PL]
+ >> rw [drop_tail_commute]
+ >> REWRITE_TAC [GSYM ADD1]
+ >> ‘infinite (drop n p)’ by PROVE_TAC [finite_drop]
+ (* stage work *)
+ >> Q.PAT_X_ASSUM ‘is_head_reduction (drop n p)’ MP_TAC
+ >> Q.PAT_X_ASSUM ‘infinite p’ MP_TAC
+ >> KILL_TAC
+ >> rw [drop_def]
+ >> ‘!i. i IN PL p’ by PROVE_TAC [infinite_PL]
+ >> ASM_SIMP_TAC std_ss [drop_tail_commute]
+ >> qabbrev_tac ‘q = drop n p’
+ >> ‘infinite q’ by PROVE_TAC [finite_drop]
+ >> ‘?x r xs. q = pcons x r xs’ by METIS_TAC [infinite_path_cases]
+ >> POP_ASSUM (fs o wrap)
 QED
 
-(* FIXME: can we put ‘ALL_DISTINCT vs’ into RHS? cf. bnf_characterisation *)
-Theorem hnf_cases :
-  !M : term. hnf M <=> ?vs args y. M = LAMl vs (VAR y @* args)
+Theorem finite_is_head_reduction_drop :
+    !p. finite p /\ is_head_reduction p ==>
+        !n. n < THE (length p) ==> is_head_reduction (drop n p)
 Proof
-  simp[FORALL_AND_THM, EQ_IMP_THM] >> conj_tac
-  >- (gen_tac >> MP_TAC (Q.SPEC ‘M’ strange_cases)
-      >> RW_TAC std_ss []
-      >- (FULL_SIMP_TAC std_ss [size_1_cases] \\
-          qexistsl_tac [‘vs’, ‘[]’, ‘y’] >> rw [])
-      >> FULL_SIMP_TAC std_ss [hnf_LAMl]
-      >> ‘hnf t /\ ~is_abs t’ by PROVE_TAC [hnf_appstar]
-      >> ‘is_var t’ by METIS_TAC [term_cases]
-      >> FULL_SIMP_TAC std_ss [is_var_cases]
-      >> qexistsl_tac [‘vs’, ‘args’, ‘y’] >> art []) >>
-  simp[PULL_EXISTS, hnf_appstar]
+    NTAC 2 STRIP_TAC
+ >> ‘?N. length p = SOME (SUC N)’ by METIS_TAC [length_cases]
+ >> fs []
+ >> Q.PAT_X_ASSUM ‘is_head_reduction p’ MP_TAC
+ >> Know ‘PL p = count (SUC N)’
+ >- (rw [PL_def, count_def])
+ >> DISCH_TAC
+ >> simp [is_head_reduction_def]
+QED
+
+Theorem infinite_head_reduction_path_to_llist :
+    !M. infinite (head_reduction_path M) <=>
+        ?l. ~LFINITE l /\ (LNTH 0 l = SOME M) /\
+            !i. THE (LNTH i l) -h-> THE (LNTH (SUC i) l)
+Proof
+    Q.X_GEN_TAC ‘M’
+ >> qabbrev_tac ‘p = head_reduction_path M’
+ >> EQ_TAC >> rpt STRIP_TAC
+ >- (Q.EXISTS_TAC ‘LGENLIST (\n. el n p) NONE’ \\
+     rw [LNTH_LGENLIST] >- (rw [Abbr ‘p’, head_reduction_path_def]) \\
+     rw [head_reduce1_def] \\
+    ‘!i. i IN PL p’ by PROVE_TAC [infinite_PL] \\
+     qabbrev_tac ‘q = drop i p’ \\
+    ‘el i p = first q’ by rw [Abbr ‘q’] >> POP_ORW \\
+     Know ‘el i (tail p) = first (tail q)’
+     >- (rw [Abbr ‘q’, REWRITE_RULE [ADD1] el_def]) >> Rewr' \\
+    ‘infinite q’ by PROVE_TAC [finite_drop] \\
+     Know ‘is_head_reduction q’
+     >- (qunabbrev_tac ‘q’ \\
+         MATCH_MP_TAC infinite_is_head_reduction_drop \\
+         rw [Abbr ‘p’, head_reduction_path_def]) >> DISCH_TAC \\
+    ‘?x r xs. q = pcons x r xs’ by METIS_TAC [infinite_path_cases] \\
+     fs [is_head_reduction_thm] \\
+     Q.EXISTS_TAC ‘r’ >> art [])
+ (* stage work *)
+ >> qabbrev_tac ‘f = \i. THE (LNTH i l)’
+ >> Know ‘!i. ?r. r is_head_redex (f i) /\ labelled_redn beta (f i) r (f (SUC i))’
+ >- (Q.X_GEN_TAC ‘n’ \\
+     Know ‘f n -h-> f (SUC n)’ >- PROVE_TAC [] \\
+     rw [head_reduce1_def] \\
+     Q.EXISTS_TAC ‘r’ >> art [])
+ (* this asserts ‘g’ as the path label generator *)
+ >> DISCH_THEN ((Q.X_CHOOSE_THEN ‘g’ STRIP_ASSUME_TAC) o
+                (SIMP_RULE std_ss [SKOLEM_THM]))
+ >> qabbrev_tac ‘q = pgenerate f g’
+ >> ‘infinite q’ by PROVE_TAC [pgenerate_infinite]
+ >> Suff ‘head_reduction_path M = q’ >- PROVE_TAC []
+ (* applying head_reduction_path_unique *)
+ >> MATCH_MP_TAC head_reduction_path_unique >> simp []
+ >> CONJ_TAC
+ >- ASM_SIMP_TAC std_ss [Abbr ‘q’, GSYM el_def, el_pgenerate, Abbr ‘f’]
+ >> Q.PAT_X_ASSUM ‘finite p’ K_TAC
+ >> qunabbrev_tac ‘p’
+ >> rename1 ‘is_head_reduction p’
+ >> ‘!i. i IN PL p’ by PROVE_TAC [infinite_PL]
+ (* applying is_head_reduction_coind *)
+ >> irule is_head_reduction_coind
+ >> Q.EXISTS_TAC ‘\q. ?i. q = drop i p’ >> simp []
+ >> CONJ_TAC >- (Q.EXISTS_TAC ‘0’ >> rw [])
+ >> rpt GEN_TAC >> STRIP_TAC
+ >> Know ‘(first (pcons x r q) = first (drop i p)) /\
+          (first_label (pcons x r q) = first_label (drop i p)) /\
+          (tail (pcons x r q) = tail (drop i p))’ >- art []
+ >> simp []
+ >> DISCH_THEN (fs o wrap)
+ >> ‘nth_label i p = g i’ by (rw [Abbr ‘p’, nth_label_pgenerate])
+ >> ‘!i. el i p = f i’    by (rw [Abbr ‘p’, el_pgenerate])
+ >> ASM_REWRITE_TAC [GSYM ADD1]
+ >> Q.EXISTS_TAC ‘SUC i’ >> REWRITE_TAC []
+QED
+
+Theorem finite_head_reduction_path_to_list :
+    !M. finite (head_reduction_path M) <=>
+        ?l. l <> [] /\ (HD l = M) /\ hnf (LAST l) /\
+            !i. SUC i < LENGTH l ==> EL i l -h-> EL (SUC i) l
+Proof
+    Q.X_GEN_TAC ‘M’
+ >> qabbrev_tac ‘p = head_reduction_path M’
+ >> EQ_TAC >> rpt STRIP_TAC
+ >- (‘?n. length p = SOME n’ by METIS_TAC [finite_length] \\
+     Cases_on ‘n’ >- fs [length_never_zero] \\
+     rename1 ‘length p = SOME (SUC n)’ \\
+     Q.EXISTS_TAC ‘GENLIST (\i. el i p) (SUC n)’ >> simp [] \\
+     STRONG_CONJ_TAC >- rw [NOT_NIL_EQ_LENGTH_NOT_0] >> DISCH_TAC \\
+     CONJ_TAC >- rw [GSYM EL, Abbr ‘p’, head_reduction_path_def] \\
+     CONJ_TAC (* hnf *)
+     >- (qabbrev_tac ‘l = GENLIST (\i. el i p) (SUC n)’ \\
+         rw [Abbr ‘l’, LAST_EL] \\
+         Suff ‘el n p = last p’ >- rw [Abbr ‘p’, head_reduction_path_def] \\
+         rw [finite_last_el]) \\
+     rw [head_reduce1_def] \\
+    ‘i IN PL p /\ i + 1 IN PL p’ by rw [PL_def] \\
+     qabbrev_tac ‘q = drop i p’ \\
+    ‘el i p = first q’ by rw [Abbr ‘q’] >> POP_ORW \\
+     Know ‘el i (tail p) = first (tail q)’
+     >- (rw [Abbr ‘q’, REWRITE_RULE [ADD1] el_def]) >> Rewr' \\
+     Know ‘is_head_reduction q’
+     >- (qunabbrev_tac ‘q’ \\
+         irule finite_is_head_reduction_drop \\
+         rw [Abbr ‘p’, head_reduction_path_def]) >> DISCH_TAC \\
+  (* perform case analysis *)
+    ‘(?x. q = stopped_at x) \/ ?x r xs. q = pcons x r xs’ by METIS_TAC [path_cases]
+     >- (Know ‘PL q = IMAGE (\n. n - i) (PL p)’
+         >- rw [Abbr ‘q’, PL_drop] \\
+        ‘PL p = count (SUC n)’ by rw [PL_def, count_def] >> POP_ORW \\
+         POP_ORW (* q = stopped_at x *) \\
+         simp [PL_stopped_at] \\
+         Suff ‘IMAGE (\n. n - i) (count (SUC n)) <> {0}’ >- METIS_TAC [] \\
+         rw [Once EXTENSION] \\
+         Q.EXISTS_TAC ‘n - i’ >> rw [] \\
+         Q.EXISTS_TAC ‘n’ >> art []) \\
+     fs [is_head_reduction_thm] \\
+     Q.EXISTS_TAC ‘r’ >> art [])
+ (* stage work *)
+ >> qabbrev_tac ‘len = LENGTH l’
+ >> ‘0 < len /\ len <> 0’ by rw [Abbr ‘len’, GSYM NOT_NIL_EQ_LENGTH_NOT_0]
+ >> Know ‘!i. SUC i < len ==>
+              ?r. r is_head_redex (EL i l) /\ labelled_redn beta (EL i l) r (EL (SUC i) l)’
+ >- (rpt STRIP_TAC \\
+     Q.PAT_X_ASSUM ‘!i. SUC i < len ==> P’ (Q.SPEC_THEN ‘i’ MP_TAC) \\
+     rw [head_reduce1_def])
+ >> DISCH_TAC
+ (* this asserts ‘f’ as the path label generator *)
+ >> FULL_SIMP_TAC std_ss [GSYM RIGHT_EXISTS_IMP_THM, SKOLEM_THM]
+ >> qabbrev_tac ‘nl = GENLIST I (PRE len)’
+ >> qabbrev_tac ‘g = \i. pcons (EL i l) (f i)’
+ >> qabbrev_tac ‘q = FOLDR g (stopped_at (LAST l)) nl’
+ >> Know ‘finite q’
+ >- (qunabbrev_tac ‘q’ \\
+     Q.PAT_X_ASSUM ‘Abbrev (nl = _)’ K_TAC \\
+     Induct_on ‘nl’ >- rw [] \\
+     rw [Abbr ‘g’])
+ >> DISCH_TAC
+ (* applying head_reduction_path_unique *)
+ >> Suff ‘head_reduction_path M = q’ >- PROVE_TAC []
+ >> MATCH_MP_TAC head_reduction_path_unique >> simp []
+ (* stage work *)
+ >> CONJ_TAC (* first q = M *)
+ >- (‘(len = 1) \/ 1 < len’ by rw []
+     >- (rw [Abbr ‘nl’, Abbr ‘q’, HD_GENLIST, LAST_EL]) \\
+     Know ‘HD nl = 0’
+     >- (rw [Abbr ‘nl’] \\
+         Cases_on ‘len’ >> rw [] \\
+         Cases_on ‘n’ >> rw [HD_GENLIST]) >> DISCH_TAC \\
+    ‘0 < PRE len’ by (Cases_on ‘len’ >> rw []) \\
+    ‘nl <> []’ by (rw [Abbr ‘nl’, NOT_NIL_EQ_LENGTH_NOT_0]) \\
+     Cases_on ‘nl’ >> fs [EL, Abbr ‘q’, Abbr ‘g’])
+ >> qunabbrev_tac ‘p’
+ >> Q.PAT_X_ASSUM ‘finite q’ K_TAC
+ (* stage work *)
+ >> reverse CONJ_TAC (* hnf (last q) *)
+ >- (qunabbrev_tac ‘q’ \\
+     Q.PAT_X_ASSUM ‘Abbrev (nl = _)’ K_TAC \\
+     Induct_on ‘nl’ >- rw [] \\
+     rw [Abbr ‘g’])
+ >> rename1 ‘is_head_reduction p’
+ (* applying is_head_reduction_thm *)
+ >> qunabbrev_tac ‘p’
+ >> ‘nl = DROP (PRE len - PRE len) nl’ by rw [] >> POP_ORW
+ >> Suff ‘!n. n < len ==>
+              is_head_reduction (FOLDR g (stopped_at (LAST l)) (DROP (PRE len - n) nl))’
+ >- rw []
+ >> Induct_on ‘n’ >> simp []
+ >- (Know ‘DROP (PRE len) nl = []’
+     >- (MATCH_MP_TAC DROP_LENGTH_TOO_LONG >> rw [Abbr ‘len’, Abbr ‘nl’]) >> Rewr' \\
+     rw [Abbr ‘g’, is_head_reduction_thm])
+ >> STRIP_TAC
+ >> Q.PAT_X_ASSUM ‘n < len ==> P’ MP_TAC
+ >> Know ‘n < len’ >- rw []
+ >> RW_TAC std_ss []
+ >> qabbrev_tac ‘k = PRE len - SUC n’
+ >> Q.PAT_X_ASSUM ‘is_head_reduction _’ MP_TAC
+ >> ‘PRE len - n = SUC k’ by rw [Abbr ‘k’] >> POP_ORW
+ >> ‘(len = 1) \/ 1 < len’ by rw [] >- rw [Abbr ‘nl’]
+ >> ‘0 < PRE len’ by (Cases_on ‘len’ >> rw [])
+ >> ‘nl <> []’ by (rw [Abbr ‘nl’, NOT_NIL_EQ_LENGTH_NOT_0])
+ >> Know ‘HD nl = 0’
+ >- (rw [Abbr ‘nl’] \\
+     Cases_on ‘len’ >> rw [] \\
+     rename1 ‘n < SUC m’ \\
+     Cases_on ‘m’ >> rw [HD_GENLIST])
+ >> DISCH_TAC
+ >> ‘?x xs. nl = x::xs’ by METIS_TAC [list_CASES] >> gs []
+ >> Cases_on ‘k = 0’ >> rw []
+ >- (RW_TAC std_ss [DROP_def ,Abbr ‘g’] \\
+     RW_TAC arith_ss [is_head_reduction_thm] \\
+    ‘SUC 0 < len’ by rw [] \\
+     Suff ‘first (FOLDR (\i. pcons (EL i l) (f i)) (stopped_at (LAST l)) xs) =
+           EL (SUC 0) l’ >- RW_TAC bool_ss [] \\
+     Cases_on ‘xs = []’
+     >- (fs [is_head_reduction_thm, LAST_EL] \\
+         Know ‘LENGTH (GENLIST I (PRE len)) = LENGTH [0]’ >- art [] \\
+         simp []) \\
+    ‘?y ys. xs = y::ys’ by METIS_TAC [list_CASES] >> rw [] \\
+     Know ‘y = EL 1 (GENLIST I (PRE len))’ >- rw [] \\
+     Know ‘LENGTH (GENLIST I (PRE len)) = LENGTH (0::y::ys)’ >- art [] \\
+     simp [])
+ (* stage work *)
+ >> qabbrev_tac ‘ys = DROP k xs’
+ >> Know ‘DROP (k - 1) xs = EL (k - 1) xs::ys’
+ >- (qunabbrev_tac ‘ys’ \\
+     MATCH_MP_TAC LIST_EQ >> rw []
+     >- (rw [SUB_LEFT_SUC] \\
+         Know ‘LENGTH (GENLIST I (PRE len)) = LENGTH (0::xs)’ >- art [] \\
+         simp [Abbr ‘k’]) \\
+     Cases_on ‘x = 0’ >- (rw [HD_DROP]) \\
+    ‘x + k - 1 < LENGTH xs’ by rw [] \\
+     rw [EL_DROP] \\
+     Cases_on ‘x’ >> rw [] \\
+     rename1 ‘SUC m + k - 1 < LENGTH xs’ \\
+    ‘m + k < LENGTH xs’ by rw [] \\
+     rw [EL_DROP] \\
+     Suff ‘k + SUC m - 1 = k + m’ >- Rewr \\
+     numLib.ARITH_TAC)
+ >> Rewr'
+ >> Know ‘EL (k - 1) xs = EL (SUC (k - 1)) (GENLIST I (PRE len))’
+ >- rw []
+ >> ‘SUC (k - 1) = k’ by rw [] >> POP_ORW
+ >> ‘k < PRE len’ by rw [Abbr ‘k’]
+ >> rw [EL_GENLIST]
+ >> Q.PAT_X_ASSUM ‘!i. SUC i < len ==> P’ (MP_TAC o (Q.SPEC ‘k’))
+ >> rw [Abbr ‘g’]
+ >> Suff ‘first (FOLDR (\i. pcons (EL i l) (f i)) (stopped_at (LAST l)) ys) =
+          EL (SUC k) l’ >- RW_TAC bool_ss []
+ >> Cases_on ‘ys = []’
+ >- (fs [is_head_reduction_thm, LAST_EL] \\
+     Suff ‘PRE len = SUC k’ >- rw [] \\
+    ‘LENGTH xs <= k’ by fs [Abbr ‘ys’, DROP_EQ_NIL] \\
+     Know ‘LENGTH (GENLIST I (PRE len)) = LENGTH (0::xs)’ >- art [] \\
+     simp [])
+ >> ‘k < LENGTH xs’ by fs [Abbr ‘ys’, DROP_EQ_NIL]
+ >> ‘?z zs. ys = z::zs’ by METIS_TAC [list_CASES] >> rw []
+ >> ‘z = HD (DROP k xs)’ by rw [] >> POP_ORW
+ >> rw [HD_DROP]
+ (* preparing for EL_GENLIST *)
+ >> Suff ‘EL k xs = I (SUC k)’ >- rw []
+ >> Know ‘EL k xs = EL (SUC k) (GENLIST I (PRE len))’ >- rw []
+ >> Rewr'
+ >> MATCH_MP_TAC EL_GENLIST
+ >> Know ‘LENGTH (GENLIST I (PRE len)) = LENGTH (0::xs)’ >- art []
+ >> simp []
 QED
 
 val _ = export_theory()

--- a/examples/lambda/barendregt/head_reductionScript.sml
+++ b/examples/lambda/barendregt/head_reductionScript.sml
@@ -605,6 +605,7 @@ val head_redex_preserved = store_thm(
     PROVE_TAC [is_comb_thm]
   ]);
 
+(* moved here from standardisationScript.sml *)
 Definition is_head_reduction_def :
   is_head_reduction s = okpath (labelled_redn beta) s /\
                         !i. i + 1 IN PL s ==>

--- a/examples/lambda/barendregt/head_reductionScript.sml
+++ b/examples/lambda/barendregt/head_reductionScript.sml
@@ -700,6 +700,7 @@ val head_reduces_TRANS = store_thm(
   ``!M N P. M head_reduces N /\ N head_reduces P ==> M head_reduces P``,
   METIS_TAC [relationTheory.RTC_RTC, head_reduces_RTC_hreduce1]);
 
+(* moved here from standardisationScript.sml *)
 val has_hnf_def = Define`
   has_hnf M = ?N. M == N /\ hnf N
 `;
@@ -832,6 +833,7 @@ val head_reduction_path_uexists = prove(
     ]
   ]);
 
+(* moved here from standardisationScript.sml *)
 val head_reduction_path_def = new_specification(
   "head_reduction_path_def",
   ["head_reduction_path"],

--- a/examples/lambda/barendregt/solvableScript.sml
+++ b/examples/lambda/barendregt/solvableScript.sml
@@ -657,7 +657,8 @@ Proof
  >> qabbrev_tac ‘n = LENGTH vs’
  >> qabbrev_tac ‘m = LENGTH Ns’
  >> Q.PAT_X_ASSUM ‘N = LAMl vs (VAR y @* Ns)’ (ONCE_REWRITE_TAC o wrap)
- >> qabbrev_tac ‘Ms = GENLIST (\i. funpow K m I) n’
+ (* now we use arithmeticTheory.FUNPOW instead of locally defined one *)
+ >> qabbrev_tac ‘Ms = GENLIST (\i. FUNPOW (APP K) m I) n’
  >> Q.EXISTS_TAC ‘Ms’
  (* applying lameq_LAMl_appstar and ssub_appstar *)
  >> MATCH_MP_TAC lameq_TRANS
@@ -665,7 +666,7 @@ Proof
  >> CONJ_TAC
  >- (MATCH_MP_TAC lameq_LAMl_appstar >> art [] \\
      CONJ_TAC >- rw [Abbr ‘Ms’] \\
-     rw [EVERY_EL, Abbr ‘Ms’, closed_def, FV_funpow])
+     rw [EVERY_EL, Abbr ‘Ms’, closed_def, FV_FUNPOW])
  >> REWRITE_TAC [ssub_appstar]
  >> Q.PAT_ASSUM ‘MEM y vs’ ((Q.X_CHOOSE_THEN ‘i’ STRIP_ASSUME_TAC) o
                             (REWRITE_RULE [MEM_EL]))
@@ -680,7 +681,7 @@ Proof
      ‘j <> i’ by rw [] \\
      METIS_TAC [EL_ALL_DISTINCT_EL_EQ])
  >> Rewr'
- >> Know ‘EL i Ms = funpow K m I’
+ >> Know ‘EL i Ms = FUNPOW (APP K) m I’
  >- (‘i < n’ by rw [Abbr ‘n’] \\
      rw [Abbr ‘Ms’, EL_GENLIST])
  >> Rewr'
@@ -689,11 +690,11 @@ Proof
  >> Know ‘LENGTH Ps = m’ >- (rw [Abbr ‘m’, Abbr ‘Ps’])
  >> KILL_TAC
  >> Q.ID_SPEC_TAC ‘Ps’
- >> Induct_on ‘m’ >- ASM_SIMP_TAC (betafy(srw_ss())) [LENGTH_NIL, funpow_def]
- >> rw [funpow_SUC]
+ >> Induct_on ‘m’ >- ASM_SIMP_TAC (betafy(srw_ss())) [LENGTH_NIL, FUNPOW]
+ >> rw [FUNPOW_SUC]
  >> Cases_on ‘Ps’ >> fs []
  >> MATCH_MP_TAC lameq_TRANS
- >> Q.EXISTS_TAC ‘funpow K m I @* t’ >> rw []
+ >> Q.EXISTS_TAC ‘FUNPOW (APP K) m I @* t’ >> rw []
  >> MATCH_MP_TAC lameq_appstar_cong >> rw [lameq_K]
 QED
 

--- a/examples/lambda/barendregt/standardisationScript.sml
+++ b/examples/lambda/barendregt/standardisationScript.sml
@@ -1,7 +1,7 @@
-open HolKernel Parse boolLib bossLib;
+open HolKernel Parse boolLib bossLib BasicProvers;
 
-open BasicProvers metisLib boolSimps relationTheory pathTheory pred_setTheory
-     listTheory finite_mapTheory hurdUtils;
+open metisLib boolSimps relationTheory listTheory llistTheory pathTheory
+     pred_setTheory finite_mapTheory hurdUtils;
 
 open nomsetTheory binderLib
 open finite_developmentsTheory
@@ -25,10 +25,6 @@ val _ = ParseExtras.temp_loose_equality()
 
 val RUNION_def = relationTheory.RUNION
 val ADD1 = arithmeticTheory.ADD1
-
-
-
-fun Store_Thm(n,t,tac) = store_thm(n,t,tac) before export_rewrites [n]
 
 (* Section 11.4 of Barendregt *)
 
@@ -67,12 +63,13 @@ val is_internal_redex_def = Define`
   p is_internal_redex t = ~(p is_head_redex t) /\ p IN redex_posns t
 `;
 
-val NIL_never_internal_redex = Store_Thm(
-  "NIL_never_internal_redex",
-  ``!t. ~([] is_internal_redex t)``,
+Theorem NIL_never_internal_redex[simp] :
+    !t. ~([] is_internal_redex t)
+Proof
   GEN_TAC THEN
   Q.SPEC_THEN `t` STRUCT_CASES_TAC term_CASES THEN
-  SRW_TAC [][is_internal_redex_def, is_head_redex_thm, redex_posns_thm]);
+  SRW_TAC [][is_internal_redex_def, is_head_redex_thm, redex_posns_thm]
+QED
 
 val _ = add_infix("i_reduces", 760, NONASSOC)
 (* definition 11.4.2 (ii) *)
@@ -132,24 +129,7 @@ val i1_reduces_def = Define`
                        ?FS. s IN complete_development M FS
 `;
 
-val head_redex_preserved = store_thm(
-  "head_redex_preserved",
-  ``!M p N.
-      labelled_redn beta M p N ==>
-      !h. h is_head_redex M /\ ~(h = p) ==> h is_head_redex N``,
-  HO_MATCH_MP_TAC strong_labelled_redn_ind THEN
-  SRW_TAC [][is_head_redex_thm, beta_def] THENL [
-    FULL_SIMP_TAC (srw_ss()) [is_head_redex_thm],
-    `?v t. M = LAM v t` by PROVE_TAC [is_abs_thm, term_CASES] THEN
-    FULL_SIMP_TAC (srw_ss()) [labelled_redn_lam],
-    `?f x. M = f @@ x` by PROVE_TAC [is_comb_APP_EXISTS] THEN
-    SRW_TAC [][] THEN
-    Q.PAT_X_ASSUM `labelled_redn beta _ _ _` MP_TAC THEN
-    ONCE_REWRITE_TAC [labelled_redn_cases] THEN
-    FULL_SIMP_TAC (srw_ss()) [is_head_redex_thm, beta_def] THEN
-    PROVE_TAC [is_comb_thm]
-  ]);
-
+(* NOTE: the antecedent ‘delta is_internal_redex M’ is unnecessary *)
 val lemma11_4_3i = store_thm(
   "lemma11_4_3i",
   ``!M delta N.
@@ -303,7 +283,6 @@ val residuals_different_singletons = store_thm(
     METIS_TAC [lr_beta_preserves_lefter_redexes]
   ]);
 
-val _ = set_trace "Unicode" 1
 val standard_coind = store_thm(
   "standard_coind",
   ``∀Q. (∀x r p. Q (pcons x r p) ⇒
@@ -337,8 +316,8 @@ val standard_coind = store_thm(
      by SRW_TAC [ARITH_ss]
                 [nth_label_drop, ADD1] THEN
   POP_ASSUM SUBST_ALL_TAC THEN
-  NewQ.ABBREV_TAC `pp = drop j p` THEN
-  NewQ.ABBREV_TAC `ii = i - j`  THEN
+  qabbrev_tac `pp = drop j p` THEN
+  qabbrev_tac `ii = i - j`  THEN
   `ii + 1 ∈ PL pp` by SRW_TAC [ARITH_ss][IN_PL_drop, Abbr`ii`, Abbr`pp`] THEN
   `∀n. n + 1 ∈ PL pp ⇒ p' < nth_label n pp`
      by (Q.ISPEC_THEN `pp` FULL_STRUCT_CASES_TAC path_cases THEN
@@ -498,89 +477,6 @@ val lemma11_4_3iii = store_thm(
     ]
   ]);
 
-val is_head_reduction_def = Define`
-  is_head_reduction s = okpath (labelled_redn beta) s /\
-                        !i. i + 1 IN PL s ==>
-                            nth_label i s is_head_redex el i s
-`;
-
-val is_head_reduction_thm = store_thm(
-  "is_head_reduction_thm",
-  ``(is_head_reduction (stopped_at x) = T) /\
-    (is_head_reduction (pcons x r p) =
-       labelled_redn beta x r (first p) /\ r is_head_redex x /\
-       is_head_reduction p)``,
-  SRW_TAC [][is_head_reduction_def, GSYM ADD1,
-             EQ_IMP_THM]
-  THENL [
-    POP_ASSUM (Q.SPEC_THEN `0` MP_TAC) THEN SRW_TAC [][],
-    RES_TAC THEN FULL_SIMP_TAC (srw_ss()) [],
-    Cases_on `i` THEN SRW_TAC [][]
-  ]);
-val _ = export_rewrites ["is_head_reduction_thm"]
-
-
-val _ = add_infix ("head_reduces", 760, NONASSOC)
-val head_reduces_def = Define`
-  M head_reduces N = ?s. finite s /\ (first s = M) /\ (last s = N) /\
-                         is_head_reduction s
-`;
-
-
-val head_reduce1_def = store_thm(
-  "head_reduce1_def",
-  ``M -h-> N = (?r. r is_head_redex M /\ labelled_redn beta M r N)``,
-  EQ_TAC THENL [
-    Q_TAC SUFF_TAC `!M N. M -h-> N ==>
-                          ?r. r is_head_redex M /\ labelled_redn beta M r N`
-          THEN1 METIS_TAC [] THEN
-    HO_MATCH_MP_TAC hreduce1_ind THEN SRW_TAC [][] THENL [
-      METIS_TAC [beta_def, is_head_redex_rules, labelled_redn_rules],
-      METIS_TAC [is_head_redex_rules, labelled_redn_rules],
-      Q.SPEC_THEN `M` FULL_STRUCT_CASES_TAC term_CASES THENL [
-        FULL_SIMP_TAC (srw_ss()) [Once labelled_redn_cases, beta_def],
-        METIS_TAC [is_head_redex_rules, labelled_redn_rules],
-        FULL_SIMP_TAC (srw_ss()) []
-      ]
-    ],
-    Q_TAC SUFF_TAC `!M r N. labelled_redn beta M r N ==>
-                            r is_head_redex M ==> M -h-> N`
-          THEN1 METIS_TAC [] THEN
-    HO_MATCH_MP_TAC labelled_redn_ind THEN
-    SIMP_TAC (srw_ss() ++ DNF_ss) [beta_def, is_head_redex_thm,
-                                   Once is_comb_APP_EXISTS, hreduce1_rwts]
-  ]);
-
-val head_reduces_RTC_hreduce1 = store_thm(
-  "head_reduces_RTC_hreduce1",
-  ``(head_reduces) = RTC (-h->)``,
-  SIMP_TAC (srw_ss()) [head_reduces_def, FUN_EQ_THM, GSYM LEFT_FORALL_IMP_THM,
-                       FORALL_AND_THM, EQ_IMP_THM] THEN
-  CONJ_TAC THENL [
-    Q_TAC SUFF_TAC `!s. finite s ==>
-                        is_head_reduction s ==>
-                        RTC (-h->) (first s) (last s)` THEN1
-          PROVE_TAC [] THEN
-    HO_MATCH_MP_TAC pathTheory.finite_path_ind THEN
-    SIMP_TAC (srw_ss()) [relationTheory.RTC_RULES] THEN
-    MAP_EVERY Q.X_GEN_TAC [`x`,`r`,`p`] THEN REPEAT STRIP_TAC THEN
-    MATCH_MP_TAC (CONJUNCT2 (SPEC_ALL relationTheory.RTC_RULES)) THEN
-    Q.EXISTS_TAC `first p` THEN SRW_TAC [][head_reduce1_def] THEN
-    PROVE_TAC [],
-    HO_MATCH_MP_TAC relationTheory.RTC_INDUCT THEN
-    SRW_TAC [][head_reduce1_def] THENL [
-      Q.EXISTS_TAC `stopped_at x` THEN SRW_TAC [][],
-      Q.EXISTS_TAC `pcons x r s` THEN SRW_TAC [][]
-    ]
-  ]);
-
-val head_reduces_reduction_beta = store_thm(
-  "head_reduces_reduction_beta",
-  ``!M N. M head_reduces N ==> reduction beta M N``,
-  SIMP_TAC (srw_ss()) [head_reduces_RTC_hreduce1] THEN
-  MATCH_MP_TAC relationTheory.RTC_MONOTONE THEN
-  METIS_TAC [head_reduce1_def, labelled_redn_cc]);
-
 val beta0_induction =
     REWRITE_RULE [relationTheory.inv_DEF]
                  (MATCH_MP relationTheory.WF_INDUCTION_THM prop11_2_20)
@@ -612,10 +508,9 @@ val lrcc_monotone = store_thm(
   REPEAT GEN_TAC THEN STRIP_TAC THEN
   HO_MATCH_MP_TAC lrcc_ind THEN PROVE_TAC [lrcc_rules]);
 
-
-val length_lift_path = Store_Thm(
-  "length_lift_path",
-  ``!M p. length (lift_path M p) = length p``,
+Theorem length_lift_path[simp] :
+    !M p. length (lift_path M p) = length p
+Proof
   REPEAT GEN_TAC THEN
   Cases_on `finite p` THENL [
     Q.ID_SPEC_TAC `M` THEN POP_ASSUM MP_TAC THEN
@@ -623,7 +518,8 @@ val length_lift_path = Store_Thm(
     HO_MATCH_MP_TAC pathTheory.finite_path_ind THEN
     SRW_TAC [][lift_path_def, pathTheory.length_thm, finite_lift_path],
     SRW_TAC [][pathTheory.length_def, finite_lift_path]
-  ]);
+  ]
+QED
 
 val PL_lift_path = store_thm(
   "PL_lift_path",
@@ -671,10 +567,11 @@ val zero_vsubst = store_thm(
   SRW_TAC [][zero_def, GSYM nlabel_vsubst_commutes, n_posns_vsubst_invariant,
              strip_label_vsubst_commutes]);
 
-val FV_zero = Store_Thm(
-  "FV_zero",
-  ``FV (zero n t) = FV t``,
-  SRW_TAC [][zero_def, FV_nlabel, FV_strip_label]);
+Theorem FV_zero[simp] :
+    FV (zero n t) = FV t
+Proof
+  SRW_TAC [][zero_def, FV_nlabel, FV_strip_label]
+QED
 
 val zero_subst = store_thm(
   "zero_subst",
@@ -917,11 +814,6 @@ val i1_reduces_i_reduces = prove(
 val _ = augment_srw_ss [rewrites [REWRITE_CONV [EMPTY_SUBSET,
                                                 redex_occurrences_SUBSET]
                                   ``{} SUBSET (M:term)``]]
-
-val head_reduces_TRANS = store_thm(
-  "head_reduces_TRANS",
-  ``!M N P. M head_reduces N /\ N head_reduces P ==> M head_reduces P``,
-  METIS_TAC [relationTheory.RTC_RTC, head_reduces_RTC_hreduce1]);
 
 val lemma11_4_5 = store_thm(
   "lemma11_4_5",
@@ -1238,12 +1130,12 @@ val i_reduces_to_LAMl = prove(
     PROVE_TAC [relationTheory.RTC_RULES, i_reduce1_under_LAMl]
   ]);
 
-val size_vsubst = Store_Thm(
-  "size_vsubst",
-  ``!M:term. size ([VAR v/u] M) = size M``,
+Theorem size_vsubst[simp] :
+    !M:term. size ([VAR v/u] M) = size M
+Proof
   HO_MATCH_MP_TAC nc_INDUCTION2 THEN Q.EXISTS_TAC `{u;v}` THEN
-  SRW_TAC [][SUB_VAR, SUB_THM]);
-
+  SRW_TAC [][SUB_VAR, SUB_THM]
+QED
 
 val size_ISUB = prove(
   ``!R N:term. RENAMING R ==> (size (N ISUB R) = size N)``,
@@ -1930,168 +1822,6 @@ val standardisation_theorem = store_thm(
     SRW_TAC [][head_standard_is_standard]
   ]);
 
-val has_hnf_def = Define`
-  has_hnf M = ?N. M == N /\ hnf N
-`;
-
-val has_bnf_hnf = store_thm(
-  "has_bnf_hnf",
-  ``has_bnf M ⇒ has_hnf M``,
-  SRW_TAC [][has_hnf_def, chap2Theory.has_bnf_def] THEN
-  METIS_TAC [bnf_hnf]);
-
-val head_reduct_def = Define`
-  head_reduct M = if ?r. r is_head_redex M then
-                    SOME (@N. M -h-> N)
-                  else NONE
-`;
-
-val head_reduct_unique = store_thm(
-  "head_reduct_unique",
-  ``!M N. M -h-> N ==> (head_reduct M = SOME N)``,
-  SRW_TAC [][head_reduce1_def, head_reduct_def] THEN1 METIS_TAC [] THEN
-  SELECT_ELIM_TAC THEN METIS_TAC [is_head_redex_unique, labelled_redn_det]);
-
-val head_reduct_NONE = store_thm(
-  "head_reduct_NONE",
-  ``(head_reduct M = NONE) = !N. ~(M -h-> N)``,
-  SRW_TAC [][head_reduct_def, head_reduce1_def] THEN
-  METIS_TAC [head_redex_is_redex, IN_term_IN_redex_posns,
-             is_redex_occurrence_def]);
-
-val head_reduct_SOME = store_thm(
-  "head_reduct_SOME",
-  ``(head_reduct M = SOME N) = M -h-> N``,
-  SIMP_TAC (srw_ss()) [EQ_IMP_THM, head_reduct_unique] THEN
-  SRW_TAC [][head_reduct_def] THEN SELECT_ELIM_TAC THEN
-  SRW_TAC [][head_reduce1_def] THEN
-  METIS_TAC [head_redex_is_redex, IN_term_IN_redex_posns,
-             is_redex_occurrence_def]);
-
-val drop_not_stopped = prove(
-  ``!i p. SUC i IN PL p ==> ?v r q. drop i p = pcons v r q``,
-  Induct THEN GEN_TAC THEN
-  Q.SPEC_THEN `p` STRUCT_CASES_TAC path_cases THEN
-  SRW_TAC [][]);
-
-val drop_tail_commute = store_thm(
-  "drop_tail_commute",
-  ``!i p. SUC i IN PL p ==> (drop i (tail p) = tail (drop i p))``,
-  Induct THEN SIMP_TAC (srw_ss()) [Once FORALL_path] THEN
-  SRW_TAC [][]);
-
-val is_head_reduction_coind = store_thm(
-  "is_head_reduction_coind",
-  ``(!x r q. P (pcons x r q) ==>
-             labelled_redn beta x r (first q) /\
-             r is_head_redex x /\ P q) ==>
-    !p. P p ==> is_head_reduction p``,
-  SIMP_TAC (srw_ss()) [is_head_reduction_def, IMP_CONJ_THM,
-                       FORALL_AND_THM] THEN CONJ_TAC
-  THENL [
-    STRIP_TAC THEN HO_MATCH_MP_TAC okpath_co_ind THEN METIS_TAC [],
-    STRIP_TAC THEN GEN_TAC THEN STRIP_TAC THEN
-    Q_TAC SUFF_TAC `!i. i + 1 IN PL p ==> nth_label i p is_head_redex el i p /\
-                                          P (drop (i + 1) p)` THEN1
-          METIS_TAC [] THEN
-    Induct THEN FULL_SIMP_TAC (srw_ss()) [GSYM ADD1] THENL [
-      Q.ISPEC_THEN `p` FULL_STRUCT_CASES_TAC path_cases THEN
-      FULL_SIMP_TAC (srw_ss()) [] THEN METIS_TAC [],
-      STRIP_TAC THEN
-      `SUC i IN PL p`
-         by METIS_TAC [PL_downward_closed, DECIDE ``x < SUC x``] THEN
-      FULL_SIMP_TAC (srw_ss()) [] THEN
-      Q.ISPEC_THEN `p` FULL_STRUCT_CASES_TAC path_cases THEN
-      FULL_SIMP_TAC (srw_ss()) [] THEN
-      `?y s q'. drop i q = pcons y s q'` by METIS_TAC [drop_not_stopped] THEN
-      `labelled_redn beta y s (first q') /\ s is_head_redex y /\ P q'`
-          by METIS_TAC [stopped_at_not_pcons, pcons_11] THEN
-      `el 0 (drop i q) = el i q` by SRW_TAC [][] THEN
-      `el i q = y` by METIS_TAC [el_def, first_thm] THEN
-      `nth_label 0 (drop i q) = nth_label i q` by SRW_TAC [][] THEN
-      `nth_label i q = s` by METIS_TAC [nth_label_def, first_label_def] THEN
-      SRW_TAC [][drop_tail_commute]
-    ]
-  ]);
-
-val head_reduction_path_uexists = prove(
-  ``!M. ?!p. (first p = M) /\ is_head_reduction p /\
-             (finite p ==> hnf (last p))``,
-  GEN_TAC THEN
-  Q.ISPEC_THEN `\M. (M, OPTION_MAP (\N. ((@r. r is_head_redex M), N))
-                                  (head_reduct M))`
-               STRIP_ASSUME_TAC path_Axiom THEN
-  `!M. first (g M) = M`
-      by (POP_ASSUM (fn th => SRW_TAC [][Once th]) THEN
-          Cases_on `head_reduct M` THEN SRW_TAC [][]) THEN
-  `!M. is_head_reduction (g M)`
-      by (Q_TAC SUFF_TAC
-                `!p. (?M. p = g M) ==> is_head_reduction p` THEN1
-                METIS_TAC [] THEN
-          HO_MATCH_MP_TAC is_head_reduction_coind THEN
-          Q.PAT_X_ASSUM `!x:term. g x = Z`
-                          (fn th => SIMP_TAC (srw_ss())
-                                             [Once th, SimpL ``(==>)``]) THEN
-          REPEAT GEN_TAC THEN STRIP_TAC THEN
-          Cases_on `head_reduct M` THEN
-          FULL_SIMP_TAC (srw_ss()) [head_reduct_SOME, head_reduce1_def] THEN
-          REPEAT VAR_EQ_TAC THEN SELECT_ELIM_TAC THEN
-          METIS_TAC [is_head_redex_unique]) THEN
-  `!p. finite p ==> !M. (p = g M) ==> hnf (last p)`
-      by (HO_MATCH_MP_TAC finite_path_ind THEN
-          SIMP_TAC (srw_ss()) [] THEN CONJ_TAC THEN REPEAT GEN_TAC THENL [
-            Q.PAT_X_ASSUM `!x:term. g x = Z`
-                        (fn th => ONCE_REWRITE_TAC [th]) THEN
-            Cases_on `head_reduct M` THEN SRW_TAC [][] THEN
-            FULL_SIMP_TAC (srw_ss()) [hnf_no_head_redex, head_reduct_NONE,
-                                      head_reduce1_def] THEN
-            METIS_TAC [head_redex_is_redex, IN_term_IN_redex_posns,
-                       is_redex_occurrence_def],
-            STRIP_TAC THEN GEN_TAC THEN
-            Q.PAT_X_ASSUM `!x:term. g x = Z`
-                        (fn th => ONCE_REWRITE_TAC [th]) THEN
-            Cases_on `head_reduct M` THEN SRW_TAC [][]
-          ]) THEN
-  SIMP_TAC (srw_ss()) [EXISTS_UNIQUE_THM] THEN CONJ_TAC THENL [
-    Q.EXISTS_TAC `g M` THEN
-    Q.PAT_X_ASSUM `!x:term. g x = Z` (K ALL_TAC) THEN METIS_TAC [],
-    REPEAT (POP_ASSUM (K ALL_TAC)) THEN
-    REPEAT STRIP_TAC THEN
-    ONCE_REWRITE_TAC [path_bisimulation] THEN
-    Q.EXISTS_TAC `\p1 p2. is_head_reduction p1 /\ is_head_reduction p2 /\
-                          (first p1 = first p2) /\
-                          (finite p1 ==> hnf (last p1)) /\
-                          (finite p2 ==> hnf (last p2))` THEN
-    SRW_TAC [][] THEN
-    Q.ISPEC_THEN `q1` (REPEAT_TCL STRIP_THM_THEN SUBST_ALL_TAC)
-                 path_cases THEN
-    Q.ISPEC_THEN `q2` (REPEAT_TCL STRIP_THM_THEN SUBST_ALL_TAC)
-                 path_cases THEN FULL_SIMP_TAC (srw_ss()) []
-    THENL [
-      METIS_TAC [hnf_no_head_redex],
-      METIS_TAC [hnf_no_head_redex],
-      METIS_TAC [is_head_redex_unique, labelled_redn_det]
-    ]
-  ]);
-
-val head_reduction_path_def = new_specification(
-  "head_reduction_path_def",
-  ["head_reduction_path"],
-  CONJUNCT1 ((SIMP_RULE bool_ss [EXISTS_UNIQUE_THM] o
-              SIMP_RULE bool_ss [UNIQUE_SKOLEM_THM])
-             head_reduction_path_uexists));
-
-val head_reduction_path_unique = store_thm(
-  "head_reduction_path_unique",
-  ``!M p. (first p = M) /\ is_head_reduction p /\
-          (finite p ==> hnf (last p)) ==>
-          (head_reduction_path M = p)``,
-  REPEAT STRIP_TAC THEN
-  Q.SPEC_THEN `M` (ASSUME_TAC o CONJUNCT2 o
-                   SIMP_RULE bool_ss [EXISTS_UNIQUE_THM])
-              head_reduction_path_uexists THEN
-  METIS_TAC [head_reduction_path_def]);
-
 val hnf_preserved = store_thm(
   "hnf_preserved",
   ``!M N. reduction beta M N ==> hnf M ==> hnf N``,
@@ -2163,7 +1893,7 @@ val has_bnf_whnf = store_thm(
   METIS_TAC [has_bnf_hnf, has_hnf_whnf]);
 
 (* Proposition 8.3.13 (i) [1, p.174] *)
-Theorem has_hnf_iff_LAM[simp] :
+Theorem has_hnf_LAM_E[simp] :
     !x M. has_hnf (LAM x M) <=> has_hnf M
 Proof
     RW_TAC std_ss [has_hnf_def]
@@ -2179,6 +1909,84 @@ Proof
  >> ‘hnf Z’ by PROVE_TAC [hnf_preserved]
  >> gs [hnf_thm]
  >> MATCH_MP_TAC betastar_lameq >> art []
+QED
+
+(* Proposition 8.3.13 (ii) [1, p.174] *)
+Theorem has_hnf_SUB_E :
+    !M N z. has_hnf ([N/z] M) ==> has_hnf M
+Proof
+    rpt STRIP_TAC
+ >> simp [corollary11_4_8, Once MONO_NOT_EQ]
+ >> CCONTR_TAC
+ >> Suff ‘infinite (head_reduction_path ([N/z] M))’
+ >- (DISCH_TAC >> fs [corollary11_4_8])
+ >> Q.PAT_X_ASSUM ‘has_hnf _’ K_TAC
+ (* stage work *)
+ >> ‘?l. ~LFINITE l /\ (LNTH 0 l = SOME M) /\
+         !i. THE (LNTH i l) -h-> THE (LNTH (SUC i) l)’
+      by METIS_TAC [infinite_head_reduction_path_to_llist]
+ >> qabbrev_tac ‘ll = LMAP [N/z] l’
+ >> rw [infinite_head_reduction_path_to_llist]
+ >> Q.EXISTS_TAC ‘ll’
+ >> rw [Abbr ‘ll’]
+ >> Know ‘!i. THE (OPTION_MAP [N/z] (LNTH i l)) = [N/z] (THE (LNTH i l))’
+ >- (Q.X_GEN_TAC ‘n’ \\
+     Q.PAT_X_ASSUM ‘~LFINITE l’
+       (STRIP_ASSUME_TAC o (Q.SPEC ‘n’) o (REWRITE_RULE [infinite_lnth_some])) \\
+     rw [])
+ >> Rewr
+ >> MATCH_MP_TAC hreduce1_substitutive >> art []
+QED
+
+(* Proposition 8.3.13 (iii) [1, p.174], cf. has_whnf_APP_E *)
+Theorem has_hnf_APP_E :
+    has_hnf (M @@ N) ==> has_hnf M
+Proof
+    rpt STRIP_TAC
+ >> ‘finite (head_reduction_path (M @@ N))’ by rw [GSYM corollary11_4_8]
+ (* this asserts a list ‘l’ *)
+ >> fs [finite_head_reduction_path_to_list]
+ >> ‘0 < LENGTH l’ by rw [GSYM NOT_NIL_EQ_LENGTH_NOT_0]
+ (* case 1 *)
+ >> Cases_on ‘EVERY (\e. is_comb e /\ ~is_abs (rator e)) l’
+ >- (POP_ASSUM MP_TAC >> rw [EVERY_MEM] \\
+     Suff ‘!i. SUC i < LENGTH l ==> rator (EL i l) -h-> rator (EL (SUC i) l)’
+     >- (DISCH_TAC \\
+         rw [corollary11_4_8, finite_head_reduction_path_to_list] \\
+         qabbrev_tac ‘l0 = MAP rator l’ \\
+        ‘(LENGTH l0 = LENGTH l) /\ l0 <> []’ by rw [Abbr ‘l0’] \\
+         Q.EXISTS_TAC ‘l0’ >> RW_TAC std_ss [] >| (* 3 subgoals *)
+         [ (* goal 1 (of 3) *)
+           ASM_SIMP_TAC arith_ss [GSYM EL, EL_MAP, Abbr ‘l0’] >> rw [],
+           (* goal 2 (of 3) *)
+           rw [LAST_MAP, Abbr ‘l0’] \\
+           Know ‘MEM (LAST l) l’
+           >- (rw [LAST_EL, MEM_EL] \\
+               Q.EXISTS_TAC ‘PRE (LENGTH l)’ >> rw []) >> DISCH_TAC \\
+           qabbrev_tac ‘e = LAST l’ \\
+          ‘is_comb e /\ ~is_abs (rator e)’ by PROVE_TAC [] \\
+          ‘?u v. e = u @@ v’ by METIS_TAC [is_comb_APP_EXISTS] \\
+           fs [] (* hnf_thm is used *),
+           (* goal 3 (of 3) *)
+          ‘i < LENGTH l’ by rw [] \\
+           rw [Abbr ‘l0’, EL_MAP] ]) \\
+     (* stage work *)
+     rpt STRIP_TAC \\
+    ‘i < LENGTH l’ by rw [] \\
+     qabbrev_tac ‘a = EL i l’ >> qabbrev_tac ‘b = EL (SUC i) l’ \\
+     Know ‘a -h-> b’ >- PROVE_TAC [] \\
+    ‘MEM a l /\ MEM b l’ by METIS_TAC [MEM_EL] \\
+    ‘is_comb a /\ ~is_abs (rator a) /\
+     is_comb b /\ ~is_abs (rator b)’ by PROVE_TAC [] \\
+    ‘?u v. a = u @@ v’ by METIS_TAC [is_comb_APP_EXISTS] \\
+    ‘?t w. b = t @@ w’ by METIS_TAC [is_comb_APP_EXISTS] \\
+     FULL_SIMP_TAC std_ss [rator_def] \\
+     DISCH_THEN (MP_TAC o (ONCE_REWRITE_RULE [hreduce1_cases])) >> rw [] \\
+     FULL_SIMP_TAC std_ss [is_abs_thm] (* a leftover *))
+ (* case 2 *)
+ >> POP_ASSUM MP_TAC
+ >> simp [NOT_EVERY, EXISTS_MEM] (* TODO: how to find the smallest one? *)
+ >> cheat
 QED
 
 val _ = export_theory()

--- a/examples/lambda/basics/appFOLDLScript.sml
+++ b/examples/lambda/basics/appFOLDLScript.sml
@@ -6,8 +6,6 @@ open termTheory binderLib;
 
 val _ = new_theory "appFOLDL"
 
-val _ = set_trace "Unicode" 1
-
 val _ = set_fixity "@*" (Infixl 901)
 val _ = Unicode.unicode_version { u = "··", tmnm = "@*"}
 val _ = overload_on ("@*", ``λf (args:term list). FOLDL APP f args``)
@@ -301,38 +299,20 @@ Proof
 QED
 
 (*---------------------------------------------------------------------------*
- *  funpow for lambda terms (cf. arithmeticTheory.FUNPOW)
+ *  funpow for lambda terms (using arithmeticTheory.FUNPOW)
  *---------------------------------------------------------------------------*)
 
-Definition funpow :
-    funpow f n (x :term) =
-        if n = 0 then x else funpow f (n - 1) (f @@ x)
-End
+Overload funpow = “\f. FUNPOW (APP (f :term))”
 
-Theorem funpow_def :
-    (!f   x. funpow f       0 x = x) /\
-    (!f n x. funpow f (SUC n) x = funpow f n (f @@ x))
-Proof
-    NTAC 2 (rw [Once funpow])
-QED
-
-Theorem funpow_SUC :
-    !f n x. funpow f (SUC n) x = f @@ (funpow f n x)
-Proof
-    Q.X_GEN_TAC ‘f’
- >> Induct_on ‘n’ >> rw [funpow_def]
- >> fs [funpow_def]
-QED
-
-Theorem FV_funpow :
-    !f x n. FV (funpow f n x) = if n = 0 then FV x else FV f UNION FV x
+Theorem FV_FUNPOW :
+    !(f :term) x n. FV (FUNPOW (APP f) n x) = if n = 0 then FV x else FV f UNION FV x
 Proof
     rpt STRIP_TAC
  >> Q.SPEC_TAC (‘n’, ‘i’)
- >> Cases_on ‘i’ >- rw [funpow_def]
+ >> Cases_on ‘i’ >- rw [FUNPOW]
  >> simp []
- >> Induct_on ‘n’ >- rw [funpow_def]
- >> fs [funpow_SUC]
+ >> Induct_on ‘n’ >- rw [FUNPOW]
+ >> fs [FUNPOW_SUC]
  >> SET_TAC []
 QED
 

--- a/examples/lambda/basics/appFOLDLScript.sml
+++ b/examples/lambda/basics/appFOLDLScript.sml
@@ -173,6 +173,15 @@ Proof
     Induct_on ‘Ns’ using SNOC_INDUCT >> simp[appstar_SNOC, MAP_SNOC]
 QED
 
+Theorem FV_appstar :
+    !M Ns. FV (M @* Ns) = FV M UNION (BIGUNION (IMAGE FV (set Ns)))
+Proof
+    Q.X_GEN_TAC ‘M’
+ >> Induct_on ‘Ns’ using SNOC_INDUCT >> simp[appstar_SNOC, MAP_SNOC]
+ >> Q.X_GEN_TAC ‘N’
+ >> simp [LIST_TO_SET_SNOC] >> SET_TAC []
+QED
+
 (*---------------------------------------------------------------------------*
  *  LAMl (was in standardisationTheory)
  *---------------------------------------------------------------------------*)

--- a/examples/lambda/basics/appFOLDLScript.sml
+++ b/examples/lambda/basics/appFOLDLScript.sml
@@ -45,17 +45,6 @@ val take_lemma = prove(
 
 val _ = augment_srw_ss[rewrites[listTheory.TAKE_def,listTheory.DROP_def]];
 
-val FRONT_TAKE = store_thm(
-  "FRONT_TAKE",
-  ``∀l n. 0 < n ∧ n ≤ LENGTH l ⇒ (FRONT (TAKE n l) = TAKE (n - 1) l)``,
-  Induct THEN SRW_TAC [ARITH_ss][] >>
-  `0 < n - 1 ∧ n - 1 ≤ LENGTH l` by DECIDE_TAC THEN
-  SRW_TAC [][listTheory.FRONT_DEF] THENL [
-    fs [],
-    `(n - 1) - 1 = n - 2` by DECIDE_TAC THEN
-    SRW_TAC [][]
-  ]);
-
 val DROP_PREn_LAST_CONS = store_thm(
   "DROP_PREn_LAST_CONS",
   ``∀t n. 0 < n ∧ n ≤ LENGTH t ⇒
@@ -309,6 +298,42 @@ Proof
     DISCH_THEN (K ALL_TAC) THEN
     SRW_TAC [][LAMl_vsub, SUB_ISUB_SINGLETON, ISUB_APPEND]
   ]
+QED
+
+(*---------------------------------------------------------------------------*
+ *  funpow for lambda terms (cf. arithmeticTheory.FUNPOW)
+ *---------------------------------------------------------------------------*)
+
+Definition funpow :
+    funpow f n (x :term) =
+        if n = 0 then x else funpow f (n - 1) (f @@ x)
+End
+
+Theorem funpow_def :
+    (!f   x. funpow f       0 x = x) /\
+    (!f n x. funpow f (SUC n) x = funpow f n (f @@ x))
+Proof
+    NTAC 2 (rw [Once funpow])
+QED
+
+Theorem funpow_SUC :
+    !f n x. funpow f (SUC n) x = f @@ (funpow f n x)
+Proof
+    Q.X_GEN_TAC ‘f’
+ >> Induct_on ‘n’ >> rw [funpow_def]
+ >> fs [funpow_def]
+QED
+
+Theorem FV_funpow :
+    !f x n. FV (funpow f n x) = if n = 0 then FV x else FV f UNION FV x
+Proof
+    rpt STRIP_TAC
+ >> Q.SPEC_TAC (‘n’, ‘i’)
+ >> Cases_on ‘i’ >- rw [funpow_def]
+ >> simp []
+ >> Induct_on ‘n’ >- rw [funpow_def]
+ >> fs [funpow_SUC]
+ >> SET_TAC []
 QED
 
 val _ = export_theory ()

--- a/examples/lambda/basics/termScript.sml
+++ b/examples/lambda/basics/termScript.sml
@@ -585,6 +585,7 @@ Proof
  >> SRW_TAC [][size_thm, size_nz]
 QED
 
+(* moved here from standardisationScript.sml *)
 Theorem size_vsubst :
     !M:term. size ([VAR v/u] M) = size M
 Proof
@@ -680,6 +681,7 @@ Proof
  >> ASM_SIMP_TAC (srw_ss()) [pairTheory.FORALL_PROD, ISUB_def]
 QED
 
+(* moved here from standardisationScript.sml *)
 Theorem ISUB_APP :
     !sub M N. (M @@ N) ISUB sub = (M ISUB sub) @@ (N ISUB sub)
 Proof
@@ -695,8 +697,6 @@ Proof
     Induct >> SRW_TAC [][ISUB_APP]
 QED
 
-Theorem ISUB_appstar = FOLDL_APP_ISUB
-
 Theorem ISUB_VAR_FRESH :
     !y sub. ~MEM y (MAP SND sub) ==> (VAR y ISUB sub = VAR y)
 Proof
@@ -710,6 +710,7 @@ QED
     RENAMING: a special iterated substitutions like tpm
    ---------------------------------------------------------------------- *)
 
+(* moved here from standardisationScript.sml *)
 Definition RENAMING_def :
   (RENAMING []     <=> T) /\
   (RENAMING (h::t) <=> (?y x:string. (h = (VAR y:term,x))) /\ RENAMING t)

--- a/examples/lambda/basics/termScript.sml
+++ b/examples/lambda/basics/termScript.sml
@@ -308,7 +308,7 @@ val _ = set_mapped_fixity { term_name = "APP", tok = "@@",
 (* NOTE: The following overload "incompatible" was in sttScript.sml.
 
    The current "incompatibility" is between a (string) variable and a term.
-   See chap2Theory for the incompatibility bwtween two terms.
+   See chap2Theory for the incompatibility between two terms.
  *)
 val _ = set_fixity "#" (Infix(NONASSOC, 450))
 Overload "#" = “λv M:term. v ∉ FV M”

--- a/src/coalgebras/llistScript.sml
+++ b/src/coalgebras/llistScript.sml
@@ -778,8 +778,12 @@ val LAPPEND = new_specification
 val _ = export_rewrites ["LAPPEND"]
 val _ = computeLib.add_persistent_funs ["LAPPEND"]
 
+(* NOTE: The last char is Latin Subscript Small Letter L (U+2097) *)
 val _ = set_mapped_fixity{fixity = Infixl 480, term_name = "LAPPEND",
                           tok = "++ₗ"};                               (* UOK *)
+
+val _ = TeX_notation { hol = "LAPPEND",
+                       TeX = ("\\HOLTokenDoublePlusL", 1) };
 
 (* properties of map and append *)
 
@@ -2182,6 +2186,18 @@ val LNTH_NONE_MONO = Q.store_thm ("LNTH_NONE_MONO",
   imp_res_tac LTAKE_LENGTH >>
   `~(m < z)` by metis_tac[LTAKE_LNTH_EL,optionTheory.NOT_SOME_NONE] >>
   rw[] >> decide_tac);
+
+(* cf. This is just another version of lnth_some_down_closed *)
+Theorem LNTH_IS_SOME_MONO :
+   !m n l.
+     IS_SOME (LNTH n l) /\ m <= n
+   ==>
+     IS_SOME (LNTH m l)
+Proof
+    rw [IS_SOME_EXISTS]
+ >> MATCH_MP_TAC lnth_some_down_closed
+ >> qexistsl_tac [‘x’, ‘n’] >> rw []
+QED
 
 (* ------------------------------------------------------------------------ *)
 (* Turning a stream-like linear order into a lazy list                      *)

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -1683,6 +1683,31 @@ Proof
   Cases_on ‘l2’ THEN FULL_SIMP_TAC(srw_ss())[EVERY_DEF, ZIP]
 QED
 
+Theorem NOT_EVERY_EXISTS_FIRST :
+    !P l. ~EVERY P l <=> ?i. i < LENGTH l /\ ~P (EL i l) /\ !j. j < i ==> P (EL j l)
+Proof
+    rpt STRIP_TAC
+ >> reverse EQ_TAC
+ >- (rw [NOT_EVERY, EXISTS_MEM] \\
+     Q.EXISTS_TAC ‘EL i l’ >> rw [MEM_EL] \\
+     Q.EXISTS_TAC ‘i’ >> rw [])
+ >> rw [EVERY_EL, EXISTS_MEM, MEM_EL]
+ >> Q.EXISTS_TAC ‘LEAST n. n < LENGTH l /\ ~P (EL n l)’
+ >> numLib.LEAST_ELIM_TAC
+ >> CONJ_TAC >- (Q.EXISTS_TAC ‘n’ >> rw [])
+ >> Q.X_GEN_TAC ‘i’ >> rw []
+ >> Q.PAT_X_ASSUM ‘!m. m < i ==> _’ (MP_TAC o (Q.SPEC ‘j’))
+ >> ‘j < LENGTH l’ by RW_TAC arith_ss []
+ >> RW_TAC bool_ss []
+QED
+
+Theorem EXISTS_FIRST :
+    !P l. EXISTS P l <=> ?i. i < LENGTH l /\ P (EL i l) /\ !j. j < i ==> ~P (EL j l)
+Proof
+    rw [EXISTS_NOT_EVERY]
+ >> MP_TAC (Q.SPEC ‘\x. ~P x’ NOT_EVERY_EXISTS_FIRST) >> rw []
+QED
+
 (* --------------------------------------------------------------------- *)
 (* REVERSE                                                               *)
 (* --------------------------------------------------------------------- *)
@@ -1945,6 +1970,18 @@ Proof
   Cases_on‘m’ >> Cases_on‘n’ >>
   SRW_TAC[numSimps.ARITH_ss][arithmeticTheory.MIN_DEF, arithmeticTheory.ADD1] >>
   FULL_SIMP_TAC (srw_ss() ++ numSimps.ARITH_ss) []
+QED
+
+Theorem FRONT_TAKE :
+    !l n. 0 < n /\ n <= LENGTH l ==> (FRONT (TAKE n l) = TAKE (n - 1) l)
+Proof
+  Induct THEN SRW_TAC [numSimps.ARITH_ss][TAKE_def, DROP_def] >>
+  `0 < n - 1 /\ n - 1 <= LENGTH l` by numLib.DECIDE_TAC THEN
+  SRW_TAC [][FRONT_DEF] THENL [
+    fs [],
+    `(n - 1) - 1 = n - 2` by numLib.DECIDE_TAC THEN
+    SRW_TAC [][]
+  ]
 QED
 
 val LENGTH_DROP = store_thm(


### PR DESCRIPTION
Hi,

This PR continues and connects #1150 and #1155, finally proved Theorem 8.3.14 (Wadsworth) [1, p.175] saying that _an λ-term is solvable iff it has hnf (head normal form):_
```
[solvable_iff_has_hnf] (solvableTheory)
⊢ ∀M. solvable M ⇔ has_hnf M
```

The proof is hard at each lemmas, especially the following one (the case analysis is much more complicated than the textbook version):
```
[has_hnf_APP_E] (standardisationTheory)
⊢ has_hnf (M @@ N) ⇒ has_hnf M
```

For easily reasoning of head reduction paths, I have established more lemmas on one-one mapping to list and llist, in the finite and infinite case, resp.:
```
[infinite_head_reduction_path_to_llist]
⊢ ∀M. infinite (head_reduction_path M) ⇔
      ∃l. ¬LFINITE l ∧ (LNTH 0 l = SOME M) ∧
          ∀i. THE (LNTH i l) -h-> THE (LNTH (SUC i) l)

[finite_head_reduction_path_to_list]
⊢ ∀M. finite (head_reduction_path M) ⇔
      ∃l. l ≠ [] ∧ (HD l = M) ∧ hnf (LAST l) ∧
          ∀i. SUC i < LENGTH l ⇒ EL i l -h-> EL (SUC i) l

[finite_head_reduction_path_to_list_every_has_hnf]
⊢ ∀M. finite (head_reduction_path M) ⇔
      ∃l. l ≠ [] ∧ (HD l = M) ∧ hnf (LAST l) ∧ EVERY has_hnf l ∧
          ∀i. SUC i < LENGTH l ⇒ EL i l -h-> EL (SUC i) l

[finite_head_reduction_path_to_list_last_has_hnf]
⊢ ∀M. finite (head_reduction_path M) ⇔
      ∃l. l ≠ [] ∧ (HD l = M) ∧ has_hnf (LAST l) ∧
          ∀i. SUC i < LENGTH l ⇒ EL i l -h-> EL (SUC i) l
```

I also added a few new useful lemmas into `listTheory` and `pathTheory`, to support some definitions.

--Chun

[1] Barendregt, H.P.: The Lambda Calculus, Its Syntax and Semantics.
       College Publications, London (1984).