### PR TITLE
Trivial cosmetic fix to Poly/ML configuration output

### DIFF
--- a/tools-poly/smart-configure.sml
+++ b/tools-poly/smart-configure.sml
@@ -303,7 +303,7 @@ fun optverdict (prompt, optvalue) =
 
 fun dfltverdict (prompt, (value, dflt)) =
     if dflt then value
-    else (print (StringCvt.padRight #" " 20 (prompt ^ ":") ^ value); value);
+    else (print (StringCvt.padRight #" " 20 (prompt ^ ":") ^ value ^ "\n"); value);
 
 verdict ("OS", OS);
 verdict ("poly", poly);


### PR DESCRIPTION
This is just to fix the missing newline when configuring, i.e. converting this:

```
MV:                 /nix/store/viin66x3cgv4x6xhj4p4hxaxvgcgqf8x-coreutils-9.1/bin/mvCP:                 /nix/store/viin66x3cgv4x6xhj4p4hxaxvgcgqf8x-coreutils-9.1/bin/cp
```

... into this:
```
MV:                 /nix/store/viin66x3cgv4x6xhj4p4hxaxvgcgqf8x-coreutils-9.1/bin/mv
CP:                 /nix/store/viin66x3cgv4x6xhj4p4hxaxvgcgqf8x-coreutils-9.1/bin/cp
```