### PR TITLE
Reworked "strange_cases" by the newly added "term_laml_cases"

### DIFF
--- a/examples/lambda/barendregt/chap2Script.sml
+++ b/examples/lambda/barendregt/chap2Script.sml
@@ -830,6 +830,16 @@ val is_comb_APP_EXISTS = store_thm(
   ``!t. is_comb t = (?u v. t = u @@ v)``,
   PROVE_TAC [term_CASES, is_comb_thm]);
 
+Theorem is_comb_appstar_exists :
+    !M. is_comb M ==> ?t args. (M = t @* args) /\ args <> [] /\ ~is_comb t
+Proof
+    HO_MATCH_MP_TAC simple_induction >> rw []
+ >> reverse (Cases_on ‘is_comb M’)
+ >- (qexistsl_tac [‘M’, ‘[M']’] >> rw [])
+ >> FULL_SIMP_TAC std_ss [GSYM appstar_SNOC]
+ >> qexistsl_tac [‘t’, ‘SNOC M' args’] >> rw []
+QED
+
 val is_comb_rator_rand = store_thm(
   "is_comb_rator_rand",
   ``!t. is_comb t ==> (rator t @@ rand t = t)``,

--- a/examples/lambda/barendregt/chap2Script.sml
+++ b/examples/lambda/barendregt/chap2Script.sml
@@ -831,7 +831,7 @@ val is_comb_APP_EXISTS = store_thm(
   PROVE_TAC [term_CASES, is_comb_thm]);
 
 Theorem is_comb_appstar_exists :
-    !M. is_comb M ==> ?t args. (M = t @* args) /\ args <> [] /\ ~is_comb t
+    !M. is_comb M <=> ?t args. (M = t @* args) /\ args <> [] /\ ~is_comb t
 Proof
     HO_MATCH_MP_TAC simple_induction >> rw []
  >> reverse (Cases_on ‘is_comb M’)
@@ -1028,13 +1028,15 @@ Proof
       (* goal 2 (of 3) *)
       DISJ2_TAC >> reverse (Cases_on ‘is_comb M1’)
       >- (qexistsl_tac [‘[]’, ‘[M2]’, ‘M1’] >> rw []) \\
-      IMP_RES_TAC is_comb_appstar_exists \\
+     ‘?t args. (M1 = t @* args) /\ args <> [] /\ ~is_comb t’
+         by METIS_TAC [is_comb_appstar_exists] \\
       qexistsl_tac [‘[]’, ‘SNOC M2 args’, ‘t’] >> rw [],
       (* goal 3 (of 3) *)
      ‘is_var Body \/ is_comb Body’ by METIS_TAC [term_cases]
       >- (DISJ1_TAC >> qexistsl_tac [‘v::vs’, ‘Body’] >> rw [] \\
           fs [is_var_cases]) \\
-      IMP_RES_TAC is_comb_appstar_exists \\
+     ‘?t args. (Body = t @* args) /\ args <> [] /\ ~is_comb t’
+         by METIS_TAC [is_comb_appstar_exists] \\
       DISJ2_TAC >> qexistsl_tac [‘v::vs’, ‘args’, ‘t’] >> rw [] ]
 QED
 

--- a/examples/lambda/barendregt/head_reductionScript.sml
+++ b/examples/lambda/barendregt/head_reductionScript.sml
@@ -238,24 +238,17 @@ QED
 Theorem hnf_cases :
     !M : term. hnf M <=> ?vs args y. ALL_DISTINCT vs /\ (M = LAMl vs (VAR y @* args))
 Proof
-    simp [FORALL_AND_THM, EQ_IMP_THM]
- (* this direction is proved by Michael Norrish *)
- >> reverse conj_tac
- >- simp [PULL_EXISTS, hnf_appstar]
- (* below is learnt from bnf_characterisation *)
- >> ho_match_mp_tac nc_INDUCTION2
- >> qexists_tac ‘{}’ >> rw [] >~ [‘VAR _ @* _ = M1 @@ M2’]
- >- (gs [app_eq_appstar] \\
-     qexists_tac ‘args ++ [M2]’ >> rw [GSYM SNOC_APPEND])
- >> gs [app_eq_appstar] >~ [‘VAR z @* Ms’]
- >> reverse (Cases_on ‘MEM y vs’)
- >- (qexistsl_tac [‘y::vs’, ‘Ms’, ‘z’] >> simp [])
- >> ‘y # LAMl vs (VAR z @* Ms)’ by simp [FV_LAMl]
- >> Q_TAC (NEW_TAC "x") ‘y INSERT (set vs) UNION (FV (VAR z @* Ms))’
- >> ‘x # LAMl vs (VAR z @* Ms)’ by simp [FV_LAMl]
- >> dxrule_then (qspec_then ‘y’ mp_tac) tpm_ALPHA
- >> simp [tpm_fresh, FV_LAMl]
- >> strip_tac >> qexists ‘x::vs’ >> simp []
+  simp[FORALL_AND_THM, EQ_IMP_THM] >> conj_tac
+  >- (gen_tac >> MP_TAC (Q.SPEC ‘M’ strange_cases)
+      >> RW_TAC std_ss []
+      >- (FULL_SIMP_TAC std_ss [size_1_cases] \\
+          qexistsl_tac [‘vs’, ‘[]’, ‘y’] >> rw [])
+      >> FULL_SIMP_TAC std_ss [hnf_LAMl]
+      >> ‘hnf t /\ ~is_abs t’ by PROVE_TAC [hnf_appstar]
+      >> ‘is_var t’ by METIS_TAC [term_cases]
+      >> FULL_SIMP_TAC std_ss [is_var_cases]
+      >> qexistsl_tac [‘vs’, ‘args’, ‘y’] >> art []) >>
+  simp[PULL_EXISTS, hnf_appstar]
 QED
 
 (* ----------------------------------------------------------------------


### PR DESCRIPTION
Recently a new lemma `term_laml_cases` has been added into `chap2Theory`:
```
[term_laml_cases]
⊢ ∀X. FINITE X ⇒
      ∀t. (∃s. t = VAR s) ∨ (∃M1 M2. t = M1 @@ M2) ∨
          ∃v vs Body.
            t = LAM v (LAMl vs Body) ∧ ¬is_abs Body ∧ v ∉ X ∧ ¬MEM v vs ∧
            ALL_DISTINCT vs ∧ DISJOINT (set vs) X
```
It's quite general, but the existing `strange_cases` is still useful in many places as the case splits are different with the above one:
```
[strange_cases] (old version)
⊢ ∀M. (∃vs M'. M = LAMl vs M' ∧ size M' = 1) ∨
      ∃vs args t.
        M = LAMl vs (t ·· args) ∧ args ≠ [] ∧ ¬is_comb t
```
Previously I have used this `strange_cases` to prove `hnf_cases`, but then I had to completely rework `hnf_cases` because it needs to assert `ALL_DISTINCT vs` which is not provided by `strange_cases`.

In this tiny PR, I reworked the proof of `strange_cases` (with `ALL_DISTINCT vs` added in all cases) by using the new `term_laml_cases`:
```
[strange_cases] (new version)
⊢ ∀M. (∃vs M'. M = LAMl vs M' ∧ size M' = 1 ∧ ALL_DISTINCT vs) ∨
      ∃vs args t.
        M = LAMl vs (t ·· args) ∧ args ≠ [] ∧ ¬is_comb t ∧ ALL_DISTINCT vs
```
and then the old shorter proof of `hnf_cases` can be recovered. The overall proof size is slightly decreased, which is good in general.

Chun
