### PR TITLE
Principle head normal forms (principle_hnf)

### DIFF
--- a/examples/lambda/barendregt/head_reductionScript.sml
+++ b/examples/lambda/barendregt/head_reductionScript.sml
@@ -262,6 +262,35 @@ Proof
   simp[PULL_EXISTS, hnf_appstar]
 QED
 
+(* A more general version of ‘hnf_cases’ directly based on term_laml_cases *)
+Theorem hnf_cases_genX :
+    !X. FINITE X ==>
+        !M. hnf M <=> ?vs args y. ALL_DISTINCT vs /\ (M = LAMl vs (VAR y @* args)) /\
+                                  DISJOINT (set vs) X
+Proof
+    reverse (rw [FORALL_AND_THM, EQ_IMP_THM])
+ >- rw [hnf_appstar]
+ >> MP_TAC (Q.SPEC ‘M’ (MATCH_MP term_laml_cases (ASSUME “FINITE (X :string -> bool)”)))
+ >> RW_TAC std_ss []
+ >| [ (* goal 1 (of 3) *)
+      qexistsl_tac [‘[]’, ‘[]’, ‘s’] >> rw [],
+      (* goal 2 (of 3) *)
+      Know ‘is_comb (M1 @@ M2)’ >- rw [] \\
+      ONCE_REWRITE_TAC [is_comb_appstar_exists] >> rw [] \\
+      Q.PAT_X_ASSUM ‘M1 @@ M2 = t @* args’ (FULL_SIMP_TAC std_ss o wrap) \\
+      fs [hnf_appstar] \\
+     ‘is_var t’ by METIS_TAC [term_cases] >> fs [is_var_cases],
+      (* goal 3 (of 3) *)
+      fs [hnf_LAMl] >> rename1 ‘hnf M’ \\
+     ‘is_var M \/ is_comb M’ by METIS_TAC [term_cases]
+      >- (fs [is_var_cases] \\
+          qexistsl_tac [‘v::vs’, ‘[]’, ‘y’] >> rw []) \\
+      FULL_SIMP_TAC std_ss [Once is_comb_appstar_exists] \\
+      gs [hnf_appstar] \\
+     ‘is_var t’ by METIS_TAC [term_cases] >> fs [is_var_cases] \\
+      qexistsl_tac [‘v::vs’, ‘args’, ‘y’] >> rw [] ]
+QED
+
 (* ----------------------------------------------------------------------
     Weak head reductions (weak_head or -w->)
    ---------------------------------------------------------------------- *)

--- a/examples/lambda/barendregt/head_reductionScript.sml
+++ b/examples/lambda/barendregt/head_reductionScript.sml
@@ -101,6 +101,14 @@ val hreduce1_unique = store_thm(
   HO_MATCH_MP_TAC hreduce1_ind THEN
   SIMP_TAC (srw_ss() ++ DNF_ss) [hreduce1_rwts]);
 
+Theorem hreduce1_rules_appstar :
+    !Ns. M1 -h-> M2 /\ ~is_abs M1 ==> M1 @* Ns -h-> M2 @* Ns
+Proof
+    Induct_on ‘Ns’ using SNOC_INDUCT
+ >> rw [appstar_SNOC]
+ >> fs [hreduce1_rules]
+QED
+
 Theorem hreduce1_gen_bvc_ind :
   !P f. (!x. FINITE (f x)) /\
         (!v M N x. v NOTIN f x ==> P (LAM v M @@ N) ([N/v] M) x) /\
@@ -182,20 +190,23 @@ QED
    ---------------------------------------------------------------------- *)
 
 val hnf_def = Define`hnf M = ∀N. ¬(M -h-> N)`;
-val hnf_thm = Store_thm(
-  "hnf_thm",
-  ``(hnf (VAR s) ⇔ T) ∧
+
+Theorem hnf_thm[simp] :
+    (hnf (VAR s) ⇔ T) ∧
     (hnf (M @@ N) ⇔ hnf M ∧ ¬is_abs M) ∧
-    (hnf (LAM v M) ⇔ hnf M)``,
+    (hnf (LAM v M) ⇔ hnf M)
+Proof
   SRW_TAC [][hnf_def, hreduce1_rwts] THEN
   Cases_on `is_abs M` THEN SRW_TAC [][hreduce1_rwts] THEN
   Q.SPEC_THEN `M` FULL_STRUCT_CASES_TAC term_CASES THEN
-  FULL_SIMP_TAC (srw_ss()) [hreduce1_rwts]);
+  FULL_SIMP_TAC (srw_ss()) [hreduce1_rwts]
+QED
 
-val hnf_tpm = Store_thm(
-  "hnf_tpm",
-  ``∀M π. hnf (π·M) = hnf M``,
-  HO_MATCH_MP_TAC simple_induction THEN SRW_TAC [][]);
+Theorem hnf_tpm[simp] :
+    ∀M π. hnf (π·M) = hnf M
+Proof
+  HO_MATCH_MP_TAC simple_induction THEN SRW_TAC [][]
+QED
 
 val strong_cc_ind = IndDefLib.derive_strong_induction (compat_closure_rules,
                                                        compat_closure_ind)
@@ -698,6 +709,13 @@ val has_hnf_def = Define`
   has_hnf M = ?N. M == N /\ hnf N
 `;
 
+Theorem hnf_has_hnf :
+    !M. hnf M ==> has_hnf M
+Proof
+    rw [has_hnf_def]
+ >> Q.EXISTS_TAC ‘M’ >> rw []
+QED
+
 val has_bnf_hnf = store_thm(
   "has_bnf_hnf",
   ``has_bnf M ⇒ has_hnf M``,
@@ -1116,3 +1134,9 @@ QED
 
 val _ = export_theory()
 val _ = html_theory "head_reduction";
+
+(* References:
+
+   [1] Barendregt, H.P.: The Lambda Calculus, Its Syntax and Semantics.
+       College Publications, London (1984).
+ *)

--- a/examples/lambda/barendregt/solvableScript.sml
+++ b/examples/lambda/barendregt/solvableScript.sml
@@ -895,20 +895,21 @@ Proof
  >> MATCH_MP_TAC principle_hnf_LAMl_appstar_lemma >> rw []
 QED
 
-(* FIXME: how to leverage Omega_starloops and prove this theorem?
+(* Example 8.3.2 [1, p.171] *)
 Theorem unsolvable_Omega :
     unsolvable Omega
 Proof
    ‘closed Omega’ by rw [closed_def]
  >> rw [solvable_alt_closed]
- >> CCONTR_TAC
+ >> CCONTR_TAC >> fs []
  >> ‘?Z. Omega @* Ns -b->* Z /\ I -b->* Z’ by METIS_TAC [lameq_CR]
  >> fs [bnf_reduction_to_self]
  >> Q.PAT_X_ASSUM ‘closed Omega’ K_TAC
  >> POP_ASSUM K_TAC (* Z = I *)
- >> cheat
+ >> ‘?Ms. I = Omega @* Ms’ by METIS_TAC [Omega_appstar_starloops]
+ >> POP_ASSUM MP_TAC
+ >> rw [Omega_def, I_def]
 QED
- *)
 
 val _ = export_theory ();
 val _ = html_theory "solvable";

--- a/examples/lambda/basics/Holmakefile
+++ b/examples/lambda/basics/Holmakefile
@@ -1,3 +1,5 @@
 SRCDIRS = string finite_maps 
 
 INCLUDES = $(patsubst %,$(dprot $(HOLDIR)/src/%),$(SRCDIRS))
+
+EXTRA_CLEANS = $(patsubst %Theory.uo,%Theory.html,$(DEFAULT_TARGETS))

--- a/examples/lambda/basics/appFOLDLScript.sml
+++ b/examples/lambda/basics/appFOLDLScript.sml
@@ -230,7 +230,7 @@ Proof
 QED
 
 Theorem LAMl_SUB :
-    !M N v vs. ALL_DISTINCT vs /\ ~MEM v vs /\ (FV N = {}) ==>
+    !M N v vs. ~MEM v vs /\ DISJOINT (set vs) (FV N) ==>
               ([N/v] (LAMl vs M) = LAMl vs ([N/v] M))
 Proof
     rpt STRIP_TAC

--- a/examples/lambda/completeness/boehm_treeScript.sml
+++ b/examples/lambda/completeness/boehm_treeScript.sml
@@ -6,7 +6,7 @@ open HolKernel boolLib Parse bossLib;
 
 (* core theories *)
 open optionTheory arithmeticTheory pred_setTheory listTheory llistTheory
-     ltreeTheory pathTheory posetTheory hurdUtils;
+     ltreeTheory pathTheory posetTheory hurdUtils rich_listTheory;
 
 open binderLib termTheory appFOLDLTheory chap2Theory chap3Theory
      head_reductionTheory standardisationTheory solvableTheory pure_dBTheory;

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -1821,13 +1821,6 @@ val LENGTH_FRONT_CONS = store_thm ("LENGTH_FRONT_CONS",
 Induct_on ‘xs’ THEN ASM_SIMP_TAC bool_ss [FRONT_CONS, LENGTH])
 val _ = export_rewrites ["LENGTH_FRONT_CONS"]
 
-Theorem LENGTH_FRONT :
-    !l. l <> [] ==> LENGTH (FRONT l) = PRE (LENGTH l)
-Proof
-    rpt STRIP_TAC
- >> Cases_on ‘l’ >> fs [LENGTH_FRONT_CONS]
-QED
-
 val FRONT_CONS_EQ_NIL = store_thm ("FRONT_CONS_EQ_NIL",
 “(!x:'a xs. (FRONT (x::xs) = []) = (xs = [])) /\
   (!x:'a xs. ([] = FRONT (x::xs)) = (xs = [])) /\
@@ -2765,23 +2758,6 @@ val SNOC_Axiom = store_thm(
 
 val SNOC_INDUCT = save_thm("SNOC_INDUCT", prove_induction_thm SNOC_Axiom_old);
 val SNOC_CASES =  save_thm("SNOC_CASES", hd (prove_cases_thm SNOC_INDUCT));
-
-Theorem ZIP_SNOC_lemma[local] :
-    ZIP (SNOC x1 (MAP FST l),SNOC x2 (MAP SND l)) = SNOC (x1,x2) l
-Proof
-    Induct_on ‘l’ >> rw [ZIP_def]
-QED
-
-Theorem ZIP_SNOC :
-    !x1 l1 x2 l2. (LENGTH l1 = LENGTH l2) ==>
-                  (ZIP (SNOC x1 l1,SNOC x2 l2) = SNOC (x1,x2) (ZIP (l1,l2)))
-Proof
-    rpt STRIP_TAC
- >> Q.ABBREV_TAC ‘l = ZIP (l1,l2)’
- >> ‘l1 = MAP FST l’ by rw [Abbr ‘l’, MAP_ZIP]
- >> ‘l2 = MAP SND l’ by rw [Abbr ‘l’, MAP_ZIP]
- >> rw [ZIP_SNOC_lemma]
-QED
 
 (*--------------------------------------------------------------*)
 (* List generator                                               *)


### PR DESCRIPTION
Hi,

This PR adds the definition and some basic properties and lemmas about **principle head normal forms** (`priciple_hnf`). A term may have several hnf's, e.g. if any of its hnf can still do beta reductions, then after such reductions the resulting term is still an hnf by definition.  The (unique) terminating term of head reduction path is called "principle" hnf: (Definition 8.3.20 [1, p.177])
```
[principle_hnf_def] (solvableTheory)
⊢ principle_hnf = last ∘ head_reduction_path
```
Given that the above definition immediately follows solvable terms in the book, all developments are in `solvableTheory` of the lambda examples.

Obviously, `principle_hnf M` is specified only if `has_hnf M` or `solvable M`, because otherwise `head_reduction_path M` is infinite and there's no last element at all. Below are some basic properties of principle hnf:

- The principle hnf of a term is _itself_ if the term is already a hnf:
```
[principle_hnf_eq_self]
⊢ ∀M. hnf M ⇒ principle_hnf M = M
```

- (As a consequence of the previous one) Repeated call of `principle_hnf` reduces to just one:
```
[principle_hnf_stable]
⊢ ∀M. has_hnf M ⇒ principle_hnf (principle_hnf M) = principle_hnf M
```

- If M one-step head reduces to N, then M and N have the same principle hnf (NOTE: this sounds like principle hnf is the normal form of head reductions but I'm not sure if the `normal_form` in `chap3Theory` can be used)
```
principle_hnf_hreduce1
⊢ ∀M N. M -h-> N ⇒ principle_hnf M = principle_hnf N
```

- `principle_hnf` can be used to do one-step beta reduction if the inner term is already a hnf:
```
principle_hnf_beta
⊢ ∀v t. hnf t ∧ y # t ⇒ principle_hnf (LAM v t @@ VAR y) = [VAR y/v] t
```

The last theorem is a generalization of the above one, showing that `principle_hnf` can be used to *eliminate* the outer abstractions of hnf in explicit form, when applied to a list of _fresh_ variables, and the result is a nice `tpm` of inner term:
```
[principle_hnf_LAMl_appstar]
⊢ ∀t xs ys.
    hnf t ∧ ALL_DISTINCT xs ∧ ALL_DISTINCT ys ∧ LENGTH xs = LENGTH ys ∧
    DISJOINT (set xs) (set ys) ∧ DISJOINT (set ys) (FV t) ⇒
    principle_hnf (LAMl xs t ·· MAP VAR ys) = tpm (ZIP (xs,ys)) t
```

Regards,

Chun TIAN

[1] Barendregt, H.P.: The Lambda Calculus, Its Syntax and Semantics.
       College Publications, London (1984).