### PR TITLE
Stage work on λ-calculus (Böhm transform and head original terms)

### DIFF
--- a/examples/lambda/barendregt/boehmScript.sml
+++ b/examples/lambda/barendregt/boehmScript.sml
@@ -6,10 +6,13 @@ open HolKernel boolLib Parse bossLib;
 
 (* core theories *)
 open optionTheory arithmeticTheory pred_setTheory listTheory rich_listTheory
-     llistTheory relationTheory ltreeTheory pathTheory posetTheory hurdUtils;
+     llistTheory relationTheory ltreeTheory pathTheory posetTheory hurdUtils
+     finite_mapTheory;
 
 open binderLib nomsetTheory termTheory appFOLDLTheory chap2Theory chap3Theory
      head_reductionTheory standardisationTheory solvableTheory reductionEval;
+
+open horeductionTheory takahashiTheory;
 
 val _ = new_theory "boehm";
 
@@ -86,37 +89,86 @@ Proof
     RW_TAC std_ss [equivalent_def]
 QED
 
-(* NOTE: this combined tactic is useful after:
+(* NOTE: the initial calls of ‘principle_hnf’ get eliminated if the involved
+         terms are already in head normal forms.
+ *)
+Theorem equivalent_of_hnf :
+    !M N. hnf M /\ hnf N ==>
+         (equivalent M N <=>
+          let n  = LAMl_size M;
+              n' = LAMl_size N;
+              vs = FRESH_list (MAX n n') (FV M UNION FV N);
+             vsM = TAKE n  vs;
+             vsN = TAKE n' vs;
+              M1 = principle_hnf (M @* (MAP VAR vsM));
+              N1 = principle_hnf (N @* (MAP VAR vsN));
+              y  = hnf_head M1;
+              y' = hnf_head N1;
+              m  = LENGTH (hnf_children M1);
+              m' = LENGTH (hnf_children N1);
+           in
+              y = y' /\ n + m' = n' + m)
+Proof
+    rpt STRIP_TAC
+ >> ‘solvable M /\ solvable N’ by PROVE_TAC [hnf_has_hnf, solvable_iff_has_hnf]
+ >> RW_TAC std_ss [equivalent_def, principle_hnf_reduce]
+ >> METIS_TAC []
+QED
 
-   RW_TAC std_ss [equivalent_def]
+(* Given a hnf ‘M0’ and a shared binding variable list ‘vs’
+
+   hnf_tac adds the following abbreviation and new assumptions:
+
+   Abbrev (M1 = principle_hnf (M0 @* MAP VAR (TAKE (LAMl_size M0) vs)))
+   M0 = LAMl (TAKE (LAMl_size M0) vs) (VAR y @* args)
+   M1 = VAR y @* args
+
+   where the names "M1", "y" and "args" can be chosen from inputs.
+ *)
+fun hnf_tac (M0,vs,M1,y,args) = let val n = “LAMl_size ^M0” in
+    qabbrev_tac ‘^M1 = principle_hnf (^M0 @* MAP VAR (TAKE ^n ^vs))’
+ >> Know ‘?^y ^args. ^M0 = LAMl (TAKE ^n ^vs) (VAR ^y @* ^args)’
+ >- (irule (iffLR hnf_cases_shared) >> rw [])
+ >> STRIP_TAC
+ >> Know ‘^M1 = VAR ^y @* ^args’
+ >- (qunabbrev_tac ‘^M1’ \\
+     Q.PAT_ASSUM ‘^M0 = LAMl (TAKE ^n ^vs) (VAR ^y @* ^args)’
+        (fn th => REWRITE_TAC [Once th]) \\
+     MATCH_MP_TAC principle_hnf_beta_reduce >> rw [hnf_appstar])
+ >> DISCH_TAC
+end;
+
+(* The following combined tactic is useful after:
+
+   RW_TAC std_ss [equivalent_of_solvables, principle_hnf_reduce]
+
+   NOTE: it doesn't work with equivalent_of_hnf
  *)
 val equivalent_tac =
-   ‘hnf M0 /\ hnf N0’ by PROVE_TAC [hnf_principle_hnf, solvable_iff_has_hnf] \\
-   ‘ALL_DISTINCT vs /\ DISJOINT (set vs) (FV M0 UNION FV N0) /\
-    LENGTH vs = MAX n n'’ by rw [Abbr ‘vs’, FRESH_list_def] \\
-    Know ‘?y2 args2. N0 = LAMl vsN (VAR y2 @* args2)’
-    >- (qunabbrevl_tac [‘vsN’, ‘n'’] \\
-        irule (iffLR hnf_cases_shared) >> rw [] \\
-        MATCH_MP_TAC DISJOINT_SUBSET \\
-        Q.EXISTS_TAC ‘FV M0 UNION FV N0’ >> rw [SUBSET_UNION]) \\
-    Know ‘?y1 args1. M0 = LAMl vsM (VAR y1 @* args1)’
-    >- (qunabbrevl_tac [‘vsM’, ‘n’] \\
-        irule (iffLR hnf_cases_shared) >> rw [] \\
-        MATCH_MP_TAC DISJOINT_SUBSET \\
-        Q.EXISTS_TAC ‘FV M0 UNION FV N0’ >> rw [SUBSET_UNION]) \\
-    NTAC 2 STRIP_TAC \\
-    Know ‘M1 = VAR y1 @* args1’
-    >- (qunabbrev_tac ‘M1’ \\
-        Q.PAT_ASSUM ‘M0 = _’ (ONCE_REWRITE_TAC o wrap) \\
-        MATCH_MP_TAC principle_hnf_reduce >> rw [hnf_appstar]) \\
-    DISCH_TAC \\
-    Know ‘N1 = VAR y2 @* args2’
-    >- (qunabbrev_tac ‘N1’ \\
-        Q.PAT_ASSUM ‘N0 = _’ (ONCE_REWRITE_TAC o wrap) \\
-        MATCH_MP_TAC principle_hnf_reduce >> rw [hnf_appstar]) \\
-    DISCH_TAC \\
-   ‘VAR y1 = y’ by rw [Abbr ‘y’, hnf_head_absfree] \\
-   ‘VAR y2 = y'’ by rw [Abbr ‘y'’, hnf_head_absfree];
+    ‘hnf M0 /\ hnf N0’ by PROVE_TAC [hnf_principle_hnf, solvable_iff_has_hnf]
+ >> ‘ALL_DISTINCT vs /\ DISJOINT (set vs) (FV M0 UNION FV N0) /\
+     LENGTH vs = MAX n n'’ by rw [Abbr ‘vs’, FRESH_list_def]
+ >> ‘DISJOINT (set vs) (FV M0) /\ DISJOINT (set vs) (FV N0)’
+      by METIS_TAC [DISJOINT_SYM, DISJOINT_UNION]
+ >> qunabbrevl_tac [‘M1’, ‘N1’]
+ >> hnf_tac (“M0 :term”, “vs :string list”,
+             “M1 :term”, “y1 :string”, “args1 :term list”)
+ >> hnf_tac (“N0 :term”, “vs :string list”,
+             “N1 :term”, “y2 :string”, “args2 :term list”)
+ >> ‘TAKE (LAMl_size M0) vs = vsM’ by rw [Abbr ‘vsM’, Abbr ‘n’]
+ >> ‘TAKE (LAMl_size N0) vs = vsN’ by rw [Abbr ‘vsN’, Abbr ‘n'’]
+ >> NTAC 2 (POP_ASSUM (rfs o wrap))
+ (* reshaping and reordering assumptions *)
+ >> qunabbrev_tac ‘M1’
+ >> qabbrev_tac ‘M1 = principle_hnf (M0 @* MAP VAR vsM)’
+ >> qunabbrev_tac ‘N1’
+ >> qabbrev_tac ‘N1 = principle_hnf (N0 @* MAP VAR vsN)’
+ >> Q.PAT_X_ASSUM ‘M0 = _’ ASSUME_TAC
+ >> Q.PAT_X_ASSUM ‘N0 = _’ ASSUME_TAC
+ >> Q.PAT_X_ASSUM ‘M1 = _’ ASSUME_TAC
+ >> Q.PAT_X_ASSUM ‘N1 = _’ ASSUME_TAC
+ >> ‘VAR y1 = y’  by rw [Abbr ‘y’ , hnf_head_absfree]
+ >> ‘VAR y2 = y'’ by rw [Abbr ‘y'’, hnf_head_absfree];
 
 (* From [1, p.238]. This concerte example shows that dB encoding is not easy in
    defining this "concept": the literal encoding of inner head variables are not
@@ -130,7 +182,7 @@ Proof
  >> ‘hnf (LAM x (VAR v @@ M)) /\ hnf (LAM v (VAR v @@ M))’ by rw []
  >> ‘solvable (LAM x (VAR v @@ M)) /\ solvable (LAM v (VAR v @@ M))’
        by rw [solvable_iff_has_hnf, hnf_has_hnf]
- >> RW_TAC std_ss [equivalent_of_solvables, principle_hnf_eq_self]
+ >> RW_TAC std_ss [equivalent_of_solvables, principle_hnf_reduce]
  (* applying shared tactics *)
  >> equivalent_tac
  >> qunabbrevl_tac [‘n’, ‘n'’]
@@ -221,6 +273,12 @@ Definition Boehm_transform_def :
     Boehm_transform pi = EVERY solving_transform pi
 End
 
+Theorem Boehm_transform_empty[simp] :
+    Boehm_transform []
+Proof
+    rw [Boehm_transform_def]
+QED
+
 Theorem Boehm_transform_CONS[simp] :
     Boehm_transform (h::pi) <=> solving_transform h /\ Boehm_transform pi
 Proof
@@ -233,9 +291,18 @@ Proof
     rw [Boehm_transform_def, EVERY_SNOC]
 QED
 
+Theorem Boehm_transform_MAP_rightctxt_o_VAR[simp] :
+    Boehm_transform (MAP (rightctxt o VAR) vs)
+Proof
+    rw [Boehm_transform_def, EVERY_MAP]
+QED
+
 (* ‘apply pi M’ (applying a Boehm transformation) means "M^{pi}" or "pi(M)"
 
-   NOTE: ‘apply [f3;f2;f1] M = (f3 o f2 o f1) M = f3 (f2 (f1 M))’ *)
+   NOTE: ‘apply [f3;f2;f1] M = (f3 o f2 o f1) M = f3 (f2 (f1 M))’
+
+   NOTE2: This function seems general: “:('a -> 'a) list -> 'a -> 'a”.
+ *)
 Definition apply_def :
     apply pi = FOLDR $o I pi
 End
@@ -285,6 +352,75 @@ Proof
  >> irule lameq_sub_cong >> rw []
 QED
 
+(* Lemma 10.3.4 (ii) [1, p.246]
+
+   Used by: Boehm_transform_lameq_appstar
+ *)
+Theorem Boehm_transform_lameq_LAMl_appstar :
+    !pi. Boehm_transform pi ==>
+         ?c. ctxt c /\ (!M. apply pi M == c M) /\
+             !vs. ALL_DISTINCT vs ==>
+                  ?Ns. !M. FV M SUBSET (set vs) ==> c M == LAMl vs M @* Ns
+Proof
+    Induct_on ‘pi’
+ >- (rw [] \\
+     Q.EXISTS_TAC ‘\x. x’ >> rw [ctxt_rules] \\
+     Q.EXISTS_TAC ‘MAP VAR vs’ >> rpt STRIP_TAC \\
+     rw [Once lameq_SYM, lameq_LAMl_appstar_VAR])
+ >> rw []
+ >> Q.PAT_X_ASSUM ‘Boehm_transform pi ==> P’ MP_TAC
+ >> RW_TAC std_ss []
+ >> FULL_SIMP_TAC std_ss [solving_transform_def] (* 2 subgoals *)
+ (* goal 1 (of 2) *)
+ >- (Q.EXISTS_TAC ‘\z. c z @@ (\z. VAR x) z’ \\
+     rw [ctxt_rules, lameq_rules] \\
+     Q.PAT_X_ASSUM ‘!vs. ALL_DISTINCT vs ==> P’ (drule_then STRIP_ASSUME_TAC) \\
+     Q.EXISTS_TAC ‘SNOC (VAR x) Ns’ \\
+     rw [appstar_SNOC, lameq_rules])
+ (* goal 2 (of 2) *)
+ >> rename1 ‘h = [P/y]’
+ >> qabbrev_tac ‘c1 = \z. LAM y (c z)’
+ >> ‘ctxt c1’ by rw [ctxt_rules, Abbr ‘c1’]
+ >> Q.EXISTS_TAC ‘\z. c1 z @@ (\z. P) z’
+ >> CONJ_TAC >- rw [ctxt_rules, constant_contexts_exist]
+ >> CONJ_TAC
+ >- (rw [Abbr ‘c1’] \\
+     MATCH_MP_TAC lameq_TRANS >> Q.EXISTS_TAC ‘[P/y] (c M)’ \\
+     rw [lameq_sub_cong, Once lameq_SYM, lameq_BETA])
+ >> rpt STRIP_TAC
+ >> Q.PAT_X_ASSUM ‘!vs. ALL_DISTINCT vs ==> _’ (drule_then STRIP_ASSUME_TAC)
+ >> Q.EXISTS_TAC ‘MAP [P/y] Ns’
+ >> rw [Abbr ‘c1’]
+ >> Q.PAT_X_ASSUM ‘!M. FV M SUBSET set vs ==> _’ (drule_then STRIP_ASSUME_TAC)
+ >> MATCH_MP_TAC lameq_TRANS
+ >> Q.EXISTS_TAC ‘[P/y] (c M)’ >> rw [lameq_BETA]
+ >> MATCH_MP_TAC lameq_TRANS
+ >> Q.EXISTS_TAC ‘[P/y] (LAMl vs M @* Ns)’ >> rw [lameq_sub_cong]
+ >> rw [appstar_SUB]
+ >> Suff ‘[P/y] (LAMl vs M) = LAMl vs M’ >- rw []
+ >> MATCH_MP_TAC lemma14b
+ >> Suff ‘FV (LAMl vs M) = {}’ >- rw []
+ >> rw [FV_LAMl]
+ >> Q.PAT_X_ASSUM ‘FV M SUBSET (set vs)’ MP_TAC >> SET_TAC []
+QED
+
+(* An corollary of the above lemma with ‘xs = {}’
+
+   Used by: closed_separability_thm
+ *)
+Theorem Boehm_transform_lameq_appstar :
+    !pi. Boehm_transform pi ==>
+         ?Ns. !M. closed M ==> apply pi M == M @* Ns
+Proof
+    rpt STRIP_TAC
+ >> POP_ASSUM (STRIP_ASSUME_TAC o (MATCH_MP Boehm_transform_lameq_LAMl_appstar))
+ >> POP_ASSUM (MP_TAC o (Q.SPEC ‘[]’))
+ >> rw [closed_def]
+ >> Q.EXISTS_TAC ‘Ns’
+ >> RW_TAC (betafy (srw_ss())) []
+QED
+
+(* Used by: distinct_benf_imp_inconsistent *)
 Theorem asmlam_apply_cong :
     !pi M N. Boehm_transform pi /\ asmlam eqns M N ==>
              asmlam eqns (apply pi M) (apply pi N)
@@ -305,12 +441,14 @@ Proof
  >> MATCH_MP_TAC solving_transform_lameq >> art []
 QED
 
+(* Used by separability_thm *)
 Theorem Boehm_transform_APPEND :
     !p1 p2. Boehm_transform p1 /\ Boehm_transform p2 ==> Boehm_transform (p1 ++ p2)
 Proof
     rw [Boehm_transform_def]
 QED
 
+(* Used by separability_thm *)
 Theorem Boehm_apply_APPEND :
     !p1 p2 M. apply (p1 ++ p2) M = apply p1 (apply p2 M)
 Proof
@@ -350,6 +488,294 @@ Proof
       (* goal 2 (of 2) *)
       CCONTR_TAC >> fs [] \\
       METIS_TAC [has_hnf_SUB_E] ]
+QED
+
+(* Definition 10.3.5 (ii) *)
+Definition head_original_def :
+    head_original M0 = let n = LAMl_size M0;
+                          vs = FRESH_list n (FV M0);
+                          M1 = principle_hnf (M0 @* MAP VAR vs);
+                       in
+                          EVERY (\e. hnf_headvar M1 # e) (hnf_children M1)
+End
+
+(* Definition 10.3.5 (iii)
+
+   NOTE: |- has_hnf M <=> ?N. M == N /\ hnf N
+ *)
+Definition is_ready_def :
+    is_ready M <=> unsolvable M \/
+                   ?N. M == N /\ hnf N /\ ~is_abs N /\ head_original N
+End
+
+(* cf. NEW_TAC (This is the multivariate version)
+
+   NOTE: “FINITE X” must be present in the assumptions or provable by rw [].
+ *)
+fun FRESH_list_tac (vs,n,X) =
+    qabbrev_tac ‘^vs = FRESH_list ^n ^X’
+ >> KNOW_TAC “ALL_DISTINCT ^vs /\ DISJOINT (set ^vs) ^X /\ LENGTH ^vs = ^n”
+ >- rw [FRESH_list_def, Abbr ‘^vs’]
+ >> STRIP_TAC;
+
+(* NOTE: This alternative definition of ‘is_ready’ consumes ‘head_original’
+         and eliminated the ‘principle_hnf’ inside it.
+ *)
+Theorem is_ready_alt :
+    !M. is_ready M <=>
+        unsolvable M \/ ?y Ns. M == VAR y @* Ns /\ EVERY (\e. y # e) Ns
+Proof
+    Q.X_GEN_TAC ‘M’
+ >> reverse EQ_TAC
+ >- (rw [is_ready_def] >- art [] \\
+     DISJ2_TAC >> Q.EXISTS_TAC ‘VAR y @* Ns’ >> art [] \\
+     CONJ_ASM1_TAC >- (rw [hnf_appstar]) >> simp [] \\
+     RW_TAC std_ss [head_original_def, LAMl_size_hnf_absfree] \\
+     qunabbrev_tac ‘n’ \\
+    ‘vs = []’ by METIS_TAC [LENGTH_NIL, FRESH_list_def, FINITE_FV] \\
+     POP_ASSUM (fs o wrap) >> qunabbrev_tac ‘vs’ \\
+    ‘M1 = VAR y @* Ns’ by rw [principle_hnf_reduce, Abbr ‘M1’] \\
+     POP_ORW >> qunabbrev_tac ‘M1’ \\
+     simp [hnf_head_hnf, hnf_children_hnf])
+ (* stage work *)
+ >> rw [is_ready_def] >- art []
+ >> DISJ2_TAC
+ >> qabbrev_tac ‘n = LAMl_size N’
+ >> FRESH_list_tac (“vs :string list”, “n :num”, “FV (N :term)”)
+ >> qabbrev_tac ‘M1 = principle_hnf (N @* MAP VAR vs)’
+ >> ‘EVERY (\e. hnf_headvar M1 # e) (hnf_children M1)’
+       by METIS_TAC [head_original_def]
+ >> Know ‘?y args. N = LAMl (TAKE (LAMl_size N) vs) (VAR y @* args)’
+ >- (Suff ‘ALL_DISTINCT vs /\ LAMl_size N <= LENGTH vs /\ DISJOINT (set vs) (FV N)’
+     >- METIS_TAC [hnf_cases_shared] \\
+     rw [Abbr ‘n’])
+ >> ‘TAKE (LAMl_size N) vs = vs’ by rw [] >> POP_ORW
+ >> STRIP_TAC
+ >> Know ‘M1 = VAR y @* args’
+ >- (rw [Abbr ‘M1’] \\
+     MATCH_MP_TAC principle_hnf_beta_reduce >> rw [hnf_appstar])
+ >> DISCH_THEN (fn th => fs [th, hnf_head_hnf, hnf_children_hnf])
+ (* stage work *)
+ >> qexistsl_tac [‘y’, ‘args’] >> art []
+QED
+
+(* Lemma 10.3.6 (i) [1, p.247] *)
+Theorem Boehm_transform_is_ready_exists :
+    !M. ?pi. Boehm_transform pi /\ is_ready (apply pi M)
+Proof
+    Q.X_GEN_TAC ‘M’
+ >> reverse (Cases_on ‘solvable M’)
+ >- (Q.EXISTS_TAC ‘[]’ >> rw [is_ready_def])
+ (* now M is solvable *)
+ >> qabbrev_tac ‘M0 = principle_hnf M’
+ >> ‘hnf M0’ by PROVE_TAC [hnf_principle_hnf, solvable_iff_has_hnf]
+ >> qabbrev_tac ‘n = LAMl_size M0’
+ >> qabbrev_tac ‘vs = FRESH_list n (FV M0)’
+ >> ‘ALL_DISTINCT vs /\ DISJOINT (set vs) (FV M0) /\ LENGTH vs = n’
+       by (rw [Abbr ‘vs’, FRESH_list_def])
+ (* applying the shared hnf_tac *)
+ >> hnf_tac (“M0 :term”, “vs :string list”,
+             “M1 :term”, “y :string”, “args :term list”)
+ >> ‘TAKE (LAMl_size M0) vs = vs’ by rw []
+ >> POP_ASSUM (REV_FULL_SIMP_TAC std_ss o wrap)
+ >> qabbrev_tac ‘xs :term list = MAP VAR vs’
+ >> qabbrev_tac ‘p1 = MAP rightctxt (REVERSE xs)’
+ >> ‘apply p1 M0 == M1’
+       by (rw [Abbr ‘p1’, Boehm_apply_MAP_rightctxt', Abbr ‘xs’])
+ >> qabbrev_tac ‘m = LENGTH args’
+ (* X collects all free variables in ‘args’ *)
+ >> qabbrev_tac ‘X = BIGUNION (IMAGE FV (set args))’
+ >> Know ‘FINITE X’
+ >- (qunabbrev_tac ‘X’ \\
+     MATCH_MP_TAC FINITE_BIGUNION >> rw [] >> rw [])
+ >> DISCH_TAC
+ (* Z needs to avoid any free variables in args' *)
+ >> FRESH_list_tac (“Z :string list”, “(m + 1) :num”, “X :string set”)
+ >> ‘Z <> []’ by rw [NOT_NIL_EQ_LENGTH_NOT_0]
+ >> qabbrev_tac ‘z = LAST Z’
+ >> ‘MEM z Z’ by rw [Abbr ‘z’, MEM_LAST_NOT_NIL]
+ (* P is a permutator *)
+ >> qabbrev_tac ‘P = LAMl Z (VAR z @* MAP VAR (FRONT Z))’
+ >> Know ‘FV P = {}’
+ >- (rw [Abbr ‘P’, FV_LAMl] \\
+     Suff ‘FV (VAR z @* MAP VAR (FRONT Z)) SUBSET set Z’ >- SET_TAC [] \\
+     rw [FV_appstar, SUBSET_DEF, MEM_MAP] >- art [] \\
+     rfs [MEM_FRONT_NOT_NIL])
+ >> DISCH_TAC
+ >> qabbrev_tac ‘p2 = [[P/y]]’
+ >> ‘apply p2 M1 = P @* MAP [P/y] args’ by (rw [Abbr ‘p2’, appstar_SUB])
+ >> qabbrev_tac ‘args' = MAP [P/y] args’
+ >> ‘!i. i < m ==> FV (EL i args') SUBSET FV (EL i args)’
+         by rw [Abbr ‘args'’, EL_MAP, FV_SUB]
+ >> ‘LENGTH args' = m’ by rw [Abbr ‘args'’, Abbr ‘m’]
+  (* Key: “args'” has less free variables than “args” *)
+ >> Know ‘BIGUNION (IMAGE FV (set args')) SUBSET
+          BIGUNION (IMAGE FV (set args))’
+ >- (rw [SUBSET_DEF, IN_BIGUNION_IMAGE, MEM_EL] \\
+     Q.EXISTS_TAC ‘EL n args’ \\
+     CONJ_TAC >- (Q.EXISTS_TAC ‘n’ >> art []) \\
+     POP_ASSUM MP_TAC \\
+     Suff ‘FV (EL n args') SUBSET FV (EL n args)’ >- METIS_TAC [SUBSET_DEF] \\
+     FIRST_X_ASSUM MATCH_MP_TAC >> art [])
+ >> DISCH_TAC
+ (* a needs to avoid any free variables in args' *)
+ >> NEW_TAC "a" “X :string set”
+ >> qabbrev_tac ‘p3 = [rightctxt (VAR a)]’
+ >> Know ‘apply p3 (P @* args') == VAR a @* args'’
+ >- (rw [Abbr ‘p3’, Abbr ‘P’, rightctxt_thm] \\
+    ‘!t. LAMl Z t = LAMl (SNOC z (FRONT Z)) t’
+         by (ASM_SIMP_TAC std_ss [Abbr ‘z’, SNOC_LAST_FRONT]) >> POP_ORW \\
+     REWRITE_TAC [LAMl_SNOC] \\
+     qabbrev_tac ‘t = LAM z (VAR z @* MAP VAR (FRONT Z))’ \\
+     MATCH_MP_TAC lameq_TRANS \\
+     Q.EXISTS_TAC ‘LAM z (VAR z @* args') @@ VAR a’ \\
+  (* applying lameq_LAMl_appstar_ssub *)
+     CONJ_TAC
+     >- (MATCH_MP_TAC lameq_APPL \\
+         Suff ‘LAM z (VAR z @* args') = (FEMPTY |++ ZIP (FRONT Z,args')) ' t’
+         >- (Rewr' >> MATCH_MP_TAC lameq_LAMl_appstar_ssub \\
+             CONJ_TAC >- rw [ALL_DISTINCT_FRONT] \\
+             CONJ_TAC >- rw [LENGTH_FRONT] \\
+             ONCE_REWRITE_TAC [DISJOINT_SYM] \\
+             MATCH_MP_TAC DISJOINT_SUBSET >> Q.EXISTS_TAC ‘set Z’ \\
+             reverse CONJ_TAC >- rw [SUBSET_DEF, MEM_FRONT_NOT_NIL] \\
+             ASM_SIMP_TAC std_ss [Once DISJOINT_SYM, Abbr ‘X’] \\
+             MATCH_MP_TAC DISJOINT_SUBSET \\
+             Q.EXISTS_TAC ‘BIGUNION (IMAGE FV (set args))’ >> art []) \\
+         qunabbrev_tac ‘t’ \\
+         qabbrev_tac ‘fm = FEMPTY |++ ZIP (FRONT Z,args')’ \\
+        ‘LENGTH (FRONT Z) = LENGTH args'’ by rw [LENGTH_FRONT] \\
+        ‘FDOM fm = set (FRONT Z)’ by rw [Abbr ‘fm’, FDOM_FUPDATE_LIST, MAP_ZIP] \\
+         Know ‘z NOTIN FDOM fm’
+         >- (rw [Abbr ‘z’] \\
+             Know ‘ALL_DISTINCT (SNOC (LAST Z) (FRONT Z))’
+             >- rw [SNOC_LAST_FRONT] \\
+             rw [ALL_DISTINCT_SNOC]) >> DISCH_TAC \\
+         qabbrev_tac ‘t = VAR z @* MAP VAR (FRONT Z)’ \\
+         qabbrev_tac ‘L = ZIP (FRONT Z,args')’ \\
+         Know ‘!n. n < LENGTH args' ==> (FEMPTY |++ L) ' (EL n (FRONT Z)) = EL n args'’
+         >- (rpt STRIP_TAC \\
+             MATCH_MP_TAC FUPDATE_LIST_APPLY_MEM \\
+             Q.EXISTS_TAC ‘n’ >> rw [Abbr ‘L’, MAP_ZIP] \\
+            ‘m <> n’ by rw [] \\
+            ‘ALL_DISTINCT (FRONT Z)’ by METIS_TAC [ALL_DISTINCT_FRONT] \\
+             METIS_TAC [EL_ALL_DISTINCT_EL_EQ]) >> DISCH_TAC \\
+         Know ‘fm ' (LAM z t) = LAM z (fm ' t)’
+         >- (MATCH_MP_TAC ssub_LAM >> art [] \\
+             rw [Abbr ‘fm’, FDOM_FUPDATE_LIST, MAP_ZIP, MEM_EL] \\
+             Know ‘(FEMPTY |++ L) ' (EL n (FRONT Z)) = EL n args'’
+             >- (FIRST_X_ASSUM MATCH_MP_TAC >> art []) >> Rewr' \\
+             Suff ‘z # EL n args’
+             >- (DISCH_TAC \\
+                 CCONTR_TAC >> fs [] >> METIS_TAC [SUBSET_DEF]) \\
+             CCONTR_TAC >> fs [] \\
+             Q.PAT_X_ASSUM ‘DISJOINT (set Z) X’ MP_TAC \\
+             rw [DISJOINT_ALT, Abbr ‘X’] \\
+             Q.EXISTS_TAC ‘FV (EL n args)’ \\
+             CONJ_TAC >- (Q.EXISTS_TAC ‘EL n args’ >> rw [MEM_EL] \\
+                          Q.EXISTS_TAC ‘n’ >> rw []) \\
+             Q.EXISTS_TAC ‘z’ >> rw [MEM_LAST_NOT_NIL, Abbr ‘z’]) >> Rewr' \\
+         simp [Abbr ‘t’, ssub_appstar] \\
+         simp [Once LIST_EQ_REWRITE] \\
+         Q.X_GEN_TAC ‘i’ \\
+         Q.PAT_X_ASSUM ‘LENGTH args = LENGTH args'’ K_TAC \\
+         REWRITE_TAC [MAP_MAP_o] \\
+         DISCH_TAC >> ‘i < LENGTH (FRONT Z)’ by rw [] \\
+         ASM_SIMP_TAC std_ss [EL_MAP] \\
+        ‘MEM (EL i (FRONT Z)) (FRONT Z)’ by METIS_TAC [MEM_EL] \\
+         rw [Abbr ‘fm’, ssub_thm]) \\
+     Suff ‘VAR a @* args' = [VAR a/z](VAR z @* args')’
+     >- (Rewr' >> rw [lameq_BETA]) \\
+     rw [appstar_SUB] \\
+     rw [Once LIST_EQ_REWRITE] >> rename1 ‘n < LENGTH args'’ \\
+     rw [EL_MAP] \\
+     MATCH_MP_TAC (GSYM lemma14b) \\
+     Know ‘DISJOINT (set Z) (BIGUNION (IMAGE FV (set args')))’
+     >- (MATCH_MP_TAC DISJOINT_SUBSET \\
+         Q.EXISTS_TAC ‘X’ >> rw [Abbr ‘X’]) \\
+     rw [DISJOINT_ALT] \\
+     FIRST_X_ASSUM irule >> art [] \\
+     Q.EXISTS_TAC ‘EL n args'’ >> rw [MEM_EL] \\
+     Q.EXISTS_TAC ‘n’ >> art [])
+ >> DISCH_TAC
+ (* final stage *)
+ >> Q.EXISTS_TAC ‘p3 ++ p2 ++ p1’
+ >> CONJ_ASM1_TAC
+ >- (MATCH_MP_TAC Boehm_transform_APPEND \\
+     reverse CONJ_TAC
+     >- (rw [Abbr ‘p1’, Abbr ‘xs’, MAP_MAP_o, GSYM MAP_REVERSE]) \\
+     MATCH_MP_TAC Boehm_transform_APPEND >> rw [Abbr ‘p2’, Abbr ‘p3’])
+ >> simp [is_ready_alt]
+ >> DISJ2_TAC
+ >> qexistsl_tac [‘a’, ‘args'’]
+ >> reverse CONJ_TAC
+ >- (rw [EVERY_MEM] \\
+     Suff ‘FV e SUBSET X’ >- METIS_TAC [SUBSET_DEF] \\
+     MATCH_MP_TAC SUBSET_TRANS \\
+     Q.EXISTS_TAC ‘BIGUNION (IMAGE FV (set args'))’ \\
+     reverse CONJ_TAC >- rw [Abbr ‘X’] \\
+     rw [SUBSET_DEF, IN_BIGUNION_IMAGE] \\
+     Q.EXISTS_TAC ‘e’ >> art [])
+ >> MATCH_MP_TAC lameq_TRANS
+ >> Q.EXISTS_TAC ‘apply (p3 ++ p2 ++ p1) M0’
+ >> CONJ_TAC
+ >- (MATCH_MP_TAC lameq_apply_cong \\
+     CONJ_TAC >- art [] \\
+     qunabbrev_tac ‘M0’ \\
+     MATCH_MP_TAC lameq_SYM \\
+     MATCH_MP_TAC lameq_principle_hnf' >> art [])
+ >> ONCE_REWRITE_TAC [Boehm_apply_APPEND]
+ >> MATCH_MP_TAC lameq_TRANS
+ >> Q.EXISTS_TAC ‘apply (p3 ++ p2) M1’
+ >> CONJ_TAC
+ >- (MATCH_MP_TAC lameq_apply_cong >> art [] \\
+     MATCH_MP_TAC Boehm_transform_APPEND >> rw [Abbr ‘p2’, Abbr ‘p3’])
+ >> REWRITE_TAC [Boehm_apply_APPEND]
+ >> MATCH_MP_TAC lameq_TRANS
+ >> Q.EXISTS_TAC ‘apply p3 (P @* args')’ >> art []
+ >> MATCH_MP_TAC lameq_apply_cong
+ >> rw [Abbr ‘p3’]
+QED
+
+(* Definition 10.3.10 (ii) *)
+Definition is_faithful_def :
+    is_faithful p Fs pi =
+       !M N. M IN Fs /\ N IN Fs ==>
+            (subterm_eta_equiv p M N <=> equivalent (apply pi M) (apply pi N)) /\
+            (!X. IS_SOME (ltree_lookup (BT X M) p) <=>
+                 solvable (apply pi M))
+End
+
+Definition term_agrees_upto_def :
+    term_agrees_upto M N p <=>
+      !q. q <<= p ==> !X. ltree_el (BT X M) q = ltree_el (BT X N) q
+End
+
+(* Definition 10.3.10 (iv) *)
+val _ = set_fixity "agrees_upto" (Infixr 490);
+Definition agrees_upto_def :
+    $agrees_upto Fs p = !M N. M IN Fs /\ N IN Fs ==> term_agrees_upto M N p
+End
+
+(* Lemma 10.3.11 (3) [1. p.251] *)
+Theorem agrees_upto_lemma :
+    !Fs p. Fs agrees_upto p ==>
+           ?pi. Boehm_transform pi /\
+                !M N. M IN Fs /\ N IN Fs ==>
+                     (subterm_eta_equiv p M N <=>
+                      subterm_eta_equiv p (apply pi M) (apply pi N))
+Proof
+    cheat
+QED
+
+(* Proposition 10.3.13 [1, p.253]
+
+   Used by separability_thm
+ *)
+Theorem agrees_upto_thm :
+    !Fs p. Fs agrees_upto p ==> ?pi. Boehm_transform pi /\ is_faithful p Fs pi
+Proof
+    cheat
 QED
 
 (*---------------------------------------------------------------------------*
@@ -521,7 +947,7 @@ Theorem separability_lemma0[local] :
           equivalent M N \/
           !P Q. ?pi. Boehm_transform pi /\ apply pi M == P /\ apply pi N == Q
 Proof
-    RW_TAC std_ss [equivalent_def]
+    RW_TAC std_ss [equivalent_of_solvables]
  (* applying the shared equivalent_tac *)
  >> equivalent_tac
  (* cleanup MAX and vsN *)

--- a/examples/lambda/barendregt/boehmScript.sml
+++ b/examples/lambda/barendregt/boehmScript.sml
@@ -737,47 +737,6 @@ Proof
  >> rw [Abbr ‘p3’]
 QED
 
-(* Definition 10.3.10 (ii) *)
-Definition is_faithful_def :
-    is_faithful p Fs pi =
-       !M N. M IN Fs /\ N IN Fs ==>
-            (subterm_eta_equiv p M N <=> equivalent (apply pi M) (apply pi N)) /\
-            (!X. IS_SOME (ltree_lookup (BT X M) p) <=>
-                 solvable (apply pi M))
-End
-
-Definition term_agrees_upto_def :
-    term_agrees_upto M N p <=>
-      !q. q <<= p ==> !X. ltree_el (BT X M) q = ltree_el (BT X N) q
-End
-
-(* Definition 10.3.10 (iv) *)
-val _ = set_fixity "agrees_upto" (Infixr 490);
-Definition agrees_upto_def :
-    $agrees_upto Fs p = !M N. M IN Fs /\ N IN Fs ==> term_agrees_upto M N p
-End
-
-(* Lemma 10.3.11 (3) [1. p.251] *)
-Theorem agrees_upto_lemma :
-    !Fs p. Fs agrees_upto p ==>
-           ?pi. Boehm_transform pi /\
-                !M N. M IN Fs /\ N IN Fs ==>
-                     (subterm_eta_equiv p M N <=>
-                      subterm_eta_equiv p (apply pi M) (apply pi N))
-Proof
-    cheat
-QED
-
-(* Proposition 10.3.13 [1, p.253]
-
-   Used by separability_thm
- *)
-Theorem agrees_upto_thm :
-    !Fs p. Fs agrees_upto p ==> ?pi. Boehm_transform pi /\ is_faithful p Fs pi
-Proof
-    cheat
-QED
-
 (*---------------------------------------------------------------------------*
  *  Separability of terms
  *---------------------------------------------------------------------------*)

--- a/examples/lambda/barendregt/head_reductionScript.sml
+++ b/examples/lambda/barendregt/head_reductionScript.sml
@@ -14,6 +14,7 @@ val _ = ParseExtras.temp_loose_equality()
 fun Store_thm(trip as (n,t,tac)) = store_thm trip before export_rewrites [n]
 
 Inductive hreduce1 :
+[~BETA:]
   (∀v M N. hreduce1 (LAM v M @@ N) ([N/v]M))
 [~LAM:]
   (∀v M1 M2. hreduce1 M1 M2 ⇒ hreduce1 (LAM v M1) (LAM v M2))
@@ -1320,12 +1321,19 @@ Proof
  >> rw []
 QED
 
-Theorem LAMl_size_hnf :
-    !vs y args. LAMl_size (LAMl vs (VAR y @* args)) = LENGTH vs
+Theorem LAMl_size_hnf[simp] :
+    LAMl_size (LAMl vs (VAR y @* args)) = LENGTH vs
 Proof
-    rpt GEN_TAC
- >> MATCH_MP_TAC LAMl_size_LAMl
+    MATCH_MP_TAC LAMl_size_LAMl
  >> Cases_on ‘args = []’ >- rw []
+ >> ‘?x l. args = SNOC x l’ by METIS_TAC [SNOC_CASES]
+ >> rw [appstar_SNOC]
+QED
+
+Theorem LAMl_size_hnf_absfree[simp] :
+    LAMl_size (VAR y @* args) = 0
+Proof
+    Cases_on ‘args = []’ >- rw []
  >> ‘?x l. args = SNOC x l’ by METIS_TAC [SNOC_CASES]
  >> rw [appstar_SNOC]
 QED

--- a/examples/lambda/barendregt/solvableScript.sml
+++ b/examples/lambda/barendregt/solvableScript.sml
@@ -238,7 +238,7 @@ Proof
  >> Q.ABBREV_TAC ‘fm = FEMPTY |++ ZIP (vs,Ns0)’
  >> Know ‘LAMl vs M @* Ns0 == fm ' M’
  >- (Q.UNABBREV_TAC ‘fm’ \\
-     MATCH_MP_TAC lameq_LAMl_appstar >> rw [])
+     MATCH_MP_TAC lameq_LAMl_appstar_ssub_closed >> rw [])
  >> DISCH_TAC
  >> ‘LAMl vs M @* Ns0 @* Ns1 == fm ' M @* Ns1’ by PROVE_TAC [lameq_appstar_cong]
  >> ‘fm ' M @* Ns1 == I’ by PROVE_TAC [lameq_TRANS, lameq_SYM]
@@ -290,7 +290,7 @@ Proof
  >> rw [solvable_def, closed_substitution_instances_def]
  >> Q.ABBREV_TAC ‘vss = FDOM fm’
  >> ‘FINITE vss’ by rw [FDOM_FINITE, Abbr ‘vss’]
- (* preparing for lameq_LAMl_appstar *)
+ (* preparing for lameq_LAMl_appstar_ssub_closed *)
  >> Q.ABBREV_TAC ‘vs = SET_TO_LIST vss’
  >> ‘ALL_DISTINCT vs’ by PROVE_TAC [Abbr ‘vs’, ALL_DISTINCT_SET_TO_LIST]
  >> Q.ABBREV_TAC ‘Ps = MAP (\v. fm ' v) vs’
@@ -316,7 +316,7 @@ Proof
  >> Rewr'
  >> DISCH_TAC
  >> Know ‘LAMl vs M @* Ps == (FEMPTY |++ ZIP (vs,Ps)) ' M’
- >- (MATCH_MP_TAC lameq_LAMl_appstar >> art [] \\
+ >- (MATCH_MP_TAC lameq_LAMl_appstar_ssub_closed >> art [] \\
      rw [Abbr ‘Ps’, EVERY_MEM, MEM_MAP] \\
      FIRST_X_ASSUM MATCH_MP_TAC \\
      POP_ASSUM MP_TAC \\
@@ -364,7 +364,7 @@ Proof
  >> Q.ABBREV_TAC ‘fm = FEMPTY |++ ZIP (vs,Ns0)’
  >> Know ‘LAMl vs M @* Ns0 == fm ' M’
  >- (Q.UNABBREV_TAC ‘fm’ \\
-     MATCH_MP_TAC lameq_LAMl_appstar >> rw [])
+     MATCH_MP_TAC lameq_LAMl_appstar_ssub_closed >> rw [])
  >> DISCH_TAC
  >> ‘LAMl vs M @* Ns0 @* Ns1 == fm ' M @* Ns1’ by PROVE_TAC [lameq_appstar_cong]
  >> ‘fm ' M @* Ns1 == I’ by PROVE_TAC [lameq_TRANS, lameq_SYM]
@@ -387,7 +387,7 @@ Proof
  >> Q.ABBREV_TAC ‘fm' = FEMPTY |++ ZIP (vs',Ns0')’
  >> Know ‘LAMl vs' M @* Ns0' == fm' ' M’
  >- (Q.UNABBREV_TAC ‘fm'’ \\
-     MATCH_MP_TAC lameq_LAMl_appstar >> rw [])
+     MATCH_MP_TAC lameq_LAMl_appstar_ssub_closed >> rw [])
  >> DISCH_TAC
  >> ‘LAMl vs' M @* Ns0' @* Ns1 == fm' ' M @* Ns1’ by PROVE_TAC [lameq_appstar_cong]
  >> MATCH_MP_TAC lameq_TRANS
@@ -502,7 +502,7 @@ Proof
         Know ‘fm = fm0 |+ (x,N)’
         >- (rw [Abbr ‘fm0’, DOMSUB_FUPDATE_THM, FUPDATE_ELIM]) >> Rewr' \\
         Know ‘(fm0 |+ (x,N)) ' M = fm0 ' ([N/x] M)’
-        >- (MATCH_MP_TAC ssub_update_apply' \\
+        >- (MATCH_MP_TAC ssub_update_apply_subst \\
             Q.PAT_X_ASSUM ‘!v. v IN FDOM fm ==> closed (fm ' v)’ MP_TAC \\
             rw [Abbr ‘fm0’, Abbr ‘N’, DOMSUB_FAPPLY_THM, closed_def]) >> Rewr' \\
         DISCH_TAC \\
@@ -666,11 +666,11 @@ Proof
  (* now we use arithmeticTheory.FUNPOW instead of locally defined one *)
  >> qabbrev_tac ‘Ms = GENLIST (\i. FUNPOW (APP K) m I) n’
  >> Q.EXISTS_TAC ‘Ms’
- (* applying lameq_LAMl_appstar and ssub_appstar *)
+ (* applying ssub_appstar *)
  >> MATCH_MP_TAC lameq_TRANS
  >> Q.EXISTS_TAC ‘(FEMPTY |++ ZIP (vs,Ms)) ' (VAR y @* Ns)’
  >> CONJ_TAC
- >- (MATCH_MP_TAC lameq_LAMl_appstar >> art [] \\
+ >- (MATCH_MP_TAC lameq_LAMl_appstar_ssub_closed >> art [] \\
      CONJ_TAC >- rw [Abbr ‘Ms’] \\
      rw [EVERY_EL, Abbr ‘Ms’, closed_def, FV_FUNPOW])
  >> REWRITE_TAC [ssub_appstar]
@@ -727,7 +727,7 @@ QED
 Theorem hnf_principle_hnf' =
    REWRITE_RULE [GSYM solvable_iff_has_hnf] hnf_principle_hnf
 
-Theorem principle_hnf_eq_self[simp] :
+Theorem principle_hnf_reduce[simp] :
     !M. hnf M ==> principle_hnf M = M
 Proof
     rw [principle_hnf_def]
@@ -745,7 +745,7 @@ Theorem principle_hnf_stable :
     !M. has_hnf M ==> principle_hnf (principle_hnf M) = principle_hnf M
 Proof
     rpt STRIP_TAC
- >> MATCH_MP_TAC principle_hnf_eq_self
+ >> MATCH_MP_TAC principle_hnf_reduce
  >> MATCH_MP_TAC hnf_principle_hnf >> art []
 QED
 
@@ -761,9 +761,7 @@ Proof
  >> qabbrev_tac ‘N = [VAR y/v] t’
  >> ‘hnf N’ by rw [Abbr ‘N’, GSYM fresh_tpm_subst]
  >> Know ‘M -h-> N’
- >- (qunabbrevl_tac [‘M’, ‘N’] \\
-     rw [Once hreduce1_cases] \\
-     qexistsl_tac [‘v’, ‘t’] >> rw [])
+ >- rw [Abbr ‘M’, Abbr ‘N’, hreduce1_BETA]
  >> rw [head_reduce1_def]
  >> qabbrev_tac ‘p = pcons M r (stopped_at N)’
  >> Suff ‘head_reduction_path M = p’ >- rw [Abbr ‘p’]
@@ -795,7 +793,7 @@ Theorem principle_hnf_LAMl_appstar_lemma[local] :
         principle_hnf (LAMl (MAP FST pi) t @* MAP VAR (MAP SND pi)) = tpm pi t
 Proof
     Induct_on ‘pi’ (* using SNOC_INDUCT *)
- >- rw [principle_hnf_eq_self]
+ >- rw [principle_hnf_reduce]
  >> rw [] (* rw [FOLDR_SNOC, MAP_SNOC] *)
  >> Cases_on ‘h’ (* ‘x’ *) >> fs []
  >> qabbrev_tac ‘M = LAMl (MAP FST pi) t’
@@ -804,9 +802,7 @@ Proof
  >> Know ‘principle_hnf (LAM q M @@ VAR r @* args) =
           principle_hnf ([VAR r/q] M @* args)’
  >- (MATCH_MP_TAC principle_hnf_hreduce1 \\
-     MATCH_MP_TAC hreduce1_rules_appstar >> simp [] \\
-     rw [Once hreduce1_cases] \\
-     qexistsl_tac [‘q’, ‘M’] >> rw [])
+     MATCH_MP_TAC hreduce1_rules_appstar >> rw [hreduce1_BETA])
  >> Rewr'
  >> Know ‘[VAR r/q] M = LAMl (MAP FST pi) ([VAR r/q] t)’
  >- (qunabbrev_tac ‘M’ \\
@@ -901,33 +897,29 @@ Proof
  >> MATCH_MP_TAC principle_hnf_LAMl_appstar_lemma >> rw []
 QED
 
-Theorem principle_hnf_reduce1 :
+Theorem principle_hnf_beta_reduce1 :
     !v t. hnf t ==> principle_hnf (LAM v t @@ VAR v) = t
 Proof
     rpt STRIP_TAC
  >> Know ‘principle_hnf (LAM v t @@ VAR v) =
           principle_hnf ([VAR v/v] t)’
  >- (MATCH_MP_TAC principle_hnf_hreduce1 \\
-     rw [Once hreduce1_cases] \\
-     qexistsl_tac [‘v’, ‘t’] >> rw [])
+     rw [hreduce1_BETA])
  >> Rewr'
- >> rw [principle_hnf_eq_self]
+ >> rw [principle_hnf_reduce]
 QED
 
-Theorem principle_hnf_reduce :
+Theorem principle_hnf_beta_reduce :
     !xs t. hnf t ==> principle_hnf (LAMl xs t @* (MAP VAR xs)) = t
 Proof
     Induct_on ‘xs’
- >- rw [principle_hnf_eq_self]
- >> rw []
+ >> rw [principle_hnf_reduce]
  >> qabbrev_tac ‘M = LAMl xs t’
  >> qabbrev_tac ‘args :term list = MAP VAR xs’
  >> Know ‘principle_hnf (LAM h M @@ VAR h @* args) =
           principle_hnf ([VAR h/h] M @* args)’
  >- (MATCH_MP_TAC principle_hnf_hreduce1 \\
-     MATCH_MP_TAC hreduce1_rules_appstar >> simp [] \\
-     rw [Once hreduce1_cases] \\
-     qexistsl_tac [‘h’, ‘M’] >> rw [])
+     MATCH_MP_TAC hreduce1_rules_appstar >> rw [hreduce1_BETA])
  >> Rewr'
  >> simp [Abbr ‘M’]
 QED
@@ -1021,6 +1013,7 @@ Proof
  >> MATCH_MP_TAC hreduces_lameq >> art []
 QED
 
+(* |- !M. solvable M ==> principle_hnf M == M *)
 Theorem lameq_principle_hnf' =
         REWRITE_RULE [GSYM solvable_iff_has_hnf] lameq_principle_hnf
 

--- a/examples/lambda/basics/termScript.sml
+++ b/examples/lambda/basics/termScript.sml
@@ -951,40 +951,80 @@ Proof
  >> SET_TAC []
 QED
 
-Theorem ssub_LAM[local] = List.nth(CONJUNCTS ssub_thm, 2)
-
-(* FIXME: can ‘(!y. y IN FDOM fm ==> closed (fm ' y))’ be removed? *)
-Theorem ssub_update_apply :
-    !fm. s NOTIN FDOM fm /\ (!y. y IN FDOM fm ==> closed (fm ' y)) ==>
-         (fm |+ (s,M)) ' N = [M/s] (fm ' (N :term))
+Theorem fresh_ssub:
+  ∀N. y ∉ FV N ∧ (∀k:string. k ∈ FDOM fm ⇒ y # fm ' k) ⇒ y # fm ' N
 Proof
-    rw [closed_def]
- >> Q.ID_SPEC_TAC ‘N’
+  ho_match_mp_tac nc_INDUCTION2 >>
+  qexists ‘fmFV fm’ >>
+  rw[] >> metis_tac[]
+QED
+
+Theorem ssub_SUBST:
+  ∀M.
+    (∀k. k ∈ FDOM fm ⇒ v # fm ' k) ∧ v ∉ FDOM fm ⇒
+    fm ' ([N/v]M) = [fm ' N / v] (fm ' M)
+Proof
+  ho_match_mp_tac nc_INDUCTION2 >>
+  qexists ‘fmFV fm ∪ {v} ∪ FV N’ >>
+  rw[] >> rw[lemma14b, SUB_VAR] >>
+  gvs[DECIDE “~p ∨ q ⇔ p ⇒ q”, PULL_FORALL] >>
+  ‘y # fm ' N’ suffices_by simp[SUB_THM] >>
+  irule fresh_ssub >> simp[]
+QED
+
+(* |- !v fm t.
+        v NOTIN FDOM fm /\ (!y. y IN FDOM fm ==> v # fm ' y) ==>
+        fm ' (LAM v t) = LAM v (fm ' t)
+ *)
+Theorem ssub_LAM = List.nth(CONJUNCTS ssub_thm, 2)
+
+Theorem ssub_update_apply :
+    !fm v N M. v NOTIN FDOM fm /\ (!k. k IN FDOM fm ==> closed (fm ' k)) ==>
+              (fm |+ (v,N)) ' M = [N/v] (fm ' (M :term))
+Proof
+    RW_TAC std_ss [closed_def]
+ >> Q.ID_SPEC_TAC ‘M’
  >> HO_MATCH_MP_TAC nc_INDUCTION2
- >> Q.EXISTS_TAC ‘s INSERT (FDOM fm UNION FV M)’
+ >> Q.EXISTS_TAC ‘v INSERT (FDOM fm UNION FV N)’
  >> rw [SUB_VAR, SUB_THM, ssub_thm, FAPPLY_FUPDATE_THM]
  >> TRY (METIS_TAC [])
  >- (MATCH_MP_TAC (GSYM lemma14b) \\
      METIS_TAC [NOT_IN_EMPTY])
- >> Suff ‘(fm |+ (s,M)) ' (LAM y N) = LAM y ((fm |+ (s,M)) ' N)’ >- rw []
- >> MATCH_MP_TAC ssub_LAM >> rw [FAPPLY_FUPDATE_THM]
+ >> Suff ‘(fm |+ (v,N)) ' (LAM y M) = LAM y ((fm |+ (v,N)) ' M)’ >- rw []
+ >> MATCH_MP_TAC ssub_LAM
+ >> rw [FAPPLY_FUPDATE_THM]
 QED
 
-(* NOTE: ‘closed M’ is additionally required *)
-Theorem ssub_update_apply' :
-    !fm. s NOTIN FDOM fm /\ (!y. y IN FDOM fm ==> closed (fm ' y)) /\ closed M ==>
-         (fm |+ (s,M)) ' N = fm ' ([M/s] N)
+(* NOTE: This theorem has the same antecedents as ssub_SUBST, plus:
+
+   ‘DISJOINT (FV N) (FDOM fm)’, which seems necessary.
+ *)
+Theorem ssub_update_apply_SUBST :
+    !M. (!k. k IN FDOM fm ==> v # fm ' k) /\ v NOTIN FDOM fm /\
+        DISJOINT (FDOM fm) (FV N) ==>
+        (fm |+ (v,N)) ' M = fm ' ([N/v] M)
 Proof
-    rw [closed_def]
- >> Q.ID_SPEC_TAC ‘N’
- >> HO_MATCH_MP_TAC nc_INDUCTION2
- >> Q.EXISTS_TAC ‘s INSERT (FDOM fm)’
+    HO_MATCH_MP_TAC nc_INDUCTION2
+ >> Q.EXISTS_TAC ‘v INSERT fmFV fm UNION FV M UNION FV N’
  >> rw [SUB_VAR, SUB_THM, ssub_thm, FAPPLY_FUPDATE_THM]
  >> TRY (METIS_TAC [])
- >- (MATCH_MP_TAC (GSYM ssub_value) >> art [])
- >> Know ‘(fm |+ (s,M)) ' (LAM y N) = LAM y ((fm |+ (s,M)) ' N)’
+ >- (MATCH_MP_TAC (GSYM ssub_14b) \\
+     rw [GSYM DISJOINT_DEF, Once DISJOINT_SYM])
+ >> Know ‘(fm |+ (v,N)) ' (LAM y M') = LAM y ((fm |+ (v,N)) ' M')’
  >- (MATCH_MP_TAC ssub_LAM >> rw [FAPPLY_FUPDATE_THM])
+ >> Rewr'
+ (* finally, applying IH *)
  >> rw []
+QED
+
+Theorem ssub_update_apply_subst :
+    !fm v N M. v NOTIN FDOM fm /\
+              (!k. k IN FDOM fm ==> closed (fm ' k)) /\ closed N ==>
+              (fm |+ (v,N)) ' M = fm ' ([N/v] M)
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC ssub_update_apply_SUBST >> art []
+ >> fs [closed_def, DISJOINT_DEF]
 QED
 
 (* ----------------------------------------------------------------------

--- a/src/list/src/rich_listScript.sml
+++ b/src/list/src/rich_listScript.sml
@@ -2965,6 +2965,14 @@ val MEM_FRONT = Q.store_thm ("MEM_FRONT",
    `!l e y. MEM y (FRONT (e::l)) ==> MEM y (e::l)`,
    Induct_on `l` THEN FULL_SIMP_TAC list_ss [DISJ_IMP_THM, MEM]);
 
+Theorem MEM_FRONT_NOT_NIL :
+    !l y. l <> [] /\ MEM y (FRONT l) ==> MEM y l
+Proof
+    rpt STRIP_TAC
+ >> Cases_on ‘l’ >> FULL_SIMP_TAC std_ss []
+ >> MATCH_MP_TAC MEM_FRONT >> ASM_REWRITE_TAC []
+QED
+
 val FRONT_APPEND = Q.store_thm ("FRONT_APPEND",
    `!l1 l2 e. FRONT (l1 ++ e::l2) = l1 ++ FRONT (e::l2)`,
    Induct_on `l1` THEN ASM_SIMP_TAC list_ss [FRONT_DEF])
@@ -2997,6 +3005,13 @@ val EL_FRONT = Q.store_thm ("EL_FRONT",
 val MEM_LAST = Q.store_thm ("MEM_LAST",
    `!e l. MEM (LAST (e::l)) (e::l)`,
    Induct_on `l` THEN ASM_SIMP_TAC arith_ss [LAST_CONS, Once MEM]);
+
+Theorem MEM_LAST_NOT_NIL :
+    !e l. l <> [] ==> MEM (LAST l) l
+Proof
+    rpt STRIP_TAC
+ >> Cases_on ‘l’ >> FULL_SIMP_TAC std_ss [MEM_LAST]
+QED
 
 val DROP_CONS_EL = Q.store_thm ("DROP_CONS_EL",
    `!n l. n < LENGTH l ==> (DROP n l = EL n l :: DROP (SUC n) l)`,
@@ -3082,6 +3097,15 @@ Theorem ALL_DISTINCT_TAKE :
 Proof
     Induct >> simp[TAKE_def] >> rw[]
  >> METIS_TAC [MEM_TAKE]
+QED
+
+Theorem ALL_DISTINCT_FRONT :
+    !l. l <> [] /\ ALL_DISTINCT l ==> ALL_DISTINCT (FRONT l)
+Proof
+    rpt STRIP_TAC
+ >> ‘ALL_DISTINCT l = ALL_DISTINCT (SNOC (LAST l) (FRONT l))’
+      by rw [SNOC_LAST_FRONT]
+ >> FULL_SIMP_TAC std_ss [ALL_DISTINCT_SNOC]
 QED
 
 val MAP_SND_FILTER_NEQ = Q.store_thm("MAP_SND_FILTER_NEQ",


### PR DESCRIPTION
Hi,

This is the last piece of (easy) work on λ-calculus mechanisation, before Böhm trees are first involved.

If a head normal form (hnf) is given by `M := LAMl vs (VAR y @* Ns)` , then:
- It is _λ-free_ if `LENGTH vs = 0` (or `vs = []`), or just `~is_abs M`
- It is _head original_ if `y` is not free in any hnf children term, i.e. `!N. MEM N Ns ==> y # N`,
- It's _ready_ if it's either unsolvable or has a λ-free and head original hnf.

Due to α-conversions, without using dB encodings the concept `head_original` has to be defined in the following complicated way, by calling `principle_hnf` once to remove the potential outer abstractions of input term:  (*NOTE*: `hnf_headvar M1` is an overload to `THE_VAR (hnf_head M1)`, where `THE_VAR (VAR y) = y` is currently put in `chap2Theory`)
```
head_original_def
⊢ ∀M0.
    head_original M0 ⇔
    (let
       n = LAMl_size M0;
       vs = FRESH_list n (FV M0);
       M1 = principle_hnf (M0 ·· MAP VAR vs)
     in
       EVERY (λe. hnf_headvar M1 # e) (hnf_children M1))
```
while the definition `is_ready` is relatively easy and straightforward:
```
is_ready_def
⊢ ∀M. is_ready M ⇔
      unsolvable M ∨ ∃N. M == N ∧ hnf N ∧ ¬is_abs N ∧ head_original N
```
But then, I managed to eliminate `head_original` and prove the following easier "equivalent definition" of `is_ready`:
```
is_ready_alt
⊢ ∀M. is_ready M ⇔
      unsolvable M ∨ ∃y Ns. M == VAR y ·· Ns ∧ EVERY (λe. y # e) Ns
```

With the above definitions, the following stage lemma (Lemma 10.3.6 (i), page 247 of [Barengredt 1984]) is proved, saying for any λ-term there exists a Böhm transform π such that π(M) is _ready_.
```
Boehm_transform_is_ready_exists
⊢ ∀M. ∃pi. Boehm_transform pi ∧ is_ready (apply pi M)
```

P. S. The next lemma, Lemma 10.3.6 (ii) will show that, for any λ-term M, there exists a Böhm transform π to access any node (at path α) of the Böhm tree BT(M), the resulting term is a substitution instance of the actual tree node, and is _ready_.

--Chun