### PR TITLE
Fix examples/l3-machine-code/arm/step/arm_stepLib for disjnorm

### DIFF
--- a/examples/l3-machine-code/arm/step/arm_stepLib.sml
+++ b/examples/l3-machine-code/arm/step/arm_stepLib.sml
@@ -1661,7 +1661,7 @@ in
          thm |> Thm.INST s
              |> REWRITE_RULE [dual_rwt, v2w_13_15_rwts, v2w_ground4, DecodeVFP]
              |> Conv.RIGHT_CONV_RULE EVAL_DATATYPE_CONV
-             |> SIMP_RULE bool_ss
+             |> SIMP_RULE (bool_ss -* ["lift_disj_eq", "lift_imp_disj"])
                   [pairTheory.UNCURRY_DEF, rand_uncurry, ConditionPassed_enc]
       end
 end


### PR DESCRIPTION
`stateLib.spec` has been broken for certain ARM instructions since https://github.com/HOL-Theorem-Prover/HOL/commit/4875b1b60d4ee6357932f6ca7e384107130d1169 was merged. This PR fixes it.

Before this PR:

```
$ echo 'load "arm_progLib"; arm_progLib.arm_spec_hex "e12fff1e"; (* bx lr *)' \
    | (cd examples/l3-machine-code/arm/prog && ../../../../bin/hol)

...

Proof of 

SPEC ARM_MODEL
  (cond
     (GoodMode $var$(%v2) ∧ v2w [x12; x13; x14; x15] ≠ 15w ∧
      ¬(v2w [x0; x1; x2; x3] = 15w ⇒
       v2w [x4; x5; x6; x7] = 15w ⇒
       v2w [x8; x9; x10; x11] ≠ 15w) ∧
      (word_bit 1 $var$(%v5) ⇒ word_bit 0 $var$(%v5)) ∧ aligned 2 pc) *
   arm_Architecture ARMv7_A * arm_exception NoException * arm_CPSR_J F *
   arm_CPSR_E F * arm_CPSR_T F * arm_CPSR_M $var$(%v2) *
   arm_Extensions Extension_Security F *
   arm_REG (R_mode $var$(%v2) (v2w [x12; x13; x14; x15])) $var$(%v5) *
   arm_REG RName_PC pc)
  {(pc,
    v2w
      [T; T; T; F; F; F; F; T; F; F; T; F; x0; x1; x2; x3; x4; x5; x6; x7;
       x8; x9; x10; x11; F; F; F; T; x12; x13; x14; x15])}
  (arm_Architecture ARMv7_A * arm_exception NoException * arm_CPSR_J F *
   arm_CPSR_E F * arm_CPSR_T (word_bit 0 $var$(%v5)) *
   arm_CPSR_M $var$(%v2) * arm_Extensions Extension_Security F *
   arm_REG (R_mode $var$(%v2) (v2w [x12; x13; x14; x15])) $var$(%v5) *
   arm_REG RName_PC
     (if word_bit 0 $var$(%v5) then align 1 $var$(%v5) else $var$(%v5)))

failed.
Exception-
   HOL_ERR
     {message = "first subgoal not solved by second tactic",
      origin_function = "THEN1", origin_structure = "Tactical"} raised
```

After this PR:

```
$ echo 'load "arm_progLib"; arm_progLib.arm_spec_hex "e12fff1e"; (* bx lr *)' \
    | (cd examples/l3-machine-code/arm/prog && ../../../../bin/hol)

...

val it =
   [ []
    ⊢ SPEC ARM_MODEL
        (arm_REG (R_mode mode 14w) r14 * arm_CONFIG (vfp,ARMv7_A,F,F,mode) *
         arm_PC pc *
         cond
           ((word_bit 1 r14 ⇒ word_bit 0 r14) ∧
            (aligned 2 pc ⇒
             if word_bit 0 r14 then aligned 2 (align 1 r14)
             else aligned 2 r14))) {(pc,0xE12FFF1Ew)}
        (arm_REG (R_mode mode 14w) r14 *
         arm_CONFIG (vfp,ARMv7_A,F,word_bit 0 r14,mode) *
         arm_PC (if word_bit 0 r14 then align 1 r14 else r14))]: thm list
```