### PR TITLE
Add ltree_every and ltree_finite_branching

### DIFF
--- a/src/coalgebras/ltreeScript.sml
+++ b/src/coalgebras/ltreeScript.sml
@@ -693,6 +693,13 @@ CoInductive ltree_every :
     P a ts /\ every (ltree_every P) ts ==> (ltree_every P (Branch a ts))
 End
 
+Theorem ltree_every_rewrite[simp] :
+    ltree_every P (Branch a ts) <=> P a ts /\ every (ltree_every P) ts
+Proof
+    GEN_REWRITE_TAC (RATOR_CONV o ONCE_DEPTH_CONV) empty_rewrites [ltree_every_cases]
+ >> EQ_TAC >> rw []
+QED
+
 Definition ltree_finite_branching_def :
     ltree_finite_branching = ltree_every (\a ts. LFINITE ts)
 End
@@ -745,6 +752,19 @@ Proof
  >> Q.PAT_X_ASSUM ‘!t. P t ==> _’ (drule_then STRIP_ASSUME_TAC)
  >> qexistsl_tac [‘a’, ‘fromList ts’]
  >> rw [LFINITE_fromList, every_fromList_EVERY]
+QED
+
+Theorem ltree_finite_branching_rewrite[simp] :
+    ltree_finite_branching (Branch a ts) <=>
+    LFINITE ts /\ every ltree_finite_branching ts
+Proof
+    GEN_REWRITE_TAC (RATOR_CONV o ONCE_DEPTH_CONV) empty_rewrites
+      [ltree_finite_branching_cases]
+ >> EQ_TAC >> rw []
+ >- rw [LFINITE_fromList]
+ >- rw [every_fromList_EVERY]
+ >> ‘?l. ts = fromList l’ by METIS_TAC [LFINITE_IMP_fromList]
+ >> fs [every_fromList_EVERY]
 QED
 
 (*---------------------------------------------------------------------------*

--- a/src/coalgebras/ltreeScript.sml
+++ b/src/coalgebras/ltreeScript.sml
@@ -696,7 +696,7 @@ End
 Theorem ltree_every_rewrite[simp] :
     ltree_every P (Branch a ts) <=> P a ts /\ every (ltree_every P) ts
 Proof
-    GEN_REWRITE_TAC (RATOR_CONV o ONCE_DEPTH_CONV) empty_rewrites [ltree_every_cases]
+    SIMP_TAC std_ss [Once ltree_every_cases]
  >> EQ_TAC >> rw []
 QED
 
@@ -758,8 +758,7 @@ Theorem ltree_finite_branching_rewrite[simp] :
     ltree_finite_branching (Branch a ts) <=>
     LFINITE ts /\ every ltree_finite_branching ts
 Proof
-    GEN_REWRITE_TAC (RATOR_CONV o ONCE_DEPTH_CONV) empty_rewrites
-      [ltree_finite_branching_cases]
+    SIMP_TAC std_ss [ltree_finite_branching_cases]
  >> EQ_TAC >> rw []
  >- rw [LFINITE_fromList]
  >- rw [every_fromList_EVERY]


### PR DESCRIPTION
Currently in `ltreeTheory` (co-inductive lazy tree, which allows for both infinite depth
  and infinite breadth), there's no predicate asserting the tree is "finite branching" (either finite or infinite depth). The existing `ltree_finite` states for both finite depth and breadth, i.e. the number of subtrees is finite.

It seems that, a `every` predicate for each subtree (thus both the node data and children are accessible) of a ltree can be simply defined like this by `CoInductive`:
```
CoInductive ltree_every :
    P a ts /\ every (ltree_every P) ts ==> (ltree_every P (Branch a ts))
End
```

And then `ltree_finite_branching` simply says that each subtree has finite number of directly children:
```
   [ltree_finite_branching_def]  Definition
      
      ⊢ ltree_finite_branching = ltree_every (λa ts. LFINITE ts)
```

To ease the use of `ltree_finite_branching`, just like it's co-inductively defined by `CoInductive`, the following 3 theorems (rules, cases, and coind) are manually proved (while the 3 for `ltree_every` are auto-generated):

```
   [ltree_finite_branching_cases]  Theorem      
      ⊢ ∀t. ltree_finite_branching t ⇔
            ∃a ts.
              t = Branch a (fromList ts) ∧ EVERY ltree_finite_branching ts
   
   [ltree_finite_branching_coind]  Theorem      
      ⊢ ∀P. (∀t. P t ⇒ ∃a ts. t = Branch a (fromList ts) ∧ EVERY P ts) ⇒
            ∀t. P t ⇒ ltree_finite_branching t
   
   [ltree_finite_branching_rules]  Theorem      
      ⊢ ∀a ts.
          EVERY ltree_finite_branching ts ⇒
          ltree_finite_branching (Branch a (fromList ts))
```

Please review the correctness (of the definitions).
