### PR TITLE
HolSmt: add support for the cvc5 SMT solver + doc update

### DIFF
--- a/Manual/Description/HolSmt.tex
+++ b/Manual/Description/HolSmt.tex
@@ -35,43 +35,46 @@ be much better).
 
 \subsection{Interface}
 
-The library currently provides three tactics to invoke different SMT
-solvers, namely \ml{YICES\_TAC}, \ml{Z3\_ORACLE\_TAC}, and
-\ml{Z3\_TAC}.  These tactics are defined in the \ml{HolSmtLib}
-structure, which is the library's main entry point.  Given a
-goal~$(\Gamma, \varphi)$ (where $\Gamma$ is a list of assumptions, and
-$\varphi$ is the goal's conclusion), each tactic returns (i)~an empty
-list of new goals, and (ii)~a validation function that returns a
-theorem~$\Gamma' \vdash \varphi$ (with $\Gamma' \subseteq \Gamma$).
-These tactics fail if the SMT solver cannot prove the
-goal.\footnote{Internally, the goal's assumptions and the
-  \emph{negated} conclusion are passed to the SMT solver.  If the SMT
-  solver determines that these formulas are unsatisfiable, then the
-  (unnegated) conclusion must be provable from the assumptions.}  In
+The library currently provides four tactics to invoke different SMT
+solvers, namely \ml{CVC\_ORACLE\_TAC}, \ml{YICES\_TAC},
+\ml{Z3\_ORACLE\_TAC}, and \ml{Z3\_TAC}.  These tactics are defined in
+the \ml{HolSmtLib} structure, which is the library's main entry point.
+Given a goal~$(\Gamma, \varphi)$ (where $\Gamma$ is a list of
+assumptions, and $\varphi$ is the goal's conclusion), each tactic
+returns (i)~an empty list of new goals, and (ii)~a validation function
+that returns a theorem~$\Gamma' \vdash \varphi$ (with $\Gamma'
+\subseteq \Gamma$). These tactics fail if the SMT solver cannot prove
+the goal.\footnote{Internally, the goal's assumptions and the
+\emph{negated} conclusion are passed to the SMT solver.  If the SMT
+solver determines that these formulas are unsatisfiable, then the
+(unnegated) conclusion must be provable from the assumptions.}  In
 other words, these tactics solve the goal (or fail).  As with other
 tactics, \ml{Tactical.TAC\_PROOF} can be used to derive functions of
 type \ml{goal -> thm}.
 
 For each tactic, the \ml{HolSmtLib} structure additionally provides a
 corresponding function of type \ml{term -> thm}.  These functions are
-called \ml{YICES\_PROVE}, \ml{Z3\_ORACLE\_PROVE}, and \ml{Z3\_PROVE},
-respectively.  Applied to a formula $\varphi$, they return the theorem
-$\emptyset \vdash \varphi$ (or fail).
+called \ml{CVC\_ORACLE\_PROVE}, \ml{YICES\_PROVE},
+\ml{Z3\_ORACLE\_PROVE}, and \ml{Z3\_PROVE}, respectively.  Applied to
+a formula $\varphi$, they return the theorem $\emptyset \vdash
+\varphi$ (or fail).
 
 \paragraph{Oracles vs.\ proof reconstruction}
 
-\ml{YICES\_TAC} and \ml{Z3\_ORACLE\_TAC} use the SMT solver (Yices and
-Z3, respectively) as an oracle: the solver's result is trusted.  Bugs
-in the SMT solver or in \ml{HolSmtLib} could potentially lead to
-inconsistent theorems.  Accordingly, the derived theorem is tagged
-with an oracle tag.
+\ml{CVC\_ORACLE\_TAC}, \ml{YICES\_TAC} and \ml{Z3\_ORACLE\_TAC} use
+the SMT solver (cvc5, Yices and Z3, respectively) as an oracle: the
+solver's result is trusted.  Bugs in the SMT solver or in
+\ml{HolSmtLib} could potentially lead to inconsistent theorems.
+Accordingly, the derived theorem is tagged with an oracle tag.
 
 \ml{Z3\_TAC}, on the other hand, performs proof reconstruction.  It
 requests a detailed proof from Z3, which is then checked in \HOL{}.
 One obtains a proper \HOL{} theorem; no (additional) oracle tags are
 introduced. However, Z3's proofs do not always contain enough
 information to allow efficient checking in \HOL{}; therefore, proof
-reconstruction may be slow or fail.
+reconstruction may be slow or fail. Furthermore, proof reconstruction
+only works with Z3~2.19. Newer versions of Z3 are only supported as an
+oracle, currently.
 
 \paragraph{Supported subsets of higher-order logic}
 
@@ -90,12 +93,12 @@ minus, \holtxt{DIV}, \holtxt{MOD}, \holtxt{ABS}, \holtxt{MIN},
 \holtxt{real}), function application, lambda abstraction, tuple
 selectors \holtxt{FST} and \holtxt{SND}, and various word operations.
 
-Z3 is integrated via a more restrictive translation into SMT-LIB~2
-format, described below.  Therefore, Yices is typically the solver of
-choice at the moment (unless you need proof reconstruction, which is
-available for Z3 only).  However, there are a few operations (\eg,
-specific word operations) that are supported by the SMT-LIB format,
-but not by Yices.  See \ml{selftest.sml} for further details.
+cvc5 and Z3 are integrated via a more restrictive translation into
+SMT-LIB~2 format, described below.  Therefore, Yices is typically the
+solver of choice at the moment (unless you need proof reconstruction,
+which is available for Z3 only).  However, there are a few operations
+(\eg, specific word operations) that are supported by the SMT-LIB
+format, but not by Yices.  See \ml{selftest.sml} for further details.
 
 Terms of higher-order logic that are not supported by the respective
 target solver/\allowbreak translation are typically treated in one of
@@ -135,27 +138,31 @@ three ways:
 - show_tags := true;
 > val it = () : unit
 
-- YICES_PROVE ``(a ==> b) /\ (b ==> a) = (a=b)``;
+- CVC_ORACLE_PROVE ``(a ==> b) /\ (b ==> a) <=> (a <=> b)``;
 > val it = [oracles: DISK_THM, HolSmtLib] [axioms: ] []
-           |- (a ==> b) /\ (b ==> a) = (a = b) : thm
+           |- (a ==> b) /\ (b ==> a) <=> (a <=> b) : thm
 
-- Z3_ORACLE_PROVE ``(a ==> b) /\ (b ==> a) = (a=b)``;
+- YICES_PROVE ``(a ==> b) /\ (b ==> a) <=> (a <=> b)``;
 > val it = [oracles: DISK_THM, HolSmtLib] [axioms: ] []
-           |- (a ==> b) /\ (b ==> a) = (a = b) : thm
+           |- (a ==> b) /\ (b ==> a) <=> (a <=> b) : thm
 
-- Z3_PROVE ``(a ==> b) /\ (b ==> a) = (a=b)``;
+- Z3_ORACLE_PROVE ``(a ==> b) /\ (b ==> a) <=> (a <=> b)``;
+> val it = [oracles: DISK_THM, HolSmtLib] [axioms: ] []
+           |- (a ==> b) /\ (b ==> a) <=> (a <=> b) : thm
+
+- Z3_PROVE ``(a ==> b) /\ (b ==> a) <=> (a <=> b)``;
 > val it = [oracles: DISK_THM] [axioms: ] []
-           |- (a ==> b) /\ (b ==> a) = (a = b) : thm
+           |- (a ==> b) /\ (b ==> a) <=> (a <=> b) : thm
 \end{verbatim}
 \end{session}
 
 \paragraph{Support for the SMT-LIB 2 file format}
 
-SMT-LIB (see \url{http://combination.cs.uiowa.edu/smtlib/}) is the
-standard input format for SMT solvers.  \ml{HolSmtLib} supports (a
-subset of) version~2.0 of this format.  A translation of \HOL{} terms
-into SMT-LIB~2 format is available in \ml{SmtLib.sml}, and a parser
-for SMT-LIB~2 files (translating them into \HOL{} types, terms, and
+SMT-LIB (see \url{https://smtlib.cs.uiowa.edu/}) is the standard input
+format for SMT solvers.  \ml{HolSmtLib} supports (a subset of)
+version~2.0 of this format.  A translation of \HOL{} terms into
+SMT-LIB~2 format is available in \ml{SmtLib.sml}, and a parser for
+SMT-LIB~2 files (translating them into \HOL{} types, terms, and
 formulas) can be found in \ml{SmtLib\_Parser.sml}, with auxiliary
 functions in \ml{SmtLib\_\{Logics,Theories\}.sml}.
 
@@ -188,40 +195,48 @@ delete temporary files automatically, \eg, when \HOL{} exits).
 
 \subsection{Installing SMT solvers}
 
-\ml{HolSmtLib} has been tested with Yices~1.0.29 and Z3~2.19. Later
-versions may or may not work.  (Yices~2 is not supported.)  To use
-\ml{HolSmtLib}, you need to install at least one of these SMT solvers
-on your machine.  As mentioned before, Yices supports a larger
-fragment of higher-order logic than Z3, but proof reconstruction has
-been implemented only for Z3.
+\ml{HolSmtLib} has been tested with cvc5~1.0.8, Yices~1.0.29, Z3~2.19
+and Z3~4.8.17. Later versions may or may not work.  (Yices~2 is not
+supported.)  To use \ml{HolSmtLib}, you need to install at least one
+of these SMT solvers on your machine.  As mentioned before, Yices
+supports a larger fragment of higher-order logic than Z3, but proof
+reconstruction has been implemented only for Z3~2.19.
+
+cvc5 is available for various platforms from
+\url{https://cvc5.github.io/}. After installation, you must set the
+environment variable {\tt \$HOL4\_CVC\_EXECUTABLE} to the pathname of
+the cvc5 executable, \eg, {tt /usr/bin/cvc5}, before you invoke \HOL.
 
 Yices is available for various platforms from
-\url{http://yices.csl.sri.com/}.  After installation, you must set the
-environment variable {\tt \$HOL4\_YICES\_EXECUTABLE} to the name of
-the Yices executable, \eg, {\tt /bin/yices}, before you invoke \HOL.
+\url{https://yices.csl.sri.com/}.  After installation, you must set
+the environment variable {\tt \$HOL4\_YICES\_EXECUTABLE} to the
+pathname of the Yices executable, \eg, {\tt /bin/yices}, before you
+invoke \HOL.
 
-The Z3 website,
-\url{http://research.microsoft.com/en-us/um/redmond/projects/z3/},
-provides Windows and Linux versions of the solver.  Alternatively, the
-Windows version can be installed on Linux and Mac OS~X---see the
-instructions at
-\url{http://www4.in.tum.de/~boehmes/z3.html}.\footnote{Later versions
-  of Z3 than 2.19 are available for Mac OS~X directly, but not
-  supported by \HOL.}  After installation, you must set the
-environment variable {\tt \$HOL4\_Z3\_EXECUTABLE} to the name of the
-Z3 executable, \eg, {\tt /bin/z3}, before you invoke \HOL.
+Precompiled binaries of Z3~2.19 for Linux can be downloaded from
+\url{https://github.com/Z3Prover/bin/tree/master/legacy}. Note that
+Z3~2.19.1 apparently cannot parse real literals (even though Z3~2.19
+can), so that version is not recommended since it won't work with
+reals. After installation, you must set the environment variable {\tt
+\$HOL4\_Z3\_EXECUTABLE} to the pathname of the Z3 executable, \eg,
+{\tt /bin/z3}, before you invoke \HOL.
+
+Newer versions of Z3 are available at
+\url{https://github.com/Z3Prover/z3}. After installation, you must set
+the environment variable {\tt \$HOL4\_Z3\_EXECUTABLE} to the pathname
+of the Z3 executable, \eg, {\tt /bin/z3}, before you invoke \HOL.
 
 It should be relatively straightforward to integrate other SMT solvers
 that support the SMT-LIB~2 input format as oracles.  However, this
 will involve a (typically small) amount of Standard ML programming,
-\eg, to interpret the solver's output.  See \ml{Z3.sml} for some
-relevant code.
+\eg, to interpret the solver's output.  See \ml{CVC.sml} and
+\ml{Z3.sml} for some relevant code.
 
 \subsection{Wishlist}
 
 The following features have not been implemented yet.  Please submit
 additional feature requests (or code contributions) via
-\url{http://github.com/HOL-Theorem-Prover/HOL}.
+\url{https://github.com/HOL-Theorem-Prover/HOL}.
 
 \paragraph{Counterexamples}
 
@@ -231,19 +246,24 @@ satisfying assignment.  This assignment could be displayed to the
 theorem, similar to the way \ml{HolSatLib} treats satisfying
 assignments.
 
-\paragraph{Proof reconstruction for other SMT solvers}
+\paragraph{Proof reconstruction}
 
-Proof reconstruction has been implemented only for Z3.  Several other
-SMT solvers can produce proofs, and it would be nice to offer \HOL{}
-users more choice.  However, in the absence of a standard proof format
-for SMT solvers, it is perhaps not worth the implementation effort.
+Proof reconstruction has been implemented only for Z3~2.19. It would
+be desirable to implement it for newer versions of Z3, since Z3~2.19
+is quite old and is only available as a binary.
 
-\paragraph{Support for Z3's SMT-LIB extensions}
+Several other SMT solvers can also produce proofs, and it would be
+nice to offer \HOL{} users more choice.  However, in the absence of a
+standard proof format for SMT solvers, it is perhaps not worth the
+implementation effort.
 
-Z3 supports extensions of the SMT-LIB language, \eg, data types.
-\ml{HolSmtLib} does not utilize these extensions yet when calling Z3.
-This would require the translation for Z3 to be distinct from the
-generic SMT-LIB translation.
+\paragraph{Support for cvc5's and Z3's SMT-LIB extensions}
+
+cvc5 and Z3 support extensions of the SMT-LIB language, \eg, data
+types, sets, multisets/bags and strings. \ml{HolSmtLib} does not
+utilize these extensions yet when calling these SMT solvers. This
+would require the translation for these solvers to be distinct from
+the generic SMT-LIB translation.
 
 \paragraph{SMT solvers as a web service}
 

--- a/Manual/Translations/IT/Description/HolSmt.tex
+++ b/Manual/Translations/IT/Description/HolSmt.tex
@@ -35,43 +35,46 @@ be much better).
 
 \subsection{Interface}
 
-The library currently provides three tactics to invoke different SMT
-solvers, namely \ml{YICES\_TAC}, \ml{Z3\_ORACLE\_TAC}, and
-\ml{Z3\_TAC}.  These tactics are defined in the \ml{HolSmtLib}
-structure, which is the library's main entry point.  Given a
-goal~$(\Gamma, \varphi)$ (where $\Gamma$ is a list of assumptions, and
-$\varphi$ is the goal's conclusion), each tactic returns (i)~an empty
-list of new goals, and (ii)~a validation function that returns a
-theorem~$\Gamma' \vdash \varphi$ (with $\Gamma' \subseteq \Gamma$).
-These tactics fail if the SMT solver cannot prove the
-goal.\footnote{Internally, the goal's assumptions and the
-  \emph{negated} conclusion are passed to the SMT solver.  If the SMT
-  solver determines that these formulas are unsatisfiable, then the
-  (unnegated) conclusion must be provable from the assumptions.}  In
+The library currently provides four tactics to invoke different SMT
+solvers, namely \ml{CVC\_ORACLE\_TAC}, \ml{YICES\_TAC},
+\ml{Z3\_ORACLE\_TAC}, and \ml{Z3\_TAC}.  These tactics are defined in
+the \ml{HolSmtLib} structure, which is the library's main entry point.
+Given a goal~$(\Gamma, \varphi)$ (where $\Gamma$ is a list of
+assumptions, and $\varphi$ is the goal's conclusion), each tactic
+returns (i)~an empty list of new goals, and (ii)~a validation function
+that returns a theorem~$\Gamma' \vdash \varphi$ (with $\Gamma'
+\subseteq \Gamma$). These tactics fail if the SMT solver cannot prove
+the goal.\footnote{Internally, the goal's assumptions and the
+\emph{negated} conclusion are passed to the SMT solver.  If the SMT
+solver determines that these formulas are unsatisfiable, then the
+(unnegated) conclusion must be provable from the assumptions.}  In
 other words, these tactics solve the goal (or fail).  As with other
 tactics, \ml{Tactical.TAC\_PROOF} can be used to derive functions of
 type \ml{goal -> thm}.
 
 For each tactic, the \ml{HolSmtLib} structure additionally provides a
 corresponding function of type \ml{term -> thm}.  These functions are
-called \ml{YICES\_PROVE}, \ml{Z3\_ORACLE\_PROVE}, and \ml{Z3\_PROVE},
-respectively.  Applied to a formula $\varphi$, they return the theorem
-$\emptyset \vdash \varphi$ (or fail).
+called \ml{CVC\_ORACLE\_PROVE}, \ml{YICES\_PROVE},
+\ml{Z3\_ORACLE\_PROVE}, and \ml{Z3\_PROVE}, respectively.  Applied to
+a formula $\varphi$, they return the theorem $\emptyset \vdash
+\varphi$ (or fail).
 
 \paragraph{Oracles vs.\ proof reconstruction}
 
-\ml{YICES\_TAC} and \ml{Z3\_ORACLE\_TAC} use the SMT solver (Yices and
-Z3, respectively) as an oracle: the solver's result is trusted.  Bugs
-in the SMT solver or in \ml{HolSmtLib} could potentially lead to
-inconsistent theorems.  Accordingly, the derived theorem is tagged
-with an oracle tag.
+\ml{CVC\_ORACLE\_TAC}, \ml{YICES\_TAC} and \ml{Z3\_ORACLE\_TAC} use
+the SMT solver (cvc5, Yices and Z3, respectively) as an oracle: the
+solver's result is trusted.  Bugs in the SMT solver or in
+\ml{HolSmtLib} could potentially lead to inconsistent theorems.
+Accordingly, the derived theorem is tagged with an oracle tag.
 
 \ml{Z3\_TAC}, on the other hand, performs proof reconstruction.  It
 requests a detailed proof from Z3, which is then checked in \HOL{}.
 One obtains a proper \HOL{} theorem; no (additional) oracle tags are
 introduced. However, Z3's proofs do not always contain enough
 information to allow efficient checking in \HOL{}; therefore, proof
-reconstruction may be slow or fail.
+reconstruction may be slow or fail. Furthermore, proof reconstruction
+only works with Z3~2.19. Newer versions of Z3 are only supported as an
+oracle, currently.
 
 \paragraph{Supported subsets of higher-order logic}
 
@@ -90,12 +93,12 @@ minus, \holtxt{DIV}, \holtxt{MOD}, \holtxt{ABS}, \holtxt{MIN},
 \holtxt{real}), function application, lambda abstraction, tuple
 selectors \holtxt{FST} and \holtxt{SND}, and various word operations.
 
-Z3 is integrated via a more restrictive translation into SMT-LIB~2
-format, described below.  Therefore, Yices is typically the solver of
-choice at the moment (unless you need proof reconstruction, which is
-available for Z3 only).  However, there are a few operations (\eg,
-specific word operations) that are supported by the SMT-LIB format,
-but not by Yices.  See \ml{selftest.sml} for further details.
+cvc5 and Z3 are integrated via a more restrictive translation into
+SMT-LIB~2 format, described below.  Therefore, Yices is typically the
+solver of choice at the moment (unless you need proof reconstruction,
+which is available for Z3 only).  However, there are a few operations
+(\eg, specific word operations) that are supported by the SMT-LIB
+format, but not by Yices.  See \ml{selftest.sml} for further details.
 
 Terms of higher-order logic that are not supported by the respective
 target solver/\allowbreak translation are typically treated in one of
@@ -135,27 +138,31 @@ three ways:
 - show_tags := true;
 > val it = () : unit
 
-- YICES_PROVE ``(a ==> b) /\ (b ==> a) = (a=b)``;
+- CVC_ORACLE_PROVE ``(a ==> b) /\ (b ==> a) <=> (a <=> b)``;
 > val it = [oracles: DISK_THM, HolSmtLib] [axioms: ] []
-           |- (a ==> b) /\ (b ==> a) = (a = b) : thm
+           |- (a ==> b) /\ (b ==> a) <=> (a <=> b) : thm
 
-- Z3_ORACLE_PROVE ``(a ==> b) /\ (b ==> a) = (a=b)``;
+- YICES_PROVE ``(a ==> b) /\ (b ==> a) <=> (a <=> b)``;
 > val it = [oracles: DISK_THM, HolSmtLib] [axioms: ] []
-           |- (a ==> b) /\ (b ==> a) = (a = b) : thm
+           |- (a ==> b) /\ (b ==> a) <=> (a <=> b) : thm
 
-- Z3_PROVE ``(a ==> b) /\ (b ==> a) = (a=b)``;
+- Z3_ORACLE_PROVE ``(a ==> b) /\ (b ==> a) <=> (a <=> b)``;
+> val it = [oracles: DISK_THM, HolSmtLib] [axioms: ] []
+           |- (a ==> b) /\ (b ==> a) <=> (a <=> b) : thm
+
+- Z3_PROVE ``(a ==> b) /\ (b ==> a) <=> (a <=> b)``;
 > val it = [oracles: DISK_THM] [axioms: ] []
-           |- (a ==> b) /\ (b ==> a) = (a = b) : thm
+           |- (a ==> b) /\ (b ==> a) <=> (a <=> b) : thm
 \end{verbatim}
 \end{session}
 
 \paragraph{Support for the SMT-LIB 2 file format}
 
-SMT-LIB (see \url{http://combination.cs.uiowa.edu/smtlib/}) is the
-standard input format for SMT solvers.  \ml{HolSmtLib} supports (a
-subset of) version~2.0 of this format.  A translation of \HOL{} terms
-into SMT-LIB~2 format is available in \ml{SmtLib.sml}, and a parser
-for SMT-LIB~2 files (translating them into \HOL{} types, terms, and
+SMT-LIB (see \url{https://smtlib.cs.uiowa.edu/}) is the standard input
+format for SMT solvers.  \ml{HolSmtLib} supports (a subset of)
+version~2.0 of this format.  A translation of \HOL{} terms into
+SMT-LIB~2 format is available in \ml{SmtLib.sml}, and a parser for
+SMT-LIB~2 files (translating them into \HOL{} types, terms, and
 formulas) can be found in \ml{SmtLib\_Parser.sml}, with auxiliary
 functions in \ml{SmtLib\_\{Logics,Theories\}.sml}.
 
@@ -188,40 +195,48 @@ delete temporary files automatically, \eg, when \HOL{} exits).
 
 \subsection{Installing SMT solvers}
 
-\ml{HolSmtLib} has been tested with Yices~1.0.29 and Z3~2.19. Later
-versions may or may not work.  (Yices~2 is not supported.)  To use
-\ml{HolSmtLib}, you need to install at least one of these SMT solvers
-on your machine.  As mentioned before, Yices supports a larger
-fragment of higher-order logic than Z3, but proof reconstruction has
-been implemented only for Z3.
+\ml{HolSmtLib} has been tested with cvc5~1.0.8, Yices~1.0.29, Z3~2.19
+and Z3~4.8.17. Later versions may or may not work.  (Yices~2 is not
+supported.)  To use \ml{HolSmtLib}, you need to install at least one
+of these SMT solvers on your machine.  As mentioned before, Yices
+supports a larger fragment of higher-order logic than Z3, but proof
+reconstruction has been implemented only for Z3~2.19.
+
+cvc5 is available for various platforms from
+\url{https://cvc5.github.io/}. After installation, you must set the
+environment variable {\tt \$HOL4\_CVC\_EXECUTABLE} to the pathname of
+the cvc5 executable, \eg, {tt /usr/bin/cvc5}, before you invoke \HOL.
 
 Yices is available for various platforms from
-\url{http://yices.csl.sri.com/}.  After installation, you must set the
-environment variable {\tt \$HOL4\_YICES\_EXECUTABLE} to the name of
-the Yices executable, \eg, {\tt /bin/yices}, before you invoke \HOL.
+\url{https://yices.csl.sri.com/}.  After installation, you must set
+the environment variable {\tt \$HOL4\_YICES\_EXECUTABLE} to the
+pathname of the Yices executable, \eg, {\tt /bin/yices}, before you
+invoke \HOL.
 
-The Z3 website,
-\url{http://research.microsoft.com/en-us/um/redmond/projects/z3/},
-provides Windows and Linux versions of the solver.  Alternatively, the
-Windows version can be installed on Linux and Mac OS~X---see the
-instructions at
-\url{http://www4.in.tum.de/~boehmes/z3.html}.\footnote{Later versions
-  of Z3 than 2.19 are available for Mac OS~X directly, but not
-  supported by \HOL.}  After installation, you must set the
-environment variable {\tt \$HOL4\_Z3\_EXECUTABLE} to the name of the
-Z3 executable, \eg, {\tt /bin/z3}, before you invoke \HOL.
+Precompiled binaries of Z3~2.19 for Linux can be downloaded from
+\url{https://github.com/Z3Prover/bin/tree/master/legacy}. Note that
+Z3~2.19.1 apparently cannot parse real literals (even though Z3~2.19
+can), so that version is not recommended since it won't work with
+reals. After installation, you must set the environment variable {\tt
+\$HOL4\_Z3\_EXECUTABLE} to the pathname of the Z3 executable, \eg,
+{\tt /bin/z3}, before you invoke \HOL.
+
+Newer versions of Z3 are available at
+\url{https://github.com/Z3Prover/z3}. After installation, you must set
+the environment variable {\tt \$HOL4\_Z3\_EXECUTABLE} to the pathname
+of the Z3 executable, \eg, {\tt /bin/z3}, before you invoke \HOL.
 
 It should be relatively straightforward to integrate other SMT solvers
 that support the SMT-LIB~2 input format as oracles.  However, this
 will involve a (typically small) amount of Standard ML programming,
-\eg, to interpret the solver's output.  See \ml{Z3.sml} for some
-relevant code.
+\eg, to interpret the solver's output.  See \ml{CVC.sml} and
+\ml{Z3.sml} for some relevant code.
 
 \subsection{Wishlist}
 
 The following features have not been implemented yet.  Please submit
 additional feature requests (or code contributions) via
-\url{http://github.com/mn200/HOL}.
+\url{https://github.com/HOL-Theorem-Prover/HOL}.
 
 \paragraph{Counterexamples}
 
@@ -231,19 +246,24 @@ satisfying assignment.  This assignment could be displayed to the
 theorem, similar to the way \ml{HolSatLib} treats satisfying
 assignments.
 
-\paragraph{Proof reconstruction for other SMT solvers}
+\paragraph{Proof reconstruction}
 
-Proof reconstruction has been implemented only for Z3.  Several other
-SMT solvers can produce proofs, and it would be nice to offer \HOL{}
-users more choice.  However, in the absence of a standard proof format
-for SMT solvers, it is perhaps not worth the implementation effort.
+Proof reconstruction has been implemented only for Z3~2.19. It would
+be desirable to implement it for newer versions of Z3, since Z3~2.19
+is quite old and is only available as a binary.
 
-\paragraph{Support for Z3's SMT-LIB extensions}
+Several other SMT solvers can also produce proofs, and it would be
+nice to offer \HOL{} users more choice.  However, in the absence of a
+standard proof format for SMT solvers, it is perhaps not worth the
+implementation effort.
 
-Z3 supports extensions of the SMT-LIB language, \eg, data types.
-\ml{HolSmtLib} does not utilize these extensions yet when calling Z3.
-This would require the translation for Z3 to be distinct from the
-generic SMT-LIB translation.
+\paragraph{Support for cvc5's and Z3's SMT-LIB extensions}
+
+cvc5 and Z3 support extensions of the SMT-LIB language, \eg, data
+types, sets, multisets/bags and strings. \ml{HolSmtLib} does not
+utilize these extensions yet when calling these SMT solvers. This
+would require the translation for these solvers to be distinct from
+the generic SMT-LIB translation.
 
 \paragraph{SMT solvers as a web service}
 

--- a/src/HolSmt/CVC.sml
+++ b/src/HolSmt/CVC.sml
@@ -1,0 +1,45 @@
+(* Functions to invoke the cvc5 SMT solver *)
+
+structure CVC = struct
+
+  (* returns SAT if cvc5 reported "sat", UNSAT if cvc5 reported "unsat" *)
+  fun is_sat_stream instream =
+    case Option.map (String.tokens Char.isSpace) (TextIO.inputLine instream) of
+      NONE => SolverSpec.UNKNOWN NONE
+    | SOME ["sat"] => SolverSpec.SAT NONE
+    | SOME ["unsat"] => SolverSpec.UNSAT NONE
+    | _ => is_sat_stream instream
+
+  fun is_sat_file path =
+    let
+      val instream = TextIO.openIn path
+    in
+      is_sat_stream instream
+        before TextIO.closeIn instream
+    end
+
+  fun is_configured () =
+    Option.isSome (OS.Process.getEnv "HOL4_CVC_EXECUTABLE")
+
+  fun mk_CVC_fun name pre cmd_stem post goal =
+    case OS.Process.getEnv "HOL4_CVC_EXECUTABLE" of
+      SOME file =>
+        SolverSpec.make_solver pre (file ^ cmd_stem) post goal
+    | NONE =>
+        raise Feedback.mk_HOL_ERR "CVC" name
+          "CVC not configured: set the HOL4_CVC_EXECUTABLE environment variable to point to the cvc5 executable file."
+
+  (* cvc5, SMT-LIB file format, no proofs *)
+  val CVC_SMT_Oracle =
+    mk_CVC_fun "CVC_SMT_Oracle"
+      (fn goal =>
+        let
+          val (goal, _) = SolverSpec.simplify (SmtLib.SIMP_TAC false) goal
+          val (_, strings) = SmtLib.goal_to_SmtLib (SOME "ALL") goal
+        in
+          ((), strings)
+        end)
+      " --lang smt "
+      (Lib.K is_sat_file)
+
+end

--- a/src/HolSmt/HolSmtLib.sig
+++ b/src/HolSmt/HolSmtLib.sig
@@ -6,10 +6,12 @@ signature HolSmtLib = sig
 
   val GENERIC_SMT_TAC : (goal -> SolverSpec.result) -> tactic
 
+  val CVC_ORACLE_TAC : tactic
   val YICES_TAC : tactic
   val Z3_ORACLE_TAC : tactic
   val Z3_TAC : tactic
 
+  val CVC_ORACLE_PROVE : term -> thm
   val YICES_PROVE : term -> thm
   val Z3_ORACLE_PROVE : term -> thm
   val Z3_PROVE : term -> thm

--- a/src/HolSmt/HolSmtLib.sml
+++ b/src/HolSmt/HolSmtLib.sml
@@ -30,11 +30,13 @@ structure HolSmtLib :> HolSmtLib = struct
       raise ERR ("solver reports 'unknown' (" ^ message ^ ")")
   end
 
+  val CVC_ORACLE_TAC = GENERIC_SMT_TAC CVC.CVC_SMT_Oracle
   val YICES_TAC = GENERIC_SMT_TAC Yices.Yices_Oracle
   val Z3_ORACLE_TAC = GENERIC_SMT_TAC Z3.Z3_SMT_Oracle
   val Z3_TAC = GENERIC_SMT_TAC Z3.Z3_SMT_Prover
 
   fun prove (tm, tac) = Tactical.TAC_PROOF(([], tm), tac)
+  fun CVC_ORACLE_PROVE tm = prove (tm, CVC_ORACLE_TAC)
   fun YICES_PROVE tm = prove (tm, YICES_TAC)
   fun Z3_ORACLE_PROVE tm = prove (tm, Z3_ORACLE_TAC)
   fun Z3_PROVE tm = prove (tm, Z3_TAC)
@@ -53,6 +55,10 @@ structure HolSmtLib :> HolSmtLib = struct
             Feedback.HOL_MESG ("HolSmtLib: " ^ message)
     in
       Feedback.set_trace "HolSmtLib" 0;
+      if CVC.is_configured () then
+        check_available CVC_ORACLE_PROVE "cvc5 (oracle)"
+      else
+        provoke_err CVC_ORACLE_PROVE;
       if Yices.is_configured () then
         check_available YICES_PROVE "Yices"
       else

--- a/src/HolSmt/SmtLib.sml
+++ b/src/HolSmt/SmtLib.sml
@@ -524,7 +524,7 @@ local
      arguments to the term.  (Because SMT-LIB is first-order,
      partially applied functions are mapped to different SMT-LIB
      identifiers, depending on the number of actual arguments.) *)
-  fun goal_to_SmtLib_aux (ts, t)
+  fun goal_to_SmtLib_aux logic (ts, t)
     : ((Type.hol_type, string) Redblackmap.dict *
       (Term.term * int, string) Redblackmap.dict) * string list =
   let
@@ -540,9 +540,12 @@ local
        declarations before all assertions) *)
     val smtlibs = List.foldl
       (fn ((xs, s), acc) => acc @ xs @ ["(assert " ^ s ^ ")\n"]) [] smtlibs
+    val set_logic =
+      case logic of
+        NONE => []
+      | SOME l => ["(set-logic " ^ l ^ ")\n"]
   in
-    (acc, [
-      (* "(set-logic AUFBVNIRA)\n", *)
+    (acc, set_logic @ [
       "(set-info :source |Automatically generated from HOL4 by SmtLib.goal_to_SmtLib.\n",
       "Copyright (c) 2011 Tjark Weber. All rights reserved.|)\n",
       "(set-info :smt-lib-version 2.0)\n"
@@ -553,11 +556,11 @@ local
 
 in
 
-  val goal_to_SmtLib =
-    Lib.apsnd (fn xs => xs @ ["(exit)\n"]) o goal_to_SmtLib_aux
+  fun goal_to_SmtLib logic =
+    Lib.apsnd (fn xs => xs @ ["(exit)\n"]) o (goal_to_SmtLib_aux logic)
 
-  val goal_to_SmtLib_with_get_proof =
-    Lib.apsnd (fn xs => xs @ ["(get-proof)\n", "(exit)\n"]) o goal_to_SmtLib_aux
+  fun goal_to_SmtLib_with_get_proof logic =
+    Lib.apsnd (fn xs => xs @ ["(get-proof)\n", "(exit)\n"]) o (goal_to_SmtLib_aux logic)
 
   (* eliminates some HOL terms that are not supported by the SMT-LIB
      translation *)

--- a/src/HolSmt/Z3.sml
+++ b/src/HolSmt/Z3.sml
@@ -37,7 +37,7 @@ structure Z3 = struct
       (fn goal =>
         let
           val (goal, _) = SolverSpec.simplify (SmtLib.SIMP_TAC false) goal
-          val (_, strings) = SmtLib.goal_to_SmtLib goal
+          val (_, strings) = SmtLib.goal_to_SmtLib NONE goal
         in
           ((), strings)
         end)
@@ -83,7 +83,7 @@ structure Z3 = struct
       (fn goal =>
         let
           val (goal, validation) = SolverSpec.simplify (SmtLib.SIMP_TAC true) goal
-          val (ty_tm_dict, strings) = SmtLib.goal_to_SmtLib_with_get_proof goal
+          val (ty_tm_dict, strings) = SmtLib.goal_to_SmtLib_with_get_proof NONE goal
         in
           (((goal, validation), ty_tm_dict), strings)
         end)

--- a/src/HolSmt/selftest.sml
+++ b/src/HolSmt/selftest.sml
@@ -24,6 +24,9 @@ val _ = Feedback.set_trace "HolSmtLib" 4
 (* check whether SMT solvers are installed                                   *)
 (*****************************************************************************)
 
+val _ = if CVC.is_configured () then () else
+  print "(cvc5 not configured, some tests will be skipped.)\n"
+
 val _ = if Yices.is_configured () then () else
   print "(Yices not configured, some tests will be skipped.)\n"
 
@@ -123,6 +126,12 @@ fun auto_tac (_, t) =
 val thm_AUTO =
   mk_test_fun true expect_thm "AUTO" (Tactical.THEN (Library.SET_SIMP_TAC, auto_tac))
 
+fun mk_CVC expect_fun =
+  mk_test_fun (CVC.is_configured ()) expect_fun "cvc5" HolSmtLib.CVC_ORACLE_TAC
+
+val thm_CVC = mk_CVC expect_thm
+val sat_CVC = mk_CVC expect_sat
+
 fun mk_Yices expect_fun =
   mk_test_fun (Yices.is_configured ()) expect_fun "Yices" HolSmtLib.YICES_TAC
 
@@ -158,23 +167,23 @@ in
   val tests = [
 
     (* propositional logic *)
-    (``T``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``F``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``p = (p:bool)``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``p ==> p``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``p \/ ~ p``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``T``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``F``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``p = (p:bool)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``p ==> p``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``p \/ ~ p``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``p /\ q ==> q /\ p``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``(p ==> q) /\ (q ==> p) ==> (p = q)``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``(p ==> q) /\ (q ==> p) <=> (p = q)``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``p \/ q ==> p /\ q``, [sat_YO, sat_Z3, sat_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``p \/ q ==> p /\ q``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``if p then (q ==> p) else (p ==> q)``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``case p of T => p | F => ~ p``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``case p of T => p | F => ~ p``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``case p of T => (q ==> p) | F => (p ==> q)``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
     (* numerals *)
 
@@ -185,37 +194,37 @@ in
 
     (* num *)
 
-    (``0n = 0n``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``1n = 1n``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``0n = 1n``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``42n = 42n``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``0n = 0n``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``1n = 1n``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``0n = 1n``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``42n = 42n``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
     (* int *)
 
-    (``0i = 0i``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``1i = 1i``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``0i = 1i``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``42i = 42i``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``0i = ~0i``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``~0i = 0i``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``~0i = ~0i``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``~42i = ~42i``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``0i = 0i``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``1i = 1i``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``0i = 1i``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``42i = 42i``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``0i = ~0i``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``~0i = 0i``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``~0i = ~0i``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``~42i = ~42i``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
     (* real *)
 
     (* Z3 2.19 prints reals as integers in its proofs; I see no way to
        reliably distinguish between them. *)
 
-    (``0r = 0r``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``1r = 1r``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``0r = 1r``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``42r = 42r``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``0r = ~0r``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``~0r = 0r``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``~0r = ~0r``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``~42r = ~42r``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``~42r = 42r``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``42r = ~42r``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``0r = 0r``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``1r = 1r``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``0r = 1r``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``42r = 42r``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``0r = ~0r``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``~0r = 0r``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``~0r = ~0r``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``~42r = ~42r``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``~42r = 42r``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``42r = ~42r``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
 
     (* arithmetic operators: SUC, +, -, *, /, DIV, MOD, ABS, MIN, MAX *)
 
@@ -225,7 +234,7 @@ in
     (``SUC x = x + 1``, [thm_AUTO, thm_YO]),
     (``x < SUC x``, [thm_AUTO, thm_YO]),
     (``(SUC x = SUC y) = (x = y)``, [thm_AUTO, thm_YO]),
-    (``SUC (x + y) = (SUC x + SUC y)``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``SUC (x + y) = (SUC x + SUC y)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
 
     (``(x:num) + 0 = x``, [thm_AUTO, thm_YO]),
     (``0 + (x:num) = x``, [thm_AUTO, thm_YO]),
@@ -234,7 +243,7 @@ in
     (``((x:num) + y = 0) <=> (x = 0) /\ (y = 0)``, [thm_AUTO, thm_YO]),
 
     (``(x:num) - 0 = x``, [thm_AUTO, thm_YO]),
-    (``(x:num) - y = y - x``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:num) - y = y - x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:num) - y - z = x - (y + z)``, [thm_AUTO, thm_YO]),
     (``(x:num) <= y ==> (x - y = 0)``, [thm_AUTO, thm_YO]),
     (``((x:num) - y = 0) \/ (y - x = 0)``, [thm_AUTO, thm_YO]),
@@ -254,11 +263,11 @@ in
     (``(x:num) DIV 1 = x``, [thm_AUTO, thm_YO]),
     (``(x:num) DIV 42 <= x``, [thm_AUTO, thm_YO]),
     (``((x:num) DIV 42 = x) = (x = 0)``, [thm_AUTO, thm_YO]),
-    (``(x:num) DIV 0 = x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:num) DIV 0 = 0``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(0:num) DIV 0 = 0``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(0:num) DIV 0 = 1``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:num) DIV 0 = x DIV 0``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:num) DIV 0 = x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:num) DIV 0 = 0``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(0:num) DIV 0 = 0``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(0:num) DIV 0 = 1``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:num) DIV 0 = x DIV 0``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
     (``(0:num) MOD 1 = 0``, [thm_AUTO, thm_YO]),
     (``(1:num) MOD 1 = 0``, [thm_AUTO, thm_YO]),
@@ -269,11 +278,11 @@ in
     (``(x:num) MOD 1 = 0``, [thm_AUTO, thm_YO]),
     (``(x:num) MOD 42 < 42``, [thm_AUTO, thm_YO]),
     (``((x:num) MOD 42 = x) = (x < 42)``, [thm_AUTO, thm_YO]),
-    (``(x:num) MOD 0 = x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:num) MOD 0 = 0``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(0:num) MOD 0 = 0``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(0:num) MOD 0 = 1``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:num) MOD 0 = x MOD 0``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:num) MOD 0 = x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:num) MOD 0 = 0``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(0:num) MOD 0 = 0``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(0:num) MOD 0 = 1``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:num) MOD 0 = x MOD 0``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
     (* cf. arithmeticTheory.DIVISION *)
     (``((x:num) = x DIV 1 * 1 + x MOD 1) /\ x MOD 1 < 1``, [thm_AUTO, thm_YO]),
@@ -283,38 +292,38 @@ in
     (``MIN (x:num) y <= x``, [thm_AUTO, thm_YO]),
     (``MIN (x:num) y <= y``, [thm_AUTO, thm_YO]),
     (``(z:num) < x /\ z < y ==> z < MIN x y``, [thm_AUTO, thm_YO]),
-    (``MIN (x:num) y < x``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``MIN (x:num) y < x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``MIN (x:num) 0 = 0``, [thm_AUTO, thm_YO]),
 
     (``MAX (x:num) y >= x``, [(*thm_AUTO,*) thm_YO]),
     (``MAX (x:num) y >= y``, [(*thm_AUTO,*) thm_YO]),
     (``(z:num) > x /\ z > y ==> z > MAX x y``, [(*thm_AUTO,*) thm_YO]),
-    (``MAX (x:num) y > x``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``MAX (x:num) y > x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``MAX (x:num) 0 = x``, [thm_AUTO, thm_YO]),
 
     (* int *)
 
-    (``(x:int) + 0 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``0 + (x:int) = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``(x:int) + y = y + x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``(x:int) + (y + z) = (x + y) + z``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``((x:int) + y = 0) = (x = 0) /\ (y = 0)``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``((x:int) + y = 0) = (x = ~y)``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:int) + 0 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``0 + (x:int) = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:int) + y = y + x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:int) + (y + z) = (x + y) + z``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``((x:int) + y = 0) = (x = 0) /\ (y = 0)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``((x:int) + y = 0) = (x = ~y)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``(x:int) - 0 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``(x:int) - y = y - x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:int) - y - z = x - (y + z)``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``(x:int) <= y ==> (x - y = 0)``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``((x:int) - y = 0) \/ (y - x = 0)``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:int) - y = x + ~y``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:int) - 0 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:int) - y = y - x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:int) - y - z = x - (y + z)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:int) <= y ==> (x - y = 0)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``((x:int) - y = 0) \/ (y - x = 0)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:int) - y = x + ~y``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``(x:int) * 0 = 0``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``0 * (x:int) = 0``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``(x:int) * 1 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``1 * (x:int) = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``(x:int) * ~1 = ~x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``~1 * (x:int) = ~x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``(x:int) * 42 = 42 * x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:int) * 0 = 0``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``0 * (x:int) = 0``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:int) * 1 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``1 * (x:int) = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:int) * ~1 = ~x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``~1 * (x:int) = ~x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:int) * 42 = 42 * x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
     (``(~42:int) / ~42 = 1``, [thm_AUTO, thm_YO]),
     (``(~1:int) / ~42 = 0``, [thm_AUTO, thm_YO]),
@@ -338,16 +347,16 @@ in
     (``(42:int) / 42 = 1``, [thm_AUTO, thm_YO]),
     (``(x:int) / 1 = x``, [thm_AUTO, thm_YO]),
     (``(x:int) / ~1 = ~x``, [thm_AUTO, thm_YO]),
-    (``(x:int) / 42 <= x``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:int) / 42 <= x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:int) / 42 <= ABS x``, [thm_AUTO, thm_YO(*, thm_Z3, thm_Z3p*)]),
-    (``((x:int) / 42 = x) = (x = 0)``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``((x:int) / 42 = x) = (x = 0)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``((x:int) / 42 = x) = (x = 0) \/ (x = ~1)``, [thm_AUTO, thm_YO]),
-    (``(x:int) / 0 = x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:int) / 0 = 0``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(0:int) / 0 = 0``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(0:int) / 0 = 1``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(0:int) / 0 = 1 / 0``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:int) / 0 = x / 0``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:int) / 0 = x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:int) / 0 = 0``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(0:int) / 0 = 0``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(0:int) / 0 = 1``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(0:int) / 0 = 1 / 0``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:int) / 0 = x / 0``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
     (* cf. integerTheory.int_div *)
     (``(x:int) < 0 ==> (x / 1 = ~(~x / 1) + if ~x % 1 = 0 then 0 else ~1)``,
@@ -384,13 +393,13 @@ in
     (``(x:int) % 1 = 0``, [thm_AUTO, thm_YO]),
     (``(x:int) % ~1 = 0``, [thm_AUTO, thm_YO]),
     (``(x:int) % 42 < 42``, [thm_AUTO, thm_YO]),
-    (``((x:int) % 42 = x) = (x < 42)``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``((x:int) % 42 = x) = (x < 42)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``((x:int) % 42 = x) <=> (0 <= x) /\ (x < 42)``, [thm_AUTO, thm_YO]),
-    (``(x:int) % 0 = x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:int) % 0 = 0``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(0:int) % 0 = 0``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(0:int) % 0 = 1``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:int) % 0 = x % 0``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:int) % 0 = x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:int) % 0 = 0``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(0:int) % 0 = 0``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(0:int) % 0 = 1``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:int) % 0 = x % 0``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
     (* cf. integerTheory.int_mod *)
     (``(x:int) % ~42 = x - x / ~42 * ~42``, [thm_AUTO, thm_YO]),
@@ -398,70 +407,70 @@ in
     (``(x:int) % 1 = x - x / 1 * 1``, [thm_AUTO, thm_YO]),
     (``(x:int) % 42 = x - x / 42 * 42``, [thm_AUTO, thm_YO]),
 
-    (``ABS (x:int) >= 0``, [thm_AUTO, thm_YO(*, thm_Z3, thm_Z3p*)]),
-    (``(ABS (x:int) = 0) = (x = 0)``, [thm_AUTO, thm_YO(*, thm_Z3, thm_Z3p*)]),
+    (``ABS (x:int) >= 0``, [thm_AUTO, thm_CVC, thm_YO(*, thm_Z3, thm_Z3p*)]),
+    (``(ABS (x:int) = 0) = (x = 0)``, [thm_AUTO, thm_CVC, thm_YO(*, thm_Z3, thm_Z3p*)]),
     (``(x:int) >= 0 ==> (ABS x = x)``, [thm_AUTO, thm_YO(*, thm_Z3, thm_Z3p*)]),
     (``(x:int) <= 0 ==> (ABS x = ~x)``, [thm_AUTO, thm_YO(*, thm_Z3, thm_Z3p*)]),
     (``ABS (ABS (x:int)) = ABS x``, [thm_AUTO, thm_YO(*, thm_Z3, thm_Z3p*)]),
-    (``ABS (x:int) = x``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``ABS (x:int) = x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
 
     (``int_min (x:int) y <= x``, [thm_AUTO, thm_YO]),
     (``int_min (x:int) y <= y``, [thm_AUTO, thm_YO]),
     (``(z:int) < x /\ z < y ==> z < int_min x y``, [thm_AUTO, thm_YO]),
-    (``int_min (x:int) y < x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``int_min (x:int) 0 = 0``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``int_min (x:int) y < x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``int_min (x:int) 0 = 0``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:int) >= 0 ==> (int_min x 0 = 0)``, [thm_AUTO, thm_YO]),
 
     (``int_max (x:int) y >= x``, [thm_AUTO, thm_YO]),
     (``int_max (x:int) y >= y``, [thm_AUTO, thm_YO]),
     (``(z:int) > x /\ z > y ==> z > int_max x y``, [thm_AUTO, thm_YO]),
-    (``int_max (x:int) y > x``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``int_max (x:int) y > x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:int) >= 0 ==> (int_max x 0 = x)``, [thm_AUTO, thm_YO]),
 
     (* real *)
 
-    (``(x:real) + 0 = x``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``0 + (x:real) = x``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``(x:real) + y = y + x``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``(x:real) + (y + z) = (x + y) + z``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``((x:real) + y = 0) = (x = 0) /\ (y = 0)``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``((x:real) + y = 0) = (x = ~y)``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``(x:real) + 0 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``0 + (x:real) = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``(x:real) + y = y + x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``(x:real) + (y + z) = (x + y) + z``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``((x:real) + y = 0) = (x = 0) /\ (y = 0)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``((x:real) + y = 0) = (x = ~y)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
-    (``(x:real) - 0 = x``, [thm_AUTO, thm_YO]),
-    (``(x:real) - y = y - x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:real) - y - z = x - (y + z)``, [thm_AUTO, thm_YO]),
-    (``(x:real) <= y ==> (x - y = 0)``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``((x:real) - y = 0) \/ (y - x = 0)``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:real) - y = x + ~y``, [thm_AUTO, thm_YO]),
+    (``(x:real) - 0 = x``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``(x:real) - y = y - x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:real) - y - z = x - (y + z)``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``(x:real) <= y ==> (x - y = 0)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``((x:real) - y = 0) \/ (y - x = 0)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:real) - y = x + ~y``, [thm_AUTO, thm_CVC, thm_YO]),
 
-    (``(x:real) * 0 = 0``, [thm_AUTO, thm_YO]),
-    (``0 * (x:real) = 0``, [thm_AUTO, thm_YO]),
-    (``(x:real) * 1 = x``, [thm_AUTO, thm_YO]),
-    (``1 * (x:real) = x``, [thm_AUTO, thm_YO]),
-    (``(x:real) * 42 = 42 * x``, [thm_AUTO, thm_YO]),
+    (``(x:real) * 0 = 0``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``0 * (x:real) = 0``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``(x:real) * 1 = x``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``1 * (x:real) = x``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``(x:real) * 42 = 42 * x``, [thm_AUTO, thm_CVC, thm_YO]),
 
-    (``(x:real) / 1 = x``, [thm_AUTO, thm_YO]),
-    (``x > 0 ==> (x:real) / 42 < x``, [(*thm_AUTO,*) thm_YO]),
-    (``x < 0 ==> (x:real) / 42 > x``, [(*thm_AUTO,*) thm_YO]),
+    (``(x:real) / 1 = x``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``x > 0 ==> (x:real) / 42 < x``, [(*thm_AUTO,*) thm_CVC, thm_YO]),
+    (``x < 0 ==> (x:real) / 42 > x``, [(*thm_AUTO,*) thm_CVC, thm_YO]),
 
     (``abs (x:real) >= 0``, [thm_AUTO, thm_YO]),
     (``(abs (x:real) = 0) = (x = 0)``, [thm_AUTO, thm_YO]),
     (``(x:real) >= 0 ==> (abs x = x)``, [thm_AUTO, thm_YO]),
     (``(x:real) <= 0 ==> (abs x = ~x)``, [thm_AUTO, thm_YO]),
     (``abs (abs (x:real)) = abs x``, [thm_AUTO, thm_YO]),
-    (``abs (x:real) = x``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``abs (x:real) = x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
 
     (``min (x:real) y <= x``, [(*thm_AUTO,*) thm_YO]),
     (``min (x:real) y <= y``, [(*thm_AUTO,*) thm_YO]),
     (``(z:real) < x /\ z < y ==> z < min x y``, [(*thm_AUTO,*) thm_YO]),
-    (``min (x:real) y < x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``min (x:real) 0 = 0``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``min (x:real) y < x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``min (x:real) 0 = 0``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:real) >= 0 ==> (min x 0 = 0)``, [(*thm_AUTO,*) thm_YO]),
 
     (``max (x:real) y >= x``, [(*thm_AUTO,*) thm_YO]),
     (``max (x:real) y >= y``, [(*thm_AUTO,*) thm_YO]),
     (``(z:real) > x /\ z > y ==> z > max x y``, [(*thm_AUTO,*) thm_YO]),
-    (``max (x:real) y > x``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``max (x:real) y > x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:real) >= 0 ==> (max x 0 = x)``, [(*thm_AUTO,*) thm_YO]),
 
     (* arithmetic inequalities: <, <=, >, >= *)
@@ -469,22 +478,22 @@ in
     (* num *)
 
     (``0n < 1n``, [thm_AUTO, thm_YO]),
-    (``1n < 0n``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:num) < x``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``1n < 0n``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:num) < x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:num) < y ==> 42 * x < 42 * y``, [thm_AUTO, thm_YO]),
 
     (``0n <= 1n``, [thm_AUTO, thm_YO]),
-    (``1n <= 0n``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``1n <= 0n``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:num) <= x``, [thm_AUTO, thm_YO]),
     (``(x:num) <= y ==> 42 * x <= 42 * y``, [thm_AUTO, thm_YO]),
 
     (``1n > 0n``, [thm_AUTO, thm_YO]),
-    (``0n > 1n``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:num) > x``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``0n > 1n``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:num) > x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:num) > y ==> 42 * x > 42 * y``, [thm_AUTO, thm_YO]),
 
     (``1n >= 0n``, [thm_AUTO, thm_YO]),
-    (``0n >= 1n``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``0n >= 1n``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:num) >= x``, [thm_AUTO, thm_YO]),
     (``(x:num) >= y ==> 42 * x >= 42 * y``, [thm_AUTO, thm_YO]),
 
@@ -500,124 +509,124 @@ in
 
     (* int *)
 
-    (``0i < 1i``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``1i < 0i``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:int) < x``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``0i < 1i``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``1i < 0i``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:int) < x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:int) < y ==> 42 * x < 42 * y``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``0i <= 1i``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``1i <= 0i``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:int) <= x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``0i <= 1i``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``1i <= 0i``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:int) <= x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``(x:int) <= y ==> 42 * x <= 42 * y``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``1i > 0i``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``0i > 1i``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:int) > x``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``1i > 0i``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``0i > 1i``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:int) > x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:int) > y ==> 42 * x > 42 * y``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``1i >= 0i``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``0i >= 1i``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:int) >= x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``1i >= 0i``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``0i >= 1i``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:int) >= x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``(x:int) >= y ==> 42 * x >= 42 * y``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``((x:int) < y) = (y > x)``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``((x:int) <= y) = (y >= x)``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``(x:int) < y /\ y <= z ==> x < z``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``(x:int) <= y /\ y <= z ==> x <= z``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``(x:int) > y /\ y >= z ==> x > z``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``(x:int) >= y /\ y >= z ==> x >= z``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``((x:int) < y) = (y > x)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``((x:int) <= y) = (y >= x)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:int) < y /\ y <= z ==> x < z``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``(x:int) <= y /\ y <= z ==> x <= z``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``(x:int) > y /\ y >= z ==> x > z``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``(x:int) >= y /\ y >= z ==> x >= z``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
     (``(x:int) >= 0``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``0 < (x:int) /\ x <= 1 ==> (x = 1)``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``0 < (x:int) /\ x <= 1 ==> (x = 1)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
     (* real *)
 
-    (``0r < 1r``, [thm_AUTO, thm_YO]),
-    (``1r < 0r``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:real) < x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:real) < y ==> 42 * x < 42 * y``, [thm_AUTO, thm_YO]),
+    (``0r < 1r``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``1r < 0r``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:real) < x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:real) < y ==> 42 * x < 42 * y``, [thm_AUTO, thm_CVC, thm_YO]),
 
     (``0n <= 1n``, [thm_AUTO, thm_YO]),
-    (``1n <= 0n``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``1n <= 0n``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:num) <= x``, [thm_AUTO, thm_YO]),
     (``(x:num) <= y ==> 2 * x <= 2 * y``, [thm_AUTO, thm_YO]),
 
-    (``1r > 0r``, [thm_AUTO, thm_YO]),
-    (``0r > 1r``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:real) > x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:real) > y ==> 42 * x > 42 * y``, [thm_AUTO, thm_YO]),
+    (``1r > 0r``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``0r > 1r``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:real) > x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:real) > y ==> 42 * x > 42 * y``, [thm_AUTO, thm_CVC, thm_YO]),
 
-    (``1r >= 0r``, [thm_AUTO, thm_YO]),
-    (``0r >= 1r``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:real) >= x``, [thm_AUTO, thm_YO]),
-    (``(x:real) >= y ==> 42 * x >= 42 * y``, [thm_AUTO, thm_YO]),
+    (``1r >= 0r``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``0r >= 1r``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:real) >= x``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``(x:real) >= y ==> 42 * x >= 42 * y``, [thm_AUTO, thm_CVC, thm_YO]),
 
-    (``((x:real) < y) = (y > x)``, [thm_AUTO, thm_YO]),
-    (``((x:real) <= y) = (y >= x)``, [thm_AUTO, thm_YO]),
-    (``(x:real) < y /\ y <= z ==> x < z``, [thm_AUTO, thm_YO]),
-    (``(x:real) <= y /\ y <= z ==> x <= z``, [thm_AUTO, thm_YO]),
-    (``(x:real) > y /\ y >= z ==> x > z``, [thm_AUTO, thm_YO]),
-    (``(x:real) >= y /\ y >= z ==> x >= z``, [thm_AUTO, thm_YO]),
+    (``((x:real) < y) = (y > x)``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``((x:real) <= y) = (y >= x)``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``(x:real) < y /\ y <= z ==> x < z``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``(x:real) <= y /\ y <= z ==> x <= z``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``(x:real) > y /\ y >= z ==> x > z``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``(x:real) >= y /\ y >= z ==> x >= z``, [thm_AUTO, thm_CVC, thm_YO]),
 
-    (``(x:real) >= 0``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:real) >= 0``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``0 < (x:real) /\ x <= 1 ==> (x = 1)``,
-      [sat_YO, sat_Z3, sat_Z3p]),
+      [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
 
     (* uninterpreted functions *)
 
-    (``(x = y) ==> (f x = f y)``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``(x = y) ==> (f x y = f y x)``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x = y) ==> (f x = f y)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x = y) ==> (f x y = f y x)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``(f (f x) = x) /\ (f (f (f (f (f x)))) = x) ==> (f x = x)``,
-      [(*thm_AUTO,*) thm_YO, thm_Z3, thm_Z3p]),
-    (``(f x = f y) ==> (x = y)``, [sat_YO, sat_Z3, sat_Z3p]),
+      [(*thm_AUTO,*) thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``(f x = f y) ==> (x = y)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
 
     (* predicates *)
 
-    (``P x ==> P x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``P x ==> Q x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``P x ==> P y``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``P x y ==> P x x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``P x y ==> P y x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``P x y ==> P y y``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``P x ==> P x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``P x ==> Q x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``P x ==> P y``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``P x y ==> P x x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``P x y ==> P y x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``P x y ==> P y y``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
 
     (* quantifiers *)
 
-    (``!x. x = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``!x. x = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (* Yices 1.0.28 reports `unknown' for the next goal, while Z3 2.13
        (somewhat surprisingly, as SMT-LIB does not seem to require
        non-empty sorts) can prove it *)
-    (``?x. x = x``, [thm_AUTO, thm_Z3(*, thm_Z3p*)]),
-    (* Z3 2.13 reports `unknown' for the next goal *)
+    (``?x. x = x``, [thm_AUTO, thm_CVC, thm_Z3(*, thm_Z3p*)]),
+    (* CVC5 1.0.8 and Z3 2.13 report `unknown' for the next goal *)
     (``(?y. !x. P x y) ==> (!x. ?y. P x y)``, [thm_AUTO, thm_YO]),
-    (* Yices 1.0.28 and Z3 2.13 report `unknown' for the next goal *)
+    (* CVC5 1.0.8, Yices 1.0.28 and Z3 2.13 report `unknown' for the next goal *)
     (``(!x. ?y. P x y) ==> (?y. !x. P x y)``, []),
     (* Z3 2.13 reports `unknown' for the next goal *)
-    (``(?x. P x) ==> !x. P x``, [sat_YO]),
+    (``(?x. P x) ==> !x. P x``, [sat_CVC, sat_YO]),
     (* Z3 2.13 reports `unknown' for the next goal *)
-    (``?x. P x ==> !x. P x``, [thm_AUTO, thm_YO]),
+    (``?x. P x ==> !x. P x``, [thm_AUTO, thm_CVC, thm_YO]),
 
     (* let binders *)
 
     (``let x = y in let x = (x /\ z) in x <=> y /\ z``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``let x = u in let x = x in let y = v in x /\ y <=> u /\ v``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
     (* lambda abstractions *)
 
-    (``(\x. x) = (\y. y)``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``(\x. x) = (\y. y)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``(\x. \x. x) x x = (\y. \y. y) y x``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``(\x. x (\x. x)) = (\y. y (\x. x))``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (* Yices 1.0.29 fails to decide this one *)
-    (``(\x. x (\x. x)) = (\y. y x)``, [(*sat_YO,*) sat_Z3, sat_Z3p]),
-    (``f x = (\x. f x) x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``f x = (\y. f y) x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``(\x. x (\x. x)) = (\y. y x)``, [sat_CVC, (*sat_YO,*) sat_Z3, sat_Z3p]),
+    (``f x = (\x. f x) x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``f x = (\y. f y) x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
     (* higher-order logic *)
 
@@ -625,32 +634,32 @@ in
        its proof *)
 
     (``(P (f x) ==> Q f) ==> P (f x) ==> Q f``,
-      [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
     (``(Q f ==> P (f x)) ==> Q f ==> P (f x)``,
-      [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
     (* tuples, FST, SND *)
 
-    (``(x, y) = (x, z)``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x, y) = (z, y)``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x, y) = (y, x)``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``(x, y) = (x, z)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x, y) = (z, y)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x, y) = (y, x)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``((x, y) = (y, x)) = (x = y)``, [(*thm_AUTO,*) thm_YO]),
     (``((x, y, z) = (y, z, x)) <=> (x = y) /\ (y = z)``,
       [(*thm_AUTO,*) thm_YO]),
     (``((x, y) = (u, v)) <=> (x = u) /\ (y = v)``, [thm_AUTO, thm_YO]),
 
-    (``y = FST (x, y)``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``y = FST (x, y)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``x = FST (x, y)``, [thm_AUTO, thm_YO]),
     (``(FST (x, y, z) = FST (u, v, w)) = (x = u)``, [thm_AUTO, thm_YO]),
     (``(FST (x, y, z) = FST (u, v, w)) <=> (x = u) /\ (y = w)``,
-      [sat_YO, sat_Z3, sat_Z3p]),
+      [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
 
     (``y = SND (x, y)``, [thm_AUTO, thm_YO]),
-    (``x = SND (x, y)``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``x = SND (x, y)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(SND (x, y, z) = SND (u, v, w)) = (y = v)``,
-       [sat_YO, sat_Z3, sat_Z3p]),
+       [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(SND (x, y, z) = SND (u, v, w)) = (z = w)``,
-       [sat_YO, sat_Z3, sat_Z3p]),
+       [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(SND (x, y, z) = SND (u, v, w)) <=> (y = v) /\ (z = w)``,
       [thm_AUTO, thm_YO]),
 
@@ -661,253 +670,253 @@ in
 
     (* words (i.e., bit vectors) *)
 
-    (``x:word2 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word3 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word4 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word5 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word6 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word7 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word8 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word12 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word16 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word20 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word24 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word28 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word30 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word32 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word64 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word2 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word3 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word4 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word5 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word6 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word7 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word8 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word12 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word16 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word20 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word24 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word28 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word30 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word32 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word64 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``x:word32 && x = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word32 && y = y && x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word32 && x = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word32 && y = y && x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``(x:word32 && y) && z = x && (y && z)``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word32 && 0w = 0w``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word32 && 0w = x``, [sat_YO, sat_Z3, sat_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word32 && 0w = 0w``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word32 && 0w = x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
 
-    (``x:word32 || x = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word32 || y = y || x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word32 || x = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word32 || y = y || x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``(x:word32 || y) || z = x || (y || z)``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word32 || 0w = 0w``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``x:word32 || 0w = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word32 || 0w = 0w``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``x:word32 || 0w = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``x:word32 ?? x = 0w``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word32 ?? y = y ?? x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word32 ?? x = 0w``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word32 ?? y = y ?? x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``(x:word32 ?? y) ?? z = x ?? (y ?? z)``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word32 ?? 0w = 0w``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``x:word32 ?? 0w = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word32 ?? 0w = 0w``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``x:word32 ?? 0w = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``~ ~ x:word32 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``~ 0w = 0w:word32``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``~ ~ x:word32 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``~ 0w = 0w:word32``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
 
     (* Yices does not support bit-vector division *)
     (* Z3 2.19 prints "extract" wrongly in its proofs *)
 
-    (``x:word32 / 4w = x / 2w / 2w``, [(*thm_AUTO, thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 / 6w = x / 2w / 3w``, [(*thm_AUTO, thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 / x = 1w``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``x:word32 <> 0w ==> (x / x = 1w)``, [(*thm_AUTO, thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``y:word8 <> 0w ==> (x / y = -x / -y)``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``y:word8 <> 0w ==> (x / y = -(-x / y))``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``y:word8 <> 0w ==> (x / y = -(x / -y))``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``x:word32 / 4w = x / 2w / 2w``, [(*thm_AUTO, thm_YO,*) thm_CVC, thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 / 6w = x / 2w / 3w``, [(*thm_AUTO, thm_YO,*) thm_CVC, thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 / x = 1w``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``x:word32 <> 0w ==> (x / x = 1w)``, [(*thm_AUTO, thm_YO,*) thm_CVC, thm_Z3(*, thm_Z3p*)]),
+    (``y:word8 <> 0w ==> (x / y = -x / -y)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``y:word8 <> 0w ==> (x / y = -(-x / y))``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``y:word8 <> 0w ==> (x / y = -(x / -y))``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``x:word8 <> 0x80w /\ y <> 0w ==> (x / y = -x / -y)``,
-      [(*thm_AUTO, thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+      [(*thm_AUTO, thm_YO,*) thm_CVC, thm_Z3(*, thm_Z3p*)]),
     (``x:word8 <> 0x80w /\ y <> 0w ==> (x / y = -(-x / y))``,
-      [(*thm_AUTO, thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+      [(*thm_AUTO, thm_YO,*) thm_CVC, thm_Z3(*, thm_Z3p*)]),
     (``x:word8 <> 0x80w /\ y <> 0w ==> (x / y = -(x / -y))``,
-      [(*thm_AUTO, thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+      [(*thm_AUTO, thm_YO,*) thm_CVC, thm_Z3(*, thm_Z3p*)]),
 
-    (``x:word32 // 4w = x // 2w // 2w``, [thm_AUTO, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 // 6w = x // 2w // 3w``, [(*thm_AUTO, thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 // x = 1w``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``x:word32 <> 0w ==> (x // x = 1w)``, [(*thm_AUTO, thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 // 4w = x // 2w // 2w``, [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 // 6w = x // 2w // 3w``, [(*thm_AUTO, thm_YO,*) thm_CVC, thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 // x = 1w``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``x:word32 <> 0w ==> (x // x = 1w)``, [(*thm_AUTO, thm_YO,*) thm_CVC, thm_Z3(*, thm_Z3p*)]),
 
     (``y:word8 <> 0w ==> (x = x // y * y + word_mod x y)``,
-      [(*thm_AUTO, thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+      [(*thm_AUTO, thm_YO,*) thm_CVC, thm_Z3(*, thm_Z3p*)]),
     (``y:word8 <> 0w ==> word_mod x y <+ y``,
-      [(*thm_AUTO, thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+      [(*thm_AUTO, thm_YO,*) thm_CVC, thm_Z3(*, thm_Z3p*)]),
 
     (``y:word8 <> 0w ==> (x = x / y * y + word_rem x y)``,
-      [(*thm_AUTO, thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+      [(*thm_AUTO, thm_YO,*) thm_CVC, thm_Z3(*, thm_Z3p*)]),
 
     (* Z3 2.19 does not handle "bvsrem ... bv0" correctly *)
 
     (``x:word8 < 0w /\ y < 0w  ==> (word_rem x y = -word_mod (-x) (-y))``,
-      [(*thm_AUTO, thm_YO,*)thm_Z3(*, thm_Z3p*)]),
+      [(*thm_AUTO, thm_YO,*)thm_CVC, thm_Z3(*, thm_Z3p*)]),
     (``x:word8 < 0w /\ y >= 0w ==> (word_rem x y = -word_mod (-x) y)``,
-      [(*thm_AUTO, thm_YO, thm_Z3, thm_Z3p*)]),
+      [thm_CVC (*thm_AUTO, thm_YO, thm_Z3, thm_Z3p*)]),
     (``x:word8 >= 0w /\ y < 0w ==> (word_rem x y = word_mod x (-y))``,
-      [(*thm_AUTO, thm_YO,*)thm_Z3(*, thm_Z3p*)]),
+      [(*thm_AUTO, thm_YO,*)thm_CVC, thm_Z3(*, thm_Z3p*)]),
     (``x:word8 >= 0w /\ y >= 0w ==> (word_rem x y = word_mod x y)``,
-      [(*thm_AUTO, thm_YO, thm_Z3, thm_Z3p*)]),
+      [thm_CVC (*thm_AUTO, thm_YO, thm_Z3, thm_Z3p*)]),
 
     (``x:word8 < 0w /\ y < 0w  ==> (word_smod x y = -word_mod (-x) (-y))``,
-      [(*thm_AUTO, thm_YO,*)thm_Z3(*, thm_Z3p*)]),
+      [(*thm_AUTO, thm_YO,*)thm_CVC, thm_Z3(*, thm_Z3p*)]),
     (``x:word8 < 0w /\ y >= 0w ==> (word_smod x y = -word_mod (-x) y + y)``,
-      [(*sat_YO,*) sat_Z3, sat_Z3p]),
+      [sat_CVC, (*sat_YO,*) sat_Z3, sat_Z3p]),
     (``x:word8 >= 0w /\ y < 0w ==> (word_smod x y = word_mod x (-y) + y)``,
-      [(*sat_YO, sat_Z3, sat_Z3p*)]),
+      [sat_CVC (*sat_YO, sat_Z3, sat_Z3p*)]),
     (``x:word8 >= 0w /\ y >= 0w ==> (word_smod x y = word_mod x y)``,
-      [(*thm_AUTO, thm_YO, thm_Z3, thm_Z3p*)]),
+      [thm_CVC (*thm_AUTO, thm_YO, thm_Z3, thm_Z3p*)]),
 
-    (``x:word32 << 0 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word32 << 31 = 0w``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``x:word32 << 0 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word32 << 31 = 0w``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:word32 << 31 = 0w) \/ (x << 31 = 1w << 31)``,
-      [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
     (* Yices does not support shifting by more than the word length *)
 
-    (``x:word32 << 99 = 0w``, [thm_AUTO, (*thm_YO,*) thm_Z3, thm_Z3p]),
+    (``x:word32 << 99 = 0w``, [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3, thm_Z3p]),
 
     (* Yices does not support shifting by a non-constant *)
 
-    (``x:word32 << n = x``, [(*sat_YO,*) sat_Z3, sat_Z3p]),
+    (``x:word32 << n = x``, [sat_CVC, (*sat_YO,*) sat_Z3, sat_Z3p]),
 
-    (``x:word32 <<~ 0w = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word32 <<~ 31w = 0w``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``x:word32 <<~ 0w = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word32 <<~ 31w = 0w``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:word32 <<~ 31w = 0w) \/ (x <<~ 31w = 1w <<~ 31w)``,
-      [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
     (``(x:word32 <<~ x) && 1w = 0w``,
-      [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 <<~ y = y <<~ x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:word32 <<~ y) <<~ z = x <<~ (y <<~ z)``, [sat_YO, sat_Z3, sat_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 <<~ y = y <<~ x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:word32 <<~ y) <<~ z = x <<~ (y <<~ z)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
 
-    (``x:word32 >>> 0 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word32 >>> 31 = 0w``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``x:word32 >>> 0 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word32 >>> 31 = 0w``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:word32 >>> 31 = 0w) \/ (x >>> 31 = 1w)``,
-      [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
     (* Yices does not support right-shift by a (non-constant) bit-vector
        amount *)
 
-    (``x:word32 >>>~ 0w = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x:word32 >>>~ 31w = 0w``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``x:word32 >>>~ 0w = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x:word32 >>>~ 31w = 0w``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:word32 >>>~ 31w = 0w) \/ (x >>>~ 31w = 1w)``,
-      [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``(x:word32 >>>~ x) = 0w``, [thm_AUTO, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 >>>~ y = y >>>~ x``, [(*sat_YO,*) sat_Z3, sat_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``(x:word32 >>>~ x) = 0w``, [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 >>>~ y = y >>>~ x``, [sat_CVC, (*sat_YO,*) sat_Z3, sat_Z3p]),
     (``(x:word32 >>>~ y) >>>~ z = x >>>~ (y >>>~ z)``,
-      [(*sat_YO,*) sat_Z3, sat_Z3p]),
+      [sat_CVC, (*sat_YO,*) sat_Z3, sat_Z3p]),
 
     (* Yices does not support arithmetical shift-right *)
 
-    (``x:word32 >> 0 = x``, [thm_AUTO, (*thm_YO,*) thm_Z3, thm_Z3p]),
-    (``x:word32 >> 31 = 0w``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``x:word32 >> 0 = x``, [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3, thm_Z3p]),
+    (``x:word32 >> 31 = 0w``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:word32 >> 31 = 0w) \/ (x >> 31 = 0xFFFFFFFFw)``,
-      [thm_AUTO, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+      [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
 
-    (``x:word32 >>~ 0w = x``, [thm_AUTO, (*thm_YO,*) thm_Z3, thm_Z3p]),
-    (``x:word32 >>~ 31w = 0w``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``x:word32 >>~ 0w = x``, [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3, thm_Z3p]),
+    (``x:word32 >>~ 31w = 0w``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:word32 >>~ 31w = 0w) \/ (x >>~ 31w = 0xFFFFFFFFw)``,
-      [thm_AUTO, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+      [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
     (``(x:word32 >>~ x = 0w)  \/ (x >>~ x = 0xFFFFFFFFw)``,
-      [thm_AUTO, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 >>~ y = y >>~ x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:word32 >>~ y) >>~ z = x >>~ (y >>~ z)``, [sat_YO, sat_Z3, sat_Z3p]),
+      [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 >>~ y = y >>~ x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:word32 >>~ y) >>~ z = x >>~ (y >>~ z)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
 
     (* Yices does not support bit-vector rotation *)
 
-    (``x:word32 #<< 0 = x``, [thm_AUTO, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 #<< 32 = x``, [thm_AUTO, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 #<< 64 = x``, [thm_AUTO, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 #<< 1 <> x``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``x:word32 #<< 0 = x``, [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 #<< 32 = x``, [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 #<< 64 = x``, [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 #<< 1 <> x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
 
-    (``x:word32 #<<~ 0w = x``, [thm_AUTO, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 #<<~ 32w = x``, [thm_AUTO, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 #<<~ 64w = x``, [thm_AUTO, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 #<<~ 1w = x``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``x:word32 #<<~ 0w = x``, [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 #<<~ 32w = x``, [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 #<<~ 64w = x``, [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 #<<~ 1w = x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
 
-    (``x:word32 #>> 0 = x``, [thm_AUTO, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 #>> 32 = x``, [thm_AUTO, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 #>> 64 = x``, [thm_AUTO, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 #>> 1 <> x``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``x:word32 #>> 0 = x``, [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 #>> 32 = x``, [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 #>> 64 = x``, [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 #>> 1 <> x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
 
-    (``x:word32 #>>~ 0w = x``, [thm_AUTO, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 #>>~ 32w = x``, [thm_AUTO, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 #>>~ 64w = x``, [thm_AUTO, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
-    (``x:word32 #>>~ 1w = x``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``x:word32 #>>~ 0w = x``, [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 #>>~ 32w = x``, [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 #>>~ 64w = x``, [thm_AUTO, thm_CVC, (*thm_YO,*) thm_Z3(*, thm_Z3p*)]),
+    (``x:word32 #>>~ 1w = x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
 
-    (``1w:word2 @@ 1w:word2 = 5w:word4``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``1w:word2 @@ 1w:word2 = 5w:word4``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``((x @@ y):word32 = y @@ x) = (x:word16 = y)``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``(31 >< 0) x:word32 = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``(1 >< 0) (0w:word32) = 0w:word2``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``(31 >< 0) x:word32 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``(1 >< 0) (0w:word32) = 0w:word2``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``(32 >< 0) (x:word32) :bool[33] = w2w x``,
-      [thm_AUTO, thm_YO(*, thm_Z3, thm_Z3p*)]),
+      [thm_AUTO(*, thm_CVC*), thm_YO(*, thm_Z3, thm_Z3p*)]),
     (``(0 >< 1) (x:word32) = 0w:word32``,
-      [thm_AUTO, thm_YO(*, thm_Z3, thm_Z3p*)]),
+      [thm_AUTO(*, thm_CVC*), thm_YO(*, thm_Z3, thm_Z3p*)]),
 
     (``(x:word2 = y) <=> (x ' 0 = y ' 0) /\ (x ' 1 = y ' 1)``,
-      [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
-    (``0w:word32 = w2w (0w:word16)``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``0w:word32 = w2w (0w:word32)``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``0w:word32 = w2w (0w:word64)``, [thm_AUTO, thm_YO(*, thm_Z3, thm_Z3p*)]),
-    (``x:word32 = w2w x``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``0w:word32 = w2w (0w:word16)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``0w:word32 = w2w (0w:word32)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``0w:word32 = w2w (0w:word64)``, [thm_AUTO, thm_CVC, thm_YO(*, thm_Z3, thm_Z3p*)]),
+    (``x:word32 = w2w x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
-    (``0w:word32 = sw2sw (0w:word16)``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``0w:word32 = sw2sw (0w:word32)``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``0w:word32 = sw2sw (0w:word64)``, [thm_AUTO, thm_YO(*, thm_Z3, thm_Z3p*)]),
-    (``x:word32 = sw2sw x``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``0w:word32 = sw2sw (0w:word16)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``0w:word32 = sw2sw (0w:word32)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``0w:word32 = sw2sw (0w:word64)``, [thm_AUTO, thm_CVC, thm_YO(*, thm_Z3, thm_Z3p*)]),
+    (``x:word32 = sw2sw x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
-    (``(x:word32) + x = x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:word32) + y = y + x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:word32) + x = x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:word32) + y = y + x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``((x:word32) + y) + z = x + (y + z)``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``(x:word32) + 0w = 0w``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:word32) + 0w = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:word32) + 0w = 0w``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:word32) + 0w = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``(x:word32) - x = x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:word32) - x = 0w``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``(x:word32) - y = y - x``, [sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:word32) - x = x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:word32) - x = 0w``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:word32) - y = y - x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``((x:word32) - y) - z = x - (y - z)``,
-      [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:word32) - 0w = 0w``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:word32) - 0w = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:word32) - 0w = 0w``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:word32) - 0w = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``(x:word32) * x = x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:word32) * y = y * x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:word32) * x = x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:word32) * y = y * x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``((x:word32) * y) * z = x * (y * z)``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``(x:word32) * 0w = 0w``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``(x:word32) * 0w = x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:word32) * 1w = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:word32) * 0w = 0w``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:word32) * 0w = x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``(x:word32) * 1w = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``- (x:word32) = x``, [sat_YO, sat_Z3, sat_Z3p]),
-    (``- 0w = 0w:word32``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``- - (x:word32) = x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``- (x:word32) = x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``- 0w = 0w:word32``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``- - (x:word32) = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``0w < 1w:word32``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``~ 0w < 0w:word32``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``0w < 1w:word32``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``~ 0w < 0w:word32``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``0w <= 1w:word32``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x <= y:word32 <=> x < y \/ (x = y)``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``~ 0w <= 0w:word32``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``0w <= 1w:word32``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x <= y:word32 <=> x < y \/ (x = y)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``~ 0w <= 0w:word32``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``1w > 0w:word32``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``0w > ~ 0w:word32``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``1w > 0w:word32``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``0w > ~ 0w:word32``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``1w >= 0w:word32``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x >= y:word32 <=> x > y \/ (x = y)``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``0w >= ~ 0w:word32``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``1w >= 0w:word32``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x >= y:word32 <=> x > y \/ (x = y)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``0w >= ~ 0w:word32``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``0w <+ 1w:word32``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``0w <+ ~ 0w:word32``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``0w <+ 1w:word32``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``0w <+ ~ 0w:word32``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``0w <=+ 1w:word32``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``0w <=+ 1w:word32``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``x <=+ y:word32 <=> x <+ y \/ (x = y)``,
-      [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``0w <=+ ~ 0w:word32``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``0w <=+ ~ 0w:word32``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``1w >+ 0w:word32``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``~ 0w >+ 0w:word32``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``1w >+ 0w:word32``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``~ 0w >+ 0w:word32``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``1w >=+ 0w:word32``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``1w >=+ 0w:word32``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``x >=+ y:word32 <=> x >+ y \/ (x = y)``,
-      [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
-    (``~ 0w >=+ 0w:word32``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``~ 0w >=+ 0w:word32``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
     (* from Magnus Myreen *)
     (``!(a:word32) b.
@@ -967,12 +976,12 @@ in
      (b <=+ a /\ a <> b <=> b <+ a) /\ (a <> b /\ b <=+ a <=> b <+ a) /\
      (b <= a /\ a <> b <=> b < a) /\ (a <> b /\ b <= a <=> b < a) /\
      (((v:word32) - w = 0w) <=> (v = w)) /\ (w - 0w = w)``,
-      [(*thm_AUTO,*) thm_YO(*, thm_Z3, thm_Z3p*)]),
+      [(*thm_AUTO,*) thm_CVC, thm_YO(*, thm_Z3, thm_Z3p*)]),
 
     (* from Yogesh Mahajan *)
     (``!(w: 18 word). (sw2sw w): 32 word = w2w ((16 >< 0) w: 17 word) +
      0xfffe0000w + ((0 >< 0) (~(17 >< 17) w: bool[unit]) << 17): 32 word``,
-      [thm_AUTO, thm_YO(*, thm_Z3, thm_Z3p*)]),
+      [thm_AUTO, thm_CVC, thm_YO(*, thm_Z3, thm_Z3p*)]),
 
     (* The Yices translation currently rejects polymorphic-width bit
        vectors; the SMT-LIB translation treats their type -- and
@@ -1018,26 +1027,26 @@ in
     (* sets (as predicates -- every set expression must be applied to an
        argument!) *)
 
-    (``x IN P <=> P x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``x IN P <=> P x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``x IN {x | P x} <=> P x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``x IN {x | P x} <=> P x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``x NOTIN {}``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x IN UNIV``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``x NOTIN {}``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x IN UNIV``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``x IN P UNION Q <=> P x \/ Q x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x IN P UNION {} <=> x IN P``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x IN P UNION UNIV``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x IN P UNION Q <=> x IN Q UNION P``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``x IN P UNION Q <=> P x \/ Q x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x IN P UNION {} <=> x IN P``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x IN P UNION UNIV``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x IN P UNION Q <=> x IN Q UNION P``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``x IN P UNION (Q UNION R) <=> x IN (P UNION Q) UNION R``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
 
-    (``x IN P INTER Q <=> P x /\ Q x``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x NOTIN P INTER {}``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x IN P INTER UNIV <=> x IN P``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
-    (``x IN P INTER Q <=> x IN Q INTER P``, [thm_AUTO, thm_YO, thm_Z3, thm_Z3p]),
+    (``x IN P INTER Q <=> P x /\ Q x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x NOTIN P INTER {}``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x IN P INTER UNIV <=> x IN P``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``x IN P INTER Q <=> x IN Q INTER P``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``x IN P INTER (Q INTER R) <=> x IN (P INTER Q) INTER R``,
-      [thm_AUTO, thm_YO, thm_Z3, thm_Z3p])
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p])
 
   ]  (* tests *)
 end

--- a/src/HolSmt/selftest.sml
+++ b/src/HolSmt/selftest.sml
@@ -407,11 +407,11 @@ in
     (``(x:int) % 1 = x - x / 1 * 1``, [thm_AUTO, thm_YO]),
     (``(x:int) % 42 = x - x / 42 * 42``, [thm_AUTO, thm_YO]),
 
-    (``ABS (x:int) >= 0``, [thm_AUTO, thm_CVC, thm_YO(*, thm_Z3, thm_Z3p*)]),
-    (``(ABS (x:int) = 0) = (x = 0)``, [thm_AUTO, thm_CVC, thm_YO(*, thm_Z3, thm_Z3p*)]),
-    (``(x:int) >= 0 ==> (ABS x = x)``, [thm_AUTO, thm_YO(*, thm_Z3, thm_Z3p*)]),
-    (``(x:int) <= 0 ==> (ABS x = ~x)``, [thm_AUTO, thm_YO(*, thm_Z3, thm_Z3p*)]),
-    (``ABS (ABS (x:int)) = ABS x``, [thm_AUTO, thm_YO(*, thm_Z3, thm_Z3p*)]),
+    (``ABS (x:int) >= 0``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``(ABS (x:int) = 0) = (x = 0)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``(x:int) >= 0 ==> (ABS x = x)``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``(x:int) <= 0 ==> (ABS x = ~x)``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``ABS (ABS (x:int)) = ABS x``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
     (``ABS (x:int) = x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
 
     (``int_min (x:int) y <= x``, [thm_AUTO, thm_YO]),
@@ -436,22 +436,22 @@ in
     (``((x:real) + y = 0) = (x = 0) /\ (y = 0)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``((x:real) + y = 0) = (x = ~y)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
-    (``(x:real) - 0 = x``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``(x:real) - 0 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
     (``(x:real) - y = y - x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:real) - y - z = x - (y + z)``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``(x:real) - y - z = x - (y + z)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
     (``(x:real) <= y ==> (x - y = 0)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``((x:real) - y = 0) \/ (y - x = 0)``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:real) - y = x + ~y``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``(x:real) - y = x + ~y``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
-    (``(x:real) * 0 = 0``, [thm_AUTO, thm_CVC, thm_YO]),
-    (``0 * (x:real) = 0``, [thm_AUTO, thm_CVC, thm_YO]),
-    (``(x:real) * 1 = x``, [thm_AUTO, thm_CVC, thm_YO]),
-    (``1 * (x:real) = x``, [thm_AUTO, thm_CVC, thm_YO]),
-    (``(x:real) * 42 = 42 * x``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``(x:real) * 0 = 0``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``0 * (x:real) = 0``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``(x:real) * 1 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``1 * (x:real) = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``(x:real) * 42 = 42 * x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
-    (``(x:real) / 1 = x``, [thm_AUTO, thm_CVC, thm_YO]),
-    (``x > 0 ==> (x:real) / 42 < x``, [(*thm_AUTO,*) thm_CVC, thm_YO]),
-    (``x < 0 ==> (x:real) / 42 > x``, [(*thm_AUTO,*) thm_CVC, thm_YO]),
+    (``(x:real) / 1 = x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``x > 0 ==> (x:real) / 42 < x``, [(*thm_AUTO,*) thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``x < 0 ==> (x:real) / 42 > x``, [(*thm_AUTO,*) thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
     (``abs (x:real) >= 0``, [thm_AUTO, thm_YO]),
     (``(abs (x:real) = 0) = (x = 0)``, [thm_AUTO, thm_YO]),
@@ -545,32 +545,32 @@ in
 
     (* real *)
 
-    (``0r < 1r``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``0r < 1r``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``1r < 0r``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:real) < x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:real) < y ==> 42 * x < 42 * y``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``(x:real) < y ==> 42 * x < 42 * y``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
     (``0n <= 1n``, [thm_AUTO, thm_YO]),
     (``1n <= 0n``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:num) <= x``, [thm_AUTO, thm_YO]),
     (``(x:num) <= y ==> 2 * x <= 2 * y``, [thm_AUTO, thm_YO]),
 
-    (``1r > 0r``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``1r > 0r``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``0r > 1r``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``(x:real) > x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:real) > y ==> 42 * x > 42 * y``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``(x:real) > y ==> 42 * x > 42 * y``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
-    (``1r >= 0r``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``1r >= 0r``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
     (``0r >= 1r``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
-    (``(x:real) >= x``, [thm_AUTO, thm_CVC, thm_YO]),
-    (``(x:real) >= y ==> 42 * x >= 42 * y``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``(x:real) >= x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:real) >= y ==> 42 * x >= 42 * y``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
-    (``((x:real) < y) = (y > x)``, [thm_AUTO, thm_CVC, thm_YO]),
-    (``((x:real) <= y) = (y >= x)``, [thm_AUTO, thm_CVC, thm_YO]),
-    (``(x:real) < y /\ y <= z ==> x < z``, [thm_AUTO, thm_CVC, thm_YO]),
-    (``(x:real) <= y /\ y <= z ==> x <= z``, [thm_AUTO, thm_CVC, thm_YO]),
-    (``(x:real) > y /\ y >= z ==> x > z``, [thm_AUTO, thm_CVC, thm_YO]),
-    (``(x:real) >= y /\ y >= z ==> x >= z``, [thm_AUTO, thm_CVC, thm_YO]),
+    (``((x:real) < y) = (y > x)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``((x:real) <= y) = (y >= x)``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3, thm_Z3p]),
+    (``(x:real) < y /\ y <= z ==> x < z``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``(x:real) <= y /\ y <= z ==> x <= z``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``(x:real) > y /\ y >= z ==> x > z``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (``(x:real) >= y /\ y >= z ==> x >= z``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
     (``(x:real) >= 0``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
     (``0 < (x:real) /\ x <= 1 ==> (x = 1)``,
@@ -600,14 +600,12 @@ in
        (somewhat surprisingly, as SMT-LIB does not seem to require
        non-empty sorts) can prove it *)
     (``?x. x = x``, [thm_AUTO, thm_CVC, thm_Z3(*, thm_Z3p*)]),
-    (* CVC5 1.0.8 and Z3 2.13 report `unknown' for the next goal *)
-    (``(?y. !x. P x y) ==> (!x. ?y. P x y)``, [thm_AUTO, thm_YO]),
-    (* CVC5 1.0.8, Yices 1.0.28 and Z3 2.13 report `unknown' for the next goal *)
-    (``(!x. ?y. P x y) ==> (?y. !x. P x y)``, []),
-    (* Z3 2.13 reports `unknown' for the next goal *)
-    (``(?x. P x) ==> !x. P x``, [sat_CVC, sat_YO]),
-    (* Z3 2.13 reports `unknown' for the next goal *)
-    (``?x. P x ==> !x. P x``, [thm_AUTO, thm_CVC, thm_YO]),
+    (* CVC5 1.0.8 reports `unknown' for the next goal *)
+    (``(?y. !x. P x y) ==> (!x. ?y. P x y)``, [thm_AUTO, thm_YO, thm_Z3(*, thm_Z3p*)]),
+    (* CVC5 1.0.8 and Yices 1.0.28 report `unknown' for the next goal *)
+    (``(!x. ?y. P x y) ==> (?y. !x. P x y)``, [sat_Z3, sat_Z3p]),
+    (``(?x. P x) ==> !x. P x``, [sat_CVC, sat_YO, sat_Z3, sat_Z3p]),
+    (``?x. P x ==> !x. P x``, [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
     (* let binders *)
 
@@ -976,12 +974,12 @@ in
      (b <=+ a /\ a <> b <=> b <+ a) /\ (a <> b /\ b <=+ a <=> b <+ a) /\
      (b <= a /\ a <> b <=> b < a) /\ (a <> b /\ b <= a <=> b < a) /\
      (((v:word32) - w = 0w) <=> (v = w)) /\ (w - 0w = w)``,
-      [(*thm_AUTO,*) thm_CVC, thm_YO(*, thm_Z3, thm_Z3p*)]),
+      [(*thm_AUTO,*) thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
     (* from Yogesh Mahajan *)
     (``!(w: 18 word). (sw2sw w): 32 word = w2w ((16 >< 0) w: 17 word) +
      0xfffe0000w + ((0 >< 0) (~(17 >< 17) w: bool[unit]) << 17): 32 word``,
-      [thm_AUTO, thm_CVC, thm_YO(*, thm_Z3, thm_Z3p*)]),
+      [thm_AUTO, thm_CVC, thm_YO, thm_Z3(*, thm_Z3p*)]),
 
     (* The Yices translation currently rejects polymorphic-width bit
        vectors; the SMT-LIB translation treats their type -- and

--- a/src/HolSmt/selftest.sml
+++ b/src/HolSmt/selftest.sml
@@ -745,11 +745,9 @@ in
     (``x:word8 < 0w /\ y < 0w  ==> (word_smod x y = -word_mod (-x) (-y))``,
       [(*thm_AUTO, thm_YO,*)thm_Z3(*, thm_Z3p*)]),
     (``x:word8 < 0w /\ y >= 0w ==> (word_smod x y = -word_mod (-x) y + y)``,
-      [(*thm_AUTO, thm_YO, thm_Z3, thm_Z3p*)]),
-(* this is false: consider x = 99, y = 255
+      [(*sat_YO,*) sat_Z3, sat_Z3p]),
     (``x:word8 >= 0w /\ y < 0w ==> (word_smod x y = word_mod x (-y) + y)``,
-      [(*thm_AUTO, thm_YO,*)thm_Z3(*, thm_Z3p*)]),
-*)
+      [(*sat_YO, sat_Z3, sat_Z3p*)]),
     (``x:word8 >= 0w /\ y >= 0w ==> (word_smod x y = word_mod x y)``,
       [(*thm_AUTO, thm_YO, thm_Z3, thm_Z3p*)]),
 


### PR DESCRIPTION
This PR adds support for the [cvc5 SMT solver](https://cvc5.github.io/). It also updates HolSmt's documentation and enables more tests for the Z3 SMT solver.

It is split into 4 commits:

* The first commit is just a small fix to a couple of HolSmt's tests. These tests seemed to expect the goals to be theorems, but in fact they are false.
  * The first one was demonstrated to be false when cvc5 gave me the `x=-127` and `y=127` counterexample, which I subsequently verified purely in HOL4 just to be sure.
  * The second one was already marked as false and commented out (with a counterexample), but I uncommented it (with an empty list of provers) in preparation for adding a cvc5 satisfiable test (which succeeds when the goal is false) in a subsequent commit.

This minor fix to these two tests was put into a separate commit for two reasons: 1) it's independent of the other improvements/commits, and 2) just to make sure that this reversal in the expected behavior wasn't lost in the noise.

* The second commit adds proper support for the cvc5 SMT solver. Adding support for it was extremely straightforward, exactly as HolSmt's documentation suggested it would be.

The only very minor issue was that cvc5 printed out a warning that performance will not be optimal if a specific logic was not specified. To avoid this warning, I modified HolSmt to prepend a `(set-logic <logic>)` command to the generated file.

Currently, and just like before this PR, no attempt is being made to determine what is the optimal logic for a query. Instead, Z3 passes `NONE` (which instructs `SmtLib.sml` to not generate a `set-logic` command) and cvc5 passes `SOME "ALL"` in order to generate a `(set-logic ALL)` command, as that is what cvc5 suggests should be done in this case.

The `HOL4_CVC_EXECUTABLE` environment variable is used to find the `cvc5` executable, following the same pattern as for the other SMT solvers.

* The third commit updates HolSmt's documentation:
  * URLs were updated and/or changed from http->https.
  * Documentation for the cvc5 solver was added.
  * It is now mentioned that a modern version of Z3 has been tested to work as an oracle (version 4.8.17 specifically, as that's the one I've been testing).
  * It is now clarified that only Z3 2.19 supports proof reconstruction.
  * I've also added a note that Z3 2.19.1 does not work with reals due to an apparent bug in parsing real literals. That said, this note is kind of buried in the download instructions, not sure if it should be mentioned more prominently.
    * As a side note, I've added a workaround to fix this, but then HolSmt failed elsewhere in reconstructing a Z3 2.19.1 proof, and since I'm not familiar with proof reconstruction I decided to scrap the workaround and just document the issue for now.
  * The example session was updated to the newer syntax.

Note: I don't know what are the build commands to generate the documentation PDFs since (ironically) I couldn't find documentation for that. I also have zero LaTeX experience, so I have no idea if the changes I've made to the documentation are correct or how they actually look in rendered form.

* The fourth commit simply enables (or re-enables) tests for Z3 that I've confirmed to be working for both Z3 2.19 (which HolSmt supports for proof reconstruction) and Z3 4.8.17 (a modern version of Z3).

There are a couple of related questions that I haven't dealt with (at least, not yet):

* Does HOL4 run the HolSmt self tests as part of some kind of CI? If so, I wonder which Z3 version is being used.

More importantly, I wonder if support for cvc5 should also be added to the CI pipeline (assuming it exists?). In theory, all that's needed is to install cvc5 and set the `HOL4_CVC_EXECUTABLE` environment variable to point to it.

* SMT solver reliability.

I know that Z3 (and I believe cvc5 as well) support deterministic queries, by setting a specific random seed and by setting the search limit to be a specific number of steps rather than a time limit.

However, HolSmt currently does not attempt to do this at all, so I'm guessing that SMT solvers default to using a random seed and running with a time limit as the criteria for giving up when the query is too difficult.

Given that, I wonder if anyone has experienced HolSmt tests to fail occasionally, due to the non-deterministic nature of these time limits and random seeds or if this hasn't been an issue at all?