### PR TITLE
Add paragraph on Inductive definitions using modern syntax

### DIFF
--- a/Manual/Description/definitions.stex
+++ b/Manual/Description/definitions.stex
@@ -2035,6 +2035,17 @@ one writes
    End
 \end{verbatim}
 where, as with other special syntaxes, the keywords (\ml{Inductive} and \ml{End}) have to be in the leftmost column of the source file.
+Additionally, users can automatically export each rule as a theorem by assigning a name using the square-bracket syntax.
+The appropriate format is \holtxt{[\(\sim\)Name:]}, where \holtxt{Name} acts as the placeholder for the rule name, see the following example:
+\begin{verbatim}
+   Inductive foo:
+   [~rule1:]
+     ...
+   [~rule2:]
+     ...
+   ...
+   End
+\end{verbatim}
 
 \paragraph{Strong induction principles}
 So called ``strong'' versions of induction principles (in which instances of the relation being defined appear as extra hypotheses), are automatically proved when an inductive definition is made.

--- a/Manual/Description/definitions.stex
+++ b/Manual/Description/definitions.stex
@@ -2036,10 +2036,12 @@ one writes
 \end{verbatim}
 where, as with other special syntaxes, the keywords (\ml{Inductive} and \ml{End}) have to be in the leftmost column of the source file.
 Additionally, users can automatically export each rule as a theorem by assigning a name using the square-bracket syntax.
-The appropriate format is \holtxt{[\(\sim\)Name:]}, where \holtxt{Name} acts as the placeholder for the rule name, see the following example:
+The appropriate format is \holtxt{[\textasciitilde Name:]}, where \holtxt{Name} acts as the placeholder for the rule name.
+Inside the square brackets, the tilde (\textasciitilde) is optional; if included, it prefixes the exported rule name with \ml{<stem>\_}.
+For instance, the following example will export rules as \ml{rule1} and \ml{foo\_rule2}.
 \begin{verbatim}
    Inductive foo:
-   [~rule1:]
+   [rule1:]
      ...
    [~rule2:]
      ...


### PR DESCRIPTION
This PR adds a small paragraph on the use of named rules in `Inductive` definitions.

![image](https://github.com/HOL-Theorem-Prover/HOL/assets/26225067/55af1545-99e9-42b1-8fc8-eb2cf5231856)
