### PR TITLE
Böhm tree with basic properties

### DIFF
--- a/examples/lambda/barendregt/chap3Script.sml
+++ b/examples/lambda/barendregt/chap3Script.sml
@@ -186,6 +186,16 @@ val ccbeta_rwt = store_thm(
     FULL_SIMP_TAC (srw_ss()) []
   ]);
 
+Theorem ccbeta_LAMl_rwt :
+    !vs M N. LAMl vs M -b-> N <=> ?M'. N = LAMl vs M' /\ M -b-> M'
+Proof
+    Induct_on ‘vs’
+ >> rw [ccbeta_rwt] (* only one goal left *)
+ >> EQ_TAC >> rw []
+ >- (Q.EXISTS_TAC ‘M'’ >> art [])
+ >> Q.EXISTS_TAC ‘LAMl vs M'’ >> rw []
+QED
+
 val beta_normal_form_bnf = store_thm(
   "beta_normal_form_bnf",
   ``normal_form beta = bnf``,
@@ -689,6 +699,7 @@ val ccbeta_lameq = store_thm(
   "ccbeta_lameq",
   ``!M N. M -b-> N ==> M == N``,
   SRW_TAC [][lameq_betaconversion, EQC_R]);
+
 val betastar_lameq = store_thm(
   "betastar_lameq",
   ``!M N. M -b->* N ==> M == N``,
@@ -1577,6 +1588,11 @@ val betastar_eq_cong = store_thm(
   "betastar_eq_cong",
   ``bnf N ==> M -b->* M' ==> (M -b->* N  <=> M' -b->* N)``,
   METIS_TAC [bnf_triangle, RTC_CASES_RTC_TWICE]);
+
+(* |- !x y z. x -b->* y /\ y -b->* z ==> x -b->* z *)
+Theorem betastar_TRANS =
+        RTC_TRANSITIVE |> Q.ISPEC ‘compat_closure beta’
+                       |> REWRITE_RULE [transitive_def]
 
 val _ = export_theory();
 val _ = html_theory "chap3";

--- a/examples/lambda/basics/appFOLDLScript.sml
+++ b/examples/lambda/basics/appFOLDLScript.sml
@@ -332,6 +332,12 @@ Proof
     rw [FOLDR_SNOC]
 QED
 
+Theorem LAMl_eq_rewrite[simp] :
+    LAMl vs t1 = LAMl vs t2 <=> t1 = t2
+Proof
+    Induct_on ‘vs’ >> rw [LAM_eq_thm]
+QED
+
 (*---------------------------------------------------------------------------*
  *  funpow for lambda terms (using arithmeticTheory.FUNPOW)
  *---------------------------------------------------------------------------*)

--- a/src/coalgebras/ltreeScript.sml
+++ b/src/coalgebras/ltreeScript.sml
@@ -8,9 +8,10 @@
   Note that this tree data structure allows for both infinite depth
   and infinite breadth.
 *)
-open HolKernel Parse boolLib bossLib term_tactic;
+open HolKernel Parse boolLib bossLib;
+
 open arithmeticTheory listTheory llistTheory alistTheory optionTheory;
-open mp_then pred_setTheory relationTheory pairTheory combinTheory;
+open pred_setTheory relationTheory pairTheory combinTheory hurdUtils;
 
 val _ = new_theory "ltree";
 
@@ -700,50 +701,65 @@ Proof
  >> EQ_TAC >> rw []
 QED
 
-Definition ltree_finite_branching_def :
-    ltree_finite_branching = ltree_every (\a ts. LFINITE ts)
+Definition finite_branching_def :
+    finite_branching = ltree_every (\a ts. LFINITE ts)
 End
 
-Theorem ltree_finite_branching_rules :
-    !a ts. EVERY ltree_finite_branching ts ==>
-           ltree_finite_branching (Branch a (fromList ts))
+Theorem finite_branching_rules :
+    !a ts. EVERY finite_branching ts ==>
+           finite_branching (Branch a (fromList ts))
 Proof
-    rw [ltree_finite_branching_def, EVERY_MEM]
+    rw [finite_branching_def, EVERY_MEM]
  >> qabbrev_tac ‘P = \(a :'a) (ts :'a ltree llist). LFINITE ts’
  >> rw [Once ltree_every_cases]
  >- rw [Abbr ‘P’, LFINITE_fromList]
  >> rw [every_fromList_EVERY, EVERY_MEM]
 QED
 
+(* The "primed" version uses ‘every’ (and ‘LFINITE’) instead of ‘EVERY’ *)
+Theorem finite_branching_rules' :
+    !a ts. LFINITE ts /\ every finite_branching ts ==>
+           finite_branching (Branch a ts)
+Proof
+    rw [finite_branching_def]
+QED
+
 Theorem ltree_finite_imp_finite_branching :
-    !t. ltree_finite t ==> ltree_finite_branching t
+    !t. ltree_finite t ==> finite_branching t
 Proof
     HO_MATCH_MP_TAC ltree_finite_ind
- >> rw [ltree_finite_branching_rules]
+ >> rw [finite_branching_rules]
 QED
 
 (* cf. ltree_cases *)
-Theorem ltree_finite_branching_cases :
-    !t. ltree_finite_branching t <=>
-        ?a ts. t = Branch a (fromList ts) /\ EVERY ltree_finite_branching ts
+Theorem finite_branching_cases :
+    !t. finite_branching t <=>
+        ?a ts. t = Branch a (fromList ts) /\ EVERY finite_branching ts
 Proof
-    rw [ltree_finite_branching_def, Once ltree_every_cases]
+    rw [finite_branching_def, Once ltree_every_cases]
  >> EQ_TAC >> rw [LFINITE_fromList, every_fromList_EVERY]
  >> ‘?l. ts = fromList l’ by METIS_TAC [LFINITE_IMP_fromList]
  >> fs [every_fromList_EVERY]
 QED
 
+Theorem finite_branching_cases' :
+    !t. finite_branching t <=>
+        ?a ts. t = Branch a ts /\ LFINITE ts /\ every finite_branching ts
+Proof
+    rw [finite_branching_def, Once ltree_every_cases]
+QED
+
 (* |- (!a0. P a0 ==> ?a ts. a0 = Branch a ts /\ LFINITE ts /\ every P ts) ==>
-      !a0. P a0 ==> ltree_finite_branching a0
+      !a0. P a0 ==> finite_branching a0
  *)
 val lemma = ltree_every_coind
          |> (Q.SPEC ‘\(a :'a) (ts :'a ltree llist). LFINITE ts’)
          |> (Q.SPEC ‘P’) |> BETA_RULE
-         |> REWRITE_RULE [GSYM ltree_finite_branching_def];
+         |> REWRITE_RULE [GSYM finite_branching_def];
 
-Theorem ltree_finite_branching_coind :
+Theorem finite_branching_coind :
     !P. (!t. P t ==> ?a ts. t = Branch a (fromList ts) /\ EVERY P ts) ==>
-         !t. P t ==> ltree_finite_branching t
+         !t. P t ==> finite_branching t
 Proof
     NTAC 2 STRIP_TAC
  >> MATCH_MP_TAC lemma
@@ -754,16 +770,120 @@ Proof
  >> rw [LFINITE_fromList, every_fromList_EVERY]
 QED
 
-Theorem ltree_finite_branching_rewrite[simp] :
-    ltree_finite_branching (Branch a ts) <=>
-    LFINITE ts /\ every ltree_finite_branching ts
+Theorem finite_branching_coind' :
+    !P. (!t. P t ==> ?a ts. t = Branch a ts /\ LFINITE ts /\ every P ts) ==>
+         !t. P t ==> finite_branching t
 Proof
-    SIMP_TAC std_ss [ltree_finite_branching_cases]
+    NTAC 2 STRIP_TAC
+ >> MATCH_MP_TAC lemma >> rw []
+QED
+
+Theorem finite_branching_rewrite[simp] :
+    finite_branching (Branch a ts) <=> LFINITE ts /\ every finite_branching ts
+Proof
+    SIMP_TAC std_ss [finite_branching_cases]
  >> EQ_TAC >> rw []
  >- rw [LFINITE_fromList]
  >- rw [every_fromList_EVERY]
  >> ‘?l. ts = fromList l’ by METIS_TAC [LFINITE_IMP_fromList]
  >> fs [every_fromList_EVERY]
+QED
+
+(*---------------------------------------------------------------------------*
+ *  More ltree operators
+ *---------------------------------------------------------------------------*)
+
+Definition ltree_node_def[simp] :
+    ltree_node (Branch a ts) = a
+End
+
+Definition ltree_children_def[simp] :
+    ltree_children (Branch a ts) = ts
+End
+
+Theorem ltree_node_children_reduce[simp] :
+    Branch (ltree_node t) (ltree_children t) = t
+Proof
+   ‘?a ts. t = Branch a ts’ by METIS_TAC [ltree_cases]
+ >> rw []
+QED
+
+Definition ltree_paths_def :
+    ltree_paths t = {p | ltree_lookup t p <> NONE}
+End
+
+Theorem IN_ltree_lookup :
+    !p t. p IN ltree_paths t <=> ltree_lookup t p <> NONE
+Proof
+    rw [ltree_paths_def]
+QED
+
+Theorem NIL_IN_ltree_paths[simp] :
+    [] IN ltree_paths t
+Proof
+    rw [ltree_paths_def, ltree_lookup_def]
+QED
+
+Theorem ltree_paths_inclusive :
+    !l1 l2 t. l1 <<= l2 /\ l2 IN ltree_paths t ==> l1 IN ltree_paths t
+Proof
+    Induct_on ‘l1’
+ >> rw [] (* only one goal left *)
+ >> Cases_on ‘l2’ >> fs []
+ >> rename1 ‘l1 <<= l2’
+ >> Q.PAT_X_ASSUM ‘h = h'’ K_TAC
+ >> rename1 ‘h::l1 IN ltree_paths t’
+ >> POP_ASSUM MP_TAC
+ >> ‘?a ts. t = Branch a ts’ by METIS_TAC [ltree_cases]
+ >> POP_ORW
+ >> simp [ltree_paths_def, ltree_lookup_def]
+ >> Cases_on ‘LNTH h ts’ >> rw []
+ >> fs [GSYM IN_ltree_lookup]
+ >> FIRST_X_ASSUM MATCH_MP_TAC
+ >> Q.EXISTS_TAC ‘l2’ >> rw []
+QED
+
+Theorem ltree_el :
+    ltree_el t [] = SOME (ltree_node t,LLENGTH (ltree_children t)) /\
+    ltree_el t (n::ns) =
+      case LNTH n (ltree_children t) of
+        NONE => NONE
+      | SOME a => ltree_el a ns
+Proof
+   ‘?a ts. t = Branch a ts’ by METIS_TAC [ltree_cases]
+ >> simp [ltree_el_def]
+QED
+
+Theorem ltree_lookup :
+    ltree_lookup t [] = SOME t /\
+    ltree_lookup t (n::ns) =
+      case LNTH n (ltree_children t) of
+        NONE => NONE
+      | SOME a => ltree_lookup a ns
+Proof
+   ‘?a ts. t = Branch a ts’ by METIS_TAC [ltree_cases]
+ >> simp [ltree_lookup_def]
+QED
+
+Theorem ltree_lookup_iff_ltree_el[local] :
+    !p t. ltree_lookup t p <> NONE <=> ltree_el t p <> NONE
+Proof
+    Induct_on ‘p’
+ >- rw [ltree_lookup, ltree_el]
+ >> rw [Once ltree_lookup, Once ltree_el]
+ >> Cases_on ‘LNTH h (ltree_children t)’ >> fs []
+QED
+
+Theorem ltree_paths_alt :
+    !t. ltree_paths A = {p | ltree_el A p <> NONE}
+Proof
+    rw [ltree_paths_def, Once EXTENSION, ltree_lookup_iff_ltree_el]
+QED
+
+Theorem ltree_el_valid :
+    !p t. p IN ltree_paths t ==> ltree_el t p <> NONE
+Proof
+    rw [ltree_paths_alt]
 QED
 
 (*---------------------------------------------------------------------------*

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -2719,7 +2719,6 @@ val f_REVERSE_lemma = TAC_PROOF (([],
       (GEN (“x:('a)list”) (BETA_RULE (AP_THM x (“REVERSE (x:('a)list)”))))))),
       ASM_REWRITE_TAC[]]);
 
-
 val SNOC_Axiom_old = prove(
   “!(e:'b) (f:'b -> ('a -> (('a)list -> 'b))).
         ?! fn1.
@@ -2765,6 +2764,13 @@ val SNOC_Axiom = store_thm(
 
 val SNOC_INDUCT = save_thm("SNOC_INDUCT", prove_induction_thm SNOC_Axiom_old);
 val SNOC_CASES =  save_thm("SNOC_CASES", hd (prove_cases_thm SNOC_INDUCT));
+
+(* cf. rich_listTheory.IS_PREFIX_SNOC *)
+Theorem isPREFIX_SNOC[simp] :
+    l <<= SNOC x l
+Proof
+    Induct_on ‘l’ >> rw [SNOC, isPREFIX]
+QED
 
 (*--------------------------------------------------------------*)
 (* List generator                                               *)


### PR DESCRIPTION
Hi,

This PR finally adds the formalization of Böhm trees (Chapter 10 of [Barendregt 1984]) , an co-inductive tree-like representation of λ terms (based on HOL's `ltreeTheory`). This work has been revised several times in the past 4 months and the current definition is finally verified by showing two β-equivalent terms have the "same" (to be explained) Böhm tree,  thus perhaps it's really correct for the need of later uses.  Note also that currently the construction is done without help of de Bruijn encoding, but a further translation (not available yet) of the resulting tree w.r.t. de Bruijn encoding may achieve the uniqueness of Böhm trees for α-equivalent λ-terms.

Let's briefly recall the "textbook construction" of Böhm trees: given an λ-term M, first we need to know if it's solvable. If not, its Böhm tree is a special "bottom" node ($\bot$). Otherwise, according to Wadsworth's theorem (Theorem 8.3.14), M has a head normal form (hnf). But a solvable term may have many hnfs, here we choose the "principle hnf" (the last element of its head reduction path), which may be represent by `M := LAMl vs ((VAR y) @* Ms)`.  Then the root of the Böhm tree is nothing but `LAMl vs (VAR y)` and the children are each terms in the list `Ms`, translated in the same way as `M`.

The problem is that, under α-conversion, it's unsound to define any function to directly retrieve `VAR y` and `Ms` from the hnf `LAMl vs ((VAR y) @* Ms)` and then construct `LAMl vs (VAR y)` as the tree node, because `vs` as a list of bound variables can be replaced by any other variables, as long as they have no conflict with the free variables of M. My solution is to first pick `vs` to avoid `FV M`, and then apply M with `MAP VAR vs`, and then we got the inner part, since `M @@ MAP VAR vs == (VAR y) @* Ms`.

The tree data structure is based on `ltreeTheory` in HOL's core theory. First, a Böhm tree generator is defined in this way: (note that, we represent `LAMl vs (VAR y)` by `(vs,y)`, thus the type of Böhm tree do not have `:term` as type arguments, it's all in `:string`.)
```
[BT_generator_def]
⊢ ∀X M.
    BT_generator (X,M) =
    if solvable M then
      (let
         M0 = principle_hnf M;
         n = LAMl_size M0;
         vs = FRESH_list n (X ∪ FV M);
         M1 = principle_hnf (M0 ·· MAP VAR vs);
         Ms = hnf_children M1;
         l = MAP ($, (X ∪ set vs)) Ms;
         y = hnf_headvar M1;
         h = (vs,y)
       in
         (SOME h,fromList l))
    else (NONE,[||])
```
Note that the generator doesn't start with just the input term `M`. Instead, it takes an extra set of variables X as the excluded set, to make sure that all generated binding variables have no conflict with either `FV M` and `X` (see `vs = FRESH_list n (X ∪ FV M)` in above definition). Further more, in hnfs like `LAMl vs ((VAR y) @* Ms)`, the binding variables `vs` may occur freely in `(VAR y) @* Ms`. Therefore, when going into the next level of tree generation, just excluding `X` (and `FV M`) is not enough, the `vs` from current level must be also added too. This is why I have `l = MAP ($, (X ∪ set vs)) Ms` in the above definition for the tree generation of children in `Ms`.

Once the ltree generator is ready, the Böhm tree itself is simply defined below:
```
[BT_def]
⊢ BT = ltree_unfold BT_generator
```
The Böhm tree of M w.r.t. X is given by `BT (X,M)` or `BTe X M` (`BTe = CURRY BT`). Clearly for each different `X` the resulting tree is also different.  The purpose of this extra set `X` can be seen by the following "key" theorem saying that two β-equivalent terms have the "same" Βöhm tree:
```
lameq_BT_cong
⊢ ∀X M N. FINITE X ∧ FV M ∪ FV N ⊆ X ⇒ M == N ⇒ BTe X M = BTe X N
```
Note that, when `M == N`, for the conclusion `BTe X M = BTe X N` to hold, the choice of `X` is NOT arbitrary: it must contains at least all free variables from M and N.   This is because, in the definition of `BT_generator`, we can easily see that `X ∪ FV M = X ∪ FV N` if `FV M ∪ FV N ⊆ X` holds, and thus at each correspond tree levels, the `FRESH_list` inside `BTe X M` and `BTe X N` will literally generate the same binding list `vs`, rendering the two Böhm trees completely identical.

The second evidence (for the correctness of `BT_generator`) is the connection of Böhm trees to the similar concept "subterm" (Definition 10.1.13), defined as below:
```
[subterm_def]
⊢ (∀X M. subterm X M [] = SOME (X,M)) ∧
  ∀X M x xs.
    subterm X M (x::xs) =
    if solvable M then
      (let
         M0 = principle_hnf M;
         n = LAMl_size M0;
         vs = FRESH_list n (X ∪ FV M);
         M1 = principle_hnf (M0 ·· MAP VAR vs);
         Ms = hnf_children M1;
         m = LENGTH Ms
       in
         if x < m then subterm (X ∪ set vs) (EL x Ms) xs else NONE)
    else NONE
```

The tool "subterm" can access the children term according to a (finite) list of numbers as the "access path". When the list is empty, the subterm of M is M itself.  Otherwise, the input term is first translated to its principle hnf, `LAMl vs ((VAR y) @* Ms)` (if not solvable then there's no subterm, returning `NONE`), then the path `[i]` will give us `EL i Ms` (the i-th element of hnf children `Ms`. For a deeper path like `[1;2]`, we first get `EL 1 Ms` and then repeat the process by getting the principle hnf of `EL 1 Ms` and then access the `EL 2` of its hnf children, etc.

We can imagine that `subterm X M p` is not any node content in the Böhm tree BT(M), because in the tree the node following the same path `p` is the head part  of the principle hnf of `subterm M p`. _But if we try to generate Böhm trees of the subterm, the resulting tree must be a subtree of the original BT(M)._ The following theorem formalized this observation and make the connection between `subterm` and `BT` (or `BTe`):
```
BT_subterm_thm
⊢ ∀p X M.
    p ∈ ltree_paths (BTe X M) ∧ subterm X M p ≠ NONE ⇒
    BT (THE (subterm X M p)) = THE (ltree_lookup (BTe X M) p)
```

Many new utility theorems were added to serve the above results. The previously added `ltree_finite_branching` has been renamed to just `finite_branching` (no conflict with other core theories), and we can prove that Böehm trees are always finite branching (but may have infinite depth, thus is coinductive in general):
```
[BT_finite_branching]
⊢ ∀X M. finite_branching (BTe X M)
```

The deep connection between Böhm trees and the concept of "Böhm transformations" added in previous PR #1169, is yet to be shown.
