### PR TITLE
[CCS] define "nil" by "I"-combinator (rec X (var X))

### DIFF
--- a/examples/CCS/CongruenceScript.sml
+++ b/examples/CCS/CongruenceScript.sml
@@ -153,7 +153,7 @@ Proof
  >> ONCE_REWRITE_TAC [CONTEXT_cases]
  >> fs [FUN_EQ_THM, IS_CONST_def]
  >> rpt STRIP_TAC
- >- (Q.EXISTS_TAC ‘nil’ >> rw [])
+ >- (Q.EXISTS_TAC ‘var X’ >> rw [])
  >> MP_TAC (Q.SPEC ‘p’ CCS_cases)
  >> rw [] >> CCONTR_TAC >> fs []
  >> rename1 ‘!t. rec X (e t) = rec Y E’
@@ -304,7 +304,7 @@ Proof
  >> fs [FUN_EQ_THM] (* 3 subgoals left *)
  >| [ (* goal 1 (of 3) *)
       POP_ASSUM (MP_TAC o (Q.SPEC `nil`)) \\
-      SIMP_TAC std_ss [CCS_distinct],
+      SIMP_TAC std_ss [CCS_distinct'],
       (* goal 2 (of 3) *)
       MP_TAC (Q.SPEC ‘p’ CCS_cases) >> rw [] >> fs [] \\
      ‘e = \t. E’ by PROVE_TAC [] >> POP_ORW \\
@@ -687,7 +687,7 @@ Proof
      STRIP_ASSUME_TAC (Q.SPEC `p` CCS_distinct_exists) >> METIS_TAC [])
  >> fs [FUN_EQ_THM]
  >> Q.PAT_X_ASSUM `!t. t = X` (ASSUME_TAC o (Q.SPEC `nil`))
- >> fs [CCS_distinct]
+ >> fs [CCS_distinct']
 QED
 
 Theorem WG_CONST :
@@ -927,7 +927,6 @@ Proof
       POP_ASSUM (ASSUME_TAC o BETA_RULE o (ONCE_REWRITE_RULE [FUN_EQ_THM])) \\
       MP_TAC (Q.SPEC ‘p’ CCS_cases) >> rw [] (* 8 subgoals *)
       >- PROVE_TAC [CCS_distinct']
-      >- PROVE_TAC [CCS_distinct']
       >- (fs [CCS_one_one, FUN_EQ_THM] \\
          ‘e = \t. E’ by PROVE_TAC [] >> POP_ORW \\
           rw [SG1])
@@ -967,14 +966,13 @@ Proof
   ( POP_ASSUM (STRIP_ASSUME_TAC o (ONCE_REWRITE_RULE [SG_cases])) (* 7 sub-goals here *)
  >| [ (* goal 1 (of 7) *)
       POP_ASSUM (ASSUME_TAC o BETA_RULE o (ONCE_REWRITE_RULE [FUN_EQ_THM])) \\
-      MP_TAC (Q.SPEC ‘p’ CCS_cases) >> rw [] (* 8 subgoals *)
-      >- PROVE_TAC [CCS_distinct]
-      >- PROVE_TAC [CCS_distinct]
-      >- PROVE_TAC [CCS_distinct]
+      MP_TAC (Q.SPEC ‘p’ CCS_cases) >> rw [] (* 7 subgoals *)
+      >- PROVE_TAC [CCS_distinct']
+      >- PROVE_TAC [CCS_distinct']
       >- (fs [FUN_EQ_THM, CCS_one_one] \\
          ‘(e = \t. E1) /\ (e' = \t. E2)’ by PROVE_TAC [] >> art [] \\
           rw [SG1])
-      >> PROVE_TAC [CCS_distinct],
+      >> PROVE_TAC [CCS_distinct'],
       (* goal 2 (of 7) *)
       qpat_x_assum `(\t. sum (e t) (e' t)) = X`
         (ASSUME_TAC o BETA_RULE o (REWRITE_RULE [FUN_EQ_THM])) \\
@@ -1010,19 +1008,17 @@ Proof
       POP_ASSUM (STRIP_ASSUME_TAC o (ONCE_REWRITE_RULE [SG_cases])) >| (* 7 sub-goals here *)
       [ (* goal 1.1 (of 7) *)
         POP_ASSUM (ASSUME_TAC o BETA_RULE o (ONCE_REWRITE_RULE [FUN_EQ_THM])) \\
-        MP_TAC (Q.SPEC ‘p’ CCS_cases) >> rw [] (* 8 subgoals *)
-        >- PROVE_TAC [CCS_distinct]
-        >- PROVE_TAC [CCS_distinct]
-        >- PROVE_TAC [CCS_distinct]
+        MP_TAC (Q.SPEC ‘p’ CCS_cases) >> rw [] (* 7 subgoals *)
+        >- PROVE_TAC [CCS_distinct']
+        >- PROVE_TAC [CCS_distinct']
         >- (fs [CCS_one_one, FUN_EQ_THM] \\
-            MP_TAC (Q.SPEC ‘E1’ CCS_cases) >> rw [] (* 8 subgoals *)
-            >- PROVE_TAC [CCS_distinct]
-            >- PROVE_TAC [CCS_distinct]
+            MP_TAC (Q.SPEC ‘E1’ CCS_cases) >> rw [] (* 7 subgoals *)
+            >- PROVE_TAC [CCS_distinct']
             >- (fs [CCS_one_one, FUN_EQ_THM] \\
                ‘e = \t. E’ by PROVE_TAC [] >> POP_ORW \\
                 rw [SG1])
-            >> PROVE_TAC [CCS_distinct])
-        >> PROVE_TAC [CCS_distinct],
+            >> PROVE_TAC [CCS_distinct'])
+        >> PROVE_TAC [CCS_distinct'],
         (* goal 1.2 (of 7) *)
         qpat_x_assum `(\t. sum (prefix tau (e t)) (prefix tau (e' t))) = X`
           (ASSUME_TAC o BETA_RULE o (REWRITE_RULE [FUN_EQ_THM])) \\
@@ -1054,19 +1050,17 @@ Proof
       POP_ASSUM (STRIP_ASSUME_TAC o (ONCE_REWRITE_RULE [SG_cases])) >| (* 7 sub-goals here *)
       [ (* goal 2.1 (of 7) *)
         POP_ASSUM (ASSUME_TAC o BETA_RULE o (ONCE_REWRITE_RULE [FUN_EQ_THM])) \\
-        MP_TAC (Q.SPEC ‘p’ CCS_cases) >> rw [] (* 8 subgoals *)
-        >- PROVE_TAC [CCS_distinct]
-        >- PROVE_TAC [CCS_distinct]
-        >- PROVE_TAC [CCS_distinct]
+        MP_TAC (Q.SPEC ‘p’ CCS_cases) >> rw [] (* 7 subgoals *)
+        >- PROVE_TAC [CCS_distinct']
+        >- PROVE_TAC [CCS_distinct']
         >- (fs [CCS_one_one, FUN_EQ_THM] \\
-            MP_TAC (Q.SPEC ‘E2’ CCS_cases) >> rw [] (* 8 subgoals *)
-            >- PROVE_TAC [CCS_distinct]
-            >- PROVE_TAC [CCS_distinct]
+            MP_TAC (Q.SPEC ‘E2’ CCS_cases) >> rw [] (* 7 subgoals *)
+            >- PROVE_TAC [CCS_distinct']
             >- (fs [CCS_one_one, FUN_EQ_THM] \\
                ‘e' = \t. E’ by PROVE_TAC [] >> POP_ORW \\
                 rw [SG1])
-            >> PROVE_TAC [CCS_distinct])
-        >> PROVE_TAC [CCS_distinct],
+            >> PROVE_TAC [CCS_distinct'])
+        >> PROVE_TAC [CCS_distinct'],
         (* goal 2.2 (of 7) *)
         qpat_x_assum `(\t. sum (prefix tau (e t)) (prefix tau (e' t))) = X`
           (ASSUME_TAC o BETA_RULE o (REWRITE_RULE [FUN_EQ_THM])) \\
@@ -1103,19 +1097,17 @@ Proof
  >> POP_ASSUM (STRIP_ASSUME_TAC o (ONCE_REWRITE_RULE [SG_cases])) (* 7 sub-goals here *)
  >| [ (* goal 1 (of 7) *)
       POP_ASSUM (ASSUME_TAC o BETA_RULE o (ONCE_REWRITE_RULE [FUN_EQ_THM])) \\
-      MP_TAC (Q.SPEC ‘p’ CCS_cases) >> rw [] (* 8 subgoals *)
-      >- PROVE_TAC [CCS_distinct]
-      >- PROVE_TAC [CCS_distinct]
-      >- PROVE_TAC [CCS_distinct]
+      MP_TAC (Q.SPEC ‘p’ CCS_cases) >> rw [] (* 7 subgoals *)
+      >- PROVE_TAC [CCS_distinct']
+      >- PROVE_TAC [CCS_distinct']
       >- (fs [CCS_one_one, FUN_EQ_THM] \\
-          MP_TAC (Q.SPEC ‘E1’ CCS_cases) >> rw [] (* 8 subgoals *)
-          >- PROVE_TAC [CCS_distinct]
-          >- PROVE_TAC [CCS_distinct]
+          MP_TAC (Q.SPEC ‘E1’ CCS_cases) >> rw [] (* 7 subgoals *)
+          >- PROVE_TAC [CCS_distinct']
           >- (fs [CCS_one_one, FUN_EQ_THM] \\
              ‘e = \t. E’ by PROVE_TAC [] >> POP_ORW \\
               rw [SG1])
-          >> PROVE_TAC [CCS_distinct])
-      >> PROVE_TAC [CCS_distinct],
+          >> PROVE_TAC [CCS_distinct'])
+      >> PROVE_TAC [CCS_distinct'],
       (* goal 2 (of 7) *)
       qpat_x_assum `(\t. sum (prefix tau (e t)) (prefix (label L) (e' t))) = X`
           (ASSUME_TAC o BETA_RULE o (REWRITE_RULE [FUN_EQ_THM])) \\
@@ -1152,19 +1144,17 @@ Proof
  >> POP_ASSUM (STRIP_ASSUME_TAC o (ONCE_REWRITE_RULE [SG_cases])) (* 7 sub-goals here *)
  >| [ (* goal 1 (of 7) *)
       POP_ASSUM (ASSUME_TAC o BETA_RULE o (ONCE_REWRITE_RULE [FUN_EQ_THM])) \\
-      MP_TAC (Q.SPEC ‘p’ CCS_cases) >> rw [] (* 8 subgoals *)
-      >- PROVE_TAC [CCS_distinct]
-      >- PROVE_TAC [CCS_distinct]
-      >- PROVE_TAC [CCS_distinct]
+      MP_TAC (Q.SPEC ‘p’ CCS_cases) >> rw [] (* 7 subgoals *)
+      >- PROVE_TAC [CCS_distinct']
+      >- PROVE_TAC [CCS_distinct']
       >- (fs [CCS_one_one, FUN_EQ_THM] \\
-          MP_TAC (Q.SPEC ‘E2’ CCS_cases) >> rw [] (* 8 subgoals *)
-          >- PROVE_TAC [CCS_distinct]
-          >- PROVE_TAC [CCS_distinct]
+          MP_TAC (Q.SPEC ‘E2’ CCS_cases) >> rw [] (* 7 subgoals *)
+          >- PROVE_TAC [CCS_distinct']
           >- (fs [CCS_one_one, FUN_EQ_THM] \\
              ‘e' = \t. E’ by PROVE_TAC [] >> POP_ORW \\
               rw [SG1])
-          >> PROVE_TAC [CCS_distinct])
-      >> PROVE_TAC [CCS_distinct],
+          >> PROVE_TAC [CCS_distinct'])
+      >> PROVE_TAC [CCS_distinct'],
       (* goal 2 (of 7) *)
       qpat_x_assum `(\t. sum (prefix (label L) (e t)) (prefix tau (e' t))) = X`
           (ASSUME_TAC o BETA_RULE o (REWRITE_RULE [FUN_EQ_THM])) \\

--- a/examples/CCS/MultivariateScript.sml
+++ b/examples/CCS/MultivariateScript.sml
@@ -1107,17 +1107,6 @@ Proof
  >> fs [FDOM_fromList] >> ASM_SET_TAC []
 QED
 
-Theorem LIST_REL_equivalence : (* unused *)
-    !R. equivalence R ==> equivalence (LIST_REL R)
-Proof
-    RW_TAC list_ss [equivalence_def, reflexive_def, symmetric_def,
-                    transitive_def, LIST_REL_EL_EQN]
- >- (EQ_TAC >> RW_TAC std_ss [])
- >> Q.PAT_X_ASSUM `!x y z. R x y /\ R y z ==> R x z` MATCH_MP_TAC
- >> Q.EXISTS_TAC `EL n y`
- >> CONJ_TAC >> FIRST_X_ASSUM MATCH_MP_TAC >> art []
-QED
-
 (* ========================================================================== *)
 (*  Section III: Weakly guarded equations                                     *)
 (* ========================================================================== *)
@@ -1412,15 +1401,13 @@ Proof
  >> HO_MATCH_MP_TAC nc_INDUCTION2
  >> Q.EXISTS_TAC ‘set Xs UNION (BIGUNION (IMAGE FV (set Es)))’
  >> rw [ssub_thm] >> rw [FINITE_FV]
- (* 9 subgoals *)
+ (* 8 subgoals *)
  >- (fs [FDOM_fromList, MEM_EL, LIST_REL_EL_EQN] \\
      rw [fromList_FAPPLY_EL] \\
      fs [EVERY_EL])
- (* 8 subgoals *)
+ (* 7 subgoals *)
  >- (fs [FDOM_fromList] \\
      MATCH_MP_TAC weakly_guarded_var_rule >> art [])
- (* 7 subgoals *)
- >- (rw [weakly_guarded_nil])
  (* 6 subgoals *)
  >- (IMP_RES_TAC context_prefix \\
      rename1 ‘weakly_guarded Xs (u..[Es/Xs] C0)’ \\
@@ -1524,22 +1511,20 @@ Theorem strong_unique_solution_lemma :
 Proof
     Q.X_GEN_TAC `Xs`
  >> HO_MATCH_MP_TAC nc_INDUCTION2
- >> Q.EXISTS_TAC ‘set Xs’ >> rw [FDOM_fromList] (* 8 subgoals *)
- (* Case 0: E = var s, impossible *)
+ >> Q.EXISTS_TAC ‘set Xs’ >> rw [FDOM_fromList]
+ (* 7 subgoals: E = var s, impossible *)
  >- (rename1 `weakly_guarded Xs (var Y)` \\
      IMP_RES_TAC weakly_guarded_var)
- (* Case 1: E = nil, still impossible *)
- >- (fs [NIL_NO_TRANS])
- (* Case 2: E = b.E' *)
+ (* 6 subgoals: E = b.E' *)
  >- (rename1 `weakly_guarded Xs (prefix b E)` \\
      fs [CCS_SUBST_def, TRANS_PREFIX_EQ] \\
      Q.EXISTS_TAC `E` >> art [] \\
      IMP_RES_TAC weakly_guarded_prefix)
- (* Case 3: E = E1 + E2 *)
+ (* 5 subgoals: E = E1 + E2 *)
  >- (IMP_RES_TAC weakly_guarded_sum \\
      fs [CCS_SUBST_def, TRANS_SUM_EQ] \\ (* 2 subgoals, same tactics *)
      RES_TAC >> Q.EXISTS_TAC `E''` >> fs [])
- (* Case 4: E = E1 || E2 *)
+ (* 4 subgoals: E = E1 || E2 *)
  >- (rename1 `weakly_guarded Xs (E1 || E2)` \\
      IMP_RES_TAC weakly_guarded_par \\
      fs [CCS_SUBST_def, TRANS_PAR_EQ, FV_def] >| (* 3 subgoals *)
@@ -1597,7 +1582,7 @@ Proof
        GEN_TAC >> DISCH_TAC >> NTAC 2 DISJ2_TAC \\
        take [`CCS_SUBST (fromList Xs Qs) E'`,
              `CCS_SUBST (fromList Xs Qs) E''`, `l`] >> fs [] ])
- (* Case 5: E = restr f E' *)
+ (* 3 subgoals: E = restr f E' *)
  >- (IMP_RES_TAC weakly_guarded_restr \\
      fs [CCS_SUBST_def, TRANS_RESTR_EQ, FV_def] >| (* 2 subgoals *)
      [ (* goal 1 (of 2) *)
@@ -1614,7 +1599,7 @@ Proof
        Q.EXISTS_TAC `restr L E'` \\
        rfs [CCS_SUBST_def, FV_def] \\
        MATCH_MP_TAC context_restr_rule >> art [] ])
- (* Case 6: E = relab E' R *)
+ (* 2 subgoals: E = relab E' R *)
  >- (IMP_RES_TAC weakly_guarded_relab \\
      Q.PAT_X_ASSUM `weakly_guarded Xs E /\ _ ==> _` MP_TAC \\
      fs [FV_def] >> rpt STRIP_TAC \\
@@ -1627,7 +1612,7 @@ Proof
      GEN_TAC >> DISCH_TAC \\
      take [`u'`, `CCS_SUBST (fromList Xs Qs) E'`] >> art [] \\
      FIRST_X_ASSUM MATCH_MP_TAC >> art [])
- (* Case 7 (difficult): E = rec Y E' *)
+ (* final goal: E = rec Y E' *)
  >> IMP_RES_TAC weakly_guarded_rec
  >> `DISJOINT (FV (rec y E)) (set Xs)` by ASM_SET_TAC [FV_def]
  (* simplify `CCS_Subst (rec y E) (Ps |-> Qs)` *)

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -1322,6 +1322,17 @@ val (rules,ind,cases) = IndDefLib.Hol_reln`
 val strong = IndDefLib.derive_strong_induction (rules,ind)
 *)
 
+Theorem LIST_REL_equivalence :
+    !R. equivalence R ==> equivalence (LIST_REL R)
+Proof
+    SRW_TAC [] [equivalence_def, reflexive_def, symmetric_def,
+                transitive_def, LIST_REL_EL_EQN]
+ >- (EQ_TAC >> SRW_TAC [][])
+ >> Q.PAT_X_ASSUM `!x y z. R x y /\ R y z ==> R x z` MATCH_MP_TAC
+ >> Q.EXISTS_TAC `EL n y`
+ >> CONJ_TAC >> FIRST_X_ASSUM MATCH_MP_TAC
+ >> ASM_REWRITE_TAC []
+QED
 
 (*---------------------------------------------------------------------------
      Congruence rules for higher-order functions. Used when making


### PR DESCRIPTION
Hi,

This small PR follows the previous #1176 and future re-defined CCS deadlock process `nil` by the "I"-combinator (`rec X (var X)`, where `X` is arbitrarily chosen).  This change slightly reduced the efforts in defining CCS terms by `generic_termsTheory` and all the proofs involving inductions on CCS terms, as now the induction case for `nil` now disappeared. This change also pave the way to some other ideas in the future.

This settles all the necessary changes before porting CWB to HOL4.

--Chun