### PR TITLE
[rich_list] Added IS_PREFIX_FINITE, etc. (The set of prefixes is finite)

### DIFF
--- a/src/list/src/rich_listScript.sml
+++ b/src/list/src/rich_listScript.sml
@@ -2712,18 +2712,6 @@ Proof
  >> rw [TAKE_LENGTH_TOO_LONG]
 QED
 
-Theorem IS_PREFIX_FINITE :
-    !l. FINITE {l1 | l1 <<= l}
-Proof
-    rw [IS_PREFIX_EQ_TAKE]
- >> Know ‘{l1 | (?n. n <= LENGTH l /\ l1 = TAKE n l)} =
-          IMAGE (\n. TAKE n l) (count (SUC (LENGTH l)))’
- >- (rw [Once EXTENSION, LT_SUC_LE] >> METIS_TAC [])
- >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
- >> MATCH_MP_TAC IMAGE_FINITE
- >> rw []
-QED
-
 (* ----------------------------------------------------------------------
     longest_prefix
 

--- a/src/list/src/rich_listScript.sml
+++ b/src/list/src/rich_listScript.sml
@@ -1178,6 +1178,10 @@ val TAKE_SNOC = Q.store_thm ("TAKE_SNOC",
    THEN RES_TAC
    THEN ASM_REWRITE_TAC []);
 
+val SNOC_EL_TAKE = Q.store_thm ("SNOC_EL_TAKE",
+   `!n l. n < LENGTH l ==> (SNOC (EL n l) (TAKE n l) = TAKE (SUC n) l)`,
+   Induct_on `n` THEN Cases_on `l` THEN ASM_SIMP_TAC list_ss [SNOC, TAKE]);
+
 val BUTLASTN_LENGTH_NIL = Q.store_thm ("BUTLASTN_LENGTH_NIL",
    `!l. BUTLASTN (LENGTH l) l = []`,
    SNOC_INDUCT_TAC THEN ASM_REWRITE_TAC [LENGTH, LENGTH_SNOC, BUTLASTN]);
@@ -2518,8 +2522,6 @@ QED
    A bunch of properties relating to the use of IS_PREFIX as a partial order
  ---------------------------------------------------------------------------*)
 
-val list_CASES = list_CASES
-
 val IS_PREFIX_NIL = Q.store_thm ("IS_PREFIX_NIL",
    `!x. IS_PREFIX x [] /\ (IS_PREFIX [] x = (x = []))`,
    STRIP_TAC
@@ -2654,6 +2656,73 @@ val prefixes_is_prefix_total = Q.store_thm("prefixes_is_prefix_total",
   Induct THEN SIMP_TAC(srw_ss())[IS_PREFIX_NIL] THEN
   GEN_TAC THEN Cases THEN SIMP_TAC(srw_ss())[] THEN
   Cases THEN SRW_TAC[][])
+
+val Know = Q_TAC KNOW_TAC;
+val Suff = Q_TAC SUFF_TAC;
+
+Theorem IS_PREFIX_EQ_TAKE :
+    !l l1. l1 <<= l <=> ?n. n <= LENGTH l /\ l1 = TAKE n l
+Proof
+    rpt GEN_TAC
+ >> reverse EQ_TAC
+ >- (STRIP_TAC \\
+     GEN_REWRITE_TAC (RAND_CONV o ONCE_DEPTH_CONV) empty_rewrites
+                     [SYM (Q.SPECL [‘n’, ‘l’] TAKE_DROP)] \\
+     POP_ASSUM (fn th => ONCE_REWRITE_TAC [th]) \\
+     PROVE_TAC [IS_PREFIX_APPEND])
+ (* stage work *)
+ >> Induct_on ‘l1’ using SNOC_INDUCT
+ >- (rw [] >> Q.EXISTS_TAC ‘0’ >> rw [])
+ >> rw [SNOC_APPEND]
+ >> Q.PAT_X_ASSUM ‘l1 <<= l ==> P’ MP_TAC
+ >> ‘l1 <<= l’ by PROVE_TAC [IS_PREFIX_APPEND1]
+ >> RW_TAC std_ss []
+ >> Q.PAT_X_ASSUM ‘TAKE n l ++ [x] <<= l’ MP_TAC
+ >> rw [IS_PREFIX_APPEND]
+ >> Q.EXISTS_TAC ‘SUC n’
+ >> CONJ_ASM1_TAC
+ >- (POP_ASSUM (fn th => ONCE_REWRITE_TAC [th]) >> rw [])
+ (* applying SNOC_EL_TAKE *)
+ >> Know ‘TAKE (SUC n) l = SNOC (EL n l) (TAKE n l)’
+ >- (ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
+     MATCH_MP_TAC SNOC_EL_TAKE >> rw [])
+ >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
+ >> Suff ‘EL n l = x’ >- rw [SNOC_APPEND]
+ >> Q.PAT_X_ASSUM ‘l = _’ (fn th => ONCE_REWRITE_TAC [th])
+ (* applying el_append3, fortunately *)
+ >> Q.ABBREV_TAC ‘l1 = TAKE n l’
+ >> ‘n = LENGTH l1’ by rw [Abbr ‘l1’, LENGTH_TAKE]
+ >> POP_ASSUM (fn th => ONCE_REWRITE_TAC [th])
+ >> rw [el_append3]
+QED
+
+(* ‘n <= LENGTH l’ can be removed from RHS *)
+Theorem IS_PREFIX_EQ_TAKE' :
+    !l l1. l1 <<= l <=> ?n. l1 = TAKE n l
+Proof
+    rpt GEN_TAC
+ >> EQ_TAC
+ >- (rw [IS_PREFIX_EQ_TAKE] \\
+     Q.EXISTS_TAC ‘n’ >> REWRITE_TAC [])
+ >> STRIP_TAC
+ >> Cases_on ‘n <= LENGTH l’
+ >- (rw [IS_PREFIX_EQ_TAKE] \\
+     Q.EXISTS_TAC ‘n’ >> ASM_REWRITE_TAC [])
+ >> ‘LENGTH l <= n’ by rw []
+ >> rw [TAKE_LENGTH_TOO_LONG]
+QED
+
+Theorem IS_PREFIX_FINITE :
+    !l. FINITE {l1 | l1 <<= l}
+Proof
+    rw [IS_PREFIX_EQ_TAKE]
+ >> Know ‘{l1 | (?n. n <= LENGTH l /\ l1 = TAKE n l)} =
+          IMAGE (\n. TAKE n l) (count (SUC (LENGTH l)))’
+ >- (rw [Once EXTENSION, LT_SUC_LE] >> METIS_TAC [])
+ >> DISCH_THEN (fn th => ONCE_REWRITE_TAC [th])
+ >> MATCH_MP_TAC IMAGE_FINITE
+ >> rw []
+QED
 
 (* ----------------------------------------------------------------------
     longest_prefix
@@ -2882,10 +2951,6 @@ QED
    General theorems about lists. From Anthony Fox's and Thomas Tuerk's theories.
    Added by Thomas Tuerk
  ---------------------------------------------------------------------------*)
-
-val SNOC_EL_TAKE = Q.store_thm ("SNOC_EL_TAKE",
-   `!n l. n < LENGTH l ==> (SNOC (EL n l) (TAKE n l) = TAKE (SUC n) l)`,
-   Induct_on `n` THEN Cases_on `l` THEN ASM_SIMP_TAC list_ss [SNOC, TAKE]);
 
 val ZIP_TAKE_LEQ = Q.store_thm ("ZIP_TAKE_LEQ",
   `!n a b.


### PR DESCRIPTION
Hi,

Today I was in the need of the following theorem stating that "the set of all prefixes of a given list, is finite":
```
   [IS_PREFIX_FINITE]  Theorem   
      ⊢ ∀l. FINITE {l1 | l1 ≼ l}
```

My idea of the proof is based on rewriting `IS_PREFIX` to `TAKE` (and then use `IMAGE_FINITE` to finish the proof):
```
   [IS_PREFIX_EQ_TAKE]  Theorem
      ⊢ ∀l l1. l1 ≼ l ⇔ ∃n. n ≤ LENGTH l ∧ l1 = TAKE n l

   [IS_PREFIX_EQ_TAKE']  Theorem
      ⊢ ∀l l1. l1 ≼ l ⇔ ∃n. l1 = TAKE n l
```
The above theorems are to be added into `rich_listTheory`.

But then this makes me wonder how to prove that "the set of all **sublists** of a list is finite", i.e. `∀l. FINITE {l1 | IS_SUBLIST l l1}`?   (I can imagine that a sublist may be obtained by first do a `TAKE` and then a `DROP`, or in reversed order, thus leads to finite number of possibilities, but this proof seems not easy)

This will subsume the above IS_PREFIX_FINITE, since we have:
```
   [IS_PREFIX_IS_SUBLIST]  Theorem      
      ⊢ ∀l1 l2. l2 ≼ l1 ⇒ IS_SUBLIST l1 l2
```
Furthermore, IS_SUFFIX_FINITE can be easily proved too, if we know "the set of all subsets of a list is finite", before suffix is also a sublist:
```
   [IS_SUFFIX_IS_SUBLIST]  Theorem      
      ⊢ ∀l1 l2. IS_SUFFIX l1 l2 ⇒ IS_SUBLIST l1 l2
```