### PR TITLE
[lambda] permutator and more/improved subterm-related lemmas

### DIFF
--- a/examples/lambda/barendregt/head_reductionScript.sml
+++ b/examples/lambda/barendregt/head_reductionScript.sml
@@ -1375,10 +1375,36 @@ Proof
  >> rw [appstar_SNOC]
 QED
 
-(* Another variant of ‘hnf_cases’ with a given (shared) list of fresh variables
+(*---------------------------------------------------------------------------*
+ *  hnf_children_size (of hnf)
+ *---------------------------------------------------------------------------*)
 
-   NOTE: "irule (iffLR hnf_cases_shared)" is a useful tactic for this theorem.
- *)
+val (hnf_children_size_thm, _) = define_recursive_term_function
+   ‘(hnf_children_size ((VAR :string -> term) s) = 0) /\
+    (hnf_children_size (t1 @@ t2) = 1 + hnf_children_size t1) /\
+    (hnf_children_size (LAM v t) = hnf_children_size t)’;
+
+val _ = export_rewrites ["hnf_children_size_thm"];
+
+Theorem hnf_children_size_LAMl[simp] :
+    hnf_children_size (LAMl vs t) = hnf_children_size t
+Proof
+    Induct_on ‘vs’ >> rw []
+QED
+
+Theorem hnf_children_size_hnf[simp] :
+    hnf_children_size (LAMl vs (VAR y @* Ms)) = LENGTH Ms
+Proof
+    rw []
+ >> Induct_on ‘Ms’ using SNOC_INDUCT >- rw []
+ >> rw [appstar_SNOC]
+QED
+
+(*---------------------------------------------------------------------------*
+ *  hnf_cases_shared - ‘hnf_cases’ with a given list of fresh variables
+ *---------------------------------------------------------------------------*)
+
+(* NOTE: "irule (iffLR hnf_cases_shared)" is a useful tactic *)
 Theorem hnf_cases_shared :
     !vs M. ALL_DISTINCT vs /\ LAMl_size M <= LENGTH vs /\
            DISJOINT (set vs) (FV M) ==>

--- a/examples/lambda/barendregt/solvableScript.sml
+++ b/examples/lambda/barendregt/solvableScript.sml
@@ -56,7 +56,7 @@ Proof
     Know ‘closure (VAR x) = LAM x (VAR x)’
  >- (MATCH_MP_TAC closure_open_sing >> rw [])
  >> Rewr'
- >> REWRITE_TAC [Q.SPEC ‘x’ I_alt]
+ >> REWRITE_TAC [Q.SPEC ‘x’ I_thm]
 QED
 
 Theorem closures_imp_closed :
@@ -1062,7 +1062,7 @@ Theorem lameq_principle_hnf_lemma :
                 M1 = principle_hnf (M @* MAP VAR vs);
                 N1 = principle_hnf (N @* MAP VAR vs)
             in
-                hnf_headvar M1 = hnf_headvar N1 /\
+                hnf_head M1 = hnf_head N1 /\
                 LENGTH (hnf_children M1) = LENGTH (hnf_children N1) /\
                 !i. i < LENGTH (hnf_children M1) ==>
                     EL i (hnf_children M1) == EL i (hnf_children N1)
@@ -1166,7 +1166,7 @@ Theorem lameq_principle_hnf_headvar_eq :
          n = LAMl_size M0 /\ vs = FRESH_list n X /\
          M1 = principle_hnf (M0 @* MAP VAR vs) /\
          N1 = principle_hnf (N0 @* MAP VAR vs)
-     ==> hnf_headvar M1 = hnf_headvar N1
+     ==> hnf_head M1 = hnf_head N1
 Proof
     RW_TAC std_ss [UNION_SUBSET]
  >> qabbrev_tac ‘M0 = principle_hnf M’
@@ -1205,7 +1205,7 @@ Theorem lameq_principle_hnf_thm :
          M1 = principle_hnf (M0 @* MAP VAR vs) /\
          N1 = principle_hnf (N0 @* MAP VAR vs)
      ==> LAMl_size M0 = LAMl_size N0 /\
-         hnf_headvar M1 = hnf_headvar N1 /\
+         hnf_head M1 = hnf_head N1 /\
          LENGTH (hnf_children M1) = LENGTH (hnf_children N1) /\
          !i. i < LENGTH (hnf_children M1) ==>
              EL i (hnf_children M1) == EL i (hnf_children N1)

--- a/examples/lambda/basics/termScript.sml
+++ b/examples/lambda/basics/termScript.sml
@@ -463,6 +463,9 @@ val SUB_THM = save_thm(
 val _ = export_rewrites ["SUB_THM"]
 val SUB_VAR = save_thm("SUB_VAR", hd (CONJUNCTS SUB_DEF))
 
+(* |- !v u N t. v <> u /\ v # N ==> [N/u] (LAM v t) = LAM v ([N/u] t) *)
+Theorem SUB_LAM = List.nth (CONJUNCTS SUB_DEF, 2)
+
 (* ----------------------------------------------------------------------
     Results about substitution
    ---------------------------------------------------------------------- *)
@@ -1080,6 +1083,402 @@ Proof
     rpt STRIP_TAC
  >> MATCH_MP_TAC ssub_update_apply_SUBST >> art []
  >> fs [closed_def, DISJOINT_DEF]
+QED
+
+Theorem ssub_reduce_thm :
+    !t. FV t INTER FDOM fm = {s} ==> fm ' t = [fm ' s/s] t
+Proof
+    HO_MATCH_MP_TAC nc_INDUCTION2
+ >> Q.EXISTS_TAC ‘fmFV fm UNION {s}’
+ >> rw [SUB_THM, ssub_thm]
+ >- (‘s' = s’ by ASM_SET_TAC [] >> fs [])
+ >- (‘s' = s’ by ASM_SET_TAC [] >> fs [ssub_thm] \\
+     ‘s IN FDOM fm’ by ASM_SET_TAC [])
+ >- (‘FV t INTER FDOM fm = {s} \/ FV t INTER FDOM fm = {}’ by ASM_SET_TAC []
+     >- rw [] \\
+     rw [ssub_14b] \\
+     MATCH_MP_TAC (GSYM lemma14b) \\
+     ASM_SET_TAC [])
+ >- (‘FV t' INTER FDOM fm = {s} \/ FV t' INTER FDOM fm = {}’ by ASM_SET_TAC []
+     >- rw [] \\
+     rw [ssub_14b] \\
+     MATCH_MP_TAC (GSYM lemma14b) \\
+     ASM_SET_TAC [])
+ >> ‘s IN FDOM fm’ by ASM_SET_TAC []
+ >> Know ‘[fm ' s/s] (LAM y t) = LAM y ([fm ' s/s] t)’
+ >- (MATCH_MP_TAC SUB_LAM >> rw [])
+ >> Rewr'
+ >> rw []
+ >> FIRST_X_ASSUM MATCH_MP_TAC
+ >> ASM_SET_TAC []
+QED
+
+Theorem ssub_reduce :
+    !t. FV t = {s} /\ s IN FDOM fm ==> fm ' t = [fm ' s/s] t
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC ssub_reduce_thm
+ >> ASM_SET_TAC []
+QED
+
+(* ----------------------------------------------------------------------
+    Simultaneous substitution given by a pair of key list and value list
+   ---------------------------------------------------------------------- *)
+
+(* from a key list and a value list (of same length) to an alist *)
+Definition fromPairs_def :
+    fromPairs (Xs :string list) (Ps :term list) = FEMPTY |++ ZIP (Xs,Ps)
+End
+
+Theorem fromPairs_single :
+    !X E E'. ssub (fromPairs [X] [E']) E = [E'/X] E
+Proof
+    RW_TAC list_ss [fromPairs_def, ZIP, FUPDATE_LIST_THM]
+ >> rw [FEMPTY_update_apply]
+QED
+
+Theorem fromPairs_EMPTY :
+    fromPairs [] [] = FEMPTY
+Proof
+    SRW_TAC [] [fromPairs_def, FUPDATE_LIST_THM]
+QED
+
+Theorem fromPairs_HD :
+    !X Xs P Ps. ~MEM X Xs /\ LENGTH Ps = LENGTH Xs ==>
+                fromPairs (X::Xs) (P::Ps) = fromPairs Xs Ps |+ (X,P)
+Proof
+    SRW_TAC [] [fromPairs_def, FUPDATE_LIST_THM]
+ >> MATCH_MP_TAC FUPDATE_FUPDATE_LIST_COMMUTES
+ >> METIS_TAC [MAP_ZIP]
+QED
+
+Theorem FDOM_fromPairs :
+    !Xs Ps. LENGTH Ps = LENGTH Xs ==> FDOM (fromPairs Xs Ps) = set Xs
+Proof
+    SRW_TAC [] [fromPairs_def, FDOM_FUPDATE_LIST, MAP_ZIP]
+QED
+
+Theorem fromPairs_DOMSUB_NOT_IN_DOM :
+    !X Xs Ps. ~MEM X Xs /\ (LENGTH Ps = LENGTH Xs) ==>
+              fromPairs Xs Ps \\ X = fromPairs Xs Ps
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC DOMSUB_NOT_IN_DOM
+ >> fs [FDOM_fromPairs]
+QED
+
+Theorem fromPairs_FAPPLY_HD :
+    !X Xs P Ps n. ~MEM X Xs /\ ALL_DISTINCT Xs /\ (LENGTH Ps = LENGTH Xs) ==>
+                  fromPairs (X::Xs) (P::Ps) ' X = P
+Proof
+    RW_TAC std_ss [fromPairs_HD, FAPPLY_FUPDATE]
+QED
+
+Theorem fromPairs_FAPPLY_EL :
+    !Xs Ps n. ALL_DISTINCT Xs /\ LENGTH Ps = LENGTH Xs /\ n < LENGTH Xs ==>
+              fromPairs Xs Ps ' (EL n Xs) = EL n Ps
+Proof
+    RW_TAC std_ss [fromPairs_def]
+ >> MATCH_MP_TAC FUPDATE_LIST_APPLY_MEM
+ >> Q.EXISTS_TAC `n`
+ >> fs [LENGTH_ZIP, MAP_ZIP]
+ >> RW_TAC list_ss []
+ >> CCONTR_TAC >> fs []
+ >> `n < LENGTH Xs /\ m <> n` by RW_TAC arith_ss []
+ >> METIS_TAC [ALL_DISTINCT_EL_IMP]
+QED
+
+Theorem fromPairs_FAPPLY_EL' :
+    !X P Xs Ps n. ~MEM X Xs /\ ALL_DISTINCT Xs /\ LENGTH Ps = LENGTH Xs /\
+                  n < LENGTH Xs
+              ==> fromPairs (X::Xs) (P::Ps) ' (EL n Xs) = EL n Ps
+Proof
+    RW_TAC std_ss [fromPairs_HD, fromPairs_def]
+ >> Know `((FEMPTY |++ ZIP (Xs,Ps)) |+ (X,P)) = ((FEMPTY |+ (X,P)) |++ ZIP (Xs,Ps))`
+ >- (MATCH_MP_TAC EQ_SYM \\
+     MATCH_MP_TAC FUPDATE_FUPDATE_LIST_COMMUTES \\
+     fs [MAP_ZIP])
+ >> Rewr'
+ >> MATCH_MP_TAC FUPDATE_LIST_APPLY_MEM
+ >> Q.EXISTS_TAC `n`
+ >> fs [LENGTH_ZIP, MAP_ZIP]
+ >> RW_TAC list_ss []
+ >> CCONTR_TAC >> fs []
+ >> `n < LENGTH Xs /\ m <> n` by RW_TAC arith_ss []
+ >> METIS_TAC [ALL_DISTINCT_EL_IMP]
+QED
+
+Theorem fromPairs_elim :
+    !Xs Ps E. DISJOINT (FV E) (set Xs) /\ LENGTH Ps = LENGTH Xs ==>
+              fromPairs Xs Ps ' E = E
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC ssub_14b
+ >> fs [FDOM_fromPairs, DISJOINT_DEF]
+QED
+
+Theorem lemma0[local] :
+    !X P E fm. X NOTIN FDOM fm /\ DISJOINT (FDOM fm) (FV P) /\
+               FEVERY (\(k,v). X NOTIN (FV v)) fm ==>
+              (fm |+ (X,P)) ' E = [P/X] (fm ' E)
+Proof
+    rw []
+ (* applying ssub_update_apply_subst *)
+ >> Know ‘ssub (fm |+ (X,P)) E = [ssub fm P/X] (ssub fm E)’
+ >- (MATCH_MP_TAC ssub_update_apply_SUBST' >> fs [FEVERY_DEF])
+ >> Rewr'
+ >> Suff ‘ssub fm P = P’ >- rw []
+ >> MATCH_MP_TAC ssub_14b
+ >> rw [GSYM DISJOINT_DEF, DISJOINT_SYM]
+QED
+
+(* fromPairs_reduce leads to fromPairs_FOLDR
+
+   NOTE: added ‘DISJOINT (set Xs) (FV P)’ when switching to ‘ssub’
+ *)
+Theorem fromPairs_reduce :
+    !X Xs P Ps. ~MEM X Xs /\ ALL_DISTINCT Xs /\ LENGTH Ps = LENGTH Xs /\
+                EVERY (\e. X NOTIN (FV e)) Ps /\
+                DISJOINT (set Xs) (FV P) ==>
+         !E. fromPairs (X::Xs) (P::Ps) ' E = [P/X] (fromPairs Xs Ps ' E)
+Proof
+    rpt STRIP_TAC
+ >> Know `fromPairs (X::Xs) (P::Ps) = (fromPairs Xs Ps) |+ (X,P)`
+ >- (MATCH_MP_TAC fromPairs_HD >> art [])
+ >> Rewr'
+ >> MATCH_MP_TAC lemma0
+ >> fs [FDOM_fromPairs, FEVERY_DEF]
+ >> RW_TAC std_ss []
+ >> rename1 `MEM Y Xs`
+ >> `?n. n < LENGTH Xs /\ (Y = EL n Xs)` by PROVE_TAC [MEM_EL]
+ >> fs [fromPairs_FAPPLY_EL, EVERY_MEM]
+ >> FIRST_X_ASSUM MATCH_MP_TAC >> rw [MEM_EL]
+ >> Q.EXISTS_TAC `n` >> art []
+QED
+
+(* fromPairs_reduce in another form *)
+Theorem lemma1[local] :
+   !E E' map.
+      map <> [] /\
+      ~MEM (FST (HD map)) (MAP FST (TL map)) /\
+      ALL_DISTINCT (MAP FST (TL map)) /\
+      DISJOINT (set (MAP FST (TL map))) (FV (SND (HD map))) /\
+      EVERY (\e. (FST (HD map)) NOTIN (FV e)) (MAP SND (TL map)) /\
+      (FEMPTY |++ (TL map)) ' E = E'
+   ==>
+      (FEMPTY |++ map) ' E = [SND (HD map)/FST (HD map)] E'
+Proof
+    rpt GEN_TAC
+ >> Cases_on `map` >- SRW_TAC [] []
+ >> RW_TAC std_ss [HD, TL]
+ >> Cases_on `h` >> fs []
+ >> Q.ABBREV_TAC `Xs = FST (UNZIP t)`
+ >> Q.ABBREV_TAC `Ps = SND (UNZIP t)`
+ >> Know `t = ZIP (Xs,Ps)`
+ >- (qunabbrevl_tac [`Xs`, `Ps`] >> fs [])
+ >> Know `LENGTH Ps = LENGTH Xs`
+ >- (qunabbrevl_tac [`Xs`, `Ps`] >> fs [])
+ >> RW_TAC std_ss []
+ >> Know `(MAP FST (ZIP (Xs,Ps))) = Xs` >- PROVE_TAC [MAP_ZIP]
+ >> DISCH_THEN (fs o wrap)
+ >> Know `(MAP SND (ZIP (Xs,Ps))) = Ps` >- PROVE_TAC [MAP_ZIP]
+ >> DISCH_THEN (fs o wrap)
+ >> rename1 ‘~MEM X Xs’
+ >> MP_TAC (REWRITE_RULE [fromPairs_def]
+                         (Q.SPECL [`X`,`Xs`,`r`,`Ps`] fromPairs_reduce))
+ >> simp []
+QED
+
+(* Let map = ZIP(Xs,Ps), to convert ssub to a folding of CCS_Subst, each P
+   of Ps must contains free variables up to the corresponding X of Xs.
+ *)
+Theorem lemma2[local] :
+    !E map. ALL_DISTINCT (MAP FST map) /\
+            EVERY (\(x,p). DISJOINT (set (MAP FST map)) (FV p)) map ==>
+           (ssub (FEMPTY |++ map) E =
+            FOLDR (\l e. [SND l/FST l] e) E map)
+Proof
+    GEN_TAC >> Induct_on `map`
+ >- SRW_TAC [] [FUPDATE_LIST_THM, ssub_FEMPTY]
+ >> rpt STRIP_TAC >> fs [MAP]
+ >> MP_TAC (Q.SPECL [`E`, `ssub (FEMPTY |++ map) E`,
+                     `h::map`] lemma1) >> fs []
+ >> Know ‘DISJOINT (set (MAP FST map)) (FV (SND h)) /\
+          EVERY (\e. FST h # e) (MAP SND map)’
+ >- (Cases_on ‘h’ >> fs [] \\
+     Q.PAT_X_ASSUM ‘EVERY (\(x,p). DISJOINT (set (MAP FST map)) (FV p) /\ q # p) map’
+       MP_TAC >> rw [EVERY_MEM, MEM_MAP] \\
+     Q.PAT_X_ASSUM ‘!e. MEM e map ==> _’ (MP_TAC o (Q.SPEC ‘y’)) \\
+     Cases_on ‘y’ >> rw [])
+ >> rw []
+ >> Cases_on `h` >> fs []
+ >> rename1 `X # P`
+ >> Suff ‘ssub (FEMPTY |++ map) E =
+          FOLDR (\l e. [SND l/FST l] e) E map’ >- rw []
+ >> FIRST_X_ASSUM MATCH_MP_TAC
+ >> Q.PAT_X_ASSUM
+     ‘EVERY (\(x,p). DISJOINT (set (MAP FST map)) (FV p) /\ X # p) map’ MP_TAC
+ >> rw [EVERY_MEM]
+ >> Q.PAT_X_ASSUM ‘!e. MEM e map ==> _’ (MP_TAC o (Q.SPEC ‘e’))
+ >> Cases_on ‘e’ >> rw []
+QED
+
+(* lemma2 in another form; this is less general than fromPairs_reduce *)
+Theorem fromPairs_FOLDR :
+    !Xs Ps E. ALL_DISTINCT Xs /\ LENGTH Ps = LENGTH Xs /\
+              EVERY (\p. DISJOINT (set Xs) (FV p)) Ps ==>
+              (fromPairs Xs Ps) ' E =
+              FOLDR (\(x,y) e. [y/x] e) E (ZIP (Xs,Ps))
+Proof
+    RW_TAC std_ss []
+ >> MP_TAC (Q.SPECL [`E`, `ZIP (Xs,Ps)`] lemma2)
+ >> RW_TAC std_ss [MAP_ZIP, fromPairs_def]
+ >> Know `(\l e. [SND l/FST l] e) = (\(x,y) e. [y/x] e)`
+ >- (rw [FUN_EQ_THM] >> Cases_on `l` >> rw [])
+ >> DISCH_THEN (fs o wrap)
+ >> POP_ASSUM MATCH_MP_TAC
+ >> POP_ASSUM MP_TAC >> rw [EVERY_MEM, MEM_ZIP]
+ >> simp []
+ >> FIRST_X_ASSUM MATCH_MP_TAC
+ >> rw [MEM_EL]
+ >> Q.EXISTS_TAC ‘n’ >> art []
+QED
+
+Theorem fromPairs_FOLDR' :
+    !Xs Ps E. ALL_DISTINCT Xs /\ LENGTH Ps = LENGTH Xs /\
+              EVERY (\p. DISJOINT (set Xs) (FV p)) Ps ==>
+              (fromPairs Xs Ps) ' E =
+              FOLDR (\(x,y) e. [y/x] e) E (ZIP (Xs,Ps))
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC fromPairs_FOLDR >> art []
+ >> fs [FEVERY_DEF, EVERY_MEM]
+ >> RW_TAC std_ss [MEM_ZIP]
+QED
+
+Theorem fromPairs_self :
+    !E Xs. ALL_DISTINCT Xs ==> fromPairs Xs (MAP VAR Xs) ' E = E
+Proof
+    Q.X_GEN_TAC ‘E’
+ >> Induct_on `Xs`
+ >> SRW_TAC [] [ssub_FEMPTY, fromPairs_EMPTY]
+ >> Q.PAT_X_ASSUM `ALL_DISTINCT Xs ==> _` MP_TAC
+ >> RW_TAC std_ss []
+ >> MP_TAC (Q.SPECL [`h`, `Xs`, `VAR h`, `MAP VAR Xs`] fromPairs_reduce)
+ >> `LENGTH (MAP VAR Xs) = LENGTH Xs` by PROVE_TAC [LENGTH_MAP]
+ >> simp []
+ >> Suff ‘EVERY (\e. h # e) (MAP VAR Xs)’
+ >- RW_TAC std_ss [EVERY_MEM, MEM_MAP]
+ >> rw [EVERY_MAP, EVERY_MEM, FV_thm]
+QED
+
+Theorem fromPairs_nested :
+    !Xs Ps Es E.
+        ALL_DISTINCT Xs /\ LENGTH Ps = LENGTH Xs /\ LENGTH Es = LENGTH Xs ==>
+        fromPairs Xs Ps ' (fromPairs Xs Es ' E) =
+        fromPairs Xs (MAP ($' (fromPairs Xs Ps)) Es) ' E
+Proof
+    Suff (* rewriting for induction *)
+   `!Xs Ps Es. ALL_DISTINCT Xs /\
+              (LENGTH Ps = LENGTH Xs) /\ (LENGTH Es = LENGTH Xs) ==>
+        !E. fromPairs Xs Ps ' (fromPairs Xs Es ' E) =
+            fromPairs Xs (MAP ($' (fromPairs Xs Ps)) Es) ' E`
+ >- METIS_TAC []
+ >> rpt GEN_TAC >> STRIP_TAC
+ >> HO_MATCH_MP_TAC nc_INDUCTION2
+ >> qabbrev_tac ‘fm2 = fromPairs Xs Ps’
+ >> Q.EXISTS_TAC ‘set Xs UNION BIGUNION (IMAGE FV (set Es))
+                         UNION BIGUNION (IMAGE FV (set Ps))
+                         UNION BIGUNION (IMAGE (\e. FV (ssub fm2 e)) (set Es))’
+ >> rw [Abbr ‘fm2’, FDOM_fromPairs] (* 5 subgoals *)
+ >> TRY (rw [FINITE_FV]) (* 2 subgoals left *)
+ >- (fs [MEM_EL] >> rename1 `X = EL n Xs` \\
+    `LENGTH (MAP (ssub (fromPairs Xs Ps)) Es) = LENGTH Xs`
+       by PROVE_TAC [LENGTH_MAP] \\
+     ASM_SIMP_TAC std_ss [fromPairs_FAPPLY_EL, EL_MAP])
+ >> `LENGTH (MAP (ssub (fromPairs Xs Ps)) Es) = LENGTH Xs`
+       by PROVE_TAC [LENGTH_MAP]
+ (* stage work *)
+ >> qabbrev_tac ‘fm1 = fromPairs Xs Es’
+ >> qabbrev_tac ‘fm2 = fromPairs Xs Ps’
+ (* applying ssub_rec *)
+ >> Know ‘ssub fm1 (LAM y E) = LAM y (ssub fm1 E)’
+ >- (MATCH_MP_TAC ssub_LAM >> rw [Abbr ‘fm1’, FDOM_fromPairs] \\
+     fs [MEM_EL] >> rename1 `X = EL n Xs` \\
+     ASM_SIMP_TAC std_ss [fromPairs_FAPPLY_EL, EL_MAP] \\
+     METIS_TAC [])
+ >> Rewr'
+ >> Know ‘ssub fm2 (LAM y (ssub fm1 E)) =
+          LAM y (ssub fm2 (ssub fm1 E))’
+ >- (MATCH_MP_TAC ssub_LAM >> rw [Abbr ‘fm2’, FDOM_fromPairs] \\
+     fs [MEM_EL] >> rename1 `X = EL n Xs` \\
+     ASM_SIMP_TAC std_ss [fromPairs_FAPPLY_EL, EL_MAP] \\
+     METIS_TAC [])
+ >> Rewr'
+ >> qabbrev_tac ‘fm3 = fromPairs Xs (MAP (ssub fm2) Es)’
+ >> Know ‘ssub fm3 (LAM y E) = LAM y (ssub fm3 E)’
+ >- (MATCH_MP_TAC ssub_LAM >> rw [Abbr ‘fm3’, FDOM_fromPairs] \\
+     FULL_SIMP_TAC std_ss [MEM_EL] >> rename1 `X = EL n Xs` \\
+     ASM_SIMP_TAC std_ss [fromPairs_FAPPLY_EL, EL_MAP] \\
+     (* NOTE: this is why we put
+          ‘BIGUNION (IMAGE (\e. FV (ssub fm2 e)) (set Es))’
+        into the exclusive set required by nc_INDUCTION2. *)
+     METIS_TAC [])
+ >> Rewr'
+ >> rw [LAM_eq_thm]
+QED
+
+(* A (non-trivial) generalization of FV_SUBSET *)
+Theorem FV_fromPairs :
+    !Xs Ps E. ALL_DISTINCT Xs /\ LENGTH Ps = LENGTH Xs ==>
+              FV (fromPairs Xs Ps ' E) SUBSET
+                 (FV E) UNION BIGUNION (IMAGE FV (set Ps))
+Proof
+    NTAC 2 GEN_TAC
+ >> HO_MATCH_MP_TAC nc_INDUCTION2
+ >> Q.EXISTS_TAC ‘set Xs UNION BIGUNION (IMAGE FV (set Ps))’
+ >> rw [FDOM_fromPairs, ssub_thm] (* 7 subgoals *)
+ >- (fs [MEM_EL, fromPairs_FAPPLY_EL] \\
+    `MEM (EL n Ps) Ps` by PROVE_TAC [MEM_EL] >> ASM_SET_TAC [])
+ >> TRY (rw [FINITE_FV] >> ASM_SET_TAC [])
+ >> qabbrev_tac ‘fm = fromPairs Xs Ps’
+ >> Know ‘ssub fm (LAM y E) = LAM y (ssub fm E)’
+ >- (MATCH_MP_TAC ssub_LAM \\
+     rw [Abbr ‘fm’, FDOM_fromPairs] \\
+     fs [MEM_EL, fromPairs_FAPPLY_EL] \\
+     METIS_TAC [])
+ >> Rewr'
+ >> fs [FV_thm]
+ >> qabbrev_tac ‘A = ssub fm E’
+ >> qabbrev_tac ‘B = BIGUNION (IMAGE FV (set Ps))’
+ >> Q.PAT_X_ASSUM ‘FV A SUBSET FV E UNION B’ MP_TAC
+ >> SET_TAC []
+QED
+
+(* A more precise estimation with `set Xs` *)
+Theorem FV_fromPairs' :
+    !Xs Ps E. ALL_DISTINCT Xs /\ LENGTH Ps = LENGTH Xs ==>
+              FV (fromPairs Xs Ps ' E) SUBSET
+                 ((FV E) DIFF (set Xs)) UNION BIGUNION (IMAGE FV (set Ps))
+Proof
+    NTAC 2 GEN_TAC
+ >> HO_MATCH_MP_TAC nc_INDUCTION2
+ >> Q.EXISTS_TAC ‘set Xs UNION BIGUNION (IMAGE FV (set Ps))’
+ >> rw [FDOM_fromPairs, ssub_thm] (* 7 subgoals *)
+ >- (fs [MEM_EL, fromPairs_FAPPLY_EL] \\
+    `MEM (EL n Ps) Ps` by PROVE_TAC [MEM_EL] >> ASM_SET_TAC [])
+ >> TRY (rw [FINITE_FV] >> ASM_SET_TAC [])
+ >> qabbrev_tac ‘fm = fromPairs Xs Ps’
+ >> Know ‘ssub fm (LAM y E) = LAM y (ssub fm E)’
+ >- (MATCH_MP_TAC ssub_LAM \\
+     rw [Abbr ‘fm’, FDOM_fromPairs] \\
+     fs [MEM_EL, fromPairs_FAPPLY_EL] \\
+     METIS_TAC []) >> Rewr'
+ >> fs [FV_thm]
+ >> qabbrev_tac ‘A = fm ' E’
+ >> qabbrev_tac ‘B = BIGUNION (IMAGE FV (set Ps))’
+ >> Q.PAT_X_ASSUM ‘FV A SUBSET FV E DIFF set Xs UNION B’ MP_TAC
+ >> SET_TAC []
 QED
 
 (* ----------------------------------------------------------------------

--- a/src/list/src/rich_listScript.sml
+++ b/src/list/src/rich_listScript.sml
@@ -2382,6 +2382,18 @@ Proof
   simp[LASTN_DROP_UNCOND]
 QED
 
+(* from examples/lambda/basics/appFOLDLScript.sml *)
+Theorem DROP_PREn_LAST_CONS :
+    !l n. 0 < n /\ n <= LENGTH l ==>
+          (DROP (n - 1) l = LAST (TAKE n l) :: DROP n l)
+Proof
+  Induct THEN SRW_TAC [numSimps.ARITH_ss][TAKE_def, DROP_def] THENL [
+    `n = 1` by numLib.DECIDE_TAC THEN SRW_TAC [][],
+    `n = 1` by numLib.DECIDE_TAC THEN SRW_TAC [][],
+    `(l = []) \/ ?h t0. l = h :: t0` by METIS_TAC [list_CASES] THEN
+    FULL_SIMP_TAC (srw_ss() ++ numSimps.ARITH_ss) [] ]
+QED
+
 val SUB_ADD_lem =
    numLib.DECIDE ``!l n m. n + m <= l ==> ((l - (n + m)) + n = l - m)``
 
@@ -2568,6 +2580,14 @@ val IS_PREFIX_BUTLAST = Q.store_thm ("IS_PREFIX_BUTLAST",
    THEN Q.SPEC_TAC (`y`, `y`)
    THEN INDUCT_THEN list_INDUCT ASSUME_TAC
    THEN ASM_SIMP_TAC boolSimps.bool_ss [FRONT_CONS, IS_PREFIX]);
+
+Theorem IS_PREFIX_BUTLAST' :
+    !l. l <> [] ==> IS_PREFIX l (FRONT l)
+Proof
+    Q.X_GEN_TAC ‘l’
+ >> Cases_on ‘l’ >- SRW_TAC[][]
+ >> SRW_TAC[][IS_PREFIX_BUTLAST]
+QED
 
 val IS_PREFIX_LENGTH = Q.store_thm ("IS_PREFIX_LENGTH",
    `!x y. IS_PREFIX y x ==> LENGTH x <= LENGTH y`,

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -829,6 +829,14 @@ val DISJOINT_ALT = store_thm (* from util_prob *)
    RW_TAC std_ss [IN_DISJOINT]
    >> PROVE_TAC []);
 
+Theorem DISJOINT_ALT' :
+    !s t. DISJOINT s t <=> !x. x IN t ==> x NOTIN s
+Proof
+    ONCE_REWRITE_TAC [DISJOINT_SYM]
+ >> RW_TAC std_ss [IN_DISJOINT]
+ >> PROVE_TAC []
+QED
+
 (* --------------------------------------------------------------------- *)
 (* A theorem from homeier@org.aero.uniblab (Peter Homeier)               *)
 (* --------------------------------------------------------------------- *)
@@ -861,6 +869,13 @@ Proof
      DISCH_THEN(fn th => GEN_TAC THEN
                          STRIP_ASSUME_TAC (SPEC (“x:'a”) th)) THEN
      ASM_REWRITE_TAC []
+QED
+
+Theorem DISJOINT_UNION' :
+    !s t u. DISJOINT u (s UNION t) <=> DISJOINT u s /\ DISJOINT u t
+Proof
+    ONCE_REWRITE_TAC [DISJOINT_SYM]
+ >> REWRITE_TAC [DISJOINT_UNION]
 QED
 
 Theorem DISJOINT_UNION_BOTH:


### PR DESCRIPTION
Hi,

I was stuck on the lambda example and finally made some new progress. This PR is a stage work for code review, it mainly adds a new combinator called "permutator" into `chap2Theory`:
```
[permutator_def]
⊢ ∀n. permutator n =
      (let
         Z = FRESH_list (n + 1) ∅;
         z = LAST Z
       in
         LAMl Z (VAR z ·· MAP VAR (FRONT Z)))
```
with its main property as the following theorem:
```
[permutator_thm]
⊢ ∀n N Ns. LENGTH Ns = n ⇒ permutator n ·· Ns @@ N == N ·· Ns
```
The proof has used the `fromPairs` in the previous closed PR #1181. I was thinking that `alistTheory` may help but actually that's not true, mostly because it's hard to use `ALOOKUP` with `ssub` in a natural way. Thus the code changes for the lambda examples in #1181 are now included in the present PR.

With the `permutator`, the existing proof of the following theorem gets simplified:
```
Boehm_transform_exists_lemma1 [boehmTheory]
⊢ ∀M. ∃pi. Boehm_transform pi ∧ is_ready (apply pi M)
```
meanwhile this `permutator` may solve my blocking issue in proving [Boehm_transform_exists_lemma2] (still in progress). Several other new lemmas about `subterm` are also added in `boehmTheory`.

Chun