### PR TITLE
Add `lambdify` - also `oneline` + cheatsheet updates

### DIFF
--- a/Manual/Cheatsheet/cheatsheet.md
+++ b/Manual/Cheatsheet/cheatsheet.md
@@ -198,6 +198,13 @@ This is most useful for certain simpset fragments:
 `DNF_ss`
 : Rewrites to convert to disjunctive normal form.
 
+<br>
+Conversely, `ExclSF` is like `Excl` above, but can be used to *exclude* a set of rewrites.
+
+<code>ExclSF <i>"simpset fragment name"</i></code>
+: Do not use the supplied simpset fragment when rewriting.
+  This allows temporary exclusion of a fragment from the stateful simpset.
+
 
 ## Provers
 In some cases, a decision procedure can save you some work.
@@ -354,6 +361,9 @@ In many cases, we may want to state exactly how the goal should be taken apart (
 
 `MK_COMB_TAC`
 : Reduces a goal of the form `f x = g y` to two subgoals, `f = g` and `x = y`.
+
+`iff_tac`<br>`eq_tac`
+: Reduces a goal of the form `P <=> Q` to two subgoals, `P ==> Q` and `Q ==> P`.
 
 `impl_tac`
 : For a goal of the form `(A ==> B) ==> C`, splits into the two subgoals `A` and `B ==> C`.

--- a/Manual/Cheatsheet/cheatsheet.md
+++ b/Manual/Cheatsheet/cheatsheet.md
@@ -164,6 +164,13 @@ Also commonly used when rewriting are:
     using `Cong AND_CONG` allows use of each conjunct in a conjunction to rewrite the others; and
     the goal `(∀ e. MEM e l ==> f e = g e) ==> h (MAP f l) = h (MAP g l)` is solved by `simp[Cong MAP_CONG]`.
 
+<code>oneline <i>theorem</i></code>
+: Converts a definition with multiple clauses into a single clause, turning pattern-matches into `case`-expressions.
+  For example, `oneline listTheory.MAP` gives `⊢ MAP f v = case v of [] => [] | h::t => f h::MAP f t`.
+
+<code>lambdify <i>theorem</i></code>
+: Converts a definition of the form `⊢ ∀ x y z. f x y z = ...` into one of the form `⊢ f = (λx y z. ...)`.
+
 <br>
 Note that the above are termed *rules* - these transform theorems to other theorems, allowing the above to be combined (e.g. `simp[Once $ GSYM thm]`).
 There are many other useful rules - see the HOL4 documentation for more details.

--- a/help/Docfiles/bossLib.lambdify.doc
+++ b/help/Docfiles/bossLib.lambdify.doc
@@ -1,0 +1,38 @@
+\DOC lambdify
+
+\TYPE {lambdify : thm -> thm}
+
+\SYNOPSIS
+Convert a theorem representing a single-line definition into a fully
+lambda-abstracted version.
+
+\DESCRIBE
+Given a theorem which describes an equation for a constant applied to a series
+of distinct variables, derive a reformulation which equates the constant with a
+lambda-abstraction over those variables.
+
+\USES
+To advance a proof by unfolding a partially-applied function. Most effectively
+used on theorems produced by {oneline}.
+
+\EXAMPLE
+Consider the result of applying {oneline} to {listTheory.MAP}:
+{
+  > oneline listTheory.MAP;
+  val it = ⊢ MAP f v = case v of [] => [] | h::t => f h::MAP f t: thm
+
+  > lambdify it;
+  val it = ⊢ MAP = (λf v. case v of [] => [] | h::t => f h::MAP f t): thm
+}
+
+\FAILURE
+Fails on theorems of the wrong form, i.e. theorems which are not a single
+equation with a left-hand side consisting of an application to a series of
+distinct variables.
+
+\COMMENTS
+Shorthand for {DefnBase.LIST_HALF_MK_ABS}.
+
+\SEEALSO
+bossLib.oneline, jrhUtils.HALF_MK_ABS
+\ENDDOC

--- a/help/Docfiles/bossLib.oneline.doc
+++ b/help/Docfiles/bossLib.oneline.doc
@@ -1,0 +1,35 @@
+\DOC oneline
+
+\TYPE {oneline : thm -> thm}
+
+\SYNOPSIS
+Collapse a theorem representing a single definition into a single line.
+
+\DESCRIBE
+Given a theorem which describes equations for a single constant, derive a
+reformulation where any pattern matching clauses have been combined and
+replaced by a single {case} expression.  This produces a left-hand side
+consisting of the constant applied only to variables.
+
+\USES
+To advance a proof by unfolding a function defined by pattern-matching, but
+where the pattern is not yet constrained enough.
+
+\EXAMPLE
+{
+  > listTheory.MAP;
+  val it = ⊢ (∀f. MAP f [] = []) ∧ ∀f h t. MAP f (h::t) = f h::MAP f t: thm
+
+  > oneline it;
+  val it = ⊢ MAP f v = case v of [] => [] | h::t => f h::MAP f t: thm
+}
+
+\FAILURE
+Fails on theorems of the wrong form, including definition of multiple constants.
+
+\COMMENTS
+Shorthand for {DefnBase.one_line_ify NONE}.
+
+\SEEALSO
+bossLib.lambdify, bossLib.AllCaseEqs
+\ENDDOC

--- a/src/boss/bossLib.sig
+++ b/src/boss/bossLib.sig
@@ -117,6 +117,10 @@ sig
   val Req0           : thm -> thm
   val ReqD           : thm -> thm
 
+  (* useful rules to use with simplification *)
+  val oneline        : thm -> thm
+  val lambdify       : thm -> thm
+
   val SIMP_CONV         : simpset -> thm list -> conv
   val SIMP_RULE         : simpset -> thm list -> thm -> thm
   val SRULE             : thm list -> thm -> thm (* uses srw_ss() *)

--- a/src/boss/bossLib.sml
+++ b/src/boss/bossLib.sml
@@ -162,6 +162,9 @@ val CasePred          = TypeBase.CasePred
 val CasePreds         = TypeBase.CasePreds
 val AllCasePreds      = TypeBase.AllCasePreds
 
+val oneline           = DefnBase.one_line_ify NONE
+val lambdify          = DefnBase.LIST_HALF_MK_ABS
+
 val completeInduct_on = numLib.completeInduct_on
 val measureInduct_on  = numLib.measureInduct_on;
 val update_induction  = BasicProvers.update_induction

--- a/src/coretypes/DefnBase.sig
+++ b/src/coretypes/DefnBase.sig
@@ -41,5 +41,6 @@ sig
   val const_eq_ref : Abbrev.conv ref
   val elim_triv_literal_CONV : Abbrev.conv
   val one_line_ify : PmatchHeuristics.pmatch_heuristic option -> thm -> thm
+  val LIST_HALF_MK_ABS : thm -> thm
 
 end

--- a/src/coretypes/DefnBase.sml
+++ b/src/coretypes/DefnBase.sml
@@ -528,4 +528,33 @@ fun one_line_ify heuristic def =
           end
     end handle FastExit th => th
 
+
+
+(* ----------------------------------------------------------------------
+    LIST_HALF_MK_ABS : thm -> thm
+
+    Convert a theorem representing a one-line function definition with an
+    all-variable-argument LHS (as returned by one_line_ify above) into a
+    theorem of the form `constant = \x y z. ...`.
+    Based on jrhUtils.HALF_MK_ABS.
+   ---------------------------------------------------------------------- *)
+
+fun LIST_HALF_MK_ABS th =
+  let
+    val err = mk_HOL_ERR "DefnBase" "LIST_HALF_MK_ABS"
+    val spec = SPEC_ALL th
+    val (left, right) = concl spec |> strip_forall |> snd |> dest_eq
+                        handle _ => raise err "expected an equality"
+    val (func, vars) = strip_comb left
+    fun unique [] = true
+      | unique (x::xs) = not (Lib.op_mem aconv x xs) andalso unique xs
+    val _ = if List.all is_var vars andalso unique vars then ()
+            else raise err "expected application to unique variables"
+    val lam = list_mk_abs (vars, right)
+    val app_eq_lam = list_mk_comb (lam, vars) |> LIST_BETA_CONV |> SYM |>
+                     TRANS spec
+  in
+    List.foldr (fn (v,th) => EXT (GEN v th)) app_eq_lam vars
+  end
+
 end


### PR DESCRIPTION
- Set up `bossLib.lambdify`, which should transform single-line definition theorems of the form `|- ∀x y z. f x y z = ...` to
  `|- f = (\x y z. ...)`. This is a shorthand for `DefnBase.LIST_HALF_MK_ABS`, which is inspired by `jrhUtils.HALF_MK_ABS`.
- `lambdify` is best used with `one_line_ify`ed definitions, so use `bossLib.oneline` as a shorthand for `DefnBase.one_line_ify NONE`.
- Help docs + cheatsheet entries for both `lambdify`/`oneline`.
- Also add `eq_tac` and `ExclSF` to the cheatsheet 
