### PR TITLE
Support cycle detection in topological_sortTheory

### DIFF
--- a/examples/algorithms/topological_sortScript.sml
+++ b/examples/algorithms/topological_sortScript.sml
@@ -475,7 +475,7 @@ Theorem SCC_SYM:
 Proof
   rw[SCC_def,EQ_IMP_THM]
 QED
-   
+
 Theorem SCC_TRANS:
   SCC E x y ∧ SCC E y z ⇒ SCC E x z
 Proof


### PR DESCRIPTION
- add `has_cycle` which checks if there are cycles in the graph
- prove that any pair of elements in a partition of the output of the `top_sort` is connected.
- add predicats `TC_depends_on` (a TC version of depends_on) and `TC_depends_on_weak` (which removes the `MEM b (MAP FST graph)` condition from `TC_depends_on`)
- prove the correctness of `has_cycle` (`has_cycle_correct` and `has_cycle_correct2`)