### PR TITLE
More properties of principle head normal forms

### DIFF
--- a/examples/lambda/basics/appFOLDLScript.sml
+++ b/examples/lambda/basics/appFOLDLScript.sml
@@ -183,6 +183,19 @@ Proof
  >> simp [LIST_TO_SET_SNOC] >> SET_TAC []
 QED
 
+(* A special case of FV_appstar *)
+Theorem FV_appstar_MAP_VAR[simp] :
+    FV (M @* MAP VAR vs) = FV M UNION set vs
+Proof
+    rw [FV_appstar]
+ >> Suff ‘BIGUNION (IMAGE FV (set (MAP VAR vs))) = set vs’ >- rw []
+ >> rw [Once EXTENSION, IN_BIGUNION_IMAGE]
+ >> reverse EQ_TAC >> rpt STRIP_TAC
+ >- (Q.EXISTS_TAC ‘VAR x’ >> rw [MEM_MAP])
+ >> rename1 ‘x IN FV t’
+ >> gs [MEM_MAP]
+QED
+
 (*---------------------------------------------------------------------------*
  *  LAMl (was in standardisationTheory)
  *---------------------------------------------------------------------------*)

--- a/examples/lambda/basics/termScript.sml
+++ b/examples/lambda/basics/termScript.sml
@@ -1053,7 +1053,8 @@ QED
 
 (* A combined version of ssub_update_apply_SUBST and ssub_SUBST *)
 Theorem ssub_update_apply_SUBST' :
-    !M. (!k. k IN FDOM fm ==> v # fm ' k) /\ v NOTIN FDOM fm /\
+    !M fm v N.
+       (!k. k IN FDOM fm ==> v # fm ' k) /\ v NOTIN FDOM fm /\
         DISJOINT (FDOM fm) (FV N) ==>
         (fm |+ (v,N)) ' M = [fm ' N/v] (fm ' M)
 Proof


### PR DESCRIPTION
Hi,

This PR adds some advanced properties about `principle_hnf` (principle head normal forms) and head reductions of λ-culculus.

If a solvable term `M` has its principle hnf, say `M0`, in the explicit form: `LAMl vs (VAR y ·· args)`. This explicit form, after applying `MAP VAR vs` (the same binding list), `M0 ·· MAP VAR vs` further head-reducts to `VAR y ·· args` (the body).  This reductions have numerous applications in the proofs of Böhm trees and subterms.

It's interesting to see what's the principle hnf of `M ·· MAP VAR vs`, i.e. the original term `M` appending the binding variables `vs` from `M0`.  This principle hnf is also `VAR y ·· args` but the proof is quite hard. The problem is that, in general we can't expect to get `M0 ·· MAP VAR vs` in the middle of the head reduction path (and then to the final `VAR y ·· args`), because the outer abstractions of M will be immediately reduced with the appended variable terms. This theorem, which I call it "principle_hnf_denude_thm", is finally proved:

```
principle_hnf_denude_thm (solvableTheory)
⊢ ∀l M vs y args.
    solvable M ∧ ALL_DISTINCT vs ∧ DISJOINT (set vs) (FV M) ∧
    principle_hnf M = LAMl vs (VAR y ·· args) ⇒
    principle_hnf (M ·· MAP VAR vs ·· MAP VAR l) = VAR y ·· args ·· MAP VAR l
```

Note that there's an additional variable list `l` in the above theorem for its actual use in my other proofs. When its takes an empty list, we get the following easy corollary as the above stated problem:
```
principle_hnf_denude_thm'
⊢ ∀M vs y args.
    solvable M ∧ ALL_DISTINCT vs ∧ DISJOINT (set vs) (FV M) ∧
    principle_hnf M = LAMl vs (VAR y ·· args) ⇒
    principle_hnf (M ·· MAP VAR vs) = VAR y ·· args
```

In the proof, first I use the following characterisation theorem to reduce all `principle_hnf` to `-h->*` (multi-steps head reduction):
```
principle_hnf_thm
⊢ ∀M N. has_hnf M ⇒ (principle_hnf M = N ⇔ M -h->* N ∧ hnf N)
```

Then I do a strong RTC "right" induction on `-h->*` and the problem is further reduced to the following advanced property of `-h->` (single-step head reduction), whose proof (by doing simple induction on `M`) is hard and tedious (with some low-level lemmas from `nomsetTheory` used):
```
hreduce1_LAMl_cases (head_reductionTheory)
⊢ ∀M vs t.
    ALL_DISTINCT vs ∧ DISJOINT (set vs) (FV M) ∧ M -h-> LAMl vs t ∧ ¬is_abs t ⇒
    ∃vs1 vs2 N.
      (vs = vs1 ++ vs2) ∧ (M = LAMl vs1 N) ∧ ¬is_abs N ∧ N -h-> LAMl vs2 t
```

There are also some other minor additions and changes in the related code.

Chun