### PR TITLE
[lambda] The "congruence" of subterm properties w.r.t different excluded lists

### DIFF
--- a/examples/lambda/barendregt/head_reductionScript.sml
+++ b/examples/lambda/barendregt/head_reductionScript.sml
@@ -84,6 +84,21 @@ Proof
   METIS_TAC [pmact_inverse, tpm_hreduce_I]
 QED
 
+Theorem tpm_hreduces_I[local] :
+    !M N. M -h->* N ==> tpm pi M -h->* tpm pi N
+Proof
+    HO_MATCH_MP_TAC RTC_INDUCT >> rw []
+ >> rw [Once RTC_CASES1]
+ >> DISJ2_TAC
+ >> Q.EXISTS_TAC ‘tpm pi M'’ >> rw []
+QED
+
+Theorem tpm_hreduces[simp] :
+    !pi M N. tpm pi M -h->* tpm pi N <=> M -h->* N
+Proof
+    METIS_TAC [pmact_inverse, tpm_hreduces_I]
+QED
+
 val hreduce1_rwts = store_thm(
   "hreduce1_rwts",
   ``(VAR s -h-> M ⇔ F) ∧
@@ -1607,6 +1622,29 @@ Proof
  >> rw [DISJOINT_ALT]
 QED
 
+Theorem hnf_children_tpm :
+    !pi M. hnf M ==> (hnf_children (tpm pi M) = MAP (tpm pi) (hnf_children M))
+Proof
+    rpt STRIP_TAC
+ >> Cases_on ‘~is_comb M’
+ >- (‘is_var M \/ is_abs M’ by METIS_TAC [term_cases]
+     >- (‘?y. M = VAR y’ by METIS_TAC [is_var_cases] \\
+         NTAC 2 (rw [Once hnf_children_def])) \\
+    ‘?v t. M = LAM v t’ by METIS_TAC [is_abs_cases] \\
+     NTAC 2 (rw [Once hnf_children_def]))
+ >> fs []
+ >> ‘?t args. (M = t @* args) /\ args <> [] /\ ~is_comb t’
+      by METIS_TAC [is_comb_appstar_exists]
+ >> rw [tpm_appstar]
+ >> Know ‘~is_abs t’
+ >- (CCONTR_TAC >> fs [hnf_appstar])
+ >> DISCH_TAC
+ >> ‘is_var t’ by METIS_TAC [term_cases]
+ >> ‘?y. t = VAR y’ by METIS_TAC [is_var_cases]
+ >> rw [hnf_children_hnf]
+ >> rw [LIST_EQ_REWRITE, EL_MAP]
+QED
+
 (*---------------------------------------------------------------------------*
  *  LAMl_size (of hnf)
  *---------------------------------------------------------------------------*)
@@ -1659,6 +1697,12 @@ Proof
  >> rw [appstar_SNOC]
 QED
 
+Theorem LAMl_size_tpm[simp] :
+    !M. LAMl_size (tpm pi M) = LAMl_size M
+Proof
+    HO_MATCH_MP_TAC simple_induction >> rw []
+QED
+
 (*---------------------------------------------------------------------------*
  *  hnf_children_size (of hnf)
  *---------------------------------------------------------------------------*)
@@ -1681,6 +1725,12 @@ Theorem hnf_children_size_appstar[simp] :
 Proof
     Induct_on ‘Ms’ using SNOC_INDUCT >- rw []
  >> rw [appstar_SNOC]
+QED
+
+Theorem hnf_children_size_tpm[simp] :
+    !M. hnf_children_size (tpm pi M) = hnf_children_size M
+Proof
+    HO_MATCH_MP_TAC simple_induction >> rw []
 QED
 
 (*---------------------------------------------------------------------------*

--- a/examples/lambda/barendregt/solvableScript.sml
+++ b/examples/lambda/barendregt/solvableScript.sml
@@ -633,7 +633,7 @@ Proof
  >> Q.EXISTS_TAC ‘tpm pi N’ >> rw []
 QED
 
-Theorem solvable_tpm :
+Theorem solvable_tpm[simp] :
     !pi M. solvable (tpm pi M) <=> solvable M
 Proof
     METIS_TAC [pmact_inverse, solvable_tpm_I]

--- a/examples/lambda/barendregt/solvableScript.sml
+++ b/examples/lambda/barendregt/solvableScript.sml
@@ -626,6 +626,23 @@ Proof
  >> MATCH_MP_TAC lameq_appstar_cong >> rw [lameq_K]
 QED
 
+Theorem solvable_tpm_I[local] :
+    !pi M. solvable M ==> solvable (tpm pi M)
+Proof
+    rw [solvable_iff_has_hnf, has_hnf_thm]
+ >> Q.EXISTS_TAC ‘tpm pi N’ >> rw []
+QED
+
+Theorem solvable_tpm :
+    !pi M. solvable (tpm pi M) <=> solvable M
+Proof
+    METIS_TAC [pmact_inverse, solvable_tpm_I]
+QED
+
+(* |- !M N z. solvable ([N/z] M) ==> solvable M *)
+Theorem solvable_from_subst =
+        has_hnf_SUB_E |> REWRITE_RULE [GSYM solvable_iff_has_hnf]
+
 (*---------------------------------------------------------------------------*
  *  Principle Head Normal Forms (principle_hnf)
  *---------------------------------------------------------------------------*)
@@ -1654,6 +1671,21 @@ Proof
  >> FIRST_X_ASSUM MATCH_MP_TAC
  >> Q.EXISTS_TAC ‘e’ >> art []
 QED
+
+Theorem principle_hnf_tpm :
+    !pi M. has_hnf M ==> principle_hnf (tpm pi M) = tpm pi (principle_hnf M)
+Proof
+    rpt GEN_TAC >> DISCH_TAC
+ >> qabbrev_tac ‘N = principle_hnf M’
+ >> Know ‘principle_hnf M = N’ >- rw [Abbr ‘N’]
+ >> DISCH_THEN (STRIP_ASSUME_TAC o
+                (REWRITE_RULE [MATCH_MP principle_hnf_thm (ASSUME “has_hnf M”)]))
+ >> ‘solvable (tpm pi M)’ by rw [solvable_tpm, solvable_iff_has_hnf]
+ >> rw [principle_hnf_thm']
+QED
+
+Theorem principle_hnf_tpm' =
+        principle_hnf_tpm |> REWRITE_RULE [GSYM solvable_iff_has_hnf]
 
 val _ = export_theory ();
 val _ = html_theory "solvable";

--- a/src/coalgebras/ltreeScript.sml
+++ b/src/coalgebras/ltreeScript.sml
@@ -881,9 +881,33 @@ Proof
 QED
 
 Theorem ltree_el_valid :
-    !p t. p IN ltree_paths t ==> ltree_el t p <> NONE
+    !p t. p IN ltree_paths t <=> ltree_el t p <> NONE
 Proof
     rw [ltree_paths_alt]
+QED
+
+Theorem ltree_el_valid_inclusive :
+    !p t. p IN ltree_paths t <=> !p'. p' <<= p ==> ltree_el t p' <> NONE
+Proof
+    rpt GEN_TAC
+ >> reverse EQ_TAC >> STRIP_TAC
+ >- (POP_ASSUM (MP_TAC o (Q.SPEC ‘p’)) \\
+     rw [ltree_el_valid])
+ >> rw [GSYM ltree_el_valid]
+ >> MATCH_MP_TAC ltree_paths_inclusive
+ >> Q.EXISTS_TAC ‘p’ >> art []
+QED
+
+Theorem ltree_lookup_valid :
+    !p t. p IN ltree_paths t <=> ltree_lookup t p <> NONE
+Proof
+    rw [ltree_lookup_iff_ltree_el, ltree_el_valid]
+QED
+
+Theorem ltree_lookup_valid_inclusive :
+    !p t. p IN ltree_paths t <=> !p'. p' <<= p ==> ltree_lookup t p' <> NONE
+Proof
+    rw [ltree_lookup_iff_ltree_el, ltree_el_valid_inclusive]
 QED
 
 (*---------------------------------------------------------------------------*

--- a/src/list/src/rich_listScript.sml
+++ b/src/list/src/rich_listScript.sml
@@ -1179,14 +1179,14 @@ val TAKE_SNOC = Q.store_thm ("TAKE_SNOC",
    THEN ASM_REWRITE_TAC []);
 
 Theorem TAKE_FRONT :
-    !l n. l <> [] /\ n <= PRE (LENGTH l) ==> TAKE n (FRONT l) = TAKE n l
+    !l n. l <> [] /\ n < LENGTH l ==> TAKE n (FRONT l) = TAKE n l
 Proof
     HO_MATCH_MP_TAC SNOC_INDUCT
  >> CONJ_TAC >- SRW_TAC [][]
  >> RW_TAC arith_ss [FRONT_SNOC, LENGTH_SNOC]
  >> ONCE_REWRITE_TAC [EQ_SYM_EQ]
  >> MATCH_MP_TAC TAKE_SNOC
- >> ASM_REWRITE_TAC []
+ >> RW_TAC arith_ss []
 QED
 
 val SNOC_EL_TAKE = Q.store_thm ("SNOC_EL_TAKE",

--- a/src/list/src/rich_listScript.sml
+++ b/src/list/src/rich_listScript.sml
@@ -1178,6 +1178,17 @@ val TAKE_SNOC = Q.store_thm ("TAKE_SNOC",
    THEN RES_TAC
    THEN ASM_REWRITE_TAC []);
 
+Theorem TAKE_FRONT :
+    !l n. l <> [] /\ n <= PRE (LENGTH l) ==> TAKE n (FRONT l) = TAKE n l
+Proof
+    HO_MATCH_MP_TAC SNOC_INDUCT
+ >> CONJ_TAC >- SRW_TAC [][]
+ >> RW_TAC arith_ss [FRONT_SNOC, LENGTH_SNOC]
+ >> ONCE_REWRITE_TAC [EQ_SYM_EQ]
+ >> MATCH_MP_TAC TAKE_SNOC
+ >> ASM_REWRITE_TAC []
+QED
+
 val SNOC_EL_TAKE = Q.store_thm ("SNOC_EL_TAKE",
    `!n l. n < LENGTH l ==> (SNOC (EL n l) (TAKE n l) = TAKE (SUC n) l)`,
    Induct_on `n` THEN Cases_on `l` THEN ASM_SIMP_TAC list_ss [SNOC, TAKE]);


### PR DESCRIPTION
Hi,

given a solvable term, the concept of "subterm", along a path of numbers, is the specified (by the path) children term of the principle hnf converted from the original term, so on until the last path element:
```
subterm_def
⊢ (∀X M. subterm X M [] = SOME (X,M)) ∧
  ∀X M x xs.
    subterm X M (x::xs) =
    if solvable M then
      (let
         M0 = principle_hnf M;
         n = LAMl_size M0;
         m = hnf_children_size M0;
         vs = FRESH_list n (X ∪ FV M0);
         M1 = principle_hnf (M0 ·· MAP VAR vs);
         Ms = hnf_children M1
       in
         if x < m then subterm (X ∪ set vs) (EL x Ms) xs else NONE)
    else NONE
```
Due to alpha-conversion, the returned subterm may contain some fresh variables generated according to an "excluded list" given as input parameter. The definition guarantees (see the part `vs = FRESH_list n (X ∪ FV M0)`) that whatever `X` (the excluded list) will give the "correct" result, in the sense that the principle hnf of `M0 ·· MAP VAR vs` is indeed the inner body of `M0` without variable captures (because `vs` is fresh, disjoint with `FV M0`).

In general, `FRESH_list` (or `NEW_TAC`) is like a blackbox: nothing can be said between `FRESH_list n X` and `FRESH_list n Y` except for their size of lists are the same. Therefore, in many related proofs, properties about `subterm X M p` cannot be directly used if `subterm Y M p` is to be discussed, even `X` and `Y` themselves have some relationships.

Here I proved a hard result saying that, for any `X` and `Y`, the actual term returned by `subterm X M p` and `subterm Y M p` differ only by a "term permutation" (`tpm`), or they are both `NONE` (either both unsolvable or the path itself is invalid, accessing out bound of the hnf children lists):
```
subterm_tpm_cong
⊢ ∀p X Y M.
    FINITE X ∧ FINITE Y ⇒
    (subterm X M p = NONE ⇔ subterm Y M p = NONE) ∧
    (subterm X M p ≠ NONE ⇒ ∃pi. tpm pi (subterm' X M p) = subterm' Y M p)
```
Actually the above theorem cannot be directly proved, without first generalizing to the following lemma involving `tpm`:
```
subterm_tpm_lemma
⊢ ∀p X Y M pi.
    FINITE X ∧ FINITE Y ⇒
    (subterm X M p = NONE ⇒ subterm Y (tpm pi M) p = NONE) ∧
    (subterm X M p ≠ NONE ⇒
     ∃pi'. tpm pi' (subterm' X M p) = subterm' Y (tpm pi M) p)
```
Here, it's interesting to see (if taking both X and Y as X) that `subterm' X (tpm pi M) p` is not `tpm pi (subterm' X p)` but with another different permutation list. This is because, although all free variables in M are permuted by `pi`, the fresh binding list is completely different, and therefore `subterm' X (tpm pi M) p` actually contains two permutations: one is the `pi` from `tpm pi M`, the other is `ZIP (vs,vs')` where `vs` and `vs'` are the two internal fresh lists generated for `M` and `tpm pi M`.  To prove the above lemma, a lot of new small theorems about `tpm` of existing concepts are added.

Once the above results are obtained, all functions built upon this concept of "subterms" but only returning some numbers, can be proved to be independent with the input excluded list, e.g. the number of hnf children:
```
subterm_hnf_children_size_cong
⊢ ∀X Y M p.
    FINITE X ∧ FINITE Y ∧ subterm X M p ≠ NONE ∧ solvable (subterm' X M p) ⇒
    hnf_children_size (principle_hnf (subterm' X M p)) =
    hnf_children_size (principle_hnf (subterm' Y M p))
```

Another more interesting application is the following concept of "subterm (tree) width", i.e. the maximal number of hnf children along the given path `p`:
```
subterm_width_def
⊢ ∀M p.
    subterm_width M p =
    (let
       Ms = {subterm' ∅ M p' | p' ≼ FRONT p}
     in
       MAX_SET (IMAGE (hnf_children_size ∘ principle_hnf) Ms))
```
Note that, when defining `subterm_width`, the empty set `{}` has been used to with `subterm`. But then we can prove that this width is independent with this excluded list (actually a set, same for all above places), i.e. this number is the same for all possible `X` used in place of `subterm X ...`:
```
subterm_width_thm
⊢ ∀X M p p'.
    FINITE X ∧ p ≠ [] ∧ p ∈ ltree_paths (BTe X M) ∧ subterm X M p ≠ NONE ∧
    p' ≼ FRONT p ⇒
    hnf_children_size (principle_hnf (subterm' X M p')) ≤ subterm_width M p
```

P. S. There are other related minor additions in core theories (`rich_list` and `ltree`) in this PR.

Chun