### PR TITLE
Upgraded GitHub actions (Node.js 16 actions are deprecated)

### DIFF
--- a/.github/workflows/docker-ci-for-pr.yml
+++ b/.github/workflows/docker-ci-for-pr.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: developers/docker-ci/Dockerfile
@@ -32,13 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: developers/docker-ci/Dockerfile

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -15,27 +15,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.USERNAME }}/hol-dev
           tags: |
             type=sha,prefix=ci-,suffix=-stdknl
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ env.USERNAME }}
           password: ${{ env.PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: developers/docker-ci/Dockerfile
@@ -53,27 +53,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.USERNAME }}/hol-dev
           tags: |
             type=sha,prefix=ci-,suffix=-expk
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ env.USERNAME }}
           password: ${{ env.PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: developers/docker-ci/Dockerfile

--- a/.github/workflows/self-runner.yml
+++ b/.github/workflows/self-runner.yml
@@ -69,14 +69,14 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ secrets.DOCKER_HUB_USERNAME }}/hol-dev
           tags: |
@@ -84,16 +84,16 @@ jobs:
             type=sha,prefix={{branch}}-,suffix=-self
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       -
         name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: developers/docker-ci/${{ env.default_dockerfile }}


### PR DESCRIPTION
Hi,

The following annotations can be seen from Github's "Actions" tab for each recent CI builds:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3,
 docker/setup-buildx-action@v2, docker/build-push-action@v3. For more information see: 
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

This PR simply upgrades all involved obsoleted GitHub actions to their latest version. Since they are perfectly backward compatible, nothing is broken after the simple version changes. We don't really need the new features provided by the new versions of those actions, but if leaving as is, eventually the old actions won't run.

P. S. I was waiting for the merge of PR #1194, where the same workflow files were modified due to Z3 default version changes.

Chun