### PR TITLE
add WF_PULL to relationTheory

### DIFF
--- a/src/relation/relationScript.sml
+++ b/src/relation/relationScript.sml
@@ -1119,6 +1119,35 @@ val WF_antisymmetric = store_thm(
   METIS_TAC [TC_RULES]);
 
 (*---------------------------------------------------------------------------
+ * If `f x` remains unchanged in relation `R'` and `f x` always satisfy `P`,
+ * and there is a mapping `g` such that `R' x y ==> R (f x) (g x) (g y)`, then
+ * to prove `WF R'`, it is sufficient to prove that `P (f x) ==> WF (R (f x))`.
+ *---------------------------------------------------------------------------*)
+Theorem WF_PULL:
+  !P f R g R'.
+    (!x. P (f x) ==> WF (R (f x))) /\
+    (!x y. R' x y ==> P (f x) /\ f x = f y /\ R (f x) (g x) (g y)) ==>
+    WF R'
+Proof
+  rw[WF_DEF] >>
+  reverse $ Cases_on `?w'. P (f w') /\ B w'`
+  >- (fs[] >> metis_tac[]) >>
+  rw[] >>
+  first_x_assum drule >>
+  qpat_x_assum `B w` kall_tac >>
+  disch_then $ qspec_then
+    `\x. ?y. x = g y /\ B y /\ P (f y) /\ f y = f w'` assume_tac >>
+  fs[PULL_EXISTS] >>
+  first_x_assum (dxrule_then dxrule) >>
+  rw[] >>
+  first_assum $ irule_at (Pos hd) >>
+  rw[] >>
+  last_x_assum drule >>
+  rw[] >>
+  gvs[]
+QED
+
+(*---------------------------------------------------------------------------
  * Inverse image theorem: mapping into a wellfounded relation gives a
  * derived well founded relation. A "size" mapping, like "length" for
  * lists is such a relation.

--- a/src/relation/relationScript.sml
+++ b/src/relation/relationScript.sml
@@ -1129,22 +1129,18 @@ Theorem WF_PULL:
     (!x y. R' x y ==> P (f x) /\ f x = f y /\ R (f x) (g x) (g y)) ==>
     WF R'
 Proof
-  rw[WF_DEF] >>
-  reverse $ Cases_on `?w'. P (f w') /\ B w'`
-  >- (fs[] >> metis_tac[]) >>
-  rw[] >>
-  first_x_assum drule >>
-  qpat_x_assum `B w` kall_tac >>
-  disch_then $ qspec_then
-    `\x. ?y. x = g y /\ B y /\ P (f y) /\ f y = f w'` assume_tac >>
-  fs[PULL_EXISTS] >>
-  first_x_assum (dxrule_then dxrule) >>
-  rw[] >>
-  first_assum $ irule_at (Pos hd) >>
-  rw[] >>
-  last_x_assum drule >>
-  rw[] >>
-  gvs[]
+  rw_tac(srw_ss())[WF_DEF] >>
+  Cases_on `?w'. P (f w') /\ B w'`
+  >- (
+    POP_ASSUM STRIP_ASSUME_TAC >>
+    FIRST_X_ASSUM drule >>
+    Q.PAT_X_ASSUM `B w` (K ALL_TAC) >>
+    DISCH_THEN $ Q.SPEC_THEN
+      `\x. ?y. x = g y /\ B y /\ P (f y) /\ f y = f w'`
+      (ASSUME_TAC o SIMP_RULE bool_ss [PULL_EXISTS]) >>
+    FIRST_X_ASSUM (dxrule_then dxrule) >>
+    METIS_TAC[]) >>
+  METIS_TAC[]
 QED
 
 (*---------------------------------------------------------------------------


### PR DESCRIPTION
- Add the theorem `WF_PULL` that allow one to pull something that stays unchanged in the relation when proving `WF` of a relation
```
  ∀P f R g R'.
    (∀x. P (f x) ⇒ WF (R (f x))) ∧
    (∀x y. R' x y ⇒ P (f x) ∧ f x = f y ∧ R (f x) (g x) (g y)) ⇒
    WF R'
```
An example would be having `f=FST` and `g=SND`, and we know that the first component of the tuple remains unchanged and always satisfy `P` then we can pull it out as an assumption and only have to prove `WF` of a relation only concerning the `SND` component under that assumption.