### PR TITLE
[lambda] Boehm_transform_exists_lemma (Lemma 10.3.6 (ii) [1, p.247])

### DIFF
--- a/examples/lambda/barendregt/boehmScript.sml
+++ b/examples/lambda/barendregt/boehmScript.sml
@@ -998,7 +998,7 @@ Proof
  >> qabbrev_tac ‘m = LENGTH Ms'’
  >> Cases_on ‘h < m’ >> simp []
  >> Cases_on ‘p = []’ >> fs []
-  (* final stage *)
+ (* final stage *)
  >> FIRST_X_ASSUM MATCH_MP_TAC >> simp []
  >> CONJ_TAC (* 2 subgoals *)
  >| [ (* goal 1 (of 2) *)
@@ -1094,7 +1094,7 @@ Proof
  >> Q.PAT_X_ASSUM ‘n = LAMl_size M0'’ (rfs o wrap o SYM)
  >> ‘TAKE n vs = vs’ by rw [TAKE_LENGTH_ID_rwt]
  >> POP_ASSUM (rfs o wrap)
-  (* refine P1 and Q1 again for clear assumptions using them *)
+ (* refine P1 and Q1 again for clear assumptions using them *)
  >> qunabbrevl_tac [‘M1’, ‘M1'’]
  >> qabbrev_tac ‘M1 = principle_hnf (M0 @* MAP VAR vs)’
  >> qabbrev_tac ‘M1' = principle_hnf (M0' @* MAP VAR vs)’
@@ -1173,7 +1173,7 @@ Proof
  >> qabbrev_tac ‘n' = LAMl_size M0'’
  >> Know ‘n' = n’ >- (rw [Abbr ‘n’, Abbr ‘n'’, LAMl_size_tpm])
  >> DISCH_TAC
-  (* special case *)
+ (* special case *)
  >> reverse (Cases_on ‘h < m’)
  >- (rw [] >> rw [subterm_of_solvables])
  (* stage work, now h < m *)
@@ -2528,7 +2528,7 @@ Proof
      Q.EXISTS_TAC ‘FRONT l’ >> rw [] \\
      MATCH_MP_TAC IS_PREFIX_FRONT_MONO >> rw [])
  >> Rewr
-  (* Michael Norrish's tactics *)
+ (* Michael Norrish's tactics *)
  >> CONV_TAC (UNBETA_CONV “subterm X M (h::p')”)
  >> qmatch_abbrev_tac ‘f _’
  >> RW_TAC bool_ss [subterm_of_solvables]
@@ -2597,8 +2597,8 @@ QED
          [Boehm_apply_unsolvable], but in this case it is, and this is needed in
          [Boehm_out_lemma] when rewriting ‘apply pi M’ to explicit forms using
          [is_ready_alt] (assuming M is solvable). The extra conclusion is added:
-        ‘solvable M ==> solvable (apply pi M)’, which is not provable outside
-         the proof of this lemma.
+         ‘solvable M ==> solvable (apply pi M)’, which is not provable outside
+          the proof of this lemma.
 
    NOTE7: The core textbook proof steps of this lemma is actually in the proof of
          [subterm_subst_cong], which has to have a ‘tpm_rel’ in the conclusion.
@@ -2613,19 +2613,19 @@ QED
 Theorem Boehm_transform_exists_lemma :
     !X M p. FINITE X /\
             p <> [] /\ p IN ltree_paths (BTe X M) /\ subterm X M p <> NONE ==>
-            ?pi. Boehm_transform pi /\
-                (solvable M ==> solvable (apply pi M)) /\
-                 is_ready (apply pi M) /\
-                ?Z ss. FINITE Z /\ subterm Z (apply pi M) p <> NONE /\
-                       tpm_rel (subterm' Z (apply pi M) p)
-                               ((subterm' Z M p) ISUB ss)
+           ?pi. Boehm_transform pi /\
+                solvable (apply pi M) /\ is_ready (apply pi M) /\
+               ?Z v N. Z = X UNION FV M /\ closed N /\
+                       subterm Z (apply pi M) p <> NONE /\
+                       tpm_rel (subterm' Z (apply pi M) p) ([N/v] (subterm' Z M p))
 Proof
     rpt STRIP_TAC
- (* trivial case: unsolvable M (useless) *)
- >> reverse (Cases_on ‘solvable M’)
- >- (Q.EXISTS_TAC ‘[]’ >> rw [is_ready_def] \\
-     Q.EXISTS_TAC ‘X’ >> rw [] \\
-     Q.EXISTS_TAC ‘[]’ >> rw [])
+ >> ‘(!q. q <<= p ==> subterm X M q <> NONE) /\
+      !q. q <<= FRONT p ==> solvable (subterm' X M q)’
+         by METIS_TAC [subterm_solvable_lemma]
+ >> Know ‘solvable M’
+ >- (POP_ASSUM (MP_TAC o Q.SPEC ‘[]’) >> rw [])
+ >> DISCH_TAC
  (* M0 is now meaningful since M is solvable *)
  >> qabbrev_tac ‘M0 = principle_hnf M’
  >> ‘hnf M0’ by PROVE_TAC [hnf_principle_hnf, solvable_iff_has_hnf]
@@ -2671,13 +2671,14 @@ Proof
     But since P is a closed term, these fresh variables seem irrelevant...
   *)
  >> qabbrev_tac ‘P = permutator d’
+ >> ‘closed P’ by rw [Abbr ‘P’, closed_permutator]
  >> qabbrev_tac ‘p2 = [[P/y]]’
  >> ‘Boehm_transform p2’ by rw [Abbr ‘p2’]
  >> ‘apply p2 M1 = P @* MAP [P/y] args’ by rw [Abbr ‘p2’, appstar_SUB]
  >> qabbrev_tac ‘args' = MAP [P/y] args’
  >> Know ‘!i. i < m ==> FV (EL i args') SUBSET FV (EL i args)’
  >- (rw [Abbr ‘args'’, EL_MAP, FV_SUB] \\
-     rw [Abbr ‘P’, closed_permutator, GSYM closed_def])
+     fs [closed_def])
  >> DISCH_TAC
  >> ‘LENGTH args' = m’ by rw [Abbr ‘args'’, Abbr ‘m’]
  (* NOTE: Z contains ‘vs’ in addition to X and FV M *)
@@ -2885,8 +2886,6 @@ Proof
  (* NOTE: for rewriting M to M0 in the goal, Z can be anything. *)
  >> Q.ABBREV_TAC ‘Y = X UNION FV M’
  >> ‘FINITE Y’ by rw [Abbr ‘Y’]
- (* stage work, there's no other choice for RHS *)
- >> Q.EXISTS_TAC ‘Y’ >> art []
  (* RHS rewriting from M to M0 *)
  >> Know ‘subterm Y M0 p = subterm Y M p’
  >- (qunabbrev_tac ‘M0’ \\
@@ -2987,7 +2986,7 @@ Proof
      MATCH_MP_TAC principle_hnf_FV_SUBSET' >> art [])
  >> DISCH_TAC
  (* stage work, there's the textbook choice *)
- >> Q.EXISTS_TAC ‘[(P,y)]’
+ >> qexistsl_tac [‘y’, ‘P’] >> art []
  >> REWRITE_TAC [GSYM SUB_ISUB_SINGLETON]
  (* preparing for subterm_subst_cong *)
  >> Suff ‘subterm Z ([P/y] N) t <> NONE /\
@@ -3094,19 +3093,14 @@ Proof
  (* applying subterm_hnf_children_size_cong *)
  >> MATCH_MP_TAC subterm_hnf_children_size_cong >> art []
  (* subgoals: subterm X M (h::p') <> NONE /\ solvable (subterm' X M (h::p')) *)
- >> qabbrev_tac ‘p = h::t’
- >> ‘p <> []’ by rw [Abbr ‘p’]
- >> MP_TAC (Q.SPECL [‘X’, ‘M’, ‘p’] subterm_solvable_lemma)
- >> simp [] >> STRIP_TAC
- >> qunabbrev_tac ‘p’
- >> CONJ_TAC (* subterm X M (h::p') <> NONE *)
+ >> reverse CONJ_TAC
  >- (FIRST_X_ASSUM MATCH_MP_TAC >> rw [] \\
-     MATCH_MP_TAC IS_PREFIX_TRANS \\
-     Q.EXISTS_TAC ‘FRONT t’ >> art [] \\
-     MATCH_MP_TAC IS_PREFIX_BUTLAST' >> art [])
- (* final goal: solvable (subterm' X M (h::p')) *)
+     Cases_on ‘t’ >> fs [])
+ (* final goal: subterm X M (h::p') <> NONE *)
  >> FIRST_X_ASSUM MATCH_MP_TAC >> rw []
- >> Cases_on ‘t’ >> fs []
+ >> MATCH_MP_TAC IS_PREFIX_TRANS
+ >> Q.EXISTS_TAC ‘FRONT t’ >> art []
+ >> MATCH_MP_TAC IS_PREFIX_BUTLAST' >> art []
 QED
 
 (*---------------------------------------------------------------------------*

--- a/examples/lambda/barendregt/chap2Script.sml
+++ b/examples/lambda/barendregt/chap2Script.sml
@@ -2,12 +2,12 @@
  * Beta-equivalence and combinators (Chapter 2 of Hankin [2])
  *---------------------------------------------------------------------------*)
 
-open HolKernel Parse boolLib bossLib;
+open HolKernel Parse boolLib bossLib BasicProvers;
 
 open pred_setTheory pred_setLib listTheory rich_listTheory finite_mapTheory
      arithmeticTheory string_numTheory hurdUtils;
 
-open termTheory BasicProvers nomsetTheory binderLib appFOLDLTheory;
+open basic_swapTheory termTheory nomsetTheory binderLib appFOLDLTheory;
 
 val _ = augment_srw_ss [rewrites [LET_THM]]
 val std_ss = std_ss ++ rewrites [LET_THM]
@@ -1211,14 +1211,14 @@ Proof
  >> qabbrev_tac ‘M = VAR z @* MAP VAR (FRONT Z)’
  (* preparing for LAMl_ALPHA_ssub *)
  >> qabbrev_tac
-     ‘Y = FRESH_list (n + 1) (set Z UNION (BIGUNION (IMAGE FV (set Ns))))’
+     ‘Y = NEWS (n + 1) (set Z UNION (BIGUNION (IMAGE FV (set Ns))))’
  >> Know ‘FINITE (set Z UNION (BIGUNION (IMAGE FV (set Ns))))’
  >- (rw [] >> rw [FINITE_FV])
  >> DISCH_TAC
  >> Know ‘ALL_DISTINCT Y /\
           DISJOINT (set Y) (set Z UNION (BIGUNION (IMAGE FV (set Ns)))) /\
           LENGTH Y = n + 1’
- >- (ASM_SIMP_TAC std_ss [FRESH_list_def, Abbr ‘Y’])
+ >- (ASM_SIMP_TAC std_ss [NEWS_def, Abbr ‘Y’])
  >> rw []
  (* applying LAMl_ALPHA_ssub *)
  >> Know ‘LAMl Z M = LAMl Y ((FEMPTY |++ ZIP (Z,MAP VAR Y)) ' M)’
@@ -1387,14 +1387,14 @@ Proof
  >> DISCH_TAC
  (* preparing for LAMl_ALPHA_ssub *)
  >> qabbrev_tac
-     ‘Y = FRESH_list n (set Z UNION (BIGUNION (IMAGE FV (set Ns))))’
+     ‘Y = NEWS n (set Z UNION (BIGUNION (IMAGE FV (set Ns))))’
  >> Know ‘FINITE (set Z UNION (BIGUNION (IMAGE FV (set Ns))))’
  >- (rw [] >> rw [FINITE_FV])
  >> DISCH_TAC
  >> Know ‘ALL_DISTINCT Y /\
           DISJOINT (set Y) (set Z UNION (BIGUNION (IMAGE FV (set Ns)))) /\
           LENGTH Y = n’
- >- (ASM_SIMP_TAC std_ss [FRESH_list_def, Abbr ‘Y’])
+ >- (ASM_SIMP_TAC std_ss [NEWS_def, Abbr ‘Y’])
  >> rw []
  (* applying LAMl_ALPHA_ssub *)
  >> Know ‘LAMl Z (VAR z) = LAMl Y ((FEMPTY |++ ZIP (Z,MAP VAR Y)) ' (VAR z))’

--- a/examples/lambda/barendregt/standardisationScript.sml
+++ b/examples/lambda/barendregt/standardisationScript.sml
@@ -3,7 +3,7 @@ open HolKernel Parse boolLib bossLib BasicProvers;
 open metisLib boolSimps relationTheory listTheory llistTheory pathTheory
      pred_setTheory finite_mapTheory hurdUtils;
 
-open nomsetTheory binderLib
+open nomsetTheory binderLib basic_swapTheory;
 open finite_developmentsTheory
 open labelledTermsTheory
 open termTheory chap2Theory horeductionTheory chap3Theory appFOLDLTheory
@@ -1087,6 +1087,16 @@ val i_reduces_to_LAMl = prove(
   ]);
 
 val _ = augment_srw_ss [rewrites [size_vsubst, size_ISUB]]
+
+Theorem FRESH_lists :
+    !n s : string set.
+       FINITE s ==> ?l'. ALL_DISTINCT l' /\ DISJOINT (LIST_TO_SET l') s /\
+                         (LENGTH l' = n)
+Proof
+    rpt STRIP_TAC
+ >> Q.EXISTS_TAC ‘NEWS n s’
+ >> MATCH_MP_TAC NEWS_def >> art []
+QED
 
 val cant_ireduce_to_lam_atom = prove(
   ``!vs M N. (size N = 1) ==> ~(M i_reduce1 LAMl vs N)``,

--- a/examples/lambda/basics/appFOLDLScript.sml
+++ b/examples/lambda/basics/appFOLDLScript.sml
@@ -202,16 +202,13 @@ QED
 
 Overload "LAMl" = “\vs (t :term). FOLDR LAM t vs”
 
-Theorem LAMl_def :
-  LAMl vs (t : term) = FOLDR LAM t vs
-Proof
-    rw []
-QED
+(* |- !e l1 l2. LAMl (l1 ++ l2) e = LAMl l1 (LAMl l2 e) *)
+Theorem LAMl_APPEND = Q.ISPEC ‘LAM’ FOLDR_APPEND
 
 Theorem LAMl_thm[simp]:
   (LAMl [] M = M) /\
   (LAMl (h::t) M = LAM h (LAMl t M))
-Proof SRW_TAC [][LAMl_def]
+Proof SRW_TAC [][]
 QED
 
 Theorem LAMl_11[simp]:
@@ -259,6 +256,15 @@ Theorem LAMl_SUB :
 Proof
     rpt STRIP_TAC
  >> Induct_on ‘vs’ >> rw []
+QED
+
+(* LAMl_ssub = ssub_LAM + LAMl_SUB *)
+Theorem LAMl_ssub :
+    !vs fm t. DISJOINT (FDOM fm) (set vs) /\
+             (!y. y IN FDOM fm ==> DISJOINT (FV (fm ' y)) (set vs)) ==>
+              fm ' (LAMl vs t) = LAMl vs (fm ' t)
+Proof
+    Induct_on ‘vs’ >> rw []
 QED
 
 Theorem tpm_LAMl:

--- a/examples/lambda/basics/basic_swapScript.sml
+++ b/examples/lambda/basics/basic_swapScript.sml
@@ -171,3 +171,4 @@ Proof
 QED
 
 val _ = export_theory();
+val _ = html_theory "basic_swap";

--- a/examples/lambda/basics/basic_swapScript.sml
+++ b/examples/lambda/basics/basic_swapScript.sml
@@ -123,6 +123,7 @@ val new_exists = store_thm(
                          pred_setTheory.IN_INFINITE_NOT_FINITE] THEN
   SRW_TAC [][INFINITE_STR_UNIV]);
 
+(* |- !s. FINITE s ==> NEW s NOTIN s *)
 val NEW_def =
     new_specification
       ("NEW_def", ["NEW"],
@@ -133,5 +134,40 @@ val NEW_ELIM_RULE = store_thm(
   ``!P X. FINITE X /\ (!v:string. ~(v IN X) ==> P v) ==>
           P (NEW X)``,
   PROVE_TAC [NEW_def]);
+
+(* ‘NEWS n s’ generates n fresh names from the excluded set ‘s’ *)
+Definition NEWS :
+    NEWS      0  s = [] /\
+    NEWS (SUC n) s = NEW s :: NEWS n (NEW s INSERT s)
+End
+
+Theorem NEWS_0[simp] :
+    NEWS 0 s = []
+Proof
+    rw [NEWS]
+QED
+
+(* NOTE: this is the old FRESH_list_def *)
+Theorem NEWS_def :
+    !n s. FINITE s ==>
+          ALL_DISTINCT (NEWS n s) /\ DISJOINT (set (NEWS n s)) s /\
+          LENGTH (NEWS n s) = n
+Proof
+    Induct_on ‘n’ >- rw [NEWS]
+ >> Q.X_GEN_TAC ‘s’ >> DISCH_TAC
+ >> simp [NEWS]
+ >> Q.PAT_X_ASSUM ‘!s. FINITE s ==> P’ (MP_TAC o (Q.SPEC ‘NEW s INSERT s’))
+ >> rw []
+ >> MATCH_MP_TAC NEW_def
+ >> ASM_REWRITE_TAC []
+QED
+
+Theorem NEWS_prefix :
+    !m n s. FINITE s /\ m <= n ==> NEWS m s <<= NEWS n s
+Proof
+    Induct_on ‘m’
+ >> rw [NEWS]
+ >> Cases_on ‘n’ >> rw [NEWS]
+QED
 
 val _ = export_theory();

--- a/examples/lambda/basics/termScript.sml
+++ b/examples/lambda/basics/termScript.sml
@@ -283,29 +283,6 @@ Theorem FRESH_LAM[simp]:
 Proof SRW_TAC [][] THEN METIS_TAC []
 QED
 
-(* NOTE: this theorem doesn't really belong here but moving it to basic_swapTheory
-         seems unnecessary (and NEW_TAC is not available).
- *)
-Theorem FRESH_lists :
-    !n s : string set.
-       FINITE s ==> ?l'. ALL_DISTINCT l' /\ DISJOINT (LIST_TO_SET l') s /\
-                         (LENGTH l' = n)
-Proof
-  Induct THEN SRW_TAC [][] THENL [
-    RES_TAC THEN
-    Q_TAC (NEW_TAC "z") `LIST_TO_SET l' UNION s` THEN
-    Q.EXISTS_TAC `z::l'` THEN
-    FULL_SIMP_TAC (srw_ss()) []
-  ]
-QED
-
-(* ‘FRESH_list’ is a function for generating fresh list of new variables *)
-local
-    val th = SIMP_RULE std_ss [GSYM RIGHT_EXISTS_IMP_THM, SKOLEM_THM] FRESH_lists
-in
-    val FRESH_list_def = new_specification ("FRESH_list_def", ["FRESH_list"], th)
-end
-
 val FV_EMPTY = store_thm(
   "FV_EMPTY",
   ``(FV t = {}) <=> !v. v NOTIN FV t``,
@@ -704,6 +681,12 @@ End
 
 val _ = set_fixity "ISUB" (Infixr 501);
 
+Theorem ISUB_NIL[simp] :
+    t ISUB [] = t
+Proof
+    rw [ISUB_def]
+QED
+
 Definition DOM_DEF :
    (DOM [] = {}) /\
    (DOM ((x,y)::rst) = {y} UNION DOM rst)
@@ -958,6 +941,9 @@ Proof
   Q.EXISTS_TAC `fmFV phi` THEN
   SRW_TAC [][SUB_THM, SUB_VAR, pred_setTheory.EXTENSION] THEN METIS_TAC []
 QED
+
+(* |- !t. DISJOINT (FV t) (FDOM phi) ==> phi ' t = t *)
+Theorem ssub_14b' = ssub_14b |> REWRITE_RULE [GSYM DISJOINT_DEF]
 
 val ssub_value = store_thm(
   "ssub_value",

--- a/src/list/src/rich_listScript.sml
+++ b/src/list/src/rich_listScript.sml
@@ -2743,6 +2743,19 @@ Proof
  >> rw [TAKE_LENGTH_TOO_LONG]
 QED
 
+Theorem IS_PREFIX_FRONT_MONO :
+    !l1 l2. l1 <> [] /\ l2 <> [] /\ l1 <<= l2 ==> FRONT l1 <<= FRONT l2
+Proof
+    rw [IS_PREFIX_EQ_TAKE]
+ >> Cases_on ‘n = 0’ >> fs []
+ >> ‘0 < LENGTH l2’ by rw []
+ >> rw [LENGTH_FRONT, FRONT_TAKE]
+ >> Q.EXISTS_TAC ‘n - 1’ >> rw []
+ >> ONCE_REWRITE_TAC [EQ_SYM_EQ]
+ >> MATCH_MP_TAC TAKE_FRONT
+ >> rw []
+QED
+
 (* ----------------------------------------------------------------------
     longest_prefix
 


### PR DESCRIPTION
Hi,

The single purpose of all code changes in this PR, is to prove the surprisingly hard _Lemma 10.3.6 (ii)_ of [Barendregt 1984, p.247]), part of Chapter 10.3 (The Böhm out technology):
<img width="879" alt="Screenshot 2024-03-08 alle 15 48 22" src="https://github.com/HOL-Theorem-Prover/HOL/assets/163421/4d232f0c-92d8-4ff9-a76e-27e1ce3c3b00">

After repeated experiments and many rounds of statement changes, the current best proved form is the following: (a better form has been replaced here, the asserted `Z` is now unique, `ISUB` has been changed to a single closed substitution, which may well escape from a outer `tpm`)
```
[Boehm_transform_exists_lemma] (boehmTheory)
⊢ ∀X M p.
    FINITE X ∧ p ≠ [] ∧ p ∈ ltree_paths (BTe X M) ∧ subterm X M p ≠ NONE ⇒
    ∃pi.
      Boehm_transform pi ∧ solvable (apply pi M) ∧ is_ready (apply pi M) ∧
      ∃Z v N.
        Z = X ∪ FV M ∧ closed N ∧ subterm Z (apply pi M) p ≠ NONE ∧
        tpm_rel (subterm' Z (apply pi M) p) ([N/v] (subterm' Z M p))
```
where `tpm_rel` is a new (equivalence) relation on lambda terms, based on `tpm`:
```
[tpm_rel_def]
⊢ ∀M N. tpm_rel M N ⇔ ∃pi. tpm pi M = N

[equivalence_tpm_rel]
⊢ equivalence tpm_rel
```

There are a huge number of new intermediate lemmas added to server the proof of the above lemma. In particular, the facility for generating fresh list of variables, now is called `NEWS`, has to be updated, and now is put into `basic_swapTheory`. Its new property (NEWS_prefix) is the key to complete the above lemma.
```
[NEWS]
⊢ (∀s. NEWS 0 s = []) ∧ ∀n s. NEWS (SUC n) s = NEW s::NEWS n (NEW s INSERT s)

[NEWS_prefix]
⊢ ∀m n s. FINITE s ∧ m ≤ n ⇒ NEWS m s ≼ NEWS n s
```

In `rich_listTheory`, I added one more theorem about `IS_PREFIX`: (with my previous added theorem  [IS_PREFIX_EQ_TAKE], the proof is surprisingly straightforward)
```
[IS_PREFIX_FRONT_MONO]  Theorem (rich_listTheory)
⊢ ∀l1 l2. l1 ≠ [] ∧ l2 ≠ [] ∧ l1 ≼ l2 ⇒ FRONT l1 ≼ FRONT l2
```

Chun

[1] Barendregt, H.P.: The lambda calculus, its syntax and semantics.
       College Publications, London (1984).