### PR TITLE
EXTENSIONAL and RESTRICTION ported from HOL-Light

### DIFF
--- a/src/combin/combinScript.sml
+++ b/src/combin/combinScript.sml
@@ -532,6 +532,18 @@ Proof
  >> ASM_REWRITE_TAC []
 QED
 
+(* NOTE: HOL-Light doesn't have this theorem. *)
+Theorem EXTENSIONAL_RESTRICTION :
+    !s (f :'a->'b). EXTENSIONAL s (RESTRICTION s (f :'a -> 'b))
+Proof
+    REWRITE_TAC [EXTENSIONAL_def, RESTRICTION, IN_DEF]
+ >> BETA_TAC
+ >> rpt STRIP_TAC
+ >> reverse COND_CASES_TAC >- REFL_TAC
+ >> POP_ASSUM MP_TAC
+ >> ASM_REWRITE_TAC []
+QED
+
 (*---------------------------------------------------------------------------*)
 
 val _ = adjoin_to_theory

--- a/src/relation/relationScript.sml
+++ b/src/relation/relationScript.sml
@@ -5,13 +5,14 @@
  * are also defined.                                                         *
  *---------------------------------------------------------------------------*)
 
-open HolKernel Parse boolLib QLib tautLib mesonLib metisLib
-     simpLib boolSimps BasicProvers;
+open HolKernel Parse boolLib BasicProvers;
+
+open QLib tautLib mesonLib metisLib simpLib boolSimps combinTheory;
 
 (* mention satTheory to work around dependency-analysis flaw in Holmake;
    satTheory is a dependency of BasicProvers, but without explicit mention
    here, Holmake will not rebuild relationTheory when satTheory changes. *)
-local open combinTheory satTheory in end;
+local open satTheory in end;
 
 val _ = new_theory "relation";
 
@@ -1218,11 +1219,19 @@ val _ = export_rewrites ["transitive_inv_image"]
  * Gordon's HOL development of the primitive recursion theorem.
  *---------------------------------------------------------------------------*)
 
-val RESTRICT_DEF =
-Q.new_definition
-("RESTRICT_DEF",
-   `RESTRICT (f:'a->'b) R (x:'a) = \y:'a. if R y x then f y else ARB`);
+(* NOTE: Now RESTRICT is based on the new combinTheory.RESTRICTION
 
+   :('a -> 'b) -> ('a -> 'a -> bool) -> 'a -> 'a -> 'b
+ *)
+val RESTRICT = new_definition
+  ("RESTRICT", “RESTRICT (f :'a->'b) R (x :'a) = RESTRICTION (\y. R y x) f”);
+
+(* The old definition of RESTRICT now becomes a theorem *)
+Theorem RESTRICT_DEF :
+    !(f :'a->'b) R x. RESTRICT f R x = \y. if R y x then f y else ARB
+Proof
+    SRW_TAC[][RESTRICT, FUN_EQ_THM, RESTRICTION, IN_DEF]
+QED
 
 (*---------------------------------------------------------------------------
  * Obvious, but crucially useful. Unary case. Handling the n-ary case might


### PR DESCRIPTION
Hi,

This PR ports the useful `EXTENSIONAL` and `RESTRICTION` from HOL Light. These concepts are to be used by the porting work (in progress) of HOL-Light's `ringtheory.sml`.

`EXTENSIONAL` asserts "extensional" functions, mapping to a fixed value ARB outside the domain:
```
   [EXTENSIONAL_def]  Definition (combinTheory)      
      ⊢ ∀s f. EXTENSIONAL s f ⇔ ∀x. x ∉ s ⇒ f x = ARB

   [EXTENSIONAL]  Theorem (pred_setTheory)
      ⊢ ∀s. EXTENSIONAL s = {f | ∀x. x ∉ s ⇒ f x = ARB}
```
On the other hand, `RESTRICTION` does restriction of a function to an EXTENSIONAL one on a subset:
```
   [RESTRICTION]  Definition (combinTheory)      
      ⊢ ∀s f x. RESTRICTION s f x = if x ∈ s then f x else ARB
```

These definitions, together with several supporting lemmas, are added in `combinTheory`. Then. in `relationTheory`, the definition of `RESTRICT` for relations, can now be based on the newly added `RESTRICTION` (and the original definition then becomes a theorem):
```
   [RESTRICT]  Definition (relationTheory)      
      ⊢ ∀f R x. RESTRICT f R x = RESTRICTION (λy. R y x) f

   [RESTRICT_DEF]  Theorem      
      ⊢ ∀f R x. RESTRICT f R x = (λy. if R y x then f y else ARB)
```

The main body of supporting theorems are then added in `pred_setTheory`, e.g.:
```
   [EXTENSIONAL_UNIV]  Theorem      
      ⊢ ∀f. EXTENSIONAL 𝕌(:α) f

   [RESTRICTION_EXTENSION]  Theorem      
      ⊢ ∀s f g. RESTRICTION s f = RESTRICTION s g ⇔ ∀x. x ∈ s ⇒ f x = g x
   
   [RESTRICTION_FIXPOINT]  Theorem      
      ⊢ ∀s f. RESTRICTION s f = f ⇔ f ∈ EXTENSIONAL s
   
   [RESTRICTION_IDEMP]  Theorem      
      ⊢ ∀s f. RESTRICTION s (RESTRICTION s f) = RESTRICTION s f
   
   [RESTRICTION_IN_EXTENSIONAL]  Theorem      
      ⊢ ∀s f. RESTRICTION s f ∈ EXTENSIONAL s
```

--Chun