### PR TITLE
TRANS_TAC ported from HOL-Light (with improvements)

### DIFF
--- a/doc/next-release.md
+++ b/doc/next-release.md
@@ -29,6 +29,9 @@ New theories:
 New tools:
 ----------
 
+- `Tactic.TRANS_TAC` (ported from HOL-Light) applies transitivity theorem to goal
+  with chosen intermediate term. See its DOC for more details.
+
 New examples:
 -------------
 

--- a/help/Docfiles/Tactic.TRANS_TAC.doc
+++ b/help/Docfiles/Tactic.TRANS_TAC.doc
@@ -55,9 +55,10 @@ type-instantiation of the theorem, whereas in highly polymorphic theorems the
 use of {MATCH_MP_TAC} may leave the wrong types for the subsequent {EXISTS_TAC}
 step.
 
-If {R1 x y}, etc. is actually overloads of negated terms, e.g., {~(R1' y x)},
-{TRANS_TAC} can still work. This is common for most "less" definitions, which
-is an overload of "not less-and-equal", i.e. {x < y} overloads {~(y <= x)}.
+If {R1 x y}, etc. are actually overloads of negated terms, e.g., {~(R1' y x)},
+{TRANS_TAC} can still work. Such overloads are common for many definitions of
+"less" as an overload of "not less-or-equal", i.e. {x < y} is an overload of
+{~(y <= x)}.
 
 \SEEALSO
 MATCH_MP_TAC, TRANS.

--- a/help/Docfiles/Tactic.TRANS_TAC.doc
+++ b/help/Docfiles/Tactic.TRANS_TAC.doc
@@ -1,0 +1,65 @@
+\DOC TRANS_TAC
+
+\TYPE {TRANS_TAC : thm -> term -> tactic}
+
+\SYNOPSIS
+Applies transitivity theorem to goal with chosen intermediate term.
+
+\KEYWORDS
+tactic, modus ponens, implication.
+
+\DESCRIBE
+When applied to a `transitivity' theorem, i.e. one of the form
+{
+   |- !xs. R1 x y /\ R2 y z ==> R3 x z
+}
+and a term {t}, {TRANS_TAC} produces a tactic that reduces a goal
+with conclusion of the form {R3 s u} to one with conclusion {R1 s t /\ R2 t u}.
+{
+       A ?- R3 s u
+  ======================== TRANS_TAC (|- !xs. R1 x y /\ R2 y z ==> R3 x z) `t`
+   A ?- R1 s t /\ R2 t u
+}
+
+\EXAMPLE
+Consider the simple inequality goal:
+{
+  > g `n < (m + 2) * (n + 1)`;
+}
+We can use the following transitivity theorem
+{
+  > LESS_EQ_LESS_TRANS;
+  val it = |- !m n p. m <= n /\ n < p ==> m < p: thm
+}
+{
+  # e (TRANS_TAC LESS_EQ_LESS_TRANS ``1 * (n + 1)``);
+  OK..
+  1 subgoal:
+  val it =
+   
+   n <= 1 * (n + 1) /\ 1 * (n + 1) < (m + 2) * (n + 1)
+   
+   : proof
+}
+
+\FAILURE
+Fails unless the input theorem is of the expected form (some of the
+relations {R1}, {R2} and {R3} may be, and often are, the same) and the
+conclusion matches the goal, in the usual sense of higher-order matching.
+
+\COMMENTS
+The effect of {TRANS_TAC th t} can often be replicated by the more primitive
+tactic sequence {MATCH_MP_TAC th THEN EXISTS_TAC t}. The use of {TRANS_TAC} is
+not only less verbose, but it is also more general in that it ensures correct
+type-instantiation of the theorem, whereas in highly polymorphic theorems the
+use of {MATCH_MP_TAC} may leave the wrong types for the subsequent {EXISTS_TAC}
+step.
+
+If {R1 x y}, etc. is actually overloads of negated terms, e.g., {~(R1' y x)},
+{TRANS_TAC} can still work. This is common for most "less" definitions, which
+is an overload of "not less-and-equal", i.e. {x < y} overloads {~(y <= x)}.
+
+\SEEALSO
+MATCH_MP_TAC, TRANS.
+
+\ENDDOC


### PR DESCRIPTION
Hi,

I found HOL-Light's `TRANS_TAC` very useful when applying "transitivity" theorems to proof goals.

Suppose the current goal is
```
R3 s u
```
and there's a theorem `th = |- !x y z. R1 x y /\ R2 y z ==> R3 x z`, normally one can do `MATCH_MP_TAC th` to arrive at
```
?y. R1 s y /\ R2 y u
```
and then `EXISTS_TAC t`, where `t` is a suitable intermediate term. But if the `y` in the transitivity theorem contains a new type variable, then after `MATCH_MP_TAC th` the type of `?y` may not match the type of `t` (and thus `EXISTS_TAC` will fail). Many transitivity theorems in `cardinalTheory` have such characters, e.g. `CARD_LTE_TRANS`:
```
|- !(s :'a -> bool) (t :'b -> bool) (u :'c -> bool). s <</= t /\ t <<= u ==> s <</= u
```
With HOL-Light's `TRANS_TAC`, one can replace `MATCH_MP_TAC th >> EXISTS_TAC t` with a single tactic `TRANS_TAC th t`, and it will do automatic type matching between the type variables of `th` and the given term `t` (and the current goal).

Furthermore, when porting HOL-Light's proofs using `TRANS_TAC`, I found that some operators of HOL-Light are actually overloads in HOL4, thus even a theorem looks like a transitivity theorem, the underlying `R1 x y` may actually be an overload to another negated term `~(R1' y x)`. For example, `cardlt` in HOL4 is an overload of `cardleq` (in HOL-Light it's an original definition):
```
val _ = overload_on ("cardlt", ``\s1 s2. ~(cardleq s2 s1)``); (* cardlt *)
```
Inside the implementation of `TRANS_TAC`, the key of type matching is to retrieve terms `x`, `y` and `z` from the input transitivity theorem, also the terms from the current goal. I have modified the implementation of `TRANS_TAC` in such a way that, even the `R1` of `R1 x y` is actually an overloaded negated term, `x` and `y` can still be retrieved correctly. This result in porting some HOL-Light's proofs in a straightforward way.

--Chun