### PR TITLE
add mk_bool

### DIFF
--- a/src/1/boolSyntax.sig
+++ b/src/1/boolSyntax.sig
@@ -175,6 +175,7 @@ sig
   (* Lifter from ML bool to HOL bool *)
 
   val lift_bool : hol_type -> bool -> term
+  val mk_bool : bool -> term
 
   (* Algebraic properties *)
 

--- a/src/1/boolSyntax.sml
+++ b/src/1/boolSyntax.sml
@@ -385,6 +385,8 @@ fun new_infix_type (x as {Name, Arity, ParseName, Prec, Assoc}) =
 fun lift_bool _ true  = T
   | lift_bool _ false = F
 
+fun mk_bool b = if b then T else F
+
 (*--------------------------------------------------------------------------*)
 (*  Some simple algebraic properties expressed at the term level.           *)
 (*--------------------------------------------------------------------------*)


### PR DESCRIPTION
This PR adds the widely used and often created `mk_bool` function to `boolSyntax`.

See https://discord.com/channels/1171421764379742258/1171423803553878117/1238370369824489474 for a discussion