### PR TITLE
HOL-Light's INTEGER_TAC

### DIFF
--- a/Manual/Description/libraries.stex
+++ b/Manual/Description/libraries.stex
@@ -2081,6 +2081,14 @@ generally perform better than Cooper's algorithm.  There are problems
 for which this is not true however, so it is useful to have both
 procedures available.
 
+In addition, the \ml{intLib.INTEGER_RULE} (and its tactic version \ml{intLib.INTEGER_TAC})
+ported from HOL-Light can solve some simple equations about divisibility of integers,
+e.g.~\holtxt{d int_divides m ==> d int_divides (m * n)}.
+As part of the procedure, multivariate polynomials of integer are expanded to their
+``normal forms'' (with respect to certain ordering), and thus equations between equivalent
+such polynomials can be decided,
+e.g.~\holtxt{w * y + x * z - (w * z + x * y) = (w - x) * (y - z)}.
+
 \paragraph{realLib}
 
 The \ml{realLib} library provides a foundational development

--- a/Manual/Description/libraries.stex
+++ b/Manual/Description/libraries.stex
@@ -1114,6 +1114,7 @@ The following session illustrates antiquotation.
 \setcounter{sessioncount}{0}
 \begin{session}
 \begin{alltt}
+>>_ load "intLib";
 >>__ remove_ovl_mapping "+" {Name = "int_add", Thy = "integer"};
 >> val y = “x+1”;
 
@@ -2183,7 +2184,6 @@ The symbols for the standard arithmetic operations (addition, subtraction and mu
 In the above, natural number addition is chosen in preference to word addition.  Conversely, words are preferred over the integers below:
 \begin{session}
 \begin{alltt}
->>_ load "intLib";
 >>__ temp_overload_on("+", ``int_add``);
 
 >> type_of ``a + b``;

--- a/doc/next-release.md
+++ b/doc/next-release.md
@@ -30,15 +30,21 @@ New theories:
    from `examples/algebra/lib`, etc. They contain some more advanced results from
    number theory (in particular properties of prime numbers) and combinatorics.
  
-- `monoid` (and `real_algebra`): These are combined theories of materials ever in
-  `examples/algebra/monoid`. A monoid as an algebraic structure: with a carrier set,
-   a binary operation and an identity element.
+- `monoid`, `group`, `ring` and `real_algebra`: These are combined theories
+   of materials ever in `examples/algebra`. A monoid as an algebraic structure:
+   with a carrier set, a binary operation and an identity element. A group is an
+   algebraic structure: a monoid with all its elements invertible. A ring takes
+   into account the interplay between its additive group and multiplicative monoid.
 
 New tools:
 ----------
 
 - `Tactic.TRANS_TAC` (ported from HOL-Light) applies transitivity theorem to goal
   with chosen intermediate term. See its DOC for more details.
+
+- `intLib.INTEGER_TAC` and `intLib.INTEGER_RULE` (ported from HOL-Light): simple
+  decision procedures for equations of multivariate polynomials of integers, and
+  simple equations about divisibility of integers.
 
 New examples:
 -------------

--- a/doc/next-release.md
+++ b/doc/next-release.md
@@ -31,7 +31,7 @@ New theories:
    number theory (in particular properties of prime numbers) and combinatorics.
  
 - `monoid`, `group`, `ring` and `real_algebra`: These are combined theories
-   of materials ever in `examples/algebra`. A monoid as an algebraic structure:
+   of materials ever in `examples/algebra`. A monoid is an algebraic structure:
    with a carrier set, a binary operation and an identity element. A group is an
    algebraic structure: a monoid with all its elements invertible. A ring takes
    into account the interplay between its additive group and multiplicative monoid.

--- a/src/integer/intLib.sig
+++ b/src/integer/intLib.sig
@@ -17,7 +17,7 @@ sig
   val COOPER_PROVE   : conv
   val COOPER_TAC     : tactic
 
-  val INTEGER_TAC         : tactic
-  val INTEGER_RULE        : term -> thm
+  val INTEGER_TAC    : tactic
+  val INTEGER_RULE   : term -> thm
 
 end

--- a/src/integer/intLib.sig
+++ b/src/integer/intLib.sig
@@ -17,5 +17,7 @@ sig
   val COOPER_PROVE   : conv
   val COOPER_TAC     : tactic
 
+  val INTEGER_TAC         : tactic
+  val INTEGER_RULE        : term -> thm
 
 end

--- a/src/integer/intLib.sml
+++ b/src/integer/intLib.sml
@@ -148,7 +148,7 @@ local
       let val i' = map (fn s => snd s |-> fst s) i in
         rhs(concl(INT_POLY_CONV (subst i' p)))
       end;
-  fun subtract2 tms1 tms2 = 
+  fun subtract2 tms1 tms2 =
       HOLset.listItems(HOLset.difference(HOLset.addList(empty_tmset,tms1),
                                          HOLset.addList(empty_tmset,tms2)));
   fun solve_idealism evs ps eqs =

--- a/src/integer/intLib.sml
+++ b/src/integer/intLib.sml
@@ -1,9 +1,22 @@
 structure intLib :> intLib =
 struct
 
-  open HolKernel Abbrev intSimps Cooper
+open HolKernel boolLib bossLib liteLib;
 
-  val operators = [("+", intSyntax.plus_tm),
+open integerTheory intSimps Omega Cooper intSyntax intReduce Canon hurdUtils
+     mesonLib tautLib integerRingLib;
+
+structure Parse = struct
+  open Parse
+  val (Type,Term) = parse_from_grammars integer_grammars
+end
+
+open Parse;
+
+val ERR = mk_HOL_ERR "intLib";
+fun failwith function = raise (ERR function "");
+
+val operators = [("+", intSyntax.plus_tm),
                    ("-", intSyntax.minus_tm),
                    ("~", intSyntax.negate_tm),
                    ("numeric_negate", intSyntax.negate_tm),
@@ -38,6 +51,170 @@ end
 val ARITH_CONV = Omega.OMEGA_CONV
 val ARITH_TAC = Omega.OMEGA_TAC
 val ARITH_PROVE = Omega.OMEGA_PROVE
+
+(* ------------------------------------------------------------------------- *)
+(* A tactic for simple divisibility/congruence/coprimality goals.            *)
+(* ------------------------------------------------------------------------- *)
+
+local
+  val INT_POLYEQ_CONV =
+      GEN_REWRITE_CONV I empty_rewrites[GSYM INT_SUB_0] THENC
+      LAND_CONV INT_POLY_CONV;
+  val INT_ARITH = OMEGA_PROVE;
+  val pth = INT_ARITH “!a x. a = &0 <=> x = x + a :int”;
+  fun is_defined v t =
+    let val mons = HOLset.addList (empty_tmset,striplist(dest_binop "int_add") t)
+    in
+        HOLset.member(mons,v) andalso
+        forall (fn m => v ~~ m orelse not(free_in v m)) (HOLset.listItems mons)
+    end;
+  fun ISOLATE_VARIABLE vars tm =
+    let val th = INT_POLYEQ_CONV tm
+        and th' = (SYM_CONV THENC INT_POLYEQ_CONV) tm;
+        val (v,th1) =
+            (case (List.find (fn v => is_defined v (lhand(rand(concl th)))) vars) of
+               SOME v => (v,th')
+             | NONE   =>
+               case (List.find (fn v => is_defined v (lhand(rand(concl th')))) vars) of
+                 SOME v => (v,th)
+               | NONE   => failwith "ISOLATE_VARIABLE failed");
+        val th2 = TRANS th1 (SPECL [lhs(rand(concl th1)), v] pth)
+    in
+        CONV_RULE(RAND_CONV(RAND_CONV INT_POLY_CONV)) th2
+    end;
+  fun subtract' tms tm =
+      List.filter (fn t => not(t ~~ tm)) tms;
+  fun UNWIND_POLYS_CONV tm = let
+    val (vars,bod) = strip_exists tm;
+    val cjs = conjuncts bod;
+    val th1 = tryfind (ISOLATE_VARIABLE vars) cjs;
+    val eq = lhand(concl th1);
+    val bod' = list_mk_conj(eq::(subtract' cjs eq)); (* eq is moved in front of cjs *)
+    val th2 = CONJ_ACI_RULE(mk_eq(bod,bod'));
+    val th3 = TRANS th2 (MK_CONJ th1 (REFL(rand(rand(concl th2)))));
+    val v = lhs(lhand(rand(concl th3)));
+    val vars' = (subtract' vars v) @ [v]; (* v is moved to the end of vars *)
+    fun MK_EXISTS t th = LIST_MK_EXISTS [t] th;
+    val th4 = CONV_RULE(RAND_CONV(REWR_CONV UNWIND_THM2)) (MK_EXISTS v th3);
+    fun IMP_RULE v v' =
+        DISCH_ALL(itlist SIMPLE_CHOOSE v (itlist SIMPLE_EXISTS v' (ASSUME bod)));
+    val th5 = IMP_ANTISYM_RULE (IMP_RULE vars vars') (IMP_RULE vars' vars)
+  in
+    TRANS th5 (itlist MK_EXISTS (subtract' vars v) th4)
+  end;
+  val isolate_monomials = let
+    val mul_tm = mult_tm and add_tm = plus_tm
+    and neg_tm = negate_tm;
+    val dest_mul = liteLib.dest_binop mult_tm
+    and dest_add = liteLib.dest_binop add_tm
+    and mk_mul = curry (mk_binop mult_tm)
+    and mk_add = curry (mk_binop add_tm);
+    fun scrub_var v m =
+      let val ps = striplist dest_mul m;
+          val ps' = subtract' ps v
+      in
+         if null ps' then one_tm else end_itlist mk_mul ps'
+      end;
+    fun find_multipliers v mons =
+      let val mons1 = List.filter (fn m => free_in v m) mons;
+          val mons2 = map (scrub_var v) mons1
+      in
+         if null mons2 then zero_tm else end_itlist mk_add mons2
+      end;
+    fun disjoint tms1 tms2 =
+      HOLset.isEmpty(HOLset.intersection(HOLset.addList(empty_tmset,tms1),
+                                         HOLset.addList(empty_tmset,tms2)));
+  in
+    fn vars => fn tm =>
+      let val (cmons,vmons) =
+              partition (fn m => disjoint (free_vars m) vars)
+                        (striplist dest_add tm);
+          val cofactors = map (fn v => find_multipliers v vmons) vars
+          and cnc = if null cmons then zero_tm
+                    else mk_comb(neg_tm,end_itlist mk_add cmons)
+      in
+        (cofactors,cnc)
+      end
+  end;
+  fun isolate_variables evs ps eq =
+    let val vars = List.filter (fn v => free_in v eq) evs;
+        val (qs,p) = isolate_monomials vars eq;
+        val rs = List.filter (fn t => type_of t = int_ty) (qs @ ps);
+        val rs = int_ideal_cofactors rs p;
+    in
+      (eq,zip (fst(chop_list(length qs) rs)) vars)
+    end;
+  fun subst_in_poly i p =
+      let val i' = map (fn s => snd s |-> fst s) i in
+        rhs(concl(INT_POLY_CONV (subst i' p)))
+      end;
+  fun subtract2 tms1 tms2 = 
+      HOLset.listItems(HOLset.difference(HOLset.addList(empty_tmset,tms1),
+                                         HOLset.addList(empty_tmset,tms2)));
+  fun solve_idealism evs ps eqs =
+    if null evs then [] else
+    let val (eq,cfs) = tryfind (isolate_variables evs ps) eqs;
+        val evs' = subtract2 evs (map snd cfs)
+        and eqs' = map (subst_in_poly cfs) (subtract' eqs eq)
+    in
+        cfs @ solve_idealism evs' ps eqs'
+    end;
+  fun GENVAR_EXISTS_CONV tm =
+    if not(is_exists tm) then REFL tm else
+    let val (ev,bod) = dest_exists tm;
+        val gv = genvar(type_of ev)
+    in
+       (GEN_ALPHA_CONV gv THENC BINDER_CONV GENVAR_EXISTS_CONV) tm
+    end;
+  fun check p x = if p x then x else failwith "check in EXISTS_POLY_TAC";
+  fun rev_assocd item = (* modified from Lib.rev_assoc *)
+   let
+      fun assc ((ob, key) :: rst) d = if item ~~ key then ob else assc rst d
+        | assc [] d = d
+   in
+      assc
+   end;
+  fun EXISTS_POLY_TAC (gl as (asl,w) :goal) =
+    let val (evs,bod) = strip_exists w;
+        (* NOTE: In HOL4, the type of goal is (term list * term), while in
+                 HOL-Light it's (string * thm) list * term *)
+        val ps = mapfilter (check (fn t => type_of t = int_ty) o
+                           lhs (* o concl o snd *)) asl;
+        val cfs = solve_idealism evs ps (map lhs (conjuncts bod))
+    in
+       (MAP_EVERY EXISTS_TAC(map (fn v => rev_assocd v cfs zero_tm) evs) THEN
+        REPEAT(POP_ASSUM MP_TAC) THEN
+     (* NOTE: EQT_INTRO must be added in HOL4 to make INT_RING conv-like *)
+        CONV_TAC (EQT_INTRO o INT_RING)) gl
+    end;
+  val SCRUB_NEQ_TAC = MATCH_MP_TAC o MATCH_MP (MESON[]
+     “~(x = y) ==> x = y \/ p ==> p”);
+  (* |- !P Q. P /\ (?x. Q x) <=> ?x. P /\ Q x *)
+  val RIGHT_AND_EXISTS_THM = GSYM RIGHT_EXISTS_AND_THM;
+  (* |- !P Q. (?x. P x) /\ Q <=> ?x. P x /\ Q *)
+  val LEFT_AND_EXISTS_THM = GSYM LEFT_EXISTS_AND_THM;
+in
+val INTEGER_TAC =
+  (* NOTE: int_coprime and int_congruent are not available in HOL4's
+           integerTheory, thus are not supported, for now. *)
+  REWRITE_TAC[(* int_coprime, int_congruent *) int_divides] THEN
+  REPEAT(STRIP_TAC ORELSE EQ_TAC) THEN
+  REWRITE_TAC[LEFT_AND_EXISTS_THM, RIGHT_AND_EXISTS_THM,
+              LEFT_OR_EXISTS_THM, RIGHT_OR_EXISTS_THM] THEN
+  CONV_TAC(REPEATC UNWIND_POLYS_CONV) THEN
+  REPEAT(FIRST_X_ASSUM SCRUB_NEQ_TAC) THEN
+  REWRITE_TAC[LEFT_AND_EXISTS_THM, RIGHT_AND_EXISTS_THM,
+              LEFT_OR_EXISTS_THM, RIGHT_OR_EXISTS_THM] THEN
+  REPEAT(FIRST_X_ASSUM(MP_TAC o SYM)) THEN
+  CONV_TAC(ONCE_DEPTH_CONV INT_POLYEQ_CONV) THEN
+  REWRITE_TAC[GSYM INT_ENTIRE,
+              TAUT `a \/ (b /\ c) <=> (a \/ b) /\ (a \/ c)`] THEN
+  POP_ASSUM_LIST(K ALL_TAC) THEN
+  REPEAT DISCH_TAC THEN CONV_TAC GENVAR_EXISTS_CONV THEN
+  CONV_TAC(ONCE_DEPTH_CONV INT_POLYEQ_CONV) THEN EXISTS_POLY_TAC;
+
+fun INTEGER_RULE tm = prove(tm,INTEGER_TAC);
+end; (* local *)
 
 val _ = if !Globals.interactive then
           Feedback.HOL_MESG ("intLib loaded.  Use intLib.deprecate_int()"^

--- a/src/integer/intReduce.sig
+++ b/src/integer/intReduce.sig
@@ -11,4 +11,15 @@ sig
   val INT_REDUCE_ss : simpLib.ssfrag
 
   val collect_additive_consts : conv
+
+  (* HOL-Light compatible conversions for int arith (int.ml) *)
+  val INT_LE_CONV  : conv
+  val INT_LT_CONV  : conv
+  val INT_GE_CONV  : conv
+  val INT_GT_CONV  : conv
+  val INT_EQ_CONV  : conv
+  val INT_ADD_CONV : conv
+  val INT_MUL_CONV : conv
+  val INT_POW_CONV : conv
+
 end

--- a/src/integer/intReduce.sml
+++ b/src/integer/intReduce.sml
@@ -1,9 +1,19 @@
 structure intReduce :> intReduce =
 struct
 
-open HolKernel boolLib integerTheory intSyntax simpLib
+open HolKernel boolLib bossLib;
 
-val ERR = mk_HOL_ERR "intSimps";
+open integerTheory intSyntax simpLib Arithconv numeralTheory tautLib;
+
+structure Parse = struct
+  open Parse arithmeticTheory
+  val (Type,Term) = parse_from_grammars integer_grammars
+end
+
+open Parse;
+
+val ERR = mk_HOL_ERR "intReduce";
+fun failwith function = raise (ERR function "");
 
 (*---------------------------------------------------------------------------*)
 (* Integer-specific compset                                                  *)
@@ -118,4 +128,241 @@ in
     end
 end
 
-end
+(* ------------------------------------------------------------------------- *)
+(* Arithmetic operations on integers. Essentially a clone of stuff for reals *)
+(* in the file "calc_int.ml" (RealArith), except for div and rem, which are  *)
+(* more like N.       (Ported from HOL-Light to HOL4 by Chun Tian, May 2024) *)
+(* ------------------------------------------------------------------------- *)
+
+local
+  val tth =
+    TAUT `(F /\ F <=> F) /\ (F /\ T <=> F) /\
+          (T /\ F <=> F) /\ (T /\ T <=> T)`;
+  val nth = TAUT `(~T <=> F) /\ (~F <=> T)`;
+  val NUM_EQ_CONV = Arithconv.NEQ_CONV;
+  val NUM2_EQ_CONV = BINOP_CONV NUM_EQ_CONV THENC
+                     GEN_REWRITE_CONV I empty_rewrites[tth];
+  val NUM2_NE_CONV = RAND_CONV NUM2_EQ_CONV THENC
+                     GEN_REWRITE_CONV I empty_rewrites[nth];
+  val NUM_LE_CONV = Arithconv.LE_CONV;
+  val INT_LE_NEG2 = INT_LE_NEG;
+  val [pth_le1, pth_le2a, pth_le2b, pth_le3] = (CONJUNCTS o prove)
+   (“(-(&m) <= &n <=> T) /\
+     (&m <= &n <=> m <= n) /\
+     (-(&m) <= -(&n) <=> n <= m) /\
+     (&m <= -(&n) <=> (m = 0) /\ (n = 0))”,
+    REWRITE_TAC[INT_LE_NEG2] THEN
+    REWRITE_TAC[INT_LE_LNEG, INT_LE_RNEG] THEN
+    REWRITE_TAC[INT_OF_NUM_ADD, INT_OF_NUM_LE, LE_0] THEN
+    REWRITE_TAC[LE, ADD_EQ_0]);
+  val INT_LE_CONV = FIRST_CONV
+   [GEN_REWRITE_CONV I empty_rewrites[pth_le1],
+    GEN_REWRITE_CONV I empty_rewrites[pth_le2a, pth_le2b] THENC NUM_LE_CONV,
+    GEN_REWRITE_CONV I empty_rewrites[pth_le3] THENC NUM2_EQ_CONV];
+  val [pth_lt1, pth_lt2a, pth_lt2b, pth_lt3] = (CONJUNCTS o prove)
+   (“(&m < -(&n) <=> F) /\
+     (&m < &n <=> m < n) /\
+     (-(&m) < -(&n) <=> n < m) /\
+     (-(&m) < &n <=> ~((m = 0) /\ (n = 0)))”,
+    REWRITE_TAC[pth_le1, pth_le2a, pth_le2b, pth_le3,
+                GSYM NOT_LE, INT_LT2] THEN
+    TAUT_TAC);
+  val NUM_LT_CONV = Arithconv.LT_CONV;
+  val INT_LT_CONV = FIRST_CONV
+   [GEN_REWRITE_CONV I empty_rewrites[pth_lt1],
+    GEN_REWRITE_CONV I empty_rewrites[pth_lt2a, pth_lt2b] THENC NUM_LT_CONV,
+    GEN_REWRITE_CONV I empty_rewrites[pth_lt3] THENC NUM2_NE_CONV];
+  val [pth_ge1, pth_ge2a, pth_ge2b, pth_ge3] = (CONJUNCTS o prove)
+   (“(&m >= -(&n) <=> T) /\
+     (&m >= &n <=> n <= m) /\
+     (-(&m) >= -(&n) <=> m <= n) /\
+     (-(&m) >= &n <=> (m = 0) /\ (n = 0))”,
+    REWRITE_TAC[pth_le1, pth_le2a, pth_le2b, pth_le3, INT_GE] THEN
+    TAUT_TAC);
+  val NUM_LE_CONV = Arithconv.LE_CONV;
+  val INT_GE_CONV = FIRST_CONV
+   [GEN_REWRITE_CONV I empty_rewrites[pth_ge1],
+    GEN_REWRITE_CONV I empty_rewrites[pth_ge2a, pth_ge2b] THENC NUM_LE_CONV,
+    GEN_REWRITE_CONV I empty_rewrites[pth_ge3] THENC NUM2_EQ_CONV];
+  val [pth_gt1, pth_gt2a, pth_gt2b, pth_gt3] = (CONJUNCTS o prove)
+   (“(-(&m) > &n <=> F) /\
+     (&m > &n <=> n < m) /\
+     (-(&m) > -(&n) <=> m < n) /\
+     (&m > -(&n) <=> ~((m = 0) /\ (n = 0)))”,
+    REWRITE_TAC[pth_lt1, pth_lt2a, pth_lt2b, pth_lt3, INT_GT] THEN
+    TAUT_TAC);
+  val NUM_LT_CONV = Arithconv.LT_CONV;
+  val INT_GT_CONV = FIRST_CONV
+   [GEN_REWRITE_CONV I empty_rewrites[pth_gt1],
+    GEN_REWRITE_CONV I empty_rewrites[pth_gt2a, pth_gt2b] THENC NUM_LT_CONV,
+    GEN_REWRITE_CONV I empty_rewrites[pth_gt3] THENC NUM2_NE_CONV];
+  val [pth_eq1a, pth_eq1b, pth_eq2a, pth_eq2b] = (CONJUNCTS o prove)
+   (“((&m = &n) <=> (m = n)) /\
+     ((-(&m) = -(&n)) <=> (m = n)) /\
+     ((-(&m) = &n) <=> (m = 0) /\ (n = 0)) /\
+     ((&m = -(&n)) <=> (m = 0) /\ (n = 0))”,
+    REWRITE_TAC[GSYM INT_LE_ANTISYM, GSYM LE_ANTISYM] THEN
+    REWRITE_TAC[pth_le1, pth_le2a, pth_le2b, pth_le3, LE, LE_0] THEN
+    TAUT_TAC);
+  val INT_EQ_CONV = FIRST_CONV
+   [GEN_REWRITE_CONV I empty_rewrites[pth_eq1a, pth_eq1b] THENC NUM_EQ_CONV,
+    GEN_REWRITE_CONV I empty_rewrites[pth_eq2a, pth_eq2b] THENC NUM2_EQ_CONV]
+in
+val (INT_LE_CONV,INT_LT_CONV,INT_GE_CONV,INT_GT_CONV,INT_EQ_CONV) =
+    (INT_LE_CONV,INT_LT_CONV,
+     INT_GE_CONV,INT_GT_CONV,INT_EQ_CONV);
+end;
+
+(*-----------------------------------------------------------------------*)
+(* INT_ADD_CONV "[x] + [y]" = |- [x] + [y] = [x+y]                       *)
+(*-----------------------------------------------------------------------*)
+
+(* NOTE: The following conversions are ported from HOL-Light's "int.ml". *)
+local
+  open Arbnum;
+  val NUM_ADD_CONV = ADD_CONV;
+  val neg_tm = negate_tm
+  and amp_tm = int_injection
+  and add_tm = plus_tm;
+  val dest = dest_binop plus_tm (ERR "INT_ADD_CONV" "");
+  val dest_numeral = numSyntax.dest_numeral
+  and mk_numeral = numSyntax.mk_numeral;
+  val m_tm = “m:num” and n_tm = “n:num”;
+  val pth0 = prove
+   (“(-(&m) + &m = &0) /\
+     (&m + -(&m) = &0)”,
+    REWRITE_TAC[INT_ADD_LINV, INT_ADD_RINV]);
+  val [pth1, pth2, pth3, pth4, pth5, pth6] = (CONJUNCTS o prove)
+   (“(-(&m) + -(&n) = -(&(m + n))) /\
+     (-(&m) + &(m + n) = &n) /\
+     (-(&(m + n)) + &m = -(&n)) /\
+     (&(m + n) + -(&m) = &n) /\
+     (&m + -(&(m + n)) = -(&n)) /\
+     (&m + &n = &(m + n))”,
+    REWRITE_TAC[GSYM INT_OF_NUM_ADD, INT_NEG_ADD] THEN
+    REWRITE_TAC[INT_ADD_ASSOC, INT_ADD_LINV, INT_ADD_LID] THEN
+    REWRITE_TAC[INT_ADD_RINV, INT_ADD_LID] THEN
+    ONCE_REWRITE_TAC[INT_ADD_SYM] THEN
+    REWRITE_TAC[INT_ADD_ASSOC, INT_ADD_LINV, INT_ADD_LID] THEN
+    REWRITE_TAC[INT_ADD_RINV, INT_ADD_LID]);
+in
+val INT_ADD_CONV =
+  GEN_REWRITE_CONV I empty_rewrites[pth0] ORELSEC
+  (fn tm =>
+    let val (l,r) = dest tm in
+        if rator l ~~ neg_tm then
+          if rator r ~~ neg_tm then
+            let val th1 = INST [m_tm |-> rand(rand l), n_tm |-> rand(rand r)] pth1;
+                val tm1 = rand(rand(rand(concl th1)));
+                val th2 = AP_TERM neg_tm (AP_TERM amp_tm (NUM_ADD_CONV tm1))
+            in
+              TRANS th1 th2
+            end
+          else (* l: neg, r: pos *)
+            let val m = rand(rand l) and n = rand r;
+                val m' = dest_numeral m and n' = dest_numeral n in
+            if m' <= n' then
+              let val p = mk_numeral (n' - m');
+                  val th1 = INST [m_tm |-> m, n_tm |-> p] pth2;
+                  val th2 = NUM_ADD_CONV (rand(rand(lhand(concl th1))));
+                  val th3 = AP_TERM (rator tm) (AP_TERM amp_tm (SYM th2))
+              in
+                TRANS th3 th1
+              end
+            else
+              let val p = mk_numeral (m' - n');
+                  val th1 = INST [m_tm |-> n, n_tm |-> p] pth3;
+                  val th2 = NUM_ADD_CONV (rand(rand(lhand(lhand(concl th1)))));
+                  val th3 = AP_TERM neg_tm (AP_TERM amp_tm (SYM th2));
+                  val th4 = AP_THM (AP_TERM add_tm th3) (rand tm)
+              in
+                TRANS th4 th1
+              end
+            end
+        else (* l: pos *)
+          if rator r ~~ neg_tm then
+            let val m = rand l and n = rand(rand r);
+                val m' = dest_numeral m and n' = dest_numeral n in
+            if n' <= m' then
+              let val p = mk_numeral (m' - n');
+                  val th1 = INST [m_tm |-> n, n_tm |-> p] pth4;
+                  val th2 = NUM_ADD_CONV (rand(lhand(lhand(concl th1))));
+                  val th3 = AP_TERM add_tm (AP_TERM amp_tm (SYM th2));
+                  val th4 = AP_THM th3 (rand tm)
+              in
+                TRANS th4 th1
+              end
+            else
+              let val p = mk_numeral (n' - m');
+                  val th1 = INST [m_tm |-> m, n_tm |-> p] pth5;
+                  val th2 = NUM_ADD_CONV (rand(rand(rand(lhand(concl th1)))));
+                  val th3 = AP_TERM neg_tm (AP_TERM amp_tm (SYM th2));
+                  val th4 = AP_TERM (rator tm) th3
+              in
+                TRANS th4 th1
+              end
+            end
+          else
+            let val th1 = INST [m_tm |-> rand l, n_tm |-> rand r] pth6;
+                val tm1 = rand(rand(concl th1));
+                val th2 = AP_TERM amp_tm (NUM_ADD_CONV tm1)
+            in
+              TRANS th1 th2
+            end
+    end
+    handle HOL_ERR _ => failwith "INT_ADD_CONV")
+end (* local *)
+
+(*-----------------------------------------------------------------------*)
+(* INT_MUL_CONV "[x] * [y]" = |- [x] * [y] = [x * y]                     *)
+(*-----------------------------------------------------------------------*)
+
+local
+  val pth0 = prove
+     (“(&0 * &x = &0) /\
+       (&0 * --(&x) = &0) /\
+       (&x * &0 = &0) /\
+       (-(&x) * &0 = &0)”,
+      REWRITE_TAC[INT_MUL_LZERO, INT_MUL_RZERO]);
+  val (pth1,pth2) = (CONJ_PAIR o prove)
+     (“((&m * &n = &(m * n)) /\
+        (-(&m) * -(&n) = &(m * n))) /\
+       ((-(&m) * &n = -(&(m * n))) /\
+        (&m * -(&n) = -(&(m * n))))”,
+      REWRITE_TAC[INT_MUL_LNEG, INT_MUL_RNEG, INT_NEG_NEG] THEN
+      REWRITE_TAC[INT_OF_NUM_MUL]);
+  val NUM_MULT_CONV = MUL_CONV;
+in
+val INT_MUL_CONV =
+    FIRST_CONV
+     [GEN_REWRITE_CONV I empty_rewrites[pth0],
+      GEN_REWRITE_CONV I empty_rewrites[pth1] THENC RAND_CONV NUM_MULT_CONV,
+      GEN_REWRITE_CONV I empty_rewrites[pth2] THENC RAND_CONV(RAND_CONV NUM_MULT_CONV)];
+end;
+
+(*-----------------------------------------------------------------------*)
+(* INT_POW_CONV "[x] EXP [y]" = |- [x] EXP [y] = [x ** y]                *)
+(*-----------------------------------------------------------------------*)
+
+local
+  val (pth1,pth2) = (CONJ_PAIR o prove)
+     (“(&x ** n = &(x ** n)) /\
+       ((-(&x)) ** n = if EVEN n then &(x ** n) else -(&(x ** n)))”,
+    REWRITE_TAC[INT_OF_NUM_POW, INT_POW_NEG]);
+  val tth = prove
+   (“((if T then x:int else y) = x) /\ ((if F then x:int else y) = y)”,
+    REWRITE_TAC[]);
+  val neg_tm = negate_tm;
+  val NUM_EXP_CONV = EXP_CONV
+  and NUM_EVEN_CONV = EVEN_CONV
+in
+val INT_POW_CONV =
+  (GEN_REWRITE_CONV I empty_rewrites[pth1] THENC RAND_CONV NUM_EXP_CONV) ORELSEC
+  (GEN_REWRITE_CONV I empty_rewrites[pth2] THENC
+   RATOR_CONV(RATOR_CONV(RAND_CONV NUM_EVEN_CONV)) THENC
+   GEN_REWRITE_CONV I empty_rewrites[tth] THENC
+   (fn tm => if rator tm ~~ neg_tm then RAND_CONV(RAND_CONV NUM_EXP_CONV) tm
+              else RAND_CONV NUM_EXP_CONV tm))
+end;
+
+end (* struct *)

--- a/src/integer/integerRingLib.sig
+++ b/src/integer/integerRingLib.sig
@@ -11,4 +11,8 @@ sig
   val INT_NORM_RULE : thm -> thm
   val INT_RING_RULE : thm -> thm
 
+  val INT_POLY_CONV       : conv
+  val INT_RING            : term -> thm
+  val int_ideal_cofactors : term list -> term -> term list
+
 end

--- a/src/integer/integerRingLib.sml
+++ b/src/integer/integerRingLib.sml
@@ -1,7 +1,22 @@
 structure integerRingLib :> integerRingLib =
 struct
 
-open HolKernel Parse boolLib integerTheory integerRingTheory
+open HolKernel boolLib bossLib liteLib;
+
+open integerTheory intSimps intSyntax intReduce Normalizer Grobner Canon
+     hurdUtils mesonLib tautLib;
+
+open integerRingTheory;
+
+structure Parse = struct
+  open Parse
+  val (Type,Term) = parse_from_grammars integer_grammars
+end
+
+open Parse;
+
+val ERR = mk_HOL_ERR "intLib";
+fun failwith function = raise (ERR function "");
 
 val num_to_int = intSyntax.int_injection;
 val int_0 = intSyntax.zero_tm
@@ -32,5 +47,80 @@ val INT_NORM_TAC = CONV_TAC INT_NORM_CONV
 
 val INT_RING_RULE = CONV_RULE INT_RING_CONV
 val INT_NORM_RULE = CONV_RULE INT_NORM_CONV
+
+(* ------------------------------------------------------------------------- *)
+(* Instantiate the normalizer (code below are ported from HOL-Light)         *)
+(* ------------------------------------------------------------------------- *)
+
+local
+  val sth = prove
+   (“(!x y z. x + (y + z) = (x + y) + z :int) /\
+     (!x y. x + y = y + x :int) /\
+     (!x. &0 + x = x) /\
+     (!x y z. x * (y * z) = (x * y) * z :int) /\
+     (!x y. x * y = y * x :int) /\
+     (!x. &1 * x = x :int) /\
+     (!(x :int). &0 * x = &0) /\
+     (!x y z. x * (y + z) = x * y + x * z :int) /\
+     (!(x :int). x ** 0 = &1) /\
+     (!(x :int) n. x ** (SUC n) = x * (x ** n))”,
+    REWRITE_TAC [INT_POW, INT_ADD_ASSOC, INT_MUL_ASSOC, INT_ADD_LID,
+                 INT_MUL_LZERO, INT_MUL_LID, INT_LDISTRIB] THEN
+    REWRITE_TAC [Once INT_ADD_SYM, Once INT_MUL_SYM]);
+  val rth = prove
+   (“(!x. -x = -(&1) * x :int) /\
+     (!x y. x - y = x + -(&1) * y :int)”,
+    REWRITE_TAC [INT_MUL_LNEG, INT_MUL_LID, int_sub]);
+  val is_semiring_constant = is_int_literal
+  and SEMIRING_ADD_CONV = INT_ADD_CONV
+  and SEMIRING_MUL_CONV = INT_MUL_CONV
+  and SEMIRING_POW_CONV = INT_POW_CONV;
+  fun term_lt u t = (Term.compare(u,t) = LESS);
+  val (_,_,_,_,_,POLY_CONV) =
+    SEMIRING_NORMALIZERS_CONV sth rth
+     (is_semiring_constant,
+      SEMIRING_ADD_CONV,SEMIRING_MUL_CONV,SEMIRING_POW_CONV)
+     term_lt
+in
+  val INT_POLY_CONV = POLY_CONV;
+end;
+
+(* ------------------------------------------------------------------------- *)
+(* Instantiate the ring and ideal procedures.                                *)
+(* ------------------------------------------------------------------------- *)
+
+local
+  val INT_INTEGRAL = prove
+   (“(!(x :int). &0 * x = &0) /\
+     (!x y (z :int). (x + y = x + z) <=> (y = z)) /\
+     (!w x y (z :int). (w * y + x * z = w * z + x * y) <=> (w = x) \/ (y = z))”,
+    REWRITE_TAC[INT_MUL_LZERO, INT_EQ_LADD] THEN
+    ONCE_REWRITE_TAC[GSYM INT_SUB_0] THEN
+    REWRITE_TAC[GSYM INT_ENTIRE] THEN
+    rpt GEN_TAC \\
+    Suff ‘w * y + x * z - (w * z + x * y) = (w - x) * (y - z :int)’
+    >- (Rewr' >> REWRITE_TAC []) \\
+    REWRITE_TAC [INT_ADD2_SUB2] \\
+    REWRITE_TAC [GSYM INT_SUB_LDISTRIB] \\
+   ‘x * (z - y) = -x * (y - z :int)’
+      by (REWRITE_TAC [INT_MUL_LNEG, INT_SUB_LDISTRIB, INT_NEG_SUB]) \\
+    POP_ORW \\
+    REWRITE_TAC [GSYM INT_RDISTRIB, GSYM int_sub]);
+  val dest_intconst = Arbrat.fromAInt o int_of_term;
+  val mk_intconst = term_of_int o Arbrat.toAInt;
+  val (pure,ideal) =
+    RING_AND_IDEAL_CONV
+      (dest_intconst,mk_intconst,INT_EQ_CONV,
+       negate_tm, plus_tm, minus_tm,
+       genvar bool, mult_tm, genvar bool, exp_tm,
+       INT_INTEGRAL,TRUTH,INT_POLY_CONV)
+in
+  val INT_RING = pure;
+  fun int_ideal_cofactors tms tm =
+      if forall (fn t => type_of t = int_ty) (tm::tms)
+      then ideal tms tm
+      else
+        failwith "int_ideal_cofactors: not all terms have type :int"
+end;
 
 end;

--- a/src/integer/selftest.sml
+++ b/src/integer/selftest.sml
@@ -50,8 +50,7 @@ val _ = List.app (ignore o rma_p) [
       (“3n ** 2n”, "3 ** 2"),
       (“((x:num) ** (y:num)):num”, "x ** y"),
       (“x:int / (y + 1)”, "x / (y + 1)")
-    ]
-
+    ];
 
 (* check prefer/deprecate rat *)
 val grammars = (type_grammar(),term_grammar());
@@ -76,4 +75,20 @@ val _ = require_msg (check_result (aconv expected2)) term_to_string
 
 val _ = temp_set_grammars grammars;
 
-val _ = Process.exit Process.success
+(* Tests for INTEGER_RULE *)
+fun rule_test prover (r as (n,tm)) =
+    let
+      fun check res = aconv tm (concl res);
+    in
+      tprint (n ^ ": " ^ term_to_string tm);
+      require_msg (check_result check) (term_to_string o concl) prover tm
+    end;
+
+val _ = List.app (rule_test INTEGER_RULE) [
+      ("INTEGER_RULE_00",
+       “w * y + x * z - (w * z + x * y) = (w - x) * (y - z:int)”),
+      ("INTEGER_RULE_01",
+       “a int_divides &n <=> a int_divides -&n”)
+      ];
+
+val _ = Process.exit Process.success;

--- a/src/meson/src/mesonLib.sig
+++ b/src/meson/src/mesonLib.sig
@@ -2,11 +2,9 @@
 (* Version of the MESON procedure a la PTTP. Various search options.         *)
 (* ========================================================================= *)
 
-
 signature mesonLib =
 sig
-type thm = Thm.thm
-type tactic = Abbrev.tactic
+   include Abbrev
 
    val depth     : bool ref
    val prefine   : bool ref
@@ -20,5 +18,6 @@ type tactic = Abbrev.tactic
    val GEN_MESON_TAC : int -> int -> int -> thm list -> tactic
    val MESON_TAC     : thm list -> tactic
    val ASM_MESON_TAC : thm list -> tactic
+   val MESON         : thm list -> term -> thm
 
 end (* sig *)

--- a/src/meson/src/mesonLib.sml
+++ b/src/meson/src/mesonLib.sml
@@ -994,6 +994,7 @@ val max_depth = ref 30;
 fun ASM_MESON_TAC e = GEN_MESON_TAC 0 (!max_depth) 1 e;
 
 fun MESON_TAC ths = POP_ASSUM_LIST (K ALL_TAC) THEN ASM_MESON_TAC ths;
+fun MESON ths tm = prove(tm,MESON_TAC ths);
 
 val _ = Parse.temp_set_grammars ambient_grammars;
 

--- a/src/metis/normalForms.sml
+++ b/src/metis/normalForms.sml
@@ -6,7 +6,7 @@
 structure normalForms :> normalForms =
 struct
 
-open HolKernel Parse boolLib simpLib;
+open HolKernel Parse boolLib simpLib Canon;
 
 (* Fix the grammar used by this file *)
 structure Parse =
@@ -15,7 +15,6 @@ struct
   val (Type,Term) = parse_from_grammars combinTheory.combin_grammars
 end
 open Parse
-
 
 (* ------------------------------------------------------------------------- *)
 (* Tracing.                                                                  *)
@@ -401,105 +400,6 @@ val PURE_NNF_CONV = PURE_NNF_CONV' NO_CONV;
 
 fun NNF_CONV' c = SIMPLIFY_CONV THENC PURE_NNF_CONV' c;
 val NNF_CONV = NNF_CONV' NO_CONV;
-
-(* ------------------------------------------------------------------------- *)
-(* ACI rearrangements of conjunctions and disjunctions. This is much faster  *)
-(* than AC xxx_ACI on large problems, as well as being more controlled.      *)
-(*            (Ported from HOL-Light by Chun Tian, June 1, 2022)             *)
-(* ------------------------------------------------------------------------- *)
-
-local
-    open Redblackmap tautLib
-    type func = (term,thm)dict;
-    val undefined :func = mkDict Term.compare;
-in
-val CONJ_ACI_RULE = let
-  fun mk_fun th (f :func) :func =
-    let val tm = concl th in
-        if is_conj tm then
-            let val (th1,th2) = CONJ_PAIR th in
-                mk_fun th1 (mk_fun th2 f)
-            end
-        else insert (f,tm,th)
-    end
-  and use_fun (f :func) tm :thm =
-    if is_conj tm then
-        let val (l,r) = dest_conj tm in
-            CONJ (use_fun f l) (use_fun f r)
-        end
-    else find (f,tm)
-in
-  fn tm => let val (p,p') = dest_eq tm in
-               if p ~~ p' then REFL p else
-               let val th = use_fun (mk_fun (ASSUME p) undefined) p'
-                   and th' = use_fun (mk_fun (ASSUME p') undefined) p
-               in
-                   IMP_ANTISYM_RULE (DISCH_ALL th) (DISCH_ALL th')
-               end
-           end
-end; (* CONJ_ACI_RULE *)
-
-val DISJ_ACI_RULE = let
-  val pth_left = UNDISCH(TAUT `~(a \/ b) ==> ~a`)
-  and pth_right = UNDISCH(TAUT `~(a \/ b) ==> ~b`)
-  and pth = repeat UNDISCH (TAUT `~a ==> ~b ==> ~(a \/ b)`)
-  and pth_neg = UNDISCH(TAUT `(~a <=> ~b) ==> (a <=> b)`)
-  and a_tm = “a:bool” and b_tm = “b:bool”;
-  fun NOT_DISJ_PAIR th = let
-      val (p,q) = dest_disj(rand(concl th));
-      val ilist = [a_tm |-> p, b_tm |-> q]
-  in
-      (PROVE_HYP th (INST ilist pth_left),
-       PROVE_HYP th (INST ilist pth_right))
-  end
-  and NOT_DISJ th1 th2 = let
-      val th3 = INST [a_tm |-> rand(concl th1),
-                      b_tm |-> rand(concl th2)] pth
-  in
-      PROVE_HYP th1 (PROVE_HYP th2 th3)
-  end;
-  fun mk_fun th (f :func) :func =
-    let val tm = rand(concl th) in
-        if is_disj tm then
-            let val (th1,th2) = NOT_DISJ_PAIR th in
-                mk_fun th1 (mk_fun th2 f)
-            end
-        else insert (f,tm,th)
-    end
-  and use_fun (f :func) tm :thm =
-    if is_disj tm then
-        let val (l,r) = dest_disj tm in
-            NOT_DISJ (use_fun f l) (use_fun f r)
-        end
-    else find (f,tm)
-in
-  fn fm => let val (p,p') = dest_eq fm in
-               if p ~~ p' then REFL p else
-               let val th = use_fun (mk_fun (ASSUME(mk_neg p)) undefined) p'
-                   and th' = use_fun (mk_fun (ASSUME(mk_neg p')) undefined) p;
-                   val th1 = IMP_ANTISYM_RULE (DISCH_ALL th) (DISCH_ALL th')
-               in
-                   PROVE_HYP th1 (INST [a_tm |-> p, b_tm |-> p'] pth_neg)
-               end
-           end
-end; (* DISJ_ACI_RULE *)
-end; (* local open Redblackmap *)
-
-(* ------------------------------------------------------------------------- *)
-(* Order canonically, right-associate and remove duplicates.                 *)
-(* ------------------------------------------------------------------------- *)
-
-local open liteLib in
-fun CONJ_CANON_CONV tm =
-  let val tm' = list_mk_conj(setify_term(strip_conj tm)) in
-      CONJ_ACI_RULE(mk_eq(tm,tm'))
-  end;
-
-fun DISJ_CANON_CONV tm =
-  let val tm' = list_mk_disj(setify_term(strip_disj tm)) in
-      DISJ_ACI_RULE(mk_eq(tm,tm'))
-  end;
-end; (* local *)
 
 (* ------------------------------------------------------------------------- *)
 (* Eliminate conditionals; CONDS_ELIM_CONV aims for disjunctive splitting,   *)

--- a/src/num/theories/arithmeticScript.sml
+++ b/src/num/theories/arithmeticScript.sml
@@ -414,6 +414,8 @@ val ZERO_LESS_EQ = store_thm ("ZERO_LESS_EQ",
    “!n. 0 <= n”,
    REWRITE_TAC [LESS_0,LESS_EQ_IFF_LESS_SUC]);
 
+Theorem LE_0 = ZERO_LESS_EQ (* HOL-Light compatible name *)
+
 val LESS_SUC_EQ_COR = store_thm ("LESS_SUC_EQ_COR",
    “!m n. ((m < n) /\ (~(SUC m = n))) ==> (SUC m < n)”,
    CONV_TAC (ONCE_DEPTH_CONV SYM_CONV) THEN
@@ -923,6 +925,16 @@ val LESS_EQUAL_ANTISYM = store_thm ("LESS_EQUAL_ANTISYM",
      REPEAT STRIP_TAC THENL
      [IMP_RES_TAC LESS_ANTISYM,
       ASM_REWRITE_TAC[]]);
+
+Theorem LE_ANTISYM :
+    !m (n :num). m <= n /\ n <= m <=> m = n
+Proof
+    rpt GEN_TAC
+ >> EQ_TAC >> rpt STRIP_TAC
+ >- (MATCH_MP_TAC LESS_EQUAL_ANTISYM \\
+     ASM_REWRITE_TAC [])
+ >> ASM_REWRITE_TAC [LESS_EQ_REFL]
+QED
 
 val LESS_ADD_SUC = store_thm ("LESS_ADD_SUC",
      “!m n. m < m + SUC n”,
@@ -3004,12 +3016,12 @@ Theorem SUB_ELIM_THM_EXISTS =
                |> SIMP_RULE bool_ss []
 
 (* some HOL-Light compatible theorem names *)
-val LTE_CASES = LESS_CASES;
-val NOT_LT    = NOT_LESS;
-val NOT_LE    = NOT_LESS_EQUAL;
-val LT_IMP_LE = LESS_IMP_LESS_OR_EQ;
-val LE_ADD    = LESS_EQ_ADD;
-val LE_EXISTS = LESS_EQ_EXISTS;
+Theorem LTE_CASES = LESS_CASES
+Theorem NOT_LT    = NOT_LESS
+Theorem NOT_LE    = NOT_LESS_EQUAL
+Theorem LT_IMP_LE = LESS_IMP_LESS_OR_EQ
+Theorem LE_ADD    = LESS_EQ_ADD
+Theorem LE_EXISTS = LESS_EQ_EXISTS
 
 (* This is HOL-Light's SUB_ELIM_THM, with a single ‘P d’ at rhs. *)
 Theorem SUB_ELIM_THM' :

--- a/src/refute/Canon.sig
+++ b/src/refute/Canon.sig
@@ -4,10 +4,7 @@
 
 signature Canon =
 sig
-
- type term = Term.term
- type thm = Thm.thm
- type conv = Abbrev.conv
+    include Abbrev
 
     val ONEWAY_SKOLEM_CONV : term list -> conv
     val NNF_CONV : conv -> bool -> conv
@@ -33,5 +30,11 @@ sig
     val EQ_ABS_CONV : conv
 
     val latest :  (thm * thm * term) option ref
+
+    (* ACI rearrangements of conjunctions and disjunctions *)
+    val CONJ_ACI_RULE   : term -> thm
+    val DISJ_ACI_RULE   : term -> thm
+    val CONJ_CANON_CONV : conv
+    val DISJ_CANON_CONV : conv
 
 end (* sig *)

--- a/src/refute/Canon.sml
+++ b/src/refute/Canon.sml
@@ -776,7 +776,10 @@ end; (* CONJ_ACI_RULE *)
 val DISJ_ACI_RULE = let
   val pth_left = UNDISCH(TAUT `~(a \/ b) ==> ~a`)
   and pth_right = UNDISCH(TAUT `~(a \/ b) ==> ~b`)
-  and pth = repeat UNDISCH (TAUT `~a ==> ~b ==> ~(a \/ b)`)
+  (* NOTE: HOL4's UNDISCH treats ‘~(a \/ b)’ as ‘a \/ b ==> F’, while HOL-Light
+     doesn't. We have changed ‘repeat’ to ‘funpow 2’ here.
+   *)
+  and pth = funpow 2 UNDISCH (TAUT `~a ==> ~b ==> ~(a \/ b)`)
   and pth_neg = UNDISCH(TAUT `(~a <=> ~b) ==> (a <=> b)`)
   and a_tm = “a:bool” and b_tm = “b:bool”;
   fun NOT_DISJ_PAIR th = let
@@ -807,7 +810,7 @@ val DISJ_ACI_RULE = let
         end
     else find (f,tm)
 in
-  fn fm => let val (p,p') = dest_eq fm in
+  fn tm => let val (p,p') = dest_eq tm in
                if p ~~ p' then REFL p else
                let val th = use_fun (mk_fun (ASSUME(mk_neg p)) undefined) p'
                    and th' = use_fun (mk_fun (ASSUME(mk_neg p')) undefined) p;


### PR DESCRIPTION
Hi,

This PR brings HOL-Light's `INTEGER_TAC` (and `INTEGER_RULE`) into HOL4. It is a by-product of another ongoing work of porting HOL-Light's `RING_TAC` to HOL4.  The underlying implementation is based on the `Normalizer` and `Grobner` packages used by `REAL_ARITH_TAC` and `REAL_FIELD_TAC`.  In `src/integer/selftest.sml`, there are two examples:
```
> INTEGER_RULE “w * y + x * z - (w * z + x * y) = (w - x) * (y - z:int)”;
val it = |- w * y + x * z - (w * z + x * y) = (w - x) * (y - z): thm
> INTEGER_RULE “a int_divides &n <=> a int_divides -&n”;
2 basis elements and 0 critical pairs
1 basis elements and 0 critical pairs
Translating certificate to HOL inferences
2 basis elements and 0 critical pairs
1 basis elements and 0 critical pairs
Translating certificate to HOL inferences
val it = |- a int_divides &n <=> a int_divides -&n: thm
```

An intermediate function, `INT_RING :term -> thm`, can be useful as the simplification step of more advanced decision procedures, namely `COOPER_TAC` and `OMEGA_TAC`. I put the related code into `integerRingLib` without depending on `Cooper` and `Omega` packages, so that later this work can be integrated into them.

The main implementation of `INTEGER_TAC` is currently in `intLib.sml`.

It uses some code (`CONJ_ACI_RULE`, etc.) previously in `normalForms.sml` without signatures. Now I have move these code to `Canon` package (which seems a partial port of HOL-Light's `canon.ml`).

In `mesonLib`, I added HOL-Light compatible `MESON` function, which has currently multiple copies in proofs ported from HOL-Light (I will clean them up later).

In `intReduce`, I added some integer arithmetic conversions (they are used by `INTEGER_TAC`) ported from HOL-Light. In theory the single `REDUCE_CONV` can also do the job, but these new conversions have better performance (by doing much less rewritings on large inputs), e.g.:
```
> Count.apply intReduce.REDUCE_CONV ``&1000 * -&1000``;
runtime: 0.00147s,    gctime: 0.00000s,     systime: 0.00328s.
Axioms: 0, Defs: 0, Disk: 0, Orcl: 0, Prims: 1953; Total: 1953
val it = |- 1000 * -1000 = -1000000: thm

> Count.apply intReduce.INT_MUL_CONV ``&1000 * -&1000``;
runtime: 0.00003s,    gctime: 0.00000s,     systime: 0.00003s.
Axioms: 0, Defs: 0, Disk: 0, Orcl: 0, Prims: 10; Total: 10
val it = |- 1000 * -1000 = -1000000: thm
```

The «HOL Description» was broken by new code added into `intLib`, because there is some code manipulating the overload of `int_add`. I resolved the manual PDF building by moving `load "intLib"` to earlier places.

Let's see how the CI tests will go (perhaps there are missing code in the PR branch).

Chun
