### PR TITLE
add lowercase rewrite tactics

### DIFF
--- a/src/1/Rewrite.sig
+++ b/src/1/Rewrite.sig
@@ -37,15 +37,19 @@ sig
   val ONCE_ASM_REWRITE_RULE     : thm list -> thm -> thm
 
   val PURE_REWRITE_TAC          : thm list -> tactic
+  val pure_rewrite_tac          : thm list -> tactic
   val REWRITE_TAC               : thm list -> tactic
   val rewrite_tac               : thm list -> tactic
   val PURE_ONCE_REWRITE_TAC     : thm list -> tactic
+  val pure_once_rewrite_tac     : thm list -> tactic
   val ONCE_REWRITE_TAC          : thm list -> tactic
   val once_rewrite_tac          : thm list -> tactic
   val PURE_ASM_REWRITE_TAC      : thm list -> tactic
+  val pure_asm_rewrite_tac      : thm list -> tactic
   val ASM_REWRITE_TAC           : thm list -> tactic
   val asm_rewrite_tac           : thm list -> tactic
   val PURE_ONCE_ASM_REWRITE_TAC : thm list -> tactic
+  val pure_once_asm_rewrite_tac : thm list -> tactic
   val ONCE_ASM_REWRITE_TAC      : thm list -> tactic
   val once_asm_rewrite_tac      : thm list -> tactic
 

--- a/src/1/Rewrite.sml
+++ b/src/1/Rewrite.sml
@@ -190,6 +190,7 @@ and ONCE_REWRITE_TAC thl =
     GEN_REWRITE_TAC Conv.ONCE_DEPTH_CONV (implicit_rewrites()) thl;
 
 val rewrite_tac = REWRITE_TAC and once_rewrite_tac = ONCE_REWRITE_TAC
+val pure_rewrite_tac = PURE_REWRITE_TAC and pure_once_rewrite_tac = PURE_ONCE_REWRITE_TAC
 
 
 (* Rewrite a goal with the help of its assumptions *)
@@ -202,6 +203,10 @@ and PURE_ONCE_ASM_REWRITE_TAC thl :tactic =
    Tactical.ASSUM_LIST (fn asl => PURE_ONCE_REWRITE_TAC (asl @ thl))
 and ONCE_ASM_REWRITE_TAC thl :tactic      =
    Tactical.ASSUM_LIST (fn asl => ONCE_REWRITE_TAC (asl @ thl));
+
+val pure_asm_rewrite_tac = PURE_ASM_REWRITE_TAC
+val pure_once_asm_rewrite_tac = PURE_ONCE_ASM_REWRITE_TAC
+
 
 val asm_rewrite_tac = ASM_REWRITE_TAC
 val once_asm_rewrite_tac = ONCE_ASM_REWRITE_TAC


### PR DESCRIPTION
This PR adds the lowercase aliases for:
- `PURE_REWRITE_TAC`
- `PURE_ONCE_REWRITE_TAC`
- `PURE_ASM_REWRITE_TAC`
- `PURE_ONCE_ASM_REWRITE_TAC`

The lowercase version (`PURE_REWRITE_TAC`) is also used in here: https://hol-theorem-prover.org/cheatsheet.html

I'm unsure how to add it to the `Manual/Description/tactics.stex` file, if requried. 