### PR TITLE
Fixed intLib to avoid noisy output

### DIFF
--- a/src/integer/intLib.sml
+++ b/src/integer/intLib.sml
@@ -4,7 +4,7 @@ struct
 open HolKernel boolLib bossLib liteLib;
 
 open integerTheory intSimps Omega Cooper intSyntax intReduce Canon hurdUtils
-     mesonLib tautLib integerRingLib;
+     tautLib integerRingLib;
 
 structure Parse = struct
   open Parse
@@ -187,8 +187,8 @@ local
      (* NOTE: EQT_INTRO must be added in HOL4 to make INT_RING conv-like *)
         CONV_TAC (EQT_INTRO o INT_RING)) gl
     end;
-  val SCRUB_NEQ_TAC = MATCH_MP_TAC o MATCH_MP (MESON[]
-     “~(x = y) ==> x = y \/ p ==> p”);
+  val SCRUB_NEQ_TAC = MATCH_MP_TAC o MATCH_MP (TAUT
+     ‘~(x = y :'a) ==> x = y \/ p ==> p’);
   (* |- !P Q. P /\ (?x. Q x) <=> ?x. P /\ Q x *)
   val RIGHT_AND_EXISTS_THM = GSYM RIGHT_EXISTS_AND_THM;
   (* |- !P Q. (?x. P x) /\ Q <=> ?x. P x /\ Q *)

--- a/src/integer/intReduce.sml
+++ b/src/integer/intReduce.sml
@@ -147,10 +147,10 @@ local
   val NUM_LE_CONV = Arithconv.LE_CONV;
   val INT_LE_NEG2 = INT_LE_NEG;
   val [pth_le1, pth_le2a, pth_le2b, pth_le3] = (CONJUNCTS o prove)
-   (“(-(&m) <= &n <=> T) /\
-     (&m <= &n <=> m <= n) /\
-     (-(&m) <= -(&n) <=> n <= m) /\
-     (&m <= -(&n) <=> (m = 0) /\ (n = 0))”,
+   (“(-(&m) <= (&n :int) <=> T) /\
+     (&m <= (&n :int) <=> m <= n) /\
+     (-(&m) <= -(&n):int <=> n <= m) /\
+     (&m <= -(&n):int <=> (m = 0) /\ (n = 0))”,
     REWRITE_TAC[INT_LE_NEG2] THEN
     REWRITE_TAC[INT_LE_LNEG, INT_LE_RNEG] THEN
     REWRITE_TAC[INT_OF_NUM_ADD, INT_OF_NUM_LE, LE_0] THEN
@@ -160,10 +160,10 @@ local
     GEN_REWRITE_CONV I empty_rewrites[pth_le2a, pth_le2b] THENC NUM_LE_CONV,
     GEN_REWRITE_CONV I empty_rewrites[pth_le3] THENC NUM2_EQ_CONV];
   val [pth_lt1, pth_lt2a, pth_lt2b, pth_lt3] = (CONJUNCTS o prove)
-   (“(&m < -(&n) <=> F) /\
-     (&m < &n <=> m < n) /\
-     (-(&m) < -(&n) <=> n < m) /\
-     (-(&m) < &n <=> ~((m = 0) /\ (n = 0)))”,
+   (“(&m < -(&n):int <=> F) /\
+     (&m < (&n :int) <=> m < n) /\
+     (-(&m) < -(&n):int <=> n < m) /\
+     (-(&m) < (&n :int) <=> ~((m = 0) /\ (n = 0)))”,
     REWRITE_TAC[pth_le1, pth_le2a, pth_le2b, pth_le3,
                 GSYM NOT_LE, INT_LT2] THEN
     TAUT_TAC);
@@ -173,10 +173,10 @@ local
     GEN_REWRITE_CONV I empty_rewrites[pth_lt2a, pth_lt2b] THENC NUM_LT_CONV,
     GEN_REWRITE_CONV I empty_rewrites[pth_lt3] THENC NUM2_NE_CONV];
   val [pth_ge1, pth_ge2a, pth_ge2b, pth_ge3] = (CONJUNCTS o prove)
-   (“(&m >= -(&n) <=> T) /\
-     (&m >= &n <=> n <= m) /\
-     (-(&m) >= -(&n) <=> m <= n) /\
-     (-(&m) >= &n <=> (m = 0) /\ (n = 0))”,
+   (“(&m >= -(&n):int <=> T) /\
+     (&m >= (&n :int) <=> n <= m) /\
+     (-(&m) >= -(&n):int <=> m <= n) /\
+     (-(&m) >= (&n :int) <=> (m = 0) /\ (n = 0))”,
     REWRITE_TAC[pth_le1, pth_le2a, pth_le2b, pth_le3, INT_GE] THEN
     TAUT_TAC);
   val NUM_LE_CONV = Arithconv.LE_CONV;
@@ -185,10 +185,10 @@ local
     GEN_REWRITE_CONV I empty_rewrites[pth_ge2a, pth_ge2b] THENC NUM_LE_CONV,
     GEN_REWRITE_CONV I empty_rewrites[pth_ge3] THENC NUM2_EQ_CONV];
   val [pth_gt1, pth_gt2a, pth_gt2b, pth_gt3] = (CONJUNCTS o prove)
-   (“(-(&m) > &n <=> F) /\
-     (&m > &n <=> n < m) /\
-     (-(&m) > -(&n) <=> m < n) /\
-     (&m > -(&n) <=> ~((m = 0) /\ (n = 0)))”,
+   (“(-(&m) > (&n :int) <=> F) /\
+     (&m > (&n :int) <=> n < m) /\
+     (-(&m) > -(&n):int <=> m < n) /\
+     (&m > -(&n):int <=> ~((m = 0) /\ (n = 0)))”,
     REWRITE_TAC[pth_lt1, pth_lt2a, pth_lt2b, pth_lt3, INT_GT] THEN
     TAUT_TAC);
   val NUM_LT_CONV = Arithconv.LT_CONV;
@@ -197,10 +197,10 @@ local
     GEN_REWRITE_CONV I empty_rewrites[pth_gt2a, pth_gt2b] THENC NUM_LT_CONV,
     GEN_REWRITE_CONV I empty_rewrites[pth_gt3] THENC NUM2_NE_CONV];
   val [pth_eq1a, pth_eq1b, pth_eq2a, pth_eq2b] = (CONJUNCTS o prove)
-   (“((&m = &n) <=> (m = n)) /\
-     ((-(&m) = -(&n)) <=> (m = n)) /\
-     ((-(&m) = &n) <=> (m = 0) /\ (n = 0)) /\
-     ((&m = -(&n)) <=> (m = 0) /\ (n = 0))”,
+   (“((&m = &n :int) <=> (m = n)) /\
+     ((-(&m) = -(&n):int) <=> (m = n)) /\
+     ((-(&m) = &n :int) <=> (m = 0) /\ (n = 0)) /\
+     ((&m = -(&n):int) <=> (m = 0) /\ (n = 0))”,
     REWRITE_TAC[GSYM INT_LE_ANTISYM, GSYM LE_ANTISYM] THEN
     REWRITE_TAC[pth_le1, pth_le2a, pth_le2b, pth_le3, LE, LE_0] THEN
     TAUT_TAC);
@@ -227,18 +227,19 @@ local
   val dest = dest_binop plus_tm (ERR "INT_ADD_CONV" "");
   val dest_numeral = numSyntax.dest_numeral
   and mk_numeral = numSyntax.mk_numeral;
-  val m_tm = “m:num” and n_tm = “n:num”;
+  val m_tm = mk_var("m",numSyntax.num)
+  and n_tm = mk_var("n",numSyntax.num);
   val pth0 = prove
    (“(-(&m) + &m = &0) /\
      (&m + -(&m) = &0)”,
     REWRITE_TAC[INT_ADD_LINV, INT_ADD_RINV]);
   val [pth1, pth2, pth3, pth4, pth5, pth6] = (CONJUNCTS o prove)
-   (“(-(&m) + -(&n) = -(&(m + n))) /\
-     (-(&m) + &(m + n) = &n) /\
-     (-(&(m + n)) + &m = -(&n)) /\
-     (&(m + n) + -(&m) = &n) /\
-     (&m + -(&(m + n)) = -(&n)) /\
-     (&m + &n = &(m + n))”,
+   (“(-(&m) + -(&n):int = -(&(m + n))) /\
+     (-(&m) + &(m + n):int = &n) /\
+     (-(&(m + n)) + (&m :int) = -(&n)) /\
+     (&(m + n) + -(&m):int = &n) /\
+     (&m + -(&(m + n)):int = -(&n)) /\
+     (&m + &n = &(m + n):int)”,
     REWRITE_TAC[GSYM INT_OF_NUM_ADD, INT_NEG_ADD] THEN
     REWRITE_TAC[INT_ADD_ASSOC, INT_ADD_LINV, INT_ADD_LID] THEN
     REWRITE_TAC[INT_ADD_RINV, INT_ADD_LID] THEN
@@ -319,16 +320,16 @@ end (* local *)
 
 local
   val pth0 = prove
-     (“(&0 * &x = &0) /\
-       (&0 * --(&x) = &0) /\
-       (&x * &0 = &0) /\
-       (-(&x) * &0 = &0)”,
+     (“(&0 * &x = &0 :int) /\
+       (&0 * -(&x) = &0 :int) /\
+       (&x * &0 = &0 :int) /\
+       (-(&x) * &0 = &0 :int)”,
       REWRITE_TAC[INT_MUL_LZERO, INT_MUL_RZERO]);
   val (pth1,pth2) = (CONJ_PAIR o prove)
-     (“((&m * &n = &(m * n)) /\
-        (-(&m) * -(&n) = &(m * n))) /\
-       ((-(&m) * &n = -(&(m * n))) /\
-        (&m * -(&n) = -(&(m * n))))”,
+     (“((&m * &n = &(m * n) :int) /\
+        (-(&m) * -(&n) = &(m * n) :int)) /\
+       ((-(&m) * &n = -(&(m * n)) :int) /\
+        (&m * -(&n) = -(&(m * n)) :int))”,
       REWRITE_TAC[INT_MUL_LNEG, INT_MUL_RNEG, INT_NEG_NEG] THEN
       REWRITE_TAC[INT_OF_NUM_MUL]);
   val NUM_MULT_CONV = MUL_CONV;
@@ -346,11 +347,11 @@ end;
 
 local
   val (pth1,pth2) = (CONJ_PAIR o prove)
-     (“(&x ** n = &(x ** n)) /\
-       ((-(&x)) ** n = if EVEN n then &(x ** n) else -(&(x ** n)))”,
+     (“(&x ** n = &(x ** n) :int) /\
+       ((-(&x):int) ** n = if EVEN n then &(x ** n) else -(&(x ** n)))”,
     REWRITE_TAC[INT_OF_NUM_POW, INT_POW_NEG]);
   val tth = prove
-   (“((if T then x:int else y) = x) /\ ((if F then x:int else y) = y)”,
+   (“((if T then (x:int) else y) = x) /\ ((if F then (x:int) else y) = y)”,
     REWRITE_TAC[]);
   val neg_tm = negate_tm;
   val NUM_EXP_CONV = EXP_CONV

--- a/src/integer/intSimps.sml
+++ b/src/integer/intSimps.sml
@@ -1,16 +1,13 @@
 structure intSimps :> intSimps =
 struct
 
-open HolKernel boolLib integerTheory intSyntax simpLib
+open HolKernel boolLib integerTheory intSyntax simpLib intReduce;
 
 val ERR = mk_HOL_ERR "intSimps";
-
-open intReduce
 
 (* ----------------------------------------------------------------------
     integer normalisations
    ---------------------------------------------------------------------- *)
-
 
 local
   open intSyntax integerTheory GenPolyCanon

--- a/src/integer/integerRingLib.sml
+++ b/src/integer/integerRingLib.sml
@@ -56,7 +56,7 @@ local
   val sth = prove
    (“(!x y z. x + (y + z) = (x + y) + z :int) /\
      (!x y. x + y = y + x :int) /\
-     (!x. &0 + x = x) /\
+     (!x. &0 + x = x :int) /\
      (!x y z. x * (y * z) = (x * y) * z :int) /\
      (!x y. x * y = y * x :int) /\
      (!x. &1 * x = x :int) /\

--- a/src/res_quan/src/hurdUtils.sig
+++ b/src/res_quan/src/hurdUtils.sig
@@ -1,11 +1,11 @@
 signature hurdUtils =
 sig
+  include Abbrev
 
   (* GENERAL *)
   type 'a thunk = unit -> 'a
   type 'a susp = 'a Susp.susp
   type ('a, 'b) maplet = {redex : 'a, residue : 'b}
-  type ('a, 'b) subst = ('a, 'b) Lib.subst
 
   (* Error handling *)
   val ERR : string -> string -> exn
@@ -32,24 +32,15 @@ sig
 
   (* Combinators *)
   val A : ('a -> 'b) -> 'a -> 'b
-  val C : ('a -> 'b -> 'c) -> 'b -> 'a -> 'c
-  val I : 'a -> 'a
-  val K : 'a -> 'b -> 'a
   val N : int -> ('a -> 'a) -> 'a -> 'a
-  val S : ('a -> 'b -> 'c) -> ('a -> 'b) -> 'a -> 'c
-  val W : ('a -> 'a -> 'b) -> 'a -> 'b
   val oo : ('a -> 'b) * ('c -> 'd -> 'a) -> 'c -> 'd -> 'b
 
   (* Pairs *)
   val ## : ('a -> 'b) * ('c -> 'd) -> 'a * 'c -> 'b * 'd
   val D : 'a -> 'a * 'a
   val Df : ('a -> 'b) -> ('a * 'a -> 'b * 'b)
-  val fst : 'a * 'b -> 'a
-  val snd : 'a * 'b -> 'b
   val add_fst : 'a -> 'b -> 'a * 'b
   val add_snd : 'a -> 'b -> 'b * 'a
-  val curry : ('a * 'b -> 'c) -> 'a -> 'b -> 'c
-  val uncurry : ('a -> 'b -> 'c) -> 'a * 'b -> 'c
   val equal : ''a -> ''a -> bool
   val pair_to_string : ('a -> string) -> ('b -> string) -> 'a * 'b -> string
 
@@ -191,16 +182,6 @@ sig
 
   (* HOL Types *)
   type 'a set = 'a HOLset.set
-  type hol_type = Type.hol_type
-  type term = Term.term
-  type thm = Thm.thm
-  type goal = term list * term
-  type conv = term -> thm
-  type rule = thm -> thm
-  type validation = thm list -> thm
-  type tactic = goal -> goal list * validation
-  type thm_tactic = thm -> tactic
-  type thm_tactical = thm_tactic -> thm_tactic
   type vars = term list * hol_type list
   type vterm = vars * term
   type vthm = vars * thm


### PR DESCRIPTION
Hi,

This PR fixes the "noisy output" when loading "intLib" (#1241). Some of these noises are actually caused by loading `hurdUtils`, in which I also did some cleanups.

Although I have learnt from @konrad-slind that the verbose outputs of the Meson prover can be turned off by setting `val _ = mesonLib.chatting := 0` (temporarily, and reset back to 1 at the end of the same library), I found the use of Meson prover in all related cases are waste: either `TAUT` or `DECIDE` can be used instead.

Now loading `intLib` there's no more "noisy" outputs:
```
---------------------------------------------------------------------
     HOL4 [Trindemossen 1 (stdknl, built Wed May 22 13:32:03 2024)]

     For introductory HOL help, type: help "hol";
     To exit type <Control>-D
---------------------------------------------------------------------
[Use-ing configuration file /Users/binghe/.hol-config.sml]
Enter `quit();' to quit.
> load "intLib";
<<HOL message: intLib loaded.  Use intLib.deprecate_int() to turn off integer parsing>>
val it = (): unit
```

--Chun