### PR TITLE
Remove RealArith.OLD_REAL_ARITH_TAC, etc.

### DIFF
--- a/doc/next-release.md
+++ b/doc/next-release.md
@@ -52,6 +52,12 @@ New examples:
 Incompatibilities:
 ------------------
 
+- The old decision procedures for real arithmetics in `RealArith` package has been
+  removed: `OLD_REAL_ARITH`, `OLD_REAL_ARITH_TAC`, `OLD_REAL_ASM_ARITH_TAC` and
+ `PURE_REAL_ARITH_TAC` (user code can switch to `REAL_ASM_ARITH_TAC`).
+  Now `realLib.REAL_ARITH_TAC` (= `RealField.REAL_ARITH_TAC`), etc. solve exactly
+  the same set of problems as in HOL-Light (in rare cases existing proofs break.)
+
 * * * * *
 
 <div class="footer">

--- a/examples/dependability/case_studies/WSNScript.sml
+++ b/examples/dependability/case_studies/WSNScript.sml
@@ -14,23 +14,17 @@
 (*                                                                           *)
 (* ========================================================================= *)
 
-(*loadPath := "/home/waqar/Downloads/RBD" :: !loadPath;*)
+open HolKernel boolLib bossLib Parse;
 
-(*app load ["arithmeticTheory", "realTheory", "prim_recTheory", "seqTheory",
-          "pred_setTheory","res_quanTheory", "res_quanTools", "listTheory", "real_probabilityTheory", "numTheory",
-          "transcTheory", "rich_listTheory", "pairTheory", "extra_pred_setTools",
-          "combinTheory","limTheory","sortingTheory", "realLib", "optionTheory","satTheory",
-          "util_probTheory", "extrealTheory", "real_measureTheory", "real_lebesgueTheory","real_sigmaTheory",
-          "dep_rewrite","RBDTheory","FT_deepTheory","VDCTheory","smart_gridTheory","ASN_gatewayTheory"];*)
-open HolKernel Parse boolLib bossLib limTheory arithmeticTheory realTheory prim_recTheory real_probabilityTheory
+open limTheory arithmeticTheory realTheory prim_recTheory real_probabilityTheory
      seqTheory pred_setTheory res_quanTheory sortingTheory res_quanTools listTheory transcTheory
      rich_listTheory pairTheory combinTheory realLib  optionTheory util_probTheory extrealTheory real_measureTheory
-     real_lebesgueTheory real_sigmaTheory satTheory numTheory dep_rewrite extra_pred_setTools
-      RBDTheory FT_deepTheory VDCTheory smart_gridTheory ASN_gatewayTheory ;
+     real_lebesgueTheory real_sigmaTheory satTheory numTheory dep_rewrite extra_pred_setTools;
+
+open RBDTheory FT_deepTheory VDCTheory smart_gridTheory ASN_gatewayTheory;
 
 fun K_TAC _ = ALL_TAC;
 
-open HolKernel boolLib bossLib Parse;
 val _ = new_theory "WSN";
 
 (*--------------------*)
@@ -62,8 +56,10 @@ RW_TAC std_ss[]
 >> RW_TAC list_ss[]
 >> RW_TAC list_ss[exp_func_list_def,list_sum_def,list_prod_def]
 >> RW_TAC real_ss[GSYM transcTheory.EXP_ADD]
+>> AP_TERM_TAC
 >> REAL_ARITH_TAC
 QED
+
 (*------------------------------------*)
 Theorem one_minus_exp_equi :
 !t c. (one_minus_list (exp_func_list c t)) =

--- a/examples/dependability/case_studies/smart_gridScript.sml
+++ b/examples/dependability/case_studies/smart_gridScript.sml
@@ -14,20 +14,18 @@
 (*                                                                           *)
 (* ========================================================================= *)
 
-(*app load ["arithmeticTheory", "realTheory", "prim_recTheory", "seqTheory",
-          "pred_setTheory","res_quanTheory", "res_quanTools", "listTheory", "real_probabilityTheory", "numTheory", "dep_rewrite",
-          "transcTheory", "rich_listTheory", "pairTheory", "extra_pred_setTools",
-          "combinTheory","limTheory","sortingTheory", "realLib", "optionTheory","satTheory",
-          "util_probTheory", "extrealTheory", "real_measureTheory", "real_lebesgueTheory","real_sigmaTheory",
-          "RBDTheory","FT_deepTheory","VDCTheory","ASN_gatewayTheory"];*)
+open HolKernel boolLib bossLib Parse;
 
-open HolKernel Parse boolLib bossLib limTheory arithmeticTheory realTheory prim_recTheory real_probabilityTheory
+open limTheory arithmeticTheory realTheory prim_recTheory real_probabilityTheory
      seqTheory pred_setTheory res_quanTheory sortingTheory res_quanTools listTheory transcTheory
      rich_listTheory pairTheory combinTheory realLib  optionTheory dep_rewrite extra_pred_setTools
-      util_probTheory extrealTheory real_measureTheory real_lebesgueTheory real_sigmaTheory satTheory numTheory
-      RBDTheory FT_deepTheory VDCTheory ASN_gatewayTheory;
-open HolKernel boolLib bossLib Parse;
+     util_probTheory extrealTheory real_measureTheory real_lebesgueTheory real_sigmaTheory
+     satTheory numTheory;
+
+open RBDTheory FT_deepTheory VDCTheory ASN_gatewayTheory;
+
 val _ = new_theory "smart_grid";
+
 (*--------------------*)
 val op by = BasicProvers.byA;
 val POP_ORW = POP_ASSUM (fn thm => ONCE_REWRITE_TAC [thm]);
@@ -933,7 +931,7 @@ RW_TAC std_ss[]
 >> `Reliability p ESWs t = exp (-C_ESWs * t)` by RW_TAC std_ss[Reliability_def]
 >- (FULL_SIMP_TAC real_ss[exp_distribution_def])
 >> POP_ORW
->> REAL_ARITH_TAC
+>> rw [REAL_NEG_LMUL]
 QED
 
 (*----------------------------------------------*)

--- a/examples/miller/formalize/extra_realScript.sml
+++ b/examples/miller/formalize/extra_realScript.sml
@@ -18,18 +18,6 @@ val Simplify = RW_TAC arith_ss;
 (* Definitions.                                                              *)
 (* ------------------------------------------------------------------------- *)
 
-Theorem inf_alt : (* was: inf_def *)
-    !p. inf p = ~(sup (IMAGE $~ p))
-Proof
-    RW_TAC real_ss [inf_def]
- >> Suff `(\r. p (-r)) = (IMAGE numeric_negate p)` >- rw []
- >> SET_EQ_TAC
- >> RW_TAC std_ss [IN_IMAGE, IN_APP]
- >> EQ_TAC >> RW_TAC std_ss []
- >- (Q.EXISTS_TAC `-x` >> rw [REAL_NEG_NEG])
- >> rw [REAL_NEG_NEG]
-QED
-
 val zreal_def = Define `zreal (x : real) = (x = 0)`;
 val nzreal_def = Define `nzreal (x : real) = ~(x = 0)`;
 val posreal_def = Define `posreal (x : real) = (0 < x)`;
@@ -40,17 +28,6 @@ val nposreal_def = Define `nposreal (x : real) = (0 <= ~x)`;
 (* ------------------------------------------------------------------------- *)
 (* Theorems.                                                                 *)
 (* ------------------------------------------------------------------------- *)
-
-val INF_DEF_ALT = store_thm
-  ("INF_DEF_ALT",
-   ``!p. inf p = ~(sup (\r. ~r IN p))``,
-   RW_TAC std_ss []
-   >> PURE_REWRITE_TAC [inf_alt, IMAGE_DEF]
-   >> Suff `{~x | x IN p} = (\r:real. ~r IN p)`
-   >- RW_TAC std_ss []
-   >> RW_TAC std_ss [EXTENSION]
-   >> RW_TAC std_ss [GSPECIFICATION, SPECIFICATION]
-   >> PROVE_TAC [REAL_NEGNEG]);
 
 val REAL_LE_EQ = store_thm
   ("REAL_LE_EQ",
@@ -282,7 +259,7 @@ val REAL_ADD_SUBTYPE = store_thm
                 (nposreal -> nposreal -> nposreal) INTER
                 (zreal -> x -> x) INTER
                 (x -> zreal -> x))``,
-   RW_TAC std_ss [IN_FUNSET, IN_NEGREAL, IN_POSREAL, IN_INTER,
+  RW_TAC real_ss [IN_FUNSET, IN_NEGREAL, IN_POSREAL, IN_INTER,
                   IN_NPOSREAL, IN_NNEGREAL, IN_NZREAL, IN_ZREAL]
    >> REPEAT (POP_ASSUM MP_TAC)
    >> REAL_ARITH_TAC);
@@ -296,7 +273,7 @@ val REAL_SUB_SUBTYPE = store_thm
                 (nposreal -> posreal -> negreal) INTER
                 (nposreal -> nnegreal -> nposreal) INTER
                 (x -> zreal -> x))``,
-   RW_TAC std_ss [IN_FUNSET, IN_NEGREAL, IN_POSREAL, IN_INTER,
+  RW_TAC real_ss [IN_FUNSET, IN_NEGREAL, IN_POSREAL, IN_INTER,
                   IN_NPOSREAL, IN_NNEGREAL, IN_NZREAL, IN_ZREAL,
                   REAL_SUB_RZERO]
    >> REPEAT (POP_ASSUM MP_TAC)

--- a/src/real/RealArith.sig
+++ b/src/real/RealArith.sig
@@ -48,18 +48,4 @@ sig
   val REAL_ARITH_TAC       : tactic
   val REAL_ASM_ARITH_TAC   : tactic
 
- (* below are Joe Hurd's old port *)
-
- (* PURE_REAL_ARITH_TAC doesn't throw away assumptions, but requires
-    them to be pre-normalised in order to work.  There also must not
-    be any non-Presburger terms lurking amongst them.
-
-    REAL_ASM_ARITH_TAC moves all assumptions into the goal, and then
-    proceeds.  It thus gets around the two restrictions above.  *)
-
-  val PURE_REAL_ARITH_TAC    : tactic
-  val OLD_REAL_ARITH         : term -> thm
-  val OLD_REAL_ARITH_TAC     : tactic
-  val OLD_REAL_ASM_ARITH_TAC : tactic
-
 end

--- a/src/real/analysis/derivativeScript.sml
+++ b/src/real/analysis/derivativeScript.sml
@@ -27,7 +27,6 @@ open hurdUtils iterateTheory real_topologyTheory;
 
 val _ = new_theory "derivative";
 
-fun MESON ths tm = prove(tm,MESON_TAC ths);
 fun METIS ths tm = prove(tm,METIS_TAC ths);
 
 val DISC_RW_KILL = DISCH_TAC THEN ONCE_ASM_REWRITE_TAC [] THEN
@@ -40,7 +39,6 @@ val ASM_ARITH_TAC = REPEAT (POP_ASSUM MP_TAC) THEN ARITH_TAC;
 val ASM_REAL_ARITH_TAC = REAL_ASM_ARITH_TAC; (* realLib *)
 val IMP_CONJ           = CONJ_EQ_IMP;        (* cardinalTheory *)
 val FINITE_SUBSET      = SUBSET_FINITE_I;    (* pred_setTheory *)
-val LE_0               = ZERO_LESS_EQ;       (* arithmeticTheory *)
 val LIM                = LIM_DEF;            (* real_topologyTheory *)
 
 (* ------------------------------------------------------------------------- *)

--- a/src/real/analysis/integrationScript.sml
+++ b/src/real/analysis/integrationScript.sml
@@ -30,7 +30,6 @@ val std_ss = std_ss -* ["lift_disj_eq", "lift_imp_disj"]
 val real_ss = real_ss -* ["lift_disj_eq", "lift_imp_disj"]
 val _ = temp_delsimps ["lift_disj_eq", "lift_imp_disj"]
 
-fun MESON ths tm = prove(tm,MESON_TAC ths);
 fun METIS ths tm = prove(tm,METIS_TAC ths);
 
 val DISC_RW_KILL = DISCH_TAC THEN ONCE_ASM_REWRITE_TAC [] THEN
@@ -43,7 +42,6 @@ val ASM_ARITH_TAC = REPEAT (POP_ASSUM MP_TAC) THEN ARITH_TAC;
 val ASM_REAL_ARITH_TAC = REAL_ASM_ARITH_TAC; (* realLib *)
 val IMP_CONJ           = CONJ_EQ_IMP;        (* cardinalTheory *)
 val FINITE_SUBSET      = SUBSET_FINITE_I;    (* pred_setTheory *)
-val LE_0               = ZERO_LESS_EQ;       (* arithmeticTheory *)
 val SUM_0              = SUM_0';             (* iterateTheory *)
 val SUM_ABS            = SUM_ABS';           (* iterateTheory *)
 val SUM_ABS_LE         = SUM_ABS_LE';        (* iterateTheory *)

--- a/src/real/analysis/real_topologyScript.sml
+++ b/src/real/analysis/real_topologyScript.sml
@@ -22,7 +22,7 @@ open numTheory numLib unwindLib tautLib prim_recTheory
      combinTheory quotientTheory arithmeticTheory realTheory
      jrhUtils pairTheory boolTheory pred_setTheory optionTheory
      sumTheory InductiveDefinition listTheory mesonLib
-     realLib topologyTheory metricTheory netsTheory;
+     RealArith realSimps topologyTheory metricTheory netsTheory;
 
 open wellorderTheory cardinalTheory permutesTheory iterateTheory hurdUtils;
 
@@ -30,7 +30,6 @@ val _ = new_theory "real_topology";
 
 val std_ss' = std_ss -* ["lift_disj_eq", "lift_imp_disj"];
 
-fun MESON ths tm = prove(tm,MESON_TAC ths);
 fun METIS ths tm = prove(tm,METIS_TAC ths);
 
 val DISC_RW_KILL = DISCH_TAC THEN ONCE_ASM_REWRITE_TAC [] THEN
@@ -43,7 +42,6 @@ val ASM_ARITH_TAC = REPEAT (POP_ASSUM MP_TAC) THEN ARITH_TAC;
 val ASM_REAL_ARITH_TAC = REAL_ASM_ARITH_TAC; (* realLib *)
 val IMP_CONJ           = CONJ_EQ_IMP;        (* cardinalTheory *)
 val FINITE_SUBSET      = SUBSET_FINITE_I;    (* pred_setTheory *)
-val LE_0               = ZERO_LESS_EQ;       (* arithmeticTheory *)
 val SUM_ABS            = SUM_ABS';           (* iterateTheory *)
 val SUM_ABS_LE         = SUM_ABS_LE';        (* iterateTheory *)
 val SUM_EQ             = SUM_EQ';            (* iterateTheory *)
@@ -1720,11 +1718,11 @@ val LINEAR_INJECTIVE_LEFT_INVERSE = store_thm ("LINEAR_INJECTIVE_LEFT_INVERSE",
    [METIS_TAC [], REWRITE_TAC [GSYM INJECTIVE_LEFT_INVERSE] THEN DISCH_TAC] THEN
    FULL_SIMP_TAC std_ss [linear] THEN KNOW_TAC ``0 = (f:real->real) 0`` THENL
    [UNDISCH_TAC ``!c x. (f:real->real) (c * x) = c * f x`` THEN
-    DISCH_THEN (MP_TAC o SPECL [``0:real``, ``0:real``]) THEN REAL_ARITH_TAC,
+    DISCH_THEN (MP_TAC o SPECL [``0:real``, ``0:real``]) >> rw [],
     DISCH_TAC THEN ONCE_ASM_REWRITE_TAC []] THEN DISCH_TAC THEN
    UNDISCH_TAC ``!x y. ((f:real->real) x = f y) ==> (x = y)`` THEN
    DISCH_THEN (MP_TAC o SPECL [``1:real``,``0:real``]) THEN
-   POP_ASSUM MP_TAC THEN REAL_ARITH_TAC,
+   POP_ASSUM MP_TAC THEN rw [],
    DISCH_THEN (X_CHOOSE_TAC ``h:real->real``) THEN EXISTS_TAC ``h:real->real`` THEN
    POP_ASSUM MP_TAC THEN
    ASM_SIMP_TAC std_ss [FORALL_IN_IMAGE, GSPECIFICATION] THEN STRIP_TAC THEN
@@ -10711,19 +10709,19 @@ val CLOSED_STANDARD_HYPERPLANE = store_thm ("CLOSED_STANDARD_HYPERPLANE",
  ``!a. closed {x:real | x = a}``,
   REPEAT GEN_TAC THEN
   MP_TAC(ISPECL [``1:real``, ``a:real``] CLOSED_HYPERPLANE) THEN
-  REAL_ARITH_TAC);
+  rw []);
 
 val CLOSED_HALFSPACE_COMPONENT_LE = store_thm ("CLOSED_HALFSPACE_COMPONENT_LE",
  ``!a. closed {x:real | x <= a}``,
   REPEAT GEN_TAC THEN
   MP_TAC(ISPECL [``1:real``, ``a:real``] CLOSED_HALFSPACE_LE) THEN
-  REAL_ARITH_TAC);
+  rw []);
 
 val CLOSED_HALFSPACE_COMPONENT_GE = store_thm ("CLOSED_HALFSPACE_COMPONENT_GE",
  ``!a. closed {x:real | x >= a}``,
   REPEAT GEN_TAC THEN
   MP_TAC(ISPECL [``1:real``, ``a:real``] CLOSED_HALFSPACE_GE) THEN
-  REAL_ARITH_TAC);
+  rw []);
 
 (* ------------------------------------------------------------------------- *)
 (* Openness of halfspaces.                                                   *)

--- a/src/real/iterateScript.sml
+++ b/src/real/iterateScript.sml
@@ -30,7 +30,6 @@ val _ = new_theory "iterate";
 (* MESON, METIS, SET_TAC, SET_RULE, ASSERT_TAC, ASM_ARITH_TAC                *)
 (* ------------------------------------------------------------------------- *)
 
-fun MESON ths tm = prove(tm,MESON_TAC ths);
 fun METIS ths tm = prove(tm,METIS_TAC ths);
 
 val DISC_RW_KILL = DISCH_TAC >> ONCE_ASM_REWRITE_TAC [] \\
@@ -44,7 +43,6 @@ val ASM_REAL_ARITH_TAC = REAL_ASM_ARITH_TAC;
 (* Minimal hol-light compatibility layer *)
 val IMP_CONJ      = CONJ_EQ_IMP;     (* cardinalTheory *)
 val FINITE_SUBSET = SUBSET_FINITE_I; (* pred_setTheory *)
-val LE_0          = ZERO_LESS_EQ;    (* arithmeticTheory *)
 
 (* ------------------------------------------------------------------------- *)
 (* misc.                                                                     *)
@@ -138,12 +136,13 @@ val REAL_BOUNDS_LT = store_thm ("REAL_BOUNDS_LT",
  ``!x k:real. -k < x /\ x < k <=> abs(x) < k``,
   REAL_ARITH_TAC);
 
-Theorem LE_EXISTS: !m n:num. (m <= n) <=> (?d. n = m + d)
+Theorem LE_EXISTS :
+  !m n:num. (m <= n) <=> (?d. n = m + d)
 Proof
   simp[EQ_IMP_THM, PULL_EXISTS] >> rw[] >> qexists ‘n - m’ >> simp[]
 QED
 
-Theorem LT_EXISTS:
+Theorem LT_EXISTS :
   !m n. (m < n) <=> (?d. n = m + SUC d)
 Proof
   simp[EQ_IMP_THM] >> rw[] >> qexists ‘n - (m + 1)’ >> simp[]
@@ -1103,7 +1102,6 @@ End
 (* syntax is similar to the version also available for lists, where
    listRangeTheory has  [ m .. n ]
  *)
-
 val _ = add_rule { block_style = (AroundEachPhrase, (PP.CONSISTENT, 0)),
                    fixity = Closefix,
                    paren_style = OnlyIfNecessary,
@@ -4760,15 +4758,6 @@ val REAL_X_LE_SUP = store_thm
    >> Suff `!y. P y ==> y <= sup P` >- PROVE_TAC [REAL_LE_TRANS]
    >> MATCH_MP_TAC REAL_SUP_UBOUND_LE
    >> PROVE_TAC []);
-
-val INF_DEF_ALT = store_thm (* c.f. "inf_alt" in seqTheory *)
-  ("INF_DEF_ALT",
-   ``!p. inf p = ~(sup (\r. ~r IN p)):real``,
-   RW_TAC std_ss []
-   >> PURE_REWRITE_TAC [inf_def, IMAGE_DEF]
-   >> Suff `(\r. p (-r)) = (\r. -r IN p)`
-   >- RW_TAC std_ss []
-   >> RW_TAC std_ss [FUN_EQ_THM,SPECIFICATION]);
 
 val LE_INF = store_thm
   ("LE_INF",

--- a/src/real/metricScript.sml
+++ b/src/real/metricScript.sml
@@ -17,7 +17,6 @@ open realTheory cardinalTheory topologyTheory;
 
 val _ = new_theory "metric";
 
-fun MESON ths tm = prove(tm,MESON_TAC ths);
 fun METIS ths tm = prove(tm,METIS_TAC ths);
 fun wrap a = [a];
 val Rewr  = DISCH_THEN (REWRITE_TAC o wrap);

--- a/src/real/realLib.sig
+++ b/src/real/realLib.sig
@@ -6,13 +6,12 @@ sig
    type conv = Abbrev.conv
    type tactic = Abbrev.tactic
 
-  val PURE_REAL_ARITH_TAC : tactic
-  val REAL_ARITH_TAC      : tactic
-  val REAL_ARITH          : term -> thm
-  val REAL_ASM_ARITH_TAC  : tactic
+   val REAL_ARITH_TAC      : tactic
+   val REAL_ARITH          : term -> thm
+   val REAL_ASM_ARITH_TAC  : tactic
 
-   val real_ss : simpLib.simpset
    (* Incorporates simpsets for bool, pair, and arithmetic *)
+   val real_ss : simpLib.simpset
 
    (* syntax *)
    val prefer_real     : unit -> unit

--- a/src/real/realLib.sml
+++ b/src/real/realLib.sml
@@ -44,15 +44,8 @@ struct
     List.app doit operators
   end
 
-  (* The default REAL_ARITH, etc. can be switched here. *)
-  val REAL_ARITH_TAC     = TRY(RealArith.OLD_REAL_ARITH_TAC)
-                           THEN RealField.REAL_ARITH_TAC;
+  val REAL_ARITH_TAC     = RealField.REAL_ARITH_TAC;
+  val REAL_ARITH         = RealField.REAL_ARITH;
+  val REAL_ASM_ARITH_TAC = RealField.REAL_ASM_ARITH_TAC;
 
-  fun REAL_ARITH tm      = RealArith.OLD_REAL_ARITH tm
-                           handle HOL_ERR _ => RealField.REAL_ARITH tm;
-
-  val REAL_ASM_ARITH_TAC = TRY(RealArith.OLD_REAL_ASM_ARITH_TAC)
-                           THEN RealField.REAL_ASM_ARITH_TAC;
-
- (* NOTE: The PURE_REAL_ARITH_TAC exported by realLib is always the old one *)
 end

--- a/src/real/realSimps.sml
+++ b/src/real/realSimps.sml
@@ -1,6 +1,7 @@
 (* ------------------------------------------------------------------------- *)
 (* A real simpset (includes Peano arithmetic and pairs).                     *)
 (* ------------------------------------------------------------------------- *)
+
 structure realSimps :> realSimps =
 struct
 
@@ -9,7 +10,7 @@ open HolKernel Parse boolLib realTheory simpLib realSyntax
 (* Fix the grammar used by this file *)
 structure Parse = struct
   open Parse
-  val (Type,Term) = parse_from_grammars realTheory.real_grammars
+  val (Type,Term) = parse_from_grammars real_grammars
 end
 
 open Parse
@@ -235,7 +236,8 @@ val ltnb12 = TAC_PROOF(([], “0 < NUMERAL (BIT1 n) /\ 0 < NUMERAL (BIT2 n)”),
                                    arithmeticTheory.BIT2,
                                    arithmeticTheory.ADD_CLAUSES,
                                    prim_recTheory.LESS_0])
-val let_id = TAC_PROOF(([], “LET (\n. n) x = x”),
+
+val let_id = TAC_PROOF(([], “LET (\n :'a. n) x = x”),
                        SIMP_TAC boolSimps.bool_ss [LET_THM])
 
 val op_rwts =
@@ -494,8 +496,7 @@ fun is_arith_thm thm =
 
 val is_arith_asm = is_arith_thm o ASSUME
 
-(* The old d.p. is faster *)
-val ARITH = RealArith.OLD_REAL_ARITH
+val ARITH = RealArith.REAL_ARITH;
 
 open Trace Cache Traverse
 fun CTXT_ARITH thms tm = let
@@ -1266,4 +1267,4 @@ val RMULRELNORM_ss = SSFRAG {
 
 val _ = addfrags [RMULRELNORM_ss]
 
-end
+end (* struct *)

--- a/src/real/selftest.sml
+++ b/src/real/selftest.sml
@@ -4,8 +4,6 @@ open simpLib realSimps isqrtLib RealArith RealField bitArithLib;
 
 open testutils;
 
-(* The original version and old port by Hurd *)
-val REAL_ARITH0 = RealArith.OLD_REAL_ARITH;
 (* The new port, only suppports integral coefficients *)
 val REAL_ARITH1 = RealArith.REAL_ARITH;
 (* The new port, also suppports rational coefficients *)
@@ -327,17 +325,9 @@ val _ = List.app (real_arith_test REAL_ARITH2) [
       (* from iterateTheory.SUM_GP_BASIC *)
       ("REAL_ARITH2_03", “1 - x * x pow n + (1 - x) * (x * x pow n) = 1 - x * (x * x pow n)”),
 
-      (* from real_topologyTheory.LINEAR_INJECTIVE_LEFT_INVERSE
-         NOTE: Hurd's REAL_ARITH can solve this but HOL-Light's original one cannot.
-       *)
-      ("REAL_ARITH2_04", “((f :real->real) (&0 * &0) = &0 * f (&0)) ==> (&0 = f (&0))”),
-
       (* from real_topologyTheory.SEQ_HARMONIC_OFFSET *)
       ("REAL_ARITH2_05", “0 < e ==> N <> 0 ==> 0 < &N ==> realinv (&N) < e ==>
                           -a <= &M ==> &M + &N <= &n ==> &n + a <> 0 ==> &N <= abs (&n + a)”),
-
-      (* from real_topologyTheory.CLOSED_STANDARD_HYPERPLANE *)
-      ("REAL_ARITH2_06", “closed {x | 1 * x = (a:real)} ==> closed {x | x = (a:real)}”),
 
       (* from integrationTheory.FUNDAMENTAL_THEOREM_OF_CALCULUS_STRONG *)
       ("REAL_ARITH2_07", “x = (b:real) ==> &0 < &1 ==> 0 <= e / 2 pow (4 + n b) * 0”)


### PR DESCRIPTION
Hi,

Recently more and more decision procedures are added into HOL4's code base. I consider these "non-proof" code will increase the overall maintenance efforts when bugs are found in them. On the other hand, currently there are many duplicate functionalities here and there, some are ported code from HOL-Light from different time periods. This PR does one such cleanups in `RealArith`.

The important decision procedure for real arithmetics, `REAL_ARITH`, currently has two versions in the code base. The old one was ported from HOL-Light by Joe Hurd in 1998 (available as `RealArith.OLD_REAL_ARITH`, etc.), and the new port was done by me in 2022 (#1043). The new version supports rational coefficients while the old one only supports integral coefficients. But the old version was kept for backward compatibility purposes with the concern that it may solve extra problems that the new one cannot.

There are indeed some use cases such that the new `REAL_ARITH` cannot solve, and the code was patched (on top of HOL-Light's original decision procedure) to handle those extra problems, which has the following shape:
```
?- f (l) = f (r)
```
where `f :real -> 'a` is an uninterpreted function and `l = r` is a solvable real arithmetic equation. Essentially `REAL_ARITH` only does some normalizations to both `l` and `r` and make them literally the same, (and then even `REWRITE_TAC []` can reduce it to `T`).

Obviously these "border" cases are not what `REAL_ARITH` are best for (i.e. solving group of inequalities of multivariate rational-coefficient real polynomials), and it turns out that all those broken cases can be alternatively handle by `rw []` (with a little more helper theorems at most).

What I did in this PR is the following: I completely removed the old port of `REAL_ARITH` (this reduced about 1,000 lines of code in `RealArith.sml`) and also removed all the patches (which slightly slows down the whole process) in the new port, and now HOL4's `REAL_ARITH` will solve exactly the same set of problems as in HOL-Light.   Now the interface from `realLib` only uses the new port.   A small number of existing proofs in the core library and examples are fixed due to the removal of those patches. This small incompatibility is documented in the next release notes.

The CI test (total run time) will show that there's no visible performance degrade after these changes (both the old and new `REAL_ARITH` has some internal caches).

--Chun
