### PR TITLE
Implement basic regex search functionality for DB.find

### DIFF
--- a/src/postkernel/DB.sml
+++ b/src/postkernel/DB.sml
@@ -227,12 +227,11 @@ fun thy s =
 
 fun findpred pat s =
     let
-      val pat = toLower pat and s = toLower s
-      val orparts = String.tokens (equal #"|") pat
-      val subparts = map (String.tokens (equal #"~")) orparts
-      val subpred = List.all (C occurs s)
+        open DBSearchParser
+        val pat = toLower pat and s = toLower s
+        val regexp = compile_pattern pat
     in
-      List.exists subpred subparts
+        matches regexp s
     end
 
 fun find0 incprivatep s =

--- a/src/postkernel/DB.sml
+++ b/src/postkernel/DB.sml
@@ -229,9 +229,8 @@ fun findpred pat s =
     let
         open DBSearchParser
         val pat = toLower pat and s = toLower s
-        val regexp = compile_pattern pat
     in
-        matches regexp s
+        contains_regexp pat s
     end
 
 fun find0 incprivatep s =

--- a/src/postkernel/DBSearchParser.sig
+++ b/src/postkernel/DBSearchParser.sig
@@ -1,0 +1,6 @@
+signature DBSearchParser =
+sig
+    type regexp
+    val compile_pattern : string -> regexp
+    val matches : regexp -> string -> bool
+end

--- a/src/postkernel/DBSearchParser.sig
+++ b/src/postkernel/DBSearchParser.sig
@@ -1,6 +1,10 @@
 signature DBSearchParser =
 sig
-    type search_regexp
+    datatype search_regexp = Optional of search_regexp
+                | Or of search_regexp * search_regexp
+                | Twiddle of search_regexp * search_regexp
+                | Seq of search_regexp * search_regexp
+                | Word of char list
     val parse_regexp : string -> search_regexp
     val translate_regexp : search_regexp -> regexpMatch.regexp
     val contains_regexp : string -> string -> bool

--- a/src/postkernel/DBSearchParser.sig
+++ b/src/postkernel/DBSearchParser.sig
@@ -1,4 +1,7 @@
 signature DBSearchParser =
 sig
+    type search_regexp
+    val parse_regexp : string -> search_regexp
+    val translate_regexp : search_regexp -> regexpMatch.regexp
     val contains_regexp : string -> string -> bool
 end

--- a/src/postkernel/DBSearchParser.sig
+++ b/src/postkernel/DBSearchParser.sig
@@ -1,6 +1,4 @@
 signature DBSearchParser =
 sig
-    type regexp
-    val compile_pattern : string -> regexp
-    val matches : regexp -> string -> bool
+    val contains_regexp : string -> string -> bool
 end

--- a/src/postkernel/DBSearchParser.sml
+++ b/src/postkernel/DBSearchParser.sml
@@ -22,13 +22,13 @@ val ERR = mk_HOL_ERR "DBSearchParser"
  * E' --> E
  *)
 
-datatype regexp = Optional of regexp
-                | Or of regexp * regexp
-                | Twiddle of regexp * regexp
-                | Seq of regexp * regexp
+datatype search_regexp = Optional of search_regexp
+                | Or of search_regexp * search_regexp
+                | Twiddle of search_regexp * search_regexp
+                | Seq of search_regexp * search_regexp
                 | Word of char list
 
-datatype token = E of regexp
+datatype token = E of search_regexp
                | T of char
                | Start
 

--- a/src/postkernel/DBSearchParser.sml
+++ b/src/postkernel/DBSearchParser.sml
@@ -1,0 +1,124 @@
+structure DBSearchParser :> DBSearchParser =
+struct
+
+open HolKernel
+
+val ERR = mk_HOL_ERR "DBSearchParser"
+
+datatype token = Tilde
+               | Question
+               | Pipe
+               | LeftBracket
+               | RightBracket
+               | Word of string
+               | EOF
+
+datatype regexp = Maybe of regexp
+                | Orderless of regexp * regexp
+                | Union of regexp * regexp
+                | Then of regexp * regexp
+                | Term of string
+
+fun isSpecialChar c = Lib.mem c [#"~", #"(", #")", #"?", #"|"]
+
+fun tokenise str = let
+    fun tokenise' [] [] = [EOF]
+      | tokenise' acc [] = [Word(String.implode (rev acc)), EOF]
+      | tokenise' acc (c::cs) =
+        (case (acc, c) of
+            ([], #"~") => Tilde :: tokenise' [] cs
+          | ([], #"?") => Question :: tokenise' [] cs
+          | ([], #"|") => Pipe :: tokenise' [] cs
+          | ([], #"(") => LeftBracket :: tokenise' [] cs
+          | ([], #")") => RightBracket :: tokenise' [] cs
+          | _ => if isSpecialChar c
+                 then Word(String.implode (rev acc)) :: tokenise' [] (c::cs)
+                 else tokenise' (c::acc) cs
+        )
+in
+    tokenise' [] (String.explode str)
+end
+
+val tokens = ref [];
+
+fun tok() = hd (!tokens)
+
+fun advance() = let
+    val head = tok()
+    val _ = tokens := tl (!tokens)
+in head end
+
+fun consume(t) = if tok() = t
+             then advance()
+             else Word "Unexpected character"
+
+fun E() = let
+    val expr = T()
+in
+    case tok() of
+        Question => (advance(); Maybe expr)
+      | _ => expr
+end
+
+and E'() = C(E())
+
+and T() =
+    case tok() of
+        Word s => T'(F())
+      | LeftBracket => T'(F())
+      | _ => raise ERR "T" "Unexpected token"
+
+and T'(a) =
+    case tok() of
+        Tilde => (advance(); Orderless(a, T'(F())))
+      | Pipe => (advance(); Union(a, T'(F())))
+      | _ => a
+
+and F() =
+    case tok() of
+        Word s => (advance(); Term(s))
+      | LeftBracket => let
+          val _ = consume(LeftBracket)
+          val v = E()
+          val _ = consume(RightBracket)
+      in T'(v) end
+      | _ => raise ERR "F" "Unexpected token"
+
+and C(expr) =
+    case tok() of
+        EOF => expr
+      | _ => Then(expr, E'())
+
+fun compile_pattern str = (tokens := tokenise str; E'())
+
+val matches = let
+    fun matches' immediate_match regexp str =
+        case regexp of
+            Union (a, b) => matches' false a str orelse matches' false b str
+          | Orderless (a, b) => matches' false a str andalso matches' false b str
+          | Then (a, Then (Maybe r, b)) => matches' immediate_match (Then(a, b)) str
+                                           orelse matches' immediate_match (Then(a, Then(r, b))) str
+          | Then (a, b) => (case split_on_match a str 0 of
+                                SOME remainder => matches' true b remainder
+                              | NONE => false)
+          | Term s => if immediate_match
+                      then String.isPrefix s str
+                      else String.isSubstring s str
+          | Maybe r => true (* the only case where maybe matters is chained Thens *)
+
+    and split_on_match regexp str n =
+        if n > String.size str then NONE
+        else let
+            val length = String.size str
+            val current = String.substring (str, 0, n)
+        in
+            if matches' false regexp current
+            then SOME (String.substring (str, n, length - n))
+            else split_on_match regexp str (n+1)
+        end
+
+in
+    matches' false
+end
+
+end


### PR DESCRIPTION
Hi,
I've implemented some regex search support for DB.find based on issue #297 with a simple precedence parser.

The grammar supports the previous two operators, in their same order of operations:
1. Searching by intersection with `~` -- e.g. `DB.find "FORALL~THM"`
2. Searching for the union of two queries with `|` -- e.g. `DB.find "FORALL|EVERY"`

And newly implements the following
3. Brackets/precedence -- e.g. `DB.find "(LEFT|RIGHT)_FORALL_OR_THM"`
4. An optional element -- e.g. `DB.find "LEFT_AND_FOR(_?)ALL"`

I guess this shouldn't have any backwards compatibility impacts since the new characters would all be illegal in a theorem name.

Examples:
<img width="551" alt="image" src="https://github.com/HOL-Theorem-Prover/HOL/assets/32805678/69b07096-9cec-4265-802e-3181ef6c0cc9">
