### PR TITLE
HolSmt: usability improvements, initial support for exponentials

### DIFF
--- a/src/HolSmt/HolSmtLib.sig
+++ b/src/HolSmt/HolSmtLib.sig
@@ -11,6 +11,10 @@ signature HolSmtLib = sig
   val Z3_ORACLE_TAC : tactic
   val Z3_TAC : tactic
 
+  (* The tactics below accept a list of theorems, like metis_tac[] *)
+  val z3_tac : thm list -> tactic
+  val z3o_tac : thm list -> tactic
+
   val CVC_ORACLE_PROVE : term -> thm
   val YICES_PROVE : term -> thm
   val Z3_ORACLE_PROVE : term -> thm

--- a/src/HolSmt/HolSmtLib.sml
+++ b/src/HolSmt/HolSmtLib.sml
@@ -7,6 +7,8 @@ structure HolSmtLib :> HolSmtLib = struct
 
   open Abbrev
 
+  val op THEN = Tactical.THEN
+
   fun GENERIC_SMT_TAC solver goal =
   let
     val ERR = Feedback.mk_HOL_ERR "HolSmtLib" "GENERIC_SMT_TAC"
@@ -34,6 +36,12 @@ structure HolSmtLib :> HolSmtLib = struct
   val YICES_TAC = GENERIC_SMT_TAC Yices.Yices_Oracle
   val Z3_ORACLE_TAC = GENERIC_SMT_TAC Z3.Z3_SMT_Oracle
   val Z3_TAC = GENERIC_SMT_TAC Z3.Z3_SMT_Prover
+
+  fun assume_thms thms = Tactical.map_every (Tactic.ASSUME_TAC o Drule.GEN_ALL) thms
+
+  (* The tactics below accept a list of theorems, like metis_tac[] *)
+  fun z3_tac thms = assume_thms thms THEN Z3_TAC
+  fun z3o_tac thms = assume_thms thms THEN Z3_ORACLE_TAC
 
   fun prove (tm, tac) = Tactical.TAC_PROOF(([], tm), tac)
   fun CVC_ORACLE_PROVE tm = prove (tm, CVC_ORACLE_TAC)

--- a/src/HolSmt/SmtLib.sml
+++ b/src/HolSmt/SmtLib.sml
@@ -639,6 +639,7 @@ in
         INT_DIV_EDIV, INT_MOD_EMOD, INT_QUOT_EDIV, INT_REM_EMOD,
         (* others *)
         int_arithTheory.INT_NUM_SUB,
+        markerTheory.Abbrev_def,
         realaxTheory.real_min, realaxTheory.real_max, realTheory.abs
       ] else []
     end

--- a/src/HolSmt/SmtLib.sml
+++ b/src/HolSmt/SmtLib.sml
@@ -622,25 +622,39 @@ in
   fun SIMP_TAC simp_let =
   let
     open Tactical simpLib
-    (* TODO: In the future we should add all relevant theorems automatically,
-       either based on which symbols are used (recursively) or, perhaps more
-       simply, just translate all the theorems defined in all the theories that
-       are being used. For now we just manually add a few useful ones. *)
     val facts =
     let
-      open arithmeticTheory integerTheory
+      open arithmeticTheory integerTheory realTheory realaxTheory
     in
       if !include_theorems then [
+        (* NOTE: when adding a theorem to the list below, make sure that it
+           doesn't have any free var -- otherwise, ASSUME_TAC will specialize
+           the theorem to any free var in the goal that happens to have the same
+           name, which very often is not what is desired. As an example,
+           integerTheory's `INT_POW` should not be added -- instead, add
+           `int_exp`. If no appropriate quantified theorem is available,
+           `Drule.GEN_ALL` can be used to quantify all free vars in a theorem.
+
+           Also, make sure the theorem is really needed -- some theorems seem to
+           cause an explosion in the time needed to solve some goals, often
+           making Z3 unable to solve them -- and it's not always easy to tell a
+           priori which ones do. As an example, arithmeticTheory.EXP_1 doesn't
+           seem to cause issues, but EXP_2 prevents Z3 from solving
+           ``x DIV 42 <= x``. *)
+
         (* arithmeticTheory *)
-        GREATER_DEF, GREATER_EQ, MIN_DEF, MAX_DEF,
+        EXP, EXP_1, EXP_POS, GREATER_DEF, GREATER_EQ, MAX_DEF, MIN_DEF,
         (* integerTheory *)
         INT, INT_ADD, INT_INJ, INT_LE, INT_LT, INT_MAX, INT_MIN, INT_OF_NUM,
         INT_POS, NUM_OF_INT, NUM_INT_MUL, NUM_INT_EDIV, NUM_INT_EMOD,
-        INT_DIV_EDIV, INT_MOD_EMOD, INT_QUOT_EDIV, INT_REM_EMOD,
+        INT_DIV_EDIV, INT_MOD_EMOD, INT_QUOT_EDIV, INT_REM_EMOD, int_exp,
+        (* realTheory *)
+        abs, POW_2, POW_ONE, REAL_POW_LT,
+        (* realaxTheory *)
+        real_max, real_min, real_pow,
         (* others *)
         int_arithTheory.INT_NUM_SUB,
-        markerTheory.Abbrev_def,
-        realaxTheory.real_min, realaxTheory.real_max, realTheory.abs
+        markerTheory.Abbrev_def
       ] else []
     end
   in


### PR DESCRIPTION
This week I've had the opportunity to use HolSmt more extensively and noticed a few shortcomings. This PR fixes a few of them.

It contains the following 3 minor improvements:

1. Allow SMT solvers to peek under abbreviations

    Otherwise, they would only be able to see the variables that are being abbreviated to, but not the terms being abbreviated. This problem was causing some goals that can be solved with `metis_tac` to fail with HolSmt. The fix is to add the definition of the `Abbrev` symbol to the list of theorems that are added to the assumptions prior to calling the SMT solver.

2. Add `z3_tac` and `z3o_tac` tactics

    These accept a list of theorems, like `metis_tac`. The free vars in the theorems are automatically quantified with `Drule.GEN_ALL` and added to the list of assumptions in the goal, prior to sending the goal to the SMT solver.

    This is needed to avoid any passed-in theorems to be specialized to free vars in the goal that happen to have the same name, which is almost always not what the user wants (and if the user really wants it, they can always assume such theorems manually if needed). This matches the behavior of `metis_tac`, thus avoiding unwanted surprises.

    Note: in particular, when using these tactics and HolSmt is configured to call Z3 with a timeout, `z3o_tac[]` basically works as a (usually) more powerful "`metis_tac[]` + `DECIDE_TAC/intLib.ARITH_TAC` + `RealField.REAL_ARITH_TAC` + `wordsLib.WORD_DECIDE` + `blastLib.BBLAST_TAC` + `HolSatLib.SAT_ORACLE` + nonlinear int and real arithmetic DP", all at once (and usually faster as well) -- although keep in mind that `z3o_tac` works as an external oracle, which is not appropriate in some circumstances. However, even in these cases it's probably still great for prototyping, i.e. as something in-between a full proof and `cheat`.
    The main limitation I've found in arithmetic-related goals is that Z3 often seems to get stuck finding proofs if the user provides definitions of recursive functions (similar to `rw[recursive_function_def]` without the `Once` modifier). This could be solved in the future using the same technique that [F*](https://www.fstar-lang.org/) uses to encode recursive function definitions: by adding a (configurable) fuel parameter that limits how many times a function definition can be unfolded during the proof search.

3. Initial support for the `num`, `int` and `real` exponential functions

    Unfortunately, this feature is more complicated than it seems. For now, all I did was add a couple of useful theorems to the proving context, so that the SMT solvers can "understand" what these exponential functions are supposed to do, but this only allows them to solve some simpler goals.
    As you can see from the self-tests, the coverage is extremely spotty: some `num` and `real` theorems can be solved, but other simple ones can't, and almost no `int` theorems can be solved. This is in part due to some theorems causing SMT solvers to become stuck finding a proof and also in part due to some theorems that are missing in HOL4. However, even if such missing theorems would be added, I wouldn't expect them to go very far in terms of solving goals efficiently. That said, it's still surprising to me that Z3 can solve a lot more `num` theorems than `int` ones, given that Z3 doesn't even support natural numbers natively. 

    Since I'm currently working with goals with many exponentials, I am planning to improve this feature in an upcoming PR.
    Namely, it turns out that Z3 also has native support for an exponential/power operator. If other arithmetic operators are any indication, I would expect Z3's native power operator to solve a lot more goals than relying on adding theorems to the proving context. However, these operators in the Z3 and HOL4 theories all have different domains and codomains. Namely (written below in SML signature syntax):
      * HOL4's arithmeticTheory: `val ** : num -> num -> num`
      * HOL4's integerTheory: `val ** : int -> num -> int`
      * HOL4's realaxTheory: `val pow : real -> num -> real`
      * Z3 int: `val ^ : int -> int -> real`
      * Z3 real: `val ^ : real -> real -> real`

    As you can see, Z3's native power operators do not exactly match any of HOL4's operators, so implementing support for them would be similar to the previous implementation of integer division (which also didn't match any of HOL4's division functions). Namely, this would require:
    * Defining Z3's integer power (^) operator as a function in HOL4 (e.g. in HolSmtTheory)
      - e.g. something like:
        * [in terms of int's `**`]:
        ```val z3ipow_def = bossLib.Define `z3ipow x y = if 0 <= y then real_of_int (x ** (Num y)) else 1 / (real_of_int (x ** (Num (-y))))` ```
        * [in terms of real's `pow`]:
        ```val z3ipow_def = bossLib.Define `z3ipow x y = if 0 <= y then (real_of_int x) pow (Num y) else 1 / ((real_of_int x) pow (Num (-y)))` ```
    * Proving theorems that allow converting between the Z3 integer power operator and HOL4's existing exponential functions
    * Adding the above definition and theorems to the list of theorems passed to the SMT solvers, so they can reason about them
    * Add grammar support for translating and parsing Z3's power operator (and possibly for type conversion operators such as `real_of_int`, if it's not implemented yet)
    * Proof reconstruction would not work because (similarly to the DIV and MOD operators) Z3 would solve these proof steps as an ordinary arithmetic proof step, relying on internal knowledge of its power operator. HolSmt wouldn't be able to reconstruct this because HOL4's arithmetic decision procedures don't seem to support exponential functions and none of the Z3 proof rules are related to exponential functions in particular.
      - Ideally, solving proof reconstruction for this, similarly for the DIV and MOD operators, would likely require Z3 to provide more information in its proof log, which would likely require new proof inference rules to be created, which would likely require significant development effort in HolSmt and especially in Z3.

    Note, however, that Z3's native power operators are a Z3 extension and not part of the SMT-LIB standard. Therefore, since it would only work for Z3 and proof reconstruction would not work, HolSmt would only use it with `z3o_tac` or `Z3_ORACLE_{TAC,PROVE}` and not with the other tactics.

   Note: no code outside HolSmt was changed in this PR.

cc @tjark