### PR TITLE
Further cleanup of hurdUtils (assert -> simple_assert)

### DIFF
--- a/examples/miller/formalize/extra_pred_setScript.sml
+++ b/examples/miller/formalize/extra_pred_setScript.sml
@@ -11,6 +11,8 @@ open ho_proverTools subtypeTheory subtypeTools boolContext listContext;
 
 val _ = new_theory "extra_pred_set";
 
+val assert = simple_assert;
+
 (* ------------------------------------------------------------------------- *)
 (* Tools.                                                                    *)
 (* ------------------------------------------------------------------------- *)

--- a/examples/miller/formalize/extra_realScript.sml
+++ b/examples/miller/formalize/extra_realScript.sml
@@ -18,18 +18,6 @@ val Simplify = RW_TAC arith_ss;
 (* Definitions.                                                              *)
 (* ------------------------------------------------------------------------- *)
 
-Theorem inf_alt : (* was: inf_def *)
-    !p. inf p = ~(sup (IMAGE $~ p))
-Proof
-    RW_TAC real_ss [inf_def]
- >> Suff `(\r. p (-r)) = (IMAGE numeric_negate p)` >- rw []
- >> SET_EQ_TAC
- >> RW_TAC std_ss [IN_IMAGE, IN_APP]
- >> EQ_TAC >> RW_TAC std_ss []
- >- (Q.EXISTS_TAC `-x` >> rw [REAL_NEG_NEG])
- >> rw [REAL_NEG_NEG]
-QED
-
 val zreal_def = Define `zreal (x : real) = (x = 0)`;
 val nzreal_def = Define `nzreal (x : real) = ~(x = 0)`;
 val posreal_def = Define `posreal (x : real) = (0 < x)`;
@@ -40,17 +28,6 @@ val nposreal_def = Define `nposreal (x : real) = (0 <= ~x)`;
 (* ------------------------------------------------------------------------- *)
 (* Theorems.                                                                 *)
 (* ------------------------------------------------------------------------- *)
-
-val INF_DEF_ALT = store_thm
-  ("INF_DEF_ALT",
-   ``!p. inf p = ~(sup (\r. ~r IN p))``,
-   RW_TAC std_ss []
-   >> PURE_REWRITE_TAC [inf_alt, IMAGE_DEF]
-   >> Suff `{~x | x IN p} = (\r:real. ~r IN p)`
-   >- RW_TAC std_ss []
-   >> RW_TAC std_ss [EXTENSION]
-   >> RW_TAC std_ss [GSPECIFICATION, SPECIFICATION]
-   >> PROVE_TAC [REAL_NEGNEG]);
 
 val REAL_LE_EQ = store_thm
   ("REAL_LE_EQ",
@@ -282,7 +259,7 @@ val REAL_ADD_SUBTYPE = store_thm
                 (nposreal -> nposreal -> nposreal) INTER
                 (zreal -> x -> x) INTER
                 (x -> zreal -> x))``,
-   RW_TAC std_ss [IN_FUNSET, IN_NEGREAL, IN_POSREAL, IN_INTER,
+  RW_TAC real_ss [IN_FUNSET, IN_NEGREAL, IN_POSREAL, IN_INTER,
                   IN_NPOSREAL, IN_NNEGREAL, IN_NZREAL, IN_ZREAL]
    >> REPEAT (POP_ASSUM MP_TAC)
    >> REAL_ARITH_TAC);
@@ -296,7 +273,7 @@ val REAL_SUB_SUBTYPE = store_thm
                 (nposreal -> posreal -> negreal) INTER
                 (nposreal -> nnegreal -> nposreal) INTER
                 (x -> zreal -> x))``,
-   RW_TAC std_ss [IN_FUNSET, IN_NEGREAL, IN_POSREAL, IN_INTER,
+  RW_TAC real_ss [IN_FUNSET, IN_NEGREAL, IN_POSREAL, IN_INTER,
                   IN_NPOSREAL, IN_NNEGREAL, IN_NZREAL, IN_ZREAL,
                   REAL_SUB_RZERO]
    >> REPEAT (POP_ASSUM MP_TAC)

--- a/examples/miller/groups/extra_arithScript.sml
+++ b/examples/miller/groups/extra_arithScript.sml
@@ -1,23 +1,19 @@
-open HolKernel Parse boolLib;
-open bossLib arithmeticTheory dividesTheory gcdTheory
-     res_quanTheory pred_setTheory subtypeTheory
-     res_quanTools subtypeTools ho_proverTools numContext hurdUtils
-     extra_numTheory ho_basicTools
+open HolKernel Parse boolLib bossLib;
 
-(* interactive mode
-quietdec := false;
-*)
+open arithmeticTheory dividesTheory gcdTheory res_quanTheory pred_setTheory
+     subtypeTheory res_quanTools subtypeTools ho_proverTools numContext
+     hurdUtils extra_numTheory ho_basicTools;
 
 val _ = new_theory "extra_arith";
 val _ = ParseExtras.temp_loose_equality()
 
-val !! = REPEAT;
+val assert = simple_assert;
 
 (* ------------------------------------------------------------------------- *)
 (* Tools.                                                                    *)
 (* ------------------------------------------------------------------------- *)
 
-val S_TAC = !! (POP_ASSUM MP_TAC) >> !! RESQ_STRIP_TAC;
+val S_TAC = rpt (POP_ASSUM MP_TAC) >> rpt RESQ_STRIP_TAC;
 
 val (R_TAC, AR_TAC, R_TAC', AR_TAC') = SIMPLIFY_TACS num_c;
 

--- a/examples/miller/ho_prover/ho_basicTools.sml
+++ b/examples/miller/ho_prover/ho_basicTools.sml
@@ -1,33 +1,13 @@
-(* non-interactive mode
-*)
 structure ho_basicTools :> ho_basicTools =
 struct
+
 open HolKernel Parse boolLib;
-
-(* interactive mode
-val () = loadPath := union ["..", "../finished"] (!loadPath);
-val () = app load
-  ["bossLib",
-   "realLib",
-   "rich_listTheory",
-   "arithmeticTheory",
-   "numTheory",
-   "pred_setTheory",
-   "pairTheory",
-   "combinTheory",
-   "listTheory",
-   "dividesTheory",
-   "primeTheory",
-   "gcdTheory",
-   "probLib",
-   "hoTools"];
-val () = show_assums := true;
-
-*)
 
 open hurdUtils;
 
 infixr 0 ##
+
+val assert = simple_assert;
 
 (* ------------------------------------------------------------------------- *)
 (* Debugging.                                                                *)

--- a/examples/miller/ho_prover/ho_proverTools.sml
+++ b/examples/miller/ho_prover/ho_proverTools.sml
@@ -1,7 +1,6 @@
-(* non-interactive mode
-*)
 structure ho_proverTools :> ho_proverTools =
 struct
+
 open HolKernel Parse boolLib BasicProvers;
 
 structure Parse = struct
@@ -12,17 +11,6 @@ structure Parse = struct
         |> parse_from_grammars
 end
 open Parse
-
-
-(* interactive mode
-val () = loadPath := union ["..", "../finished"] (!loadPath);
-val () = app load
-  ["HurdUseful",
-   "ho_basicTools",
-   "unifyTools",
-   "skiTheory"];
-val () = show_assums := true;
-*)
 
 open Susp combinTheory hurdUtils skiTools;
 
@@ -36,10 +24,10 @@ val op|| = op ORELSE;
 val op>> = op THEN1;
 val !! = REPEAT;
 
-(* non-interactive mode
-*)
 fun trace _ _ = ();
 fun printVal _ = ();
+
+val assert = simple_assert;
 
 (* ------------------------------------------------------------------------- *)
 (* vterm operations                                                          *)

--- a/examples/miller/ho_prover/skiTools.sml
+++ b/examples/miller/ho_prover/skiTools.sml
@@ -1,18 +1,7 @@
-(* non-interactive mode
-*)
 structure skiTools :> skiTools =
 struct
-open HolKernel Parse boolLib;
 
-(* interactive mode
-val () = loadPath := union ["..", "../finished"] (!loadPath);
-val () = app load
-  ["HurdUseful",
-   "ho_basicTools",
-   "unifyTools",
-   "skiTheory"];
-val () = show_assums := true;
-*)
+open HolKernel Parse boolLib;
 
 open hurdUtils ho_basicTools unifyTools skiTheory;
 
@@ -25,10 +14,10 @@ val op|| = op ORELSE;
 val op>> = op THEN1;
 val !! = REPEAT;
 
-(* non-interactive mode
-*)
 fun trace _ _ = ();
 fun printVal _ = ();
+
+val assert = simple_assert;
 
 (* ------------------------------------------------------------------------- *)
 (* Type/term substitutions                                                   *)
@@ -113,7 +102,7 @@ local
          let
            val _ = assert (Name = Name') (ERR "ski_unify" "different vars")
            val _ = assert (Ty = Ty')
-             (BUG "ski_unify" "same var, different types?")
+                          (BUG "ski_unify" "same var, different types?")
          in
            solve vars sub rest
          end
@@ -121,7 +110,7 @@ local
          let
            val _ =
              assert (Name = Name' andalso Thy = Thy')
-             (ERR "ski_unify" "different vars")
+                    (ERR "ski_unify" "different vars")
            val sub_extra = var_type_unify (snd vars) Ty Ty'
            val sub' = refine_subst sub ([], sub_extra)
            val vars' = (map (inst_ty sub_extra) ## I) vars

--- a/examples/miller/ho_prover/unifyTools.sml
+++ b/examples/miller/ho_prover/unifyTools.sml
@@ -1,29 +1,7 @@
-(* non-interactive mode
-*)
 structure unifyTools :> unifyTools =
 struct
-open HolKernel Parse boolLib;
 
-(* interactive mode
-val () = loadPath := union ["..", "../finished"] (!loadPath);
-val () = app load
-  ["bossLib",
-   "realLib",
-   "rich_listTheory",
-   "arithmeticTheory",
-   "numTheory",
-   "pred_setTheory",
-   "pairTheory",
-   "combinTheory",
-   "listTheory",
-   "dividesTheory",
-   "primeTheory",
-   "gcdTheory",
-   "probLib",
-   "prob_extraTools",
-   "HurdUseful"];
-val () = show_assums := true;
-*)
+open HolKernel Parse boolLib;
 
 open hurdUtils;
 
@@ -35,6 +13,8 @@ val op<< = op THENL;
 val op|| = op ORELSE;
 val op>> = op THEN1;
 val !! = REPEAT;
+
+val assert = simple_assert;
 
 (* ------------------------------------------------------------------------- *)
 (* Type unification.                                                         *)

--- a/examples/miller/subtypes/subtypeScript.sml
+++ b/examples/miller/subtypes/subtypeScript.sml
@@ -1,11 +1,10 @@
-(* non-interactive mode
-*)
-open HolKernel Parse boolLib;
+open HolKernel Parse boolLib bossLib;
+
+open combinTheory pred_setTheory hurdUtils res_quanTheory ho_proverTools
+     pairTheory;
+
 val _ = new_theory "subtype";
 val _ = ParseExtras.temp_loose_equality()
-
-open bossLib combinTheory pred_setTheory hurdUtils
-     res_quanTheory ho_proverTools pairTheory;
 
 infixr 0 ++ << || THENC ORELSEC ORELSER ##;
 infix 1 >>;

--- a/examples/miller/subtypes/subtypeTools.sml
+++ b/examples/miller/subtypes/subtypeTools.sml
@@ -1,38 +1,16 @@
-(* non-interactive mode
-*)
 structure subtypeTools :> subtypeTools =
 struct
-open HolKernel Parse boolLib;
 
-(* interactive mode
-val () = loadPath := "../ho_prover" :: !loadPath;
-val () = app load
-  ["Susp",
-   "combinTheory",
-   "pred_setTheory",
-   "prob_extraTheory",
-   "BasicProvers",
-   "HurdUseful",
-   "ho_basicTools",
-   "ho_discrimTools",
-   "ho_proverTools",
-   "subtypeTheory"];
-val () = show_assums := true;
-*)
+open HolKernel Parse boolLib BasicProvers;
 
-open Susp combinTheory pred_setTheory BasicProvers
-     hurdUtils subtypeTheory ho_discrimTools
+open Susp combinTheory pred_setTheory hurdUtils subtypeTheory ho_discrimTools
      ho_proverTools ho_basicTools;
 
-infixr 0 oo ## ++ << || THENC ORELSEC THENR ORELSER -->;
-infix 1 >> |->;
+infixr 0 oo ## THENC ORELSEC THENR ORELSER -->;
+infix 1 |->;
 infix thenf orelsef then_frule orelse_frule join_frule;
 
-val op++ = op THEN;
-val op<< = op THENL;
-val op|| = op ORELSE;
-val op>> = op THEN1;
-val !! = REPEAT;
+val assert = simple_assert;
 
 (* ------------------------------------------------------------------------- *)
 (* Debugging.                                                                *)
@@ -806,8 +784,8 @@ fun SIMPLIFY_TAC_X conv ctext ths =
   end;
 
 fun PRESIMPLIFY_TAC ctext ths =
-  EVERY (map (ASSUME_TAC o GEN_ALL) ths)
-  ++ ASM_MATCH_MP_TAC (ths @ context_forwards ctext);
+    EVERY (map (ASSUME_TAC o GEN_ALL) ths)
+ >> ASM_MATCH_MP_TAC (ths @ context_forwards ctext);
 
 val SIMPLIFY_TAC' = SIMPLIFY_TAC_X SIMPLIFY_CONV';
 val SIMPLIFY_TAC = SIMPLIFY_TAC_X SIMPLIFY_CONV;

--- a/src/prekernel/Lib.sig
+++ b/src/prekernel/Lib.sig
@@ -148,6 +148,7 @@ sig
    val set_diff : ''a list -> ''a list -> ''a list
    val set_eq : ''a list -> ''a list -> bool
    val setify : (''a -> ''a -> bool) -> ''a list -> ''a list
+   val simple_assert : bool -> exn -> unit
    val single : 'a -> 'a list
    val singleton_of_list : 'a list -> 'a
    val snd : 'a * 'b -> 'b

--- a/src/prekernel/Lib.sml
+++ b/src/prekernel/Lib.sml
@@ -40,6 +40,8 @@ fun try f x = f x handle e => Feedback.Raise e
 
 fun assert P x = assert_exn P x (ERR "assert" "predicate not true")
 
+fun simple_assert b e = if b then () else raise e;
+
 (*---------------------------------------------------------------------------*
  *        Common list operations                                             *
  *---------------------------------------------------------------------------*)

--- a/src/res_quan/src/hurdUtils.sig
+++ b/src/res_quan/src/hurdUtils.sig
@@ -13,9 +13,6 @@ sig
   val BUG_to_string : exn -> string
   val err_BUG : string -> exn -> exn
 
-  (* Success and failure *)
-  val simple_assert : bool -> exn -> unit
-
   (* Exception combinators *)
   val nof : 'a -> 'b
   val allf : 'a -> 'a

--- a/src/res_quan/src/hurdUtils.sig
+++ b/src/res_quan/src/hurdUtils.sig
@@ -14,11 +14,7 @@ sig
   val err_BUG : string -> exn -> exn
 
   (* Success and failure *)
-  val assert : bool -> exn -> unit
-  val try : ('a -> 'b) -> 'a -> 'b
-  val total : ('a -> 'b) -> 'a -> 'b option
-  val can : ('a -> 'b) -> 'a -> bool
-  val partial : exn -> ('a -> 'b option) -> 'a -> 'b
+  val simple_assert : bool -> exn -> unit
 
   (* Exception combinators *)
   val nof : 'a -> 'b

--- a/src/res_quan/src/hurdUtils.sml
+++ b/src/res_quan/src/hurdUtils.sml
@@ -65,9 +65,7 @@ fun err_BUG s (h as HOL_ERR _) =
 
 (* Success and failure *)
 
-(* renamed due to conflict with Lib.assert *)
-fun simple_assert b e = if b then () else raise e;
-val assert = simple_assert; (* only for the rest of this file *)
+val assert = simple_assert; (* renamed and moved to Lib *)
 
 (* Exception combinators *)
 

--- a/src/res_quan/src/hurdUtils.sml
+++ b/src/res_quan/src/hurdUtils.sml
@@ -7,8 +7,9 @@
 structure hurdUtils :> hurdUtils =
 struct
 
-open Susp HolKernel Parse Hol_pp boolLib metisLib bossLib BasicProvers;
-open pairTheory res_quanTools pred_setTheory; (* for RESQ_STRIP_TAC *)
+open HolKernel boolLib BasicProvers;
+
+open Susp Hol_pp metisLib simpLib pairTheory res_quanTools numLib;
 
 infixr 0 oo THENR ORELSER ## thenf orelsef;
 
@@ -64,15 +65,9 @@ fun err_BUG s (h as HOL_ERR _) =
 
 (* Success and failure *)
 
-fun assert b e = if b then () else raise e;
-fun try f a = f a
-  handle (h as HOL_ERR _) => (print (exn_to_string h); raise h)
-       | (b as BUG_EXN _) => (print (BUG_to_string b); raise b)
-       | e => (print "\ntry: strange exception raised\n"; raise e);
-fun total f x = SOME (f x) handle HOL_ERR _ => NONE;
-fun can f = Option.isSome o total f;
-fun partial (e as HOL_ERR _) f x = (case f x of SOME y => y | NONE => raise e)
-  | partial _ _ _ = raise BUG "partial" "must take a HOL_ERR";
+(* renamed due to conflict with Lib.assert *)
+fun simple_assert b e = if b then () else raise e;
+val assert = simple_assert; (* only for the rest of this file *)
 
 (* Exception combinators *)
 
@@ -713,7 +708,7 @@ fun var_match vars tm tm' =
 val FUN_EQ = FUN_EQ_THM;
 
 val SET_EQ = prove (“!s t :'a -> bool. (s = t) <=> (!x. x IN s <=> x IN t)”,
-                    SIMP_TAC std_ss [IN_DEF, FUN_EQ_THM]);
+                    SIMP_TAC bool_ss [IN_DEF, FUN_EQ_THM]);
 
 val hyps = foldl (fn (h,t) => tunion (hyp h) t) [];
 
@@ -1057,12 +1052,8 @@ val Suff = Q_TAC SUFF_TAC
 (* A simple-minded CNF conversion.                                       *)
 (* --------------------------------------------------------------------- *)
 
-local
-  open simpLib
-in
-  val EXPAND_COND_CONV =
-    QCONV (SIMP_CONV (pureSimps.pure_ss ++ boolSimps.COND_elim_ss) [])
-end
+val EXPAND_COND_CONV =
+    QCONV (SIMP_CONV (pureSimps.pure_ss ++ boolSimps.COND_elim_ss) []);
 
 val EQ_IFF_CONV = QCONV (PURE_REWRITE_CONV [EQ_IMP_THM]);
 


### PR DESCRIPTION
Hi,

Currently there's a function `assert` in `hurdUtils` which has name conflict with `Lib.assert` (and this stops user code using `Lib.assert`, to open `hurdUtils` safely.) It has the following signature:
```
val assert : bool -> exn -> unit
```
This `assert` function simply checks if the first argument is true and return `()`, or throw the exception provided by the 2nd argument. The function `assert` (and `assert_exn`) in `Lib` is slightly more advanced, in the sense that they take a predicate and a value and calls the predicate on the value to know the assertion condition:
```
val assert : ('a -> bool) -> 'a -> 'a
val assert_exn : ('a -> bool) -> 'a -> exn -> 'a
```
I think the one in `hurdUtils` could be renamed to `simple_assert`, whose behavior is actually the one found in many other programming languages including C.

All code using `hurdUtils.assert` are under `examples/miller`, where I made minimal fixes by putting `val assert = simple_assert` at the beginning of the related scripts (beside some other minor cleanups).

P.S. With this change, I'm going to `open hurdUtils` in `transcScript.sml` (where `Lib.assert` is used), to upgrade the definition of `rpow`.

Chun