### PR TITLE
Extended domain of rpow (powr)

### DIFF
--- a/src/probability/martingaleScript.sml
+++ b/src/probability/martingaleScript.sml
@@ -1898,6 +1898,12 @@ Proof
  >> PROVE_TAC [FCP_CONCAT_THM]
 QED
 
+Theorem pair_operation_CONS :
+    pair_operation (\x y. [x; y]) (EL 0) (EL 1)
+Proof
+    rw [pair_operation_def]
+QED
+
 val general_cross_def = Define
    ‘general_cross (cons :'a -> 'b -> 'c) A B = {cons a b | a IN A /\ b IN B}’;
 
@@ -7696,6 +7702,7 @@ Proof
  >> rw [extreal_abs_def]
  >> ‘0 < abs (a + b) /\ 0 < abs a /\ 0 < abs b’ by rw []
  >> rw [normal_powr, extreal_of_num_def, extreal_add_def, extreal_mul_def, extreal_le_eq]
+ >> ONCE_REWRITE_TAC [REAL_MUL_COMM]
  (* below is real-only *)
  >> MATCH_MP_TAC REAL_LE_TRANS
  >> Q.EXISTS_TAC ‘(max (abs a powr r) (abs b powr r)) * 2 powr r’

--- a/src/real/analysis/derivativeScript.sml
+++ b/src/real/analysis/derivativeScript.sml
@@ -1704,6 +1704,7 @@ QED
 (* CONTINUOUS_ON_EXP                                                         *)
 (* ------------------------------------------------------------------------- *)
 
+(* See limTheory.HAS_DERIVATIVE_POW' for a better version without sum *)
 val HAS_DERIVATIVE_POW = store_thm ("HAS_DERIVATIVE_POW",
  ``!q0 n.
      ((\q. q pow n) has_derivative

--- a/src/real/analysis/limScript.sml
+++ b/src/real/analysis/limScript.sml
@@ -5,8 +5,8 @@
 open HolKernel Parse bossLib boolLib;
 
 open numLib reduceLib pairLib pairTheory arithmeticTheory numTheory jrhUtils
-     prim_recTheory realTheory realLib metricTheory netsTheory combinTheory;
-open pred_setTheory mesonLib;
+     prim_recTheory realTheory realLib metricTheory netsTheory combinTheory
+     pred_setTheory mesonLib hurdUtils;
 
 open topologyTheory real_topologyTheory derivativeTheory seqTheory;
 
@@ -15,17 +15,9 @@ val _ = ParseExtras.temp_loose_equality()
 
 val _ = Parse.reveal "B";
 
-(* mini hurdUtils *)
-val Know = Q_TAC KNOW_TAC;
-val Suff = Q_TAC SUFF_TAC;
-fun wrap a = [a];
-val Rewr = DISCH_THEN (REWRITE_TAC o wrap);
-val Rewr' = DISCH_THEN (ONCE_REWRITE_TAC o wrap);
-val POP_ORW = POP_ASSUM (ONCE_REWRITE_TAC o wrap);
-val art = ASM_REWRITE_TAC;
-
 val tendsto = netsTheory.tendsto;   (* conflict with real_topologyTheory.tendsto *)
 val GEN_ALL = hol88Lib.GEN_ALL;     (* this gives old (reverted) variable orders *)
+val EXACT_CONV = jrhUtils.EXACT_CONV; (* there's one also in hurdUtils *)
 
 (*---------------------------------------------------------------------------*)
 (* Specialize nets theorems to the pointwise limit of real->real functions   *)
@@ -699,6 +691,18 @@ val DIFF_POW = store_thm("DIFF_POW",
     REWRITE_TAC[REAL_MUL_ASSOC] THEN AP_TERM_TAC THEN
     REWRITE_TAC[ONE, pow] THEN
     REWRITE_TAC[SYM ONE, REAL_MUL_RID]]);
+
+val lemma = REWRITE_RULE [diffl_has_derivative, Once REAL_MUL_COMM] DIFF_POW;
+
+Theorem HAS_DERIVATIVE_POW' :
+    !n x. ((\x. x pow n) has_derivative (\y. &n * x pow (n - 1) * y)) (at x)
+Proof
+    REWRITE_TAC [lemma]
+QED
+
+(* !n x. ((\x. x pow n) has_vector_derivative &n * x pow (n - 1)) (at x) *)
+Theorem HAS_VECTOR_DERIVATIVE_POW =
+        REWRITE_RULE [diffl_has_vector_derivative] DIFF_POW
 
 (*---------------------------------------------------------------------------*)
 (* Now power of -1 (then differentiation of inverses follows from chain rule)*)

--- a/src/real/analysis/transcScript.sml
+++ b/src/real/analysis/transcScript.sml
@@ -2673,7 +2673,8 @@ local
      ‘?f :real -> real -> real.
          (!a b. 0 < a ==> f a b = exp (b * ln a)) /\
          (!b. 0 < b ==> f 0 b = 0) /\
-         (!a n. f a &n = a pow n /\ f a (-&SUC n) = inv (a pow (SUC n)))’,
+         (!a n. f a &n = a pow n) /\
+         (!a n. f a (-&n) = inv (a pow n))’,
    (* proof *)
       Q.EXISTS_TAC ‘\a b. if 0 < a then exp (b * ln a) else
                           if a = 0 /\ 0 < b then 0 else
@@ -2689,8 +2690,8 @@ local
 in
   (* |- (!a b. 0 < a ==> a powr b = exp (b * ln a)) /\
         (!b. 0 < b ==> 0 powr b = 0) /\
-         !a n. a powr &n = a pow n /\
-               a powr -&SUC n = inv (a pow SUC n)
+        (!a n. a powr &n = a pow n) /\
+         !a n. a powr -&n = inv (a pow n)
    *)
   val powr_def = new_specification ("powr_def", ["powr"], thm);
 end;


### PR DESCRIPTION
Hi,

Inspired by #1247, this PR extends the domain of `rpow` (`powr :real -> real -> real`). Previously `rpow` has the following definition:
```
   [rpow_def]  Definition (transcTheory)      
      ⊢ ∀a b. a powr b = exp (b * ln a)
```
Since `ln a` is only specified when `0 < a`, the valid domain of `a powr b` is `0 < a` and `b` arbitrary. (Outside this domain `a powr b` is an unspecified positive real.) But there are two more cases when `a powr b` is a (finite) real number:

1. `a = 0` and `0 < b`.
2. `a` is arbitrary and `b` is an integer.

Now I extend the definition of `rpow` (by `new_specification`) to cover the above cases:
```
   [powr_def]  Definition      
      ⊢ (∀a b. 0 < a ⇒ a powr b = exp (b * ln a)) ∧
        (∀b. 0 < b ⇒ 0 powr b = 0) ∧
        ∀a n. a powr &n = a pow n ∧ a powr -&SUC n = (a pow SUC n)⁻¹
```

With this new definition, the following theorems can be proved unconditionally (i.e. without requiring `0 < a` for `a powr b`):
```
   [RPOW_0]  Theorem      
      ⊢ ∀a. a powr 0 = 1
   
   [RPOW_1]  Theorem      
      ⊢ ∀a. a powr 1 = a
```

But the following theorems now have to have the antecedent `0 < a` for `a powr b`, because the old definition of `rpow` as a rewriting rule `a powr b = exp (b * ln a)` is no more available:
```
   [RPOW_ADD]  Theorem      
      ⊢ ∀a b c. 0 < a ⇒ a powr (b + c) = a powr b * a powr c
   
   [RPOW_ADD_MUL]  Theorem      
      ⊢ ∀a b c. 0 < a ⇒ a powr (b + c) * a powr -b = a powr c
```

The hardest part is to fix the proof of `DIFF_RPOW` by using some advanced results from `real_topologyTheory` (which has some minor updates):
```
   [DIFF_RPOW]  Theorem      
      ⊢ ∀x y. 0 < x ⇒ ((λx. x powr y) diffl (y * x powr (y − 1))) x
```

P. S. opening `realLib` instead of `RealArith` in `real_topologyScript.sml` greatly reduced the building time of `real_topologyTheory` by 100s, because the old, faster `REAL_ARITH` is tried first).

--Chun