### PR TITLE
Fixed C++ compilation failure of zc2hs on macOS

### DIFF
--- a/src/HolSat/sat_solvers/minisat/Global.h
+++ b/src/HolSat/sat_solvers/minisat/Global.h
@@ -260,15 +260,17 @@ const lbool l_Undef = toLbool( 0);
 //=================================================================================================
 // Relation operators -- extend definitions from '==' and '<'
 
-
 #ifndef __SGI_STL_INTERNAL_RELOPS   // (be aware of SGI's STL implementation...)
 #define __SGI_STL_INTERNAL_RELOPS
+/* NOTE: The following definition broke the build of zc2hs with late versions of Apple's clang++
+   As a workaround, there are two expressions (in Main.C and zc2hs.cpp) of `x != y` modified
+   to `~(x == y)`. -- Chun Tian (with help of Oskar Abrahamsson), 14/6/2024
 template <class T> static inline bool operator != (const T& x, const T& y) { return !(x == y); }
+*/
 template <class T> static inline bool operator >  (const T& x, const T& y) { return y < x;     }
 template <class T> static inline bool operator <= (const T& x, const T& y) { return !(y < x);  }
 template <class T> static inline bool operator >= (const T& x, const T& y) { return !(x < y);  }
 #endif
-
 
 //=================================================================================================
 #endif

--- a/src/HolSat/sat_solvers/minisat/Main.C
+++ b/src/HolSat/sat_solvers/minisat/Main.C
@@ -122,7 +122,7 @@ static void resolve(vec<Lit>& main, vec<Lit>& other, Var x)
         if (var(other[i]) != x)
             main.push(other[i]);
         else{
-            if (p != ~other[i])
+            if (!(p == ~other[i]))
                 printf("PROOF ERROR! Resolved on variable with SAME polarity in both clauses: %d\n", x+1);
             ok2 = true;
         }

--- a/src/HolSat/sat_solvers/zc2hs/Makefile
+++ b/src/HolSat/sat_solvers/zc2hs/Makefile
@@ -2,6 +2,8 @@
 
 all: zc2hs
 
+CXX = $(or $(MINISAT_CXX),c++)
+
 zc2hs: 
 	ln -fs ../minisat/Proof.o
 	ln -fs ../minisat/File.o
@@ -10,7 +12,7 @@ zc2hs:
 	ln -fs ../minisat/Global.h
 	ln -fs ../minisat/Sort.h
 	ln -fs ../minisat/SolverTypes.h
-	g++ -O3 Proof.o File.o zc2hs.cpp -o zc2hs
+	@$(CXX) -O3 Proof.o File.o zc2hs.cpp -o zc2hs
 
 clean:
 	@rm -f zc2hs *.h *.o

--- a/src/HolSat/sat_solvers/zc2hs/zc2hs.cpp
+++ b/src/HolSat/sat_solvers/zc2hs/zc2hs.cpp
@@ -124,7 +124,7 @@ static void resolve(vec<Lit>& main, vec<Lit>& other, Var x)
         if (var(other[i]) != x)
             main.push(other[i]);
         else{
-            if (p != ~other[i])
+            if (!(p == ~other[i]))
                 printf("PROOF ERROR! Resolved on variable with SAME polarity in both clauses: %d\n", x+1);
             ok2 = true;
         }


### PR DESCRIPTION
Hi,

Once again, with help of @oskarabrahamsson (#1233, also see #985 for the last time), the failure of C++ compilation of `zc2hs` on macOS with Apple's `clang++` is now fixed. I can only guess that, the following template function is too general to create a conflict with some other (internal) definitions:
```
template <class T> static inline bool operator != (const T& x, const T& y) { return !(x == y); }
```
There are only two places where this overloaded operator `!=` is actually used. By rewriting them to `!(x == y)`, I'm sure the semantics doesn't change, and the compilation error is gone.

Let's see when these C++ code will be broken again:)

--Chun

P.S. In `src/HolSat/sat_solvers/zc2hs/Makefile`, I followed the idea of Minisat's Makefile to use `$(MINISAT_CXX)` (with a default value `c++`) instead of the explicit `g++`.  On potential *unix systems without GCC but with other C/C++ compilers, the command `g++` may not be available while `c++` should exist.  (I have been using the command `Makefile MINISAT_CXX=g++-mp-13` to compile `zc2hs` manually for quite several months.)