### PR TITLE
Move NUM_FLOOR/NUM_CEILING to realaxTheory

### DIFF
--- a/examples/probability/large_numberScript.sml
+++ b/examples/probability/large_numberScript.sml
@@ -42,11 +42,7 @@ val _ = hide "W";
 val _ = intLib.deprecate_int ();
 val _ = ratLib.deprecate_rat ();
 
-(* NOTE: The above deprecate settings do not cover "flr" and "clg", which
-   are overloaded again in intrealTheory.
- *)
-val _ = bring_to_front_overload "flr" {Name = "NUM_FLOOR",   Thy = "real"};
-val _ = bring_to_front_overload "clg" {Name = "NUM_CEILING", Thy = "real"};
+val _ = realLib.prefer_num_floor ();
 
 (* ------------------------------------------------------------------------- *)
 (*  Definitions                                                              *)

--- a/examples/probability/large_numberScript.sml
+++ b/examples/probability/large_numberScript.sml
@@ -42,7 +42,11 @@ val _ = hide "W";
 val _ = intLib.deprecate_int ();
 val _ = ratLib.deprecate_rat ();
 
-val _ = realLib.prefer_num_floor ();
+(* Prefer NUM_FLOOR and NUM_CEILING (over INT_FLOOR/INT_CEILING) by redefining
+   their overloads.
+ *)
+Overload flr = “realax$NUM_FLOOR”
+Overload clg = “realax$NUM_CEILING”
 
 (* ------------------------------------------------------------------------- *)
 (*  Definitions                                                              *)

--- a/src/real/realLib.sig
+++ b/src/real/realLib.sig
@@ -11,11 +11,13 @@ sig
   val REAL_ARITH          : term -> thm
   val REAL_ASM_ARITH_TAC  : tactic
 
-   val real_ss : simpLib.simpset
    (* Incorporates simpsets for bool, pair, and arithmetic *)
+   val real_ss : simpLib.simpset
 
    (* syntax *)
    val prefer_real     : unit -> unit
    val deprecate_real  : unit -> unit
+
+   val prefer_num_floor : unit -> unit
 
 end

--- a/src/real/realLib.sig
+++ b/src/real/realLib.sig
@@ -18,6 +18,4 @@ sig
    val prefer_real     : unit -> unit
    val deprecate_real  : unit -> unit
 
-   val prefer_num_floor : unit -> unit
-
 end

--- a/src/real/realLib.sml
+++ b/src/real/realLib.sml
@@ -44,20 +44,6 @@ struct
     List.app doit operators
   end
 
-  (* NOTE: intrealTheory also contains overloads of ‘flr’ and ‘clg’ *)
-  val flr_operators = [("flr", realSyntax.NUM_FLOOR_tm),
-                       ("clg", realSyntax.NUM_CEILING_tm)];
-
-  (* Prefer NUM_FLOOR (and also NUM_CEILING) (again INT_FLOOR, etc., maybe) *)
-  fun prefer_num_floor () = let
-    fun doit (s, t) =
-       let val {Name,Thy,...} = dest_thy_const t in
-          Parse.temp_bring_to_front_overload s {Name = Name, Thy = Thy}
-       end
-  in
-    List.app doit flr_operators
-  end
-
   (* The default REAL_ARITH, etc. can be switched here. *)
   val REAL_ARITH_TAC     = TRY(RealArith.OLD_REAL_ARITH_TAC)
                            THEN RealField.REAL_ARITH_TAC;

--- a/src/real/realLib.sml
+++ b/src/real/realLib.sml
@@ -44,6 +44,20 @@ struct
     List.app doit operators
   end
 
+  (* NOTE: intrealTheory also contains overloads of ‘flr’ and ‘clg’ *)
+  val flr_operators = [("flr", realSyntax.NUM_FLOOR_tm),
+                       ("clg", realSyntax.NUM_CEILING_tm)];
+
+  (* Prefer NUM_FLOOR (and also NUM_CEILING) (again INT_FLOOR, etc., maybe) *)
+  fun prefer_num_floor () = let
+    fun doit (s, t) =
+       let val {Name,Thy,...} = dest_thy_const t in
+          Parse.temp_bring_to_front_overload s {Name = Name, Thy = Thy}
+       end
+  in
+    List.app doit flr_operators
+  end
+
   (* The default REAL_ARITH, etc. can be switched here. *)
   val REAL_ARITH_TAC     = TRY(RealArith.OLD_REAL_ARITH_TAC)
                            THEN RealField.REAL_ARITH_TAC;

--- a/src/real/realScript.sml
+++ b/src/real/realScript.sml
@@ -3797,19 +3797,12 @@ val lt_int = store_thm(
     Q.EXISTS_TAC `0` THEN SRW_TAC [][REAL_NEG_LE0]
   ]);
 
-
 (*---------------------------------------------------------------------------*)
-(* Floor and ceiling (nums)                                                  *)
+(* Floor and ceiling (nums) (NOTE: Their definitions are moved to realax)    *)
 (*---------------------------------------------------------------------------*)
 
-val NUM_FLOOR_def = zDefine`
-   NUM_FLOOR (x:real) = LEAST (n:num). real_of_num (n+1) > x`;
-
-val NUM_CEILING_def = zDefine`
-   NUM_CEILING (x:real) = LEAST (n:num). x <= real_of_num n`;
-
-val _ = overload_on ("flr",``NUM_FLOOR``);
-val _ = overload_on ("clg",``NUM_CEILING``);
+Theorem NUM_FLOOR_def   = NUM_FLOOR_def
+Theorem NUM_CEILING_def = NUM_CEILING_def
 
 val lem = SIMP_RULE arith_ss [REAL_POS,REAL_ADD_RID]
               (Q.SPECL[`y`,`&n`,`0r`,`1r`] REAL_LTE_ADD2);

--- a/src/real/realSyntax.sig
+++ b/src/real/realSyntax.sig
@@ -12,6 +12,8 @@ sig
   val negate_tm      : term
   val real_injection : term (* the injection from :num -> :real *)
   val inv_tm         : term
+  val NUM_FLOOR_tm   : term
+  val NUM_CEILING_tm : term
 
   (* binary operators *)
   val div_tm         : term

--- a/src/real/realSyntax.sml
+++ b/src/real/realSyntax.sml
@@ -1,8 +1,8 @@
 structure realSyntax :> realSyntax =
 struct
-
-  local open realaxTheory in end;
   open HolKernel Abbrev;
+
+  local open realaxTheory numSyntax in end;
 
   val ERR = mk_HOL_ERR "realSyntax";
 
@@ -12,8 +12,9 @@ struct
   val real_ty = mk_thy_type {Thy = "realax", Tyop = "real", Args = []}
   val bop_ty = real_ty --> real_ty --> real_ty
   val rel_ty = real_ty --> real_ty --> bool
+  val num_ty = numSyntax.num
 
-  val real_injection = mk_raconst("real_of_num", numSyntax.num --> real_ty)
+  val real_injection = mk_raconst("real_of_num", num_ty --> real_ty)
 
   val zero_tm = mk_comb(real_injection, numSyntax.zero_tm)
   val one_tm = mk_comb(real_injection, numSyntax.mk_numeral (Arbnum.fromInt 1))
@@ -23,7 +24,7 @@ struct
   val minus_tm = mk_raconst("real_sub", bop_ty)
   val mult_tm = mk_raconst("real_mul", bop_ty)
   val div_tm = mk_raconst("/", bop_ty)
-  val exp_tm = mk_raconst("pow", real_ty --> numSyntax.num --> real_ty)
+  val exp_tm = mk_raconst("pow", real_ty --> num_ty --> real_ty)
 
   val real_eq_tm = mk_thy_const { Thy = "min", Name = "=", Ty = rel_ty}
   val less_tm = mk_raconst("real_lt", rel_ty)
@@ -33,6 +34,9 @@ struct
 
   val min_tm = mk_raconst("min", bop_ty)
   val max_tm = mk_raconst("max", bop_ty)
+
+  val NUM_FLOOR_tm   = mk_raconst("NUM_FLOOR",   real_ty --> num_ty);
+  val NUM_CEILING_tm = mk_raconst("NUM_CEILING", real_ty --> num_ty);
 
   (* Functions *)
 

--- a/src/real/realaxScript.sml
+++ b/src/real/realaxScript.sml
@@ -284,6 +284,18 @@ Proof
   end
 QED
 
+(* Floor and ceiling (nums) *)
+Definition NUM_FLOOR_def[nocompute] :
+   NUM_FLOOR (x:real) = LEAST (n:num). real_of_num (n+1) > x
+End
+
+Definition NUM_CEILING_def[nocompute] :
+   NUM_CEILING (x:real) = LEAST (n:num). x <= real_of_num n
+End
+
+Overload flr = “NUM_FLOOR”
+Overload clg = “NUM_CEILING”
+
 (* ------------------------------------------------------------------------- *)
 (* Some elementary "bootstrapping" lemmas needed by RealArith.sml            *)
 (*                                                                           *)


### PR DESCRIPTION
Hi,

The floor and ceiling of real numbers are more naturally defined on integers (see `INT_FLOOR` and `INT_CEILING` in `intrealTheory`), but the `NUM_FLOOR` and `NUM_CEILING` defined in `realTheory` are still useful (they only work on positive reals) sometimes:
```
val NUM_FLOOR_def = zDefine`
   NUM_FLOOR (x:real) = LEAST (n:num). real_of_num (n+1) > x`;

val NUM_CEILING_def = zDefine`
   NUM_CEILING (x:real) = LEAST (n:num). x <= real_of_num n`;
```

The problem is that both `NUM_FLOOR` and `INT_FLOOR` are overloaded by `flr` (so is `clg` for `NUM_CEILING`, etc.), and currently there's no good way to set preferences to `NUM_FLOOR`.  Since `real_of_rat` was opened somewhere in the middle of dependencies, this has become a problem.

For example, in `examples/probability/large_numberTheory` (NOTE: the whole probability theory was developed without using any integers, directly), I had to use the following code to put `NUM_FLOOR` over `INT_FLOOR`:
```
val _ = bring_to_front_overload "flr" {Name = "NUM_FLOOR",   Thy = "real"};
val _ = bring_to_front_overload "clg" {Name = "NUM_CEILING", Thy = "real"};
```

I was thinking (also due to some discussions on Discord) that putting `NUM_FLOOR` and `NUM_CEILING` into the operator list of `realLib.prefer_real` may help, but actually it doesn't: I cannot call `prefer_real()` in `large_numberTheory` where extreals should be preferred. Instead, I had to use `deprecate_int ()` and `deprecate_rat ()` to disable the parsing preferences of integers and rationals.

To minimize incompatibilities, I think it's reasonable to add a new function `realLib.prefer_num_floor`, focusing on these two operators. (Other solutions are welcome.)  This is what's done in this PR.

--Chun