### PR TITLE
Add NOT_AND' (|- ~(~t /\ t)) to BOOL_ss

### DIFF
--- a/examples/lambda/barendregt/standardisationScript.sml
+++ b/examples/lambda/barendregt/standardisationScript.sml
@@ -416,16 +416,12 @@ val residuals_to_right_of_reduction = store_thm(
     PROVE_TAC [lrcc_new_labels'],
     PROVE_TAC [],
     PROVE_TAC [lrcc_new_labels'],
-    PROVE_TAC [],
     FULL_SIMP_TAC (srw_ss()) [n_posns_nlabel] THEN SRW_TAC [][],
     PROVE_TAC [],
     FULL_SIMP_TAC (srw_ss()) [n_posns_nlabel] THEN SRW_TAC [][],
-    FULL_SIMP_TAC (srw_ss()) [n_posns_nlabel] THEN SRW_TAC [][],
-    PROVE_TAC [],
     PROVE_TAC [],
     PROVE_TAC []
   ]);
-
 
 val lemma11_4_3iii = store_thm(
   "lemma11_4_3iii",

--- a/src/pred_set/src/more_theories/iterateScript.sml
+++ b/src/pred_set/src/more_theories/iterateScript.sml
@@ -1004,11 +1004,16 @@ val ITERATE_UNION_GEN = store_thm ("ITERATE_UNION_GEN",
 
 val lemma = prove (
  ``!t s. t SUBSET s ==> (s = (s DIFF t) UNION t) /\ DISJOINT (s DIFF t) t``,
-  REPEAT STRIP_TAC THENL [SIMP_TAC std_ss [UNION_DEF, DIFF_DEF, EXTENSION, GSPECIFICATION]
-  THEN GEN_TAC THEN EQ_TAC THENL [FULL_SIMP_TAC std_ss [], STRIP_TAC THEN
-  FULL_SIMP_TAC std_ss [SUBSET_DEF]], SIMP_TAC std_ss [DISJOINT_DEF, INTER_DEF, DIFF_DEF,
-  EXTENSION, GSPECIFICATION] THEN GEN_TAC THEN EQ_TAC THENL [STRIP_TAC,
-  FULL_SIMP_TAC std_ss [NOT_IN_EMPTY]]]);
+    rpt STRIP_TAC
+ >| [ (* goal 1 (of 2) *)
+      SIMP_TAC std_ss [UNION_DEF, DIFF_DEF, EXTENSION, GSPECIFICATION] \\
+      GEN_TAC \\
+      EQ_TAC >- FULL_SIMP_TAC std_ss [] \\
+      STRIP_TAC \\
+      FULL_SIMP_TAC std_ss [SUBSET_DEF],
+      (* goal 2 (of 2) *)
+      SIMP_TAC std_ss [DISJOINT_DEF, INTER_DEF, DIFF_DEF,
+                       EXTENSION, GSPECIFICATION, NOT_IN_EMPTY] ]);
 
 val ITERATE_DIFF = store_thm ("ITERATE_DIFF",
  ``!op. monoidal op

--- a/src/simp/src/boolSimps.sml
+++ b/src/simp/src/boolSimps.sml
@@ -101,13 +101,13 @@ val BOOL_ss = SSFRAG
      ("EXISTS_REFL'", GSYM EXISTS_REFL),
      ("EXISTS_UNIQUE_REFL'", GSYM EXISTS_UNIQUE_REFL),
      ("EXCLUDED_MIDDLE'", ONCE_REWRITE_RULE [DISJ_COMM] EXCLUDED_MIDDLE),
+     ("NOT_AND'",         ONCE_REWRITE_RULE [CONJ_COMM] NOT_AND),
      ("literal_I_thm", literal_I_thm),
      ("COND_BOOL_CLAUSES", COND_BOOL_CLAUSES),
      ("lift_disj_eq", lift_disj_eq),
      ("lift_imp_disj", lift_imp_disj)
    ],
    congs = [literal_cong], filter = NONE, ac = [], dprocs = []};
-
 
 (*---------------------------------------------------------------------------
    Need to rewrite cong. rules to the iterated implication format assumed


### PR DESCRIPTION
Hi,

Currently `bool_ss` (`BOOL_ss`) can simplify `P /\ ~P` to `F` but cannot handle the symmetric form `~P /\ P`, e.g.:
```
> SIMP_CONV bool_ss [] ``P /\ ~P``;
val it = |- P /\ ~P <=> F: thm
> SIMP_CONV bool_ss [] ``~P /\ P``;
Exception- UNCHANGED raised
```
This is because `boolTheory.NOT_AND` (`|- ~(t /\ ~t)`) is part of `BOOL_ss` without its symmetric version (which we may call it "NOT_AND'").  I found this issue because I met a proof which could benefit from it.

So I added the missing part into `BOOL_ss` (following the idea of  `EXCLUDED_MIDDLE'` in it).  I would say this is *fixing* the asymmetry of `BOOL_ss`, but anyway it brings a minor incompatibility.  The good news is, among all core theories and examples (part of the CI tests), there are only two proofs to fix, trivially.

--Chun