### PR TITLE
Extirpate THENL from the HOL tutorial

### DIFF
--- a/Manual/Tutorial/combin.stex
+++ b/Manual/Tutorial/combin.stex
@@ -402,11 +402,10 @@ Again we can (and should) package up the lemma, avoiding the sub-goal package co
              !x p z. RTC R x p ∧ R x z ⇒
                      ∃u. RTC R p u ∧ RTC R z u
        Proof
-         strip_tac >> strip_tac >> Induct_on `RTC` >> rw[] >| [
-           metis_tac [RTC_rules],
-           `?v. R x' v /\ R z v` by metis_tac [diamond_def] >>
-           metis_tac [RTC_rules]
-         ]
+         strip_tac >> strip_tac >> Induct_on `RTC` >> rw[]
+         >- metis_tac [RTC_rules]
+         >- (`?v. R x' v /\ R z v` by metis_tac [diamond_def] >>
+             metis_tac [RTC_rules])
        QED
 \end{alltt}
 \end{session}
@@ -482,11 +481,10 @@ We can now package up our desired result:
          !R. diamond R ==> diamond (RTC R)
        Proof
          strip_tac >> strip_tac >> simp[diamond_def] >>
-         Induct_on `RTC R x y` >> rw[] >| [
-           metis_tac[RTC_rules],
-           `?v. RTC R x' v /\ RTC R z v` by metis_tac[R_RTC_diamond] >>
-           metis_tac [RTC_RTC, RTC_rules]
-         ]
+         Induct_on `RTC R x y` >> rw[]
+         >-  metis_tac[RTC_rules]
+         >- (`?v. RTC R x' v /\ RTC R z v` by metis_tac[R_RTC_diamond] >>
+             metis_tac [RTC_RTC, RTC_rules])
        QED
 \end{alltt}
 \end{session}
@@ -677,16 +675,13 @@ reduction relation.
 \end{session}
 
 There are four conjuncts here, and it should be clear that all but the second can be proved immediately by appeal to the rules for the transitive closure and for $\rightarrow$ itself.
-So, we split apart the conjunctions and enter a \texttt{THENL} branch, putting in an \ml{all\_tac} in the 2nd position so that this falls through to be dealt with more carefully.
+So, we split apart the conjunctions, use a \texttt{THEN1} to discharge the first subgoal, thus putting the second subgoal into focus to be be dealt with more carefully. Note that \texttt{>-} is sugar for \texttt{THEN1}.
 \begin{session}
 \begin{alltt}
->> e (rpt conj_tac >| [metis_tac[RTC_rules, redn_rules],
-                       all_tac,
-                       metis_tac[RTC_rules, redn_rules],
-                       metis_tac[RTC_rules, redn_rules] ]);
+>> e (rpt conj_tac >- metis_tac[RTC_rules, redn_rules]);
 \end{alltt}
 \end{session}
-What of this latest sub-goal?
+What of this sub-goal?
 If we look at it for long enough, we should see that it is another monotonicity fact.
 More accurately, we need what is called a \emph{congruence} result for \holtxt{-->*}.
 In this form, it's not quite right for easy proof.
@@ -1043,23 +1038,21 @@ The final goal proof can be packaged into:
          !x y. x -||-> y ==>
                !z. x -||-> z ==> ?u. y -||-> u /\ z -||-> u
        Proof
-         Induct_on ‘x -||-> y’ >> rpt conj_tac >| [
-           metis_tac [predn_rules],
-           rw[] >>
-           qpat_x_assum ‘_ # _ -||-> _’
-             (strip_assume_tac o SIMP_RULE std_ss [x_ap_y_predn]) >>
-           rw[] >| [
-             metis_tac[predn_rules],
-             metis_tac[predn_rules],
-             ‘?w. (y = K # w) /\ (z -||-> w)’ by metis_tac [Kx_predn] >>
-             rw[] >> metis_tac [predn_rules],
-             ‘?p q. (y = S # p # q) /\ (f -||-> p) /\ (g -||-> q)’ by
-                metis_tac [Sxy_predn] >>
-             rw [] >> metis_tac [predn_rules]
-           ],
-           rw[Kxy_predn] >> metis_tac [predn_rules],
-           rw[Sxyz_predn] >> metis_tac [predn_rules]
-         ]
+         Induct_on ‘x -||-> y’ >> rpt conj_tac
+         >- (metis_tac [predn_rules],
+             rw[] >>
+             qpat_x_assum ‘_ # _ -||-> _’
+               (strip_assume_tac o SIMP_RULE std_ss [x_ap_y_predn]) >>
+             rw[]
+             >- metis_tac[predn_rules]
+             >- metis_tac[predn_rules]
+             >- (‘?w. (y = K # w) /\ (z -||-> w)’ by metis_tac [Kx_predn] >>
+                 rw[] >> metis_tac [predn_rules],
+                 ‘?p q. (y = S # p # q) /\ (f -||-> p) /\ (g -||-> q)’ by
+                    metis_tac [Sxy_predn] >>
+                 rw [] >> metis_tac [predn_rules])
+         >- (rw[Kxy_predn] >> metis_tac [predn_rules])
+         >- (rw[Sxyz_predn] >> metis_tac [predn_rules])
        QED
 \end{alltt}
 \end{session}

--- a/Manual/Tutorial/combin.stex
+++ b/Manual/Tutorial/combin.stex
@@ -1050,7 +1050,7 @@ The final goal proof can be packaged into:
                  rw[] >> metis_tac [predn_rules],
                  ‘?p q. (y = S # p # q) /\ (f -||-> p) /\ (g -||-> q)’ by
                     metis_tac [Sxy_predn] >>
-                 rw [] >> metis_tac [predn_rules])
+                 rw [] >> metis_tac [predn_rules]))
          >- (rw[Kxy_predn] >> metis_tac [predn_rules])
          >- (rw[Sxyz_predn] >> metis_tac [predn_rules])
        QED

--- a/Manual/Tutorial/combin.stex
+++ b/Manual/Tutorial/combin.stex
@@ -1039,16 +1039,16 @@ The final goal proof can be packaged into:
                !z. x -||-> z ==> ?u. y -||-> u /\ z -||-> u
        Proof
          Induct_on ‘x -||-> y’ >> rpt conj_tac
-         >- (metis_tac [predn_rules],
-             rw[] >>
+         >- metis_tac [predn_rules]
+         >- (rw[] >>
              qpat_x_assum ‘_ # _ -||-> _’
                (strip_assume_tac o SIMP_RULE std_ss [x_ap_y_predn]) >>
              rw[]
              >- metis_tac[predn_rules]
              >- metis_tac[predn_rules]
              >- (‘?w. (y = K # w) /\ (z -||-> w)’ by metis_tac [Kx_predn] >>
-                 rw[] >> metis_tac [predn_rules],
-                 ‘?p q. (y = S # p # q) /\ (f -||-> p) /\ (g -||-> q)’ by
+                 rw[] >> metis_tac [predn_rules])
+             >- (‘?p q. (y = S # p # q) /\ (f -||-> p) /\ (g -||-> q)’ by
                     metis_tac [Sxy_predn] >>
                  rw [] >> metis_tac [predn_rules]))
          >- (rw[Kxy_predn] >> metis_tac [predn_rules])

--- a/Manual/Tutorial/euclid.stex
+++ b/Manual/Tutorial/euclid.stex
@@ -544,7 +544,10 @@ tactic:
 \end{alltt}
 \end{hol}
 
-\noindent This can be tested to see that we have made no errors:
+\noindent
+The above uses two operators to compose tactics. The \ml{\gt\gt} operator sequentially composes two tactics. The \ml{\gt-} is used to create a subproof for the first goal in situations with multiple subgoals. Here, the tactic after the first top-level \ml{\gt-} proves the base case, and the second proves the inductive case. Such subproofs can be nested, as illustrated in the base case.
+
+This can be tested to see that we have made no errors:
 
 \begin{session}
 \begin{alltt}

--- a/Manual/Tutorial/euclid.stex
+++ b/Manual/Tutorial/euclid.stex
@@ -377,10 +377,12 @@ following\footnote{This and subsequent proofs use the theorems proved
     `!p m. 0 < m ==> m divides (FACT (m + p))`
       suffices_by metis_tac[LESS_EQ_EXISTS] >>
     Induct_on `p` >>
-    rw[FACT,ADD_CLAUSES] >| [
-      Cases_on `m`, ALL_TAC
-    ] >> metis_tac [FACT, DECIDE ``!x. ~(x < x)``,
-                    DIVIDES_RMUL, DIVIDES_LMUL, DIVIDES_REFL])
+    rw[FACT,ADD_CLAUSES]
+    >- (Cases_on `m` >>
+        metis_tac [FACT, DECIDE ``!x. ~(x < x)``,
+                   DIVIDES_RMUL, DIVIDES_LMUL, DIVIDES_REFL]) >>
+    metis_tac [FACT, DECIDE ``!x. ~(x < x)``,
+                   DIVIDES_RMUL, DIVIDES_LMUL, DIVIDES_REFL]);
 \begin{description}
 \item [\small{({\it DIVIDES\_FACT\/})}]
 \begin{tabular}[t]{l}
@@ -531,13 +533,12 @@ tactic:
 \begin{alltt}
   ##eval[tac] `!m p.  0 < m ==> m divides FACT (m + p)`
                 suffices_by metis_tac[LESS_EQ_EXISTS] >>
-              Induct_on `p` >| [
-                rw[] >> Cases_on `m` >| [
-                  fs[],
-                  rw[FACT, DIVIDES_LMUL, DIVIDES_REFL]
-                ],
-                rw[FACT, ADD_CLAUSES] >> rw[DIVIDES_RMUL]
-              ]
+              Induct_on `p`
+              >- (
+                rw[] >> Cases_on `m`
+                >- fs[]
+                >- rw[FACT, DIVIDES_LMUL, DIVIDES_REFL])
+              >- (rw[FACT, ADD_CLAUSES] >> rw[DIVIDES_RMUL])
 >>__ restart(); e tac;
 ##assert can top_thm ()
 \end{alltt}
@@ -549,14 +550,14 @@ tactic:
 \begin{alltt}
 >>_ restart();
 >> e (`!m p.  0 < m ==> m divides FACT (m + p)`
-        suffices_by metis_tac[LESS_EQ_EXISTS] >>
-      Induct_on `p` >| [
-        rw[] >> Cases_on `m` >| [
-          fs[],
-          rw[FACT, DIVIDES_LMUL, DIVIDES_REFL]
-        ],
-        rw[FACT, ADD_CLAUSES] >> rw[DIVIDES_RMUL]
-      ]);
+                suffices_by metis_tac[LESS_EQ_EXISTS] >>
+              Induct_on `p`
+              >- (
+                rw[] >> Cases_on `m`
+                >- fs[]
+                >- rw[FACT, DIVIDES_LMUL, DIVIDES_REFL])
+              >- (rw[FACT, ADD_CLAUSES] >> rw[DIVIDES_RMUL])
+      );
 ##assert can top_thm ()
 \end{alltt}
 \end{session}
@@ -571,19 +572,18 @@ One obvious step would be to merge the two successive invocations of the simplif
 \begin{alltt}
   ##eval[tac] `!m p.  0 < m ==> m divides FACT (m + p)`
                 suffices_by metis_tac[LESS_EQ_EXISTS] >>
-              Induct_on `p`  >| [
-                Cases_on `m` >| [
-                  fs[],
-                  rw[FACT, DIVIDES_LMUL, DIVIDES_REFL]
-                ],
-                rw[FACT, ADD_CLAUSES, DIVIDES_RMUL]
-              ]
+              Induct_on `p`
+              >- (
+                rw[] >> Cases_on `m`
+                >- fs[]
+                >- rw[FACT, DIVIDES_LMUL, DIVIDES_REFL])
+              >- (rw[FACT, ADD_CLAUSES, DIVIDES_RMUL])
 >>__ restart(); e tac;
 ##assert can top_thm()
 \end{alltt}
 \end{hol}
 
-Now we'll make the occasionally dangerous assumption that the simplifications of the step case won't interfere with what is happening in the base case, and move the step case's tactic to precede the first \ml{\gt|}, using \ml{\gt\gt}.
+Now we'll make the occasionally dangerous assumption that the simplifications of the step case won't interfere with what is happening in the base case, and move the step case's tactic to precede the first \ml{\gt-}, using \ml{\gt\gt}.
 When the \ml{Induct} tactic generates two sub-goals, the step case's simplification will be applied to both of them:
 \begin{session}
 \begin{alltt}
@@ -602,10 +602,9 @@ This means that our tactic can become
              Induct_on `p` >>
              rw[FACT, ADD_CLAUSES,DIVIDES_RMUL] >>
              (* base case only remains *)
-             Cases_on `m` >| [
-               fs[],
-               rw[FACT,DIVIDES_LMUL,DIVIDES_REFL]
-             ]
+             Cases_on `m`
+             >- fs[]
+             >- rw[FACT,DIVIDES_LMUL,DIVIDES_REFL]
 >>__ val tac = it; restart(); e tac;
 ##assert can top_thm ()
 \end{alltt}
@@ -782,12 +781,12 @@ or $n$.  The polished tactic is the following:
 \verb+!n. ~(n = 1) ==> ?p. prime p /\ p divides n+ \\ \hline
 \verb+completeInduct_on `n` >>+ \\
 \verb+  rw [] >>+ \\
-\verb+  Cases_on `prime n` >| [+ \\
-\verb+    metis_tac [DIVIDES_REFL], + \\
-\verb+    `?x. x divides n /\ x<>1 /\ x<>n` + \\
-\verb+      by METIS_TAC[prime_def] >>+ \\
-\verb+    metis_tac [LESS_OR_EQ, PRIME_2, +\\
-\verb+               DIVIDES_LE,DIVIDES_TRANS,DIVIDES_0]]+ \\
+\verb+  Cases_on `prime n` + \\
+\verb+  >- metis_tac [DIVIDES_REFL] >> + \\
+\verb+  `?x. x divides n /\ x<>1 /\ x<>n` + \\
+\verb+    by METIS_TAC[prime_def] >>+ \\
+\verb+  metis_tac [LESS_OR_EQ, PRIME_2, +\\
+\verb+             DIVIDES_LE,DIVIDES_TRANS,DIVIDES_0]+ \\
 \end{tabular}
 \end{description}
 We start by invoking complete induction. This gives us an inductive

--- a/Manual/Tutorial/logic.tex
+++ b/Manual/Tutorial/logic.tex
@@ -1101,12 +1101,13 @@ tactic as its result.  The various parameters passed to tacticals are
 reflected in the various \ML{} types that the built-in tacticals have.
 Some important tacticals in the \HOL{} system are listed below.
 
-\subsubsection{\tt THENL : tactic -> tactic list -> tactic}
+\subsubsection{\tt THEN1 : tactic -> tactic -> tactic}
 
-If tactic $T$ produces $n$ subgoals and $T_1$, $\ldots$ , $T_n$ are tactics then \ml{$T$~THENL~[$T_1$,$\ldots$,$T_n$]} is a tactic which first applies $T$ and then applies $T_i$ to the $i$th subgoal produced by $T$.
-The tactical \ml{THENL} is useful if one wants to do different things to different subgoals.
+If tactic $T$ produces $n$ subgoals and $T_1$ is a tactic, then \ml{$T$~THEN1~($T_1$)} is a tactic which first applies $T$ and then applies $T_1$ to the first subgoal produced by $T$. The composite tactic fails if $T_1$ does not completely solve the first subgoal.
+The tactical \ml{THEN1} is useful if one wants to do different things to different subgoals.
+To discharge more than one subgoal in this manner, sequentially compose the tactics separated by \ml{THEN1} like so: \ml{$T$~THEN1~($T_1$)THEN1~$\dots$~THEN1~($T_n$)}
 
-\ml{THENL} can be illustrated by doing the proof of $\vdash \uquant{m}m+0=m$ in
+\ml{THEN1} can be illustrated by doing the proof of $\vdash \uquant{m}m+0=m$ in
 one step.
 
 \setcounter{sessioncount}{0}
@@ -1119,7 +1120,7 @@ one step.
          Initial goal:
          !m. m + 0 = m
 
-- e (INDUCT_TAC THENL [REWRITE_TAC[ADD], ASM_REWRITE_TAC[ADD]]);
+- e (INDUCT_TAC THEN1 (REWRITE_TAC[ADD]) THEN1 (ASM_REWRITE_TAC[ADD]));
 OK..
 > val it =
     Initial goal proved.
@@ -1128,12 +1129,12 @@ OK..
 \end{session}
 
 \noindent The compound tactic \[
-\ml{INDUCT\_TAC~THENL~[REWRITE\_TAC~[ADD],~ASM\_REWRITE\_TAC~[ADD]]}
+\ml{INDUCT\_TAC~THEN1~(REWRITE\_TAC~[ADD])~THEN1~(ASM\_REWRITE\_TAC~[ADD])}
 \]
 first applies \ml{INDUCT_TAC} and then applies \ml{REWRITE\_TAC[ADD]} to the first subgoal (the basis) and \ml{ASM\_REWRITE\_TAC[ADD]} to the second subgoal (the step).
 
-The tactical {\small\verb|THENL|} is useful for doing different things
-to different subgoals. The tactical \ml{THEN} can be used to apply the
+While {\small\verb|THEN1|} is useful for doing different things
+to different subgoals, the tactical \ml{THEN} can be used to apply the
 same tactic to all subgoals.
 
 \subsubsection{\tt THEN : tactic -> tactic -> tactic}\label{THEN}
@@ -1141,7 +1142,7 @@ same tactic to all subgoals.
 The tactical {\small\verb|THEN|} is an \ML{} infix. If $T_1$ and $T_2$
 are tactics, then the \ML{} expression $T_1${\small\verb| THEN |}$T_2$
 evaluates to a tactic which first applies $T_1$ and then applies $T_2$
-to all the subgoals produced by $T_1$.
+to \emph{all} the subgoals produced by $T_1$.
 
 In fact, \ml{ASM\_REWRITE\_TAC[ADD]} will solve the basis as well as
 the step case of the induction for $\uquant{m}m+0=m$, so there is an
@@ -1209,7 +1210,6 @@ theory \ml{arithmetic} \HOL{} is made.
 theorems are saved in the theory \ml{arithmetic}. The complete list of
 proofs for this built-in theory can be found in the file
 \ml{src/num/theories/arithmeticScript.sml}.
-
 
 \subsubsection{\tt ORELSE : tactic -> tactic -> tactic}\label{ORELSE}
 
@@ -1461,13 +1461,12 @@ achieved by $th$.
   then prove theorems $th_1$ , $\dots$, $th_n$ respectively achieving
   these goals by forward proof. The tactic
 
-\[\ml{  T THENL[ACCEPT\_TAC }th_1\ml{,}\ldots\ml{,ACCEPT\_TAC }th_n\ml{]}
+\[\ml{  T THEN1(ACCEPT\_TAC }th_1\ml{) THEN1}\ldots\ml{(ACCEPT\_TAC }th_n\ml{)}
 \]
 
-would then solve $g$, where \ml{THENL}
-%\index{THENL@\ml{THENL}}
-is the tactical that applies the respective elements of the tactic
-list to the subgoals produced by \ml{T}.
+would then solve $g$, where \ml{THEN1}
+%\index{THEN1@\ml{THEN1}}
+applies its RHS tactic to the first subgoal not solved by its LHS tactic.
 
 \end{itemize}
 
@@ -1479,15 +1478,8 @@ list to the subgoals produced by \ml{T}.
 \item{\bf Summary:} Identity tactic for the tactical {\small\verb%THEN%}
 (see \DESCRIPTION).
 
-\item{\bf Uses:}
-\begin{enumerate}
-\item Writing tacticals (see description of {\small\verb|REPEAT|}
+\item{\bf Uses:} Writing tacticals (see description of {\small\verb|REPEAT|}
 in \DESCRIPTION).
-\item With {\small\verb%THENL%}; for example, if tactic $T$ produces two subgoals
-and we want to apply $T_1$
-to the first one but to do nothing to the second, then
-the tactic to use is \ml{$T$~THENL[$T_1$,ALL_TAC]}.
-\end{enumerate}
 \end{itemize}
 
 \subsubsection{\tt NO\_TAC : tactic}

--- a/Manual/Tutorial/parity.stex
+++ b/Manual/Tutorial/parity.stex
@@ -486,12 +486,11 @@ interactively:
 >>_ restart();
 >> e (PURE_REWRITE_TAC [PARITY_IMP_def, ONE_def, NOT_def,
                         MUX_def, REG_def] >>
-     rpt strip_tac >| [
-       metis_tac [],
-       qpat_x_assum ‘!t. out t = X t’
+     rpt strip_tac
+     >- metis_tac []
+     >- (qpat_x_assum ‘!t. out t = X t’
                   (fn th => REWRITE_TAC [SPEC “SUC t” th]) >>
-       rw[]
-     ]);
+         rw[]));
 \end{alltt}
 \end{session}
 


### PR DESCRIPTION
I often send people off to learn HOL by going through the Euclid tutorial as a warmup. This has the unfortunate side effect that they come back with some antiquated habits that you have to disabuse them of. In particular, the tutorial teaches them `>|`, they become enamoured with it, and then you have to step in and break their hearts.

With this PR, we have a unique opportunity to put an end to heartbreak as we know it. It removes all occurrences of `>|`/`THENL`, and instead teaches  `>-`/`THEN1`, which was curiously absent before.