### PR TITLE
COUNTABLE_LIST_UNIV (new) and CARD_COUNTABLE_CONG (fixed)

### DIFF
--- a/src/pred_set/src/more_theories/cardinalScript.sml
+++ b/src/pred_set/src/more_theories/cardinalScript.sml
@@ -21,7 +21,7 @@ open HolKernel Parse boolLib bossLib mesonLib
 open boolSimps pred_setTheory set_relationTheory tautLib
 
 open prim_recTheory arithmeticTheory numTheory numLib pairTheory
-open optionTheory sumTheory ind_typeTheory wellorderTheory;
+open optionTheory sumTheory ind_typeTheory wellorderTheory hurdUtils;
 
 val _ = new_theory "cardinal";
 
@@ -3005,13 +3005,19 @@ Proof
   metis_tac[FINITE_EXPONENT_SETEXP_COUNTABLE]
 QED
 
-val CARD_EQ_COUNTABLE = store_thm ("CARD_EQ_COUNTABLE",
- ``!s:'a->bool t:'a->bool. COUNTABLE t /\ s =_c t ==> COUNTABLE s``,
-  REWRITE_TAC[GSYM CARD_LE_ANTISYM] THEN MESON_TAC[CARD_LE_COUNTABLE]);
+(* NOTE: Changed the type of ‘t’ to ‘:'b->bool’ (was: 'a->bool) *)
+Theorem CARD_EQ_COUNTABLE :
+    !s:'a->bool t:'b->bool. COUNTABLE t /\ s =_c t ==> COUNTABLE s
+Proof
+  REWRITE_TAC[GSYM CARD_LE_ANTISYM] THEN MESON_TAC[CARD_LE_COUNTABLE]
+QED
 
-val CARD_COUNTABLE_CONG = store_thm ("CARD_COUNTABLE_CONG",
- ``!s:'a->bool t:'a->bool. s =_c t ==> (COUNTABLE s <=> COUNTABLE t)``,
-  REWRITE_TAC[GSYM CARD_LE_ANTISYM] THEN MESON_TAC[CARD_LE_COUNTABLE]);
+(* NOTE: Changed the type of ‘t’ to ‘:'b->bool’ (was: 'a->bool) *)
+Theorem CARD_COUNTABLE_CONG :
+    !s:'a->bool t:'b->bool. s =_c t ==> (COUNTABLE s <=> COUNTABLE t)
+Proof
+  REWRITE_TAC[GSYM CARD_LE_ANTISYM] THEN MESON_TAC[CARD_LE_COUNTABLE]
+QED
 
 val COUNTABLE_RESTRICT = store_thm ("COUNTABLE_RESTRICT",
  ``!s P. COUNTABLE s ==> COUNTABLE {x | x IN s /\ P x}``,
@@ -3185,6 +3191,32 @@ Proof
   SIMP_TAC std_ss [IN_IMAGE, FORALL_PROD, IN_ELIM_PAIR_THM,
               EXISTS_PROD, IN_CROSS, IN_UNIV] THEN
   ASM_SET_TAC[]
+QED
+
+(* cf. listTheory.INFINITE_LIST_UNIV |- INFINITE univ(:'a list) *)
+Theorem COUNTABLE_LIST_UNIV :
+    countable univ(:'a) ==> countable univ(:'a list)
+Proof
+    rw [UNIV_list]
+ >> MP_TAC (INST [“A :'a set” |-> “univ(:'a)”] list_BIGUNION_EXP)
+ >> qmatch_abbrev_tac ‘list univ(:'a) =~ s ==> _’
+ >> DISCH_TAC
+ >> Suff ‘countable s’
+ >- (MP_TAC (Q.SPEC ‘s’ (INST_TYPE [“:'b” |-> “:num # (num -> 'a)”]
+                          (ISPEC “list univ(:'a)” CARD_EQ_COUNTABLE))) \\
+     rw [])
+ >> qunabbrev_tac ‘s’
+ >> MATCH_MP_TAC COUNTABLE_BIGUNION >> rw []
+ >> MATCH_MP_TAC COUNTABLE_CROSS >> rw []
+ >> rw [countable_setexp]
+QED
+
+Theorem COUNTABLE_LIST_UNIV' :
+    FINITE univ(:'a) ==> countable univ(:'a list)
+Proof
+    DISCH_TAC
+ >> MATCH_MP_TAC COUNTABLE_LIST_UNIV
+ >> MATCH_MP_TAC FINITE_IMP_COUNTABLE >> art []
 QED
 
 Definition BIGPRODi_def:

--- a/src/pred_set/src/more_theories/topologyScript.sml
+++ b/src/pred_set/src/more_theories/topologyScript.sml
@@ -29,7 +29,6 @@ open boolSimps simpLib mesonLib metisLib pairTheory pairLib tautLib combinTheory
 
 val _ = new_theory "topology";
 
-fun MESON ths tm = prove(tm,MESON_TAC ths);
 fun METIS ths tm = prove(tm,METIS_TAC ths);
 
 fun K_TAC _ = ALL_TAC;
@@ -41,7 +40,6 @@ fun wrap a = [a];
 Theorem IMP_CONJ      = cardinalTheory.CONJ_EQ_IMP
 Theorem IMP_IMP       = boolTheory.AND_IMP_INTRO
 Theorem FINITE_SUBSET = pred_setTheory.SUBSET_FINITE_I
-Theorem LE_0          = arithmeticTheory.ZERO_LESS_EQ
 
 Theorem FINITE_INDUCT_STRONG :
    !P:('a->bool)->bool.

--- a/src/pred_set/src/more_theories/wellorderScript.sml
+++ b/src/pred_set/src/more_theories/wellorderScript.sml
@@ -9,7 +9,6 @@ val _ = new_theory "wellorder"
 val _ = temp_delsimps ["NORMEQ_CONV"]
 
 fun K_TAC _ = ALL_TAC;
-fun MESON ths tm = prove(tm,MESON_TAC ths);
 fun METIS ths tm = prove(tm,METIS_TAC ths);
 
 fun SET_TAC L =

--- a/src/real/analysis/real_topologyScript.sml
+++ b/src/real/analysis/real_topologyScript.sml
@@ -16547,12 +16547,14 @@ val UNCOUNTABLE_REAL = store_thm ("UNCOUNTABLE_REAL",
   REWRITE_TAC[CANTOR_THM_UNIV] THEN MATCH_MP_TAC CARD_EQ_IMP_LE THEN
   ONCE_REWRITE_TAC[CARD_EQ_SYM] THEN REWRITE_TAC[CARD_EQ_REAL]);
 
-val CARD_EQ_REAL_IMP_UNCOUNTABLE = store_thm ("CARD_EQ_REAL_IMP_UNCOUNTABLE",
- ``!s:real->bool. s =_c univ(:real) ==> ~COUNTABLE s``,
+Theorem CARD_EQ_REAL_IMP_UNCOUNTABLE :
+    !s:real->bool. s =_c univ(:real) ==> ~COUNTABLE s
+Proof
   GEN_TAC THEN STRIP_TAC THEN
-  DISCH_THEN (MP_TAC o SPEC ``univ(:real)`` o MATCH_MP
+  DISCH_THEN (MP_TAC o ISPEC ``univ(:real)`` o MATCH_MP
     (SIMP_RULE std_ss [CONJ_EQ_IMP] CARD_EQ_COUNTABLE)) THEN
-  REWRITE_TAC[UNCOUNTABLE_REAL] THEN ASM_MESON_TAC[CARD_EQ_SYM]);
+  REWRITE_TAC[UNCOUNTABLE_REAL] THEN ASM_MESON_TAC[CARD_EQ_SYM]
+QED
 
 (* ------------------------------------------------------------------------- *)
 (* Cardinalities of various useful sets.                                     *)


### PR DESCRIPTION
Hi,

In `cardinalTheory`, the following two existing theorems saying two sets are both countable if they have the same cardinality, are fixed (trivially) by making the two involved sets type-different (the type of `t` was `:'a -> bool`, rendering the theorems less useful):
```
> CARD_EQ_COUNTABLE;
val it = |- !(s :'a -> bool) (t :'b -> bool). countable t /\ s =~ t ==> countable s: thm
> CARD_COUNTABLE_CONG;
val it = |- !(s :'a -> bool) (t :'b -> bool). s =~ t ==> (countable s <=> countable t): thm
```

I found this issue when I was trying to use them on two sets having different types. Then, I added the following two new theorems about the cardinality of the universe of all lists:
```
   [COUNTABLE_LIST_UNIV]  Theorem      
      ⊢ countable 𝕌(:α) ⇒ countable 𝕌(:α list)
   
   [COUNTABLE_LIST_UNIV']  Theorem      
      ⊢ FINITE 𝕌(:α) ⇒ countable 𝕌(:α list)
```

The proof of the above first theorem heavily relies on the `list` constant in `cardinalTheory` and several advanced set-theoretic results there.

The above second one is an easy corollary of the first one (because `FINITE_IMP_COUNTABLE |- ∀s. FINITE s ⇒ countable s`) but is actually more useful. For example, with `FINITE_UNIV_char ⊢ FINITE 𝕌(:char)`, one can easily prove `COUNTABLE_STR_UNIV ⊢ countable 𝕌(:string)` (but there's no good place to put this theorem, as `stringTheory` is built much earlier than `cardinalTheory`.)

P. S. `COUNTABLE_STR_UNIV` is currently in `basic_swapTheory` of the lambda example.

--Chun