### PR TITLE
Fix DB.find slowness when searching with regexes

### DIFF
--- a/src/coretypes/pairScript.sml
+++ b/src/coretypes/pairScript.sml
@@ -273,6 +273,19 @@ val UNCURRY_ONE_ONE_THM =
 
 Theorem UNCURRY_ONE_ONE_THM[simp] = UNCURRY_ONE_ONE_THM;
 
+(* ----------------------------------------------------------------------
+    UNCURRY_EQ = |- UNCURRY f x = y <=> ?a b. x = (a,b) /\ f a b = y
+
+    (given that UNCURRY = flip pair_CASE, this is the "case equality"
+     theorem recast)
+   ---------------------------------------------------------------------- *)
+
+Theorem UNCURRY_EQ:
+  UNCURRY f x = y <=> ?a b. x = (a,b) /\ f a b = y
+Proof
+  Q.SPEC_THEN ‘x’ STRIP_ASSUME_TAC pair_CASES >>
+  ASM_SIMP_TAC bool_ss [UNCURRY_DEF, PAIR_EQ]
+QED
 
 (* ------------------------------------------------------------------------- *)
 (* pair_Axiom = |- !f. ?fn. !x y. fn (x,y) = f x y                           *)
@@ -559,15 +572,21 @@ val pair_case_def = save_thm("pair_case_def", pair_case_thm)
 val _ = overload_on("case", ``pair_CASE``)
 
 
+Theorem pair_CASE_UNCURRY:
+  pair_CASE = flip UNCURRY
+Proof
+  SIMP_TAC bool_ss [FUN_EQ_THM, pair_CASE_def, combinTheory.C_DEF, UNCURRY]
+QED
+
 val pair_case_cong = save_thm("pair_case_cong",
   Prim_rec.case_cong_thm pair_CASES pair_case_thm);
 val pair_rws = [PAIR, FST, SND];
 
-val pair_case_eq = Q.store_thm(
-  "pair_case_eq",
-  ‘(pair_CASE p f = v) <=> ?x y. (p = (x,y)) /\ (f x y = v)’,
-  Q.ISPEC_THEN ‘p’ STRUCT_CASES_TAC pair_CASES THEN
-  SRW_TAC[][pair_CASE_def, FST, SND, PAIR_EQ]);
+Theorem pair_case_eq:
+  (pair_CASE p f = v) <=> ?x y. (p = (x,y)) /\ (f x y = v)
+Proof
+  SIMP_TAC bool_ss [pair_CASE_UNCURRY, UNCURRY_EQ, combinTheory.C_DEF]
+QED
 
 val pair_case_ho_elim = Q.store_thm(
   "pair_case_ho_elim",

--- a/src/postkernel/DBSearchParser.sig
+++ b/src/postkernel/DBSearchParser.sig
@@ -7,5 +7,5 @@ sig
                 | Word of char list
     val parse_regexp : string -> search_regexp
     val translate_regexp : search_regexp -> regexpMatch.regexp
-    val contains_regexp : string -> string -> bool
+    val contains : regexpMatch.regexp -> regexpMatch.regexp
 end

--- a/src/postkernel/DBSearchParser.sig
+++ b/src/postkernel/DBSearchParser.sig
@@ -5,6 +5,8 @@ sig
                 | Twiddle of search_regexp * search_regexp
                 | Seq of search_regexp * search_regexp
                 | Word of char list
+                | Many of search_regexp
+                | Any
     val parse_regexp : string -> search_regexp
     val translate_regexp : search_regexp -> regexpMatch.regexp
     val contains : regexpMatch.regexp -> regexpMatch.regexp

--- a/src/postkernel/DBSearchParser.sml
+++ b/src/postkernel/DBSearchParser.sml
@@ -103,15 +103,6 @@ end
 
 val is_regexp = List.exists is_special_char o String.explode
 
-fun contains_regexp pattern string =
-    if is_regexp pattern then
-        let val intermediate = parse_regexp pattern
-            val compiled_pattern = translate_regexp intermediate
-            fun contains pat = Dot (any, Dot (pat, any))
-        in
-            match (contains compiled_pattern) string
-        end
-    else
-        String.isSubstring pattern string
+fun contains pat = Dot (any, Dot (pat, any))
 
 end

--- a/tools/Holmake/regexpMatch.sig
+++ b/tools/Holmake/regexpMatch.sig
@@ -46,6 +46,11 @@ sig
                    start : int,
                    final : bool vector}
 
+  val match_with_dfa
+      : {delta : int vector vector,
+         start : int,
+         final : bool vector} -> string -> bool
+
   val match : regexp -> string -> bool
 
 end

--- a/tools/Holmake/regexpMatch.sml
+++ b/tools/Holmake/regexpMatch.sml
@@ -345,8 +345,7 @@ fun match_with_dfa {delta,start,final} = let
                                  Int.toString(Vector.length delta),".\n"])
     fun step (a,q) = Vector.sub(Vector.sub(delta,q), Char.ord a)
     fun exec ss = Substring.foldl step start ss
-    val go: string -> bool = fn s => Vector.sub(final,exec (Substring.full s))
-in go 
+in fn s => Vector.sub(final,exec (Substring.full s))
 end;
 
 val match = match_with_dfa o regexp_to_dfa_arrays;

--- a/tools/Holmake/regexpMatch.sml
+++ b/tools/Holmake/regexpMatch.sml
@@ -340,15 +340,16 @@ fun dfa_to_arrays (Q,q0,deltaMap,F) =
 
 val regexp_to_dfa_arrays = dfa_to_arrays o regexp_to_dfa;
 
-fun match r =
- let val {delta,start,final} = regexp_to_dfa_arrays r
-     val _ = print (String.concat["DFA states: ",
-                    Int.toString(Vector.length delta),".\n"])
-     fun step (a,q) = Vector.sub(Vector.sub(delta,q), Char.ord a)
-     fun exec ss = Substring.foldl step start ss
- in
-   fn s => Vector.sub(final,exec (Substring.full s))
- end;
+fun match_with_dfa {delta,start,final} = let
+    val _ = print (String.concat["DFA states: ",
+                                 Int.toString(Vector.length delta),".\n"])
+    fun step (a,q) = Vector.sub(Vector.sub(delta,q), Char.ord a)
+    fun exec ss = Substring.foldl step start ss
+    val go: string -> bool = fn s => Vector.sub(final,exec (Substring.full s))
+in go 
+end;
+
+val match = match_with_dfa o regexp_to_dfa_arrays;
 
 fun pred_to_set P =
     Binaryset.foldl (fn (c, acc) => if P c then Binaryset.add(acc, c) else acc)


### PR DESCRIPTION
*edit* I messed this branch up I'm closing this and opening a different one with the commits cherry picked on

Currently in draft mode since I think it needs everyone to run the smart configure tool to rebuild regexpMatch.sml, and I'm not too sure how to get around that

---

After adding basic regex support to DB.find (https://github.com/HOL-Theorem-Prover/HOL/pull/1246), DB.find is unusably slow, which I didn't realise since I didn't have many theories built when testing.

Previously, the DB.find search regexp was compiled into a DFA every time an entry in the database was checked. This compilation step has now been moved so this only happens once per search.

![image](https://github.com/user-attachments/assets/59318950-1a05-4fd0-850e-1cd2b9cf0bc3)


Also, added `.` and `*` operators for any character and zero-or-more matches respectively:

<img width="479" alt="image" src="https://github.com/user-attachments/assets/d2ec4660-fb61-4f9d-9106-ac6f94ab383b">

