### PR TITLE
New example for cv translate

### DIFF
--- a/examples/cv_compute/finite_fun_exampleScript.sml
+++ b/examples/cv_compute/finite_fun_exampleScript.sml
@@ -1,0 +1,153 @@
+open HolKernel Parse boolLib bossLib;
+open wordsTheory wordsLib cv_stdTheory cv_transLib;
+open cv_typeTheory sptreeTheory;
+
+val _ = new_theory "finite_fun_example";
+
+(* --- setup --- *)
+
+Type mem = “:256 word -> num”;
+
+Definition to_mem_def:
+  to_mem cv =
+    let t = to_sptree_spt cv$c2n cv in
+      ((λa. case lookup (w2n a) t of
+            | NONE => 0n
+            | SOME n => n):mem)
+End
+
+Definition build_spt_def:
+  build_spt 0 (m:mem) = LN ∧
+  build_spt (SUC a) m =
+    if m (n2w a) = 0 then build_spt a m else
+      insert a (m (n2w a)) (build_spt a m)
+End
+
+Definition from_mem_def:
+  from_mem (m:mem) =
+    from_sptree_sptree_spt Num (build_spt (dimword (:256)) m)
+End
+
+Triviality wf_build_spt[simp]:
+  ∀n m. wf (build_spt n m)
+Proof
+  Induct \\ gvs [build_spt_def] \\ rw [] \\ gvs [wf_insert]
+QED
+
+Triviality lookup_build_spt_lemma1:
+  ∀k n. n < k ⇒ lookup n (build_spt k x) = lookup n (build_spt (SUC n) x)
+Proof
+  Induct \\ gvs []
+  \\ strip_tac
+  \\ Cases_on ‘n = k’ \\ gvs []
+  \\ simp [Once build_spt_def]
+  \\ rw [] \\ gvs [lookup_insert]
+QED
+
+Triviality lookup_build_spt_lemma2:
+  ∀k n. k ≤ n ⇒ lookup n (build_spt k x) = NONE
+Proof
+  Induct \\ gvs [build_spt_def] \\ rw [lookup_insert]
+QED
+
+Theorem from_to_mem[cv_from_to]:
+  from_to from_mem to_mem
+Proof
+  gvs [from_to_def,to_mem_def,from_mem_def,FUN_EQ_THM,
+       cv_typeLib.from_to_thm_for “:num spt” |> SRULE [cv_typeTheory.from_to_def]]
+  \\ strip_tac \\ Cases \\ rw [] \\ gvs []
+  \\ simp [lookup_build_spt_lemma1] \\ rw [build_spt_def]
+  \\ simp [lookup_build_spt_lemma2]
+QED
+
+Definition mem_lookup_def:
+  mem_lookup a (m:mem) = m a
+End
+
+Definition mem_update_def:
+  mem_update a v (m:mem) = (a =+ v) m
+End
+
+Definition mem_empty_def:
+  mem_empty = ((λa. 0):mem)
+End
+
+Definition cv_mem_lookup_def:
+  cv_mem_lookup (a:cv) (m:cv) =
+    let res = cv_lookup a m in
+      cv_if (cv_ispair res) (cv_snd res) (Num 0)
+End
+
+Definition cv_mem_update_def:
+  cv_mem_update (a:cv) (v:cv) (m:cv) =
+    cv_if (cv_eq v (Num 0))
+      (cv_delete a m)
+      (cv_insert a v m)
+End
+
+Theorem mem_empty_cv_rep[cv_rep]:
+  from_mem mem_empty = Num 0
+Proof
+  gvs [from_mem_def]
+  \\ qsuff_tac ‘∀n. build_spt n mem_empty = LN’
+  >- (gvs [] \\ EVAL_TAC)
+  \\ Induct \\ gvs [build_spt_def,mem_empty_def]
+QED
+
+Theorem mem_lookup_cv_rep[cv_rep]:
+  Num (mem_lookup a m) =
+  cv_mem_lookup (from_word a) (from_mem m)
+Proof
+  gvs [mem_lookup_def,cv_mem_lookup_def,from_mem_def,from_word_def]
+  \\ gvs [GSYM cv_lookup_thm]
+  \\ rewrite_tac [GSYM (EVAL “dimword (:256)”)]
+  \\ Cases_on ‘lookup (w2n a) (build_spt (dimword (:256)) m)’ \\ gvs []
+  \\ gvs [from_option_def]
+  \\ pop_assum mp_tac
+  \\ qspec_then ‘a’ assume_tac w2n_lt
+  \\ dxrule lookup_build_spt_lemma1 \\ gvs []
+  \\ gvs [build_spt_def] \\ rw [] \\ gvs [lookup_insert] \\ rw []
+  \\ gvs [lookup_build_spt_lemma2]
+QED
+
+Theorem mem_update_cv_rep[cv_rep]:
+  from_mem (mem_update a v m) =
+  cv_mem_update (from_word a) (Num v) (from_mem m)
+Proof
+  gvs [mem_update_def,cv_mem_update_def,from_mem_def,from_word_def]
+  \\ Cases_on ‘v = 0’ \\ gvs [GSYM cv_delete_thm]
+  \\ gvs [GSYM cv_insert_thm] \\ AP_TERM_TAC
+  \\ dep_rewrite.DEP_REWRITE_TAC [sptreeTheory.spt_eq_thm]
+  \\ gvs [lookup_delete,wf_delete,wf_insert,lookup_insert]
+  \\ rw [] \\ gvs []
+  \\ qspec_then ‘a’ assume_tac w2n_lt
+  \\ dxrule lookup_build_spt_lemma1 \\ gvs [] \\ rw []
+  \\ gvs [build_spt_def] \\ rw [] \\ gvs [lookup_insert] \\ rw []
+  \\ gvs [lookup_build_spt_lemma2]
+  \\ Cases_on ‘n < dimword (:256)’
+  \\ gvs [lookup_build_spt_lemma1,lookup_build_spt_lemma2]
+  \\ Cases_on ‘a’ \\ gvs []
+  \\ gvs [build_spt_def,combinTheory.APPLY_UPDATE_THM]
+  \\ rw [] \\ gvs [lookup_build_spt_lemma2]
+QED
+
+Theorem to_mem_funs =
+  LIST_CONJ [mem_empty_def,mem_lookup_def,mem_update_def] |> GSYM;
+
+(* --- test --- *)
+
+Definition mem_test_def:
+  mem_test (mem1:mem) (mem2:mem) a =
+   if mem1 a + mem2 a < 100 then
+     (1n,mem2⦇60w ↦ 45; a ↦ mem1 a + 1⦈)
+   else (2n,λa. 0)
+End
+
+val _ = cv_trans (mem_test_def |> SRULE [to_mem_funs]);
+
+val th = fetch "-" "cv_mem_test_thm";
+val def = fetch "-" "cv_mem_test_def";
+
+val res = cv_eval “mem_test mem_empty mem_empty 3w”;
+
+val _ = export_theory();

--- a/src/num/theories/cv_compute/automation/cv_transLib.sml
+++ b/src/num/theories/cv_compute/automation/cv_transLib.sml
@@ -359,10 +359,13 @@ fun preprocess_def def = let
            in adjust_def (AP_THM th var) end
     end;
   val defs = map adjust_def defs
+  fun is_bad_arg_ty ty =
+    if can cv_typeLib.from_to_thm_for ty then false else
+      contains_fun_ty ty;
   (* val th = hd defs *)
   fun check_arg_tys th =
     let val (const,args) = th |> concl |> dest_eq |> fst |> strip_comb
-        val bad_args = filter (contains_fun_ty o type_of) args
+        val bad_args = filter (is_bad_arg_ty o type_of) args
     in
       if null bad_args then ()
       else let

--- a/src/num/theories/cv_compute/automation/cv_transLib.sml
+++ b/src/num/theories/cv_compute/automation/cv_transLib.sml
@@ -338,7 +338,6 @@ val clean_name = let
                     c = #"_" orelse c = #"'"
   in String.translate (fn c => if okay_char c then implode [c] else "_") end;
 
-
 (*
   val _ = Define `bar x = x + 5n`
   val def = Define `foo = bar`
@@ -352,11 +351,12 @@ fun preprocess_def def = let
         val l_ty = type_of l
         val is_fun = can dom_rng l_ty
     in
-      if not is_fun then th
-      else let val dom_ty = fst (dom_rng l_ty)
-               val var = mk_var ("arg", dom_ty)
-               val var = numvariant (free_vars (concl th)) var
-           in adjust_def (AP_THM th var) end
+      if not is_fun then th else
+      if can cv_typeLib.from_to_thm_for l_ty then th else
+        let val dom_ty = fst (dom_rng l_ty)
+            val var = mk_var ("arg", dom_ty)
+            val var = numvariant (free_vars (concl th)) var
+        in adjust_def (AP_THM th var) end
     end;
   val defs = map adjust_def defs
   fun is_bad_arg_ty ty =

--- a/src/num/theories/cv_compute/automation/cv_typeLib.sml
+++ b/src/num/theories/cv_compute/automation/cv_typeLib.sml
@@ -124,10 +124,6 @@ fun from_to_for_tyvar tyvar = let
   in ISPECL [f,t] from_to_def |> concl |> dest_eq |> fst |> ASSUME end
 
 fun from_to_for tyvars_alist ty =
-  if can dom_rng ty then (
-    cv_print Silent ("cv translator encountered a function type: " ^ type_to_string ty ^ "\n");
-    failwith  "cv translator does not support function types")
-  else
   if ty = oneSyntax.one_ty then from_to_unit else
   if ty = Type.bool then from_to_bool else
   if ty = numSyntax.num then from_to_num else
@@ -182,7 +178,13 @@ fun from_to_for tyvars_alist ty =
     in
       case find_first match_from_to_thm thms of
         SOME th => th
-      | NONE => raise Missing_from_to ty
+      | NONE =>
+         if can dom_rng ty then (
+           cv_print Silent ("cv translator encountered a function type: " ^
+                            type_to_string ty ^ "\n");
+           failwith  "cv translator does not support function types")
+         else
+           raise Missing_from_to ty
     end
 
 fun from_for tyvars_alist ty = from_to_for tyvars_alist ty |> concl |> rator |> rand;


### PR DESCRIPTION
The new example shows that function values with a finite domain can be used with cv translate. The new example teaches `cv_transLib` about the type `:256 word → num`. Values of this type are represented on the `cv` side as `cv` representations of an `num spt`, where lack of mapping for a given key `k` means that `k` maps to 0. This way the size of the cv representation is manageable as long as most entries map to 0.