### PR TITLE
Make `buildheap --exe` not create a temporary `.ML` file

### DIFF
--- a/tools-poly/execompile.ML
+++ b/tools-poly/execompile.ML
@@ -1,7 +1,6 @@
 structure BuildHeap_EXE_Compile :
 sig
-  val res : OS.Process.status ref
-  val exe_compile : {fnname: string, output_exe: string, keep_temp_files : bool}
+  val exe_compile : {fnname: string, output_exe: string, keep_temp_files: bool}
                       ->
                     'a
 end =
@@ -9,7 +8,7 @@ struct
 
 fun quietremove f = OS.FileSys.remove f handle SysErr _ => ()
 
-fun withtemp_file {stem, extension, keep_file} (k : string -> unit) =
+fun withtemp_file {stem, extension, keep_file} (k : string -> 'a) : 'a =
   let
     fun gen i =
       let
@@ -17,52 +16,38 @@ fun withtemp_file {stem, extension, keep_file} (k : string -> unit) =
         val fname = OS.Path.joinBaseExt{base = stem, ext = SOME extension}
       in
         if OS.FileSys.access(fname, [OS.FileSys.A_READ]) then gen (i + 1)
-        else (
-          k fname;
-          if keep_file then () else quietremove fname
-        )
+        else
+          k fname
+            before (if keep_file then () else quietremove fname)
       end
   in
     gen 0
   end
 
-
-fun gen_ml_compile_file {functionname, mlfilename, objfilename, execname} k =
+fun compile {functionname, objfilename, execname} =
   let
-    val out = TextIO.openOut mlfilename
-    fun p s = TextIO.output(out, s ^ "\n")
+    val old_print_depth = !PolyML.Compiler.printDepth
+    val codestream = TextIO.openString ("val () = " ^ functionname ^ " ()")
+    val () = PolyML.print_depth ~1;
+    val function = PolyML.compiler (fn () => TextIO.input1 codestream, [])
   in
-    p ("PolyML.print_depth ~1;");
-    p ("PolyML.shareCommonData PolyML.rootFunction;");
-    p ("PolyML.export(\"" ^ String.toString objfilename ^ "\", " ^
-       functionname ^");");
-    p ("val _ = BuildHeap_EXE_Compile.res := "^
-       "Systeml.systeml ([\"cc\", \"-o\", \"" ^ execname ^ "\", \"" ^
-       String.toString objfilename ^ "\"] @ Systeml.POLY_LDFLAGS);");
-    TextIO.closeOut out;
-    k ()
+    PolyML.shareCommonData PolyML.rootFunction;
+    PolyML.export (objfilename, function);
+    Systeml.systeml (["cc", "-o", execname, objfilename] @ Systeml.POLY_LDFLAGS)
+      before PolyML.print_depth old_print_depth
   end
 
-val res = ref OS.Process.success
-
-fun exe_compile {fnname: string, output_exe: string, keep_temp_files : bool} =
+fun exe_compile {fnname: string, output_exe: string, keep_temp_files: bool} =
   let
     val output_stem = OS.Path.file output_exe
-    fun withobj_and_ml obj ml =
-      gen_ml_compile_file {functionname = fnname,
-                           mlfilename = ml,
-                           objfilename = obj,
-                           execname = output_exe}
-                          (fn () => PolyML.use ml)
     fun withobj obj =
-      withtemp_file {stem = "poly-mk" ^ output_stem, extension = "ML",
-                     keep_file = keep_temp_files}
-                    (withobj_and_ml obj)
+      compile {functionname = fnname, objfilename = obj, execname = output_exe}
+
+    val res = withtemp_file {stem = output_stem, extension = "o",
+                             keep_file = keep_temp_files}
+                            withobj
   in
-    withtemp_file {stem = output_stem, extension = "o",
-                   keep_file = keep_temp_files}
-                  withobj ;
-    OS.Process.exit (!res)
+    OS.Process.exit res
   end
 
 end (* struct *)


### PR DESCRIPTION
**Note:** This PR follows from the recent discussion in the `#hol` Discord channel about the appearance of some (apparently) mysterious `.ML` files. The creation of these files was traced to the code in `tools-poly/execompile.ML`, which runs as part of the `buildheap` command when using options `-o` and `--exe`.

**Note 2:** It's hard to tell for sure why the original code was creating the temporary `.ML` file in the first place. My guess is that the function to be compiled is only available as a string (since the user provides it as a command-line option) containing the name of the function, while `PolyML.use` expects an entire file. However, I believe the latter is easily worked around by using the Poly/ML compiler directly rather than the `PolyML.use` wrapper, as can be seen in the code of this PR. Hopefully, there is no other reason why the temporary `.ML` file was being used, which presumably might invalidate this PR. This PR contains 1 commit, whose description follows:

In some situations, these temporary `.ML` files would be left laying around the HOL source tree instead of being deleted, even when buildheap's `--dbg` option is not being used.

This could happen for multiple reasons, namely: due to a system crash or abrupt power off, the user or the OS killing the buildheap process, or more commonly, due to Holmake killing buildheap because some other build step that was running in parallel failed.

The result of the above situations is that these `.ML` file(s), which are untracked by git, suddenly appeared in the HOL source tree. More importantly, the user might not notice this happening until much later, at which point he might no longer realize what was the cause of the problem or whether they can be deleted.

This commit removes the creation of the temporary `.ML` files altogether, calling the Poly/ML compiler directly instead to create the compiled object file.

Note that this commit does not remove the similar creation of the temporary `.o` object files, created by `PolyML.export(...)`.

Initially, it was considered that `OS.FileSys.tmpName ()` could be used to create these temporary files (including the object files), but this option was rejected for the following reasons:

1. `tmpName ()` does not allow the calling code to choose the file extension, and indeed, in Poly/ML the resulting files don't have an extension.

2. It does not seem possible to extend or recreate `tmpName ()` securely within SML, in a way that allows choosing an extension (although, it might be possible to do it with the FFI, but the effort does not seem worthwhile).

3. According to the documentation, the `cc` command typically expects object files to have a `.o` extension, to differentiate them from C source files. In practice, both gcc and clang's `cc` command seem to link object files successfully even when they don't have a `.o` extension, but this seems to be undocumented (thus probably not a good idea to rely on this behavior) and it might not work for other compilers.

Fortunately, leftover `.o` files are not as bothersome as leftover `.ML` files, because the former have an entry in `.gitignore`, thus being hidden from most git commands.