### PR TITLE
listRanges and isPREFIX, etc.

### DIFF
--- a/examples/formal-languages/context-free/NTpropertiesScript.sml
+++ b/examples/formal-languages/context-free/NTpropertiesScript.sml
@@ -182,7 +182,7 @@ Proof
   HO_MATCH_MP_TAC grammarTheory.ptree_ind >>
   strip_tac >- (rw[] >> Cases_on`pt` >> fs[]) >>
   qx_gen_tac `subs` >> strip_tac >> dsimp[] >>
-  dsimp[FLAT_EQ_NIL, listTheory.MEM_MAP] >>
+  dsimp[FLAT_EQ_NIL', listTheory.MEM_MAP] >>
   map_every qx_gen_tac [`N`, `sn`] >> Cases_on `N` >>
   simp[nullableML_def, ptree_NTs_def, ptree_rptfree_def] >>
   strip_tac >> simp[EXTENSION] >>
@@ -202,12 +202,12 @@ Proof
   HO_MATCH_MP_TAC grammarTheory.ptree_ind >>
   strip_tac >- (rw[] >> Cases_on`pt` >> fs[]) >>
   simp[ptree_rptfree_def, ptree_NTs_def] >> qx_gen_tac `subs` >> strip_tac >>
-  dsimp[listTheory.MEM_MAP, FLAT_EQ_NIL] >>
+  dsimp[listTheory.MEM_MAP, FLAT_EQ_NIL'] >>
   NTAC 2 strip_tac >>
   Cases_on `pt` >>
-  fs[ptree_rptfree_def, FLAT_EQ_NIL, listTheory.MEM_MAP,ptree_NTs_def]
+  fs[ptree_rptfree_def, FLAT_EQ_NIL', listTheory.MEM_MAP,ptree_NTs_def]
   >-(qexists_tac `Nd (N, ARB) subs` >>
-     fs[ptree_rptfree_def, FLAT_EQ_NIL, listTheory.MEM_MAP] >> dsimp[]) >>
+     fs[ptree_rptfree_def, FLAT_EQ_NIL', listTheory.MEM_MAP] >> dsimp[]) >>
   metis_tac[]
 QED
 
@@ -220,7 +220,7 @@ Theorem rptfree_nullable_ptrees_possible:
 Proof
   HO_MATCH_MP_TAC grammarTheory.ptree_ind >>
   strip_tac >- (rw[] >> Cases_on`pt` >> fs[]) >>
-  dsimp[FLAT_EQ_NIL, listTheory.MEM_MAP] >>
+  dsimp[FLAT_EQ_NIL', listTheory.MEM_MAP] >>
   map_every qx_gen_tac [`subs`, `N`] >> rpt strip_tac >>
   Cases_on `N` >> fs[] >>
   `∃subs' : (α,β,γ) parsetree list.
@@ -235,7 +235,7 @@ Proof
   Cases_on `∃pt. MEM pt subs' ∧ q ∈ ptree_NTs pt`
   >- (fs[] >> metis_tac[rptfree_subtree]) >>
   fs[] >> qexists_tac `Nd (q,r) subs'` >>
-  dsimp[ptree_rptfree_def, FLAT_EQ_NIL, listTheory.MEM_MAP] >> metis_tac[]
+  dsimp[ptree_rptfree_def, FLAT_EQ_NIL', listTheory.MEM_MAP] >> metis_tac[]
 QED
 
 Theorem nullable_nullableML:
@@ -507,7 +507,7 @@ Proof
   imp_res_tac heads_give_first >> rveq >> fs[DISJ_IMP_THM, FORALL_AND_THM] >>
   `nullable G (MAP ptree_head p)`
     by (dsimp[nullable_alltrees, MEM_MAP] >>
-        full_simp_tac (srw_ss() ++ boolSimps.DNF_ss) [MEM_MAP, FLAT_EQ_NIL] >>
+        full_simp_tac (srw_ss() ++ boolSimps.DNF_ss) [MEM_MAP, FLAT_EQ_NIL'] >>
         metis_tac[]) >>
   Cases_on `sym` >> Cases_on `p'` >> fs[]
   >- (qexists_tac `[N]` >> simp[] >> metis_tac[]) >>

--- a/src/list/src/listRangeScript.sml
+++ b/src/list/src/listRangeScript.sml
@@ -1103,17 +1103,13 @@ val listRangeLHI_has_divisors = store_thm(
 Theorem isPREFIX_listRangeLHI :
     !m n m' n'. m = m' /\ n <= n' ==> [m ..< n] <<= [m' ..< n']
 Proof
-    rw [listRangeLHI_def]
- >> MATCH_MP_TAC isPREFIX_GENLIST
- >> rw []
+    rw [listRangeLHI_def, isPREFIX_GENLIST]
 QED
 
 Theorem isPREFIX_listRangeINC :
     !m n m' n'. m = m' /\ n <= n' ==> [m .. n] <<= [m' .. n']
 Proof
-    rw [listRangeINC_def]
- >> MATCH_MP_TAC isPREFIX_GENLIST
- >> rw []
+    rw [listRangeINC_def, isPREFIX_GENLIST]
 QED
 
 Theorem listRangeLHI_11 :
@@ -1147,8 +1143,7 @@ Theorem isPREFIX_listRangeLHI_EQ :
 Proof
     rpt GEN_TAC >> STRIP_TAC
  >> reverse EQ_TAC
- >- (rw [listRangeLHI_def] \\
-     MATCH_MP_TAC isPREFIX_GENLIST >> rw [])
+ >- rw [listRangeLHI_def, isPREFIX_GENLIST]
  >> rw [listRangeLHI_CONS]
  >> Cases_on ‘m + 1 = n’ >- POP_ASSUM (fs o wrap o SYM)
  >> Cases_on ‘m + 1 = n'’

--- a/src/list/src/listRangeScript.sml
+++ b/src/list/src/listRangeScript.sml
@@ -7,6 +7,8 @@ open HolKernel Parse boolLib BasicProvers;
 open arithmeticTheory TotalDefn simpLib numSimps numLib listTheory metisLib
      pred_setTheory listSimps dividesTheory;
 
+val _ = new_theory "listRange";
+
 val decide_tac = DECIDE_TAC;
 val metis_tac = METIS_TAC;
 val qabbrev_tac = Q.ABBREV_TAC;
@@ -15,8 +17,9 @@ fun simp l = ASM_SIMP_TAC (srw_ss() ++ ARITH_ss) l;
 fun fs l = FULL_SIMP_TAC (srw_ss() ++ ARITH_ss) l;
 fun rfs l = REV_FULL_SIMP_TAC (srw_ss() ++ ARITH_ss) l;
 val rw = SRW_TAC [ARITH_ss];
-
-val _ = new_theory "listRange";
+val Know = Q_TAC KNOW_TAC;
+fun wrap a = [a];
+val Rewr' = DISCH_THEN (ONCE_REWRITE_TAC o wrap);
 
 (* ------------------------------------------------------------------------- *)
 (* Range Conjunction and Disjunction                                         *)
@@ -1092,5 +1095,83 @@ val listRangeLHI_has_divisors = store_thm(
   "listRangeLHI_has_divisors",
   ``!m n x. 0 < n /\ m <= x /\ x divides n ==> MEM x [m ..< n + 1]``,
   metis_tac[listRangeINC_has_divisors, listRangeLHI_to_INC]);
+
+(* ------------------------------------------------------------------------- *)
+(*  isPREFIX-related theorems (by Chun Tian)                                 *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem isPREFIX_listRangeLHI :
+    !m n m' n'. m = m' /\ n <= n' ==> [m ..< n] <<= [m' ..< n']
+Proof
+    rw [listRangeLHI_def]
+ >> MATCH_MP_TAC isPREFIX_GENLIST
+ >> rw []
+QED
+
+Theorem isPREFIX_listRangeINC :
+    !m n m' n'. m = m' /\ n <= n' ==> [m .. n] <<= [m' .. n']
+Proof
+    rw [listRangeINC_def]
+ >> MATCH_MP_TAC isPREFIX_GENLIST
+ >> rw []
+QED
+
+Theorem listRangeLHI_11 :
+    !m n m' n'. m < n /\ m' < n' ==>
+               ([m ..< n] = [m' ..< n'] <=> m = m' /\ n = n')
+Proof
+    rpt GEN_TAC >> STRIP_TAC
+ >> reverse EQ_TAC >- rw []
+ >> rw [LIST_EQ_REWRITE, listRangeLHI_EL]
+ >- (rfs [listRangeLHI_EL] \\
+     FIRST_X_ASSUM MATCH_MP_TAC \\
+     Q.EXISTS_TAC ‘0’ >> rw [])
+ >> rfs [listRangeLHI_EL]
+ >> POP_ASSUM (MP_TAC o Q.SPEC ‘0’)
+ >> rw []
+QED
+Theorem listRangeINC_11 :
+    !m n m' n'. m <= n /\ m' <= n' ==>
+               ([m .. n] = [m' .. n'] <=> m = m' /\ n = n')
+Proof
+    rw [listRangeINC_to_LHI]
+ >> Know ‘[m ..< SUC n] = [m' ..< SUC n'] <=> m = m' /\ SUC n = SUC n'’
+ >- (MATCH_MP_TAC listRangeLHI_11 >> rw [])
+ >> Rewr'
+ >> rw []
+QED
+
+Theorem isPREFIX_listRangeLHI_EQ :
+    !m n m' n'. m < n /\ m' < n' ==>
+               ([m ..< n] <<= [m' ..< n'] <=> m = m' /\ n <= n')
+Proof
+    rpt GEN_TAC >> STRIP_TAC
+ >> reverse EQ_TAC
+ >- (rw [listRangeLHI_def] \\
+     MATCH_MP_TAC isPREFIX_GENLIST >> rw [])
+ >> rw [listRangeLHI_CONS]
+ >> Cases_on ‘m + 1 = n’ >- POP_ASSUM (fs o wrap o SYM)
+ >> Cases_on ‘m + 1 = n'’
+ >- (POP_ASSUM (fs o wrap o SYM) \\
+     fs [listRangeLHI_NIL])
+ >> CCONTR_TAC
+ >> ‘n' <= n’ by rw []
+ >> ‘[m + 1 ..< n'] <<= [m + 1 ..< n]’ by PROVE_TAC [isPREFIX_listRangeLHI]
+ >> ‘[m + 1 ..< n] = [m + 1 ..< n']’ by PROVE_TAC [isPREFIX_ANTISYM]
+ >> Know ‘[m + 1 ..< n] = [m + 1 ..< n'] <=> m + 1 = m + 1 /\ n = n'’
+ >- (MATCH_MP_TAC listRangeLHI_11 >> simp [])
+ >> rw []
+QED
+
+Theorem isPREFIX_listRangeINC_EQ :
+    !m n m' n'. m <= n /\ m' <= n' ==>
+               ([m .. n] <<= [m' .. n'] <=> m = m' /\ n <= n')
+Proof
+    rw [listRangeINC_to_LHI]
+ >> Know ‘[m ..< SUC n] <<= [m' ..< SUC n'] <=> m = m' /\ SUC n <= SUC n'’
+ >- (MATCH_MP_TAC isPREFIX_listRangeLHI_EQ >> rw [])
+ >> Rewr'
+ >> rw []
+QED
 
 val _ = export_theory();

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -3270,7 +3270,25 @@ Proof
  >> fs []
 QED
 
-Theorem isPREFIX_GENLIST :
+Theorem isPREFIX_SNOC_EQ :
+   !x y z. z <<= SNOC x y <=> z <<= y \/ z = SNOC x y
+Proof
+    NTAC 2 GEN_TAC
+ >> Q.ID_SPEC_TAC `x`
+ >> Q.ID_SPEC_TAC `y`
+ >> INDUCT_THEN list_INDUCT ASSUME_TAC
+ >- (rpt GEN_TAC \\
+     MP_TAC (Q.SPEC `z` list_CASES) \\
+     STRIP_TAC \\
+     rw [SNOC, isPREFIX_NIL, isPREFIX, CONS_11, NOT_CONS_NIL])
+ >> rpt GEN_TAC
+ >> MP_TAC (Q.SPEC `z` list_CASES)
+ >> STRIP_TAC
+ >> rw [SNOC, isPREFIX_NIL, isPREFIX, CONS_11, NOT_CONS_NIL]
+ >> PROVE_TAC []
+QED
+
+Theorem isPREFIX_GENLIST_lemma[local] :
     !f m n. m <= n ==> GENLIST f m <<= GENLIST f n
 Proof
     qx_gen_tac ‘f’
@@ -3281,6 +3299,24 @@ Proof
  >> MATCH_MP_TAC isPREFIX_TRANS
  >> Q.EXISTS_TAC ‘GENLIST f n’ >> rw []
  >> rw [GENLIST, isPREFIX_SNOC]
+QED
+
+Theorem isPREFIX_GENLIST :
+    !(f :num -> 'a) m n. GENLIST f m <<= GENLIST f n <=> m <= n
+Proof
+    rpt GEN_TAC
+ >> reverse EQ_TAC
+ >- rw [isPREFIX_GENLIST_lemma]
+ >> qid_spec_tac ‘m’
+ >> qid_spec_tac ‘n’
+ >> Induct_on ‘n’
+ >- (rw [] >> fs [GENLIST_EQ_NIL])
+ >> GEN_TAC
+ >> simp [GENLIST, isPREFIX_SNOC_EQ]
+ >> STRIP_TAC
+ >- (MATCH_MP_TAC LESS_EQ_TRANS \\
+     Q.EXISTS_TAC ‘n’ >> rw [])
+ >> fs [LIST_EQ_REWRITE]
 QED
 
 Theorem isPREFIX_MAP :

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -39,6 +39,13 @@ fun DECIDE_TAC (g as (asl,_)) =
     CONV_TAC Arith.ARITH_CONV)
    ORELSE tautLib.TAUT_TAC) g;
 val decide_tac = DECIDE_TAC;
+val qexists_tac = Q.EXISTS_TAC;
+val qid_spec_tac = Q.ID_SPEC_TAC;
+val qx_gen_tac = Q.X_GEN_TAC;
+
+val qxch = Q.X_CHOOSE_THEN;
+fun qxchl [] ttac = ttac
+  | qxchl (q::qs) ttac = qxch q (qxchl qs ttac);
 
 val _ = new_theory "list";
 
@@ -3226,6 +3233,66 @@ val GENLIST_CONSTANT = store_thm(
   rw_tac std_ss[] >>
   metis_tac[prim_recTheory.LESS_THM]);
 
+Theorem isPREFIX_NIL :
+    !x. [] <<= x /\ (x <<= [] <=> (x = []))
+Proof
+    qx_gen_tac ‘x’
+ >> Cases_on ‘x’ >- rw []
+ >> rw [isPREFIX]
+QED
+
+Theorem isPREFIX_REFL :
+    !x. x <<= x
+Proof
+    Induct_on ‘x’ >> rw [isPREFIX]
+QED
+
+Theorem isPREFIX_TRANS :
+    !x y z. x <<= y /\ y <<= z ==> x <<= z
+Proof
+    Induct_on ‘x’ >- rw []
+ >> rpt GEN_TAC
+ >> Cases_on ‘y’ >- rw []
+ >> Cases_on ‘z’ >- rw []
+ >> rw []
+ >> FIRST_X_ASSUM MATCH_MP_TAC
+ >> Q.EXISTS_TAC ‘l’ >> rw []
+QED
+
+Theorem isPREFIX_ANTISYM :
+    !x y. x <<= y /\ y <<= x ==> x = y
+Proof
+    Induct_on ‘x’ >- rw []
+ >> rpt GEN_TAC
+ >> Cases_on ‘y’ >- rw []
+ >> STRIP_TAC
+ >> rw []
+ >> fs []
+QED
+
+Theorem isPREFIX_GENLIST :
+    !f m n. m <= n ==> GENLIST f m <<= GENLIST f n
+Proof
+    qx_gen_tac ‘f’
+ >> Induct_on ‘n’ >- rw []
+ >> rpt STRIP_TAC
+ >> ‘m = SUC n \/ m <= n’ by METIS_TAC [LE]
+ >- rw [isPREFIX_REFL]
+ >> MATCH_MP_TAC isPREFIX_TRANS
+ >> Q.EXISTS_TAC ‘GENLIST f n’ >> rw []
+ >> rw [GENLIST, isPREFIX_SNOC]
+QED
+
+Theorem isPREFIX_MAP :
+    !f l1 l2. l1 <<= l2 ==> MAP f l1 <<= MAP f l2
+Proof
+    qx_gen_tac ‘f’
+ >> Induct_on ‘l1’ >- rw []
+ >> rpt STRIP_TAC
+ >> Cases_on ‘l2’ >- fs []
+ >> fs []
+QED
+
 (* ---------------------------------------------------------------------- *)
 
 val FOLDL_SNOC = store_thm("FOLDL_SNOC",
@@ -4388,6 +4455,48 @@ val ALL_DISTINCT_FILTER_EL_IMP = Q.store_thm("ALL_DISTINCT_FILTER_EL_IMP",
 val FLAT_EQ_NIL = Q.store_thm("FLAT_EQ_NIL",
    ‘!ls. (FLAT ls = []) = (EVERY ($= []) ls)’,
    Induct >> SRW_TAC [] [EQ_IMP_THM] >> rw [APPEND]);
+
+Theorem FLAT_EQ_NIL' :
+    FLAT l = [] <=> !e. MEM e l ==> e = []
+Proof simp[FLAT_EQ_NIL, EVERY_MEM] >> metis_tac[]
+QED
+
+Theorem FLAT_EQ_SING:
+  FLAT l = [x] <=>
+    ?p s. l = p ++ [[x]] ++ s /\ FLAT p = [] /\ FLAT s = []
+Proof
+  Induct_on `l` >> simp[] >> simp[APPEND_EQ_CONS] >>
+  simp_tac (srw_ss() ++ DNF_ss) [] >> metis_tac[]
+QED
+
+Theorem FLAT_EQ_APPEND:
+  FLAT l = x ++ y <=>
+    (?p s. l = p ++ s /\ x = FLAT p /\ y = FLAT s) \/
+    (?p s ip is.
+       l = p ++ [ip ++ is] ++ s /\ ip <> [] /\ is <> [] /\
+       x = FLAT p ++ ip /\
+       y = is ++ FLAT s)
+Proof
+  reverse eq_tac >- (rw[] >> rw[APPEND_ASSOC, FLAT_APPEND]) >>
+  map_every qid_spec_tac [`y`,`x`,`l`] >> Induct_on `l` >- simp[] >>
+  simp[] >> map_every qx_gen_tac [`h`, `x`, `y`] >>
+  simp[APPEND_EQ_APPEND] >>
+  disch_then (DISJ_CASES_THEN (qxch `m` strip_assume_tac))
+  >- (Cases_on `x = []`
+      >- (fs[] >> map_every qexists_tac [`[]`, `m::l`] >> simp[]) >>
+      Cases_on `m = []`
+      >- (fs[] >> disj1_tac >> map_every qexists_tac [`[x]`, `l`] >>
+          simp[]) >>
+      disj2_tac >>
+      map_every qexists_tac [`[]`, `l`, `x`, `m`] >> simp[]) >>
+  `(?p s. l = p ++ s /\ FLAT p = m /\ FLAT s = y) \/
+   (?p s ip is.
+       l = p ++ [ip ++ is] ++ s /\ m = FLAT p ++ ip /\ ip <> [] /\ is <> [] /\
+       y = is ++ FLAT s)` by metis_tac[]
+  >- (disj1_tac >> map_every qexists_tac [`h::p`, `s`] >> simp[]) >>
+  disj2_tac >> map_every qexists_tac [`h::p`, `s`] >> simp[APPEND_ASSOC] >>
+  map_every qexists_tac [`ip`, `is`] >> rw []
+QED
 
 val ALL_DISTINCT_MAP_INJ = Q.store_thm("ALL_DISTINCT_MAP_INJ",
    ‘!ls f. (!x y. MEM x ls /\ MEM y ls /\ (f x = f y) ==> (x = y)) /\

--- a/src/list/src/rich_listScript.sml
+++ b/src/list/src/rich_listScript.sml
@@ -2746,6 +2746,25 @@ Proof
  >> rw []
 QED
 
+(* NOTE: This theorem is more general than listTheory.isPREFIX_GENLIST *)
+Theorem IS_PREFIX_GENLIST :
+    !f m n. m <= n <=> GENLIST f m <<= GENLIST f n
+Proof
+    rpt GEN_TAC
+ >> EQ_TAC
+ >- rw [isPREFIX_GENLIST]
+ >> qid_spec_tac ‘m’
+ >> qid_spec_tac ‘n’
+ >> Induct_on ‘n’
+ >- (rw [] >> fs [GENLIST_EQ_NIL])
+ >> qx_gen_tac ‘m’
+ >> simp [GENLIST, IS_PREFIX_SNOC]
+ >> STRIP_TAC
+ >- (MATCH_MP_TAC LESS_EQ_TRANS \\
+     Q.EXISTS_TAC ‘n’ >> rw [])
+ >> fs [LIST_EQ_REWRITE]
+QED
+
 (* ----------------------------------------------------------------------
     longest_prefix
 

--- a/src/list/src/rich_listScript.sml
+++ b/src/list/src/rich_listScript.sml
@@ -2616,29 +2616,8 @@ Proof
           THEN PROVE_TAC [numTheory.INV_SUC, IS_PREFIX_REFL]]
 QED
 
-Theorem IS_PREFIX_SNOC:
-   !x y z. IS_PREFIX (SNOC x y) z <=> IS_PREFIX y z \/ (z = SNOC x y)
-Proof
-   GEN_TAC
-   THEN GEN_TAC
-   THEN Q.SPEC_TAC (`x`, `x`)
-   THEN Q.SPEC_TAC (`y`, `y`)
-   THEN INDUCT_THEN list_INDUCT ASSUME_TAC
-   THENL [REPEAT GEN_TAC
-          THEN MP_TAC (Q.SPEC `z` list_CASES)
-          THEN STRIP_TAC
-          THEN ASM_SIMP_TAC boolSimps.bool_ss
-                 [SNOC, IS_PREFIX_NIL, IS_PREFIX, CONS_11,
-                  NOT_CONS_NIL]
-          THEN PROVE_TAC [],
-          REPEAT GEN_TAC
-          THEN MP_TAC (Q.SPEC `z` list_CASES)
-          THEN STRIP_TAC
-          THEN ASM_SIMP_TAC boolSimps.bool_ss
-                 [SNOC, IS_PREFIX_NIL, IS_PREFIX, CONS_11,
-                  NOT_CONS_NIL]
-          THEN PROVE_TAC []]
-QED
+(* |- !x y z. z <<= SNOC x y <=> z <<= y \/ z = SNOC x y *)
+Theorem IS_PREFIX_SNOC = isPREFIX_SNOC
 
 val IS_PREFIX_APPEND1 = Q.store_thm ("IS_PREFIX_APPEND1",
    `!a b c. IS_PREFIX c (APPEND a b) ==> IS_PREFIX c a`,
@@ -2746,24 +2725,8 @@ Proof
  >> rw []
 QED
 
-(* NOTE: This theorem is more general than listTheory.isPREFIX_GENLIST *)
-Theorem IS_PREFIX_GENLIST :
-    !(f :num -> 'a) m n. GENLIST f m <<= GENLIST f n <=> m <= n
-Proof
-    rpt GEN_TAC
- >> reverse EQ_TAC
- >- rw [isPREFIX_GENLIST]
- >> qid_spec_tac ‘m’
- >> qid_spec_tac ‘n’
- >> Induct_on ‘n’
- >- (rw [] >> fs [GENLIST_EQ_NIL])
- >> GEN_TAC
- >> simp [GENLIST, IS_PREFIX_SNOC]
- >> STRIP_TAC
- >- (MATCH_MP_TAC LESS_EQ_TRANS \\
-     Q.EXISTS_TAC ‘n’ >> rw [])
- >> fs [LIST_EQ_REWRITE]
-QED
+(* |- !f m n. GENLIST f m <<= GENLIST f n <=> m <= n *)
+Theorem IS_PREFIX_GENLIST = isPREFIX_GENLIST
 
 (* ----------------------------------------------------------------------
     longest_prefix

--- a/src/list/src/rich_listScript.sml
+++ b/src/list/src/rich_listScript.sml
@@ -2748,7 +2748,7 @@ QED
 
 (* NOTE: This theorem is more general than listTheory.isPREFIX_GENLIST *)
 Theorem IS_PREFIX_GENLIST :
-    !f m n. m <= n <=> GENLIST f m <<= GENLIST f n
+    !(f :num -> 'a) m n. m <= n <=> GENLIST f m <<= GENLIST f n
 Proof
     rpt GEN_TAC
  >> EQ_TAC
@@ -2757,7 +2757,7 @@ Proof
  >> qid_spec_tac ‘n’
  >> Induct_on ‘n’
  >- (rw [] >> fs [GENLIST_EQ_NIL])
- >> qx_gen_tac ‘m’
+ >> GEN_TAC
  >> simp [GENLIST, IS_PREFIX_SNOC]
  >> STRIP_TAC
  >- (MATCH_MP_TAC LESS_EQ_TRANS \\

--- a/src/list/src/rich_listScript.sml
+++ b/src/list/src/rich_listScript.sml
@@ -2748,10 +2748,10 @@ QED
 
 (* NOTE: This theorem is more general than listTheory.isPREFIX_GENLIST *)
 Theorem IS_PREFIX_GENLIST :
-    !(f :num -> 'a) m n. m <= n <=> GENLIST f m <<= GENLIST f n
+    !(f :num -> 'a) m n. GENLIST f m <<= GENLIST f n <=> m <= n
 Proof
     rpt GEN_TAC
- >> EQ_TAC
+ >> reverse EQ_TAC
  >- rw [isPREFIX_GENLIST]
  >> qid_spec_tac ‘m’
  >> qid_spec_tac ‘n’

--- a/src/list/src/rich_listScript.sml
+++ b/src/list/src/rich_listScript.sml
@@ -2559,44 +2559,23 @@ QED
    A bunch of properties relating to the use of IS_PREFIX as a partial order
  ---------------------------------------------------------------------------*)
 
-val IS_PREFIX_NIL = Q.store_thm ("IS_PREFIX_NIL",
-   `!x. IS_PREFIX x [] /\ (IS_PREFIX [] x = (x = []))`,
-   STRIP_TAC
-   THEN MP_TAC (Q.SPEC `x` list_CASES)
-   THEN STRIP_TAC
-   THEN ASM_SIMP_TAC boolSimps.bool_ss [IS_PREFIX]
-   THEN PROVE_TAC [NOT_NIL_CONS]);
+(* |- !x. [] <<= x /\ (x <<= [] <=> x = []) *)
+Theorem IS_PREFIX_NIL = isPREFIX_NIL
 
-val IS_PREFIX_REFL = Q.store_thm ("IS_PREFIX_REFL",
-   `!x. IS_PREFIX x x`,
-   INDUCT_THEN list_INDUCT MP_TAC
-   THEN SIMP_TAC boolSimps.bool_ss [IS_PREFIX]);
-val _ = export_rewrites ["IS_PREFIX_REFL"]
+(* |- !x. x <<= x *)
+Theorem IS_PREFIX_REFL[simp] = isPREFIX_REFL
 
-val IS_PREFIX_ANTISYM = Q.store_thm ("IS_PREFIX_ANTISYM",
-   `!x y. IS_PREFIX y x /\ IS_PREFIX x y ==> (x = y)`,
-   INDUCT_THEN list_INDUCT ASSUME_TAC
-   THEN SIMP_TAC boolSimps.bool_ss [IS_PREFIX_NIL]
-   THEN REPEAT GEN_TAC
-   THEN MP_TAC (Q.SPEC `y` list_CASES)
-   THEN STRIP_TAC
-   THEN ASM_SIMP_TAC boolSimps.bool_ss [IS_PREFIX_NIL]
-   THEN ONCE_REWRITE_TAC [IS_PREFIX]
-   THEN PROVE_TAC []);
+(* |- !x y. x <<= y /\ y <<= x ==> x = y *)
+Theorem IS_PREFIX_ANTISYM = isPREFIX_ANTISYM
 
-val IS_PREFIX_TRANS = Q.store_thm ("IS_PREFIX_TRANS",
-   `!x y z. IS_PREFIX x y /\ IS_PREFIX y z ==> IS_PREFIX x z`,
-   INDUCT_THEN list_INDUCT ASSUME_TAC
-   THEN SIMP_TAC boolSimps.bool_ss [IS_PREFIX_NIL]
-   THEN REPEAT GEN_TAC
-   THEN MP_TAC (Q.SPEC `y` list_CASES)
-   THEN STRIP_TAC
-   THEN ASM_SIMP_TAC boolSimps.bool_ss [IS_PREFIX_NIL]
-   THEN MP_TAC (Q.SPEC `z` list_CASES)
-   THEN STRIP_TAC
-   THEN ASM_SIMP_TAC boolSimps.bool_ss [IS_PREFIX_NIL]
-   THEN ASM_SIMP_TAC boolSimps.bool_ss [IS_PREFIX]
-   THEN PROVE_TAC []);
+(* |- !x y z. y <<= x /\ z <<= y ==> z <<= x *)
+Theorem IS_PREFIX_TRANS :
+    !x y z. IS_PREFIX x y /\ IS_PREFIX y z ==> IS_PREFIX x z
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC isPREFIX_TRANS
+ >> Q.EXISTS_TAC ‘y’ >> rw []
+QED
 
 val IS_PREFIX_BUTLAST = Q.store_thm ("IS_PREFIX_BUTLAST",
    `!x y. IS_PREFIX (x::y) (FRONT (x::y))`,


### PR DESCRIPTION
Hi,

Somehow I started to use `listRangeTheory` (in lambda materials). I added some new `listRange` theorems related to `isPREFIX`:
```
   [isPREFIX_listRangeINC]  Theorem      
      ⊢ ∀m n m' n'. m = m' ∧ n ≤ n' ⇒ [m .. n] ≼ [m' .. n']
   
   [isPREFIX_listRangeINC_EQ]  Theorem      
      ⊢ ∀m n m' n'.
          m ≤ n ∧ m' ≤ n' ⇒ ([m .. n] ≼ [m' .. n'] ⇔ m = m' ∧ n ≤ n')
   
   [isPREFIX_listRangeLHI]  Theorem      
      ⊢ ∀m n m' n'. m = m' ∧ n ≤ n' ⇒ [m ..< n] ≼ [m' ..< n']
   
   [isPREFIX_listRangeLHI_EQ]  Theorem      
      ⊢ ∀m n m' n'.
          m < n ∧ m' < n' ⇒ ([m ..< n] ≼ [m' ..< n'] ⇔ m = m' ∧ n ≤ n')
```
together with the following "one-one" theorems for listRanges:
```
   [listRangeINC_11]  Theorem      
      ⊢ ∀m n m' n'.
          m ≤ n ∧ m' ≤ n' ⇒ ([m .. n] = [m' .. n'] ⇔ m = m' ∧ n = n')

   [listRangeLHI_11]  Theorem      
      ⊢ ∀m n m' n'.
          m < n ∧ m' < n' ⇒ ([m ..< n] = [m' ..< n'] ⇔ m = m' ∧ n = n')
```

To prevent `listRangeTheory` depending on `rich_listTheory`, I have moved some `isPREFIX/IS_PREFIX` theorems from `rich_listTheory` to `listTheory` (with new proofs).

Besides, in `listTheory`, I have moved some `FLAT`-related theorem from `examples/formal-languages/context-free/grammarTheory` (when studying that materials):
```
   [FLAT_EQ_NIL']  Theorem      
      ⊢ FLAT l = [] ⇔ ∀e. MEM e l ⇒ e = []

   [FLAT_EQ_SING]  Theorem      
      ⊢ FLAT l = [x] ⇔ ∃p s. l = p ⧺ [[x]] ⧺ s ∧ FLAT p = [] ∧ FLAT s = []
   
   [FLAT_EQ_APPEND]  Theorem      
      ⊢ FLAT l = x ⧺ y ⇔
        (∃p s. l = p ⧺ s ∧ x = FLAT p ∧ y = FLAT s) ∨
        ∃p s ip is.
          l = p ⧺ [ip ⧺ is] ⧺ s ∧ ip ≠ [] ∧ is ≠ [] ∧ x = FLAT p ⧺ ip ∧
          y = is ⧺ FLAT s
```
The last one looks complex and not easy to prove (but still quite general in my opinion to be included in `listTheory`). Note that there's already one `FLAT_EQ_NIL` theorem in `listTheory`, thus I have renamed the new one to `FLAT_EQ_NIL'`. As a result, all its uses in the context-free materials must be also renamed. (This fixed a potential name conflict, which can be exposed when user code opens `grammarTheory` and `listTheory` in different orders.)

Regards,

Chun