### PR TITLE
Improved SET_TAC (learnt from HOL-Light's latest code)

### DIFF
--- a/src/boss/bossLib.sml
+++ b/src/boss/bossLib.sml
@@ -342,19 +342,23 @@ val wlog_then = wlog_then
 (*---------------------------------------------------------------------------*)
 
 local open pairTheory pred_setTheory in
-fun SET_TAC L =
+
+fun SET_TAC ths =
     POP_ASSUM_LIST (K ALL_TAC) \\
     rpt COND_CASES_TAC \\
-    REWRITE_TAC (append [EXTENSION, SUBSET_DEF, PSUBSET_DEF, DISJOINT_DEF,
-                         SING_DEF] L) \\
-    SIMP_TAC std_ss [NOT_IN_EMPTY, IN_UNIV, IN_UNION, IN_INTER, IN_DIFF,
-      IN_INSERT, IN_DELETE, IN_REST, IN_BIGINTER, IN_BIGUNION, IN_IMAGE,
-      GSPECIFICATION, IN_DEF, EXISTS_PROD] \\
+    REWRITE_TAC ([EXTENSION, SUBSET_DEF, PSUBSET_DEF, DISJOINT_DEF, SING_DEF]
+                 @ ths) \\
+    SIMP_TAC pure_ss
+      [BIGINTER_IMAGE, BIGINTER_GSPEC, BIGUNION_IMAGE, BIGUNION_GSPEC] \\
+    SIMP_TAC std_ss
+      [NOT_IN_EMPTY, IN_UNIV, IN_UNION, IN_INTER, IN_DIFF,
+       IN_INSERT, IN_DELETE, IN_REST, IN_BIGINTER, IN_BIGUNION, IN_IMAGE,
+       GSPECIFICATION, IN_DEF, EXISTS_PROD] \\
     METIS_TAC [];
 
 fun ASM_SET_TAC L = rpt (POP_ASSUM MP_TAC) >> SET_TAC L;
-
 fun SET_RULE tm = prove (tm, SET_TAC []);
+
 end (* local *)
 
 end

--- a/src/pred_set/src/more_theories/iterateScript.sml
+++ b/src/pred_set/src/more_theories/iterateScript.sml
@@ -122,22 +122,6 @@ val BOUNDS_LINEAR_0 = store_thm ("BOUNDS_LINEAR_0",
   MP_TAC (SPECL [``A:num``, ``0:num``, ``B:num``] BOUNDS_LINEAR) THEN
   REWRITE_TAC[MULT_CLAUSES, ADD_CLAUSES, LE]);
 
-val BIGUNION_GSPEC = store_thm ("BIGUNION_GSPEC",
- ``(!P f. BIGUNION {f x | P x} = {a | ?x. P x /\ a IN (f x)}) /\
-   (!P f. BIGUNION {f x y | P x y} = {a | ?x y. P x y /\ a IN (f x y)}) /\
-   (!P f. BIGUNION {f x y z | P x y z} =
-            {a | ?x y z. P x y z /\ a IN (f x y z)})``,
-  REPEAT STRIP_TAC THEN GEN_REWR_TAC I [EXTENSION] THEN
-  SIMP_TAC std_ss [IN_BIGUNION, GSPECIFICATION, EXISTS_PROD] THEN MESON_TAC[]);
-
-val BIGINTER_GSPEC = store_thm ("BIGINTER_GSPEC",
- ``(!P f. BIGINTER {f x | P x} = {a | !x. P x ==> a IN (f x)}) /\
-   (!P f. BIGINTER {f x y | P x y} = {a | !x y. P x y ==> a IN (f x y)}) /\
-   (!P f. BIGINTER {f x y z | P x y z} =
-                {a | !x y z. P x y z ==> a IN (f x y z)})``,
-  REPEAT STRIP_TAC THEN GEN_REWR_TAC I [EXTENSION] THEN
-  SIMP_TAC std_ss [IN_BIGINTER, GSPECIFICATION, EXISTS_PROD] THEN MESON_TAC[]);
-
 val FINITE_POWERSET = store_thm ("FINITE_POWERSET",
   ``!s. FINITE s ==> FINITE {t | t SUBSET s}``,
     METIS_TAC [FINITE_POW, POW_DEF]);

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -201,7 +201,6 @@ val SET_SPEC_ss = SSFRAG
 
 val _ = augment_srw_ss [SET_SPEC_ss]
 
-
 (* --------------------------------------------------------------------- *)
 (* activate generalized specification parser/pretty-printer.             *)
 (* --------------------------------------------------------------------- *)
@@ -4402,6 +4401,14 @@ Proof
   MESON_TAC []
 QED
 
+val BIGUNION_GSPEC = store_thm ("BIGUNION_GSPEC",
+ ``(!P f. BIGUNION {f x | P x} = {a | ?x. P x /\ a IN (f x)}) /\
+   (!P f. BIGUNION {f x y | P x y} = {a | ?x y. P x y /\ a IN (f x y)}) /\
+   (!P f. BIGUNION {f x y z | P x y z} =
+            {a | ?x y z. P x y z /\ a IN (f x y z)})``,
+  REPEAT STRIP_TAC THEN ONCE_REWRITE_TAC [EXTENSION] THEN
+  SIMP_TAC std_ss [IN_BIGUNION, GSPECIFICATION, EXISTS_PROD] THEN MESON_TAC[]);
+
 val IN_BIGUNION_IMAGE = store_thm (* from util_prob *)
   ("IN_BIGUNION_IMAGE",
    ``!f s y. (y IN BIGUNION (IMAGE f s)) = (?x. x IN s /\ y IN f x)``,
@@ -4627,6 +4634,14 @@ Theorem IN_BIGINTER[simp]:
 Proof
   SIMP_TAC bool_ss [BIGINTER, GSPECIFICATION, pairTheory.PAIR_EQ]
 QED
+
+val BIGINTER_GSPEC = store_thm ("BIGINTER_GSPEC",
+ ``(!P f. BIGINTER {f x | P x} = {a | !x. P x ==> a IN (f x)}) /\
+   (!P f. BIGINTER {f x y | P x y} = {a | !x y. P x y ==> a IN (f x y)}) /\
+   (!P f. BIGINTER {f x y z | P x y z} =
+                {a | !x y z. P x y z ==> a IN (f x y z)})``,
+  REPEAT STRIP_TAC THEN ONCE_REWRITE_TAC [EXTENSION] THEN
+  SIMP_TAC std_ss [IN_BIGINTER, GSPECIFICATION, EXISTS_PROD] THEN MESON_TAC[]);
 
 Theorem IN_BIGINTER_IMAGE:
   !x f s. (x IN BIGINTER (IMAGE f s)) = (!y. y IN s ==> x IN f y)
@@ -6449,6 +6464,26 @@ val MAX_SET_UNION = Q.store_thm
         by SRW_TAC[][EXTENSION,AC DISJ_COMM DISJ_ASSOC]
    THEN FULL_SIMP_TAC (srw_ss()) [MAX_SET_THM, AC MAX_COMM MAX_ASSOC]);
 
+Theorem FINITE_INTER :
+    !s1 s2. ((FINITE s1) \/ (FINITE s2)) ==> FINITE (s1 INTER s2)
+Proof
+  METIS_TAC[INTER_COMM, INTER_FINITE]
+QED
+
+Theorem MAX_SET_INTER :
+    !A B. FINITE A /\ FINITE B ==>
+          MAX_SET (A INTER B) <= MIN (MAX_SET A) (MAX_SET B)
+Proof
+    Q_TAC SUFF_TAC
+   ‘!A. FINITE A ==> !B. FINITE B ==>
+       MAX_SET (A INTER B) <= MIN (MAX_SET A) (MAX_SET B)’
+ >- METIS_TAC []
+ >> SET_INDUCT_TAC >> simp []
+ >> rpt STRIP_TAC (* 2 subgoals, same tactics *)
+ >> MATCH_MP_TAC SUBSET_MAX_SET
+ >> rw [FINITE_INTER, INTER_SUBSET]
+QED
+
 val set_ss = arith_ss ++ SET_SPEC_ss ++
              rewrites [CARD_INSERT,CARD_EMPTY,FINITE_EMPTY,FINITE_INSERT,
                        NOT_IN_EMPTY];
@@ -8210,9 +8245,6 @@ val IN_INSERT_EXPAND = store_thm ("IN_INSERT_EXPAND",
   SIMP_TAC bool_ss [IN_INSERT] THEN
   METIS_TAC[]);
 
-val FINITE_INTER = store_thm ("FINITE_INTER",
-  ``!s1 s2. ((FINITE s1) \/ (FINITE s2)) ==> FINITE (s1 INTER s2)``,
-  METIS_TAC[INTER_COMM, INTER_FINITE]);
 (* END misc thms *)
 
 (*---------------------------------------------------------------------------*)


### PR DESCRIPTION
Hi,

I occasionally took a look at HOL-Light's latest version of `SET_TAC` [1] and found that, in comparison with HOL4's current (ported) version, HOL-Light uses the following 4 theorems additionally as the first step of rewriting:
```
   [BIGINTER_GSPEC]  Theorem      
      ⊢ (∀P f. BIGINTER {f x | P x} = {a | ∀x. P x ⇒ a ∈ f x}) ∧
        (∀P f. BIGINTER {f x y | P x y} = {a | ∀x y. P x y ⇒ a ∈ f x y}) ∧
        ∀P f.
          BIGINTER {f x y z | P x y z} =
          {a | ∀x y z. P x y z ⇒ a ∈ f x y z}
   
   [BIGINTER_IMAGE]  Theorem      
      ⊢ ∀f s. BIGINTER (IMAGE f s) = {y | ∀x. x ∈ s ⇒ y ∈ f x}

   [BIGUNION_GSPEC]  Theorem      
      ⊢ (∀P f. BIGUNION {f x | P x} = {a | ∃x. P x ∧ a ∈ f x}) ∧
        (∀P f. BIGUNION {f x y | P x y} = {a | ∃x y. P x y ∧ a ∈ f x y}) ∧
        ∀P f.
          BIGUNION {f x y z | P x y z} =
          {a | ∃x y z. P x y z ∧ a ∈ f x y z}
   
   [BIGUNION_IMAGE]  Theorem      
      ⊢ ∀f s. BIGUNION (IMAGE f s) = {y | ∃x. x ∈ s ∧ y ∈ f x}
```
I think this additional rewriting doesn't enlarge the solvable set of problems, but may reduce the inputs to the final `METIS_TAC`, eliminating some existential quantifiers (and speeding up the whole process).

Note that, `BIGINTER_GSPEC` and `BIGUNION_GSPEC` contain higher order predicates, thus can only be handled by `SIMP_TAC` (or `Ho_rewrite.REWRITE_TAC`). Previous these two theorems were in `iterateTheory`, now I moved them to `pred_setTheory`. This change to `SET_TAC` shouldn't break any existing code.

--Chun

[1] https://github.com/jrh13/hol-light/blob/16b184e30e7e3fe9add7d1ee93242323ed2e1726/sets.ml#L320