### PR TITLE
On cardinality of the universe of all words (of fixed width)

### DIFF
--- a/examples/miller/formalize/extra_numScript.sml
+++ b/examples/miller/formalize/extra_numScript.sml
@@ -1,6 +1,6 @@
 open HolKernel Parse boolLib bossLib;
 
-open arithmeticTheory hurdUtils
+open arithmeticTheory hurdUtils res_quanTools
      pred_setTheory subtypeTheory extra_boolTheory combinTheory;
 
 val _ = new_theory "extra_num";
@@ -10,6 +10,8 @@ val _ = new_theory "extra_num";
 (* ------------------------------------------------------------------------- *)
 
 val Simplify = RW_TAC arith_ss;
+val S_TAC = rpt (POP_ASSUM MP_TAC) >> rpt RESQ_STRIP_TAC;
+val Strip = S_TAC;
 
 (* ------------------------------------------------------------------------- *)
 (* Needed for definitions.                                                   *)

--- a/examples/miller/formalize/extra_pred_setScript.sml
+++ b/examples/miller/formalize/extra_pred_setScript.sml
@@ -18,6 +18,7 @@ val assert = simple_assert;
 (* ------------------------------------------------------------------------- *)
 
 val S_TAC = rpt (POP_ASSUM MP_TAC) >> rpt RESQ_STRIP_TAC;
+val Strip = S_TAC;
 
 val std_pc = precontext_mergel [bool_pc, list_pc];
 val std_c = precontext_compile std_pc;

--- a/examples/miller/formalize/extra_realScript.sml
+++ b/examples/miller/formalize/extra_realScript.sml
@@ -1,6 +1,6 @@
 open HolKernel Parse boolLib bossLib;
 
-open realTheory realLib
+open realTheory realLib res_quanTools
      hurdUtils subtypeTheory extra_numTheory transcTheory
      pred_setTheory arithmeticTheory seqTheory combinTheory pairTheory
      extra_pred_setTheory extra_boolTheory real_sigmaTheory
@@ -13,6 +13,8 @@ val _ = new_theory "extra_real";
 (* ------------------------------------------------------------------------- *)
 
 val Simplify = RW_TAC arith_ss;
+val S_TAC = rpt (POP_ASSUM MP_TAC) >> rpt RESQ_STRIP_TAC;
+val Strip = S_TAC;
 
 (* ------------------------------------------------------------------------- *)
 (* Definitions.                                                              *)

--- a/examples/probability/Holmakefile
+++ b/examples/probability/Holmakefile
@@ -1,5 +1,5 @@
 INCLUDES = $(HOLDIR)/src/probability $(HOLDIR)/src/n-bit $(HOLDIR)/src/real \
-	   $(HOLDIR)/src/res_quan/src $(HOLDIR)/src/real/analysis legacy
+	   $(HOLDIR)/src/real/analysis
 
 CLINE_OPTIONS = -r
 
@@ -12,7 +12,7 @@ EXTRA_CLEANS = heap \
 
 ifdef POLY
 HOLHEAP = heap
-OBJS = real/realLib n-bit/fcpLib res_quan/src/hurdUtils probability/probabilityTheory
+OBJS = real/realLib n-bit/fcpLib probability/probabilityTheory
 FULL_OBJPATHS = $(patsubst %,$(HOLDIR)/src/%.uo,$(OBJS)) \
                 $(HOLDIR)/sigobj/posetTheory.uo
 

--- a/examples/probability/legacy/real_measureScript.sml
+++ b/examples/probability/legacy/real_measureScript.sml
@@ -18,6 +18,9 @@ val _ = new_theory "real_measure";
 val _ = intLib.deprecate_int ();
 val _ = ratLib.deprecate_rat ();
 
+val S_TAC = rpt (POP_ASSUM MP_TAC) >> rpt RESQ_STRIP_TAC;
+val Strip = S_TAC;
+
 (* ------------------------------------------------------------------------- *)
 (* Basic measure theory definitions.                                         *)
 (* ------------------------------------------------------------------------- *)

--- a/src/boss/bossLib.sml
+++ b/src/boss/bossLib.sml
@@ -336,25 +336,4 @@ val wlog_then = wlog_then
   fun qx_choosel_then [] ttac = ttac
     | qx_choosel_then (q::qs) ttac = qx_choose_then q (qx_choosel_then qs ttac)
 
-(*---------------------------------------------------------------------------*)
-(* Tactic to automate some routine set theory by reduction to FOL            *)
-(* (Ported from HOL Light)                                                   *)
-(*---------------------------------------------------------------------------*)
-
-local open pairTheory pred_setTheory in
-fun SET_TAC L =
-    POP_ASSUM_LIST (K ALL_TAC) \\
-    rpt COND_CASES_TAC \\
-    REWRITE_TAC (append [EXTENSION, SUBSET_DEF, PSUBSET_DEF, DISJOINT_DEF,
-                         SING_DEF] L) \\
-    SIMP_TAC std_ss [NOT_IN_EMPTY, IN_UNIV, IN_UNION, IN_INTER, IN_DIFF,
-      IN_INSERT, IN_DELETE, IN_REST, IN_BIGINTER, IN_BIGUNION, IN_IMAGE,
-      GSPECIFICATION, IN_DEF, EXISTS_PROD] \\
-    METIS_TAC [];
-
-fun ASM_SET_TAC L = rpt (POP_ASSUM MP_TAC) >> SET_TAC L;
-
-fun SET_RULE tm = prove (tm, SET_TAC []);
-end (* local *)
-
 end

--- a/src/n-bit/wordsScript.sml
+++ b/src/n-bit/wordsScript.sml
@@ -4971,6 +4971,22 @@ Proof
   \\ rw[word_index]
 QED
 
+Theorem FINITE_BOOL[local] :
+  FINITE univ(:bool)
+Proof
+  simp[]
+QED
+
+Theorem CARD_BOOL[local] :
+  CARD univ(:bool) = 2
+Proof
+  simp[]
+QED
+
+(* |- FINITE univ(:'N) ==> CARD univ(:'N word) = 2 ** dimindex (:'N) *)
+Theorem CARD_WORD = CARD_CART_UNIV |> INST_TYPE [alpha |-> bool]
+                                   |> SIMP_RULE bool_ss [CARD_BOOL,FINITE_BOOL]
+
 (* -------------------------------------------------------------------------
     Create a few word sizes
    ------------------------------------------------------------------------- *)
@@ -4995,6 +5011,9 @@ fun mk_word_size n =
       val dimword = save ("dimword_" ^ SN,
                      (SIMP_RULE std_ss [INT_MIN] o
                       Thm.INST_TYPE [``:'a`` |-> typ]) dimword_IS_TWICE_INT_MIN)
+      val card = REWRITE_RULE [dimindex,finite]
+                              (INST_TYPE [“:'N” |-> typ] CARD_WORD)
+      val _ = save ("card_word" ^ SN, card)
   in
     type_abbrev_pp("word" ^ SN, TYPE)
   end

--- a/src/num/theories/arithmeticScript.sml
+++ b/src/num/theories/arithmeticScript.sml
@@ -514,6 +514,15 @@ val LESS_EQ_ANTISYM = store_thm ("LESS_EQ_ANTISYM",
      ASM_REWRITE_TAC [LESS_MONO_EQ, LESS_EQ_MONO,
        ZERO_LESS_EQ, LESS_0, NOT_LESS_0, NOT_SUC_LESS_EQ_0]) ;
 
+Theorem LTE_ANTISYM = LESS_EQ_ANTISYM (* HOL-Light compatible name *)
+Theorem LET_ANTISYM :
+    !m n. ~(m <= n /\ n < m)
+Proof
+    rpt GEN_TAC
+ >> ONCE_REWRITE_TAC [CONJ_COMM]
+ >> REWRITE_TAC [LESS_EQ_ANTISYM]
+QED
+
 val LESS_EQ_0 = store_thm ("LESS_EQ_0",
   “!n. (n <= 0) = (n = 0)”,
   REWRITE_TAC [LESS_OR_EQ, NOT_LESS_0]) ;
@@ -820,6 +829,10 @@ val LESS_LESS_EQ_TRANS = store_thm ("LESS_LESS_EQ_TRANS",
   REPEAT GEN_TAC THEN REWRITE_TAC[LESS_OR_EQ] THEN
   ASM_CASES_TAC (“n:num = p”) THEN ASM_REWRITE_TAC[LESS_TRANS]);
 
+Theorem LE_TRANS  = LESS_EQ_TRANS      (* HOL-Light compatible name *)
+Theorem LET_TRANS = LESS_EQ_LESS_TRANS (* HOL-Light compatible name *)
+Theorem LTE_TRANS = LESS_LESS_EQ_TRANS (* HOL-Light compatible name *)
+
 (* % Proof modified for new IMP_RES_TAC                 [TFM 90.04.25]  *)
 
 val LESS_EQ_LESS_EQ_MONO = store_thm ("LESS_EQ_LESS_EQ_MONO",
@@ -837,6 +850,8 @@ val LESS_EQ_REFL = store_thm ("LESS_EQ_REFL",
    “!m. m <= m”,
    GEN_TAC
     THEN REWRITE_TAC[LESS_OR_EQ]);
+
+Theorem LE_REFL = LESS_EQ_REFL (* HOL-Light compatible name *)
 
 val LESS_IMP_LESS_OR_EQ = store_thm ("LESS_IMP_LESS_OR_EQ",
    “!m n. (m < n) ==> (m <= n)”,
@@ -1105,6 +1120,17 @@ val SUB_LESS_OR = store_thm ("SUB_LESS_OR",
    DISCH_THEN (STRIP_THM_THEN SUBST1_TAC o MATCH_MP LESS_ADD_1) THEN
    REWRITE_TAC [SYM (SPEC_ALL PRE_SUB1)] THEN
    REWRITE_TAC [PRE,ONE,ADD_CLAUSES,LESS_EQ_ADD]);
+
+Theorem SUB_LESS_OR_EQ :
+    !m n. 0 < m ==> (n <= m - 1 <=> n < m)
+Proof
+    rpt STRIP_TAC
+ >> reverse EQ_TAC
+ >- REWRITE_TAC [SUB_LESS_OR]
+ >> Cases_on ‘m’
+ >- FULL_SIMP_TAC std_ss [LESS_REFL]
+ >> REWRITE_TAC [SUC_SUB1, LT_SUC_LE]
+QED
 
 val LESS_SUB_ADD_LESS = store_thm ("LESS_SUB_ADD_LESS",
  “!n m i. (i < (n - m)) ==> ((i + m) < n)”,
@@ -3454,6 +3480,19 @@ val MIN_DEF = new_definition("MIN_DEF", “MIN m n = if m < n then m else n”);
 
 val MAX = MAX_DEF;
 val MIN = MIN_DEF;
+
+(* Alternative definitions of MAX and MIN using ‘<=’ instead of ‘<’ *)
+Theorem MIN_ALT :
+    !m n. MIN m n = if m <= n then m else n
+Proof
+    rw [LESS_OR_EQ, MIN_DEF] >> fs []
+QED
+
+Theorem MAX_ALT :
+    !m n. MAX m n = if m <= n then n else m
+Proof
+    rw [LESS_OR_EQ, MAX_DEF] >> fs []
+QED
 
 val ARW = RW_TAC bool_ss
 

--- a/src/pred_set/src/hurdUtils.sig
+++ b/src/pred_set/src/hurdUtils.sig
@@ -310,8 +310,6 @@ sig
   val ASMLIST_CASES : tactic -> (term -> tactic) -> tactic
   val POP_ASSUM_TAC : tactic -> tactic
   val TRUTH_TAC : tactic
-  val S_TAC : tactic
-  val Strip : tactic
   val K_TAC : 'a -> tactic
   val KILL_TAC : tactic
   val FUN_EQ_TAC : tactic

--- a/src/pred_set/src/hurdUtils.sml
+++ b/src/pred_set/src/hurdUtils.sml
@@ -7,27 +7,11 @@
 structure hurdUtils :> hurdUtils =
 struct
 
-open HolKernel boolLib BasicProvers;
+open HolKernel Parse boolLib BasicProvers;
 
-open Susp Hol_pp metisLib simpLib pairTheory res_quanTools numLib;
+open Susp Hol_pp metisLib simpLib pairTheory (* res_quanTools *) numLib;
 
 infixr 0 oo THENR ORELSER ## thenf orelsef;
-
-(* obsoleted:
-infix 1 >> |->;
-val op++ = op THEN;
-val op<< = op THENL;
-val op|| = op ORELSE;
- *)
-
-structure Parse = struct
-  open Parse
-  val (Type,Term) =
-      pred_setTheory.pred_set_grammars
-        |> apsnd ParseExtras.grammar_loose_equality
-        |> parse_from_grammars
-end
-open Parse
 
 (* ------------------------------------------------------------------------- *)
 (* Basic ML datatypes/functions.                                             *)
@@ -44,11 +28,6 @@ exception BUG_EXN of
   {origin_structure : string, origin_function : string, message : string};
 
 val ERR = mk_HOL_ERR "hurdUtils"
-
-(* old definition:
-fun ERR f s = HOL_ERR
-  {origin_structure = "hurdUtils", origin_function = f, message = s};
- *)
 
 fun BUG f s = BUG_EXN
   {origin_structure = "hurdUtils", origin_function = f, message = s};
@@ -962,8 +941,10 @@ fun POP_ASSUM_TAC tac =
 
 val TRUTH_TAC = ACCEPT_TAC TRUTH;
 
+(*
 val S_TAC = rpt (POP_ASSUM MP_TAC) >> rpt RESQ_STRIP_TAC;
 val Strip = S_TAC;
+ *)
 
 fun K_TAC _ = ALL_TAC;
 

--- a/src/pred_set/src/iterateScript.sml
+++ b/src/pred_set/src/iterateScript.sml
@@ -1,5 +1,4 @@
 (* ========================================================================= *)
-(*                                                                           *)
 (*    Generic iterated operations and special cases of sums over N           *)
 (*                                                                           *)
 (*        (c) Copyright 2014-2015,                                           *)
@@ -16,15 +15,30 @@
 (*              (c) Copyright, Lars Schewe 2007                              *)
 (* ========================================================================= *)
 
-open HolKernel Parse boolLib bossLib;
+open HolKernel Parse boolLib BasicProvers;
 
-open numLib unwindLib tautLib Arith prim_recTheory combinTheory quotientTheory
-     arithmeticTheory jrhUtils pairTheory mesonLib pred_setTheory pred_setLib
-     optionTheory relationTheory permutesTheory hurdUtils;
-
-open wellorderTheory cardinalTheory;
+open numLib tautLib Arith prim_recTheory combinTheory quotientTheory metisLib
+     arithmeticTheory pairTheory mesonLib pred_setTheory pred_setLib simpLib
+     optionTheory relationTheory permutesTheory pureSimps numSimps hurdUtils
+     TotalDefn computeLib TypeBase boolSimps unwindLib;
 
 val _ = new_theory "iterate";
+
+val qexists_tac = Q.EXISTS_TAC;
+val qabbrev_tac = Q.ABBREV_TAC;
+val qid_spec_tac = Q.ID_SPEC_TAC;
+val rename = Q.RENAME_TAC;
+val rename1 = Q.RENAME1_TAC;
+val rw = SRW_TAC [];
+fun simp ths = ASM_SIMP_TAC (srw_ss()) ths;
+fun fs ths = FULL_SIMP_TAC (srw_ss()) ths;
+fun rfs ths = REV_FULL_SIMP_TAC (srw_ss()) ths;
+
+val metis_tac = METIS_TAC;
+
+val _ = augment_srw_ss [ARITH_ss];
+
+val GEN_REWR_TAC = Lib.C Rewrite.GEN_REWRITE_TAC Rewrite.empty_rewrites;
 
 (* ------------------------------------------------------------------------- *)
 (* MESON, METIS, SET_TAC, SET_RULE, ASSERT_TAC, ASM_ARITH_TAC                *)
@@ -39,9 +53,40 @@ fun ASSERT_TAC tm = SUBGOAL_THEN tm STRIP_ASSUME_TAC;
 
 val ASM_ARITH_TAC = rpt (POP_ASSUM MP_TAC) >> ARITH_TAC;
 
+Theorem CONJ_EQ_IMP[local] :
+    !p q r. p /\ q ==> r <=> p ==> q ==> r
+Proof
+    REWRITE_TAC [AND_IMP_INTRO]
+QED
+
 (* Minimal hol-light compatibility layer *)
-val IMP_CONJ      = CONJ_EQ_IMP;     (* cardinalTheory *)
 val FINITE_SUBSET = SUBSET_FINITE_I; (* pred_setTheory *)
+
+Theorem LEFT_IMP_EXISTS_THM[local] :
+    !P Q. (?x. P x) ==> Q <=> (!x. P x ==> Q)
+Proof
+    SIMP_TAC std_ss [PULL_EXISTS]
+QED
+
+Theorem FORALL_IN_GSPEC[local] :
+   (!P f. (!z. z IN {f x | P x} ==> Q z) <=> (!x. P x ==> Q(f x))) /\
+   (!P f. (!z. z IN {f x y | P x y} ==> Q z) <=>
+          (!x y. P x y ==> Q(f x y))) /\
+   (!P f. (!z. z IN {f w x y | P w x y} ==> Q z) <=>
+          (!w x y. P w x y ==> Q(f w x y)))
+Proof
+   SRW_TAC [][] THEN SET_TAC []
+QED
+
+Theorem CONJ_ACI[local] :
+   !p q. (p /\ q <=> q /\ p) /\
+   ((p /\ q) /\ r <=> p /\ (q /\ r)) /\
+   (p /\ (q /\ r) <=> q /\ (p /\ r)) /\
+   (p /\ p <=> p) /\
+   (p /\ (p /\ q) <=> p /\ q)
+Proof
+  METIS_TAC [CONJ_ASSOC, CONJ_SYM]
+QED
 
 (* ------------------------------------------------------------------------- *)
 (* misc.                                                                     *)
@@ -88,20 +133,21 @@ val EMPTY_BIGUNION = store_thm ("EMPTY_BIGUNION",
 Theorem UPPER_BOUND_FINITE_SET:
   !f:('a->num) s. FINITE(s) ==> ?a. !x. x IN s ==> f(x) <= a
 Proof
-  rpt strip_tac >> qexists ‘MAX_SET (IMAGE f s)’ >>
+  rpt strip_tac >> qexists_tac ‘MAX_SET (IMAGE f s)’ >>
   rpt strip_tac >> irule X_LE_MAX_SET >> simp[]
 QED
 
 Theorem LE_EXISTS :
   !m n:num. (m <= n) <=> (?d. n = m + d)
 Proof
-  simp[EQ_IMP_THM, PULL_EXISTS] >> rw[] >> qexists ‘n - m’ >> simp[]
+    simp[EQ_IMP_THM, PULL_EXISTS] >> rw[]
+ >> qexists_tac ‘n - m’ >> simp[]
 QED
 
 Theorem LT_EXISTS :
   !m n. (m < n) <=> (?d. n = m + SUC d)
 Proof
-  simp[EQ_IMP_THM] >> rw[] >> qexists ‘n - (m + 1)’ >> simp[]
+  simp[EQ_IMP_THM] >> rw[] >> qexists_tac ‘n - (m + 1)’ >> simp[]
 QED
 
 val BOUNDS_LINEAR = store_thm ("BOUNDS_LINEAR",
@@ -121,22 +167,6 @@ val BOUNDS_LINEAR_0 = store_thm ("BOUNDS_LINEAR_0",
   REPEAT GEN_TAC THEN
   MP_TAC (SPECL [``A:num``, ``0:num``, ``B:num``] BOUNDS_LINEAR) THEN
   REWRITE_TAC[MULT_CLAUSES, ADD_CLAUSES, LE]);
-
-val BIGUNION_GSPEC = store_thm ("BIGUNION_GSPEC",
- ``(!P f. BIGUNION {f x | P x} = {a | ?x. P x /\ a IN (f x)}) /\
-   (!P f. BIGUNION {f x y | P x y} = {a | ?x y. P x y /\ a IN (f x y)}) /\
-   (!P f. BIGUNION {f x y z | P x y z} =
-            {a | ?x y z. P x y z /\ a IN (f x y z)})``,
-  REPEAT STRIP_TAC THEN GEN_REWR_TAC I [EXTENSION] THEN
-  SIMP_TAC std_ss [IN_BIGUNION, GSPECIFICATION, EXISTS_PROD] THEN MESON_TAC[]);
-
-val BIGINTER_GSPEC = store_thm ("BIGINTER_GSPEC",
- ``(!P f. BIGINTER {f x | P x} = {a | !x. P x ==> a IN (f x)}) /\
-   (!P f. BIGINTER {f x y | P x y} = {a | !x y. P x y ==> a IN (f x y)}) /\
-   (!P f. BIGINTER {f x y z | P x y z} =
-                {a | !x y z. P x y z ==> a IN (f x y z)})``,
-  REPEAT STRIP_TAC THEN GEN_REWR_TAC I [EXTENSION] THEN
-  SIMP_TAC std_ss [IN_BIGINTER, GSPECIFICATION, EXISTS_PROD] THEN MESON_TAC[]);
 
 val FINITE_POWERSET = store_thm ("FINITE_POWERSET",
   ``!s. FINITE s ==> FINITE {t | t SUBSET s}``,
@@ -485,6 +515,31 @@ val CHOOSE_SUBSET = store_thm ("CHOOSE_SUBSET",
  ``!s:'a->bool. FINITE s ==> !n. n <= CARD s ==> ?t. t SUBSET s /\ t HAS_SIZE n``,
   MESON_TAC[CHOOSE_SUBSET_STRONG]);
 
+val HAS_SIZE_NUMSEG_LT = store_thm ("HAS_SIZE_NUMSEG_LT",
+ ``!n. {m | m < n} HAS_SIZE n``,
+  INDUCT_TAC THENL
+   [SUBGOAL_THEN ``{m:num | m < 0} = {}``
+       (fn th => REWRITE_TAC[HAS_SIZE_0, th]) THEN
+    SIMP_TAC std_ss [EXTENSION, NOT_IN_EMPTY, GSPECIFICATION, LESS_THM, NOT_LESS_0],
+    SUBGOAL_THEN ``{m | m < SUC n} = n INSERT {m | m < n}`` SUBST1_TAC THENL
+     [SIMP_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INSERT] THEN ARITH_TAC,
+      ALL_TAC] THEN
+    RULE_ASSUM_TAC(REWRITE_RULE[HAS_SIZE]) THEN
+    ASM_SIMP_TAC std_ss [HAS_SIZE, CARD_EMPTY, CARD_INSERT, FINITE_INSERT] THEN
+    SIMP_TAC std_ss [GSPECIFICATION, LESS_REFL]]);
+
+val FINITE_NUMSEG_LT = store_thm ("FINITE_NUMSEG_LT",
+ ``!n:num. FINITE {m | m < n}``,
+  REWRITE_TAC[REWRITE_RULE[HAS_SIZE] HAS_SIZE_NUMSEG_LT]);
+
+val HAS_SIZE_NUMSEG_LE = store_thm ("HAS_SIZE_NUMSEG_LE",
+ ``!n. {m | m <= n} HAS_SIZE (n + 1)``,
+  REWRITE_TAC[GSYM LT_SUC_LE, HAS_SIZE_NUMSEG_LT, ADD1]);
+
+val FINITE_NUMSEG_LE = store_thm ("FINITE_NUMSEG_LE",
+ ``!n:num. FINITE {m | m <= n}``,
+ SIMP_TAC std_ss [REWRITE_RULE[HAS_SIZE] HAS_SIZE_NUMSEG_LE]);
+
 (* ------------------------------------------------------------------------- *)
 (* A natural notation for segments of the naturals.                          *)
 (* ------------------------------------------------------------------------- *)
@@ -572,16 +627,17 @@ Theorem CARD_NUMSEG_LEMMA:
   !m d. CARD{m..m+d} = d + 1
 Proof
   GEN_TAC THEN INDUCT_TAC THEN
-  gs[NUMSEG_SING, ADD_CLAUSES, NUMSEG_REC, FINITE_NUMSEG]
+  fs[NUMSEG_SING, ADD_CLAUSES, NUMSEG_REC, FINITE_NUMSEG]
 QED
 
 Theorem CARD_NUMSEG:
   !m n. CARD {m..n} = n + 1 - m
 Proof
-  REPEAT GEN_TAC >> Cases_on ‘m <= n’
-  >- gs[LESS_EQ_EXISTS, CARD_NUMSEG_LEMMA] >>
-  gs[NOT_LESS_EQUAL] >> drule_then assume_tac (iffRL NUMSEG_EMPTY) >>
-  simp[]
+    REPEAT GEN_TAC >> Cases_on ‘m <= n’
+ >- fs[LESS_EQ_EXISTS, CARD_NUMSEG_LEMMA]
+ >> fs[NOT_LESS_EQUAL]
+ >> drule_then assume_tac (iffRL NUMSEG_EMPTY)
+ >> simp[]
 QED
 
 val HAS_SIZE_NUMSEG = store_thm ("HAS_SIZE_NUMSEG",
@@ -619,7 +675,7 @@ Proof
   >- (simp[EXTENSION, combinTheory.APPLY_UPDATE_THM, AllCaseEqs(), SF DNF_ss] >>
       metis_tac[LE, DECIDE “x <= y ==> x <> SUC y”]) >>
   rpt gen_tac >> simp[AllCaseEqs()] >>
-  ‘!i. 1 <= i /\ i <= C ==> f i <> e’ by (gvs[] >> metis_tac[]) >>
+  ‘!i. 1 <= i /\ i <= C ==> f i <> e’ by (rfs[] >> rw[Abbr ‘C’] >> metis_tac[]) >>
   simp[LE] >> rpt strip_tac >> metis_tac[]
 QED
 
@@ -739,7 +795,7 @@ val INFINITE_FROM = store_thm ("INFINITE_FROM",
    GEN_TAC THEN KNOW_TAC ``from n = univ(:num) DIFF {i | i < n}`` THENL
   [SIMP_TAC std_ss [EXTENSION, from_def, IN_DIFF, IN_UNIV, GSPECIFICATION] THEN
    ARITH_TAC, DISCH_TAC THEN ASM_REWRITE_TAC [] THEN
-   MATCH_MP_TAC INFINITE_DIFF_FINITE THEN
+   MATCH_MP_TAC INFINITE_DIFF_FINITE' THEN
    REWRITE_TAC [FINITE_NUMSEG_LT, num_INFINITE]]);
 
 (* ------------------------------------------------------------------------- *)

--- a/src/pred_set/src/more_theories/cardinalScript.sml
+++ b/src/pred_set/src/more_theories/cardinalScript.sml
@@ -16,12 +16,11 @@
 (*                                                                           *)
 (* ========================================================================= *)
 
-open HolKernel Parse boolLib bossLib mesonLib
+open HolKernel Parse boolLib bossLib;
 
-open boolSimps pred_setTheory set_relationTheory tautLib
-
-open prim_recTheory arithmeticTheory numTheory numLib pairTheory
-open optionTheory sumTheory ind_typeTheory wellorderTheory hurdUtils;
+open boolSimps pred_setTheory set_relationTheory tautLib permutesTheory
+     prim_recTheory arithmeticTheory numTheory numLib pairTheory mesonLib
+     optionTheory sumTheory ind_typeTheory wellorderTheory hurdUtils;
 
 val _ = new_theory "cardinal";
 
@@ -1511,6 +1510,12 @@ QED
 Definition bijns_def:
   bijns A = { f | BIJ f A A /\ !a. a NOTIN A ==> f a = a }
 End
+
+Theorem bijns_alt_permutes:
+    !f s. f IN bijns s <=> f permutes s
+Proof
+  simp[permutes_alt, bijns_def]
+QED
 
 Theorem cardeq_bijns_cong:
   A =~ B ==> bijns A =~ bijns B

--- a/src/pred_set/src/more_theories/cardinalScript.sml
+++ b/src/pred_set/src/more_theories/cardinalScript.sml
@@ -1150,40 +1150,6 @@ val finite_subsets_bijection = store_thm(
   qx_gen_tac `s` >> strip_tac >> qexists_tac `SET_TO_LIST s` >>
   simp[listTheory.SET_TO_LIST_INV] >> fs[SUBSET_DEF]);
 
-Theorem image_eq_empty[local]: ({} = IMAGE f Q) <=> (Q = {})
-Proof METIS_TAC[IMAGE_EQ_EMPTY]
-QED
-
-val FINITE_IMAGE_INJ' = store_thm(
-  "FINITE_IMAGE_INJ'",
-  ``(!x y. x IN s /\ y IN s ==> ((f x = f y) <=> (x = y))) ==>
-    (FINITE (IMAGE f s) <=> FINITE s)``,
-  STRIP_TAC THEN EQ_TAC THEN SIMP_TAC (srw_ss()) [IMAGE_FINITE] THEN
-  `!P. FINITE P ==> !Q. Q SUBSET s /\ (P = IMAGE f Q) ==> FINITE Q`
-    suffices_by METIS_TAC[SUBSET_REFL] THEN
-  Induct_on `FINITE` THEN SIMP_TAC (srw_ss())[image_eq_empty] THEN
-  Q.X_GEN_TAC `P` THEN STRIP_TAC THEN Q.X_GEN_TAC `e` THEN STRIP_TAC THEN
-  Q.X_GEN_TAC `Q` THEN STRIP_TAC THEN
-  `e IN IMAGE f Q` by METIS_TAC [IN_INSERT] THEN
-  `?d. d IN Q /\ (e = f d)`
-    by (POP_ASSUM MP_TAC THEN SIMP_TAC (srw_ss())[] THEN METIS_TAC[]) THEN
-  `P = IMAGE f (Q DELETE d)`
-    by (Q.UNDISCH_THEN `e INSERT P = IMAGE f Q` MP_TAC THEN
-        SIMP_TAC (srw_ss()) [EXTENSION] THEN STRIP_TAC THEN
-        Q.X_GEN_TAC `e0` THEN EQ_TAC THEN1
-          (STRIP_TAC THEN `e0 <> e` by METIS_TAC[] THEN
-           `?d0. (e0 = f d0) /\ d0 IN Q` by METIS_TAC[] THEN
-           Q.EXISTS_TAC `d0` THEN ASM_SIMP_TAC (srw_ss()) [] THEN
-           STRIP_TAC THEN METIS_TAC [SUBSET_DEF]) THEN
-        DISCH_THEN (Q.X_CHOOSE_THEN `d0` STRIP_ASSUME_TAC) THEN
-        METIS_TAC [SUBSET_DEF]) THEN
-  `Q DELETE d SUBSET s` by FULL_SIMP_TAC(srw_ss())[SUBSET_DEF] THEN
-  `FINITE (Q DELETE d)` by METIS_TAC[] THEN
-  `Q = d INSERT (Q DELETE d)`
-    by (SIMP_TAC (srw_ss()) [EXTENSION] THEN METIS_TAC[]) THEN
-  POP_ASSUM SUBST1_TAC THEN ASM_SIMP_TAC (srw_ss())[]);
-
-
 fun qxchl qs thtac = case qs of [] => thtac
                               | q::rest => Q.X_CHOOSE_THEN q (qxchl rest thtac)
 
@@ -1702,14 +1668,6 @@ val FINITE_IMAGE_INJ = store_thm ("FINITE_IMAGE_INJ",
   MP_TAC(SPECL [``f:'a->'b``, ``A:'b->bool``, ``UNIV:'a->bool``]
     FINITE_IMAGE_INJ_GENERAL) THEN REWRITE_TAC[IN_UNIV]);
 
-Theorem FINITE_IMAGE_INJ_EQ:
- !(f:'a->'b) s.
-   (!x y. x IN s /\ y IN s /\ (f(x) = f(y)) ==> (x = y)) ==>
-   (FINITE(IMAGE f s) <=> FINITE s)
-Proof
-  metis_tac[FINITE_IMAGE_INJ']
-QED
-
 Theorem INFINITE_IMAGE_INJ:
  !f:'a->'b. (!x y. (f x = f y) ==> (x = y)) ==>
             !s. INFINITE s ==> INFINITE(IMAGE f s)
@@ -1721,39 +1679,6 @@ Theorem INFINITE_NONEMPTY:
   !s. INFINITE(s) ==> ~(s = EMPTY)
 Proof MESON_TAC[FINITE_EMPTY]
 QED
-
-val FINITE_PRODUCT_DEPENDENT = store_thm ("FINITE_PRODUCT_DEPENDENT",
- ``!f:'a->'b->'c s t.
-        FINITE s /\ (!x. x IN s ==> FINITE(t x))
-        ==> FINITE {f x y | x IN s /\ y IN (t x)}``,
-  REPEAT STRIP_TAC THEN KNOW_TAC ``{f x y | x IN s /\ y IN (t x)} SUBSET
-   IMAGE (\(x,y). (f:'a->'b->'c) x y) {x,y | x IN s /\ y IN t x}`` THENL
-  [SRW_TAC [][SUBSET_DEF, IN_IMAGE, EXISTS_PROD], ALL_TAC] THEN
-  KNOW_TAC ``FINITE (IMAGE (\(x,y). (f:'a->'b->'c) x y)
-                    {x,y | x IN s /\ y IN t x})`` THENL
-  [MATCH_MP_TAC IMAGE_FINITE THEN MAP_EVERY UNDISCH_TAC
-   [``!x:'a. x IN s ==> FINITE(t x :'b->bool)``, ``FINITE(s:'a->bool)``]
-  THEN MAP_EVERY (fn t => SPEC_TAC(t,t)) [``t:'a->'b->bool``, ``s:'a->bool``]
-  THEN SIMP_TAC std_ss [RIGHT_FORALL_IMP_THM] THEN GEN_TAC THEN
-  KNOW_TAC ``(!(t:'a->'b->bool). (!x. x IN s ==> FINITE (t x)) ==>
-             FINITE {(x,y) | x IN s /\ y IN t x}) =
-         (\s. !(t:'a->'b->bool). (!x. x IN s ==> FINITE (t x)) ==>
-             FINITE {(x,y) | x IN s /\ y IN t x}) (s:'a->bool)`` THENL
-  [FULL_SIMP_TAC std_ss [], ALL_TAC] THEN DISCH_TAC THEN
-  ONCE_ASM_REWRITE_TAC [] THEN MATCH_MP_TAC FINITE_INDUCT THEN BETA_TAC
-  THEN CONJ_TAC THENL [GEN_TAC THEN
-  SUBGOAL_THEN ``{(x:'a,y:'b) | x IN {} /\ y IN (t x)} = {}``
-     (fn th => REWRITE_TAC[th, FINITE_EMPTY]) THEN SRW_TAC [][],
-  SIMP_TAC std_ss [GSYM RIGHT_FORALL_IMP_THM] THEN REPEAT GEN_TAC THEN
-  SUBGOAL_THEN ``{(x:'a, y:'b) | x IN (e INSERT s') /\ y IN (t x)} =
-    IMAGE (\y. e,y) (t e) UNION {(x,y) | x IN s' /\ y IN (t x)}``
-   (fn th => ASM_SIMP_TAC std_ss [IN_INSERT, IMAGE_FINITE, FINITE_UNION, th])
-  THEN SRW_TAC [][EXTENSION, IN_IMAGE, IN_INSERT, IN_UNION] THEN MESON_TAC[]],
-  PROVE_TAC [SUBSET_FINITE]]);
-
-val FINITE_PRODUCT = store_thm ("FINITE_PRODUCT",
- ``!s t. FINITE s /\ FINITE t ==> FINITE {(x:'a,y:'b) | x IN s /\ y IN t}``,
-  SIMP_TAC std_ss [FINITE_PRODUCT_DEPENDENT]);
 
 val SURJECTIVE_IMAGE_THM = store_thm ("SURJECTIVE_IMAGE_THM",
  ``!f:'a->'b. (!y. ?x. f x = y) <=> (!P. IMAGE f {x | P(f x)} = {x | P x})``,
@@ -1817,39 +1742,6 @@ val CARD_LE_INJ = store_thm ("CARD_LE_INJ",
   SIMP_TAC std_ss [IN_INSERT, SUBSET_DEF, IN_IMAGE] THEN
   METIS_TAC[SUBSET_DEF, IN_IMAGE]);
 
-val SURJECTIVE_IFF_INJECTIVE_GEN = store_thm ("SURJECTIVE_IFF_INJECTIVE_GEN",
- ``!s t f:'a->'b.
-        FINITE s /\ FINITE t /\ (CARD s = CARD t) /\ (IMAGE f s) SUBSET t
-        ==> ((!y. y IN t ==> ?x. x IN s /\ (f x = y)) <=>
-             (!x y. x IN s /\ y IN s /\ (f x = f y) ==> (x = y)))``,
-  REPEAT STRIP_TAC THEN EQ_TAC THEN REPEAT STRIP_TAC THENL
-  [ASM_CASES_TAC ``x:'a = y`` THENL [ASM_REWRITE_TAC[],
-  SUBGOAL_THEN ``CARD s <= CARD (IMAGE (f:'a->'b) (s DELETE y))`` MP_TAC THENL
-  [ASM_REWRITE_TAC[] THEN KNOW_TAC  ``(!(s :'b -> bool).
-            FINITE s ==> !(t :'b -> bool). t SUBSET s ==> CARD t <= CARD s)``
-  THENL [METIS_TAC [CARD_SUBSET], DISCH_TAC THEN
-  POP_ASSUM (MP_TAC o Q.SPEC `IMAGE (f:'a->'b) ((s:'a->bool) DELETE y)`) THEN
-  KNOW_TAC ``FINITE (IMAGE (f :'a -> 'b) ((s :'a -> bool) DELETE (y :'a)))``
-  THENL [FULL_SIMP_TAC std_ss [IMAGE_FINITE, FINITE_DELETE], DISCH_TAC
-  THEN FULL_SIMP_TAC std_ss [] THEN DISCH_TAC THEN POP_ASSUM (MP_TAC o Q.SPEC `t:'b->bool`)
-  THEN KNOW_TAC ``(t :'b -> bool) SUBSET IMAGE (f :'a -> 'b) ((s :'a -> bool) DELETE (y :'a))``
-  THENL [REWRITE_TAC[SUBSET_DEF, IN_IMAGE, IN_DELETE] THEN ASM_MESON_TAC[], ASM_MESON_TAC[]]]],
-  FULL_SIMP_TAC std_ss [] THEN REWRITE_TAC[NOT_LESS_EQUAL] THEN
-  MATCH_MP_TAC LESS_EQ_LESS_TRANS THEN EXISTS_TAC ``CARD(s DELETE (y:'a))`` THEN
-  CONJ_TAC THENL [ASM_SIMP_TAC std_ss [CARD_IMAGE_LE, FINITE_DELETE],
-  KNOW_TAC ``!x. x - 1 < x:num <=> ~(x = 0)`` THENL [ARITH_TAC, DISCH_TAC
-  THEN ASM_SIMP_TAC std_ss [CARD_DELETE] THEN
-  ASM_MESON_TAC[CARD_EQ_0, MEMBER_NOT_EMPTY]]]]],
-  SUBGOAL_THEN ``IMAGE (f:'a->'b) s = t`` MP_TAC THENL
-  [ALL_TAC, ASM_MESON_TAC[EXTENSION, IN_IMAGE]] THEN
-  METIS_TAC [CARD_IMAGE_INJ, SUBSET_EQ_CARD, IMAGE_FINITE]]);
-
-val SURJECTIVE_IFF_INJECTIVE = store_thm ("SURJECTIVE_IFF_INJECTIVE",
- ``!s f:'a->'a. FINITE s /\ (IMAGE f s) SUBSET s
-     ==> ((!y. y IN s ==> ?x. x IN s /\ (f x = y)) <=>
-     (!x y. x IN s /\ y IN s /\ (f x = f y) ==> (x = y)))``,
-  SIMP_TAC std_ss [SURJECTIVE_IFF_INJECTIVE_GEN]);
-
 val CARD_EQ_BIJECTION = store_thm ("CARD_EQ_BIJECTION",
  ``!s t. FINITE s /\ FINITE t /\ (CARD s = CARD t)
    ==> ?f:'a->'b. (!x. x IN s ==> f(x) IN t) /\
@@ -1898,30 +1790,6 @@ Theorem FINITE_FINITE_BIGUNION[local]:
 Proof
   metis_tac[FINITE_BIGUNION_EQ]
 QED
-
-val num_FINITE = store_thm ("num_FINITE",
- ``!s:num->bool. FINITE s <=> ?a. !x. x IN s ==> x <= a``,
-  GEN_TAC THEN EQ_TAC THENL
-   [SPEC_TAC(``s:num->bool``,``s:num->bool``) THEN GEN_TAC THEN
-   KNOW_TAC ``(?a. !x. x IN s ==> x <= a) =
-          (\s. ?a. !x. x IN s ==> x <= a) (s:num->bool)`` THENL
-    [FULL_SIMP_TAC std_ss [], ALL_TAC] THEN DISC_RW_KILL THEN
-    MATCH_MP_TAC FINITE_INDUCT THEN BETA_TAC THEN
-    REWRITE_TAC[IN_INSERT, NOT_IN_EMPTY] THEN MESON_TAC[LESS_EQ_CASES, LESS_EQ_TRANS],
-    DISCH_THEN(X_CHOOSE_TAC ``n:num``) THEN
-    KNOW_TAC ``s SUBSET {m:num | m <= n}`` THENL [REWRITE_TAC [SUBSET_DEF] THEN
-    RW_TAC std_ss [GSPECIFICATION], ALL_TAC] THEN MATCH_MP_TAC SUBSET_FINITE THEN
-    KNOW_TAC ``{m:num | m <= n} = {m | m < n} UNION {n}``
-    THENL [SIMP_TAC std_ss [UNION_DEF, EXTENSION, GSPECIFICATION, IN_SING, LESS_OR_EQ],
-    SIMP_TAC std_ss [FINITE_UNION, FINITE_SING, GSYM count_def, FINITE_COUNT]]]);
-
-val num_FINITE_AVOID = store_thm ("num_FINITE_AVOID",
- ``!s:num->bool. FINITE(s) ==> ?a. ~(a IN s)``,
-  MESON_TAC[num_FINITE, LESS_THM, NOT_LESS]);
-
-val num_INFINITE = store_thm ("num_INFINITE",
- ``INFINITE univ(:num)``,
-  MESON_TAC[num_FINITE_AVOID, IN_UNIV]);
 
 (* ------------------------------------------------------------------------- *)
 (* This is often more useful as a rewrite.                                   *)
@@ -2005,61 +1873,8 @@ Theorem FINITE_BOOL[simp]: FINITE univ(:bool)
 Proof simp[]
 QED
 
-(* ----------------------------------------------------------------------
-    More cardinality results for whole universe.
-
-    currently a nonsense: see HOL Light's cart.ml for what these should
-    be, using a[b] instead of HOL Light's a^b
-
-    would need to bring in at least fcpTheory as an ancestor
-   ---------------------------------------------------------------------- *)
-val HAS_SIZE_CART_UNIV = store_thm ("HAS_SIZE_CART_UNIV",
- ``!m. univ(:'a) HAS_SIZE m ==> univ(:'a) HAS_SIZE m EXP (1:num)``,
-  REWRITE_TAC [EXP_1]);
-
-val CARD_CART_UNIV = store_thm ("CARD_CART_UNIV",
- ``FINITE univ(:'a) ==> (CARD univ(:'a) = CARD univ(:'a) EXP (1:num))``,
-  MESON_TAC[HAS_SIZE_CART_UNIV, HAS_SIZE]);
-
-val FINITE_CART_UNIV = store_thm ("FINITE_CART_UNIV",
- ``FINITE univ(:'a) ==> FINITE univ(:'a)``,
-  MESON_TAC[HAS_SIZE_CART_UNIV, HAS_SIZE]);
-
-(* ------------------------------------------------------------------------- *)
-
-val HAS_SIZE_NUMSEG_LT = store_thm ("HAS_SIZE_NUMSEG_LT",
- ``!n. {m | m < n} HAS_SIZE n``,
-  INDUCT_TAC THENL
-   [SUBGOAL_THEN ``{m:num | m < 0} = {}``
-       (fn th => REWRITE_TAC[HAS_SIZE_0, th]) THEN
-    SIMP_TAC std_ss [EXTENSION, NOT_IN_EMPTY, GSPECIFICATION, LESS_THM, NOT_LESS_0],
-    SUBGOAL_THEN ``{m | m < SUC n} = n INSERT {m | m < n}`` SUBST1_TAC THENL
-     [SIMP_TAC std_ss [EXTENSION, GSPECIFICATION, IN_INSERT] THEN ARITH_TAC,
-      ALL_TAC] THEN
-    RULE_ASSUM_TAC(REWRITE_RULE[HAS_SIZE]) THEN
-    ASM_SIMP_TAC std_ss [HAS_SIZE, CARD_EMPTY, CARD_INSERT, FINITE_INSERT] THEN
-    SIMP_TAC std_ss [GSPECIFICATION, LESS_REFL]]);
-
-val FINITE_NUMSEG_LT = store_thm ("FINITE_NUMSEG_LT",
- ``!n:num. FINITE {m | m < n}``,
-  REWRITE_TAC[REWRITE_RULE[HAS_SIZE] HAS_SIZE_NUMSEG_LT]);
-
-val HAS_SIZE_NUMSEG_LE = store_thm ("HAS_SIZE_NUMSEG_LE",
- ``!n. {m | m <= n} HAS_SIZE (n + 1)``,
-  REWRITE_TAC[GSYM LT_SUC_LE, HAS_SIZE_NUMSEG_LT, ADD1]);
-
-val FINITE_NUMSEG_LE = store_thm ("FINITE_NUMSEG_LE",
- ``!n:num. FINITE {m | m <= n}``,
- SIMP_TAC std_ss [REWRITE_RULE[HAS_SIZE] HAS_SIZE_NUMSEG_LE]);
-
-val INFINITE_DIFF_FINITE = store_thm ("INFINITE_DIFF_FINITE",
- ``!s:'a->bool t. INFINITE(s) /\ FINITE(t) ==> INFINITE(s DIFF t)``,
-  REPEAT GEN_TAC THEN
-  MATCH_MP_TAC(TAUT `(b /\ ~c ==> ~a) ==> a /\ b ==> c`) THEN
-  REWRITE_TAC [] THEN STRIP_TAC THEN
-  MATCH_MP_TAC SUBSET_FINITE_I THEN
-  EXISTS_TAC ``(t:'a->bool) UNION (s DIFF t)`` THEN
-  ASM_REWRITE_TAC[FINITE_UNION] THEN SET_TAC[]);
+(* NOTE: This theorem has been moved to pred_setTheory with a different name *)
+Theorem INFINITE_DIFF_FINITE = INFINITE_DIFF_FINITE'
 
 (* ------------------------------------------------------------------------- *)
 (* misc.                                                                     *)

--- a/src/pred_set/src/pred_setLib.sig
+++ b/src/pred_set/src/pred_setLib.sig
@@ -17,4 +17,9 @@ sig
 
   val add_pred_set_compset : computeLib.compset -> unit
 
+  (* Automate some routine set theory by reduction to FOL *)
+  val SET_TAC        : thm list -> tactic
+  val ASM_SET_TAC    : thm list -> tactic
+  val SET_RULE       : term -> thm
+
 end

--- a/src/pred_set/src/pred_setLib.sml
+++ b/src/pred_set/src/pred_setLib.sml
@@ -1,9 +1,10 @@
 structure pred_setLib :> pred_setLib =
 struct
 
-local open pred_setTheory in end
+open HolKernel Parse boolLib;
 
-open Abbrev HolKernel PFset_conv pred_setSyntax;
+open pairTheory pred_setTheory pred_setSyntax PFset_conv simpLib pureSimps
+     metisLib numLib;
 
 val SET_SPEC_CONV  = PGspec.SET_SPEC_CONV pred_setTheory.GSPECIFICATION
 val SET_INDUCT_TAC = PSet_ind.SET_INDUCT_TAC pred_setTheory.FINITE_INDUCT
@@ -37,6 +38,24 @@ in
   MATCH_MP_TAC pred_setTheory.MAX_SET_ELIM THEN BETA_TAC
 end g
 end
+
+(*---------------------------------------------------------------------------*)
+(* Tactic to automate some routine set theory by reduction to FOL            *)
+(* (Ported from HOL Light)                                                   *)
+(*---------------------------------------------------------------------------*)
+
+fun SET_TAC L =
+    POP_ASSUM_LIST (K ALL_TAC) \\
+    rpt COND_CASES_TAC \\
+    REWRITE_TAC (append [EXTENSION, SUBSET_DEF, PSUBSET_DEF, DISJOINT_DEF,
+                         SING_DEF] L) \\
+    SIMP_TAC std_ss [NOT_IN_EMPTY, IN_UNIV, IN_UNION, IN_INTER, IN_DIFF,
+      IN_INSERT, IN_DELETE, IN_REST, IN_BIGINTER, IN_BIGUNION, IN_IMAGE,
+      GSPECIFICATION, IN_DEF, EXISTS_PROD] \\
+    METIS_TAC [];
+
+fun ASM_SET_TAC L = rpt (POP_ASSUM MP_TAC) >> SET_TAC L;
+fun SET_RULE tm = prove (tm, SET_TAC []);
 
 (*---------------------------------------------------------------------------*)
 (* Set up computeLib for sets                                                *)

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -3065,7 +3065,7 @@ QED
 Theorem FINITE_IMAGE_INJ' :
     (!x y. x IN s /\ y IN s ==> ((f x = f y) <=> (x = y))) ==>
     (FINITE (IMAGE f s) <=> FINITE s)
-Proof 
+Proof
   STRIP_TAC THEN EQ_TAC THEN SIMP_TAC (srw_ss()) [IMAGE_FINITE] THEN
   `!P. FINITE P ==> !Q. Q SUBSET s /\ (P = IMAGE f Q) ==> FINITE Q`
     suffices_by METIS_TAC[SUBSET_REFL] THEN

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -12,7 +12,7 @@
 
 open HolKernel Parse boolLib BasicProvers;
 
-open Prim_rec pairLib numLib numpairTheory
+open Prim_rec pairLib numLib numpairTheory hurdUtils tautLib pureSimps
      pairTheory numTheory prim_recTheory arithmeticTheory whileTheory
      metisLib mesonLib simpLib boolSimps dividesTheory
      combinTheory relationTheory optionTheory TotalDefn;
@@ -27,12 +27,16 @@ val metis_tac = METIS_TAC;
 val qabbrev_tac = Q.ABBREV_TAC;
 val qid_spec_tac = Q.ID_SPEC_TAC;
 val qexists_tac = Q.EXISTS_TAC;
+val rename1 = Q.RENAME1_TAC;
 
 (* don't eta-contract these; that will force tactics to use one fixed version
    of srw_ss() *)
 fun fs thl = FULL_SIMP_TAC (srw_ss() ++ ARITH_ss) thl
 fun simp thl = ASM_SIMP_TAC (srw_ss() ++ ARITH_ss) thl
 fun rw thl = SRW_TAC[ARITH_ss]thl
+
+val DISC_RW_KILL = DISCH_TAC >> ONCE_ASM_REWRITE_TAC [] \\
+                   POP_ASSUM K_TAC;
 
 fun store_thm(r as(n,t,tac)) = let
   val th = boolLib.store_thm r
@@ -69,12 +73,6 @@ structure Q = struct
       foo(n,t,tac)
     end
 end
-
-(* from hurdUtils *)
-fun K_TAC _ = ALL_TAC;
-val KILL_TAC = POP_ASSUM_LIST K_TAC;
-val Know = Q_TAC KNOW_TAC;
-val Suff = Q_TAC SUFF_TAC;
 
 (* ---------------------------------------------------------------------*)
 (* Create the new theory.                                               *)
@@ -200,7 +198,6 @@ val SET_SPEC_ss = SSFRAG
    name = "SET_SPEC_CONV", trace = 2}]}
 
 val _ = augment_srw_ss [SET_SPEC_ss]
-
 
 (* --------------------------------------------------------------------- *)
 (* activate generalized specification parser/pretty-printer.             *)
@@ -2835,6 +2832,15 @@ Proof
    ASM_REWRITE_TAC []]
 QED
 
+(* HOL-Light compatible name. It's not stronger than the above FINITE_INDUCT. *)
+Theorem FINITE_INDUCT_STRONG :
+    !P. P {} /\ (!x s. P s /\ ~(x IN s) /\ FINITE s ==> P (x INSERT s))
+         ==> (!s. FINITE s ==> P s)
+Proof
+    GEN_TAC >> STRIP_TAC
+ >> MATCH_MP_TAC FINITE_INDUCT >> rw []
+QED
+
 (* --------------------------------------------------------------------- *)
 (* Load the set induction tactic in...                                   *)
 (* --------------------------------------------------------------------- *)
@@ -3050,19 +3056,58 @@ Proof
   METIS_TAC [FINITE_DIFF_down]
 QED
 
-val INJECTIVE_IMAGE_FINITE = Q.store_thm
-("INJECTIVE_IMAGE_FINITE",
-  `!f. (!x y. (f x = f y) = (x = y)) ==>
-       !s. FINITE (IMAGE f s) = FINITE s`,
-  REPEAT STRIP_TAC THEN MATCH_MP_TAC FINITELY_INJECTIVE_IMAGE_FINITE THEN
-  GEN_TAC THEN Cases_on `?e. x = f e` THENL [
-    POP_ASSUM STRIP_ASSUME_TAC THEN
-    Q_TAC SUFF_TAC `{y | x = f y} = {e}` THEN1 SRW_TAC [][] THEN
-    ASM_SIMP_TAC (srw_ss()) [GSPECIFICATION, EXTENSION] THEN PROVE_TAC [],
-    Q_TAC SUFF_TAC `{y | x = f y} = {}` THEN1 SRW_TAC [][] THEN
-    FULL_SIMP_TAC (srw_ss()) [EXTENSION, GSPECIFICATION]
-  ]);
-val _ = export_rewrites ["INJECTIVE_IMAGE_FINITE"]
+Theorem image_eq_empty[local] :
+    ({} = IMAGE f Q) <=> (Q = {})
+Proof
+  METIS_TAC[IMAGE_EQ_EMPTY]
+QED
+
+Theorem FINITE_IMAGE_INJ' :
+    (!x y. x IN s /\ y IN s ==> ((f x = f y) <=> (x = y))) ==>
+    (FINITE (IMAGE f s) <=> FINITE s)
+Proof 
+  STRIP_TAC THEN EQ_TAC THEN SIMP_TAC (srw_ss()) [IMAGE_FINITE] THEN
+  `!P. FINITE P ==> !Q. Q SUBSET s /\ (P = IMAGE f Q) ==> FINITE Q`
+    suffices_by METIS_TAC[SUBSET_REFL] THEN
+  Induct_on `FINITE` THEN SIMP_TAC (srw_ss())[image_eq_empty] THEN
+  Q.X_GEN_TAC `P` THEN STRIP_TAC THEN Q.X_GEN_TAC `e` THEN STRIP_TAC THEN
+  Q.X_GEN_TAC `Q` THEN STRIP_TAC THEN
+  `e IN IMAGE f Q` by METIS_TAC [IN_INSERT] THEN
+  `?d. d IN Q /\ (e = f d)`
+    by (POP_ASSUM MP_TAC THEN SIMP_TAC (srw_ss())[] THEN METIS_TAC[]) THEN
+  `P = IMAGE f (Q DELETE d)`
+    by (Q.UNDISCH_THEN `e INSERT P = IMAGE f Q` MP_TAC THEN
+        SIMP_TAC (srw_ss()) [EXTENSION] THEN STRIP_TAC THEN
+        Q.X_GEN_TAC `e0` THEN EQ_TAC THEN1
+          (STRIP_TAC THEN `e0 <> e` by METIS_TAC[] THEN
+           `?d0. (e0 = f d0) /\ d0 IN Q` by METIS_TAC[] THEN
+           Q.EXISTS_TAC `d0` THEN ASM_SIMP_TAC (srw_ss()) [] THEN
+           STRIP_TAC THEN METIS_TAC [SUBSET_DEF]) THEN
+        DISCH_THEN (Q.X_CHOOSE_THEN `d0` STRIP_ASSUME_TAC) THEN
+        METIS_TAC [SUBSET_DEF]) THEN
+  `Q DELETE d SUBSET s` by FULL_SIMP_TAC(srw_ss())[SUBSET_DEF] THEN
+  `FINITE (Q DELETE d)` by METIS_TAC[] THEN
+  `Q = d INSERT (Q DELETE d)`
+    by (SIMP_TAC (srw_ss()) [EXTENSION] THEN METIS_TAC[]) THEN
+  POP_ASSUM SUBST1_TAC THEN ASM_SIMP_TAC (srw_ss())[]
+QED
+
+Theorem FINITE_IMAGE_INJ_EQ :
+ !(f:'a->'b) s.
+   (!x y. x IN s /\ y IN s /\ (f(x) = f(y)) ==> (x = y)) ==>
+   (FINITE(IMAGE f s) <=> FINITE s)
+Proof
+  metis_tac[FINITE_IMAGE_INJ']
+QED
+
+Theorem INJECTIVE_IMAGE_FINITE[simp] :
+   !f. (!x y. (f x = f y) = (x = y)) ==>
+       !s. FINITE (IMAGE f s) = FINITE s
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC FINITE_IMAGE_INJ_EQ
+ >> RW_TAC std_ss []
+QED
 
 val lem = Q.prove
 (`!t. FINITE t ==> !s f. INJ f s t ==> FINITE s`,
@@ -3891,6 +3936,111 @@ Proof
    THEN PROVE_TAC [LT_REFL, IN_DELETE]
 QED
 
+Theorem HAS_SIZE_UNION :
+    !(s:'a->bool) t m n.
+        s HAS_SIZE m /\ t HAS_SIZE n /\ DISJOINT s t
+        ==> (s UNION t) HAS_SIZE (m + n)
+Proof
+    RW_TAC std_ss[HAS_SIZE, FINITE_UNION, DISJOINT_DEF]
+ >> MP_TAC (Q.SPEC ‘t’ (MATCH_MP (Q.SPEC ‘s’ CARD_UNION)
+                                 (ASSUME “FINITE (s :'a set)”)))
+ >> simp []
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Cardinality of product.                                                   *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem IMP_CONJ[local] :
+    !p q r. p /\ q ==> r <=> p ==> q ==> r
+Proof
+    REWRITE_TAC [AND_IMP_INTRO]
+QED
+
+Theorem HAS_SIZE_PRODUCT_DEPENDENT :
+    !s m t n.
+         s HAS_SIZE m /\ (!x. x IN s ==> t(x) HAS_SIZE n)
+         ==> {(x:'a,y:'b) | x IN s /\ y IN t(x)} HAS_SIZE (m * n)
+Proof
+  GEN_REWRITE_TAC (funpow 4 BINDER_CONV o funpow 2 LAND_CONV)
+                  empty_rewrites [HAS_SIZE] THEN
+  SIMP_TAC pure_ss[IMP_CONJ, RIGHT_FORALL_IMP_THM] THEN
+  HO_MATCH_MP_TAC FINITE_INDUCT_STRONG THEN
+  SIMP_TAC std_ss[CARD_CLAUSES, NOT_IN_EMPTY, IN_INSERT] THEN CONJ_TAC
+  >- (REWRITE_TAC[HAS_SIZE_0] THEN rw [Once EXTENSION]) THEN
+  rpt GEN_TAC THEN STRIP_TAC THEN
+  rpt GEN_TAC THEN
+  REWRITE_TAC[TAUT `a \/ b ==> c <=> (a ==> c) /\ (b ==> c)`] THEN
+  SIMP_TAC std_ss[FORALL_AND_THM, LEFT_FORALL_IMP_THM, EXISTS_REFL] THEN
+  STRIP_TAC THEN
+  rename1 ‘t a HAS_SIZE n’ THEN
+  REWRITE_TAC[MULT_CLAUSES] THEN
+  Suff ‘{(x,y) | (x = a \/ x IN s) /\ y IN t(x)} =
+        {(x,y) | x IN s /\ y IN t(x)} UNION
+        IMAGE (\y. (a,y)) (t a)’
+  >- (Rewr' \\
+      MATCH_MP_TAC HAS_SIZE_UNION >> simp [] \\
+      CONJ_TAC
+      >- (MATCH_MP_TAC HAS_SIZE_IMAGE_INJ >> simp []) \\
+      rw [DISJOINT_ALT] >> PROVE_TAC []) THEN
+  rw [Once EXTENSION] >> EQ_TAC >> rw []
+QED
+
+Theorem FINITE_PRODUCT_DEPENDENT :
+    !f:'a->'b->'c s t.
+        FINITE s /\ (!x. x IN s ==> FINITE(t x))
+        ==> FINITE {f x y | x IN s /\ y IN (t x)}
+Proof
+  REPEAT STRIP_TAC THEN KNOW_TAC ``{f x y | x IN s /\ y IN (t x)} SUBSET
+   IMAGE (\(x,y). (f:'a->'b->'c) x y) {x,y | x IN s /\ y IN t x}`` THENL
+  [SRW_TAC [][SUBSET_DEF, IN_IMAGE, EXISTS_PROD], ALL_TAC] THEN
+  KNOW_TAC ``FINITE (IMAGE (\(x,y). (f:'a->'b->'c) x y)
+                    {x,y | x IN s /\ y IN t x})`` THENL
+  [MATCH_MP_TAC IMAGE_FINITE THEN MAP_EVERY UNDISCH_TAC
+   [``!x:'a. x IN s ==> FINITE(t x :'b->bool)``, ``FINITE(s:'a->bool)``]
+  THEN MAP_EVERY (fn t => SPEC_TAC(t,t)) [``t:'a->'b->bool``, ``s:'a->bool``]
+  THEN SIMP_TAC std_ss [RIGHT_FORALL_IMP_THM] THEN GEN_TAC THEN
+  KNOW_TAC ``(!(t:'a->'b->bool). (!x. x IN s ==> FINITE (t x)) ==>
+             FINITE {(x,y) | x IN s /\ y IN t x}) =
+         (\s. !(t:'a->'b->bool). (!x. x IN s ==> FINITE (t x)) ==>
+             FINITE {(x,y) | x IN s /\ y IN t x}) (s:'a->bool)`` THENL
+  [FULL_SIMP_TAC std_ss [], ALL_TAC] THEN DISCH_TAC THEN
+  ONCE_ASM_REWRITE_TAC [] THEN MATCH_MP_TAC FINITE_INDUCT THEN BETA_TAC
+  THEN CONJ_TAC THENL [GEN_TAC THEN
+  SUBGOAL_THEN ``{(x:'a,y:'b) | x IN {} /\ y IN (t x)} = {}``
+     (fn th => REWRITE_TAC[th, FINITE_EMPTY]) THEN SRW_TAC [][],
+  SIMP_TAC std_ss [GSYM RIGHT_FORALL_IMP_THM] THEN REPEAT GEN_TAC THEN
+  SUBGOAL_THEN ``{(x:'a, y:'b) | x IN (e INSERT s') /\ y IN (t x)} =
+    IMAGE (\y. e,y) (t e) UNION {(x,y) | x IN s' /\ y IN (t x)}``
+   (fn th => ASM_SIMP_TAC std_ss [IN_INSERT, IMAGE_FINITE, FINITE_UNION, th])
+  THEN SRW_TAC [][EXTENSION, IN_IMAGE, IN_INSERT, IN_UNION] THEN MESON_TAC[]],
+  PROVE_TAC [SUBSET_FINITE]] THEN
+  rw [Once EXTENSION, NOT_IN_EMPTY]
+QED
+
+Theorem FINITE_PRODUCT :
+    !s t. FINITE s /\ FINITE t ==> FINITE {(x:'a,y:'b) | x IN s /\ y IN t}
+Proof
+  SIMP_TAC std_ss [FINITE_PRODUCT_DEPENDENT]
+QED
+
+Theorem CARD_PRODUCT :
+    !s t. FINITE s /\ FINITE t
+         ==> (CARD {(x:'a,y:'b) | x IN s /\ y IN t} = CARD s * CARD t)
+Proof
+  REPEAT STRIP_TAC THEN
+  MP_TAC(Q.SPECL [`s`, `CARD s`, `\x. (t :'b set)`, `CARD (t :'b set)`]
+                  HAS_SIZE_PRODUCT_DEPENDENT) THEN
+  ASM_SIMP_TAC std_ss[HAS_SIZE]
+QED
+
+Theorem HAS_SIZE_PRODUCT :
+    !s m t n. s HAS_SIZE m /\ t HAS_SIZE n
+             ==> {(x:'a,y:'b) | x IN s /\ y IN t} HAS_SIZE (m * n)
+Proof
+  SIMP_TAC std_ss[HAS_SIZE, CARD_PRODUCT, FINITE_PRODUCT]
+QED
+
 (* ====================================================================== *)
 (* Sets of size n.                                                        *)
 (* ====================================================================== *)
@@ -4046,6 +4196,36 @@ val INFINITE_INJ = store_thm (* from util_prob *)
   ("INFINITE_INJ",
    ``!f s t. INJ f s t /\ INFINITE s ==> INFINITE t``,
    PROVE_TAC [FINITE_INJ]);
+
+Theorem num_FINITE :
+    !s:num->bool. FINITE s <=> ?a. !x. x IN s ==> x <= a
+Proof
+  GEN_TAC THEN EQ_TAC THENL
+   [SPEC_TAC(``s:num->bool``,``s:num->bool``) THEN GEN_TAC THEN
+   KNOW_TAC ``(?a. !x. x IN s ==> x <= a) =
+          (\s. ?a. !x. x IN s ==> x <= a) (s:num->bool)`` THENL
+    [FULL_SIMP_TAC std_ss [], ALL_TAC] THEN DISC_RW_KILL THEN
+    MATCH_MP_TAC FINITE_INDUCT THEN BETA_TAC THEN
+    REWRITE_TAC[IN_INSERT, NOT_IN_EMPTY] THEN MESON_TAC[LESS_EQ_CASES, LESS_EQ_TRANS],
+    DISCH_THEN(X_CHOOSE_TAC ``n:num``) THEN
+    KNOW_TAC ``s SUBSET {m:num | m <= n}`` THENL [REWRITE_TAC [SUBSET_DEF] THEN
+    RW_TAC std_ss [GSPECIFICATION], ALL_TAC] THEN MATCH_MP_TAC SUBSET_FINITE THEN
+    KNOW_TAC ``{m:num | m <= n} = {m | m < n} UNION {n}``
+    THENL [SIMP_TAC std_ss [UNION_DEF, EXTENSION, GSPECIFICATION, IN_SING, LESS_OR_EQ],
+    SIMP_TAC std_ss [FINITE_UNION, FINITE_SING, GSYM count_def, FINITE_COUNT]]]
+QED
+
+Theorem num_FINITE_AVOID :
+    !s:num->bool. FINITE(s) ==> ?a. ~(a IN s)
+Proof
+  MESON_TAC[num_FINITE, LESS_THM, NOT_LESS]
+QED
+
+Theorem num_INFINITE :
+   INFINITE univ(:num)
+Proof
+  MESON_TAC[num_FINITE_AVOID, IN_UNIV]
+QED
 
 (* ---------------------------------------------------------------------- *)
 (* The next series of lemmas are used for proving that if UNIV: set       *)
@@ -4213,14 +4393,7 @@ val INFINITE_UNIV = store_thm (
 
   simp[INFINITE_INJ_NOT_SURJ, INJ_DEF, SURJ_DEF]);
 
-(* a natural consequence *)
-val INFINITE_NUM_UNIV = store_thm(
-  "INFINITE_NUM_UNIV",
-  ``INFINITE univ(:num)``,
-  REWRITE_TAC [] THEN
-  SRW_TAC [][INFINITE_UNIV] THEN Q.EXISTS_TAC `SUC` THEN SRW_TAC [][] THEN
-  Q.EXISTS_TAC `0` THEN SRW_TAC [][]);
-val _ = export_rewrites ["INFINITE_NUM_UNIV"]
+Theorem INFINITE_NUM_UNIV[simp] = num_INFINITE
 
 val FINITE_PSUBSET_INFINITE = store_thm("FINITE_PSUBSET_INFINITE",
 (“!s. INFINITE (s:'a set) =
@@ -4240,13 +4413,23 @@ val FINITE_PSUBSET_UNIV = store_thm("FINITE_PSUBSET_UNIV",
      PURE_ONCE_REWRITE_TAC [FINITE_PSUBSET_INFINITE] THEN
      REWRITE_TAC [PSUBSET_DEF,SUBSET_UNIV]);
 
-val INFINITE_DIFF_FINITE = store_thm("INFINITE_DIFF_FINITE",
-     (“!s t. (INFINITE s /\ FINITE t) ==> ~(s DIFF t = ({}:'a set))”),
-     REPEAT GEN_TAC THEN STRIP_TAC THEN
-     IMP_RES_TAC IN_INFINITE_NOT_FINITE THEN
-     REWRITE_TAC [EXTENSION,IN_DIFF,NOT_IN_EMPTY] THEN
-     CONV_TAC NOT_FORALL_CONV THEN
-     EXISTS_TAC “x:'a” THEN ASM_REWRITE_TAC[]);
+Theorem INFINITE_DIFF_FINITE' :
+    !s:'a->bool t. INFINITE(s) /\ FINITE(t) ==> INFINITE(s DIFF t)
+Proof
+  REPEAT GEN_TAC THEN
+  MATCH_MP_TAC(TAUT `(b /\ ~c ==> ~a) ==> a /\ b ==> c`) THEN
+  REWRITE_TAC [] THEN STRIP_TAC THEN
+  MATCH_MP_TAC SUBSET_FINITE_I THEN
+  EXISTS_TAC ``(t:'a->bool) UNION (s DIFF t)`` THEN
+  ASM_REWRITE_TAC[FINITE_UNION] THEN
+  rw [SUBSET_DEF]
+QED
+
+Theorem INFINITE_DIFF_FINITE :
+    !s t. (INFINITE s /\ FINITE t) ==> ~(s DIFF t = ({}:'a set))
+Proof
+  PROVE_TAC [INFINITE_DIFF_FINITE', INFINITE_INHAB, MEMBER_NOT_EMPTY]
+QED
 
 val FINITE_INDUCT' =
   Ho_Rewrite.REWRITE_RULE [PULL_FORALL] FINITE_INDUCT ;
@@ -4401,6 +4584,14 @@ Proof
   SIMP_TAC bool_ss [GSPECIFICATION, BIGUNION, pairTheory.PAIR_EQ] THEN
   MESON_TAC []
 QED
+
+val BIGUNION_GSPEC = store_thm ("BIGUNION_GSPEC",
+ ``(!P f. BIGUNION {f x | P x} = {a | ?x. P x /\ a IN (f x)}) /\
+   (!P f. BIGUNION {f x y | P x y} = {a | ?x y. P x y /\ a IN (f x y)}) /\
+   (!P f. BIGUNION {f x y z | P x y z} =
+            {a | ?x y z. P x y z /\ a IN (f x y z)})``,
+  REPEAT STRIP_TAC THEN ONCE_REWRITE_TAC [EXTENSION] THEN
+  SIMP_TAC std_ss [IN_BIGUNION, GSPECIFICATION, EXISTS_PROD] THEN MESON_TAC[]);
 
 val IN_BIGUNION_IMAGE = store_thm (* from util_prob *)
   ("IN_BIGUNION_IMAGE",
@@ -4627,6 +4818,14 @@ Theorem IN_BIGINTER[simp]:
 Proof
   SIMP_TAC bool_ss [BIGINTER, GSPECIFICATION, pairTheory.PAIR_EQ]
 QED
+
+val BIGINTER_GSPEC = store_thm ("BIGINTER_GSPEC",
+ ``(!P f. BIGINTER {f x | P x} = {a | !x. P x ==> a IN (f x)}) /\
+   (!P f. BIGINTER {f x y | P x y} = {a | !x y. P x y ==> a IN (f x y)}) /\
+   (!P f. BIGINTER {f x y z | P x y z} =
+                {a | !x y z. P x y z ==> a IN (f x y z)})``,
+  REPEAT STRIP_TAC THEN ONCE_REWRITE_TAC [EXTENSION] THEN
+  SIMP_TAC std_ss [IN_BIGINTER, GSPECIFICATION, EXISTS_PROD] THEN MESON_TAC[]);
 
 Theorem IN_BIGINTER_IMAGE:
   !x f s. (x IN BIGINTER (IMAGE f s)) = (!y. y IN s ==> x IN f y)
@@ -6449,6 +6648,26 @@ val MAX_SET_UNION = Q.store_thm
         by SRW_TAC[][EXTENSION,AC DISJ_COMM DISJ_ASSOC]
    THEN FULL_SIMP_TAC (srw_ss()) [MAX_SET_THM, AC MAX_COMM MAX_ASSOC]);
 
+Theorem FINITE_INTER :
+    !s1 s2. ((FINITE s1) \/ (FINITE s2)) ==> FINITE (s1 INTER s2)
+Proof
+  METIS_TAC[INTER_COMM, INTER_FINITE]
+QED
+
+Theorem MAX_SET_INTER :
+    !A B. FINITE A /\ FINITE B ==>
+          MAX_SET (A INTER B) <= MIN (MAX_SET A) (MAX_SET B)
+Proof
+    Q_TAC SUFF_TAC
+   ‘!A. FINITE A ==> !B. FINITE B ==>
+       MAX_SET (A INTER B) <= MIN (MAX_SET A) (MAX_SET B)’
+ >- METIS_TAC []
+ >> SET_INDUCT_TAC >> simp []
+ >> rpt STRIP_TAC (* 2 subgoals, same tactics *)
+ >> MATCH_MP_TAC SUBSET_MAX_SET
+ >> rw [FINITE_INTER, INTER_SUBSET]
+QED
+
 val set_ss = arith_ss ++ SET_SPEC_ss ++
              rewrites [CARD_INSERT,CARD_EMPTY,FINITE_EMPTY,FINITE_INSERT,
                        NOT_IN_EMPTY];
@@ -8209,9 +8428,6 @@ val IN_INSERT_EXPAND = store_thm ("IN_INSERT_EXPAND",
   SIMP_TAC bool_ss [IN_INSERT] THEN
   METIS_TAC[]);
 
-val FINITE_INTER = store_thm ("FINITE_INTER",
-  ``!s1 s2. ((FINITE s1) \/ (FINITE s2)) ==> FINITE (s1 INTER s2)``,
-  METIS_TAC[INTER_COMM, INTER_FINITE]);
 (* END misc thms *)
 
 (*---------------------------------------------------------------------------*)
@@ -8787,6 +9003,47 @@ Proof
  >> RW_TAC std_ss []
  >> Cases_on ‘x IN s’
  >> RW_TAC std_ss []
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Classic result on function of finite set into itself.                     *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem SURJECTIVE_IFF_INJECTIVE_GEN :
+   !s t f:'a->'b.
+        FINITE s /\ FINITE t /\ (CARD s = CARD t) /\ (IMAGE f s) SUBSET t
+        ==> ((!y. y IN t ==> ?x. x IN s /\ (f x = y)) <=>
+             (!x y. x IN s /\ y IN s /\ (f x = f y) ==> (x = y)))
+Proof
+  REPEAT STRIP_TAC THEN EQ_TAC THEN REPEAT STRIP_TAC THENL
+  [ASM_CASES_TAC ``x:'a = y`` THENL [ASM_REWRITE_TAC[],
+  SUBGOAL_THEN ``CARD s <= CARD (IMAGE (f:'a->'b) (s DELETE y))`` MP_TAC THENL
+  [ASM_REWRITE_TAC[] THEN KNOW_TAC  ``(!(s :'b -> bool).
+            FINITE s ==> !(t :'b -> bool). t SUBSET s ==> CARD t <= CARD s)``
+  THENL [METIS_TAC [CARD_SUBSET], DISCH_TAC THEN
+  POP_ASSUM (MP_TAC o Q.SPEC `IMAGE (f:'a->'b) ((s:'a->bool) DELETE y)`) THEN
+  KNOW_TAC ``FINITE (IMAGE (f :'a -> 'b) ((s :'a -> bool) DELETE (y :'a)))``
+  THENL [FULL_SIMP_TAC std_ss [IMAGE_FINITE, FINITE_DELETE], DISCH_TAC
+  THEN FULL_SIMP_TAC std_ss [] THEN DISCH_TAC THEN POP_ASSUM (MP_TAC o Q.SPEC `t:'b->bool`)
+  THEN KNOW_TAC ``(t :'b -> bool) SUBSET IMAGE (f :'a -> 'b) ((s :'a -> bool) DELETE (y :'a))``
+  THENL [REWRITE_TAC[SUBSET_DEF, IN_IMAGE, IN_DELETE] THEN ASM_MESON_TAC[], ASM_MESON_TAC[]]]],
+  FULL_SIMP_TAC std_ss [] THEN REWRITE_TAC[NOT_LESS_EQUAL] THEN
+  MATCH_MP_TAC LESS_EQ_LESS_TRANS THEN EXISTS_TAC ``CARD(s DELETE (y:'a))`` THEN
+  CONJ_TAC THENL [ASM_SIMP_TAC std_ss [CARD_IMAGE_LE, FINITE_DELETE],
+  KNOW_TAC ``!x. x - 1 < x:num <=> ~(x = 0)`` THENL [ARITH_TAC, DISCH_TAC
+  THEN ASM_SIMP_TAC std_ss [CARD_DELETE] THEN
+  ASM_MESON_TAC[CARD_EQ_0, MEMBER_NOT_EMPTY]]]]],
+  SUBGOAL_THEN ``IMAGE (f:'a->'b) s = t`` MP_TAC THENL
+  [ALL_TAC, ASM_MESON_TAC[EXTENSION, IN_IMAGE]] THEN
+  METIS_TAC [CARD_IMAGE_INJ, SUBSET_EQ_CARD, IMAGE_FINITE]]
+QED
+
+Theorem SURJECTIVE_IFF_INJECTIVE :
+   !s f:'a->'a. FINITE s /\ (IMAGE f s) SUBSET s
+     ==> ((!y. y IN s ==> ?x. x IN s /\ (f x = y)) <=>
+     (!x y. x IN s /\ y IN s /\ (f x = f y) ==> (x = y)))
+Proof
+  SIMP_TAC std_ss [SURJECTIVE_IFF_INJECTIVE_GEN]
 QED
 
 (*---------------------------------------------------------------------------*)

--- a/src/probability/sigma_algebraScript.sml
+++ b/src/probability/sigma_algebraScript.sml
@@ -17,7 +17,7 @@ open HolKernel Parse boolLib bossLib;
 
 open arithmeticTheory optionTheory pairTheory combinTheory pred_setTheory
      pred_setLib numLib realLib seqTheory topologyTheory hurdUtils
-     util_probTheory;
+     util_probTheory res_quanTools;
 
 val _ = new_theory "sigma_algebra";
 
@@ -25,6 +25,8 @@ val DISC_RW_KILL = DISCH_TAC >> ONCE_ASM_REWRITE_TAC [] >> POP_ASSUM K_TAC;
 fun METIS ths tm = prove(tm, METIS_TAC ths);
 val set_ss = std_ss ++ PRED_SET_ss;
 val std_ss' = std_ss ++ boolSimps.ETA_ss;
+val S_TAC = rpt (POP_ASSUM MP_TAC) >> rpt RESQ_STRIP_TAC;
+val Strip = S_TAC;
 
 val _ = hide "S";
 
@@ -3906,14 +3908,40 @@ Proof
  >> MATCH_MP_TAC ALGEBRA_FINITE_UNION >> art []
 QED
 
+(* NOTE: The trivial algebras below are also sigma-algebra by above lemmas *)
+Theorem trivial_algebra_of_space :
+    !sp. algebra (sp, {{}; sp})
+Proof
+    rw [algebra_def, subset_class_def]
+ >> SET_TAC []
+QED
+
+Theorem trivial_algebra_of_two_sets :
+    !sp s. s SUBSET sp ==> algebra (sp, {{}; s; sp DIFF s; sp})
+Proof
+    rw [algebra_def, subset_class_def]
+ >> ASM_SET_TAC []
+QED
+
+(* NOTE: This is head (h) and tail (t) of one-time coin tossing *)
+Theorem trivial_algebra_of_two_points :
+    !h t. algebra ({h; t}, {{}; {h}; {t}; {h; t}})
+Proof
+    rw [algebra_def, subset_class_def]
+ >> ASM_SET_TAC []
+QED
+
 val _ = export_theory ();
 
 (* References:
 
-  [1] Hurd, J.: Formal verification of probabilistic algorithms. University of Cambridge (2001).
-  [2] Coble, A.R.: Anonymity, information, and machine-assisted proof. University of Cambridge (2010).
-  [3] Mhamdi, T., Hasan, O., Tahar, S.: Formalization of Measure Theory and Lebesgue Integration
-      for Probabilistic Analysis in HOL. ACM Trans. Embedded Comput. Syst. 12, 1--23 (2013).
+  [1] Hurd, J.: Formal verification of probabilistic algorithms. University of
+      Cambridge (2001).
+  [2] Coble, A.R.: Anonymity, information, and machine-assisted proof.
+      University of Cambridge (2010).
+  [3] Mhamdi, T., Hasan, O., Tahar, S.: Formalization of Measure Theory and
+      Lebesgue Integration for Probabilistic Analysis in HOL. ACM Trans.
+      Embedded Comput. Syst. 12, 1--23 (2013).
   [4] Wikipedia: https://en.wikipedia.org/wiki/Ring_of_sets
   [5] Wikipedia: https://en.wikipedia.org/wiki/Eugene_Dynkin
   [6] Wikipedia: https://en.wikipedia.org/wiki/Dynkin_system

--- a/src/real/analysis/integrationScript.sml
+++ b/src/real/analysis/integrationScript.sml
@@ -5826,17 +5826,23 @@ Proof
    ``\d. ((x:real) = (A:(real->bool)->real)(d)):bool``
    lemma) THEN
   REPEAT CONJ_TAC THENL
-   [ALL_TAC,
+  [ (* goal 1 (of 3) *)
+    ALL_TAC,
+    (* goal 2 (of 3) *)
     ONCE_REWRITE_TAC [METIS [] ``{k | k IN d /\ content k <> 0 /\ x IN k} =
                             {k | k IN d /\ (\k. content k <> 0 /\ x IN k) k}``] THEN
     MATCH_MP_TAC FINITE_RESTRICT THEN ASM_MESON_TAC[division_of],
+    (* goal 3 (of 3) *)
     MATCH_MP_TAC LESS_EQ_TRANS THEN EXISTS_TAC ``CARD univ(:bool)`` THEN CONJ_TAC THENL
-     [KNOW_TAC ``(IMAGE (\(d :real -> bool). (x :real) = (A :(real -> bool) -> real) d)
+    [ (* goal 3.1 (of 2) *)
+      KNOW_TAC ``(IMAGE (\(d :real -> bool). (x :real) = (A :(real -> bool) -> real) d)
          {k | k IN (d :(real -> bool) -> bool) /\ content k <> (0 :real) /\
           x IN k}) SUBSET univ(:bool)`` THENL [REWRITE_TAC [SUBSET_UNIV], ALL_TAC] THEN
       MATCH_MP_TAC CARD_SUBSET THEN
       SIMP_TAC std_ss [FINITE_BOOL],
-      SIMP_TAC std_ss [FINITE_BOOL, CARD_CART_UNIV, CARD_BOOL, LESS_EQ_REFL]]] THEN
+      (* goal 3.2 (of 2) *)
+      SIMP_TAC std_ss [FINITE_BOOL, CARD_BOOL, LESS_EQ_REFL] ] ] THEN
+ (* NOTE: below are tactics for goal 1 *)
   MAP_EVERY X_GEN_TAC [``k:real->bool``, ``l:real->bool``] THEN
   SIMP_TAC std_ss [GSPECIFICATION] THEN STRIP_TAC THEN
   UNDISCH_TAC ``d division_of s`` THEN DISCH_TAC THEN

--- a/src/real/analysis/seqScript.sml
+++ b/src/real/analysis/seqScript.sml
@@ -20,6 +20,9 @@ val assert = Lib.assert;              (* conflict with hurdUtils.assert *)
 
 val _ = add_implicit_rewrites pairTheory.pair_rws;
 
+val S_TAC = rpt (POP_ASSUM MP_TAC) >> rpt RESQ_STRIP_TAC;
+val Strip = S_TAC;
+
 (*---------------------------------------------------------------------------*)
 (* Specialize net theorems to sequences:num->real                            *)
 (*---------------------------------------------------------------------------*)

--- a/tools/sequences/core-theories
+++ b/tools/sequences/core-theories
@@ -37,6 +37,7 @@ src/num/termination
 # speed up the last few theories (sets, extra numbers, and lists) before
 # bossLib
 src/num/extra_theories
+src/unwind
 src/pred_set/src
 src/datatype/record
 src/datatype
@@ -44,7 +45,6 @@ src/datatype
 src/monad
 src/list/src
 src/quantHeuristics
-src/unwind
 src/pattern_matches
 !src/pattern_matches/interactive_tests
 src/HolSat/vector_def_CNF


### PR DESCRIPTION
Hi,

The original purpose of this PR is to prove the following theorem for `:word32` (for the needs in one of my student's project, where a theorem says DES has 2^32 fixed points, each corresponding to one 32-bit word):
```
   [card_word32]  Theorem (wordsTheory)
      ⊢ CARD 𝕌(:word32) = 2 ** 32
```
For each word of predefined sizes, there's one theorem like the above, now exported in `wordsTheory`, together with the general version:
```
  [CARD_WORD]  Theorem (wordsTheory)      
      ⊢ FINITE 𝕌(:'N) ⇒ CARD 𝕌(:'N word) = 2 ** dimindex (:'N)
```
And they are proved by more general theorems in `fcpTheory`, ported from HOL-Light (but the proofs are reworked, due to differences between their FCP formalization):
```
   [CARD_CART]  Theorem (fcpTheory)
      ⊢ ∀P. FINITE 𝕌(:'N) ∧ (∀i. i < dimindex (:'N) ⇒ FINITE {x | P i x}) ⇒
            CARD {v | (∀i. i < dimindex (:'N) ⇒ P i (v ' i))} =
            nproduct {0 .. dimindex (:'N) − 1} (λi. CARD {x | P i x})
   
   [CARD_CART_UNIV]  Theorem
      ⊢ FINITE 𝕌(:α) ∧ FINITE 𝕌(:'N) ⇒
        CARD 𝕌(:α['N]) = CARD 𝕌(:α) ** dimindex (:'N)

   [FINITE_CART_UNIV]  Theorem      
      ⊢ FINITE 𝕌(:α) ∧ FINITE 𝕌(:'N) ⇒ FINITE 𝕌(:α['N])
   
   [HAS_SIZE_CART]  Theorem      
      ⊢ ∀P m.
          FINITE 𝕌(:'N) ∧
          (∀i. i < dimindex (:'N) ⇒ {x | P i x} HAS_SIZE m i) ⇒
          {v | ∀i. i < dimindex (:'N) ⇒ P i (v ' i)} HAS_SIZE
          nproduct {0 .. dimindex (:'N) − 1} m
   
   [HAS_SIZE_CART_UNIV]  Theorem      
      ⊢ ∀m. 𝕌(:α) HAS_SIZE m ∧ FINITE 𝕌(:'N) ⇒
            𝕌(:α['N]) HAS_SIZE m ** dimindex (:'N)
```
(NOTE: Previously there are `CARD_CART_UNIV`, etc. in `cardinalTheory`, with meaningless statements. Now those theorems are removed.)

Note that the above `CARD_CART` theorem uses `nproduct` from `iterateTheory`, which currently depends on `cardinalTheory`.  I don't want `fcpTheory` to depend on `cardinalTheory` (nor I want `cardinalTheory` to depend on `fcpTheory`), so I worked hard and completely changed some dependencies between core theories:

1. Now `iterateTheory` and `permutesTheory` only depends on `pred_setTheory`, and they are moved into `src/pred_set/src` from `src/pred_set/src/more_theories`. As a side effect (now they cannot use `bossLib`), I had to move `SET_TAC` to `pred_setLib` (which seems a good place), and move the build of `unwindLib` slightly upper, and move some set theorems from `cardinalTheory` to `pred_setTheory` (some proofs are reworked). Finally, `hurdUtils` is also moved into `src/pred_set/src`.

2. Previously `hurdUtils` contains a function called `S_TAC` (aka `Strip`) which used `res_quanTools`. I think this was the reason that `hurdUtils` was moved into `src/res_quan` last time. Now I have removed `S_TAC` from `hurdUtils` and for theoreies who still need `Strip/S_TAC`, now I put a copy of the function definition into them. Such cases are not many.  And `hurdUtils` gets further tiny up.

3. Below are some new useful theorems about cardinality of finite product sets, newly ported from HOL-Light (or moved from `cardinalTheory`):
```
   [CARD_PRODUCT]  Theorem (pred_setTheory)      
      ⊢ ∀s t.
          FINITE s ∧ FINITE t ⇒
          CARD {(x,y) | x ∈ s ∧ y ∈ t} = CARD s * CARD t

   [FINITE_PRODUCT]  Theorem      
      ⊢ ∀s t. FINITE s ∧ FINITE t ⇒ FINITE {(x,y) | x ∈ s ∧ y ∈ t}
   
   [FINITE_PRODUCT_DEPENDENT]  Theorem      
      ⊢ ∀f s t.
          FINITE s ∧ (∀x. x ∈ s ⇒ FINITE (t x)) ⇒
          FINITE {f x y | x ∈ s ∧ y ∈ t x}

   [HAS_SIZE_PRODUCT]  Theorem      
      ⊢ ∀s m t n.
          s HAS_SIZE m ∧ t HAS_SIZE n ⇒
          {(x,y) | x ∈ s ∧ y ∈ t} HAS_SIZE m * n
   
   [HAS_SIZE_PRODUCT_DEPENDENT]  Theorem      
      ⊢ ∀s m t n.
          s HAS_SIZE m ∧ (∀x. x ∈ s ⇒ t x HAS_SIZE n) ⇒
          {(x,y) | x ∈ s ∧ y ∈ t x} HAS_SIZE m * n
```

Finally, after moving `permutesTheory` to `HOLDIR/src/pred_set/src`, for the first time, its' OT article are generated, but this process was broken due to some type mismatch of generated proofs:
```
690.3              (HOL4.combin.o f HOL4.combin.I = f))
690.3    vs HOL4.bool.!
690.3         (\f.
690.3            HOL4.bool./\ (HOL4.combin.o HOL4.combin.I f = f)
690.3              (HOL4.combin.o f HOL4.combin.I = f))
690.3  different constant types at path 0 subterms: HOL4.bool.! vs HOL4.bool.!
690.3  different types: ((A -> A) -> bool) -> bool vs ((A -> C) -> bool) -> bool
690.3  different type variables at path 001 subtypes: A vs C
```
This is strange, indicating bugs either in OpenTheory itself or the related code in HOL4. But I found the direct root cause and also a workaround solution, by adding the following local theorems into `permutesTheory`:
```
(* |- !(f :'a -> 'a) (g :'a -> 'a). f o g = (\(x :'a). f (g x)) *)
Theorem o_ALPHA[local] = o_DEF |> INST_TYPE [gamma |-> alpha, beta |-> alpha]

(* |- !(f :'a -> 'b) (g :'b -> 'a). f o g = (\(x :'b). f (g x)) *)
Theorem o_BETA[local] = o_DEF |> INST_TYPE [alpha |-> beta]
                              |> INST_TYPE [gamma |-> alpha]

(* |- !(f :'a -> 'a) (g :'a -> 'a) (h :'a -> 'a). f o g o h = (f o g) o h *)
Theorem o_ASSOC[local] = combinTheory.o_ASSOC
     |> INST_TYPE [gamma |-> alpha, beta |-> alpha, delta |-> alpha]
```
It seems that, when `REWRITE_TAC` was called on `o_THM` which contains type variable `'c`, the proof completes but the generated OT article somehow is wrong.  Using `SIMP_TAC` with the above specialized versions of `o`-theorems without type variable `'c`, can resolve the problem.    Currently I have no ability to debug and fix this issue in OT or OT-related code, but it's easy to revert these theorems and expose the problem again. Let's postpone it to the future...

--Chun
