### PR TITLE
List-based n-dimensional Borel spaces

### DIFF
--- a/examples/probability/stochastic_processScript.sml
+++ b/examples/probability/stochastic_processScript.sml
@@ -1,8 +1,7 @@
 (* ========================================================================= *)
-(* The Theory of (General) Stochastic Processes (ongoing)                    *)
+(* stochastic_processScript.sml: Theory of General Stochastic Processes      *)
 (*                                                                           *)
-(* Author: Chun Tian (binghe) <binghe.lisp@gmail.com> (2021)                 *)
-(* Fondazione Bruno Kessler and University of Trento, Italy                  *)
+(* Author: Chun Tian (binghe) <binghe.lisp@gmail.com> (2021 - 2024)          *)
 (* ========================================================================= *)
 
 open HolKernel Parse boolLib bossLib;
@@ -18,22 +17,53 @@ open util_probTheory sigma_algebraTheory extrealTheory real_borelTheory
 
 val _ = new_theory "stochastic_process";
 
+(* "The theory of probability, as a mathematical discipline, can and should
+    be developed from axioms in exactly the same way as Geometry and Algebra.
+    This means that after we have defined the elements to be studied and their
+    basic relations, and have stated the axioms by which these relations are
+    to be governed, all further exposition must be based exclusively on these
+    axioms, independent of the usual concerte meaning of these elements and
+    their relations."
+
+  -- A. N. Kolmogorov, "Foundations of the Theory of Probability" [1]. *)
+
 val set_ss = std_ss ++ PRED_SET_ss;
 val fcp_ss = std_ss ++ FCP_ss ++ PRED_SET_ss;
 
+val _ = intLib.deprecate_int ();
+val _ = ratLib.deprecate_rat ();
+
 (* ------------------------------------------------------------------------- *)
 (*  General filtration/martingale with poset indexes (Chapter 25 of [9])     *)
-(*  (moved here from martingaleTheory)                                       *)
 (* ------------------------------------------------------------------------- *)
+
+(* Any non-empty set with (=) is a poset *)
+Theorem poset_trivial :
+    !(s :'a set). s <> {} ==> poset(s,$=)
+Proof
+    RW_TAC std_ss [poset_def]
+ >> rw [REWRITE_RULE [IN_APP] MEMBER_NOT_EMPTY]
+QED
+
+(* Any non-empty set of numbers with (<=) is a poset *)
+Theorem poset_num_sets :
+    !(N :num set). N <> {} ==> poset(N,$<=)
+Proof
+    RW_TAC std_ss [poset_def]
+ >| [ (* goal 1 (of 3) *)
+      rw [REWRITE_RULE [IN_APP] MEMBER_NOT_EMPTY],
+      (* goal 2 (of 3) *)
+      rw [GSYM LESS_EQUAL_ANTISYM],
+      (* goal 3 (of 3) *)
+      MATCH_MP_TAC LESS_EQ_TRANS \\
+      Q.EXISTS_TAC ‘y’ >> art [] ]
+QED
 
 Theorem poset_num[simp] :
     poset (univ(:num),$<=)
 Proof
-    RW_TAC std_ss [poset_def]
- >- (Q.EXISTS_TAC ‘0’ >> REWRITE_TAC [GSYM IN_APP, IN_UNIV])
- >- (MATCH_MP_TAC LESS_EQUAL_ANTISYM >> art [])
- >> MATCH_MP_TAC LESS_EQ_TRANS
- >> Q.EXISTS_TAC ‘y’ >> art []
+    MP_TAC (Q.SPEC ‘univ(:num)’ poset_num_sets)
+ >> RW_TAC std_ss [UNIV_NOT_EMPTY]
 QED
 
 Theorem poset_nnreal[simp] :
@@ -47,52 +77,64 @@ Proof
  >> Q.EXISTS_TAC ‘y’ >> art []
 QED
 
-(* below J is an index set, R is a partial order on J *)
-Definition general_filtration_def :
-   general_filtration A a J =
-     (poset J /\ (!n. n IN (carrier J) ==> sub_sigma_algebra (a n) A) /\
+Definition gen_filtration_def :
+    gen_filtration A a J <=>
+      poset J /\ (!n. n IN (carrier J) ==> sub_sigma_algebra (a n) A) /\
       (!i j. i IN (carrier J) /\ j IN (carrier J) /\ (relation J) i j ==>
-             subsets (a i) SUBSET subsets (a j)))
+             subsets (a i) SUBSET subsets (a j))
 End
 
-Theorem filtration_alt_general : (* was: filtration_alt *)
-    !A a. filtration A a = general_filtration A a (univ(:num),$<=)
+Theorem gen_filtration_imp_sigma_algebra :
+    !A a J. gen_filtration A a J ==> sigma_algebra A
 Proof
-    rw [filtration_def, general_filtration_def, poset_num]
+    rw [gen_filtration_def]
+ >> Know ‘?x. x IN carrier J’
+ >- (Cases_on ‘J’ >> fs [IN_APP] \\
+     MATCH_MP_TAC poset_nonempty \\
+     Q.EXISTS_TAC ‘r’ >> art [])
+ >> STRIP_TAC
+ >> Q.PAT_X_ASSUM ‘!n. n IN carrier J ==> P’ (MP_TAC o Q.SPEC ‘x’)
+ >> rw [sub_sigma_algebra_def]
 QED
 
-Definition general_filtered_measure_space_def :
-    general_filtered_measure_space m a J =
-      (measure_space m /\ general_filtration (m_space m,measurable_sets m) a J)
+Theorem filtration_alt_gen : (* was: filtration_alt *)
+    !A a. filtration A a = gen_filtration A a (univ(:num),$<=)
+Proof
+    rw [filtration_def, gen_filtration_def, poset_num]
+QED
+
+Definition gen_filtered_measure_space_def :
+    gen_filtered_measure_space m a J =
+      (measure_space m /\ gen_filtration (m_space m,measurable_sets m) a J)
 End
 
-Theorem filtered_measure_space_alt_general :
+Theorem filtered_measure_space_alt_gen :
     !m a. filtered_measure_space m a <=>
-          general_filtered_measure_space m a (univ(:num),$<=)
+          gen_filtered_measure_space m a (univ(:num),$<=)
 Proof
-    rw [filtered_measure_space_def, general_filtered_measure_space_def,
-        filtration_alt_general, poset_num]
+    rw [filtered_measure_space_def, gen_filtered_measure_space_def,
+        filtration_alt_gen, poset_num]
 QED
 
-Definition general_sigma_finite_filtered_measure_space_def :
-    general_sigma_finite_filtered_measure_space m a J =
-      (general_filtered_measure_space m a J /\
+Definition gen_sigma_finite_filtered_measure_space_def :
+    gen_sigma_finite_filtered_measure_space m a J =
+      (gen_filtered_measure_space m a J /\
        !n. n IN (carrier J) ==> sigma_finite (m_space m,subsets (a n),measure m))
 End
 
-Theorem sigma_finite_filtered_measure_space_alt_general :
+Theorem sigma_finite_filtered_measure_space_alt_gen :
     !m a. sigma_finite_filtered_measure_space m a <=>
-          general_sigma_finite_filtered_measure_space m a (univ(:num),$<=)
+          gen_sigma_finite_filtered_measure_space m a (univ(:num),$<=)
 Proof
     rw [sigma_finite_filtered_measure_space_alt_all, GSYM CONJ_ASSOC,
-        general_sigma_finite_filtered_measure_space_def,
-        GSYM filtered_measure_space_alt_general, filtered_measure_space_def]
+        gen_sigma_finite_filtered_measure_space_def,
+        GSYM filtered_measure_space_alt_gen, filtered_measure_space_def]
 QED
 
-(* ‘general_martingale m a u (univ(:num),$<=) = martingale m a u’ [1, p.301] *)
-Definition general_martingale_def :
-   general_martingale m a u J =
-     (general_sigma_finite_filtered_measure_space m a J /\
+(* ‘gen_martingale m a u (univ(:num),$<=) = martingale m a u’ [1, p.301] *)
+Definition gen_martingale_def :
+   gen_martingale m a u J =
+     (gen_sigma_finite_filtered_measure_space m a J /\
       (!n. n IN (carrier J) ==> integrable m (u n)) /\
       !i j s. i IN (carrier J) /\ j IN (carrier J) /\ (relation J) i j /\
               s IN (subsets (a i)) ==>
@@ -115,23 +157,23 @@ Proof
 QED
 
 Theorem upwards_filtering_nnreal[simp] :
-    upwards_filtering ({x | 0r <= x},$<=)
+    upwards_filtering ({x | 0r <= x},real_lte)
 Proof
     rw [upwards_filtering_def]
  >> Q.EXISTS_TAC ‘max i j’ >> rw [REAL_LE_MAX]
 QED
 
 (* ------------------------------------------------------------------------- *)
-(*  n-dimensional (general and extreal-based) Borel spaces                   *)
+(*  N-dimensional (gen and extreal-based) Borel spaces                       *)
 (* ------------------------------------------------------------------------- *)
 
-(* ‘fcp_rectangle’ is a generalization of ‘fcp_prod’ *)
+(* ‘fcp_rectangle’ is a generalisation of ‘fcp_prod’ *)
 Definition fcp_rectangle_def :
     fcp_rectangle (h :num -> 'a set) (:'N) =
       {(v :'a['N]) | !i. i < dimindex(:'N) ==> v ' i IN h i}
 End
+
 Overload rectangle = “fcp_rectangle”
-Theorem rectangle_def[local] = fcp_rectangle_def
 
 Theorem RECTANGLE_UNIV :
     rectangle (\n. univ(:'a)) (:'N) = univ(:'a['N])
@@ -164,13 +206,17 @@ val _ = set_fixity "of_dimension" (Infix(NONASSOC, 470));
 
 (* cf. Theorem 14.17 [9, p.149] for this alternative way of product algebra.
 
-   This general definition can be used to convert any (1-dimensional) Borel
+   This is the smallest sigma-algebra on n-dimensional `space B` that makes
+   all N-1 projections simultaneously measurable.
+
+   NOTE: ‘(\n v. v ' n) = flip $fcp_index’ (C $fcp_index)
+
+   This gen definition can be used to convert any (1-dimensional) Borel
    sigma-algebra (e.g. ‘borel’ and ‘Borel’) into n-dimensional Borel spaces.
  *)
 Definition sigma_of_dimension_def :
     sigma_of_dimension (B :'a algebra) (:'N) =
-    sigma_functions (rectangle (\n. space B) (:'N))
-                    (\n. B) (\n v. v ' n)
+    sigma_functions (rectangle (\n. space B) (:'N)) (\n. B) (\n v. v ' n)
                     (count (dimindex(:'N)))
 End
 Overload of_dimension = “sigma_of_dimension”
@@ -198,9 +244,9 @@ QED
    This definition is sometimes easier to use, because it requires only the plain
    sigma-generator ‘sigma’ which has many supporting theorems available.
 
-   The proof is a generalization of (the proof of) prod_sigma_alt_sigma_functions.
+   The proof is a genization of (the proof of) prod_sigma_alt_sigma_functions.
 
-   NOTE: in theory, this theorem (and sigma_of_dimension_def) can be further generalized
+   NOTE: In theory, this theorem (and sigma_of_dimension_def) can be generalised
    to support differrent (space B) at each dimensions. So far this is not needed.
  *)
 Theorem sigma_of_dimension_alt :
@@ -380,7 +426,7 @@ Proof
     RW_TAC set_ss []
  >> rename1 ‘!i. i < dimindex (:'N) ==> g i IN subsets B’
  >> Q.EXISTS_TAC ‘\i. (g i) INTER (h i)’
- >> rw [rectangle_def, Once EXTENSION]
+ >> rw [fcp_rectangle_def, Once EXTENSION]
  >> EQ_TAC >> rw []
 QED
 
@@ -404,7 +450,7 @@ Theorem SIGMA_ALGEBRA_BOREL_SPACE =
     REWRITE_RULE [GSYM Borel_space_def]
                  (ISPEC “Borel” sigma_algebra_of_dimension)
 
-(* alternative definition following of_dimension_def *)
+(* alternative definition of ‘borel’ following "of_dimension_def" *)
 Theorem borel_space_alt_sigma_functions :
     borel_space (:'N) =
     sigma_functions univ(:real['N]) (\n. borel) (\n v. v ' n)
@@ -421,7 +467,7 @@ Proof
     rw [SPACE_BOREL, Borel_space_def, sigma_of_dimension_def, RECTANGLE_UNIV]
 QED
 
-(* alternative definition following of_dimension_alt *)
+(* alternative definition of ‘borel’ following "of_dimension_alt" *)
 Theorem borel_space_alt_sigma :
     borel_space (:'N) =
     sigma univ(:real['N])
@@ -440,23 +486,19 @@ Proof
         sigma_of_dimension_alt_sigma_algebra, RECTANGLE_UNIV]
 QED
 
-Theorem rectangle_in_borel_space :
-    !h. (!i. i < dimindex(:'N) ==> h i IN subsets borel) ==>
-        rectangle h (:'N) IN subsets (borel_space(:'N))
-Proof
-    rpt STRIP_TAC
- >> MP_TAC (ISPECL [“borel”, “h :num -> real set”] rectangle_in_sigma_of_dimension)
- >> rw [sigma_algebra_borel, GSYM borel_space_def]
-QED
+(* |- !h. (!i. i < dimindex (:'N) ==> h i IN subsets borel) ==>
+          rectangle h (:'N) IN subsets (borel_space (:'N))
+ *)
+Theorem rectangle_in_borel_space =
+    REWRITE_RULE [sigma_algebra_borel, GSYM borel_space_def]
+                 (ISPEC “borel” rectangle_in_sigma_of_dimension)
 
-Theorem RECTANGLE_IN_BOREL_SPACE :
-    !h. (!i. i < dimindex(:'N) ==> h i IN subsets Borel) ==>
-        rectangle h (:'N) IN subsets (Borel_space(:'N))
-Proof
-    rpt STRIP_TAC
- >> MP_TAC (ISPECL [“Borel”, “h :num -> extreal set”] rectangle_in_sigma_of_dimension)
- >> rw [SIGMA_ALGEBRA_BOREL, GSYM Borel_space_def]
-QED
+(* |- !h. (!i. i < dimindex (:'N) ==> h i IN subsets Borel) ==>
+          rectangle h (:'N) IN subsets (Borel_space (:'N))
+ *)
+Theorem RECTANGLE_IN_BOREL_SPACE =
+    REWRITE_RULE [SIGMA_ALGEBRA_BOREL, GSYM Borel_space_def]
+                 (ISPEC “Borel” rectangle_in_sigma_of_dimension)
 
 (* (M + N)-dimensional prod space is the product sigma-algebra of M- and N-dimensional
     prod spaces. (The key of this proof is prod_sigma_of_generator.)
@@ -605,6 +647,507 @@ Proof
  >> REWRITE_TAC [SIGMA_ALGEBRA_BOREL]
 QED
 
+(* |- !sp A f J.
+        (!i. i IN J ==> sigma_algebra (A i)) /\
+        (!i. f i IN (sp -> space (A i))) ==>
+        !i. i IN J ==> f i IN measurable (sigma sp A f J) (A i)
+ *)
+val lemma =
+    SIGMA_SIMULTANEOUSLY_MEASURABLE |> INST_TYPE [“:'b” |-> “:'temp”]
+                                    |> INST_TYPE [“:'a” |-> “:'a['N]”]
+                                    |> INST_TYPE [“:'index” |-> “:num”]
+                                    |> INST_TYPE [“:'temp” |-> “:'a”];
+
+Theorem fcp_simultaneously_measurable :
+    !B. sigma_algebra B /\
+       (!i. (\v. v ' i) IN (rectangle (\n. space B) (:'N) -> space B)) ==>
+        !i. i < dimindex(:'N) ==> (\v. v ' i) IN measurable (B of_dimension(:'N)) B
+Proof
+    rw [sigma_of_dimension_def, C_DEF]
+ >> irule (SIMP_RULE std_ss [C_DEF]
+                     (Q.SPECL [‘rectangle (\n. space B) (:'N)’, ‘\n. B’,
+                               ‘flip $fcp_index’] lemma))
+ >> rw []
+QED
+
+(* |- !i. i < dimindex (:'N) ==>
+          (\v. v ' i) IN borel_measurable (borel of_dimension (:'N))
+ *)
+Theorem in_borel_measurable_fcp =
+    SIMP_RULE (srw_ss()) [space_borel, sigma_algebra_borel, IN_FUNSET]
+              (ISPEC “borel” fcp_simultaneously_measurable)
+
+(* |- !i. i < dimindex (:'N) ==>
+          (\v. v ' i) IN Borel_measurable (Borel of_dimension (:'N))
+ *)
+Theorem IN_MEASURABLE_BOREL_FCP =
+    SIMP_RULE (srw_ss()) [SPACE_BOREL, SIGMA_ALGEBRA_BOREL, IN_FUNSET]
+              (ISPEC “Borel” fcp_simultaneously_measurable)
+
+(* ------------------------------------------------------------------------- *)
+(*  List-based n-dimensional Borel spaces                                    *)
+(* ------------------------------------------------------------------------- *)
+
+(* NOTE: ‘0 < N’ is a reasonable assumption sometimes *)
+Definition list_rectangle_def :
+    list_rectangle (h :num -> 'a set) N =
+      {v | LENGTH v = N /\ !i. i < N ==> EL i v IN h i}
+End
+Overload rectangle = “list_rectangle”
+
+Theorem list_rectangle_UNIV :
+    list_rectangle (\n. UNIV) N = {v | LENGTH v = N}
+Proof
+    rw [list_rectangle_def, Once EXTENSION]
+QED
+
+Theorem IN_list_rectangle :
+    !v h N. v IN list_rectangle h N <=>
+            LENGTH v = N /\ !i. i < N ==> EL i v IN h i
+Proof
+    rw [list_rectangle_def, Once EXTENSION]
+QED
+
+Theorem PREIMAGE_list_rectangle :
+    !(f :'a -> 'b list) (h :num -> 'b set) N.
+        (!x. LENGTH (f x) = N) ==>
+        PREIMAGE f (list_rectangle h N) =
+        BIGINTER (IMAGE (\n. PREIMAGE (\x. EL n (f x)) (h n)) (count N))
+Proof
+    rw [Once EXTENSION, IN_PREIMAGE, IN_list_rectangle]
+ >> EQ_TAC >> rw [PREIMAGE_def] >- rw []
+ >> Q.PAT_X_ASSUM ‘!P. _ ==> x IN P’
+       (MP_TAC o (Q.SPEC ‘{x | EL i ((f :'a -> 'b list) x) IN h i}’))
+ >> simp []
+ >> DISCH_THEN MATCH_MP_TAC
+ >> Q.EXISTS_TAC ‘i’ >> art []
+QED
+
+Definition sigma_lists_def :
+   sigma_lists B N = sigma_functions (rectangle (\n. space B) N)
+                                     (\n. B) EL (count N)
+End
+
+Theorem sigma_algebra_sigma_lists :
+    !(B :'a algebra) N. sigma_algebra (sigma_lists B N)
+Proof
+    rw [sigma_lists_def, sigma_functions_def, list_rectangle_def]
+ >> MATCH_MP_TAC SIGMA_ALGEBRA_SIGMA
+ >> rw [subset_class_def, SUBSET_DEF, IN_BIGUNION_IMAGE]
+ >> fs [IN_INTER, IN_PREIMAGE]
+QED
+
+Theorem space_sigma_lists :
+    !(B :'a algebra) N. space (sigma_lists B N) = list_rectangle (\n. space B) N
+Proof
+    rw [sigma_lists_def, sigma_functions_def, SPACE_SIGMA]
+QED
+
+(* cf. sigma_of_dimension_alt *)
+Theorem sigma_lists_alt :
+    !(B :'a algebra) N.
+      subset_class (space B) (subsets B) /\ space B IN subsets B /\ 0 < N ==>
+      sigma_lists B N =
+      sigma (list_rectangle (\n. space B) N)
+            {list_rectangle h N | h | !i. i < N ==> h i IN subsets B}
+Proof
+    rw [sigma_lists_def, sigma_functions_def]
+ >> Q.ABBREV_TAC (* this is part of the goal, to be replaced by ‘sts’ *)
+   ‘src = BIGUNION
+            (IMAGE (\n. IMAGE (\s. PREIMAGE (EL n) s INTER rectangle (\n. space B) N)
+                              (subsets B))
+                   (count N))’
+ >> Q.ABBREV_TAC
+   ‘sts = BIGUNION (IMAGE (\n. {rectangle h N | h |
+                                                h n IN subsets B /\
+                                                !i. i < N /\ i <> n ==> h i = space B})
+                          (count N))’
+ >> Know ‘src = sts’
+ >- (rw [Abbr ‘src’, Abbr ‘sts’, Once EXTENSION, PREIMAGE_def] \\
+     EQ_TAC >> rw [] >| (* 2 subgoals *)
+     [ (* goal 1 (of 2) *)
+       fs [IN_IMAGE] >> rename1 ‘b IN subsets B’ \\
+       Q.EXISTS_TAC ‘{rectangle h N | h |
+                      h n IN subsets B /\ !i. i < N /\ i <> n ==> h i = space B}’ \\
+       reverse (rw []) >- (Q.EXISTS_TAC ‘n’ >> art []) \\
+       Q.EXISTS_TAC ‘\i. if i = n then b else space B’ >> rw [] \\
+       rw [list_rectangle_def, Once EXTENSION] \\
+       EQ_TAC >> rw [] >| (* 3 trivial subgoals *)
+       [ (* goal 1.1 (of 3) *)
+         Cases_on ‘i = n’ >> rw [],
+         (* goal 1.2 (of 3) *)
+         POP_ASSUM (MP_TAC o (Q.SPEC ‘n’)) >> rw [],
+         (* goal 1.3 (of 3) *)
+         rename1 ‘EL i x IN space B’ \\
+         Q.PAT_X_ASSUM ‘!i. i < LENGTH x ==> P’ (MP_TAC o (Q.SPEC ‘i’)) \\
+         Cases_on ‘i = n’ >> rw [] \\
+         FULL_SIMP_TAC std_ss [subset_class_def] \\
+         METIS_TAC [SUBSET_DEF] ],
+       (* goal 2 (of 2) *)
+       fs [] \\
+       Q.EXISTS_TAC ‘IMAGE (\s. {v | EL n v IN s} INTER rectangle (\n. space B) N)
+                           (subsets B)’ \\
+       reverse (rw []) >- (Q.EXISTS_TAC ‘n’ >> art []) \\
+       Q.EXISTS_TAC ‘h n’ \\
+       rw [list_rectangle_def, Once EXTENSION] \\
+       EQ_TAC >> rw [] >| (* 2 trivial subgoals *)
+       [ (* goal 2.1 (of 2) *)
+         rename1 ‘EL i x IN space B’ \\
+         Cases_on ‘i = n’
+         >- (Q.PAT_X_ASSUM ‘!i. i < LENGTH x ==> EL i x IN h i’ (MP_TAC o (Q.SPEC ‘n’)) \\
+             rw [] \\
+             FULL_SIMP_TAC std_ss [subset_class_def] \\
+             METIS_TAC [SUBSET_DEF]) \\
+         Q.PAT_X_ASSUM ‘!i. i < LENGTH x /\ i <> n ==> P’ (MP_TAC o (Q.SPEC ‘i’)) \\
+         Q.PAT_X_ASSUM ‘!i. i < LENGTH x ==> EL i x IN h i’ (MP_TAC o (Q.SPEC ‘i’)) \\
+         rw [] >> fs [],
+         (* goal 2.2 (of 2) *)
+         Cases_on ‘i = n’ >> rw [] ] ])
+ >> Rewr'
+ >> Q.UNABBREV_TAC ‘src’ (* not needed any more *)
+ (* stage work *)
+ >> Know ‘sigma_algebra (sigma (rectangle (\n. space B) N) sts)’
+ >- (MATCH_MP_TAC SIGMA_ALGEBRA_SIGMA \\
+     rw [Abbr ‘sts’, subset_class_def, SUBSET_DEF] \\
+     gs [IN_list_rectangle] \\
+     Q.PAT_X_ASSUM ‘x = rectangle h N’ K_TAC \\
+     rename1 ‘!i. i < N ==> EL i x IN h i’ \\
+     Q.X_GEN_TAC ‘i’ >> DISCH_TAC \\
+     Q.PAT_X_ASSUM ‘!i. i < N ==> P’ (MP_TAC o (Q.SPEC ‘i’)) \\
+     RW_TAC std_ss [] \\
+     FULL_SIMP_TAC std_ss [subset_class_def] \\
+     Cases_on ‘i = n’ >- (rw [] >> METIS_TAC [SUBSET_DEF]) \\
+     Q.PAT_X_ASSUM ‘!i. i < N /\ i <> n ==> P’ (MP_TAC o (Q.SPEC ‘i’)) \\
+     RW_TAC std_ss [] >> fs [])
+ >> DISCH_TAC
+ >> ‘sts SUBSET subsets (sigma (rectangle (\n. space B) N) sts)’
+       by PROVE_TAC [SIGMA_SUBSET_SUBSETS]
+ >> Q.ABBREV_TAC ‘prod = {rectangle h N | h | !i. i < N ==> h i IN subsets B}’
+ >> Know ‘prod SUBSET subsets (sigma (rectangle (\n. space B) N) sts)’
+ >- (rw [Abbr ‘prod’, SUBSET_DEF] \\
+     Know ‘rectangle h N =
+           BIGINTER (IMAGE (\n. {v | LENGTH v = N /\ EL n v IN h n /\
+                                     !i. i < N /\ i <> n ==> EL i v IN space B})
+                           (count N))’
+     >- (rw [list_rectangle_def, Once EXTENSION, IN_BIGINTER_IMAGE] \\
+         reverse EQ_TAC >> rw []
+         >- (POP_ASSUM (MP_TAC o Q.SPEC ‘0’) >> rw []) \\ (* 0 < N is used here *)
+         FULL_SIMP_TAC std_ss [subset_class_def] \\
+         METIS_TAC [SUBSET_DEF]) >> Rewr' \\
+  (* applying SIGMA_ALGEBRA_FINITE_INTER *)
+     MATCH_MP_TAC SIGMA_ALGEBRA_FINITE_INTER >> rw [] \\
+     qmatch_abbrev_tac ‘A IN _’ \\
+     Suff ‘A IN sts’ >- PROVE_TAC [SUBSET_DEF] \\
+     Q.PAT_X_ASSUM ‘sigma_algebra _’ K_TAC \\
+     Q.PAT_X_ASSUM ‘sts SUBSET _’    K_TAC \\
+     rw [Abbr ‘A’, Abbr ‘sts’, IN_BIGUNION_IMAGE] \\
+     Q.EXISTS_TAC ‘i’ >> rw [] \\
+     rename1 ‘n < N’ \\
+     Q.EXISTS_TAC ‘\i. if i = n then h n else space B’ >> rw [] \\
+     rw [list_rectangle_def, Once EXTENSION] \\
+     EQ_TAC >> rw [] >| (* 3 trivial subgoals *)
+     [ (* goal 1.1 (of 3) *)
+       Cases_on ‘i = n’ >> rw [],
+       (* goal 1.2 (of 3) *)
+       POP_ASSUM (MP_TAC o (Q.SPEC ‘n’)) >> rw [],
+       (* goal 1.3 (of 3) *)
+       rename1 ‘EL i x IN space B’ \\
+       Q.PAT_X_ASSUM ‘!i. i < N ==> P’ (MP_TAC o (Q.SPEC ‘i’)) \\
+       Cases_on ‘i = n’ >> rw [] ])
+ >> DISCH_TAC
+ >> Suff ‘subsets (sigma (rectangle (\n. space B) N) sts) =
+          subsets (sigma (rectangle (\n. space B) N) prod)’
+ >- METIS_TAC [SPACE, SPACE_SIGMA]
+ >> MATCH_MP_TAC SIGMA_SMALLEST >> art []
+ >> reverse CONJ_TAC >- METIS_TAC [SPACE, SPACE_SIGMA]
+ (* stage work *)
+ >> MP_TAC (ISPECL [“sts :('a list set) set”,
+                    “sigma (rectangle (\n. space B) N) (prod :('a list set) set)”]
+                    SIGMA_SUBSET)
+ >> REWRITE_TAC [SPACE_SIGMA]
+ >> DISCH_THEN MATCH_MP_TAC
+ >> CONJ_TAC
+ >- (MATCH_MP_TAC SIGMA_ALGEBRA_SIGMA \\
+     rw [Abbr ‘prod’, subset_class_def, IN_list_rectangle, SUBSET_DEF]
+     >- (fs [IN_list_rectangle]) \\
+     rename1 ‘EL n x IN space B’ \\
+     fs [IN_list_rectangle] \\
+     FULL_SIMP_TAC std_ss [subset_class_def] \\
+     METIS_TAC [SUBSET_DEF])
+ >> MATCH_MP_TAC SUBSET_TRANS
+ >> Q.EXISTS_TAC ‘prod’
+ >> REWRITE_TAC [SIGMA_SUBSET_SUBSETS]
+ >> Q.PAT_X_ASSUM ‘sigma_algebra _’ K_TAC
+ >> Q.PAT_X_ASSUM ‘sts SUBSET _’    K_TAC
+ >> Q.PAT_X_ASSUM ‘prod SUBSET _’   K_TAC
+ >> rw [Abbr ‘sts’, Abbr ‘prod’, SUBSET_DEF]
+ >> fs [IN_list_rectangle]
+ >> Q.EXISTS_TAC ‘h’ >> rw []
+ >> Cases_on ‘i = n’ >> rw []
+QED
+
+(* cf. sigma_of_dimension_alt_sigma_algebra *)
+Theorem sigma_lists_alt_sigma_algebra :
+    !(B :'a algebra) N. sigma_algebra B /\ 0 < N ==>
+      sigma_lists B N =
+      sigma (rectangle (\n. space B) N)
+            {rectangle h N | h | !i. i < N ==> h i IN subsets B}
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC sigma_lists_alt >> art []
+ >> reverse CONJ_TAC
+ >- (MATCH_MP_TAC SIGMA_ALGEBRA_SPACE >> art [])
+ >> fs [sigma_algebra_def, algebra_def]
+QED
+
+(* cf. rectangle_in_sigma_of_dimension *)
+Theorem list_rectangle_in_sigma_lists :
+    !B h N. sigma_algebra B /\ (!i. i < N ==> h i IN subsets B) /\ 0 < N ==>
+            rectangle h N IN subsets (sigma_lists B N)
+Proof
+    RW_TAC std_ss [sigma_lists_alt_sigma_algebra]
+ >> MATCH_MP_TAC IN_SIGMA >> rw [] (* ‘sigma’ is eliminated here *)
+ >> Q.EXISTS_TAC ‘h’ >> art []
+QED
+
+(* cf. RECTANGLE_INTER_STABLE *)
+Theorem list_rectangle_INTER_STABLE :
+  !(B :'a algebra) N C.
+     C = {rectangle h N | h | !i. i < N ==> h i IN subsets B} /\
+     (!s t. s IN subsets B /\ t IN subsets B ==> s INTER t IN subsets B) ==>
+      !s t. s IN C /\ t IN C ==> s INTER t IN C
+Proof
+    RW_TAC set_ss []
+ >> rename1 ‘!i. i < N ==> g i IN subsets B’
+ >> Q.EXISTS_TAC ‘\i. (g i) INTER (h i)’
+ >> rw [list_rectangle_def, Once EXTENSION]
+ >> EQ_TAC >> rw []
+QED
+
+(* cf. Borel_space (:'N) in stochastic_processTheory. This is the list version. *)
+Definition Borel_lists_def :
+   Borel_lists N = sigma_lists Borel N
+End
+
+(* |- !N. sigma_algebra (Borel_lists N) *)
+Theorem sigma_algebra_Borel_lists =
+    REWRITE_RULE [GSYM Borel_lists_def]
+                 (ISPEC “Borel” sigma_algebra_sigma_lists)
+
+(* |- !N. Borel_lists N = sigma {v | LENGTH v = N} (\n. Borel) EL (count N): *)
+Theorem Borel_lists_alt_sigma_functions =
+        Borel_lists_def
+     |> REWRITE_RULE [sigma_lists_def, SPACE_BOREL, list_rectangle_UNIV]
+
+(* cf. Borel_space_alt_sigma *)
+Theorem Borel_lists_alt_sigma :
+    !N. 0 < N ==>
+        Borel_lists N =
+        sigma {v | LENGTH v = N}
+              {rectangle h N | h | !i. i < N ==> h i IN subsets Borel}
+Proof
+    rw [SPACE_BOREL, SIGMA_ALGEBRA_BOREL, Borel_lists_def,
+        sigma_lists_alt_sigma_algebra, list_rectangle_UNIV]
+QED
+
+(* |- !h N.
+        (!i. i < N ==> h i IN subsets Borel) /\ 0 < N ==>
+        rectangle h N IN subsets (Borel_lists N)
+ *)
+Theorem list_rectangle_IN_Borel_lists =
+    REWRITE_RULE [SIGMA_ALGEBRA_BOREL, GSYM Borel_lists_def]
+                 (ISPEC “Borel” list_rectangle_in_sigma_lists)
+
+(* list (cons) version of ‘CROSS’ *)
+Definition cons_cross_def :
+    cons_cross A B = {CONS a b | a IN A /\ b IN B}
+End
+
+Theorem cons_cross_alt_gen :
+    !A B. cons_cross A B = general_cross CONS A B
+Proof
+    rw [cons_cross_def, general_cross_def]
+QED
+
+(* list (cons) version of ‘prod_sets’ *)
+Definition cons_prod_def :
+    cons_prod a b = {cons_cross s t | s IN a /\ t IN b}
+End
+
+Theorem cons_prod_alt_gen :
+    !a b. cons_prod a b = general_prod CONS a b
+Proof
+    rw [cons_prod_def, general_prod_def, cons_cross_alt_gen]
+QED
+
+(* list (cons) version of ‘prod_sigma’ *)
+Definition cons_sigma_def :
+    cons_sigma (a :'a algebra) (b :'a list algebra) =
+      sigma (cons_cross (space a) (space b)) (cons_prod (subsets a) (subsets b))
+End
+
+Theorem cons_sigma_alt_gen :
+    !a b. cons_sigma a b = general_sigma CONS a b
+Proof
+    rw [cons_sigma_def, cons_cross_alt_gen, cons_prod_alt_gen, general_sigma_def]
+QED
+
+val lemma = general_sigma_of_generator
+         |> INST_TYPE [beta  |-> “:'a list”, gamma |-> “:'a list”]
+         |> Q.SPECL [‘CONS’, ‘HD’, ‘TL’, ‘X’, ‘Y’, ‘E’, ‘G’]
+         |> REWRITE_RULE [pair_operation_CONS,
+                          GSYM cons_cross_alt_gen,
+                          GSYM cons_prod_alt_gen,
+                          GSYM cons_sigma_alt_gen];
+
+(* |- !X E Y G.
+        subset_class X E /\ subset_class Y G /\
+        has_exhausting_sequence (X,E) /\ has_exhausting_sequence (Y,G) ==>
+        cons_sigma (X,E) (Y,G) = cons_sigma (sigma X E) (sigma Y G)
+ *)
+Theorem cons_sigma_of_generator = general_sigma_of_generator
+     |> INST_TYPE [beta  |-> “:'a list”, gamma |-> “:'a list”]
+     |> Q.SPECL [‘CONS’, ‘HD’, ‘TL’, ‘X’, ‘Y’, ‘E’, ‘G’]
+     |> REWRITE_RULE [pair_operation_CONS,
+                      GSYM cons_cross_alt_gen,
+                      GSYM cons_prod_alt_gen,
+                      GSYM cons_sigma_alt_gen]
+     |> Q.GENL [‘X’, ‘E’, ‘Y’, ‘G’]
+
+(* ‘SUC N’-dimensional prod space is the product sigma-algebra of 1- and N-dimensional
+    prod sigmas. (The key of this proof is cons_sigma_of_generator.)
+ *)
+Theorem sigma_lists_decomposition :
+    !(B :'a algebra) N. sigma_algebra B /\ 0 < N ==>
+        sigma_lists B (SUC N) = cons_sigma B (sigma_lists B N)
+Proof
+    rpt GEN_TAC >> STRIP_TAC
+ >> ‘subset_class (space B) (subsets B)’ by (fs [sigma_algebra_def, algebra_def])
+ >> ‘space B IN subsets B ’ by PROVE_TAC [SIGMA_ALGEBRA_SPACE]
+ >> RW_TAC std_ss [sigma_lists_alt]
+ (* preparing for prod_sigma_of_generator *)
+ >> Q.ABBREV_TAC ‘X = rectangle (\n. space B) N’
+ >> Q.ABBREV_TAC ‘E = {rectangle h N | h | !i. i < N ==> h i IN subsets B}’
+ (* applying cons_sigma_of_generator *)
+ >> Know ‘cons_sigma (sigma (space B) (subsets B)) (sigma X E) =
+          cons_sigma (space B,subsets B) (X,E)’
+ >- (ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
+     MATCH_MP_TAC cons_sigma_of_generator >> rw [] >| (* 3 subgoals *)
+     [ (* goal 1 (of 3) *)
+       rw [Abbr ‘X’, Abbr ‘E’, subset_class_def, SUBSET_DEF] \\
+       fs [IN_list_rectangle, subset_class_def] \\
+       rpt STRIP_TAC >> rename1 ‘LENGTH v = N’ \\
+       Q.PAT_X_ASSUM ‘!i. i < N ==> EL i v IN h i’ (MP_TAC o Q.SPEC ‘n’) \\
+       simp [] \\
+       Suff ‘h n SUBSET space B’ >- (REWRITE_TAC [SUBSET_DEF] >> rw []) \\
+       FIRST_X_ASSUM MATCH_MP_TAC >> rw [],
+       (* goal 3 (of 4) *)
+       rw [has_exhausting_sequence_def, IN_FUNSET] \\
+       Q.EXISTS_TAC ‘\i. space B’ >> rw [] \\
+       rw [Once EXTENSION, IN_BIGUNION_IMAGE],
+       (* goal 3 (of 3) *)
+       rw [has_exhausting_sequence_def, IN_FUNSET, Abbr ‘X’, Abbr ‘E’] \\
+       Q.EXISTS_TAC ‘\n. list_rectangle (\i. space B) N’ >> rw []
+       >- (Q.EXISTS_TAC ‘\i. space B’ >> rw []) \\
+       rw [Once EXTENSION, IN_BIGUNION_IMAGE, IN_list_rectangle] ])
+ >> simp [SIGMA_STABLE]
+ >> DISCH_THEN K_TAC
+ (* stage work *)
+ >> rw [Abbr ‘X’, Abbr ‘E’, cons_sigma_def]
+ >> Know ‘cons_cross (space B) (rectangle (\n. space B) N) =
+          rectangle (\n. space B) (SUC N)’
+ >- (rw [Once EXTENSION, cons_cross_def] \\
+     EQ_TAC >> rw [IN_list_rectangle] >| (* 3 subgoals *)
+     [ (* goal 1 (of 3) *)
+       rw [],
+       (* goal 2 (of 3) *)
+       Cases_on ‘n’ >> rw [],
+       (* goal 3 (of 3) *)
+       Cases_on ‘x’ >> fs [] \\
+       CONJ_TAC >- (POP_ASSUM (MP_TAC o Q.SPEC ‘0’) >> rw []) \\
+       rpt STRIP_TAC \\
+       Q.PAT_X_ASSUM ‘!n. n < SUC N ==> P’ (MP_TAC o Q.SPEC ‘SUC n’) \\
+       rw [] ])
+ >> Rewr'
+ >> Suff ‘cons_prod (subsets B)
+            {rectangle h N | h | (!i. i < N ==> h i IN subsets B)} =
+          {rectangle h (SUC N) | h | !i. i < SUC N ==> h i IN subsets B}’
+ >- Rewr
+ >> rw [Once EXTENSION, cons_prod_def]
+ >> EQ_TAC >> rw []
+ >| [ (* goal 1 (of 2) *)
+      rename1 ‘!i. i < N ==> g i IN subsets B’ \\
+      Q.EXISTS_TAC ‘\i. if i = 0 then s else g (i - 1)’ \\
+      reverse CONJ_TAC >- rw [] \\
+      rw [Once EXTENSION, cons_cross_def, IN_list_rectangle] \\
+      EQ_TAC >> rw [] >| (* 3 subgoals *)
+      [ (* goal 1.1 (of 3) *)
+        rw [],
+        (* goal 1.2 (of 3) *)
+        Cases_on ‘i’ >> fs [],
+        (* goal 1.3 (of 3) *)
+        Cases_on ‘x’ >> fs [] \\
+        CONJ_TAC >- (POP_ASSUM (MP_TAC o Q.SPEC ‘0’) >> rw []) \\
+        rpt STRIP_TAC \\
+        Q.PAT_X_ASSUM ‘!i. i < SUC N ==> P’ (MP_TAC o Q.SPEC ‘SUC i’) \\
+        rw [] ],
+      (* goal 2 (of 2) *)
+      qexistsl_tac [‘h 0’, ‘rectangle (\n. h (SUC n)) N’] \\
+      rpt STRIP_TAC >| (* 3 subgoals *)
+      [ (* goal 2.1 (of 3) *)
+        rw [Once EXTENSION, cons_cross_def, IN_list_rectangle] \\
+        EQ_TAC >> rw [] >| (* 3 subgoals *)
+        [ (* goal 2.1.1 (of 3) *)
+          Cases_on ‘x’ >> fs [] \\
+          CONJ_TAC >- (POP_ASSUM (MP_TAC o Q.SPEC ‘0’) >> rw []) \\
+          rpt STRIP_TAC \\
+          Q.PAT_X_ASSUM ‘!i. i < SUC N ==> P’ (MP_TAC o Q.SPEC ‘SUC n’) \\
+          rw [],
+          (* goal 2.1.2 (of 3) *)
+          rw [],
+          (* goal 2.1.2 (of 3) *)
+          Cases_on ‘i’ >> fs [] ],
+        (* goal 2.2 (of 3) *)
+        FIRST_X_ASSUM MATCH_MP_TAC >> rw [],
+        (* goal 2.3 (of 3) *)
+        Q.EXISTS_TAC ‘\n. h (SUC n)’ >> rw [] ] ]
+QED
+
+Theorem Borel_lists_decomposition :
+    !N. 0 < N ==> Borel_lists (SUC N) = cons_sigma Borel (Borel_lists N)
+Proof
+    RW_TAC std_ss [Borel_lists_def]
+ >> MATCH_MP_TAC sigma_lists_decomposition
+ >> rw [SIGMA_ALGEBRA_BOREL]
+QED
+
+(* |- !sp A f J.
+        (!i. i IN J ==> sigma_algebra (A i)) /\
+        (!i. f i IN (sp -> space (A i))) ==>
+        !i. i IN J ==> f i IN measurable (sigma sp A f J) (A i)
+ *)
+val lemma =
+    SIGMA_SIMULTANEOUSLY_MEASURABLE |> INST_TYPE [“:'b” |-> “:'temp”]
+                                    |> INST_TYPE [“:'a” |-> “:'a list”]
+                                    |> INST_TYPE [“:'index” |-> “:num”]
+                                    |> INST_TYPE [“:'temp” |-> “:'a”];
+
+Theorem sigma_lists_simultaneously_measurable :
+    !B N. sigma_algebra B /\
+         (!i. (EL i) IN (rectangle (\n. space B) N -> space B)) ==>
+          !i. i < N ==> (EL i) IN measurable (sigma_lists B N) B
+Proof
+    rw [sigma_lists_def]
+ >> irule (SRULE []
+           (Q.SPECL [‘rectangle (\n. space B) N’, ‘\n. B’, ‘EL’, ‘count N’] lemma))
+ >> rw []
+QED
+
+(* |- !N i. i < N ==> EL i IN Borel_measurable (sigma_lists Borel N) *)
+Theorem IN_MEASURABLE_BOREL_EL =
+        SRULE [SPACE_BOREL, SIGMA_ALGEBRA_BOREL, IN_FUNSET]
+              (ISPEC “Borel” sigma_lists_simultaneously_measurable)
+
 val _ = export_theory ();
 val _ = html_theory "stochastic_process";
 
@@ -617,7 +1160,7 @@ val _ = html_theory "stochastic_process";
       World Scientific Publishing Company (2006).
   [4] Shiryaev, A.N.: Probability-1. Springer-Verlag New York (2016).
   [5] Shiryaev, A.N.: Probability-2. Springer-Verlag New York (2019).
-  [6] Billingsley, P.: Probability and Measure (Third Edition). Wiley-Interscience (1995).
+  [6] Billingsley, P.: Probability and Measure (3rd Edition). Wiley-Interscience (1995).
   [7] Cinlar, E.: Probability and Stochastics. Springer (2011).
   [8] J.L. Doob (1953), Stochastic processes (2nd ed.). John Wiley & Sons, New York.
   [9] Schilling, R.L.: Measures, Integrals and Martingales (Second Edition).

--- a/examples/probability/stochastic_processScript.sml
+++ b/examples/probability/stochastic_processScript.sml
@@ -1143,9 +1143,9 @@ Proof
  >> rw []
 QED
 
-(* |- !N i. i < N ==> EL i IN Borel_measurable (sigma_lists Borel N) *)
+(* |- !N i. i < N ==> EL i IN Borel_measurable (Borel_lists N) *)
 Theorem IN_MEASURABLE_BOREL_EL =
-        SRULE [SPACE_BOREL, SIGMA_ALGEBRA_BOREL, IN_FUNSET]
+        SRULE [SPACE_BOREL, SIGMA_ALGEBRA_BOREL, IN_FUNSET, GSYM Borel_lists_def]
               (ISPEC “Borel” sigma_lists_simultaneously_measurable)
 
 val _ = export_theory ();

--- a/src/probability/martingaleScript.sml
+++ b/src/probability/martingaleScript.sml
@@ -58,12 +58,12 @@ End
 
 (* the set of all filtrations of A *)
 Definition filtration_def :
-   filtration A (a :num -> 'a algebra) =
-     ((!n. sub_sigma_algebra (a n) A) /\
-      (!i j. i <= j ==> subsets (a i) SUBSET subsets (a j)))
+   filtration A (a :num -> 'a algebra) <=>
+      (!n. sub_sigma_algebra (a n) A) /\
+      (!i j. i <= j ==> subsets (a i) SUBSET subsets (a j))
 End
 
-(* usually denoted by (sp,sts,a,m) in textbooks *)
+(* NOTE: This is usually denoted by (sp,sts,a,m) in textbooks *)
 Definition filtered_measure_space_def :
    filtered_measure_space m a =
       (measure_space m /\ filtration (m_space m,measurable_sets m) a)
@@ -1899,7 +1899,7 @@ Proof
 QED
 
 Theorem pair_operation_CONS :
-    pair_operation (\x y. [x; y]) (EL 0) (EL 1)
+    pair_operation CONS HD TL
 Proof
     rw [pair_operation_def]
 QED

--- a/src/probability/sigma_algebraScript.sml
+++ b/src/probability/sigma_algebraScript.sml
@@ -511,6 +511,14 @@ val SIGMA_ALGEBRA_SIGMA = store_thm
    >> RW_TAC std_ss []
    >> PROVE_TAC [SUBSET_DEF]);
 
+Theorem SIGMA_ALGEBRA_SIGMA_UNIV :
+    !sts. sigma_algebra (sigma UNIV sts)
+Proof
+    Q.X_GEN_TAC ‘sts’
+ >> MATCH_MP_TAC SIGMA_ALGEBRA_SIGMA
+ >> rw [subset_class_def]
+QED
+
 (* power set of any space gives the largest possible algebra and sigma-algebra *)
 val POW_ALGEBRA = store_thm
   ("POW_ALGEBRA", ``!sp. algebra (sp, POW sp)``,


### PR DESCRIPTION
Hi,

N-dimensional Borel spaces (LaTeX: $R^\inf$) is the basis of the theory of stochastic process.  In 2021, I ever submitted #969 for N-dimensional Borel spaces based on `fcpTheory`, which based on my work of general product measure spaces (in `martingaleTheory` of core theories).  `fcpTheory` is very elegant, but it depends on fixed type variables `:'N` where the number `CARD univ(:'N)` is used as the dimension. In probability proofs, however, sometimes the number of random variables comes from either a universal quantified variable or just a number calculated locally, and then the Borel spaces of the same dimension gets involved. In such cases, there's no way to use FCP-based formalizations of Borel spaces. Instead, a list-based version would be more natural: in this case a n-dimensional point of (ext)reals is nothing but a list of (ext)reals of length N, which N is the dimension.

This PR adds the list-based version of n-dimensional Borel space with necessary supporting theorems. The code lies in `examples/probability/stochastic_processScript.sml` where I'm working on a general theory of stochastic processes.

First we have the so-called "rectangle" (now list-based) which is a N-dimensional number set where each dimension is limited by a set:
```
[list_rectangle_def] (stochastic_processTheory)
⊢ ∀h N. rectangle h N = {v | LENGTH v = N ∧ ∀i. i < N ⇒ EL i v ∈ h i}
```
Then, the (general, list-based) sigma-algebra (called `sigma_lists`) is defined on top of the list-based rectangle and the `sigma` generator of functions (see `sigma_algebraTheory.sigma_functions_def`):
```
[sigma_lists_def]
⊢ ∀B N.
    sigma_lists B N = sigma (rectangle (λn. space B) N) (λn. B) EL (count N)
```
Then, the extreal-based N-dimensional Borel sets is defined by the above `sigma_lists` and the extreal-based 1-dimensional `Borel` set:
```
[Borel_lists_def]
⊢ ∀N. Borel_lists N = sigma_lists Borel N
```

Note that, zero-dimension `N = 0` is meaningless, thus many theorems here may require that `0 < N`. Below are some basic properties of `Borel_lists`:
- Alternative definition using the most basic `sigma`-generator:
```
[Borel_lists_alt_sigma]
⊢ ∀N. 0 < N ⇒
      Borel_lists N =
      sigma {v | LENGTH v = N}
        {rectangle h N | h | (∀i. i < N ⇒ h i ∈ subsets Borel)}
```
- Construction (or decomposition) of N+1-dimensional Borel sets by "product sigma-algebra" of 1- and N-dimensional Borel sets:
```
[Borel_lists_decomposition]
⊢ ∀N. 0 < N ⇒ Borel_lists (SUC N) = cons_sigma Borel (Borel_lists N)
```
where `cons_sigma` involves a chain of new list-based definitions:
```
[cons_cross_def]
⊢ ∀A B. cons_cross A B = {a::b | a ∈ A ∧ b ∈ B}
[cons_prod_def]
⊢ ∀a b. cons_prod a b = {cons_cross s t | s ∈ a ∧ t ∈ b}
[cons_sigma_def]
⊢ ∀a b.
    cons_sigma a b =
    sigma (cons_cross (space a) (space b)) (cons_prod (subsets a) (subsets b))
```
- The list access function (`EL`) is Borel-measurable:
```
[IN_MEASURABLE_BOREL_EL]
⊢ ∀N i. i < N ⇒ EL i ∈ Borel_measurable (Borel_lists N)
```
(All other intermediate theorems were used to prove the above major theorems.)


---
Chun