### PR TITLE
Infinite-dimensional Borel space

### DIFF
--- a/src/probability/borelScript.sml
+++ b/src/probability/borelScript.sml
@@ -18,7 +18,7 @@ open prim_recTheory arithmeticTheory numLib combinTheory res_quanTheory
      res_quanTools pairTheory pred_setTheory pred_setLib relationTheory;
 
 open realTheory realLib seqTheory transcTheory real_sigmaTheory RealArith
-     real_topologyTheory listTheory;
+     real_topologyTheory listTheory metricTheory;
 
 open util_probTheory extrealTheory sigma_algebraTheory iterateTheory
      real_borelTheory measureTheory hurdUtils;
@@ -2656,6 +2656,27 @@ val BOREL_MEASURABLE_SETS = store_thm
                    BOREL_MEASURABLE_SETS_SING,       (* x = c *)
                    BOREL_MEASURABLE_SETS_NOT_SING]); (* x <> c *)
 
+(* NOTE: This is similar with Borel_eq_le but this generator contains exhausting
+   sequences, which is needed when generating product sigma-algebras.
+ *)
+Theorem Borel_eq_le_ext :
+    Borel = sigma univ(:extreal) (IMAGE (\c. {x | x <= c}) univ(:extreal))
+Proof
+    Suff ‘subsets Borel =
+          subsets (sigma univ(:extreal) (IMAGE (\c. {x | x <= c}) univ(:extreal)))’
+ >- METIS_TAC [SPACE, SPACE_BOREL, SPACE_SIGMA]
+ >> MATCH_MP_TAC SUBSET_ANTISYM
+ >> reverse CONJ_TAC
+ >- (rw [GSYM SPACE_BOREL] \\
+     MATCH_MP_TAC SIGMA_SUBSET \\
+     rw [SPACE_BOREL, SIGMA_ALGEBRA_BOREL] \\
+     rw [SUBSET_DEF] \\
+     rw [BOREL_MEASURABLE_SETS_RC])
+ >> rw [Borel_eq_le]
+ >> MATCH_MP_TAC SIGMA_MONOTONE
+ >> rw [SUBSET_DEF]
+ >> Q.EXISTS_TAC ‘Normal a’ >> rw []
+QED
 
 (* ******************************************* *)
 (*        Borel measurable functions           *)

--- a/src/probability/probabilityScript.sml
+++ b/src/probability/probabilityScript.sml
@@ -16,7 +16,7 @@ open pairTheory combinTheory optionTheory prim_recTheory arithmeticTheory
      pred_setTheory pred_setLib topologyTheory hurdUtils;
 
 open realTheory realLib iterateTheory seqTheory transcTheory real_sigmaTheory
-     real_topologyTheory;
+     real_topologyTheory metricTheory;
 
 open util_probTheory extrealTheory sigma_algebraTheory measureTheory
      real_borelTheory borelTheory lebesgueTheory martingaleTheory;
@@ -1032,6 +1032,42 @@ Proof
   \\ metis_tac[]
 QED
 
+(* NOTE: This is one of the rare theorems having ‘prob_space p’ at the conclusion.
+         It's most common uniform distribution over discrete sample space.
+ *)
+Theorem prob_space_on_finite_set :
+    !p. FINITE (p_space p) /\ p_space p <> {} /\ events p = POW (p_space p) /\
+        (!s. s IN events p ==> prob p s = &CARD s / &CARD (p_space p)) ==>
+        prob_space p
+Proof
+    rw [p_space_def, events_def, prob_def]
+ >> ‘CARD (m_space p) <> 0’ by rw [CARD_EQ_0]
+ >> rw [prob_on_finite_set]
+ >| [ (* goal 1 (of 3) *)
+      rw [positive_def]
+      >- (MATCH_MP_TAC zero_div >> rw [extreal_of_num_def]) \\
+      qabbrev_tac ‘N = CARD (m_space p)’ \\
+     ‘&N = Normal (&N)’ by rw [extreal_of_num_def] >> POP_ORW \\
+      MATCH_MP_TAC le_div \\
+      rw [extreal_lt_eq, extreal_of_num_def],
+      (* goal 2 (of 3) *)
+      rw [prob_def, p_space_def] \\
+     ‘m_space p IN measurable_sets p’ by rw [IN_POW] \\
+      rw [] \\
+      MATCH_MP_TAC div_refl >> rw [extreal_of_num_def],
+      (* goal 3 (of 3) *)
+      rw [additive_def] \\
+      Know ‘CARD (s UNION t) = CARD s + CARD t’
+      >- (MATCH_MP_TAC CARD_UNION_DISJOINT >> art [] \\
+          fs [IN_POW] \\
+          CONJ_TAC \\ (* 2 subgoals, same tactics *)
+          MATCH_MP_TAC FINITE_SUBSET >> Q.EXISTS_TAC ‘m_space p’ >> art []) >> Rewr' \\
+      Know ‘&(CARD s + CARD t) = &CARD s + (&CARD t :extreal)’
+      >- rw [extreal_of_num_def, extreal_add_def] >> Rewr' \\
+      ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
+      MATCH_MP_TAC div_add >> rw [extreal_of_num_def] ]
+QED
+
 (* ************************************************************************* *)
 
 Theorem distribution_distr :
@@ -1039,6 +1075,13 @@ Theorem distribution_distr :
 Proof
     rpt FUN_EQ_TAC >> qx_genl_tac [`p`, `X`, `s`]
  >> RW_TAC std_ss [distribution_def, distr_def, prob_def, p_space_def]
+QED
+
+Theorem distribution_GSPEC :
+    !s. distribution p X s = prob p {x | x IN p_space p /\ X x IN s}
+Proof
+    rw [distribution_def, PREIMAGE_def]
+ >> simp [PROB_GSPEC]
 QED
 
 (* alternative definition of ‘distribution_function’ *)

--- a/src/probability/sigma_algebraScript.sml
+++ b/src/probability/sigma_algebraScript.sml
@@ -3617,6 +3617,120 @@ Proof
       rw [Once EXTENSION, IN_PREIMAGE, IN_BIGUNION_IMAGE] >> METIS_TAC [] ]
 QED
 
+(* A good corollary of PREIMAGE_SIGMA *)
+Theorem IMAGE_SIGMA :
+    !sp sts f. subset_class sp sts /\ BIJ f sp (IMAGE f sp) ==>
+               IMAGE (IMAGE f) (subsets (sigma sp sts)) =
+               subsets (sigma (IMAGE f sp) (IMAGE (IMAGE f) sts))
+Proof
+    rpt STRIP_TAC
+ >> MP_TAC (MATCH_MP BIJ_INV
+                     (ASSUME “BIJ (f :'a -> 'b) (sp :'a -> bool) (IMAGE f sp)”))
+ >> rw []
+ >> qabbrev_tac ‘Z = IMAGE f sp’
+ >> qabbrev_tac ‘H = \s. PREIMAGE g s INTER Z’
+ >> Know ‘IMAGE (IMAGE f) sts = IMAGE H sts’
+ >- (rw [Abbr ‘H’, FUN_EQ_THM, Once EXTENSION, PREIMAGE_def] \\
+     EQ_TAC >> rw [Abbr ‘Z’]
+     >- (rename1 ‘s IN sts’ >> Q.EXISTS_TAC ‘s’ >> rw [] \\
+         EQ_TAC >> rw [] >| (* 3 subgoals *)
+         [ (* goal 1 (of 3) *)
+           rename1 ‘g (f y) IN s’ \\
+           Suff ‘g (f y) = y’ >- rw [] \\
+           FIRST_X_ASSUM MATCH_MP_TAC \\
+           POP_ASSUM MP_TAC \\
+           Suff ‘s SUBSET sp’ >- rw [SUBSET_DEF] \\
+           fs [subset_class_def],
+           (* goal 2 (of 3) *)
+           rename1 ‘y IN s’ >> Q.EXISTS_TAC ‘y’ >> rw [] \\
+           POP_ASSUM MP_TAC \\
+           Suff ‘s SUBSET sp’ >- rw [SUBSET_DEF] \\
+           fs [subset_class_def],
+           (* goal 3 (of 3) *)
+           rename1 ‘y IN sp’ >> Q.EXISTS_TAC ‘y’ >> rw [] \\
+           Suff ‘g (f y) = y’ >- PROVE_TAC [] \\
+           FIRST_X_ASSUM MATCH_MP_TAC \\
+           POP_ASSUM MP_TAC \\
+           Suff ‘s SUBSET sp’ >- rw [SUBSET_DEF] \\
+           fs [subset_class_def] ]) \\
+    rename1 ‘s IN sts’ \\
+    Q.EXISTS_TAC ‘s’ >> rw [] \\
+    EQ_TAC >> rw [] >| (* 3 subgoals *)
+    [ (* goal 1 (of 3) *)
+      rename1 ‘y IN sp’ >> Q.EXISTS_TAC ‘y’ >> rw [] \\
+      Suff ‘g (f y) = y’ >- PROVE_TAC [] \\
+      FIRST_X_ASSUM MATCH_MP_TAC \\
+      POP_ASSUM MP_TAC \\
+      Suff ‘s SUBSET sp’ >- rw [SUBSET_DEF] \\
+      fs [subset_class_def],
+      (* goal 2 (of 3) *)
+      rename1 ‘g (f y) IN s’ \\
+      Suff ‘g (f y) = y’ >- PROVE_TAC [] \\
+      FIRST_X_ASSUM MATCH_MP_TAC \\
+      POP_ASSUM MP_TAC \\
+      Suff ‘s SUBSET sp’ >- rw [SUBSET_DEF] \\
+      fs [subset_class_def],
+      (* goal 3 (of 3) *)
+      rename1 ‘y IN s’ >> Q.EXISTS_TAC ‘y’ >> rw [] \\
+      POP_ASSUM MP_TAC \\
+      Suff ‘s SUBSET sp’ >- rw [SUBSET_DEF] \\
+      fs [subset_class_def] ])
+ >> Rewr'
+ >> qabbrev_tac ‘a = sigma sp sts’
+ >> ‘sigma_algebra a’ by rw [Abbr ‘a’, SIGMA_ALGEBRA_SIGMA]
+ >> Know ‘IMAGE (IMAGE f) (subsets a) = IMAGE H (subsets a)’
+ >- (rw [Abbr ‘H’, Once EXTENSION, PREIMAGE_def] \\
+     EQ_TAC >> rw [Abbr ‘Z’]
+     >- (rename1 ‘s IN subsets a’ \\
+         Q.EXISTS_TAC ‘s’ >> art [] \\
+         rw [Once EXTENSION] \\
+         EQ_TAC >> rw [] >| (* 3 subgoals *)
+         [ (* goal 1 (of 3) *)
+           rename1 ‘g (f y) IN s’ \\
+           Suff ‘g (f y) = y’ >- rw [] \\
+           FIRST_X_ASSUM MATCH_MP_TAC \\
+           POP_ASSUM MP_TAC \\
+           Suff ‘s SUBSET sp’ >- rw [SUBSET_DEF] \\
+          ‘space a = sp’ by rw [Abbr ‘a’, SPACE_SIGMA] \\
+           fs [sigma_algebra_def, algebra_def, subset_class_def],
+           (* goal 2 (of 3) *)
+           rename1 ‘y IN s’ >> Q.EXISTS_TAC ‘y’ >> rw [] \\
+           POP_ASSUM MP_TAC \\
+           Suff ‘s SUBSET sp’ >- rw [SUBSET_DEF] \\
+          ‘space a = sp’ by rw [Abbr ‘a’, SPACE_SIGMA] \\
+           fs [sigma_algebra_def, algebra_def, subset_class_def],
+           (* goal 3 (of 3) *)
+           rename1 ‘y IN sp’ >> Q.EXISTS_TAC ‘y’ >> rw [] \\
+           Suff ‘g (f y) = y’ >- PROVE_TAC [] \\
+           FIRST_X_ASSUM MATCH_MP_TAC >> art [] ]) \\
+     rename1 ‘s IN subsets a’ \\
+     Q.EXISTS_TAC ‘s’ >> art [] \\
+     rw [Once EXTENSION] \\
+     EQ_TAC >> rw []
+     >- (rename1 ‘y IN sp’ >> Q.EXISTS_TAC ‘y’ >> art [] \\
+         Suff ‘g (f y) = y’ >- PROVE_TAC [] \\
+         FIRST_X_ASSUM MATCH_MP_TAC >> art [])
+     >- (rename1 ‘g (f y) IN s’ \\
+         Suff ‘g (f y) = y’ >- rw [] \\
+         FIRST_X_ASSUM MATCH_MP_TAC \\
+         POP_ASSUM MP_TAC \\
+         Suff ‘s SUBSET sp’ >- rw [SUBSET_DEF] \\
+        ‘space a = sp’ by rw [Abbr ‘a’, SPACE_SIGMA] \\
+         fs [sigma_algebra_def, algebra_def, subset_class_def]) \\
+     rename1 ‘y IN s’ >> Q.EXISTS_TAC ‘y’ >> art [] \\
+     POP_ASSUM MP_TAC \\
+     Suff ‘s SUBSET sp’ >- rw [SUBSET_DEF] \\
+    ‘space a = sp’ by rw [Abbr ‘a’, SPACE_SIGMA] \\
+     fs [sigma_algebra_def, algebra_def, subset_class_def])
+ >> Rewr'
+ >> qunabbrevl_tac [‘H’, ‘a’]
+ >> MATCH_MP_TAC PREIMAGE_SIGMA
+ >> rw [Abbr ‘Z’, IN_FUNSET]
+ >> rename1 ‘g (f y) IN sp’
+ >> Suff ‘g (f y) = y’ >- rw []
+ >> FIRST_X_ASSUM MATCH_MP_TAC >> art []
+QED
+
 (* Lemma 2.2.5 of [9, p.177] (moving INTER outside of the sigma generator) *)
 Theorem SIGMA_RESTRICT :
     !sp sts B. subset_class sp sts /\ B SUBSET sp ==>


### PR DESCRIPTION
Hi,

This PR adds the formalisation of infinite-dimensional Borel space (`Borel_inf`) [1, p.178-179], another important part for the general theory of stochastic processes. One of its alternative definitions depends on the list-based n-dimensional Borel spaces (#1288), committed days ago.

Here a "point" of infinite dimensional space is an infinite (countable) sequence of extended reals (`extreal`), represented by a function of type `:num -> extreal`.  A "cylinder" in this space is a set of such points such that the first N dimension forms a rectangle (while other dimensions range over all possible values, i.e. no requirements at all):
```
[cylinder_def] (stochastic_processTheory)
⊢ ∀h N. cylinder h N = {f | ∀n. n < N ⇒ f n ∈ h n}
```
A cylinder can be cut off to first N dimensions, to form a rectangle (see #1288 for its definition). This operation is a function called `cylinder2rect`:
```
[cylinder2rect_def]
⊢ ∀c N. cylinder2rect c N = IMAGE (λf. GENLIST f N) c
```
Furthermore, note that the type of "cylinder" is `:(num -> α) -> bool` (a set of `num -> 'a` functions), but not every term of this type is a valid cylinder. The following predicate `is_cylinder` can be used to test if it's really a cylinder:
```
[is_cylinder_def]
⊢ ∀c N. is_cylinder c N ⇔ c = ∅ ∨ ∀f. GENLIST f N ∈ cylinder2rect c N ⇒ f ∈ c
```

Now there are 3 different ways to define this `Borel_inf`, based the previous defined `Borel_lists` and the above new cylinder concepts:
```
[Borel_inf_def]
⊢ Borel_inf =
  sigma 𝕌(:num -> extreal)
    {cylinder h N | 0 < N ∧ ∀i. i < N ⇒ ∃c. h i = {x | x ≤ c}}

[Borel_inf1_def]
⊢ Borel_inf1 =
  sigma 𝕌(:num -> extreal)
    {cylinder h N | 0 < N ∧ ∀i. i < N ⇒ h i ∈ subsets Borel}

[Borel_inf2_def]
⊢ Borel_inf2 =
  sigma 𝕌(:num -> extreal)
    {c |
     (∃N. 0 < N ∧ is_cylinder c N ∧
          cylinder2rect c N ∈ subsets (Borel_lists N))}
```

It turns out that the above 3 definitions are equivalent: (thus in proofs using them one can choose the more appropriate one to use)
```
[Borel_inf_eq_Borel_inf1]
⊢ Borel_inf = Borel_inf1

[Borel_inf_eq_Borel_inf2]
⊢ Borel_inf = Borel_inf2
```

The most difficult part of this work is the following theorem (with 500 lines of proof) about the alternative definition (list-based) n-dimensional sigma-algebra by sigma-generators:
```
[sigma_lists_alt_generator]
⊢ ∀sp sts N.
    subset_class sp sts ∧ has_exhausting_sequence (sp,sts) ∧ 0 < N ⇒
    sigma_lists (sigma sp sts) N =
    sigma (rectangle (λn. sp) N) {rectangle h N | h | (∀i. i < N ⇒ h i ∈ sts)}
```
which requires a new fundamental theorem about the images of sigma generators:
```
   [IMAGE_SIGMA]  Theorem (sigma_algebraTheory)
      ⊢ ∀sp sts f.
          subset_class sp sts ∧ BIJ f sp (IMAGE f sp) ⇒
          IMAGE (IMAGE f) (subsets (sigma sp sts)) =
          subsets (sigma (IMAGE f sp) (IMAGE (IMAGE f) sts))
```

# Other changes

In `probabilityTheory` I added the following theorem for fast constructing discrete probability spaces of with a household uniform distribution:
```
   [prob_space_on_finite_set]  Theorem (probabilityTheory)      
      ⊢ ∀p. FINITE (p_space p) ∧ p_space p ≠ ∅ ∧
            events p = POW (p_space p) ∧
            (∀s. s ∈ events p ⇒ prob p s = &CARD s / &CARD (p_space p)) ⇒
            prob_space p
```

[1] Shiryaev, A.N.: Probability-1. Springer-Verlag New York, New York, NY (2016).