### PR TITLE
Fix bug in L3 spec of RISC-V (JAL and JALR addr alignment)

### DIFF
--- a/examples/l3-machine-code/riscv/src/riscv.spec
+++ b/examples/l3-machine-code/riscv/src/riscv.spec
@@ -2428,7 +2428,7 @@ define MulDiv > REMUW(rd::reg, rs1::reg, rs2::reg) =
 -----------------------------------
 define Branch > JAL(rd::reg, imm::imm20) =
 { addr = PC + SignExtend(imm) << 1
-; if addr<0>
+; if addr<1>
   then signalAddressException(Fetch_Misaligned, addr)
   else { writeRD(rd, PC + Skip)
        ; branchTo(addr)
@@ -2440,7 +2440,7 @@ define Branch > JAL(rd::reg, imm::imm20) =
 -----------------------------------
 define Branch > JALR(rd::reg, rs1::reg, imm::imm12) =
 { addr = (GPR(rs1) + SignExtend(imm)) && SignExtend('10')
-; if addr<0>
+; if addr<1>
   then signalAddressException(Fetch_Misaligned, addr)
   else { writeRD(rd, PC + Skip)
        ; branchTo(addr)


### PR DESCRIPTION
This PR fixes a bug in the L3 spec of RISC-V.

The previous version of the spec tautologically checks that bit0 is 0 after masking it (for JALR). Both JAL and JALR fail to check that bit1 is 0. It seems to simply be a typo.

This relates mainly to this sentence:
"The JAL and JALR instructions will generate a misaligned instruction fetch exception if the target address is not aligned to a four-byte boundary."
page 16 in https://riscv.org/wp-content/uploads/2017/05/riscv-spec-v2.2.pdf

For both instructions the check should include bit0 and bit1, but bit0 is always zero in both cases. So the check only needs to be for bit1.