### PR TITLE
Add definition of r-partite graphs and in particular bipartite graphs

### DIFF
--- a/examples/generic_graphs/fsgraphScript.sml
+++ b/examples/generic_graphs/fsgraphScript.sml
@@ -1,3 +1,7 @@
+(*---------------------------------------------------------------------------*
+ * fsgraphTheory: Theory of Finite Simple Graphs                             *
+ *---------------------------------------------------------------------------*)
+
 open HolKernel Parse boolLib bossLib;
 
 open arithmeticTheory pairTheory listTheory pred_setTheory sortingTheory
@@ -717,4 +721,114 @@ Proof
   irule adjacent_append2 >> simp[]
 QED
 
+(* ----------------------------------------------------------------------
+    r-partite graphs and (in particular) bipartite graphs [2, p.17]
+   ---------------------------------------------------------------------- *)
+
+Overload V[local] = “nodes (g :fsgraph)”
+Overload E[local] = “fsgedges (g :fsgraph)”
+
+Theorem fsgraph_valid :
+    !g n1 n2. {n1;n2} IN E ==> n1 IN V /\ n2 IN V /\ n1 <> n2
+Proof
+    rpt GEN_TAC
+ >> DISCH_THEN (STRIP_ASSUME_TAC o MATCH_MP alledges_valid)
+ >> ASM_SET_TAC []
+QED
+
+(* r-partite graphs [2, p.17]
+
+   NOTE: ‘partitions’ requires that each partiton must be non-empty. This is not
+   explicitly mentioned in the textbook but seems reasonable.
+ *)
+Definition partite_def :
+    partite r (g :fsgraph) v <=>
+      v partitions (nodes g) /\ CARD v = r /\
+      !n1 n2. {n1;n2} IN fsgedges g ==> part v n1 <> part v n2
+End
+
+(* "Instead of '2-partite' one usually says bipartite." *)
+Overload bipartite = “partite 2”
+
+Theorem bipartite_def :
+    !g A B. bipartite (g :fsgraph) {A;B} <=>
+           (DISJOINT A B /\ A <> {} /\ B <> {} /\ A UNION B = nodes g /\ 
+            !n1 n2. {n1;n2} IN fsgedges g ==>
+                    (n1 IN A /\ n2 IN B) \/ (n1 IN B /\ n2 IN A))
+Proof
+    rw [partite_def]
+ >> EQ_TAC >> simp []
+ >- (STRIP_TAC \\
+     CONJ_ASM1_TAC (* DISJOINT A B *)
+     >- (MATCH_MP_TAC partitions_DISJOINT \\
+         qexistsl_tac [‘{A;B}’, ‘V’] >> rw []) \\
+     CONJ_TAC (* A <> {} *) >- fs [partitions_PAIR_DISJOINT] \\
+     CONJ_TAC (* B <> {} *) >- fs [partitions_PAIR_DISJOINT] \\
+     CONJ_ASM1_TAC (* A UNION B = V *)
+     >- (Q.PAT_X_ASSUM ‘{A;B} partitions V’ (MP_TAC o MATCH_MP partitions_covers) \\
+         SET_TAC []) \\
+     rpt STRIP_TAC \\
+    ‘n1 IN V /\ n2 IN V /\ n1 <> n2’ by PROVE_TAC [fsgraph_valid] \\
+     Q.PAT_X_ASSUM ‘!n1 n2. P’ (MP_TAC o Q.SPECL [‘n1’, ‘n2’]) >> rw [] \\
+     Cases_on ‘n1 IN A’
+     >- (DISJ1_TAC >> rw [] (* goal: n2 IN B *) \\
+         Know ‘A = part {A; B} n1’
+         >- (MATCH_MP_TAC part_unique \\
+             Q.EXISTS_TAC ‘V’ >> rw []) \\
+         DISCH_THEN (fs o wrap o SYM) \\
+         Cases_on ‘n2 IN A’
+         >- (Know ‘A = part {A; B} n2’
+             >- (MATCH_MP_TAC part_unique \\
+                 Q.EXISTS_TAC ‘V’ >> rw []) \\
+             DISCH_THEN (fs o wrap o SYM)) \\
+         ASM_SET_TAC []) \\
+     simp [] \\
+     CONJ_ASM1_TAC >- ASM_SET_TAC [] \\
+     Know ‘B = part {A; B} n1’
+     >- (MATCH_MP_TAC part_unique \\
+         Q.EXISTS_TAC ‘V’ >> rw []) \\
+     DISCH_THEN (fs o wrap o SYM) \\
+     Cases_on ‘n2 IN B’
+     >- (Know ‘B = part {A; B} n2’
+         >- (MATCH_MP_TAC part_unique \\
+             Q.EXISTS_TAC ‘V’ >> rw []) \\
+         DISCH_THEN (fs o wrap o SYM)) \\ 
+     ASM_SET_TAC [])
+ >> STRIP_TAC
+ >> CONJ_ASM1_TAC (* {A; B} partitions V *)
+ >- (rw [partitions_PAIR_DISJOINT] >- art [] \\
+     rw [Once DISJOINT_SYM])
+ >> rpt STRIP_TAC
+ >> ‘n1 IN V /\ n2 IN V /\ n1 <> n2’ by PROVE_TAC [fsgraph_valid]
+ >> Q.PAT_X_ASSUM ‘!n1 n2. P’ (MP_TAC o Q.SPECL [‘n1’, ‘n2’]) >> rw []
+ >| [ (* goal 1 (of 2) *)
+      CCONTR_TAC >> fs [] \\
+      Know ‘A = part {A; B} n1’
+      >- (MATCH_MP_TAC part_unique \\
+          Q.EXISTS_TAC ‘V’ >> rw []) \\
+      DISCH_THEN (fs o wrap o SYM) \\
+      Know ‘B = part {A; B} n2’
+      >- (MATCH_MP_TAC part_unique \\
+          Q.EXISTS_TAC ‘V’ >> rw []) \\
+      DISCH_THEN (fs o wrap o SYM),
+      (* goal 2 (of 2) *)
+      CCONTR_TAC >> fs [] \\
+      Know ‘B = part {A; B} n1’
+      >- (MATCH_MP_TAC part_unique \\
+          Q.EXISTS_TAC ‘V’ >> rw []) \\
+      DISCH_THEN (fs o wrap o SYM) \\
+      Know ‘A = part {A; B} n2’
+      >- (MATCH_MP_TAC part_unique \\
+          Q.EXISTS_TAC ‘V’ >> rw []) \\
+      DISCH_THEN (fs o wrap o SYM) ]
+QED
+
 val _ = export_theory();
+val _ = html_theory "fsgraph";
+
+(* References:
+
+   [1] Harris, J., Hirst, J.L., Mossinghoff, M.: Combinatorics and Graph Theory.
+       2nd Edition. Springer Science & Business Media (2008).
+   [2] Diestel, R.: Graph Theory, 5th Electronic Edition. Springer-Verlag, Berlin (2017).
+ *)

--- a/examples/generic_graphs/fsgraphScript.sml
+++ b/examples/generic_graphs/fsgraphScript.sml
@@ -752,7 +752,7 @@ Overload bipartite = “partite 2”
 
 Theorem bipartite_def :
     !g A B. bipartite (g :fsgraph) {A;B} <=>
-           (DISJOINT A B /\ A <> {} /\ B <> {} /\ A UNION B = nodes g /\ 
+           (DISJOINT A B /\ A <> {} /\ B <> {} /\ A UNION B = nodes g /\
             !n1 n2. {n1;n2} IN fsgedges g ==>
                     (n1 IN A /\ n2 IN B) \/ (n1 IN B /\ n2 IN A))
 Proof
@@ -792,7 +792,7 @@ Proof
      >- (Know ‘B = part {A; B} n2’
          >- (MATCH_MP_TAC part_unique \\
              Q.EXISTS_TAC ‘V’ >> rw []) \\
-         DISCH_THEN (fs o wrap o SYM)) \\ 
+         DISCH_THEN (fs o wrap o SYM)) \\
      ASM_SET_TAC [])
  >> STRIP_TAC
  >> CONJ_ASM1_TAC (* {A; B} partitions V *)


### PR DESCRIPTION
Hi,

This PR adds the definition of r-partite graphs and in particular bipartite graphs, in `fsgraphTheory`.

A graph is called r-partite if its vertex set admits a partition into r classes such that every edge has its ends in different classes (see, e.g., [1, p.17]). Using `partitions` and `part` from `pred_setTheory`, the following definition can be made to precisely capture the textbook definition:
```
[partite_def]
⊢ ∀r g v.
    partite r g v ⇔
    v partitions V ∧ CARD v = r ∧ ∀n1 n2. {n1; n2} ∈ E ⇒ part v n1 ≠ part v n2
```
Then the particularly important concept "bipartite graphs" can be defined as an overload:
```
Overload bipartite = “partite 2”
```
The following theorem can be seen as a direct definition of bipartite graphs, where `A` and `B` are the two partitions:
```
[bipartite_def]
⊢ ∀g A B.
    bipartite g {A; B} ⇔
    DISJOINT A B ∧ A ≠ ∅ ∧ B ≠ ∅ ∧ A ∪ B = V ∧
    ∀n1 n2. {n1; n2} ∈ E ⇒ n1 ∈ A ∧ n2 ∈ B ∨ n1 ∈ B ∧ n2 ∈ A
```

P. S. This small work is mainly for our student projects (on `fsgraphTheory`) where only bipartite graphs are needed so far. The student may just define bipartite graphs directly while my this extra work can be used to replace the direct definition by the above equivalent theorem.

Chun

[1] Diestel, R.: Graph Theory, 5th Electronic Edition (2016). Springer-Verlag, Berlin (2017).