### PR TITLE
Seq vs List Correspondence

### DIFF
--- a/examples/fun-op-sem/imp/impScript.sml
+++ b/examples/fun-op-sem/imp/impScript.sml
@@ -104,54 +104,35 @@ val cval_ind = prove(
 
 Theorem cval_ind[allow_rebind] = cval_ind
 
-
-(* not only does this say larger clocks produce larger clocks...but it also says the resultant state stays the same i.e. monotonicity *)
-(* not sure how I was able to prove this directly yet needed it as a lemma to prove a weaker statement *)
-(* maybe the stronger induction hypothesis given by this is in fact needed *)
-(* probably could have said t' is larger too *)
 Theorem lrg_clk:
     !c s t t' s1 t1. ((t <= t') /\ (cval c s t = SOME (s1, t1))) ==> (?t2.(cval c s t' = SOME (s1, t2)) /\ t1 <= t2)
 Proof
-    recInduct cval_ind >>
-    rw[]
-        >- (qexists `t'` >> fs[cval_def])
-        >- (qexists `t'` >> fs[cval_def])
-        >- (Cases_on `cval c1 s t` >>
-            Cases_on `cval c1 s t'`
-                >- fs[cval_def]
-                >- fs[cval_def]
-                >- (Cases_on `x` >> first_x_assum $ qspecl_then [`t'`, `q`, `r`] assume_tac >> rfs[]) (* rfs works but fs doesn't...not clear why *)
-                >- (Cases_on `x` >>
-                    Cases_on `x'` >>
-                    simp[cval_def] >>
-                    rw[] >> (* this rw automated the instantion I was doing manually...huh???? *)
-                    first_x_assum $ qspec_then `t'` assume_tac >>
-                    gvs[] >> (* this automatically gave me r <= r' which I want *)
-                    first_x_assum $ qspecl_then [`r'`, `s1`, `t1`] assume_tac >>
-                    fs[cval_def] (* automation doing a lot of the tedious steps...might have been able to do more automation earlier *)
-                )
-        )
-        >- (simp[cval_def] >>
-            first_x_assum $ qspecl_then [`t'`, `s1`, `t1`] assume_tac >>
-            rfs[cval_def]
-        )
-        >- (simp[cval_def] >>
-            first_x_assum $ qspecl_then [`t'`, `s1`, `t1`] assume_tac >>
-            rfs[cval_def]
-        )
-        >- (Cases_on `t` >>
-            Cases_on `bval b s`
-                >- fs[Once cval_def] (* need once otherwise it loops *)
-                >- fs[Once cval_def]
-                >- (gvs[] >>
-                    first_x_assum $ qspecl_then [`t'-1`, `s1`, `t1`] assume_tac >>
-                    fs[Once cval_def] >>
-                    Cases_on `cval c s n`
-                        >- fs[Once cval_def]
-                        >- (Cases_on `x` >> gvs[Once cval_def])
-                )
-                >- fs[Once cval_def]
-        )
+  recInduct cval_ind >>
+  rw[]
+    >>~- ([`(If _ _ _)`], (first_x_assum $ qspecl_then [`t'`, `s1`, `t1`] assume_tac >> rfs[cval_def]))
+    >- (qexists `t'` >> fs[cval_def])
+    >- (qexists `t'` >> fs[cval_def])
+    >- (Cases_on `cval c1 s t` >>
+        Cases_on `cval c1 s t'`
+            >- fs[cval_def]
+            >- fs[cval_def]
+            >- (Cases_on `x` >> first_x_assum $ qspecl_then [`t'`, `q`, `r`] assume_tac >> rfs[])
+            >- (Cases_on `x` >>
+                Cases_on `x'` >>
+                first_x_assum $ qspec_then `t'` assume_tac >>
+                rfs[] >>
+                first_x_assum $ qspecl_then [`r'`, `s1`, `t1`] assume_tac >>
+                fs[cval_def]
+            )
+    )
+    >- (Cases_on `t` >>
+        Cases_on `bval b s` >>
+        fs[Once cval_def]
+          >- (first_x_assum $ qspecl_then [`t'-1`, `s1`, `t1`] assume_tac >>
+              Cases_on `cval c s n` >>
+              gvs[Once cval_def]
+          )
+    )
 QED
 
 

--- a/examples/fun-op-sem/imp/impScript.sml
+++ b/examples/fun-op-sem/imp/impScript.sml
@@ -239,4 +239,50 @@ Proof
     )
 QED
 
+
+
+Theorem arb_clock:
+    !c s t s1 t1. cval c s t = SOME (s1, t1) ==> (!t2. t1 <= t2 ==> (?t'. cval c s t' = SOME (s1, t2)))
+Proof
+    recInduct cval_ind >>
+    rw[]
+        >- fs[cval_def]
+        >- fs[cval_def]
+        >- (fs[cval_def] >>
+            Cases_on `cval c1 s t`
+                >- fs[]
+                >- (Cases_on `x` >>
+                    fs[] >>
+                    last_x_assum drule >>
+                    rw[] >>
+                    qspecl_then [`c2`, `q`, `r`, `t'`, `s1`, `t1`, `t2`] assume_tac lrg_clk2 >>
+                    rfs[] >>
+                    last_x_assum drule >>
+                    rw[] >>
+                    qexists `t''` >>
+                    simp[]
+                )
+        )
+        >- rfs[cval_def]
+        >- rfs[cval_def]
+        >- (Cases_on `bval b s` >>
+            Cases_on `t`
+              >- fs[Once cval_def]
+              >- (fs[] >>
+                  qpat_x_assum `cval _ _ _ = _` mp_tac >>
+                  once_rewrite_tac[cval_def] >>
+                  simp[] >>
+                  rw[] >>
+                  last_x_assum $ qspecl_then [`s1`, `t1`] assume_tac >>
+                  rfs[] >>
+                  pop_assum $ qspec_then `t2` assume_tac >>
+                  rfs[] >>
+                  qexists `SUC t'` >>
+                  simp[]
+              )
+              >- fs[Once cval_def]
+              >- fs[Once cval_def]
+        )
+QED
+
 val _ = export_theory();

--- a/examples/fun-op-sem/imp/impScript.sml
+++ b/examples/fun-op-sem/imp/impScript.sml
@@ -108,31 +108,25 @@ Theorem lrg_clk:
     !c s t t' s1 t1. ((t <= t') /\ (cval c s t = SOME (s1, t1))) ==> (?t2.(cval c s t' = SOME (s1, t2)) /\ t1 <= t2)
 Proof
   recInduct cval_ind >>
-  rw[]
-    >>~- ([`(If _ _ _)`], (first_x_assum $ qspecl_then [`t'`, `s1`, `t1`] assume_tac >> rfs[cval_def]))
-    >- (qexists `t'` >> fs[cval_def])
-    >- (qexists `t'` >> fs[cval_def])
-    >- (Cases_on `cval c1 s t` >>
-        Cases_on `cval c1 s t'`
-            >- fs[cval_def]
-            >- fs[cval_def]
-            >- (Cases_on `x` >> first_x_assum $ qspecl_then [`t'`, `q`, `r`] assume_tac >> rfs[])
-            >- (Cases_on `x` >>
-                Cases_on `x'` >>
-                first_x_assum $ qspec_then `t'` assume_tac >>
-                rfs[] >>
-                first_x_assum $ qspecl_then [`r'`, `s1`, `t1`] assume_tac >>
-                fs[cval_def]
-            )
-    )
-    >- (Cases_on `t` >>
-        Cases_on `bval b s` >>
-        fs[Once cval_def]
-          >- (first_x_assum $ qspecl_then [`t'-1`, `s1`, `t1`] assume_tac >>
-              Cases_on `cval c s n` >>
-              gvs[Once cval_def]
-          )
-    )
+  rw[] >>~-
+  ([`(While _ _)`],
+    Cases_on `t` >>
+    Cases_on `bval b s` >>
+    fs[Once cval_def] >>
+    first_x_assum $ qspecl_then [`t'-1`, `s1`, `t1`] assume_tac >>
+    Cases_on `cval c s n` >>
+    gvs[Once cval_def]
+  ) >>~-
+  ([`(If _ _ _)`],
+    first_x_assum $ qspecl_then [`t'`, `s1`, `t1`] assume_tac >>
+    rfs[cval_def]
+  ) >>
+  gvs[cval_def] >>
+  fs[CaseEq"option"] >>
+  Cases_on `v` >>
+  fs[] >>
+  first_x_assum $ qspec_then `t'` assume_tac >>
+  rfs[]
 QED
 
 Theorem cval_mono:

--- a/examples/fun-op-sem/imp/impScript.sml
+++ b/examples/fun-op-sem/imp/impScript.sml
@@ -151,37 +151,36 @@ Theorem lrg_clk2:
   !c s t t' s1 t1 t2. ((t1 <= t2) /\ (cval c s t = SOME (s1, t1)) /\ (cval c s t' = SOME (s1, t2))) ==> t <= t'
 Proof
   recInduct cval_ind >>
-  rw[] >>
-  fs[Once cval_def]
-    >- (fs[CaseEq"option"] >>
-        first_x_assum irule >>
-        last_x_assum $ irule_at Any >>
-        Cases_on `v` >>
-        Cases_on `v'` >>
-        gvs[] >>
-        qexists `t2` >>
-        Cases_on `t <= t'` >>
-        fs[NOT_LESS_EQUAL] >>
-        imp_res_tac LESS_IMP_LESS_OR_EQ >>
-        drule cval_mono >>
-        disch_then $ qspecl_then [`c1`, `s`] assume_tac >>
-        gvs[]
-    )
-    >- rfs[cval_def]
-    >- rfs[cval_def]
-    >- (Cases_on `bval b s` >>
-        Cases_on `t` >>
-        Cases_on `t'` >>
-        fs[Once cval_def] >>
-        last_x_assum $ qspecl_then [`n'`, `s1`, `t1`, `t2`] assume_tac >>
-        rfs[CaseEq"option"] >>
-        rfs[] >>
-        Cases_on `v` >>
-        Cases_on `v'` >>
-        rfs[Once cval_def] >>
-        pop_assum mp_tac >>
-        simp[Once cval_def]
-    )
+  rw[] >>~-
+  ([`(While _ _)`],
+    fs[Once cval_def] >>
+    Cases_on `bval b s` >>
+    Cases_on `t` >>
+    Cases_on `t'` >>
+    fs[Once cval_def] >>
+    last_x_assum $ qspecl_then [`n'`, `s1`, `t1`, `t2`] assume_tac >>
+    rfs[CaseEq"option"] >>
+    rfs[] >>
+    Cases_on `v` >>
+    Cases_on `v'` >>
+    rfs[Once cval_def] >>
+    pop_assum mp_tac >>
+    simp[Once cval_def]
+  ) >>
+  gvs[cval_def] >>
+  fs[CaseEq"option"] >>
+  first_x_assum irule >>
+  last_x_assum $ irule_at Any >>
+  Cases_on `v` >>
+  Cases_on `v'` >>
+  gvs[] >>
+  qexists `t2` >>
+  Cases_on `t <= t'` >>
+  fs[NOT_LESS_EQUAL] >>
+  imp_res_tac LESS_IMP_LESS_OR_EQ >>
+  drule cval_mono >>
+  disch_then $ qspecl_then [`c1`, `s`] assume_tac >>
+  gvs[]
 QED
 
 Theorem arb_resc:

--- a/examples/fun-op-sem/imp/impScript.sml
+++ b/examples/fun-op-sem/imp/impScript.sml
@@ -239,59 +239,6 @@ Proof
     )
 QED
 
-
-
-Theorem arb_clock:
-    !c s t s1 t1. cval c s t = SOME (s1, t1) ==> (!t2. t1 <= t2 ==> (?t'. cval c s t' = SOME (s1, t2)))
-Proof
-    recInduct cval_ind >>
-    rw[]
-        >- fs[cval_def]
-        >- fs[cval_def]
-        >- (fs[cval_def] >>
-            Cases_on `cval c1 s t`
-                >- fs[]
-                >- (Cases_on `x` >>
-                    fs[] >>
-                    last_x_assum drule >>
-                    rw[] >>
-                    qspecl_then [`c2`, `q`, `r`, `t'`, `s1`, `t1`, `t2`] assume_tac lrg_clk2 >>
-                    rfs[] >>
-                    last_x_assum drule >>
-                    rw[] >>
-                    qexists `t''` >>
-                    simp[]
-                )
-        )
-        >- rfs[cval_def]
-        >- rfs[cval_def]
-        >- (Cases_on `bval b s` >>
-            Cases_on `t`
-              >- fs[Once cval_def]
-              >- (fs[] >>
-                  qpat_x_assum `cval _ _ _ = _` mp_tac >>
-                  once_rewrite_tac[cval_def] >>
-                  simp[] >>
-                  rw[] >>
-                  last_x_assum $ qspecl_then [`s1`, `t1`] assume_tac >>
-                  rfs[] >>
-                  pop_assum $ qspec_then `t2` assume_tac >>
-                  rfs[] >>
-                  qexists `SUC t'` >>
-                  simp[]
-              )
-              >- fs[Once cval_def]
-              >- fs[Once cval_def]
-        )
-QED
-
-
-(* don't think I proved the right lemmas...want to say if it is a terminating computation then we can find a high enough initial clock to get any arbitrary clock *)
-(* don't think we need to care about the resultant state here ...unless it is important information for seq case...we'll see *)
-(* actually I think I should use it...it can't be anything else anyway *)
-(* doing suc because don't think can actually get 0 in result and if can...ignoring this case *)
-(* actually can have 0 as a result...the 0 only becomes a problem if we decide to keep looping *)
-(* can find a t' so the program perfectly terminates at 0 before timing out *)
 Theorem arb_resc:
   !c s t s1 t1. cval c s t = SOME (s1, t1) ==> (!k. ?t'. cval c s t' = SOME (s1, k))
 Proof

--- a/examples/fun-op-sem/imp/impScript.sml
+++ b/examples/fun-op-sem/imp/impScript.sml
@@ -170,4 +170,73 @@ Proof
     )
 QED
 
+
+(* actually this proof might be good to do by contradiction *)
+Theorem lrg_clk2:
+  !c s t t' s1 t1 t2. ((t1 <= t2) /\ (cval c s t = SOME (s1, t1)) /\ (cval c s t' = SOME (s1, t2))) ==> t <= t'
+Proof
+  recInduct cval_ind >>
+  rw[]
+    >- fs[cval_def]
+    >- fs[cval_def]
+    >- (pop_assum mp_tac >>
+        pop_assum mp_tac >>
+        simp[cval_def] >>
+        Cases_on `cval c1 s t` >>
+        Cases_on `cval c1 s t'`
+          >- simp[]
+          >- simp[]
+          >- simp[]
+          >- (simp[] >>
+              Cases_on `x` >>
+              Cases_on `x'` >>
+              simp[] >>
+              disch_then assume_tac >>
+              disch_then assume_tac >>
+              first_x_assum irule >>
+              last_x_assum $ irule_at Any >>
+              rw[] >>
+              qexists `t2` >>
+              Cases_on `t <= t'`
+                >- (qspecl_then [`c1`, `s`, `t`, `t'`] mp_tac cval_mono >>
+                    rw[]
+                )
+                >- (fs[NOT_LESS_EQUAL] >>
+                    qspecl_then [`c1`, `s`, `t'`, `t`] mp_tac cval_mono >>
+                    rw[] >>
+                    simp[]
+                )
+          )
+    )
+    >- (pop_assum mp_tac >>
+        pop_assum mp_tac >>
+        simp[cval_def]
+    )
+    >- (pop_assum mp_tac >>
+        pop_assum mp_tac >>
+        simp[cval_def]
+    ) 
+    >- (Cases_on `bval b s` >>
+        Cases_on `t` >>
+        Cases_on `t'`
+          >- simp[]
+          >- simp[]
+          >- fs[Once cval_def]
+          >- (fs[] >>
+              pop_assum mp_tac >>
+              pop_assum mp_tac >>
+              pop_assum mp_tac >>
+              once_rewrite_tac[cval_def] >>
+              simp[] >>
+              rw[] >>
+              last_x_assum $ qspecl_then [`n'`, `s1`, `t1`, `t2`] assume_tac >>
+              rfs[]
+          )
+          >- simp[]
+          >- simp[]
+          >- fs[Once cval_def]
+          >- fs[Once cval_def]
+    )
+QED
+
 val _ = export_theory();

--- a/examples/fun-op-sem/imp/impScript.sml
+++ b/examples/fun-op-sem/imp/impScript.sml
@@ -215,7 +215,7 @@ Proof
     >- (pop_assum mp_tac >>
         pop_assum mp_tac >>
         simp[cval_def]
-    ) 
+    )
     >- (Cases_on `bval b s` >>
         Cases_on `t` >>
         Cases_on `t'`

--- a/examples/fun-op-sem/imp/impScript.sml
+++ b/examples/fun-op-sem/imp/impScript.sml
@@ -194,44 +194,29 @@ Theorem arb_resc:
   !c s t s1 t1. cval c s t = SOME (s1, t1) ==> (!k. ?t'. cval c s t' = SOME (s1, k))
 Proof
   recInduct cval_ind >>
-  rw[]
-    >- (qexists `k` >> fs[cval_def])
-    >- (qexists `k` >> fs[cval_def])
-    >- (fs[cval_def] >>
-        Cases_on `cval c1 s t`
-          >- fs[]
-          >- (fs[] >>
-              Cases_on `x` >>
-              fs[] >>
-              last_x_assum $ qspec_then `k` assume_tac >>
-              fs[] >>
-              last_x_assum $ qspec_then `t'` assume_tac >>
-              fs[] >>
-              qexists `t''` >>
-              simp[]
-          )
-    )
-    >- gvs[cval_def] (* got lazy doing the rewrites myself *)
-    >- gvs[cval_def]
-    >- (Cases_on `bval b s` >>
-        Cases_on `t`
-          >- fs[Once cval_def]
-          >- (fs[] >>
-              qpat_x_assum `cval _ _ _ = _` mp_tac >>
-              once_rewrite_tac[cval_def] >>
-              simp[] >>
-              disch_then assume_tac >>
-              last_x_assum $ qspecl_then [`s1`, `t1`] assume_tac >>
-              rfs[] >>
-              pop_assum $ qspec_then `k` assume_tac >>
-              fs[] >>
-              qexists `SUC t'` >>
-              simp[]
-          )
-          >- fs[Once cval_def]
-          >- fs[Once cval_def]
-    )
+  rw[] >>~-
+  ([`(While _ _)`],
+    Cases_on `bval b s` >>
+    Cases_on `t` >>
+    fs[Once cval_def] >>
+    last_x_assum $ qspecl_then [`s1`, `t1`] assume_tac >>
+    rfs[Once cval_def] >>
+    pop_assum $ qspec_then `k` assume_tac >>
+    fs[] >>
+    qexists `t' + 1` >>
+    simp[]
+  ) >>
+  gvs[cval_def] >>
+  fs[CaseEq"option"] >>
+  Cases_on `v` >>
+  fs[] >>
+  last_x_assum $ qspec_then `k` assume_tac >>
+  fs[] >>
+  last_x_assum $ qspec_then `t'` assume_tac >>
+  fs[] >>
+  qexists `t''` >>
+  qexists `(q, t')` >>
+  simp[]
 QED
-
 
 val _ = export_theory();

--- a/examples/fun-op-sem/imp/impScript.sml
+++ b/examples/fun-op-sem/imp/impScript.sml
@@ -154,4 +154,20 @@ Proof
         )
 QED
 
+
+(* I think this should immediatly follow from the above theorem *)
+(* NOTE this is provable without the above lemma ...though probably reconstructs the lemma in some way*)
+Theorem cval_mono:
+    !c s t t'. ((t <= t') /\ (cval c s t <> NONE)) ==> (OPTION_MAP FST (cval c s t)) = (OPTION_MAP FST (cval c s t'))
+Proof
+  rpt strip_tac >>
+  Cases_on `cval c s t`
+    >- fs[]
+    >- (Cases_on `x` >>
+        (* drule_then lrg_clk assume_tac *) (* type error?? *)
+        qspecl_then [`c`, `s`, `t`, `t'`, `q`, `r`] assume_tac lrg_clk >>
+        rfs[]
+    )
+QED
+
 val _ = export_theory();

--- a/examples/fun-op-sem/imp/impScript.sml
+++ b/examples/fun-op-sem/imp/impScript.sml
@@ -285,4 +285,55 @@ Proof
         )
 QED
 
+
+(* don't think I proved the right lemmas...want to say if it is a terminating computation then we can find a high enough initial clock to get any arbitrary clock *)
+(* don't think we need to care about the resultant state here ...unless it is important information for seq case...we'll see *)
+(* actually I think I should use it...it can't be anything else anyway *)
+(* doing suc because don't think can actually get 0 in result and if can...ignoring this case *)
+(* actually can have 0 as a result...the 0 only becomes a problem if we decide to keep looping *)
+(* can find a t' so the program perfectly terminates at 0 before timing out *)
+Theorem arb_resc:
+  !c s t s1 t1. cval c s t = SOME (s1, t1) ==> (!k. ?t'. cval c s t' = SOME (s1, k))
+Proof
+  recInduct cval_ind >>
+  rw[]
+    >- (qexists `k` >> fs[cval_def])
+    >- (qexists `k` >> fs[cval_def])
+    >- (fs[cval_def] >>
+        Cases_on `cval c1 s t`
+          >- fs[]
+          >- (fs[] >>
+              Cases_on `x` >>
+              fs[] >>
+              last_x_assum $ qspec_then `k` assume_tac >>
+              fs[] >>
+              last_x_assum $ qspec_then `t'` assume_tac >>
+              fs[] >>
+              qexists `t''` >>
+              simp[]
+          )
+    )
+    >- gvs[cval_def] (* got lazy doing the rewrites myself *)
+    >- gvs[cval_def]
+    >- (Cases_on `bval b s` >>
+        Cases_on `t`
+          >- fs[Once cval_def]
+          >- (fs[] >>
+              qpat_x_assum `cval _ _ _ = _` mp_tac >>
+              once_rewrite_tac[cval_def] >>
+              simp[] >>
+              disch_then assume_tac >>
+              last_x_assum $ qspecl_then [`s1`, `t1`] assume_tac >>
+              rfs[] >>
+              pop_assum $ qspec_then `k` assume_tac >>
+              fs[] >>
+              qexists `SUC t'` >>
+              simp[]
+          )
+          >- fs[Once cval_def]
+          >- fs[Once cval_def]
+    )
+QED
+
+
 val _ = export_theory();

--- a/examples/fun-op-sem/imp/impScript.sml
+++ b/examples/fun-op-sem/imp/impScript.sml
@@ -133,12 +133,12 @@ Theorem cval_mono:
     !c s t t'. ((t <= t') /\ (cval c s t <> NONE)) ==> (OPTION_MAP FST (cval c s t)) = (OPTION_MAP FST (cval c s t'))
 Proof
   rpt strip_tac >>
-  Cases_on `cval c s t`
-    >- fs[]
-    >- (Cases_on `x` >>
-        qspecl_then [`c`, `s`, `t`, `t'`, `q`, `r`] assume_tac lrg_clk >>
-        rfs[]
-    )
+  Cases_on `cval c s t` >>
+  gs[] >>
+  Cases_on `x` >>
+  rev_drule_all lrg_clk >>
+  rw[] >>
+  simp[]
 QED
 
 Theorem lrg_clk2:

--- a/examples/fun-op-sem/imp/impScript.sml
+++ b/examples/fun-op-sem/imp/impScript.sml
@@ -153,25 +153,19 @@ Proof
   recInduct cval_ind >>
   rw[] >>
   fs[Once cval_def]
-    >- (Cases_on `cval c1 s t` >>
-        Cases_on `cval c1 s t'` >>
-        fs[]
-          >- (Cases_on `x` >>
-              Cases_on `x'` >>
-              fs[] >>
-              first_x_assum irule >>
-              last_x_assum $ irule_at Any >>
-              qexists `t2` >>
-              Cases_on `t <= t'`
-                >- (qspecl_then [`c1`, `s`, `t`, `t'`] mp_tac cval_mono >>
-                    rw[]
-                )
-                >- (fs[NOT_LESS_EQUAL] >>
-                    qspecl_then [`c1`, `s`, `t'`, `t`] mp_tac cval_mono >>
-                    rw[] >>
-                    simp[]
-                )
-          )
+    >- (fs[CaseEq"option"] >>
+        first_x_assum irule >>
+        last_x_assum $ irule_at Any >>
+        Cases_on `v` >>
+        Cases_on `v'` >>
+        gvs[] >>
+        qexists `t2` >>
+        Cases_on `t <= t'` >>
+        fs[NOT_LESS_EQUAL] >>
+        imp_res_tac LESS_IMP_LESS_OR_EQ >>
+        drule cval_mono >>
+        disch_then $ qspecl_then [`c1`, `s`] assume_tac >>
+        gvs[]
     )
     >- rfs[cval_def]
     >- rfs[cval_def]
@@ -180,7 +174,7 @@ Proof
         Cases_on `t'` >>
         fs[Once cval_def] >>
         last_x_assum $ qspecl_then [`n'`, `s1`, `t1`, `t2`] assume_tac >>
-        rfs[CaseEq"option"] >> (* what does this actually do?? *)
+        rfs[CaseEq"option"] >>
         rfs[] >>
         Cases_on `v` >>
         Cases_on `v'` >>

--- a/examples/fun-op-sem/imp/impScript.sml
+++ b/examples/fun-op-sem/imp/impScript.sml
@@ -135,9 +135,6 @@ Proof
     )
 QED
 
-
-(* I think this should immediatly follow from the above theorem *)
-(* NOTE this is provable without the above lemma ...though probably reconstructs the lemma in some way*)
 Theorem cval_mono:
     !c s t t'. ((t <= t') /\ (cval c s t <> NONE)) ==> (OPTION_MAP FST (cval c s t)) = (OPTION_MAP FST (cval c s t'))
 Proof
@@ -145,38 +142,25 @@ Proof
   Cases_on `cval c s t`
     >- fs[]
     >- (Cases_on `x` >>
-        (* drule_then lrg_clk assume_tac *) (* type error?? *)
         qspecl_then [`c`, `s`, `t`, `t'`, `q`, `r`] assume_tac lrg_clk >>
         rfs[]
     )
 QED
 
-
-(* actually this proof might be good to do by contradiction *)
 Theorem lrg_clk2:
   !c s t t' s1 t1 t2. ((t1 <= t2) /\ (cval c s t = SOME (s1, t1)) /\ (cval c s t' = SOME (s1, t2))) ==> t <= t'
 Proof
   recInduct cval_ind >>
-  rw[]
-    >- fs[cval_def]
-    >- fs[cval_def]
-    >- (pop_assum mp_tac >>
-        pop_assum mp_tac >>
-        simp[cval_def] >>
-        Cases_on `cval c1 s t` >>
-        Cases_on `cval c1 s t'`
-          >- simp[]
-          >- simp[]
-          >- simp[]
-          >- (simp[] >>
-              Cases_on `x` >>
+  rw[] >>
+  fs[Once cval_def]
+    >- (Cases_on `cval c1 s t` >>
+        Cases_on `cval c1 s t'` >>
+        fs[]
+          >- (Cases_on `x` >>
               Cases_on `x'` >>
-              simp[] >>
-              disch_then assume_tac >>
-              disch_then assume_tac >>
+              fs[] >>
               first_x_assum irule >>
               last_x_assum $ irule_at Any >>
-              rw[] >>
               qexists `t2` >>
               Cases_on `t <= t'`
                 >- (qspecl_then [`c1`, `s`, `t`, `t'`] mp_tac cval_mono >>
@@ -189,34 +173,20 @@ Proof
                 )
           )
     )
-    >- (pop_assum mp_tac >>
-        pop_assum mp_tac >>
-        simp[cval_def]
-    )
-    >- (pop_assum mp_tac >>
-        pop_assum mp_tac >>
-        simp[cval_def]
-    )
+    >- rfs[cval_def]
+    >- rfs[cval_def]
     >- (Cases_on `bval b s` >>
         Cases_on `t` >>
-        Cases_on `t'`
-          >- simp[]
-          >- simp[]
-          >- fs[Once cval_def]
-          >- (fs[] >>
-              pop_assum mp_tac >>
-              pop_assum mp_tac >>
-              pop_assum mp_tac >>
-              once_rewrite_tac[cval_def] >>
-              simp[] >>
-              rw[] >>
-              last_x_assum $ qspecl_then [`n'`, `s1`, `t1`, `t2`] assume_tac >>
-              rfs[]
-          )
-          >- simp[]
-          >- simp[]
-          >- fs[Once cval_def]
-          >- fs[Once cval_def]
+        Cases_on `t'` >>
+        fs[Once cval_def] >>
+        last_x_assum $ qspecl_then [`n'`, `s1`, `t1`, `t2`] assume_tac >>
+        rfs[CaseEq"option"] >> (* what does this actually do?? *)
+        rfs[] >>
+        Cases_on `v` >>
+        Cases_on `v'` >>
+        rfs[Once cval_def] >>
+        pop_assum mp_tac >>
+        simp[Once cval_def]
     )
 QED
 

--- a/examples/fun-op-sem/imp2/Holmakefile
+++ b/examples/fun-op-sem/imp2/Holmakefile
@@ -1,0 +1,1 @@
+INCLUDES = $(HOLDIR)/src/string $(HOLDIR)/src/integer ../imp

--- a/examples/fun-op-sem/imp2/imp2Script.sml
+++ b/examples/fun-op-sem/imp2/imp2Script.sml
@@ -81,4 +81,63 @@ Proof
         >- simp[com_lt]
 QED
 
+
+(* Theorem pval_NONE[simp]:
+    pval 0 cs s = NONE
+Proof
+    rw[cval_def]
+QED *)
+
+Theorem cval_mono:
+    (!t1 c s t2. t1 <= t2 /\ cval t1 c s <> NONE ==> cval t1 c s = cval t2 c s) /\
+    (!t1 cs s t2. t1 <= t2 /\ pval t1 cs s <> NONE ==> pval t1 cs s = pval t2 cs s)
+Proof
+    ho_match_mp_tac cval_ind >>
+    rw[] >>
+    Cases_on `t2`
+        >- fs[cval_def]
+        >- fs[cval_def]
+        >- fs[]
+        >- simp[cval_def]
+        >- fs[]
+        >- (simp[cval_def] >>
+            first_x_assum $ qspec_then `SUC n` assume_tac >>
+            gvs[cval_def]
+        )
+        >- fs[]
+        >- (simp[cval_def] >>
+            first_x_assum $ qspec_then `SUC n` assume_tac >>
+            gvs[cval_def]
+        )
+        >- fs[]
+        >- (Cases_on `bval b s` >>
+            fs[]
+                >- (simp[cval_def] >>
+                    first_x_assum $ qspec_then `n` assume_tac >>
+                    gvs[cval_def]
+                )
+                >- simp[cval_def]
+        )
+        >- simp[]
+        >- fs[cval_def]
+        >- fs[]
+        >- simp[cval_def]
+        >- fs[]
+        >- (simp[cval_def] >>
+            first_x_assum $ qspec_then `SUC n` assume_tac >>
+            Cases_on `cval (SUC v26) c s`
+                >- gvs[cval_def] (* got lazy trying to do granularly but seems straight forward *)
+                >- (gvs[] >>
+                    last_x_assum $ qspec_then `SUC n` assume_tac >>
+                    Cases_on `cval (SUC n) c s` (* why do I have to do this to force rewrite *)
+                        >- fs[]
+                        >- (gvs[] >>
+                            Cases_on `pval (SUC v26) cs x`
+                                >- gvs[cval_def]
+                                >- gvs[]
+                        )
+                )
+        )
+QED
+
 val _ = export_theory();

--- a/examples/fun-op-sem/imp2/imp2Script.sml
+++ b/examples/fun-op-sem/imp2/imp2Script.sml
@@ -37,4 +37,25 @@ Termination
     rw[]
 End
 
+Definition imp2imp2_def:
+    (imp2imp2 (SKIP:imp$com) = []) /\
+    (imp2imp2 (Assign v a) = [((Assign v a):com)]) /\
+    (imp2imp2 (Seq c1 c2) = (imp2imp2 c1) ++ (imp2imp2 c2)) /\
+    (imp2imp2 (If b c1 c2) = [(If b (imp2imp2 c1) (imp2imp2 c2))]) /\
+    (imp2imp2 (While b c) = [(While b (imp2imp2 c))])
+End
+
+Definition p2imp_def:
+    (p2imp [] = SKIP) /\
+    (p2imp (x::xs) = Seq (imp2imp x) (p2imp xs)) /\
+    (imp2imp ((Assign v a):com) = ((Assign v a):imp$com)) /\
+    (imp2imp (If b c1s c2s) = (If b (p2imp c1s) (p2imp c2s))) /\
+    (imp2imp (While b cs) = (While b (p2imp cs)))
+Termination
+    WF_REL_TAC `inv_image (measure I) (\r. case r of
+        | INR c => com_size c
+        | INL cs => com1_size cs)`
+End
+(* wow terminationa actually worked...I thought it had to be stricly decreasing but I don't think this is *)
+
 val _ = export_theory();

--- a/examples/fun-op-sem/imp2/imp2Script.sml
+++ b/examples/fun-op-sem/imp2/imp2Script.sml
@@ -166,4 +166,214 @@ Proof
     fs[]
 QED
 
+Theorem equiv_exists:
+    !c s t. ?t'. OPTION_MAP FST (cval c s t) = pval t' (imp2imp2 c) s
+Proof
+    recInduct impTheory.cval_ind >>
+    rw[]
+        >- (simp[impTheory.cval_def] >>
+            simp[imp2imp2_def] >>
+            qexists `SUC k` >>
+            simp[cval_def]
+        )
+        >- (simp[impTheory.cval_def] >>
+            simp[imp2imp2_def] >>
+            qexists `SUC k` >>
+            simp[cval_def]
+        )
+        >- (simp[impTheory.cval_def] >>
+            simp[imp2imp2_def] >>
+            simp[pval_concat] >>
+            Cases_on `cval c1 s t`
+                >- (fs[] >>
+                    qexists `0` >>
+                    simp[cval_def]
+                )
+                >- (Cases_on `x` >>
+                    simp[] >>
+                    Cases_on `cval c2 q r`
+                        >- (fs[] >>
+                            qexists `0` >>
+                            simp[cval_def]
+                        )
+                        >- (Cases_on `x` >>
+                            simp[] >>
+                            gvs[] >>
+                            (* pick a t bigger than both t'' and t' and apply the monotonicity lemma ...do cases on order*)
+                            Cases_on `t' <= t''`
+                                >- (qspecl_then [`t''`, `imp2imp2 c2`, `q`, `SUC t''`] assume_tac (cj 2 cval_mono) >>
+                                    qspecl_then [`t'`, `imp2imp2 c1`, `s`, `SUC t''`] assume_tac (cj 2 cval_mono) >>
+                                    gvs[] >>
+                                    Cases_on `pval t'' (imp2imp2 c2) q` >>
+                                    Cases_on `pval t' (imp2imp2 c1) s` >>
+                                    fs[] >>
+                                    qexists `SUC t''` >>
+                                    qexists `q` >>
+                                    simp[]
+                                )
+                                >- (fs[NOT_LESS_EQUAL] >>
+                                    qspecl_then [`t''`, `imp2imp2 c2`, `q`, `SUC t'`] assume_tac (cj 2 cval_mono) >>
+                                    qspecl_then [`t'`, `imp2imp2 c1`, `s`, `SUC t'`] assume_tac (cj 2 cval_mono) >>
+                                    gvs[] >>
+                                    Cases_on `pval t'' (imp2imp2 c2) q` >>
+                                    Cases_on `pval t' (imp2imp2 c1) s` >>
+                                    fs[] >>
+                                    qexists `SUC t'` >>
+                                    qexists `q` >>
+                                    simp[]
+                                )
+                        )
+                )
+        )
+        >- (simp[impTheory.cval_def] >>
+            simp[imp2imp2_def] >>
+            Cases_on `t'`
+                >- (qexists `0` >> simp[cval_def])
+                >- (qexists `SUC n` >>
+                    simp[cval_def] >>
+                    Cases_on `pval (SUC n) (imp2imp2 c1) s` >>
+                    simp[]
+                )
+        )
+        >- (simp[impTheory.cval_def] >>
+            simp[imp2imp2_def] >>
+            Cases_on `t'`
+                >- (qexists `0` >> simp[cval_def])
+                >- (qexists `SUC n` >>
+                    simp[cval_def] >>
+                    Cases_on `pval (SUC n) (imp2imp2 c2) s` >>
+                    simp[]
+                )
+        )
+        >- (Cases_on `bval b s` >>
+            Cases_on `t`
+                >- (simp[Once impTheory.cval_def] >>
+                    qexists `0` >>
+                    simp[cval_def]
+                )
+                >- (fs[] >>
+                    simp[Once impTheory.cval_def] >>
+                    simp[imp2imp2_def] >>
+                    qexists `SUC t'` >>
+                    simp[cval_def] >>
+                    Cases_on `pval t' (imp2imp2 c ⧺ [While b (imp2imp2 c)]) s` >>
+                    simp[]
+                )
+                >- (simp[Once impTheory.cval_def] >>
+                    qexists `SUC k` >>
+                    simp[imp2imp2_def] >>
+                    simp[cval_def]
+                )
+                >- (simp[Once impTheory.cval_def] >>
+                    qexists `SUC k` >>
+                    simp[imp2imp2_def] >>
+                    simp[cval_def]
+                )
+        )
+QED
+
+Theorem conc_lemma:
+    !s t. OPTION_MAP FST (imp$cval (p2imp (cs ++ ds)) s t) = OPTION_MAP FST (imp$cval (Seq (p2imp cs) (p2imp ds)) s t)
+Proof
+    Induct_on `cs` (* I wonder if it would be better to induct on ds??? *)
+        >- (simp[p2imp_def] >>
+            simp[impTheory.cval_def]
+        )
+        >- (strip_tac >>
+            simp[p2imp_def] >>
+            simp[impTheory.cval_def] >>
+            rpt strip_tac >>
+            Cases_on `cval (imp2imp h) s t`
+                >- simp[]
+                >- (simp[] >>
+                    Cases_on `x` >>
+                    simp[] >>
+                    Cases_on `cval (p2imp cs) q r`
+                        >- (simp[] >>
+                            simp[impTheory.cval_def]
+                        )
+                        >- (simp[] >>
+                            Cases_on `x` >>
+                            simp[] >>
+                            simp[impTheory.cval_def]
+                        )
+                )
+        )
+QED
+
+Theorem equiv_exists2:
+    (!t1 c s. cval t1 c s <> NONE ==> ?t2. cval t1 c s =  OPTION_MAP FST (cval (imp2imp c) s t2)) /\
+    (!t1 cs s. pval t1 cs s <> NONE ==> ?t2. pval t1 cs s = OPTION_MAP FST (cval (p2imp cs) s t2))
+Proof
+    ho_match_mp_tac cval_ind >>
+    rw[]
+        >- fs[cval_def]
+        >- (simp[p2imp_def] >>
+            qexists `SUC v8` >>
+            simp[cval_def, impTheory.cval_def]
+        )
+        >- (simp[cval_def] >>
+            simp[p2imp_def] >>
+            simp[impTheory.cval_def] >>
+            fs[cval_def] >>
+            rfs[]
+        )
+        >- (simp[cval_def] >>
+            simp[p2imp_def] >>
+            simp[impTheory.cval_def] >>
+            fs[cval_def] >>
+            rfs[]
+        )
+        (* try and simplify and apply conc_lemma before doing case split so don't have to repeat so much work *)
+        >- (fs[cval_def] >>
+            last_x_assum mp_tac >>
+            rewrite_tac[conc_lemma] >>
+            simp[p2imp_def] >>
+            simp[Once impTheory.cval_def] >>
+            simp[Once impTheory.cval_def] >>
+            Cases_on `bval b s` >>
+            Cases_on `pval v10 (cs ⧺ [While b cs]) s`
+                >- fs[]
+                >- (rw[] >>
+                    fs[CaseEq"option"] >>
+                    Cases_on `v` >>
+                    fs[] >>
+                    fs[CaseEq"option"] >>
+                    Cases_on `v` >> (* why does v show up again *)
+                    fs[] >>
+                    qexists `SUC t2` >>
+                    qexists `z` >>
+                    simp[] >>
+                    simp[Once impTheory.cval_def] >>
+                    simp[Once impTheory.cval_def] >>
+                    fs[Once impTheory.cval_def]
+                )
+                >- simp[Once impTheory.cval_def] (* not entirely sure why this simp solves the subgoal *)
+                >- simp[Once impTheory.cval_def] (* similarly *)
+        )
+        >- fs[cval_def]
+        >- (simp[p2imp_def] >>
+            qexists `t2` >>
+            simp[impTheory.cval_def] >>
+            simp[cval_def]
+        )
+        >- (simp[cval_def] >>
+            Cases_on `cval (SUC v26) c s`
+                >- gvs[cval_def] (* contradiction in assumptions *)
+                >- (simp[CaseEq"option"] >>
+                    simp[p2imp_def] >>
+                    simp[impTheory.cval_def] >>
+                    fs[cval_def] >>
+                    Cases_on `z` >>
+                    fs[] >>
+                    qspecl_then [`(imp2imp c)`, `s`, `t2'`, `q`, `r`] assume_tac arb_resc >>
+                    rfs[] >>
+                    pop_assum $ qspec_then `t2` assume_tac >>
+                    fs[] >>
+                    qexists `t'` >>
+                    simp[]
+                )
+        )
+QED
+
 val _ = export_theory();

--- a/examples/fun-op-sem/imp2/imp2Script.sml
+++ b/examples/fun-op-sem/imp2/imp2Script.sml
@@ -1,0 +1,40 @@
+
+open HolKernel Parse boolLib bossLib;
+open stringLib integerTheory;
+open listTheory;
+open arithmeticTheory;
+open impTheory;
+val ect = BasicProvers.EVERY_CASE_TAC;
+
+val _ = new_theory "imp2";
+
+
+val _ = temp_type_abbrev("vname",``:string``);
+
+Datatype:
+    com = Assign vname imp$aexp
+        | If imp$bexp (com list) (com list)
+        | While imp$bexp (com list)
+End
+
+val com_size_def = fetch "-" "com_size_def";
+
+Definition cval_def:
+    (cval 0 _ _ = NONE) /\
+    (cval (t:num) (Assign v a) s = SOME ((v =+ aval a s) s)) /\
+    (cval t (If b cs1 cs2) s = pval t (if bval b s then cs1 else cs2) s) /\
+    (cval t (While b cs) s = if bval b s then pval (t-1) (cs ++ [(While b cs)]) s else SOME s) /\
+
+    (pval 0 _ _ = NONE) /\
+    (pval (t:num) [] s = SOME s) /\
+    (pval t (c::cs) s = case cval t c s of
+        | NONE => NONE
+        | SOME s' => pval t cs s')
+Termination
+    WF_REL_TAC `inv_image (measure I LEX measure I) (\r. case r of
+        | INR (t, cs, _) => (t, com1_size cs)
+        | INL (t, c, _) => (t, com_size c))` >>
+    rw[]
+End
+
+val _ = export_theory();

--- a/examples/fun-op-sem/imp2/imp2Script.sml
+++ b/examples/fun-op-sem/imp2/imp2Script.sml
@@ -58,4 +58,27 @@ Termination
 End
 (* wow terminationa actually worked...I thought it had to be stricly decreasing but I don't think this is *)
 
+
+Theorem com_lt:
+    !c h t. MEM c t ==> com_size c < com1_size (h::t)
+Proof
+    rw[] >>
+    simp[com_size_def] >>
+    Induct_on `t` >>
+    rw[] >>
+    simp[com_size_def] >>
+    fs[]
+QED
+
+Theorem com_ineq:
+    !c cs. MEM c cs ==> com_size c <= com1_size cs
+Proof
+    rw[] >>
+    simp[LESS_OR_EQ] >>
+    Cases_on `cs` >>
+    fs[MEM]
+        >- simp[com_size_def]
+        >- simp[com_lt]
+QED
+
 val _ = export_theory();

--- a/examples/fun-op-sem/imp2/imp2Script.sml
+++ b/examples/fun-op-sem/imp2/imp2Script.sml
@@ -140,4 +140,30 @@ Proof
         )
 QED
 
+Theorem pval_concat:
+    ! t l1 l2 s. pval t (l1 ++ l2) s = OPTION_BIND (pval t l1 s) (pval t l2)
+Proof
+    Cases_on `t`
+        >- simp[cval_def]
+        >- (Induct_on `l1`
+            >- simp[cval_def]
+            >- (simp[cval_def] >>
+                rpt strip_tac >>
+                Cases_on `cval (SUC n) h s`
+                    >- simp[]
+                    >- fs[cval_def]
+            )
+        )
+QED
+
+(* is an equality theorem more useful than an inequality theorem??? *)
+Theorem seq_none:
+    cval (Seq c c') s t <> NONE ==> cval c s t <> NONE
+Proof
+    rw[] >>
+    fs[impTheory.cval_def] >>
+    Cases_on `cval c s t` >>
+    fs[]
+QED
+
 val _ = export_theory();


### PR DESCRIPTION
- Current imperative example uses a tree structure for sequential composition
- This PR adds a similar example language that instead uses lists for sequences of statements
- Proofs to show that any (terminating) program in one language can be written as a program in the other

- Please critique
- Proofs are verbose and could be simplified