### PR TITLE
Remove pauses in configure script

### DIFF
--- a/tools-poly/smart-configure.sml
+++ b/tools-poly/smart-configure.sml
@@ -60,8 +60,7 @@ in
   loop 0
 end;
 
-fun determining s =
-    (print (s^" "); delay 1 (fn _ => ()));
+fun determining s = print (s^" ");
 
 (* action starts here *)
 print "\nHOL smart configuration.\n\n";


### PR DESCRIPTION
When determining the properties of dependencies, it would pause for 1 second after each one, making it look like more work than it actually is and also slowing down the tool. I left the 3 second countdown after all settings are confirmed, although 3 seconds is a bit short for a human to respond to the information.