### PR TITLE
Report error locations on unhandled exceptions

### DIFF
--- a/tools-poly/buildheap.ML
+++ b/tools-poly/buildheap.ML
@@ -397,4 +397,8 @@ in
         OS.Process.exit OS.Process.success
       end
 end handle e =>
-           BuildHeap_CLINE.die ("Uncaught exception: "^General.exnMessage e)
+      BuildHeap_CLINE.die ("Uncaught exception" ^
+        (case PolyML.Exception.exceptionLocation e of
+            NONE => ""
+          | SOME {file, startLine, ...} => " at " ^ file ^ ":" ^ FixedInt.toString startLine) ^
+        ": " ^ General.exnMessage e)

--- a/tools-poly/poly/poly-init2.ML
+++ b/tools-poly/poly/poly-init2.ML
@@ -58,7 +58,7 @@ end handle OS.Path.Path => die ("Path exception in quse "^s)
                                    "error in quse " ^ s ^ " : " ^
                                    General.exnMessage e ^ "\n");
                      TextIO.flushOut TextIO.stdErr;
-                     raise e)
+                     PolyML.Exception.reraise e)
 
 fun myuse f =
   let val op ++ = OS.Path.concat
@@ -66,7 +66,7 @@ fun myuse f =
       val pd = !PolyML.Compiler.printDepth
   in
     PolyML.print_depth 0;
-    (quse f handle e => (PolyML.print_depth pd; raise e));
+    (quse f handle e => (PolyML.print_depth pd; PolyML.Exception.reraise e));
     PolyML.print_depth pd
   end handle OS.Path.Path => die ("Path exception in myuse "^f)
 
@@ -130,12 +130,12 @@ and load ps modPath =
        (l ".ui"; l ".uo")
        handle e =>
               (loadedMods := Binaryset.delete (!loadedMods, modName);
-               raise e))
+               PolyML.Exception.reraise e))
   end handle e => (TextIO.output(TextIO.stdErr,
                                  "error in load " ^ modPath ^ " : " ^
                                  General.exnMessage e ^ "\n");
                    TextIO.flushOut TextIO.stdErr;
-                   raise e)
+                   PolyML.Exception.reraise e)
 in
 
   structure Meta = struct


### PR DESCRIPTION
PolyML keeps track of the location of every exception (the position of the `raise` keyword), and this information is very useful for debugging, so let's show that. In VSCode it also enables the ability to click in the terminal to go directly to the error.

A few other locations had to be adjusted to use `reraise` to avoid clobbering the location information.