### PR TITLE
Zero-terminated REPL

### DIFF
--- a/tools-poly/buildheap.ML
+++ b/tools-poly/buildheap.ML
@@ -15,31 +15,31 @@ val _ = use "execompile.ML";
 val SIGOBJ = OS.Path.concat(Systeml.HOLDIR, "sigobj")
 local
   open FunctionalRecordUpdate
-  fun makeUpdateT z = makeUpdate14 z
+  fun makeUpdateT z = makeUpdate15 z
 in
 fun updateT z = let
   fun from all_forced base_state checkerr checkfors debug defaultout exe
-           extra_data forced_objs help multithread output quietp repl =
+           extra_data forced_objs help multithread output quietp repl z_repl =
     {all_forced = all_forced, base_state = base_state,
      checkerr = checkerr, checkfors = checkfors, debug = debug,
      defaultout = defaultout, exe = exe,
      extra_data = extra_data, forced_objs = forced_objs, help = help,
      multithread = multithread,
-     output = output, quietp = quietp, repl = repl}
-  fun from' repl quietp output multithread help forced_objs extra_data exe
+     output = output, quietp = quietp, repl = repl, z_repl = z_repl}
+  fun from' z_repl repl quietp output multithread help forced_objs extra_data exe
             defaultout debug checkfors checkerr base_state all_forced =
     {all_forced = all_forced, base_state = base_state, checkfors = checkfors,
      checkerr = checkerr, debug = debug,
      defaultout = defaultout, exe = exe,
      extra_data = extra_data, forced_objs = forced_objs, help = help,
      multithread = multithread,
-     output = output, quietp = quietp, repl = repl}
+     output = output, quietp = quietp, repl = repl, z_repl = z_repl}
   fun to f {all_forced, base_state, checkerr, checkfors, debug, defaultout, exe,
             extra_data,
-            forced_objs, help, multithread, output, quietp, repl} =
+            forced_objs, help, multithread, output, quietp, repl, z_repl} =
     f all_forced base_state checkerr checkfors debug defaultout exe extra_data
       forced_objs help multithread
-      output quietp repl
+      output quietp repl z_repl
 in
   makeUpdateT (from, from', to)
 end z
@@ -66,7 +66,8 @@ datatype option_record = OR of {
   multithread : int option,
   output : string option,
   quietp : bool,
-  repl : bool
+  repl : bool,
+  z_repl : bool
 }
 
 local
@@ -136,7 +137,9 @@ val cline_opts = [
   {help = "reduce verbosity", long = ["quiet"], short = "q",
    desc = mkBoolT #quietp},
   {help = "start REPL after loading", long = ["repl"], short = "",
-   desc = mkBoolT #repl}
+   desc = mkBoolT #repl},
+  {help = "use zero-terminated REPL style", long = ["zero"], short = "z",
+   desc = mkBoolT #z_repl}
 ]
 val initial_cline = OR {all_forced = false,
                         base_state = !heapname,
@@ -151,7 +154,8 @@ val initial_cline = OR {all_forced = false,
                         multithread = NONE,
                         output = NONE,
                         quietp = false,
-                        repl = false}
+                        repl = false,
+                        z_repl = false}
 end
 
 fun member s [] = false
@@ -291,8 +295,8 @@ fun main() = let
                      errFn = die}
                     (CommandLine.arguments())
   val OR options = List.foldl (fn (f, opts) => f opts) initial_cline cline_upds
-  val {quietp = qp, output, base_state, all_forced, forced_objs, ...} = options
-  val {repl, help, debug, extra_data, defaultout, exe, ...} = options
+  val {quietp = qp, output, base_state, all_forced, forced_objs,
+       repl, z_repl, help, debug, extra_data, defaultout, exe, ...} = options
   val diag = if debug then (fn s => warn ("DIAG: "^s)) else (fn s => ())
   val _ = not help orelse (print usage; OS.Process.exit OS.Process.success)
   val outrepl_error = "Can't simultaneously dump output and start REPL"
@@ -380,6 +384,7 @@ in
                                    exitLoop = fn () => false,
                                    exitOnError = false,
                                    isInteractive = true,
+                                   zeroTerm = z_repl,
                                    nameSpace = PolyML.globalNameSpace} )
         else
           case exe of

--- a/tools-poly/holrepl.ML
+++ b/tools-poly/holrepl.ML
@@ -5,7 +5,8 @@ sig
                  {nameSpace : PolyML.NameSpace.nameSpace,
                   exitLoop : unit -> bool, startExec : unit -> unit,
                   endExec : unit -> unit, exitOnError : bool,
-                  isInteractive : bool} -> unit
+                  isInteractive : bool,
+                  zeroTerm : bool} -> unit
 end;
 
 
@@ -21,8 +22,8 @@ val timing = PolyML.Compiler.timing
 (* code here derived from Poly/ML's implementation of its REPL.  Poly/ML code
    is all under LGPL; see required copy at doc/copyrights/lgpl2.1.txt
 *)
-fun topLevel diag {nameSpace, exitLoop, exitOnError, isInteractive, startExec,
-                   endExec} =
+fun topLevel diag {nameSpace, exitLoop, exitOnError, isInteractive, zeroTerm,
+                   startExec, endExec} =
   let
     (* This is used as the main read-eval-print loop.  It is also invoked
        by running code that has been compiled with the debug option on
@@ -33,8 +34,7 @@ fun topLevel diag {nameSpace, exitLoop, exitOnError, isInteractive, startExec,
     (* Don't use the end_of_stream because it may have been set by typing
        EOT to the command we were running. *)
     val endOfFile    = ref false;
-    val realDataRead = ref false;
-    val lastWasEol   = ref true;
+
     (* It seems like the only way to *really* reset a lexer, in particular, to
        force it back into its INITIAL state, is to create a fresh one. So,
        this is what bind_cgen() does, and this is what is called in the
@@ -47,39 +47,41 @@ fun topLevel diag {nameSpace, exitLoop, exitOnError, isInteractive, startExec,
         in
           cgenref := read
         end
-    val _ = bind_cgen()
 
-    (* Each character typed is fed into the compiler but leading
-       blank lines result in the prompt remaining as firstPrompt until
-       significant characters are typed. *)
-    fun readin cgen () : char option =
-      let
-        val () =
-            if isInteractive andalso !lastWasEol (* Start of line *) then
-              if !realDataRead then
-                printOut (!prompt2)
-              else printOut (!prompt1)
-            else ();
-      in
-        case cgen() of
-            NONE => (endOfFile := true; NONE)
-         |   SOME #"\n" => ( lastWasEol := true; SOME #"\n" )
-         |   SOME ch =>
-             (
-               lastWasEol := false;
-               if ch <> #" " then realDataRead := true else ();
-               SOME ch
-             )
-      end; (* readin *)
+    fun reportTiming compileTime runTime =
+      (* Print the times if required. *)
+      if !timing
+      then printOut(concat["Timing - compile: ", Time.fmt 1 compileTime,
+        " run: ", Time.fmt 1 runTime, "\n"])
+      else ()
 
-    (* Remove all buffered but unread input. *)
-    fun flushInput () =
-      case TextIO.canInput(TextIO.stdIn, 1) of
-          SOME 1 => (TextIO.inputN(TextIO.stdIn, 1); flushInput())
-       |   _ => (* No input waiting or we're at EOF. *) ()
+    fun reportResult NONE = () (* No exceptions raised. *)
+      | reportResult (SOME exn) = (* Report exceptions in running code. *)
+        let
+          open PolyML PolyML.Exception PolyML.Compiler
+          val exLoc =
+            case exceptionLocation exn of
+              NONE => []
+            | SOME loc => [ContextLocation loc]
+        in
+          PolyML.prettyPrint(TextIO.print, !lineLength)
+            (PrettyBlock(0, false, [],
+                        [
+                          PrettyBlock(0, false, exLoc,
+                                      [PrettyString "Exception-"]),
+                          PrettyBreak(1, 3),
+                          prettyRepresentation(exn,
+                                                FixedInt.fromInt
+                                                  (! printDepth)),
+                          PrettyBreak(1, 3),
+                          PrettyString "raised"
+            ]));
+          PolyML.Exception.reraise exn
+        end
 
     val polyCompiler = PolyML.compiler
-    fun readEvalPrint () : unit =
+    fun readEvalPrint1 readin resetAfterCompileFail :
+        {compileTime : Time.time, runTime : Time.time, result : exn option} =
       let
         (* If we have executed a deeply recursive function the stack
            will have extended to be very large. It's better to reduce
@@ -94,88 +96,153 @@ fun topLevel diag {nameSpace, exitLoop, exitOnError, isInteractive, startExec,
           RunCall.run_call1 RuntimeCalls.POLY_SYS_shrink_stack newsize
         val () = shrink_stack 8000 *)
         val _ = diag "At top of readEvalPrint"
-      in
-        realDataRead := false;
-                (* Compile and then run the code. *)
-        let
-          val startCompile = Timer.startCPUTimer()
 
-          (* Compile a top-level declaration/expression. *)
-          val code = let
-            open PolyML.Compiler
-          in
-            polyCompiler (readin cgen , [CPNameSpace nameSpace,
-                                         CPOutStream TextIO.print])
-          end
-              (* Don't print any times if this raises an exception. *)
-              handle exn as Fail s =>
-                        (
-                            printOut(s ^ "\n");
-                            flushInput();
-                            lastWasEol := true;
-                            bind_cgen();
-                            PolyML.Exception.reraise exn
-                        )
+        (* Compile and then run the code. *)
+        val startCompile = Timer.startCPUTimer()
 
-          val endCompile = Timer.checkCPUTimer startCompile
-
-          (* Run the code *)
-          val startRun = Timer.startCPUTimer()
-          val () = startExec() (* Enable any debugging *)
-          (* Run the code and capture any exception (temporarily). *)
-          val finalResult = (code(); NONE) handle exn => SOME exn
-          val () = endExec() (* Turn off debugging *)
-          (* Print the times if required. *)
-          val endRun = Timer.checkCPUTimer startRun
-          val () =
-              if !timing
-              then printOut(
-                  concat["Timing - compile: ",
-                         Time.fmt 1 (#usr endCompile + #sys endCompile),
-                         " run: ", Time.fmt 1 (#usr endRun + #sys endRun), "\n"]
-                 )
-              else ()
+        (* Compile a top-level declaration/expression. *)
+        val code = let
+          open PolyML.Compiler
         in
-          case finalResult of
-              NONE => () (* No exceptions raised. *)
-           |   SOME exn => (* Report exceptions in running code. *)
-               let
-                 open PolyML PolyML.Exception PolyML.Compiler
-                 val exLoc =
-                     case exceptionLocation exn of
-                         NONE => []
-                      |   SOME loc => [ContextLocation loc]
-               in
-                 PolyML.prettyPrint(TextIO.print, !lineLength)
-                   (PrettyBlock(0, false, [],
-                                [
-                                  PrettyBlock(0, false, exLoc,
-                                              [PrettyString "Exception-"]),
-                                  PrettyBreak(1, 3),
-                                  prettyRepresentation(exn,
-                                                       FixedInt.fromInt
-                                                         (! printDepth)),
-                                  PrettyBreak(1, 3),
-                                  PrettyString "raised"
-                   ]));
-                 PolyML.Exception.reraise exn
-               end
+          polyCompiler (readin, [CPNameSpace nameSpace,
+                                  CPOutStream TextIO.print])
         end
-      end; (* readEvalPrint *)
+            (* Don't print any times if this raises an exception. *)
+            handle exn as Fail s => (
+              printOut(s ^ "\n");
+              resetAfterCompileFail();
+              PolyML.Exception.reraise exn
+            )
+
+        val endCompile = Timer.checkCPUTimer startCompile
+
+        (* Run the code *)
+        val startRun = Timer.startCPUTimer()
+        val () = startExec() (* Enable any debugging *)
+        (* Run the code and capture any exception (temporarily). *)
+        val finalResult = (code(); NONE) handle exn => SOME exn
+        val () = endExec() (* Turn off debugging *)
+        val endRun = Timer.checkCPUTimer startRun
+      in
+        {compileTime = #usr endCompile + #sys endCompile,
+         runTime = #usr endRun + #sys endRun,
+         result = finalResult}
+      end; (* readEvalPrint1 *)
+
+    val readEvalPrint : unit -> unit =
+      if zeroTerm then
+        let
+          val endOfCommand = ref false;
+          (* Each character typed is fed into the compiler but a "\0"
+             terminates the input. *)
+          fun readin () =
+            case cgen() of
+              NONE => (endOfFile := true; NONE)
+            | SOME #"\000" => (endOfCommand := true; NONE)
+            | SOME ch => SOME ch;
+
+          (* Remove all buffered but unread input. *)
+          fun flushInput () =
+            case cgen () of
+              NONE => endOfFile := true
+            | SOME #"\000" => ()
+            | SOME ch => flushInput ();
+
+          fun resetAfterCompileFail () = (
+            if !endOfCommand then () else flushInput();
+            endOfCommand := false;
+            bind_cgen()
+          );
+
+          fun readEvalPrint compileAcc runAcc =
+            let
+              val () = bind_cgen();
+              val {compileTime, runTime, result} =
+                readEvalPrint1 readin resetAfterCompileFail;
+              val () = reportResult result;
+            in
+              if !endOfCommand orelse !endOfFile then
+                reportTiming compileTime runTime
+              else
+                readEvalPrint (compileAcc + compileTime) (runAcc + runTime)
+            end;
+
+        in fn () => readEvalPrint Time.zeroTime Time.zeroTime end
+      else (* not zeroTerm *)
+        let
+          val realDataRead = ref false;
+          val lastWasEol   = ref true;
+
+          val () = bind_cgen();
+
+          (* Each character typed is fed into the compiler but leading
+            blank lines result in the prompt remaining as firstPrompt until
+            significant characters are typed. *)
+          fun readin () =
+            let
+              val () =
+                if isInteractive andalso !lastWasEol (* Start of line *) then
+                  if !realDataRead then
+                    printOut (!prompt2)
+                  else printOut (!prompt1)
+                else ();
+            in
+              case cgen() of
+                NONE => (endOfFile := true; NONE)
+              | SOME #"\n" => (lastWasEol := true; SOME #"\n")
+              | SOME ch => (
+                  lastWasEol := false;
+                  if ch <> #" " then realDataRead := true else ();
+                  SOME ch
+                )
+            end; (* readin *)
+
+          (* Remove all buffered but unread input. *)
+          fun flushInput () =
+            case TextIO.canInput(TextIO.stdIn, 1) of
+                SOME 1 => (TextIO.inputN(TextIO.stdIn, 1); flushInput())
+            |   _ => (* No input waiting or we're at EOF. *) ();
+
+          fun resetAfterCompileFail () = (
+            flushInput();
+            lastWasEol := true;
+            bind_cgen()
+          );
+
+        in fn () =>
+          let
+            (* If we have executed a deeply recursive function the stack
+              will have extended to be very large. It's better to reduce
+              the stack if we can. This is RISKY. Each function checks on
+              entry that the stack has sufficient space for everything it
+              will allocate and assumes the stack will not shrink. It's
+              unlikely that any of the functions here will have asked for
+              very much but as a precaution we allow for an extra 8k
+              words. *)
+            (*
+            fun shrink_stack (newsize : int) : unit =
+              RunCall.run_call1 RuntimeCalls.POLY_SYS_shrink_stack newsize
+            val () = shrink_stack 8000 *)
+            val _ = realDataRead := false
+            val {compileTime, runTime, result} =
+              readEvalPrint1 readin resetAfterCompileFail
+            val () = reportTiming compileTime runTime
+          in reportResult result end
+        end; (* readEvalPrint *)
 
     fun handledLoop () : unit =
       (
         (* Process a single top-level command. *)
         readEvalPrint()
         handle Thread.Thread.Interrupt =>
-               (* Allow ^C to terminate the debugger and raise Interrupt in
-                  the called program. *)
-               if exitOnError then OS.Process.exit OS.Process.failure
-               else ()
-           |   _ =>
-               if exitOnError then OS.Process.exit OS.Process.failure else ();
-                (* Exit if we've seen end-of-file or we're in the debugger
-                   and we've run "continue". *)
+          (* Allow ^C to terminate the debugger and raise Interrupt in
+            the called program. *)
+          if exitOnError then OS.Process.exit OS.Process.failure else ()
+        | _ =>
+          if exitOnError then OS.Process.exit OS.Process.failure else ();
+        if zeroTerm then printOut "\000" else ();
+        (* Exit if we've seen end-of-file or we're in the debugger
+           and we've run "continue". *)
         if !endOfFile orelse exitLoop() then ()
         else handledLoop ()
       )

--- a/tools-poly/holrepl.ML
+++ b/tools-poly/holrepl.ML
@@ -133,6 +133,10 @@ fun topLevel diag {nameSpace, exitLoop, exitOnError, isInteractive, zeroTerm,
       if zeroTerm then
         let
           val endOfCommand = ref false;
+
+          (* Initial prompt / end of splash message *)
+          val () = printOut "\000";
+
           (* Each character typed is fed into the compiler but a "\0"
              terminates the input. *)
           fun readin () =


### PR DESCRIPTION
This adds a new flag `--zero` to `hol`, which when enabled in conjunction with `--repl` causes HOL to use a zero-terminated REPL. This has the following semantics:

* User commands are separated by `\0`. All open lexer state is reset between blocks.
* Response from ML is terminated by `\0`. (The end of input counts as one additional input terminator, so if the input contains `n` `\0`'s then the output contains `n+1` `\0`'s unless there is an abnormal exit.)
* As with the usual REPL, ML can begin processing commands as soon as it sees a complete command terminated by `;`, but it will not send a `\0` until the full block is concluded, and when timing is enabled, the timing will be aggregated over all commands in the block.

This resolves some parsing issues I encountered when writing the VSCode wrapper over the REPL.