### PR TITLE
more context lines on failure

### DIFF
--- a/tools/Holmake/poly/MB_Monitor.sml
+++ b/tools/Holmake/poly/MB_Monitor.sml
@@ -294,7 +294,7 @@ fun new {info,warn,genLogFile,time_limit,multidir} =
           let
             val strm = TextIO.openOut (genLogFile{tag = tag, dir = dir})
             val tb = tailbuffer.new {
-                  numlines = 10,
+                  numlines = 50,
                   patterns = [cheat_string, oracle_string, used_cheat_string,
                               fastcheat_string]
                 }


### PR DESCRIPTION
ML error messages tend to be closer to 20 lines:
```
 /home/mario/Documents/HOL/src/portableML/Portable.sml:15: error: Structure does not match signature.
    Signature: val export: string * 'a -> unit
    Structure: Not present
 Found near
   struct
    structure Process = OS.Process 
    structure FileSys = OS.FileSys 
    exception Div = General.Div 
    exception Mod = ... 
    fun ... 
    ... 
    ...
    end
 error in quse /home/mario/Documents/HOL/src/portableML/Portable.sml : Fail "Static Errors"
 error in load $(HOLDIR)/sigobj/Portable : Fail "Static Errors"
 error in load $(HOLDIR)/sigobj/Feedback : Fail "Static Errors"
 error in load /home/mario/Documents/HOL/src/bool/boolScript : Fail "Static Errors"
 Uncaught exception at ./basis/FinalPolyML.sml:492: Fail "Static Errors"
 ```
 Getting just the last 10 lines of this error message is dropping everything important. (For a while I didn't even realize the error message is truncated and just thought ML had really bad error messages...)
 
 Perhaps it would be better to just have no limit? Is this a performance optimization?