### PR TITLE
Allow passing .sig files to `hol`

### DIFF
--- a/tools-poly/buildheap.ML
+++ b/tools-poly/buildheap.ML
@@ -241,6 +241,7 @@ fun maybe_check_load diag (obj,_) =
   in
     case ext of
         SOME "sml" => (diag ("Using "^obj); QUse.use obj)
+      | SOME "sig" => (diag ("Using "^obj); QUse.use obj)
       | SOME "ML" => (diag ("Using "^obj); QUse.use obj)
       | SOME "uo" => (diag ("Loading "^obj); load (fix obj))
       | NONE => (diag ("Loading "^obj); load obj)


### PR DESCRIPTION
You can't parse some `sml` files on the command line without passing the `sig` file first, but `hol` (or rather `buildheap`) doesn't let you do that.