### PR TITLE
Add `pandoc` flag to cheatsheet generation

### DIFF
--- a/Manual/Cheatsheet/Holmakefile
+++ b/Manual/Cheatsheet/Holmakefile
@@ -1,6 +1,6 @@
 CHEATSHEET_SOURCES = cheatsheet.md cheatsheet.css
 
 cheatsheet.html: $(CHEATSHEET_SOURCES)
-	pandoc -s --toc -c cheatsheet.css -o cheatsheet.html cheatsheet.md
+	pandoc -s --toc -c cheatsheet.css -o cheatsheet.html --from commonmark_x cheatsheet.md
 
 EXTRA_CLEANS = cheatsheet.html


### PR DESCRIPTION
At some point `pandoc`'s behaviour seems to have changed, and its default Markdown flavour is a bit more picky about whitespace around e.g. unordered lists. This PR specifies a flavour of Markdown which seems to be a lot less picky, avoiding the need to introduce lots of whitespace into the cheatsheet Markdown.