### PR TITLE
back up polyml Thread structure

### DIFF
--- a/src/portableML/poly/ConcIsaLib.sml
+++ b/src/portableML/poly/ConcIsaLib.sml
@@ -2,4 +2,5 @@ structure Mutex = Thread.Mutex;
 structure ConditionVar = Thread.ConditionVar;
 exception Thread = Thread.Thread
 
+structure PolyThread = Thread;
 structure Thread = Thread.Thread;


### PR DESCRIPTION
This makes it possible to undo this (I needed this to be able to compile bits of the PolyML compiler on top of the HOL basis)