### PR TITLE
improve binder preterm positions

### DIFF
--- a/src/parse/Parse_support.sig
+++ b/src/parse/Parse_support.sig
@@ -13,8 +13,8 @@ sig
                               preterm_in_env
   val make_preterm          : preterm_in_env -> preterm Pretype.in_env
   val make_aq               : locn.locn -> term -> preterm_in_env
-  val make_binding_occ      : locn.locn -> string -> bvar_in_env
-  val make_aq_binding_occ   : locn.locn -> term -> bvar_in_env
+  val make_binding_occ      : locn.locn -> locn.locn -> string -> bvar_in_env
+  val make_aq_binding_occ   : locn.locn -> locn.locn -> term -> bvar_in_env
   val make_atom             : overload_info -> locn.locn ->
                               string -> preterm_in_env
   val make_qconst           : locn.locn -> string * string -> preterm_in_env

--- a/src/parse/Parse_support.sml
+++ b/src/parse/Parse_support.sml
@@ -122,23 +122,23 @@ end
  * Binding occurrences of variables
  *---------------------------------------------------------------------------*)
 
-fun make_binding_occ l s E = let
+fun make_binding_occ lAbs lVar s E = let
   open Preterm
   val (ntv,E') = ptylift Pretype.new_uvar E
   val E'' = add_scope((s,ntv),E')
 in
-  ((fn b => Abs{Bvar=Var{Name=s, Ty=ntv, Locn=l},Body=b,
-                Locn=locn.near (Preterm.locn b)}), E'')
+  ((fn b => Abs{Bvar=Var{Name=s, Ty=ntv, Locn=lVar},Body=b,
+                Locn=locn.near lAbs}), E'')
 end
 
-fun make_aq_binding_occ l aq E = let
+fun make_aq_binding_occ lAbs lVar aq E = let
   val (v as (Name,Ty)) = Term.dest_var aq
   val pty = Pretype.fromType Ty
-  val v' = {Name=Name, Ty=Pretype.fromType Ty, Locn=l}
+  val v' = {Name=Name, Ty=Pretype.fromType Ty, Locn=lVar}
   val E' = add_scope ((Name,pty),E)
   open Preterm
 in
-  ((fn b => Abs{Bvar=Var v', Body=b, Locn=locn.near (Preterm.locn b)}), E')
+  ((fn b => Abs{Bvar=Var v', Body=b, Locn=lAbs}), E')
 end
 
 

--- a/src/parse/TermParse.sml
+++ b/src/parse/TermParse.sml
@@ -100,11 +100,10 @@ local open Parse_support Absyn
 in
   fun absyn_to_preterm_in_env TmG t = let
     val oinfo = term_grammar.overload_info TmG
-    fun binder(VIDENT (l,s))    = make_binding_occ l s
-      | binder(VPAIR(l,v1,v2))  = make_vstruct oinfo l [binder v1, binder v2]
-                                               NONE
-      | binder(VAQ (l,x))       = make_aq_binding_occ l x
-      | binder(VTYPED(l,v,pty)) = make_vstruct oinfo l [binder v] (SOME pty)
+    fun binder l' (VIDENT (l,s))    = make_binding_occ l' l s
+      | binder l' (VPAIR(l,v1,v2))  = make_vstruct oinfo l [binder l' v1, binder l' v2] NONE
+      | binder l' (VAQ (l,x))       = make_aq_binding_occ l' l x
+      | binder l' (VTYPED(l,v,pty)) = make_vstruct oinfo l [binder l' v] (SOME pty)
     open parse_term Absyn Parse_support
     val to_ptmInEnv = absyn_to_preterm_in_env TmG
     val (f, args) = Absyn.strip_app t
@@ -202,7 +201,7 @@ in
             | APP(l, t1, t2)     => list_make_comb l (map to_ptmInEnv [t1, t2])
             | IDENT (l, s)       => make_atom oinfo l s
             | QIDENT (l, s1, s2) => make_qconst l (s1,s2)
-            | LAM(l, vs, t)      => bind_term l [binder vs] (to_ptmInEnv t)
+            | LAM(l, vs, t)      => bind_term l [binder l vs] (to_ptmInEnv t)
             | TYPED(l, t, pty)   => make_constrained l (to_ptmInEnv t) pty
             | AQ (l, t)          => make_aq l t
         end


### PR DESCRIPTION
It was previously associating binders with the body only, which is weird and imprecise, and causes some [funny issues](https://discord.com/channels/1171421764379742258/1201829002776420362/1307065300356825088) when trying to locate the outermost term with a given span.