### PR TITLE
don't use Loc_None in typed_parse_in_context

### DIFF
--- a/src/parse/Parse.sml
+++ b/src/parse/Parse.sml
@@ -474,7 +474,9 @@ fun grammar_typed_parse_in_context gs ty ctxt q =
 
 fun typed_parse_in_context ty ctxt q =
   let
-    fun mkA q = Absyn.TYPED(locn.Loc_None, Absyn q, Pretype.fromType ty)
+    fun mkA q = let
+      val a = Absyn q
+      in Absyn.TYPED(Absyn.locn_of_absyn a, a, Pretype.fromType ty) end
   in
     case seq.cases (TermParse.prim_ctxt_termS mkA (term_grammar()) ctxt q) of
         SOME (tm, _) => tm


### PR DESCRIPTION
This might be debatable; the issue is that using `Loc_None` on the outermost node causes my code to assume that the whole syntax is missing position info and skip it. Ideally one should be able to navigate the tree using spans in strict containment relationship to zoom in on a subterm, but having intermediate nodes with `Loc_None` spoils this. In this particular case there is a natural location to use anyway.