### PR TITLE
don't gitignore Theory.sml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *Theory.sig
 *Theory.sml
 *Theory.dat
+!Theory.sig
+!Theory.sml
 *.uo
 *.ui
 *.o


### PR DESCRIPTION
`Theory.sml` is a regular SML file which should not be ignored by the `*Theory.sml` grep (which is intended to only find files generated from `*Script.sml`).