### PR TITLE
[lambda] agree_upto_lemma

### DIFF
--- a/examples/lambda/basics/basic_swapScript.sml
+++ b/examples/lambda/basics/basic_swapScript.sml
@@ -292,6 +292,13 @@ Proof
  >> Q.EXISTS_TAC ‘y’ >> rw []
 QED
 
+Theorem ROW_DISJOINT :
+    !r1 r2. r1 <> r2 ==> DISJOINT (ROW r1) (ROW r2)
+Proof
+    rw [DISJOINT_ALT, ROW]
+ >> rw [n2s_11]
+QED
+
 Definition RANK_DEF :
     RANK r = BIGUNION (IMAGE ROW (count r))
 End
@@ -363,6 +370,18 @@ Proof
  >> Q.EXISTS_TAC ‘j’ >> rw []
 QED
 
+Theorem DISJOINT_RNEWS :
+    !r1 r2 n1 n2 s1 s2. FINITE s1 /\ FINITE s2 /\ r1 <> r2 ==>
+        DISJOINT (set (RNEWS r1 n1 s1)) (set (RNEWS r2 n2 s2))
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC DISJOINT_SUBSET
+ >> Q.EXISTS_TAC ‘ROW r2’ >> rw [RNEWS_SUBSET_ROW]
+ >> MATCH_MP_TAC DISJOINT_SUBSET'
+ >> Q.EXISTS_TAC ‘ROW r1’ >> rw [RNEWS_SUBSET_ROW]
+ >> MATCH_MP_TAC ROW_DISJOINT >> art []
+QED
+
 Theorem DISJOINT_RANK_RNEWS :
     !r1 r2 n s.
         FINITE s /\ r1 <= r2 ==> DISJOINT (RANK r1) (set (RNEWS r2 n s))
@@ -373,12 +392,22 @@ Proof
  >> rw [RANK_ROW_DISJOINT, RNEWS_SUBSET_ROW]
 QED
 
+(* |- !r1 r2 n s.
+        FINITE s /\ r1 <= r2 ==> DISJOINT (set (RNEWS r2 n s)) (RANK r1)
+ *)
+Theorem DISJOINT_RNEWS_RANK =
+    ONCE_REWRITE_RULE [DISJOINT_SYM] DISJOINT_RANK_RNEWS
+
 Theorem DISJOINT_RANK_RNEWS' :
     !r n s. FINITE s ==> DISJOINT (RANK r) (set (RNEWS r n s))
 Proof
     rpt STRIP_TAC
  >> MATCH_MP_TAC DISJOINT_RANK_RNEWS >> rw []
 QED
+
+(* |- !r n s. FINITE s ==> DISJOINT (set (RNEWS r n s)) (RANK r) *)
+Theorem DISJOINT_RNEWS_RANK' =
+    ONCE_REWRITE_RULE [DISJOINT_SYM] DISJOINT_RANK_RNEWS'
 
 Theorem RNEWS_SUBSET_RANK :
     !r1 r2 n s. FINITE s /\ r1 < r2 ==>

--- a/examples/lambda/basics/generic_termsScript.sml
+++ b/examples/lambda/basics/generic_termsScript.sml
@@ -8,6 +8,7 @@
 open HolKernel Parse boolLib bossLib;
 
 open BasicProvers boolSimps pred_setTheory listTheory quotientLib;
+open relationTheory;
 
 open binderLib basic_swapTheory nomsetTheory;
 
@@ -176,7 +177,7 @@ val (aeq_rules, aeq_ind, aeq_cases) = Hol_reln`
   (!u v bv z bndts1 bndts2 us1 us2.
       aeql us1 us2 ∧
       aeql (ptpml [(u,z)] bndts1) (ptpml [(v,z)] bndts2) ∧
-      z ∉ allatomsl bndts1 ∧ z ∉  allatomsl bndts2 ∧ z ≠ u ∧ z ≠ v ⇒
+      z ∉ allatomsl bndts1 ∧ z ∉ allatomsl bndts2 ∧ z ≠ u ∧ z ≠ v ⇒
       aeq (lam u bv bndts1 us1) (lam v bv bndts2 us2)) ∧
   aeql [] [] ∧
   (∀h1 h2 t1 t2. aeq h1 h2 ∧ aeql t1 t2 ⇒ aeql (h1::t1) (h2::t2))
@@ -358,7 +359,6 @@ val aeq_trans = store_thm(
     metis_tac [aeq_rules]
   ]);
 
-open relationTheory
 val aeq_equiv = store_thm(
   "aeq_equiv",
   ``!t1 t2. aeq t1 t2 = (aeq t1 = aeq t2)``,

--- a/src/coalgebras/ltreeScript.sml
+++ b/src/coalgebras/ltreeScript.sml
@@ -938,6 +938,20 @@ Proof
  >> gs [GSYM IS_SOME_EQ_NOT_NONE, IS_SOME_EXISTS]
 QED
 
+Theorem ltree_paths_map_cong[simp] :
+    !f t. ltree_paths (ltree_map f t) = ltree_paths t
+Proof
+    rw [ltree_paths_def, Once EXTENSION]
+ >> Q.ID_SPEC_TAC ‘t’
+ >> Q.SPEC_TAC (‘x’, ‘p’)
+ >> Induct_on ‘p’
+ >- rw [ltree_lookup_def]
+ >> rpt GEN_TAC
+ >> Cases_on ‘t’
+ >> rw [ltree_lookup_def, ltree_map]
+ >> Cases_on ‘LNTH h ts’ >> rw []
+QED
+
 (*---------------------------------------------------------------------------*
  *  Rose tree is a finite variant of ltree, defined inductively.
  *---------------------------------------------------------------------------*)

--- a/src/list/src/rich_listScript.sml
+++ b/src/list/src/rich_listScript.sml
@@ -2713,6 +2713,23 @@ Proof
  >> rw [TAKE_LENGTH_TOO_LONG]
 QED
 
+(* NOTE: This theorem can also be proved by IS_PREFIX_LENGTH_ANTI and
+   prefixes_is_prefix_total, but IS_PREFIX_EQ_TAKE is more natural.
+ *)
+Theorem IS_PREFIX_EQ_REWRITE :
+    !l1 l2 l. l1 <<= l /\ l2 <<= l ==> (l1 = l2 <=> LENGTH l1 = LENGTH l2)
+Proof
+    rw [IS_PREFIX_EQ_TAKE]
+ >> rw [LENGTH_TAKE, TAKE_EQ_REWRITE]
+QED
+
+Theorem IS_PREFIX_ALL_DISTINCT :
+    !l l1. l1 <<= l /\ ALL_DISTINCT l ==> ALL_DISTINCT l1
+Proof
+    rw [IS_PREFIX_EQ_TAKE']
+ >> MATCH_MP_TAC ALL_DISTINCT_TAKE >> rw []
+QED
+
 Theorem IS_PREFIX_FRONT_MONO :
     !l1 l2. l1 <> [] /\ l2 <> [] /\ l1 <<= l2 ==> FRONT l1 <<= FRONT l2
 Proof


### PR DESCRIPTION
Hi,

This PR finally completes the proof of "agree up to lemma" (Lemma 10.3.11 [1. p.251]). Recall that a set (or finite list) of λ-terms are "agree up to" a path `p` if the Böhm tree nodes of any two terms in it are the same (i.e. same binding variables, same number of children) along the path:
```
[agree_upto_def]
⊢ ∀X Ms p r.
    agree_upto X Ms p r ⇔
    ∀M N.
      MEM M Ms ∧ MEM N Ms ⇒
      ∀q. q ≼ p ⇒ ltree_el (BT' X M r) q = ltree_el (BT' X N r) q
```

The "agree up to" lemma says, for a (non-empty) list (or finite set) of λ-terms agree up to path `p` , under suitable condition (the path is valid, the excluded set is big enough, etc.) there exists a Böhm transform `pi` such that, after applying `pi` the resulting terms still agree up to `p`. This proof is quite tedious, requiring a lot of new lemmas.
```
[agree_upto_lemma]
⊢ ∀X Ms p r.
    FINITE X ∧ p ≠ [] ∧ 0 < r ∧ Ms ≠ [] ∧
    BIGUNION (IMAGE FV (set Ms)) ⊆ X ∪ RANK r ∧
    EVERY (λM. subterm X M p r ≠ NONE) Ms ⇒
    ∃pi.
      Boehm_transform pi ∧ EVERY is_ready' (MAP (apply pi) Ms) ∧
      (agree_upto X Ms p r ⇒ agree_upto X (MAP (apply pi) Ms) p r)
```

NOTE: The above theorem only covers part (1) and (2) of the textbook theorem. There's still a part (3) whose proof should be similar with (2) and I'm still working on it.

Chun

[1] Barendregt, H.P.: The lambda calculus, its syntax and semantics. College Publications, London (1984).