### PR TITLE
Updated Dockerfile for CI tests

### DIFF
--- a/developers/Dockerfile
+++ b/developers/Dockerfile
@@ -21,6 +21,6 @@ COPY . .
 
 RUN poly < tools/smart-configure.sml && ./bin/build
 
-ENV PATH /HOL/bin:$PATH
+ENV PATH=/HOL/bin:$PATH
 
 ENTRYPOINT ["/HOL/bin/hol"]

--- a/developers/docker-ci/Dockerfile
+++ b/developers/docker-ci/Dockerfile
@@ -5,7 +5,7 @@
 # NOTE: this docker image is NOT for HOL developers to use interactively.
 
 # This "base" image is described in "base/Dockerfile"
-FROM --platform=$TARGETPLATFORM binghelisp/hol-dev:latest
+FROM binghelisp/hol-dev:latest
 
 # The following two arguments are supported by "docker buildx" commands
 ARG TARGETPLATFORM
@@ -25,16 +25,14 @@ ARG Z3_VERSION
 ARG CVC_VERSION
 ARG YICES_VERSION
 
-# if --build-arg Z3_VERSION=2.19, set HOL4_Z3_EXECUTABLE to its full path,
-# or set to null otherwise.
-ENV HOL4_Z3_EXECUTABLE=${Z3_VERSION:+/ML/z3-${Z3_VERSION}/bin/z3}
+# if --build-arg Z3_VERSION=anything, set HOL4_Z3_EXECUTABLE to system-installed z3
+ENV HOL4_Z3_EXECUTABLE=${Z3_VERSION:+/usr/bin/z3}
 RUN if [ "" != "${Z3_VERSION}" ]; then \
     echo "Using Z3 solver: `${HOL4_Z3_EXECUTABLE} -version`"; \
 fi
 
-# if --build-arg CVC_VERSION=5, set HOL4_CVC_EXECUTABLE to its full path,
-# or set to null otherwise.
-ENV HOL4_CVC_EXECUTABLE=${CVC_VERSION:+/ML/cvc${CVC_VERSION}-Linux}
+# if --build-arg CVC_VERSION=5, set HOL4_CVC_EXECUTABLE to system-installed cvc5
+ENV HOL4_CVC_EXECUTABLE=${CVC_VERSION:+/usr/bin/cvc5}
 RUN if [ "" != "${CVC_VERSION}" ]; then \
     echo "Using CVC solver: `${HOL4_CVC_EXECUTABLE} --version | head -1`"; \
 fi

--- a/developers/docker-ci/base/Dockerfile
+++ b/developers/docker-ci/base/Dockerfile
@@ -2,17 +2,17 @@
 #
 # HOL4 building environment (Docker), base image
 #
-# e.g. docker buildx build --platform linux/386,linux/amd64,linux/arm64 .
+# e.g. docker buildx build --platform linux/amd64,linux/arm64v8 .
 
 # GitHub Actions recommends Debian-based systems as base images
-FROM --platform=$TARGETPLATFORM debian:stable
+FROM debian:trixie
 
-MAINTAINER Chun Tian <binghe.lisp@gmail.com>
+LABEL org.opencontainers.image.authors="Chun Tian (binghe) <binghe.lisp@gmail.com>"
 
 # The following two arguments are supported by "docker buildx"
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
-ARG POLY_VERSION="5.9.1"
+ARG POLY_VERSION="master"
 
 RUN echo "I was running on $BUILDPLATFORM, building for $TARGETPLATFORM" > /tmp/log
 
@@ -24,56 +24,80 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LD_LIBRARY_PATH=/usr/local/lib
 ENV PATH=/ML/HOL/bin:$PATH
 
-# some necessary Debian packages
+# Some necessary Debian packages
+# NOTE: GCC 13 is necessary for building Moscow ML (default compiler is now GCC 14).
 RUN apt-get update -qy
-RUN apt-get install -qy build-essential graphviz git libgmp-dev wget curl procps file unzip
+RUN apt-get install -qy build-essential git libgmp-dev wget curl procps file unzip vim gcc-13
+RUN apt-get clean
 
 # for Unicode display, learnt from Magnus Myreen
-RUN apt-get install -qy locales-all terminfo man aptitude
+RUN apt-get install -qy locales-all terminfo
+
+# Extra graphics-related tools
+RUN apt-get install -qy graphviz emacs-nox
 
 # clean up downloaded packages after installation (this reduces Docker image sizes)
 RUN apt-get clean
 
-# 1. install Moscow ML (https://github.com/kfl/mosml.git)
+# 1. install Moscow ML (https://github.com/kfl/mosml.git) with GCC 13
+COPY mosml-gcc-13.patch /ML
 RUN wget -q -O - https://github.com/kfl/mosml/archive/refs/tags/ver-2.10.1.tar.gz | tar xzf -
-RUN make -C mosml-ver-2.10.1/src world install
-RUN rm -rf mosml-ver-2.10.1
+RUN cd mosml-ver-2.10.1/src; patch -p0 < /ML/mosml-gcc-13.patch;
+RUN cd mosml-ver-2.10.1; make -C src world install
+RUN rm -rf mosml-ver-2.10.1 *.patch
 
 # 2. install polyml (https://github.com/polyml/polyml.git)
-RUN wget -q -O polyml-${POLY_VERSION}.tar.gz \
-    https://github.com/polyml/polyml/archive/refs/tags/v${POLY_VERSION}.tar.gz
-RUN tar xzf polyml-${POLY_VERSION}.tar.gz
+RUN if [ "master" = "$POLY_VERSION" ]; then \
+       wget -q -O polyml-${POLY_VERSION}.zip \
+         https://github.com/polyml/polyml/archive/refs/heads/master.zip; \
+       unzip polyml-${POLY_VERSION}.zip; \
+    else \
+       wget -q -O polyml-${POLY_VERSION}.tar.gz \
+         https://github.com/polyml/polyml/archive/refs/tags/v${POLY_VERSION}.tar.gz; \
+       tar xzf polyml-${POLY_VERSION}.tar.gz; \
+    fi
+
 RUN if [ "linux/386" = "$TARGETPLATFORM" ]; then \
        cd polyml-${POLY_VERSION} && ./configure --build=i686-pc-linux-gnu --enable-intinf-as-int; \
+    elif [ "linux/riscv64" = "$TARGETPLATFORM" ]; then \
+       cd polyml-${POLY_VERSION} && ./configure --build=riscv64-pc-linux-gnu --enable-intinf-as-int; \
     else \
        cd polyml-${POLY_VERSION} && ./configure --enable-intinf-as-int; \
     fi
+
 RUN make -C polyml-${POLY_VERSION} -j4
 RUN make -C polyml-${POLY_VERSION} install
-RUN rm -rf polyml-${POLY_VERSION} polyml-${POLY_VERSION}.tar.gz
+RUN rm -rf polyml-${POLY_VERSION}*
 
 # 3. install MLton binary (https://github.com/MLton/mlton.git) for linux/amd64 only
 RUN if [ "linux/amd64" = "$TARGETPLATFORM" ]; then \
-    wget -q -O - https://github.com/MLton/mlton/releases/download/on-20210117-release/mlton-20210117-1.amd64-linux-glibc2.31.tgz | tar xzf -; fi
-RUN if [ "linux/amd64" = "$TARGETPLATFORM" ]; then make -C mlton-20210117-1.amd64-linux-glibc2.31; fi
+       wget -q -O - \
+          https://github.com/MLton/mlton/releases/download/on-20210117-release/mlton-20210117-1.amd64-linux-glibc2.31.tgz | tar xzf -; \
+    fi
+RUN if [ "linux/amd64" = "$TARGETPLATFORM" ]; then \
+       make -C mlton-20210117-1.amd64-linux-glibc2.31; \
+    fi
 RUN rm -rf mlton-20210117-1.amd64-linux-glibc2.31
 
 # 4. install OpenTheory (develop version)
 RUN wget -q -O opentheory-develop.zip \
     https://github.com/binghe/opentheory/archive/refs/heads/develop.zip && unzip opentheory-develop.zip
+
 RUN if [ "linux/amd64" = "$TARGETPLATFORM" ]; then \
         make -C opentheory-develop mlton; \
     else \
         make -C opentheory-develop polyml; \
     fi
+
 RUN if [ "linux/amd64" = "$TARGETPLATFORM" ]; then \
         cp opentheory-develop/bin/mlton/opentheory /usr/local/bin; \
     else \
         cp opentheory-develop/bin/polyml/opentheory /usr/local/bin; \
     fi
+
 RUN rm -rf opentheory-develop opentheory-develop.zip
 RUN opentheory init && opentheory install base
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8

--- a/developers/docker-ci/base/Makefile
+++ b/developers/docker-ci/base/Makefile
@@ -1,10 +1,8 @@
 DOCKER_IMAGE=binghelisp/hol-dev:base
 
 build:
-	docker buildx build --platform linux/386 .
-	docker buildx build --platform linux/amd64 .
-	docker buildx build --platform linux/arm64 .
-	docker buildx build --platform linux/386,linux/amd64,linux/arm64 -t $(DOCKER_IMAGE) .
+	docker buildx build --platform linux/386,linux/amd64,linux/arm64,linux/riscv64 \
+		-t $(DOCKER_IMAGE) .
 
 push:
 	docker push $(DOCKER_IMAGE)

--- a/developers/docker-ci/base/mosml-gcc-13.patch
+++ b/developers/docker-ci/base/mosml-gcc-13.patch
@@ -1,0 +1,12 @@
+--- Makefile.inc.orig	2024-11-12 07:10:57.020568891 +0000
++++ Makefile.inc	2024-11-12 07:11:09.550402058 +0000
+@@ -37,7 +37,7 @@
+ 
+ # This works with most systems, including MacOS X with XCode installed:
+ 
+-CC=gcc
++CC=gcc-13
+ # CC=gcc -mmacosx-version-min=10.7 # for building OS X package
+ # CC=/usr/sepp/bin/gcc		# Solaris at KVL
+ 
+

--- a/developers/docker-ci/latest/Dockerfile
+++ b/developers/docker-ci/latest/Dockerfile
@@ -2,10 +2,11 @@
 #
 # HOL4 building environment (Docker), base image
 #
-# e.g. docker buildx build --platform linux/386,linux/amd64,linux/arm64 .
+# e.g. docker buildx build --platform linux/amd64,linux/arm64v8 .
 
-# GitHub Actions recommends Debian-based systems as base images
-FROM --platform=$TARGETPLATFORM binghelisp/hol-dev:base
+FROM binghelisp/hol-dev:base
+
+LABEL org.opencontainers.image.authors="Chun Tian (binghe) <binghe.lisp@gmail.com>"
 
 # The following two arguments are supported by "docker buildx"
 ARG TARGETPLATFORM
@@ -106,7 +107,12 @@ fi
 
 ENV HOL4_SMV_EXECUTABLE=/ML/solvers/NuRV
 
-# necessary TeXlive packages for buliding HOL manuals (+pandoc for Markdown)
-RUN apt-get install -qy texlive-latex-recommended pandoc latexmk texlive-latex-extra \
-                        texlive-fonts-extra texlive-science
+# more packages for buliding HOL manuals (+pandoc for Markdown), etc.
+RUN apt-get install -qy texlive-latex-recommended
+RUN apt-get install -qy pandoc latexmk texlive-latex-extra
+RUN apt-get install -qy texlive-fonts-extra texlive-science
+RUN apt-get clean
+
+# z3 and cvc5 as system packages
+RUN apt-get install -qy z3 cvc5
 RUN apt-get clean

--- a/developers/docker-ci/latest/Makefile
+++ b/developers/docker-ci/latest/Makefile
@@ -1,10 +1,8 @@
 DOCKER_IMAGE=binghelisp/hol-dev:latest
 
 build:
-	docker buildx build --platform linux/386 .
-	docker buildx build --platform linux/amd64 .
-	docker buildx build --platform linux/arm64 .
-	docker buildx build --platform linux/386,linux/amd64,linux/arm64 -t $(DOCKER_IMAGE) .
+	docker buildx build --platform linux/386,linux/amd64,linux/arm64,linux/riscv64 \
+		-t $(DOCKER_IMAGE) .
 
 push:
 	docker push $(DOCKER_IMAGE)


### PR DESCRIPTION
Hi,

This PR contains latest updates to the docker images that HOL office is already using (because the images are under my Docker Hub account). Now the Linux-based images are based on Debian 13 "trixie" (currently testing, to be released in early next year), with 4 architectures (`linux/386,linux/amd64,linux/arm64,linux/riscv64`) under the same tags: (`latest` = `base` + SMT solvers)

```
docker pull binghelisp/hol-dev:latest
docker pull binghelisp/hol-dev:base
```

(NOTE: Currently HOL4 cannot be built normally on Linux riscv64 by Poly/ML in interpreter mode. The blocking issue is actually at `mllex` and `mlyacc` source code. I will find time to look into these issues.)

On Debian 13, Moscow ML cannot be compiled by the default GCC 14. Instead, GCC 13 must be used (I've made a small patch to Moscow ML's `Makefile` to enforce using GCC 13).

I also found that there are system packages of Z3 and CVC5 SMT solvers, and I've installed them and make the CI tests always using them:
```
#13 [ 4/10] RUN if [ "" != "4.13.0" ]; then     echo "Using Z3 solver: `/usr/bin/z3 -version`"; fi
#13 0.061 Using Z3 solver: Z3 version 4.13.3 - 64 bit
#13 DONE 0.1s
#14 [ 5/10] RUN if [ "" != "5" ]; then     echo "Using CVC solver: `/usr/bin/cvc5 --version | head -1`"; fi
#14 0.065 Using CVC solver: This is cvc5 version 1.1.2
#14 DONE 0.1s
```

I think in the future we only need to use these system-installed SMT solvers as part of the CI tests and no need to install more versions (this will shrink the image size).

Chun