### PR TITLE
Faster evaluation for Keccak_256_bytes

### DIFF
--- a/examples/Crypto/Keccak/keccakScript.sml
+++ b/examples/Crypto/Keccak/keccakScript.sml
@@ -2054,7 +2054,36 @@ Termination
   \\ rw[LENGTH_DROP]
 End
 
-(*
+Theorem TAKE_FLAT_bytes[local]:
+  ∀n (ls:word8 list). 8 * (n + 1) ≤ LENGTH ls ==>
+  FLAT (MAP (PAD_RIGHT 0 8 o word_to_bin_list) (TAKE 8 (DROP (8 * n) ls))) =
+  TAKE 64 (DROP (64 * n) (FLAT (MAP (PAD_RIGHT 0 8 o word_to_bin_list) ls)))
+Proof
+  Induct \\ rw[]
+  >- (
+    Cases_on`ls` \\ gs[]
+    \\ qmatch_asmsub_rename_tac`LENGTH ls` \\ Cases_on`ls` \\ gs[]
+    \\ qmatch_asmsub_rename_tac`LENGTH ls` \\ Cases_on`ls` \\ gs[]
+    \\ qmatch_asmsub_rename_tac`LENGTH ls` \\ Cases_on`ls` \\ gs[]
+    \\ qmatch_asmsub_rename_tac`LENGTH ls` \\ Cases_on`ls` \\ gs[]
+    \\ qmatch_asmsub_rename_tac`LENGTH ls` \\ Cases_on`ls` \\ gs[]
+    \\ qmatch_asmsub_rename_tac`LENGTH ls` \\ Cases_on`ls` \\ gs[]
+    \\ qmatch_asmsub_rename_tac`LENGTH ls` \\ Cases_on`ls` \\ gs[]
+    \\ simp[TAKE_APPEND]
+    \\ simp[TAKE_LENGTH_TOO_LONG, LENGTH_PAD_RIGHT_0_8_word_to_bin_list] )
+  \\ gs[LEFT_ADD_DISTRIB, MULT_SUC]
+  \\ Cases_on`ls` \\ gs[]
+  \\ qmatch_asmsub_rename_tac`LENGTH ls` \\ Cases_on`ls` \\ gs[]
+  \\ qmatch_asmsub_rename_tac`LENGTH ls` \\ Cases_on`ls` \\ gs[]
+  \\ qmatch_asmsub_rename_tac`LENGTH ls` \\ Cases_on`ls` \\ gs[]
+  \\ qmatch_asmsub_rename_tac`LENGTH ls` \\ Cases_on`ls` \\ gs[]
+  \\ qmatch_asmsub_rename_tac`LENGTH ls` \\ Cases_on`ls` \\ gs[]
+  \\ qmatch_asmsub_rename_tac`LENGTH ls` \\ Cases_on`ls` \\ gs[]
+  \\ qmatch_asmsub_rename_tac`LENGTH ls` \\ Cases_on`ls` \\ gs[]
+  \\ simp[DROP_APPEND, LENGTH_PAD_RIGHT_0_8_word_to_bin_list,
+          DROP_LENGTH_TOO_LONG]
+QED
+
 Theorem pad10s1_136_64w_thm:
   ∀zs bytes acc bools.
   bools = MAP ((=) 1) $ FLAT $ MAP (PAD_RIGHT 0 8 o word_to_bin_list) bytes ∧
@@ -2190,7 +2219,33 @@ Proof
       \\ disch_then SUBST_ALL_TAC
       \\ AP_TERM_TAC
       \\ simp[Abbr`ls`]
-*)
+      \\ qunabbrev_tac`fb`
+      \\ irule TAKE_FLAT_bytes
+      \\ simp[] )
+    \\ simp[Abbr`lm2`]
+    \\ AP_TERM_TAC
+    \\ AP_TERM_TAC
+    \\ AP_TERM_TAC
+    \\ AP_TERM_TAC
+    \\ simp[pad10s1_def]
+    \\ AP_THM_TAC
+    \\ AP_TERM_TAC
+    \\ qmatch_goalsub_abbrev_tac`A MOD N = B MOD N`
+    \\ `B = A + (N - 1) * N`
+    by (
+      qunabbrev_tac`A`
+      \\ qunabbrev_tac`B`
+      \\ qunabbrev_tac`N`
+      \\ simp[LEFT_ADD_DISTRIB] )
+    \\ qunabbrev_tac`B`
+    \\ pop_assum SUBST_ALL_TAC
+    \\ irule EQ_SYM
+    \\ ONCE_REWRITE_TAC[ADD_COMM]
+    \\ irule MOD_TIMES
+    \\ simp[Abbr`N`] )
+  \\ simp[PULL_EXISTS]
+  \\ cheat
+QED
 
 Definition Keccak_256_bytes_def:
   Keccak_256_bytes (bs:word8 list) : word8 list =

--- a/examples/Crypto/Keccak/keccakScript.sml
+++ b/examples/Crypto/Keccak/keccakScript.sml
@@ -3683,6 +3683,7 @@ Definition Keccak_256_bytes_def:
     MAP (PAD_RIGHT 0 8 o word_to_bin_list) bs
 End
 
+(*
 Theorem Keccak_256_w64_thm:
   Keccak_256_w64 = Keccak_256_bytes
 Proof
@@ -3721,6 +3722,7 @@ Proof
   \\ simp[MAP_TAKE, GSYM chunks_MAP]
   \\ cheat
 QED
+*)
 
 (* TODO: move/replace *)
 Definition hex_to_rev_bytes_def:

--- a/examples/Crypto/Keccak/keccakScript.sml
+++ b/examples/Crypto/Keccak/keccakScript.sml
@@ -3994,7 +3994,30 @@ Proof
       \\ strip_tac \\ gs[] )
     \\ simp[EL_TAKE, EL_MAP]
     \\ qx_gen_tac`x` \\ strip_tac
-    \\ cheat )
+    \\ simp[PAD_RIGHT, EL_GENLIST, EL_APPEND_EQN]
+    \\ Cases_on`b0` \\ gs[]
+    >- (
+      rw[bool_to_bit_def]
+      \\ qhdtm_x_assum`EVERY`mp_tac
+      \\ simp[EXISTS_MEM, MEM_EL, PULL_EXISTS]
+      \\ qexists_tac`x`
+      \\ DEP_REWRITE_TAC[EL_TAKE, EL_MAP]
+      \\ simp[bool_to_bit_def] )
+    \\ DEP_REWRITE_TAC[TAKE_TAKE, LENGTH_TAKE]
+    \\ simp[]
+    \\ conj_asm1_tac
+    >- (
+      reverse conj_asm1_tac >- simp[Abbr`m`]
+      \\ simp[Abbr`m`]
+      \\ qmatch_goalsub_abbrev_tac`dropWhile P ls`
+      \\ qspecl_then[`P`,`ls`]mp_tac LENGTH_dropWhile_LESS_EQ
+      \\ simp[Abbr`ls`] )
+    \\ simp[EL_TAKE, EL_MAP]
+    \\ rw[]
+    \\ fs[NOT_LESS]
+    \\ qunabbrev_tac`m`
+    \\ qpat_x_assum`m <= x`(mp_then Any mp_tac EL_LENGTH_dropWhile_REVERSE)
+    \\ simp[EL_TAKE, EL_MAP])
   \\ fs[Abbr`ww`]
   \\ simp[Abbr`w`, EL_TAKE, EL_MAP]
   \\ simp[bool_to_bit_neq_add]

--- a/examples/Crypto/Keccak/keccakScript.sml
+++ b/examples/Crypto/Keccak/keccakScript.sml
@@ -100,6 +100,31 @@ Proof
   \\ simp[ADD_DIV_RWT]
 QED
 
+Theorem EL_chunks:
+  ∀k ls n.
+  n < LENGTH (chunks k ls) /\ 0 < k /\ ~NULL ls ==>
+  EL n (chunks k ls) = TAKE k (DROP (n * k) ls)
+Proof
+  recInduct chunks_ind \\ rw[NULL_EQ]
+  \\ qpat_x_assum`_ < LENGTH _ `mp_tac
+  \\ rw[Once chunks_def] \\ gs[]
+  >- rw[Once chunks_def]
+  \\ rw[Once chunks_def]
+  \\ qmatch_goalsub_rename_tac`EL m _`
+  \\ Cases_on`m` \\ gs[]
+  \\ pop_assum mp_tac
+  \\ DEP_REWRITE_TAC[LENGTH_chunks]
+  \\ simp[NULL_EQ]
+  \\ strip_tac
+  \\ DEP_REWRITE_TAC[DROP_DROP]
+  \\ simp[MULT_SUC]
+  \\ qmatch_goalsub_rename_tac`n + n * m <= _`
+  \\ `n * m <= LENGTH ls - n` suffices_by simp[]
+  \\ `m <= (LENGTH ls - n) DIV n` suffices_by simp[X_LE_DIV]
+  \\ fs[bool_to_bit_def]
+  \\ pop_assum mp_tac \\ rw[]
+QED
+
 Theorem LENGTH_PAD_RIGHT_0_8_word_to_bin_list[simp]:
   LENGTH (PAD_RIGHT 0 8 (word_to_bin_list (w: word8))) = 8
 Proof
@@ -2130,7 +2155,41 @@ Proof
     \\ conj_tac
     >- (
       simp[Abbr`l1`, Abbr`b1`, Abbr`bools1`]
-    concat_word_list_bytes_to_64
+      \\ reverse conj_tac
+      >- (
+        simp[Abbr`l0`, Abbr`b0`]
+        \\ simp[LIST_EQ_REWRITE, EL_REPLICATE]
+        \\ rpt strip_tac
+        \\ DEP_REWRITE_TAC[EL_MAP]
+        \\ DEP_REWRITE_TAC[LENGTH_chunks]
+        \\ simp[LENGTH_REPLICATE, NULL_EQ]
+        \\ DEP_REWRITE_TAC[EL_chunks]
+        \\ simp[LENGTH_REPLICATE, NULL_EQ]
+        \\ DEP_REWRITE_TAC[LENGTH_chunks]
+        \\ simp[LENGTH_REPLICATE, NULL_EQ]
+        \\ simp[REPLICATE_GENLIST, TAKE_GENLIST]
+        \\ simp[word_from_bin_list_def, l2w_def]
+        \\ qmatch_goalsub_abbrev_tac`A MOD N = 0`
+        \\ `A = 0` suffices_by simp[]
+        \\ qunabbrev_tac`A`
+        \\ simp[l2n_eq_0, EVERY_GENLIST] )
+      \\ simp[LIST_EQ_REWRITE]
+      \\ rpt strip_tac
+      \\ DEP_REWRITE_TAC[EL_MAP]
+      \\ conj_asm1_tac
+      >- (
+        DEP_REWRITE_TAC[LENGTH_chunks]
+        \\ simp[NULL_EQ]
+        \\ (conj_tac \\ strip_tac \\ gs[]))
+      \\ DEP_REWRITE_TAC[EL_chunks]
+      \\ gs[NULL_EQ]
+      \\ conj_tac >- (conj_tac \\ strip_tac \\ gs[])
+      \\ qmatch_goalsub_abbrev_tac`_ ls = _`
+      \\ `LENGTH ls = 8` by simp[Abbr`ls`]
+      \\ drule concat_word_list_bytes_to_64
+      \\ disch_then SUBST_ALL_TAC
+      \\ AP_TERM_TAC
+      \\ simp[Abbr`ls`]
 *)
 
 Definition Keccak_256_bytes_def:

--- a/examples/Crypto/Keccak/keccakScript.sml
+++ b/examples/Crypto/Keccak/keccakScript.sml
@@ -2074,7 +2074,7 @@ Definition pad10s1_136_64w_def:
   else let
     n = 136 - lm;
     pad = if n = 1 then [0x81w] else
-            0x80w::(REPLICATE (n - 2) 0w)++[0x01w];
+            0x01w::(REPLICATE (n - 2) 0w)++[0x80w];
     w64s = MAP concat_word_list $ chunks 8 $ m ++ pad
   in REVERSE $ (w64s ++ zs) :: a
 Termination
@@ -2482,7 +2482,58 @@ Proof
       conj_tac >- (strip_tac \\ gs[])
       \\ strip_tac \\ gs[Abbr`l1`]
       \\ strip_tac \\ gs[] )
-    \\ cheat (* concat_word_list_bytes_to_64, TAKE_FLAT_bytes or similar *) )
+    \\ DEP_REWRITE_TAC[concat_word_list_bytes_to_64]
+    \\ simp[]
+    \\ DEP_REWRITE_TAC[TAKE_FLAT_bytes]
+    \\ simp[]
+    \\ AP_TERM_TAC
+    \\ qunabbrev_tac`ls`
+    \\ AP_TERM_TAC
+    \\ AP_TERM_TAC
+    \\ simp[Abbr`l1`]
+    \\ qmatch_goalsub_abbrev_tac`p1 ++ p2 = p3 ++ p4`
+    \\ `p1 = p3`
+    by (
+      simp[Abbr`p1`,Abbr`p3`,MAP_MAP_o]
+      \\ qmatch_goalsub_abbrev_tac`ls = _`
+      \\ simp[LIST_EQ_REWRITE, EL_MAP, bool_to_bit_def]
+      \\ rw[]
+      \\ qmatch_goalsub_abbrev_tac`b = 0`
+      \\ `MEM b ls` by metis_tac[MEM_EL]
+      \\ pop_assum mp_tac
+      \\ simp[Abbr`ls`, PAD_RIGHT, word_to_bin_list_def,
+              PULL_EXISTS, MEM_GENLIST, MEM_MAP, MEM_FLAT]
+      \\ qx_gen_tac`e` \\ rw[]
+      \\ `b < 2` suffices_by rw[]
+      \\ qspec_then`e`irule(Q.GEN`w`MEM_w2l_less)
+      \\ simp[]
+      \\ metis_tac[])
+    \\ simp[]
+    \\ gs[Abbr`p2`,Abbr`p4`]
+    \\ gs[Abbr`l2`]
+    \\ IF_CASES_TAC
+    >- (
+      `8 * LENGTH m = 1080` by gs[]
+      \\ simp[pad10s1_def, bool_to_bit_def, REPLICATE_GENLIST, PAD_RIGHT] )
+    \\ simp[pad10s1_def, PAD_RIGHT, bool_to_bit_def]
+    \\ simp[REPLICATE_GENLIST]
+    \\ qmatch_goalsub_abbrev_tac`_ = GENLIST _ (n MOD 1088)`
+    \\ gs[]
+    \\ gs[pad10s1_def, ADD1]
+    \\ `n MOD 1088 = 1086 - 8 * LENGTH m` by gs[]
+    \\ pop_assum SUBST1_TAC
+    \\ simp[LIST_EQ_REWRITE, ADD1, LENGTH_FLAT]
+    \\ qmatch_goalsub_abbrev_tac`SUM ls`
+    \\ `ls = REPLICATE (134 - LENGTH m) 8`
+    by simp[Abbr`ls`, LIST_EQ_REWRITE, EL_REPLICATE, EL_MAP]
+    \\ conj_asm1_tac >- simp[SUM_REPLICATE]
+    \\ rw[]
+    \\ qmatch_goalsub_abbrev_tac`EL i ls`
+    \\ `LENGTH ls = 1086 - 8 * LENGTH m`
+    by simp[Abbr`ls`, ADD1, LENGTH_FLAT]
+    \\ `MEM (EL i ls) ls` by metis_tac[MEM_EL]
+    \\ `EVERY (λx. x = 0) ls` suffices_by simp[EVERY_MEM]
+    \\ simp[Abbr`ls`, EVERY_FLAT, EVERY_GENLIST] )
   \\ gs[Abbr`m2`, Abbr`m4`, LIST_EQ_REWRITE, EL_MAP, EL_REPLICATE]
   \\ rw[]
   \\ DEP_REWRITE_TAC[EL_chunks]

--- a/examples/Crypto/Keccak/keccakScript.sml
+++ b/examples/Crypto/Keccak/keccakScript.sml
@@ -2900,17 +2900,17 @@ Proof
   \\ simp[ADD1] \\ rw[]
 QED
 
-Definition theta_w64_def:
-  theta_w64 s =
-  let t = theta_d_w64 s in
-    GENLIST (λi. EL i s ?? EL (i DIV 5) t) 25
-End
-
 Theorem LENGTH_theta_d_w64[simp]:
   LENGTH (theta_d_w64 s) = 5
 Proof
   rw[theta_d_w64_def]
 QED
+
+Definition theta_w64_def:
+  theta_w64 s =
+  let t = theta_d_w64 s in
+    GENLIST (λi. EL i s ?? EL (i MOD 5) t) 25
+End
 
 Theorem LENGTH_theta_w64[simp]:
   LENGTH (theta_w64 s) = 25
@@ -2918,7 +2918,6 @@ Proof
   rw[theta_w64_def]
 QED
 
-(*
 Theorem theta_w64_thm:
   state_bools_64w bs ws /\
   string_to_state_array bs = s
@@ -2984,7 +2983,21 @@ Proof
   \\ DEP_REWRITE_TAC[EL_GENLIST]
   \\ simp[]
   \\ simp[restrict_def, DIV_LT_X]
-*)
+  \\ `i DIV 64 = 0` by simp[DIV_EQ_0]
+  \\ simp[]
+  \\ qmatch_goalsub_abbrev_tac`EL ix bs`
+  \\ qmatch_goalsub_abbrev_tac`s.A t`
+  \\ `EL ix bs = s.A t` suffices_by rw[bool_to_bit_def]
+  \\ rw[string_to_state_array_def, b2w_def, Abbr`t`, restrict_def, DIV_LT_X]
+  \\ rw[Abbr`ix`]
+  \\ AP_THM_TAC
+  \\ AP_TERM_TAC
+  \\ simp[]
+  \\ qspec_then`5`mp_tac DIVISION
+  \\ impl_tac >- rw[]
+  \\ disch_then(qspec_then`x`mp_tac)
+  \\ simp[]
+QED
 
 (*
 TODO: define Rnd w64 version

--- a/examples/Crypto/Keccak/keccakScript.sml
+++ b/examples/Crypto/Keccak/keccakScript.sml
@@ -3040,6 +3040,12 @@ Definition rho_w64_shifts_def:
     ;20 ;13 ;08 ;04 ;05 ;15 ;19 ;10 ;21 ;14 ;11]
 End
 
+Theorem LENGTH_rho_w64_shifts[simp]:
+  LENGTH rho_w64_shifts = 24
+Proof
+  rw[rho_w64_shifts_def]
+QED
+
 Definition rho_w64_def:
   rho_w64 (s: word64 list) =
   HD s ::
@@ -3224,6 +3230,25 @@ Proof
   \\ CONV_TAC(LAND_CONV(SIMP_CONV std_ss [NUMERAL_LESS_THM]))
   \\ strip_tac \\ BasicProvers.VAR_EQ_TAC
   \\ EVAL_TAC
+QED
+
+Theorem rho_w64_MAP2:
+  LENGTH s = 25 ==>
+  rho_w64 s =
+  case s of h::t =>
+    h :: MAP2 (λx y. word_ror x y) t rho_w64_shifts
+  | _ => []
+Proof
+  strip_tac
+  \\ CASE_TAC >- fs[]
+  \\ rewrite_tac[LIST_EQ_REWRITE]
+  \\ conj_tac >- gs[rho_w64_def, LENGTH_TL, ADD1, MIN_DEF]
+  \\ Cases >- rw[rho_w64_def]
+  \\ strip_tac
+  \\ rewrite_tac[rho_w64_def]
+  \\ DEP_REWRITE_TAC[EL_CONS, EL_GENLIST, EL_MAP2]
+  \\ conj_tac >- fs[rho_w64_def, LENGTH_TL]
+  \\ simp[]
 QED
 
 (*

--- a/examples/Crypto/Keccak/keccakScript.sml
+++ b/examples/Crypto/Keccak/keccakScript.sml
@@ -2470,52 +2470,6 @@ Proof
   \\ simp[] \\ strip_tac \\ simp[bool_to_bit_def]
 QED
 
-Theorem word_xor_bits_neq:
-  LENGTH b1 = LENGTH b2 ==>
-  word_from_bin_list b1 ?? word_from_bin_list b2 =
-  word_from_bin_list (MAP (λ(x,y). (x + y) MOD 2) (ZIP (b1, b2)))
-Proof
-  qid_spec_tac`b2`
-  \\ Induct_on`b1`
-  \\ rw[]
-  >- EVAL_TAC
-  \\ Cases_on`b2` \\ gs[]
-  \\ gs[word_from_bin_list_def, l2w_def, l2n_def]
-  \\ gs[GSYM word_add_n2w, GSYM word_mul_n2w]
-  \\ first_x_assum(qspec_then`t`(mp_tac o GSYM))
-  \\ simp[] \\ disch_then kall_tac
-  \\ DEP_REWRITE_TAC[WORD_ADD_XOR]
-  \\ `n2w 2 = n2w (2 ** 1)` by simp[]
-  \\ pop_assum SUBST_ALL_TAC
-  \\ simp[GSYM WORD_MUL_LSL]
-  \\ rewrite_tac[LSL_BITWISE]
-  \\ DEP_REWRITE_TAC[word_and_lsl_eq_0]
-  \\ simp[]
-  \\ conj_tac
-  >- (
-    rw[]
-    \\ Cases_on`2 < dimword(:'a)` \\ gs[MOD_LESS, MOD_MOD_LESS_EQ]
-    \\ Cases_on`dimword(:'a) = 2` \\ gs[MOD_MOD]
-    \\ `dimword(:'a) = 1` by simp[ZERO_LT_dimword]
-    \\ gs[] )
-  \\ rewrite_tac[GSYM WORD_XOR_ASSOC]
-  \\ AP_THM_TAC \\ AP_TERM_TAC
-  \\ AP_THM_TAC \\ AP_TERM_TAC
-  \\ qmatch_goalsub_rename_tac`x + y`
-  \\ `x MOD 2 < 2 ∧ y MOD 2 < 2` by simp[]
-  \\ ntac 2 (pop_assum mp_tac)
-  \\ rewrite_tac[NUMERAL_LESS_THM]
-  \\ Cases_on`ODD (x + y)`
-  >- (
-    `(x + y) MOD 2 = 1` by gs[ODD_MOD2_LEM]
-    \\ gs[ODD_ADD]
-    \\ Cases_on`ODD x` \\ gs[ODD_MOD2_LEM] )
-  \\ gs[GSYM EVEN_ODD]
-  \\ drule (iffLR EVEN_ADD)
-  \\ gs[EVEN_MOD2]
-  \\ Cases_on`x MOD 2 = 0` \\ gs[]
-QED
-
 Theorem xor_state_bools_w64:
   state_bools_w64 b1 w1 /\
   state_bools_w64 b2 w2
@@ -2545,7 +2499,7 @@ Proof
     \\ DEP_REWRITE_TAC[EL_chunks]
     \\ gs[NULL_EQ, bool_to_bit_def, divides_def]
     \\ rw[] \\ strip_tac \\ gs[] )
-  \\ DEP_REWRITE_TAC[word_xor_bits_neq]
+  \\ DEP_REWRITE_TAC[word_from_bin_list_xor]
   \\ simp[]
   \\ DEP_REWRITE_TAC[ZIP_MAP |> SPEC_ALL |> UNDISCH |> cj 1 |> DISCH_ALL]
   \\ DEP_REWRITE_TAC[ZIP_MAP |> SPEC_ALL |> UNDISCH |> cj 2 |> DISCH_ALL]
@@ -2603,7 +2557,7 @@ Proof
   \\ conj_tac >- ( rw[Abbr`n`] \\ strip_tac \\ gs[] )
   \\ conj_tac >- ( rw[Abbr`n`, divides_def] \\ strip_tac \\ gs[] )
   \\ simp[GSYM MAP_DROP, GSYM MAP_TAKE]
-  \\ DEP_REWRITE_TAC[word_xor_bits_neq]
+  \\ DEP_REWRITE_TAC[word_from_bin_list_xor]
   \\ conj_tac >- simp[Abbr`n`]
   \\ AP_TERM_TAC
   \\ DEP_REWRITE_TAC[ZIP_MAP |> SPEC_ALL |> UNDISCH |> cj 1 |> DISCH_ALL]
@@ -2669,7 +2623,7 @@ Proof
   \\ `MIN (n - 1) n = n - 1` by simp[Abbr`n`]
   \\ simp[LASTN_DROP, BUTLASTN_TAKE]
   \\ simp[GSYM MAP_DROP, GSYM MAP_TAKE, DROP_GENLIST, TAKE_GENLIST]
-  \\ DEP_REWRITE_TAC[word_xor_bits_neq]
+  \\ DEP_REWRITE_TAC[word_from_bin_list_xor]
   \\ conj_tac >- simp[Abbr`n`]
   \\ AP_TERM_TAC
   \\ rewrite_tac[GSYM MAP_APPEND, GSYM MAP]
@@ -2743,7 +2697,7 @@ Proof
     \\ DEP_REWRITE_TAC[LENGTH_chunks]
     \\ gs[NULL_EQ]
     \\ rpt strip_tac \\ gs[] )
-  \\ DEP_REWRITE_TAC[word_xor_bits_neq]
+  \\ DEP_REWRITE_TAC[word_from_bin_list_xor]
   \\ conj_tac >- simp[]
   \\ AP_TERM_TAC
   \\ rewrite_tac[GSYM MAP_DROP, GSYM MAP_TAKE]
@@ -3175,7 +3129,7 @@ Proof
     \\ rw[EVERY_MEM] \\ rw[] )
   \\ DEP_REWRITE_TAC[word_from_bin_list_and]
   \\ simp[]
-  \\ DEP_REWRITE_TAC[word_xor_bits_neq]
+  \\ DEP_REWRITE_TAC[word_from_bin_list_xor]
   \\ simp[]
   \\ AP_TERM_TAC
   \\ simp[LIST_EQ_REWRITE, LENGTH_TAKE_EQ]
@@ -3335,7 +3289,7 @@ Proof
   \\ `g = word_from_bin_list (PAD_RIGHT 0 64 $ word_to_bin_list g)`
   by simp[word_from_bin_list_def, word_to_bin_list_def, l2w_w2l]
   \\ pop_assum SUBST1_TAC
-  \\ DEP_REWRITE_TAC[word_xor_bits_neq]
+  \\ DEP_REWRITE_TAC[word_from_bin_list_xor]
   \\ simp[]
   \\ AP_TERM_TAC
   \\ BasicProvers.VAR_EQ_TAC
@@ -3650,7 +3604,7 @@ Proof
       \\ simp[NULL_LENGTH]
       \\ conj_tac >- (rpt strip_tac \\ gs[MAP2_MAP, ZIP_EQ_NIL])
       \\ conj_tac >- (rpt strip_tac \\ gs[MAP2_MAP, ZIP_EQ_NIL])
-      \\ simp[word_xor_bits_neq]
+      \\ simp[word_from_bin_list_xor]
       \\ AP_TERM_TAC
       \\ simp[LIST_EQ_REWRITE]
       \\ rpt strip_tac

--- a/examples/Crypto/Keccak/keccakScript.sml
+++ b/examples/Crypto/Keccak/keccakScript.sml
@@ -3702,7 +3702,12 @@ Theorem iota_w64_RCz_rc_thm:
     bool_to_bit $ rc (7 * i + LOG 2 (SUC z))
   else 0
 Proof
-  simp_tac std_ss [NUMERAL_LESS_THM]
+  strip_tac
+  \\ qpat_x_assum`i < _`mp_tac
+  \\ simp_tac std_ss [NUMERAL_LESS_THM]
+  \\ strip_tac \\ rpt BasicProvers.VAR_EQ_TAC \\ EVAL_TAC
+  \\ pop_assum mp_tac
+  \\ simp_tac std_ss [NUMERAL_LESS_THM]
   \\ strip_tac \\ rpt BasicProvers.VAR_EQ_TAC \\ EVAL_TAC
 QED
 
@@ -3899,15 +3904,56 @@ Proof
   \\ fs[]
 QED
 
+Definition Rnd_w64_def:
+  Rnd_w64 s =
+  iota_w64 $
+  chi_w64 $
+  pi_w64 $
+  rho_w64 $
+  theta_w64 s
+End
+
+Theorem Rnd_w64_thm:
+  state_bools_w64 bs ws ∧
+  string_to_state_array bs = s ∧
+  i < 24 ⇒
+  state_bools_w64 (state_array_to_string (Rnd s i))
+    (Rnd_w64 ws (EL i iota_w64_RCz))
+Proof
+  rewrite_tac[Rnd_w64_def, Rnd_def]
+  \\ strip_tac
+  \\ irule iota_w64_thm
+  \\ rw[]
+  \\ qmatch_goalsub_abbrev_tac`string_to_state_array _ = s`
+  \\ qexists_tac`state_array_to_string s`
+  \\ DEP_REWRITE_TAC[state_array_to_string_to_state_array]
+  \\ simp[Abbr`s`]
+  \\ irule chi_w64_thm
+  \\ qmatch_goalsub_abbrev_tac`string_to_state_array _ = s`
+  \\ qexists_tac`state_array_to_string s`
+  \\ DEP_REWRITE_TAC[state_array_to_string_to_state_array]
+  \\ simp[Abbr`s`]
+  \\ irule pi_w64_thm
+  \\ qmatch_goalsub_abbrev_tac`string_to_state_array _ = s`
+  \\ qexists_tac`state_array_to_string s`
+  \\ DEP_REWRITE_TAC[state_array_to_string_to_state_array]
+  \\ simp[Abbr`s`]
+  \\ irule rho_w64_thm
+  \\ qmatch_goalsub_abbrev_tac`string_to_state_array _ = s`
+  \\ qexists_tac`state_array_to_string s`
+  \\ DEP_REWRITE_TAC[state_array_to_string_to_state_array]
+  \\ simp[Abbr`s`]
+  \\ irule theta_w64_thm
+  \\ metis_tac[]
+QED
+
 (*
-TODO: define Rnd w64 version
 TODO: define (Keccak_p 24) w64 version
 
 Keccak_256_def
 Keccak_def
 sponge_def
 Keccak_p_def
-Rnd_def
 *)
 
 Definition Keccak_256_bytes_def:

--- a/src/n-bit/wordsScript.sml
+++ b/src/n-bit/wordsScript.sml
@@ -5230,6 +5230,54 @@ Proof
   \\ simp[dimword_def]
 QED
 
+Theorem word_from_bin_list_xor:
+  LENGTH b1 = LENGTH b2 ==>
+  word_from_bin_list b1 ?? word_from_bin_list b2 =
+  word_from_bin_list (MAP (\(x,y). (x + y) MOD 2) (ZIP (b1, b2)))
+Proof
+  qid_spec_tac`b2`
+  \\ Induct_on`b1`
+  \\ rw[]
+  >- (EVAL_TAC \\ rw[WORD_XOR_CLAUSES])
+  \\ Cases_on`b2` \\ gs[]
+  \\ gs[word_from_bin_list_def, l2w_def, l2n_def]
+  \\ gs[GSYM word_add_n2w, GSYM word_mul_n2w]
+  \\ first_x_assum(qspec_then`t`(mp_tac o GSYM))
+  \\ simp[] \\ disch_then kall_tac
+  \\ DEP_REWRITE_TAC[WORD_ADD_XOR]
+  \\ `n2w 2 = n2w (2 ** 1)` by simp[]
+  \\ pop_assum SUBST_ALL_TAC
+  \\ simp[GSYM WORD_MUL_LSL]
+  \\ rewrite_tac[LSL_BITWISE]
+  \\ DEP_REWRITE_TAC[word_and_lsl_eq_0]
+  \\ simp[]
+  \\ conj_tac
+  >- (
+    rw[]
+    \\ Cases_on`2 < dimword(:'a)` \\ gs[MOD_LESS, MOD_MOD_LESS_EQ]
+    \\ Cases_on`dimword(:'a) = 2` \\ gs[MOD_MOD]
+    \\ `dimword(:'a) = 1` by simp[ZERO_LT_dimword]
+    \\ gs[] )
+  \\ rewrite_tac[GSYM WORD_XOR_ASSOC, GSYM LSL_BITWISE]
+  \\ AP_THM_TAC \\ AP_TERM_TAC
+  \\ rewrite_tac[Once WORD_XOR_COMM]
+  \\ rewrite_tac[GSYM WORD_XOR_ASSOC]
+  \\ AP_THM_TAC \\ AP_TERM_TAC
+  \\ qmatch_goalsub_rename_tac`x + y`
+  \\ `x MOD 2 < 2 /\ y MOD 2 < 2` by simp[]
+  \\ ntac 2 (pop_assum mp_tac)
+  \\ rewrite_tac[NUMERAL_LESS_THM]
+  \\ Cases_on`ODD (x + y)`
+  >- (
+    `(x + y) MOD 2 = 1` by gs[ODD_MOD2_LEM]
+    \\ gs[ODD_ADD]
+    \\ Cases_on`ODD x` \\ gs[ODD_MOD2_LEM, WORD_XOR_CLAUSES] )
+  \\ gs[GSYM EVEN_ODD]
+  \\ drule (iffLR EVEN_ADD)
+  \\ gs[EVEN_MOD2]
+  \\ Cases_on`x MOD 2 = 0` \\ gs[WORD_XOR_CLAUSES]
+QED
+
 (* -------------------------------------------------------------------------
     Create a few word sizes
    ------------------------------------------------------------------------- *)

--- a/src/parallel_builds/core/Holmakefile
+++ b/src/parallel_builds/core/Holmakefile
@@ -32,7 +32,7 @@ ifdef HOLSELFTESTLEVEL
 # example directories to build at selftest level 1
 EXDIRS = algebra/aat \
          arm/arm6-verification arm/armv8-memory-model arm/experimental \
-         CCS Crypto/RSA Crypto/SHA-2 Hoare-for-divergence MLsyntax \
+         CCS Crypto/RSA Crypto/SHA-2 Crypto/Keccak Hoare-for-divergence MLsyntax \
          PSL/1.01/executable-semantics PSL/1.1/official-semantics \
 	 STE algorithms computability countchars dependability dev \
          developers/ThmSetData \


### PR DESCRIPTION
Define a version that operates on word64s and cv translate that instead of the one based on bool lists (at least for Keccak_256_bytes -- the other Keccak functions are still using the old spts from bool lists).