### PR TITLE
Improved subtree_equiv_lemma without subtree_equiv'

### DIFF
--- a/examples/lambda/barendregt/boehmScript.sml
+++ b/examples/lambda/barendregt/boehmScript.sml
@@ -444,13 +444,13 @@ Proof
  >> qunabbrev_tac ‘M'’
  >> qabbrev_tac ‘Y  = RANK r’
  >> qabbrev_tac ‘Y' = RANK (SUC r)’
- (* #1 *)
+ (* transitivity no.1 *)
  >> Q_TAC (TRANS_TAC SUBSET_TRANS) ‘FV M1’
  >> CONJ_TAC >- (FIRST_X_ASSUM MATCH_MP_TAC >> rw [])
- (* #2 *)
+ (* transitivity no.2 *)
  >> Q_TAC (TRANS_TAC SUBSET_TRANS) ‘FV M0 UNION set vs’
  >> CONJ_TAC >- simp [FV_LAMl]
- (* #3 *)
+ (* transitivity no.3 *)
  >> Q_TAC (TRANS_TAC SUBSET_TRANS) ‘FV M UNION set vs’
  >> CONJ_TAC
  >- (Suff ‘FV M0 SUBSET FV M’ >- SET_TAC [] \\
@@ -611,7 +611,7 @@ Proof
  >> MATCH_MP_TAC EL_MEM >> art []
 QED
 
-(* NOTE: This lemma is suitable for doing induction. A better estimate is
+(* NOTE: This lemma is suitable for doing induction. A better upper bound is
    given by the next [subterm_headvar_lemma'].
  *)
 Theorem subterm_headvar_lemma :
@@ -1814,7 +1814,7 @@ Proof
  >> qabbrev_tac ‘N' = tpm p1 N’ >> T_TAC
  (* finally, using IH in a bulk way *)
  >> FIRST_X_ASSUM MATCH_MP_TAC
- (* extra goal #1 (easy) *)
+ (* extra goal no.1 (easy) *)
  >> CONJ_TAC
  >- (simp [Abbr ‘N'’, SUBSET_DEF, FV_tpm] \\
      rpt STRIP_TAC \\
@@ -1863,7 +1863,7 @@ Proof
      DISJ2_TAC \\
      qunabbrev_tac ‘p1’ \\
      MATCH_MP_TAC MEM_lswapstr >> rw [])
-  (* extra goal #2 (hard) *)
+  (* extra goal no.2 (hard) *)
  >> CONJ_TAC
  >- (simp [Abbr ‘N'’, FV_tpm, SUBSET_DEF] \\
      simp [GSYM lswapstr_append, GSYM REVERSE_APPEND] \\
@@ -3310,6 +3310,14 @@ Proof
  >> qexistsl_tac [‘X’, ‘r’, ‘d’] >> art []
 QED
 
+(* NOTE: This is the first of a series of lemmas of increasing permutators.
+   In theory the proof works if each permutator is larger than the previous
+   one, not necessary increased just by one (which is enough for now).
+
+   In other words, ‘ss = GENLIST (\i. (permutator (d + i),y i)) k’ can be
+   replaced by ‘ss = GENLIST (\i. (permutator (f i),y i)) k’ where ‘f’ is
+   increasing (or non-decreasing).
+ *)
 Theorem solvable_isub_permutator_alt :
     !X r d y k ss M.
        FINITE X /\ FV M SUBSET X UNION RANK r /\
@@ -4235,9 +4243,9 @@ Proof
  >> simp [] >> DISCH_THEN K_TAC
  (* applying SUBSET_MAX_SET *)
  >> MATCH_MP_TAC SUBSET_MAX_SET
- >> CONJ_TAC (* FINITE #1 *)
+ >> CONJ_TAC (* FINITE _ *)
  >- (MATCH_MP_TAC IMAGE_FINITE >> rw [FINITE_prefix])
- >> CONJ_TAC (* FINITE #2 *)
+ >> CONJ_TAC (* FINITE _ *)
  >- (MATCH_MP_TAC IMAGE_FINITE >> rw [FINITE_prefix])
  >> rw [SUBSET_DEF] (* this asserts q' <<= q *)
  >> Know ‘q' <<= t’
@@ -5915,11 +5923,26 @@ QED
 Theorem ltree_equiv_some_bot_imp' =
     ONCE_REWRITE_RULE [ltree_equiv_comm] ltree_equiv_some_bot_imp
 
-(* Definition 10.2.32 (v) [1, p.245] *)
+(* Definition 10.2.32 (v) [1, p.245]
+
+   NOTE: It's assumed that ‘X SUBSET FV M UNION FV N’ in applications.
+ *)
 Definition subtree_equiv_def :
     subtree_equiv X M N p r =
     ltree_equiv (ltree_el (BT' X M r) p) (ltree_el (BT' X N r) p)
 End
+
+Theorem subtree_equiv_refl[simp] :
+    subtree_equiv X M M p r
+Proof
+    rw [subtree_equiv_def]
+QED
+
+Theorem subtree_equiv_comm :
+    !X M N p r. subtree_equiv X M N p r <=> subtree_equiv X N M p r
+Proof
+    rw [subtree_equiv_def, Once ltree_equiv_comm]
+QED
 
 (* This HUGE theorem is an improved version of Lemma 10.3.11 [1. p.251], to be
    proved later in ‘lameta_completeTheory’ as [agree_upto_lemma].
@@ -5940,8 +5963,8 @@ End
    on the construction of Boehm transform ‘pi’.
 
    NOTE: This is the LAST theorem of the current theory, because this proof is
-   so long. Further results (plus users of this lemma) are to be found in next
-   theory (lameta_complete).
+   so long. Further results (plus users of this lemma) are to be found in the
+   next lameta_completeTheory.
  *)
 Theorem subtree_equiv_lemma :
     !X Ms p r.
@@ -6244,7 +6267,7 @@ Proof
      qunabbrev_tac ‘vs’ \\
      MATCH_MP_TAC RNEWS_SUBSET_RANK >> rw [])
  >> DISCH_TAC
- (* A better estimate on ‘y i’ using subterm_headvar_lemma_alt *)
+ (* A better upper bound on ‘y i’ using subterm_headvar_lemma_alt *)
  >> Know ‘!i. i < k ==> y i IN Y UNION set (TAKE (n i) vs)’
  >- (rpt STRIP_TAC \\
      Know ‘FV (M i) SUBSET Y’
@@ -6272,7 +6295,7 @@ Proof
      POP_ASSUM (REWRITE_TAC o wrap) \\
      simp [UNION_SUBSET])
  >> DISCH_TAC
- (* A better estimate on BIGUNION (IMAGE FV (set (args i))) *)
+ (* a better upper bound of BIGUNION (IMAGE FV (set (args i))) *)
  >> Know ‘!i. i < k ==> BIGUNION (IMAGE FV (set (args i))) SUBSET
                         FV (M i) UNION set (TAKE (n i) vs)’
  >- (rpt STRIP_TAC \\

--- a/examples/lambda/barendregt/head_reductionScript.sml
+++ b/examples/lambda/barendregt/head_reductionScript.sml
@@ -2531,6 +2531,21 @@ Proof
  >> PROVE_TAC [hreduce_abs] (* is_abs N *)
 QED
 
+(* NOTE: This theorem depends on LAMl_size and cannot move to chap2Theory *)
+Theorem permutator_11[simp] :
+    permutator m = permutator n <=> m = n
+Proof
+    reverse EQ_TAC >- rw []
+ >> rw [permutator_def, GENLIST]
+ >> qabbrev_tac ‘vs1 = GENLIST n2s m’
+ >> qabbrev_tac ‘vs2 = GENLIST n2s n’
+ >> ‘LENGTH vs1 = m /\ LENGTH vs2 = n’ by rw [Abbr ‘vs1’, Abbr ‘vs2’]
+ >> Q.PAT_X_ASSUM ‘LAMl vs1 _ = LAMl vs2 _’
+      (MP_TAC o AP_TERM “LAMl_size :term -> num”)
+ >> REWRITE_TAC [GSYM LAMl_SNOC, LAMl_size_hnf]
+ >> simp []
+QED
+
 val _ = export_theory()
 val _ = html_theory "head_reduction";
 

--- a/examples/lambda/barendregt/lameta_completeScript.sml
+++ b/examples/lambda/barendregt/lameta_completeScript.sml
@@ -81,7 +81,7 @@ Proof
 QED
 
 (*---------------------------------------------------------------------------*
- *  Separability of terms
+ *  Separability of lambda terms
  *---------------------------------------------------------------------------*)
 
 Theorem separability_lemma0_case2[local] :

--- a/examples/lambda/barendregt/lameta_completeScript.sml
+++ b/examples/lambda/barendregt/lameta_completeScript.sml
@@ -7,7 +7,8 @@
 
 open HolKernel Parse boolLib bossLib;
 
-open hurdUtils arithmeticTheory pred_setTheory listTheory rich_listTheory;
+open hurdUtils arithmeticTheory pred_setTheory listTheory rich_listTheory
+     ltreeTheory llistTheory;
 
 open termTheory basic_swapTheory appFOLDLTheory chap2Theory chap3Theory
      horeductionTheory solvableTheory head_reductionTheory head_reductionLib
@@ -37,13 +38,13 @@ val _ = hide "Y";
  *)
 Definition agree_upto_def :
     agree_upto X Ms p r <=>
-      !M N q. MEM M Ms /\ MEM N Ms /\ q <<= p ==> subtree_equiv X M N q r
+    !M N q. MEM M Ms /\ MEM N Ms /\ q <<= p ==> subtree_equiv X M N q r
 End
 
-(* NOTE: subterm_equiv_lemma and this theorem together implies the original
+(* NOTE: subtree_equiv_lemma and this theorem together implies the original
    agree_upto_lemma (see below).
  *)
-Theorem subterm_equiv_imp_agree_upto :
+Theorem subtree_equiv_imp_agree_upto :
     !X Ms p r pi.
       (!M N q.
          MEM M Ms /\ MEM N Ms /\ q <<= p /\ subtree_equiv X M N q r ==>
@@ -55,22 +56,28 @@ Proof
  >> FIRST_X_ASSUM MATCH_MP_TAC >> art []
 QED
 
+(* Lemma 10.3.11 [1. p.251] *)
 Theorem agree_upto_lemma :
     !X Ms p r.
        FINITE X /\ p <> [] /\ 0 < r /\ Ms <> [] /\
        BIGUNION (IMAGE FV (set Ms)) SUBSET X UNION RANK r /\
        EVERY (\M. subterm X M p r <> NONE) Ms ==>
-      ?pi. Boehm_transform pi /\ EVERY is_ready' (MAP (apply pi) Ms) /\
-          (agree_upto X Ms p r ==> agree_upto X (MAP (apply pi) Ms) p r) /\
-          !M N. MEM M Ms /\ MEM N Ms /\
-                subtree_equiv X (apply pi M) (apply pi N) p r ==>
-                subtree_equiv' X M N p r
+       ?pi. Boehm_transform pi /\ EVERY is_ready' (MAP (apply pi) Ms) /\
+           (agree_upto X Ms p r ==> agree_upto X (MAP (apply pi) Ms) p r) /\
+            !M N. MEM M Ms /\ MEM N Ms /\
+                  subtree_equiv X (apply pi M) (apply pi N) p r ==>
+                  subtree_equiv X M N p r
 Proof
     rpt GEN_TAC
- >> DISCH_THEN (MP_TAC o (MATCH_MP subterm_equiv_lemma))
+ >> DISCH_THEN (MP_TAC o (MATCH_MP subtree_equiv_lemma))
  >> rpt STRIP_TAC
- >> Q.EXISTS_TAC ‘pi’ >> rw []
- >> MATCH_MP_TAC subterm_equiv_imp_agree_upto >> art []
+ >> Q.EXISTS_TAC ‘pi’
+ >> RW_TAC std_ss []
+ >- (MATCH_MP_TAC subtree_equiv_imp_agree_upto >> rw [] \\
+     METIS_TAC [])
+ >> Q.PAT_X_ASSUM ‘!M N q. MEM M Ms /\ MEM N Ms /\ q <<= p ==> _’
+      (MP_TAC o Q.SPECL [‘M’, ‘N’, ‘p’])
+ >> simp []
 QED
 
 (*---------------------------------------------------------------------------*

--- a/examples/lambda/basics/termScript.sml
+++ b/examples/lambda/basics/termScript.sml
@@ -742,6 +742,16 @@ Definition DOM_DEF :
    (DOM ((x,y)::rst) = {y} UNION DOM rst)
 End
 
+Theorem DOM_SNOC :
+    !x y rst. DOM (SNOC (x,y) rst) = {y} UNION DOM rst
+Proof
+    NTAC 2 GEN_TAC
+ >> Induct_on ‘rst’ >- rw [DOM_DEF]
+ >> simp [FORALL_PROD]
+ >> rw [DOM_DEF]
+ >> SET_TAC []
+QED
+
 Theorem DOM_ALT_MAP_SND :
     !phi. DOM phi = set (MAP SND phi)
 Proof
@@ -755,6 +765,16 @@ Definition FVS_DEF :
    (FVS [] = {}) /\
    (FVS ((t,x)::rst) = FV t UNION FVS rst)
 End
+
+Theorem FVS_SNOC :
+    !t x rst. FVS (SNOC (t,x) rst) = FV t UNION FVS rst
+Proof
+    NTAC 2 GEN_TAC
+ >> Induct_on ‘rst’ >- rw [FVS_DEF]
+ >> simp [FORALL_PROD]
+ >> rw [FVS_DEF]
+ >> SET_TAC []
+QED
 
 Theorem FVS_ALT :
     !ss. FVS ss = BIGUNION (set (MAP (FV o FST) ss))
@@ -944,6 +964,14 @@ Proof
      Q.EXISTS_TAC ‘{x}’ >> simp [])
  >> Rewr'
  >> CCONTR_TAC >> gs []
+QED
+
+Theorem ISUB_SNOC :
+    !s x rst t. t ISUB SNOC (s,x) rst = [s/x] (t ISUB rst)
+Proof
+    NTAC 2 GEN_TAC
+ >> Induct_on ‘rst’ >- rw []
+ >> simp [FORALL_PROD]
 QED
 
 (* ----------------------------------------------------------------------


### PR DESCRIPTION
Hi,

This PR improves the previous #1367. With an improved construction of Böhm transform (beyond textbook), I have removed the needs of `subtree_equiv'` and proved a better version of `subtree_equiv_lemma` (NOTE: In previous PR the theorem name was wrongly written in the code as `subterm_equiv_lemma`, this typo is fixed here.):
```
[subtree_equiv_lemma]
⊢ ∀X Ms p r.
    FINITE X ∧ p ≠ [] ∧ 0 < r ∧ Ms ≠ [] ∧
    BIGUNION (IMAGE FV (set Ms)) ⊆ X ∪ RANK r ∧
    EVERY (λM. subterm X M p r ≠ NONE) Ms ⇒
    ∃pi.
      Boehm_transform pi ∧ EVERY is_ready' (MAP (apply pi) Ms) ∧
      (∀M. MEM M Ms ⇒ p ∈ ltree_paths (BT' X (apply pi M) r)) ∧
      ∀M N q.
        MEM M Ms ∧ MEM N Ms ∧ q ≼ p ⇒
        (subtree_equiv X M N q r ⇔
         subtree_equiv X (apply pi M) (apply pi N) q r)
```

The previous added definitions `subtree_equiv'` and `ltree_equiv'`, etc. are now useless and removed.

NOTE: For the next applications of this lemma, the antecedent `EVERY (λM. subterm X M p r ≠ NONE) Ms` may still need to be weaken to `p ∈ ltree_paths (BT' X M r))` or even completely eliminated, and the involved `is_ready'` (a variant of `is_ready`) can then be recovered to the original `is_ready`. These changes will bring a few more trivial cases and further increases the proof size (now `boehmScript.sml` has more than 10K lines.)

--Chun