### PR TITLE
Avoid excessive computation for cv_eval word_lsr

### DIFF
--- a/src/num/theories/cv_compute/automation/cv_primScript.sml
+++ b/src/num/theories/cv_compute/automation/cv_primScript.sml
@@ -904,8 +904,9 @@ QED
 Theorem cv_rep_word_lsr[cv_rep]:
   from_word (word_lsr (w:'a word) n)
   =
-  cv_if (cv_lt (Num n) (Num (dimindex (:'a))))
-    (cv_div (from_word w) (cv_exp (Num 2) (Num n)))
+  let k = Num n in
+  cv_if (cv_lt k (Num (dimindex (:'a))))
+    (cv_div (from_word w) (cv_exp (Num 2) k))
     (Num 0)
 Proof
   gvs [cv_rep_def] \\ rw [] \\ gvs []

--- a/src/num/theories/cv_compute/automation/cv_primScript.sml
+++ b/src/num/theories/cv_compute/automation/cv_primScript.sml
@@ -904,10 +904,15 @@ QED
 Theorem cv_rep_word_lsr[cv_rep]:
   from_word (word_lsr (w:'a word) n)
   =
-  cv_div (from_word w) (cv_exp (Num 2) (Num n))
+  cv_if (cv_lt (Num n) (Num (dimindex (:'a))))
+    (cv_div (from_word w) (cv_exp (Num 2) (Num n)))
+    (Num 0)
 Proof
   gvs [cv_rep_def] \\ rw [] \\ gvs []
-  \\ gvs [from_word_def,cv_exp_def,w2n_lsr]
+  >- gvs [from_word_def,cv_exp_def,w2n_lsr]
+  \\ gvs[from_word_def]
+  \\ irule LSR_LIMIT
+  \\ pop_assum mp_tac \\ rw[]
 QED
 
 Theorem word_asr_add[cv_inline]:


### PR DESCRIPTION
When the shift amount is large we know the result will be 0.

We can do even better for lsl using modexp (see [verifereum](https://github.com/verifereum/verifereum/commit/155bda521dde50155591b44c79dc952ee1a72a7d)), so not touching that here now.