### PR TITLE
[lambda] agree_upto_thm

### DIFF
--- a/examples/lambda/barendregt/chap2Script.sml
+++ b/examples/lambda/barendregt/chap2Script.sml
@@ -1454,6 +1454,48 @@ QED
 (* |- !i n. i < n ==> FV (selector i n) = {} *)
 Theorem FV_selector[simp] = REWRITE_RULE [closed_def] closed_selector
 
+Theorem selector_alt :
+    !X i n. FINITE X /\ i < n ==>
+            ?vs v. LENGTH vs = n /\ ALL_DISTINCT vs /\ DISJOINT X (set vs) /\
+                   v = EL i vs /\ selector i n = LAMl vs (VAR v)
+Proof
+    RW_TAC std_ss [selector_def]
+ >> qabbrev_tac ‘Z = GENLIST n2s n’
+ >> ‘ALL_DISTINCT Z /\ LENGTH Z = n’ by rw [Abbr ‘Z’, ALL_DISTINCT_GENLIST]
+ >> ‘Z <> []’ by rw [NOT_NIL_EQ_LENGTH_NOT_0]
+ >> qabbrev_tac ‘z = EL i Z’
+ >> ‘MEM z Z’ by rw [Abbr ‘z’, EL_MEM]
+ >> ‘n2s i = z’ by rw [Abbr ‘z’, Abbr ‘Z’, EL_GENLIST]
+ >> POP_ORW
+ (* preparing for LAMl_ALPHA_ssub *)
+ >> qabbrev_tac ‘Y = NEWS n (set Z UNION X)’
+ >> ‘FINITE (set Z UNION X)’ by rw []
+ >> ‘ALL_DISTINCT Y /\ DISJOINT (set Y) (set Z UNION X) /\ LENGTH Y = n’
+       by rw [NEWS_def, Abbr ‘Y’]
+ >> fs []
+ >> qabbrev_tac ‘M = VAR z’
+ >> Know ‘LAMl Z M = LAMl Y ((FEMPTY |++ ZIP (Z,MAP VAR Y)) ' M)’
+ >- (MATCH_MP_TAC LAMl_ALPHA_ssub >> rw [Abbr ‘M’] \\
+     Q.PAT_X_ASSUM ‘DISJOINT (set Z) (set Y)’ MP_TAC \\
+     rw [DISJOINT_ALT])
+ >> Rewr'
+ >> ‘Y <> []’ by rw [NOT_NIL_EQ_LENGTH_NOT_0]
+ >> REWRITE_TAC [GSYM fromPairs_def]
+ >> qabbrev_tac ‘fm = fromPairs Z (MAP VAR Y)’
+ >> ‘FDOM fm = set Z’ by rw [FDOM_fromPairs, Abbr ‘fm’]
+ >> qabbrev_tac ‘y = EL i Y’
+ >> Know ‘fm ' M = VAR y’
+ >- (simp [Abbr ‘M’, ssub_appstar] \\
+     rw [Abbr ‘fm’, Abbr ‘z’] \\
+     Know ‘fromPairs Z (MAP VAR Y) ' (EL i Z) = EL i (MAP VAR Y)’
+     >- (MATCH_MP_TAC fromPairs_FAPPLY_EL >> rw []) >> Rewr' \\
+     rw [EL_MAP, Abbr ‘y’])
+ >> Rewr'
+ >> Q.EXISTS_TAC ‘Y’
+ >> rw [Abbr ‘y’]
+QED
+
+(* TODO: rework this proof by (the new) selector_alt *)
 Theorem selector_thm :
     !i n Ns. i < n /\ LENGTH Ns = n ==> selector i n @* Ns == EL i Ns
 Proof

--- a/examples/lambda/barendregt/head_reductionScript.sml
+++ b/examples/lambda/barendregt/head_reductionScript.sml
@@ -639,6 +639,12 @@ Proof
   dsimp[SF CONJ_ss] >> metis_tac[]
 QED
 
+Theorem hnf_absfree_hnf[simp] :
+    hnf (VAR y @* args)
+Proof
+    rw [hnf_appstar]
+QED
+
 (* NOTE: ‘ALL_DISTINCT vs’ has been added to RHS. *)
 Theorem hnf_cases :
     !M : term. hnf M <=> ?vs args y. ALL_DISTINCT vs /\ (M = LAMl vs (VAR y @* args))
@@ -2544,6 +2550,33 @@ Proof
       (MP_TAC o AP_TERM “LAMl_size :term -> num”)
  >> REWRITE_TAC [GSYM LAMl_SNOC, LAMl_size_hnf]
  >> simp []
+QED
+
+(* This theorem is more general than selector_thm *)
+Theorem hreduce_selector :
+    !i n Ns. i < n /\ LENGTH Ns = n ==> selector i n @* Ns -h->* EL i Ns
+Proof
+    rpt STRIP_TAC
+ >> qabbrev_tac ‘X = BIGUNION (IMAGE FV (set Ns))’
+ >> ‘FINITE X’ by rw [Abbr ‘X’]
+ >> MP_TAC (Q.SPECL [‘X’, ‘i’, ‘n’] selector_alt) >> rw []
+ >> POP_ORW
+ >> qabbrev_tac ‘t :term = VAR (EL i vs)’
+ >> qabbrev_tac ‘fm = fromPairs vs Ns’
+ >> ‘FDOM fm = set vs’ by rw [Abbr ‘fm’, FDOM_fromPairs]
+ >> Know ‘EL i Ns = fm ' t’
+ >- (simp [ssub_thm, Abbr ‘t’, EL_MEM] \\
+     simp [Abbr ‘fm’, Once EQ_SYM_EQ] \\
+     MATCH_MP_TAC fromPairs_FAPPLY_EL >> art [])
+ >> Rewr'
+ >> qunabbrev_tac ‘fm’
+ >> MATCH_MP_TAC hreduce_LAMl_appstar
+ >> rw [EVERY_MEM]
+ >> Q.PAT_X_ASSUM ‘DISJIONT X (set vs)’ MP_TAC
+ >> rw [DISJOINT_ALT, Abbr ‘X’]
+ >> FIRST_X_ASSUM irule
+ >> Q.EXISTS_TAC ‘FV e’ >> art []
+ >> Q.EXISTS_TAC ‘e’ >> art []
 QED
 
 val _ = export_theory()

--- a/examples/lambda/barendregt/solvableScript.sml
+++ b/examples/lambda/barendregt/solvableScript.sml
@@ -659,6 +659,20 @@ Proof
  >> MATCH_MP_TAC unsolvable_subst >> art []
 QED
 
+Theorem solvable_hnf[simp] :
+    solvable (LAMl vs (VAR y @* args))
+Proof
+    REWRITE_TAC [solvable_iff_has_hnf]
+ >> MATCH_MP_TAC hnf_has_hnf >> rw []
+QED
+
+Theorem solvable_absfree_hnf[simp] :
+    solvable (VAR y @* args)
+Proof
+    REWRITE_TAC [solvable_iff_has_hnf]
+ >> MATCH_MP_TAC hnf_has_hnf >> rw []
+QED
+
 (*---------------------------------------------------------------------------*
  *  Principle Head Normal Forms (principle_hnf)
  *---------------------------------------------------------------------------*)
@@ -1146,6 +1160,14 @@ Proof
  >> ‘solvable N <=> solvable N0’ by (rw [Abbr ‘N0’]) >> POP_ORW
  >> ‘M0 == N0’ by (rw [Abbr ‘M0’, Abbr ‘N0’, lameq_LAMl_cong])
  >> MATCH_MP_TAC lameq_solvable_cong_lemma >> art []
+QED
+
+Theorem hreduce_solvable_cong :
+    !M N. M -h->* N ==> (solvable M <=> solvable N)
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC lameq_solvable_cong
+ >> MATCH_MP_TAC hreduces_lameq >> art []
 QED
 
 Theorem lameq_principle_hnf :

--- a/examples/lambda/basics/appFOLDLScript.sml
+++ b/examples/lambda/basics/appFOLDLScript.sml
@@ -308,10 +308,18 @@ Proof
 QED
 
 Theorem tpm_LAMl:
-  tpm π (LAMl vs M) = LAMl (listpm string_pmact π vs) (tpm π M)
+    !vs pi M. tpm pi (LAMl vs M) = LAMl (listpm string_pmact pi vs) (tpm pi M)
 Proof
-  Induct_on ‘vs’ >> simp[]
+    Induct_on ‘vs’ >> simp[]
 QED
+
+(* |- !vs pi M.
+        LAMl vs (tpm pi M) =
+        tpm pi (LAMl (listpm string_pmact (REVERSE pi) vs) M)
+ *)
+Theorem LAMl_tpm = tpm_LAMl |> Q.SPECL [‘vs’, ‘REVERSE pi’, ‘tpm pi M’]
+                            |> SRULE [tpm_eql]
+                            |> Q.GENL [‘vs’, ‘pi’, ‘M’]
 
 Theorem tpm_appstar:
   tpm π (M ·· Ms) = tpm π M ·· listpm term_pmact π Ms
@@ -375,10 +383,23 @@ Proof
   ]
 QED
 
+Theorem LAMl_ALPHA_tpm :
+    !xs ys M. LENGTH xs = LENGTH ys /\ ALL_DISTINCT xs /\ ALL_DISTINCT ys /\
+              DISJOINT (set ys) (set xs UNION FV M) ==>
+              LAMl xs M = LAMl ys (tpm (ZIP (xs,ys)) M)
+Proof
+    rpt STRIP_TAC
+ >> Know ‘LAMl xs M = LAMl ys (M ISUB REVERSE (ZIP (MAP VAR ys, xs)))’
+ >- (MATCH_MP_TAC LAMl_ALPHA >> art [])
+ >> Rewr'
+ >> fs [DISJOINT_UNION']
+ >> simp [fresh_tpm_isub, REVERSE_ZIP, MAP_REVERSE]
+QED
+
 Theorem LAMl_ALPHA_ssub :
     !vs vs' M.
        LENGTH vs = LENGTH vs' /\ ALL_DISTINCT vs /\ ALL_DISTINCT vs' /\
-       DISJOINT (LIST_TO_SET vs') (LIST_TO_SET vs UNION FV M) ==>
+       DISJOINT (set vs') (set vs UNION FV M) ==>
        LAMl vs M = LAMl vs' ((FEMPTY |++ ZIP (vs, MAP VAR vs')) ' M)
 Proof
     rpt STRIP_TAC

--- a/examples/lambda/basics/termScript.sml
+++ b/examples/lambda/basics/termScript.sml
@@ -494,6 +494,7 @@ Theorem tpm_subst_out:
 Proof SRW_TAC [][tpm_subst]
 QED
 
+(* Lemma 1.15 (a) [2, p.8] (NOTE: It was Lemma 1.14 (a) of 1st edition of [2]) *)
 Theorem lemma14a[simp]:
   !t. [VAR v/v] t = t
 Proof
@@ -501,6 +502,7 @@ Proof
   SRW_TAC [][SUB_THM, SUB_VAR]
 QED
 
+(* Lemma 1.15 (b) [2, p.8] *)
 Theorem lemma14b:
   !M. ~(v IN FV M) ==> ([N/v] M = M)
 Proof
@@ -605,6 +607,7 @@ Proof
  >> ASM_SET_TAC []
 QED
 
+(* Lemma 1.16 (a) [2, p.9] *)
 Theorem lemma15a:
   !M. v ∉ FV M ==> [N/v]([VAR v/x]M) = [N/x]M
 Proof
@@ -612,6 +615,7 @@ Proof
   SRW_TAC [][SUB_THM, SUB_VAR]
 QED
 
+(* Lemma 1.16 (b) [2, p.9] *)
 Theorem lemma15b:
   v ∉ FV M ==> [VAR u/v]([VAR v/u] M) = M
 Proof SRW_TAC [][lemma15a]
@@ -1928,3 +1932,11 @@ val _ = adjoin_after_completion (fn _ => PP.add_string term_info_string)
 
 val _ = export_theory()
 val _ = html_theory "term";
+
+(* References:
+
+ [1] Barendregt, H.P.: The lambda calculus, its syntax and semantics.
+     College Publications, London (1984).
+ [2] Hindley, J.R., Seldin, J.P.: Lambda-calculus and combinators, an introduction.
+     Second Edition. Cambridge University Press, Cambridge (2008).
+ *)

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -4669,6 +4669,16 @@ Proof
   PROVE_TAC []
 QED
 
+Theorem BIGUNION_IMAGE_SUBSET :
+    !f s t. BIGUNION (IMAGE f s) SUBSET t <=> !x. x IN s ==> f x SUBSET t
+Proof
+    RW_TAC std_ss [BIGUNION_SUBSET, IN_IMAGE]
+ >> reverse EQ_TAC >> rw []
+ >- (FIRST_X_ASSUM MATCH_MP_TAC >> art [])
+ >> FIRST_X_ASSUM MATCH_MP_TAC
+ >> Q.EXISTS_TAC ‘x’ >> art []
+QED
+
 val BIGUNION_IMAGE_UNIV = store_thm (* from util_prob *)
   ("BIGUNION_IMAGE_UNIV",
    ``!f N.


### PR DESCRIPTION
This PR contains the following "agree upto therem" (Proposition 10.3.13 [1, p.253])

```
[agree_upto_thm] (lameta_completeTheory)
⊢ ∀X p Ms r.
    FINITE X ∧ Ms ≠ [] ∧ 0 < r ∧ (∀M. MEM M Ms ⇒ FV M ⊆ X ∪ RANK r) ∧
    (∀M. MEM M Ms ⇒ p ∈ ltree_paths (BT' X M r)) ∧ agree_upto X Ms p r ⇒
    ∃pi. Boehm_transform pi ∧ is_faithful p X Ms pi r
```
where `is_faithful` is defined below:
```
[is_faithful_def] (lameta_completeTheory)
⊢ ∀p X Ms pi r.
    is_faithful p X Ms pi r ⇔
    (∀M. MEM M Ms ⇒ (p ∈ BT_valid_paths M ⇔ solvable (apply pi M))) ∧
    ∀M N.
      MEM M Ms ∧ MEM N Ms ⇒
      (subtree_equiv X M N p r ⇔ equivalent (apply pi M) (apply pi N))
```

Among all newly added lemmas, I have found the following nice alpha-conversion lemma between `LAMl`:
```
[LAMl_ALPHA_tpm] (appFOLDLTheory)
⊢ ∀xs ys M.
    LENGTH xs = LENGTH ys ∧ ALL_DISTINCT xs ∧ ALL_DISTINCT ys ∧
    DISJOINT (set ys) (set xs ∪ FV M) ⇒
    LAMl xs M = LAMl ys (tpm (ZIP (xs,ys)) M)
```

[1] Barendregt, H.P.: The lambda calculus, its syntax and semantics.
     College Publications, London (1984).