### PR TITLE
[ltree] More supporting theorems for rose trees

### DIFF
--- a/src/coalgebras/llistScript.sml
+++ b/src/coalgebras/llistScript.sml
@@ -1,7 +1,11 @@
+(* ===================================================================== *)
+(* FILE          : llistScript.sml                                       *)
+(* DESCRIPTION   : Possibly infinite sequences (llist)                   *)
+(* ===================================================================== *)
 
 open HolKernel boolLib Parse bossLib
 
-open BasicProvers boolSimps markerLib optionTheory ;
+open BasicProvers boolSimps markerLib optionTheory hurdUtils;
 
 val _ = new_theory "llist";
 
@@ -3220,6 +3224,15 @@ Theorem LMAP_fromList:
   LMAP f (fromList l) = fromList(MAP f l)
 Proof
   Induct_on `l` >> fs[]
+QED
+
+Theorem MAP_toList :
+    !ll f. LFINITE ll ==> MAP f (THE (toList ll)) = THE (toList (LMAP f ll))
+Proof
+    rpt STRIP_TAC
+ >> ‘ll = fromList (THE (toList ll))’ by METIS_TAC [to_fromList]
+ >> POP_ORW
+ >> simp [LMAP_fromList, to_fromList, from_toList]
 QED
 
 Theorem exists_fromSeq[simp]:

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -1767,6 +1767,13 @@ val MEM_EL = store_thm(
     ASM_MESON_TAC []
   ]);
 
+Theorem EL_MEM :
+    !n l. n < LENGTH l ==> MEM (EL n l) l
+Proof
+    RW_TAC std_ss [MEM_EL]
+ >> Q.EXISTS_TAC ‘n’ >> ASM_REWRITE_TAC []
+QED
+
 val SUM_MAP_PLUS_ZIP = store_thm(
   "SUM_MAP_PLUS_ZIP",
   “!ls1 ls2.

--- a/src/list/src/rich_listScript.sml
+++ b/src/list/src/rich_listScript.sml
@@ -2302,14 +2302,7 @@ val TAKE_SEG_DROP = Q.store_thm("TAKE_SEG_DROP",
   first_x_assum (Q.SPECL_THEN [‘SUC n’, ‘m’] mp_tac) >>
   SIMP_TAC (srw_ss() ++ numSimps.ARITH_ss) [ADD1]);
 
-val EL_MEM = Q.store_thm ("EL_MEM",
-   `!n l. n < LENGTH l ==> (MEM (EL n l) l)`,
-   INDUCT_TAC
-   THEN LIST_INDUCT_TAC
-   THEN ASM_REWRITE_TAC [LENGTH, EL, HD, TL, NOT_LESS_0, LESS_MONO_EQ, MEM]
-   THEN REPEAT STRIP_TAC
-   THEN DISJ2_TAC
-   THEN RES_TAC);
+Theorem EL_MEM = listTheory.EL_MEM
 
 val TL_SNOC = Q.store_thm ("TL_SNOC",
    `!x l. TL (SNOC x l) = if NULL l then [] else SNOC x (TL l)`,
@@ -4423,6 +4416,13 @@ Theorem HD_APPEND:
   !h t ls. HD (h::t ++ ls) = h
 Proof
   simp[]
+QED
+
+Theorem HD_APPEND_NOT_NIL :
+  !l1 l2. l1 <> [] ==> HD (l1 ++ l2) = HD l1
+Proof
+    rpt GEN_TAC
+ >> Cases_on ‘l1’ >> rw [HD_APPEND]
 QED
 
 (* Theorem: 0 <> n ==> (EL (n-1) t = EL n (h::t)) *)


### PR DESCRIPTION
Hi,

This PR adds some useful definitions and theorems for the "rose tree" inside `ltreeTheory`.

In `ltreeTheory`, there's a "rose tree" [*] inductively defined by a regular use of the datatype package:
```
Datatype:
  rose_tree = Rose 'a (rose_tree list)
End
```
and the constant `from_rose` is defined to map any rose tree into a corresponding ltree (this is always possible):
```
   [from_rose_def]  Theorem (ltreeTheory)      
      ⊢ ∀ts a.
          from_rose (Rose a ts) =
          Branch a (fromList (MAP (λa'. from_rose a') ts))
```
On the other hand, for any ltree which is finite (`ltree_finite`), there exists a corresponding rose tree:
```
   [ltree_finite_from_rose]  Theorem
      ⊢ ltree_finite t ⇔ ∃r. from_rose r = t
```
This is basically all we had before for the rose trees.

In this PR, first, I proved that the mapping `from_rose` is injective (by induction on one of the two rose trees):
```
   [from_rose_11]  Theorem      
      ⊢ ∀r1 r2. from_rose r1 = from_rose r2 ⇔ r1 = r2
```
Then, using the injective result and the above `ltree_finite_from_rose` theorem, I defined the constant `to_rose` for mapping ltree to rose tree (this is only possible when the ltree is finite) and proved the from/to relationships:
```
   [to_rose_def]  Definition      
      ⊢ ∀t. ltree_finite t ⇒ from_rose (to_rose t) = t

   [to_rose_thm]  Theorem      
      ⊢ ∀r. to_rose (from_rose r) = r
```
Then, I added the following accessor contants for easy accessing rose tree components (ltree has them too):
```
   [rose_children_def]  Definition      
      ⊢ ∀a ts. rose_children (Rose a ts) = ts
   
   [rose_node_def]  Definition      
      ⊢ ∀a ts. rose_node (Rose a ts) = a
```
And I prove what happens if these accessors were put on a rose tree converted from a (finite) ltree:
```
   [rose_node_to_rose]  Theorem      
      ⊢ ∀t. ltree_finite t ⇒ rose_node (to_rose t) = ltree_node t

   [rose_children_to_rose]  Theorem      
      ⊢ ∀t. ltree_finite t ⇒
            rose_children (to_rose t) =
            MAP to_rose (THE (toList (ltree_children t)))
   
   [rose_children_to_rose']  Theorem      
      ⊢ ∀t. ltree_finite t ⇒
            rose_children (to_rose t) =
            THE (toList (LMAP to_rose (ltree_children t)))
```
Finally, I added the following `rose_reduce` function as a general recursive function on rose trees:
```
   [rose_reduce_def]  Theorem      
      ⊢ ∀ts f a.
          rose_reduce f (Rose a ts) = f a (MAP (λa'. rose_reduce f a') ts)
```
There's no other supporting theorems for this `rose_reduce`, but I'm using it to re-construct lambda-terms from their Boehm trees (when they are finite and are mapped to rose trees).

--Chun

[*] But, according to Wikipedia [1], "rose tree" a term for the value of a tree data structure with a variable and **unbounded** number of branches per node. Our "rose tree" here is only finite branching.
[1] https://en.wikipedia.org/wiki/Rose_tree