### PR TITLE
disable export_theory in interactive mode

### DIFF
--- a/src/datatype/theory_tests/monofldBScript.sml
+++ b/src/datatype/theory_tests/monofldBScript.sml
@@ -30,4 +30,5 @@ val _ = if msg = "" then print "No message\n"
 
 val _ = save_thm("MFB", TRUTH)
 
+val _ = Globals.interactive := false
 val _ = export_theory();

--- a/src/postkernel/Theory.sig
+++ b/src/postkernel/Theory.sig
@@ -57,6 +57,7 @@ sig
   val adjoin_after_completion: (unit -> HOLPP.pretty) -> unit
   val quote_adjoin_to_theory : string quotation -> string quotation -> unit
   val export_theory          : unit -> unit
+  val disable_export_theory  : bool ref
 
 (* Make hooks available so that theory changes can be seen by
    "interested parties" *)

--- a/src/postkernel/Theory.sig
+++ b/src/postkernel/Theory.sig
@@ -57,7 +57,6 @@ sig
   val adjoin_after_completion: (unit -> HOLPP.pretty) -> unit
   val quote_adjoin_to_theory : string quotation -> string quotation -> unit
   val export_theory          : unit -> unit
-  val disable_export_theory  : bool ref
 
 (* Make hooks available so that theory changes can be seen by
    "interested parties" *)

--- a/src/postkernel/Theory.sml
+++ b/src/postkernel/Theory.sml
@@ -886,6 +886,8 @@ val new_theory_time = ref (total_cpu (Timer.checkCPUTimer Globals.hol_clock))
 val report_times = ref true
 val _ = Feedback.register_btrace ("report_thy_times", report_times)
 
+val disable_export_theory = ref false
+
 local
   val mesg = Lib.with_flag(Feedback.MESG_to_string, Lib.I) HOL_MESG
   fun maybe_log_time_to_disk thyname timestr = let
@@ -909,7 +911,7 @@ local
     | NONE => ()
   end
 in
-fun export_theory () = let
+fun export_theory () = if !disable_export_theory then () else let
   val _ = call_hooks (TheoryDelta.ExportTheory (current_theory()))
   val {thid,facts,adjoin,adjoinpc,thydata,mldeps,...} = scrubCT()
   val all_thms = Symtab.fold(fn (s,(th,i)) => fn A => (s,th,i)::A) facts []

--- a/src/postkernel/Theory.sml
+++ b/src/postkernel/Theory.sml
@@ -886,8 +886,6 @@ val new_theory_time = ref (total_cpu (Timer.checkCPUTimer Globals.hol_clock))
 val report_times = ref true
 val _ = Feedback.register_btrace ("report_thy_times", report_times)
 
-val disable_export_theory = ref false
-
 local
   val mesg = Lib.with_flag(Feedback.MESG_to_string, Lib.I) HOL_MESG
   fun maybe_log_time_to_disk thyname timestr = let
@@ -911,7 +909,7 @@ local
     | NONE => ()
   end
 in
-fun export_theory () = if !disable_export_theory then () else let
+fun export_theory () = if !Globals.interactive then () else let
   val _ = call_hooks (TheoryDelta.ExportTheory (current_theory()))
   val {thid,facts,adjoin,adjoinpc,thydata,mldeps,...} = scrubCT()
   val all_thms = Symtab.fold(fn (s,(th,i)) => fn A => (s,th,i)::A) facts []


### PR DESCRIPTION
~~Also a possibility: using `Globals.interactive` as the default value of the flag. I decided not to because I am not sure if users like to run `export_theory` manually in REPL sessions (they shouldn't).~~ Edit: implemented

This flag is needed to prevent hol4-vscode from generating actual theory outputs when the server reads and runs the file in fast-cheat mode. (Yes, I tried rebinding `export_theory`. It's not reliable because the massive block of opens at the top of most script files has a tendency to re-rebind it.)