### PR TITLE
add theory of coinduction up-to context

### DIFF
--- a/examples/lambda/barendregt/lameta_completeScript.sml
+++ b/examples/lambda/barendregt/lameta_completeScript.sml
@@ -1443,6 +1443,24 @@ Proof
  >> Q_TAC (TRANS_TAC SUBSET_TRANS) ‘FV M’ >> art []
 QED
 
+Theorem ltree_finite_BT_has_benf :
+    !X M r. FINITE X /\ FV M SUBSET X UNION RANK r /\ has_benf M ==>
+            ltree_finite (BT' X M r)
+Proof
+    rw [has_benf_has_bnf]
+ >> MATCH_MP_TAC ltree_finite_BT_has_bnf >> art []
+QED
+
+Theorem ltree_finite_BT_benf :
+    !X M r. FINITE X /\ FV M SUBSET X UNION RANK r /\ benf M ==>
+            ltree_finite (BT' X M r)
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC ltree_finite_BT_has_benf
+ >> rw [has_benf_def]
+ >> Q.EXISTS_TAC ‘M’ >> rw [lameta_REFL]
+QED
+
 (*---------------------------------------------------------------------------*
  *  Separability of (two) lambda terms
  *---------------------------------------------------------------------------*)

--- a/src/coalgebras/companionScript.sml
+++ b/src/coalgebras/companionScript.sml
@@ -179,7 +179,7 @@ Proof
   drule_then irule poset_antisym >> rw[]
   >- (fs[companion_def, function_in, bottom_def])
   >- (fs[gfp_def])
-  (* t⊥ <= tb⊥ <= bt⊥ *)
+  (* t0 <= tb0 <= bt0 *)
   >- (match_mp_tac gfp_coinduct >>
       ‘function s s t’ by fs[companion_def] >>
       fs[function_in, bottom_def] >>
@@ -685,7 +685,8 @@ Proof
           drule_then irule poset_trans >>
           rw[SF SFY_ss, endo_in, endo_function] >-
            (metis_tac[companion_def, function_def, endo_def]) >>
-          qexists_tac ‘t x'³'’ >> rw[SF SFY_ss, endo_in] >-
+          rename1 ‘_ /\ r (b a) _ /\ _’ >>
+          qexists_tac ‘t a’ >> rw[SF SFY_ss, endo_in] >-
            (‘lift_rel (s,r) b t’ suffices_by rw[lift_rel] >>
             drule_then irule compatible_below_companion >>
             metis_tac[compatible_self, function_def, endo_def, lift_rel]) >>
@@ -788,7 +789,7 @@ Proof
   rw[set_compatible_def, monotone_def, gfp_greatest_fixedpoint]
 QED
 
-(* to prove X is in a coinductive set from b, consider t⊥ *)
+(* to prove X is in a coinductive set from b, consider t0 *)
 Theorem set_param_coind_init:
   monotone b /\
   X SUBSET set_companion b {}

--- a/src/coalgebras/companionScript.sml
+++ b/src/coalgebras/companionScript.sml
@@ -1,0 +1,703 @@
+(*
+  This development is based on Damien Pous' "Coinduction All the Way Up,
+  including the derivation of parameterized coinduction system.
+*)
+open HolKernel Parse boolLib bossLib;
+open pred_setTheory;
+open posetTheory;
+
+val _ = new_theory "companion";
+
+Theorem glb_unique:
+  poset (s,r) /\
+  glb (s,r) P x /\ glb (s,r) P y
+  ==> x = y
+Proof
+  rw[glb_def] >>
+  drule_then irule poset_antisym >> simp[]
+QED
+
+Theorem lub_unique:
+  poset (s,r) /\
+  lub (s,r) P x /\ lub (s,r) P y
+  ==> x = y
+Proof
+  rw[lub_def] >>
+  drule_then irule poset_antisym >> simp[]
+QED
+
+Theorem lub_is_gfp:
+  poset (s,r) /\ function s s f /\ monotonic (s,r) f /\
+  lub (s,r) { x | r x (f x) } l
+  ==> gfp (s,r) f l
+Proof
+  rw[lub_def, gfp_def, monotonic_def, function_def] >>
+  subgoal ‘r l (f l)’ >-
+   (first_x_assum irule >> rw[] >>
+    drule_then irule poset_trans >>
+    first_assum $ irule_at Any >> rw[]) >>
+  drule_then irule poset_antisym >> rw[]
+QED
+
+(* core *)
+
+Definition lift_rel:
+  lift_rel (s,r) f g = !x. s x ==> r (f x) (g x)
+End
+
+(* f (b x) steps to f x *)
+Definition compatible_def:
+  compatible (s,r) b f = (function s s f /\ monotonic (s,r) f /\
+                          lift_rel (s,r) (f o b) (b o f))
+End
+
+Theorem compatible_self:
+  poset (s,r) /\ function s s b /\ monotonic (s,r) b
+  ==> compatible (s,r) b b
+Proof
+  rw[poset_def, compatible_def, function_def, lift_rel]
+QED
+
+Theorem compatible_id:
+  poset (s,r) /\ function s s b /\ monotonic (s,r) b
+  ==> compatible (s,r) b I
+Proof
+  rw[compatible_def, monotonic_def, poset_def, function_def, lift_rel]
+QED
+
+(* this technique is 'complete' for valid deductions *)
+Theorem compatible_const_gfp:
+  poset (s,r) /\ function s s b /\ monotonic (s,r) b /\
+  gfp (s,r) b fp
+  ==> compatible (s,r) b (K fp)
+Proof
+  rw[compatible_def, gfp_def, poset_def, monotonic_def,
+     function_def, lift_rel]
+QED
+
+(* λX. BIGUNION {f X | f | compatible b f} *)
+Definition companion_def:
+  companion (s,r) b t = (function s s t /\
+     !x. lub (s,r) { f x | f | compatible (s,r) b f } (t x))
+End
+
+Theorem compatible_below_companion:
+  poset (s,r) /\
+  compatible (s,r) b f /\ companion (s,r) b t
+  ==> lift_rel (s,r) f t
+Proof
+  rw[companion_def, lift_rel] >>
+  ‘function s s f’ by fs[compatible_def] >>
+  gvs[lub_def, PULL_EXISTS, function_def]
+QED
+
+(* f x <= f y <= t y is upper bound, compatible f must be mono *)
+Theorem companion_mono:
+  poset (s,r) /\ function s s b /\ monotonic (s,r) b /\
+  companion (s,r) b t ==> monotonic (s,r) t
+Proof
+  rw[companion_def, lub_def, PULL_EXISTS] >>
+  drule_all_then strip_assume_tac compatible_self >>
+  rw[monotonic_def] >>
+  first_assum $ qspec_then ‘x’ strip_assume_tac >>
+  pop_assum match_mp_tac >> rw[] >>
+  (* establish fx < ty *)
+  last_x_assum $ qspec_then ‘y’ strip_assume_tac >> pop_assum kall_tac >>
+  pop_assum $ qspec_then ‘f’ strip_assume_tac >>
+  fs[compatible_def, poset_def, function_def] >>
+  metis_tac[compatible_def, monotonic_def]
+QED
+
+Theorem compatible_companion:
+  poset (s,r) /\ function s s b /\ monotonic (s,r) b /\
+  companion (s,r) b t ==> compatible (s,r) b t
+Proof
+  rw[compatible_def]
+  >- (fs[companion_def])
+  >- (metis_tac[companion_mono]) >>
+  rw[lift_rel] >>
+  gvs[companion_def, lub_def, PULL_EXISTS] >>
+  first_assum $ qspec_then ‘b x’ strip_assume_tac >>
+  pop_assum irule >>
+  rw[function_in] >>
+  fs[compatible_def] >>
+  drule_then irule poset_trans >>
+  rw[function_in] >>
+  qexists_tac ‘b (f x)’ >>
+  gvs[function_def, monotonic_def, lift_rel]
+QED
+
+Theorem compatible_compose:
+  poset (s,r) /\ function s s b /\ monotonic (s,r) b /\
+  compatible (s,r) b f /\ compatible (s,r) b g
+  ==> compatible (s,r) b (f o g)
+Proof
+  rw[compatible_def, lift_rel] >-
+   (fs[function_def]) >-
+   (fs[function_in, monotonic_def]) >>
+  ‘r (f (g (b x))) (f (b (g x)))’ by metis_tac[monotonic_def, function_in] >>
+  drule_then irule poset_trans >> rw[function_in] >>
+  metis_tac[function_in]
+QED
+
+Theorem companion_gt:
+  poset (s,r) /\ function s s b /\ monotonic (s,r) b /\
+  companion (s,r) b t /\
+  s x ==> r x (t x)
+Proof
+  strip_tac >>
+  ‘lift_rel (s,r) I t’ suffices_by rw[lift_rel] >>
+  ho_match_mp_tac compatible_below_companion >>
+  rw[function_def, compatible_companion] >>
+  rw[GSYM combinTheory.I_EQ_IDABS, compatible_id]
+QED
+
+Theorem companion_idem:
+  poset (s,r) /\ function s s b /\ monotonic (s,r) b /\
+  companion (s,r) b t /\
+  s x ==> t (t x) = t x
+Proof
+  rw[] >>
+  ‘function s s t’ by fs[companion_def] >>
+  drule_then irule poset_antisym >>
+  rw[function_in] >-
+   (‘lift_rel (s,r) (t o t) t’ suffices_by rw[lift_rel] >>
+    ho_match_mp_tac compatible_below_companion >>
+    rw[function_def, GSYM combinTheory.o_DEF] >>
+    irule compatible_compose >>
+    rw[compatible_companion]) >-
+   (metis_tac[companion_def, function_def, companion_gt])
+QED
+
+Theorem companion_bot_gfp:
+  poset (s,r) /\ monotonic (s,r) b /\ function s s b /\
+  bottom (s,r) bot /\ gfp (s,r) b gfix /\
+  companion (s,r) b t
+  ==> t bot = gfix
+Proof
+  rw[] >>
+  drule_then irule poset_antisym >> rw[]
+  >- (fs[companion_def, function_in, bottom_def])
+  >- (fs[gfp_def])
+  (* t⊥ <= tb⊥ <= bt⊥ *)
+  >- (match_mp_tac gfp_coinduct >>
+      ‘function s s t’ by fs[companion_def] >>
+      fs[function_in, bottom_def] >>
+      drule_then match_mp_tac poset_trans >>
+      qexists_tac ‘t (b bot)’ >>
+      rw[bottom_def, function_in]
+      >- (irule (iffLR monotonic_def) >> metis_tac[companion_mono, function_def]) >>
+      ‘compatible (s,r) b t’ suffices_by fs[compatible_def, lift_rel] >>
+      irule compatible_companion >> rw[])
+  >- (drule_all compatible_const_gfp >> strip_tac >>
+      fs[companion_def, lub_def] >>
+      first_x_assum $ qspec_then ‘bot’ strip_assume_tac >>
+      first_x_assum irule >>
+      fs[gfp_def] >>
+      qexists_tac ‘K gfix’ >> rw[function_def])
+QED
+
+(* any post fixpoint is below the greatest fixpoint *)
+Theorem companion_coinduct:
+  poset (s,r) /\ monotonic (s,r) b /\ function s s b /\
+  companion (s,r) b t /\
+  gfp (s,r) b gfix /\
+  s x /\ r x ((b o t) x) ==> r x gfix
+Proof
+  rw[] >>
+  ‘function s s t’ by fs[companion_def] >>
+  drule_then match_mp_tac poset_trans >>
+  qexists_tac ‘t x’ >> rw[function_in]
+  >- (fs[gfp_def])
+  >- (ho_match_mp_tac companion_gt >> rw[]) >>
+  match_mp_tac gfp_coinduct >>
+  rw[function_in] >>
+  drule_all compatible_companion >> strip_tac >>
+  drule_then match_mp_tac poset_trans >>
+  qexists_tac ‘t (b (t x))’ >>
+  reverse (rw[function_in])
+  >- (fs[compatible_def, lift_rel] >>
+      metis_tac[companion_idem, function_def]) >>
+  metis_tac[monotonic_def, companion_mono, function_in]
+QED
+
+(* bt is a sound enhancement *)
+Theorem enhanced_gfp:
+  poset (s,r) /\ monotonic (s,r) b /\ function s s b /\
+  gfp (s,r) b gfix /\
+  companion (s,r) b t /\ gfp (s,r) (b o t) efix
+  ==> efix = gfix
+Proof
+  rw[] >>
+  ‘function s s t’ by fs[companion_def] >>
+  drule_then irule poset_antisym >> rw[]
+  >- (fs[gfp_def])
+  >- (fs[gfp_def])
+  >- (drule_then match_mp_tac companion_coinduct >>
+      qexistsl_tac [‘t’,‘b’] >>
+      fs[gfp_def, poset_def]) >>
+  irule gfp_coinduct >>
+  qexistsl_tac [‘(b o t)’, ‘s’] >>
+  fs[gfp_def] >>
+  metis_tac[monotonic_def, function_def, companion_gt]
+QED
+
+(*
+ * parameterized coinduction
+ *)
+
+Theorem param_coind_init:
+  poset (s,r) /\ monotonic (s,r) b /\ function s s b /\
+  bottom (s,r) bot /\ gfp (s,r) b gfix /\
+  companion (s,r) b t
+  ==> r x (t bot) ==> r x gfix
+Proof
+  metis_tac[companion_bot_gfp]
+QED
+
+Theorem param_coind_done:
+  poset (s,r) /\ monotonic (s,r) b /\ function s s b /\
+  companion (s,r) b t
+  ==> s x /\ s y /\ r y x ==> r y (t x)
+Proof
+  rw[] >>
+  ‘function s s t’ by fs[companion_def] >>
+  drule_then match_mp_tac poset_trans >>
+  qexists_tac ‘x’ >> rw[function_in] >>
+  metis_tac[companion_gt]
+QED
+
+Theorem param_coind_upto_f:
+  poset (s,r) /\ monotonic (s,r) b /\ function s s b /\
+  companion (s,r) b t
+  ==> function s s f /\ (!x. r (f x) (t x))
+  ==> s x /\ s y /\ r y (f (t x))
+  ==> r y (t x)
+Proof
+  rw[] >>
+  drule_then match_mp_tac poset_trans >>
+  first_x_assum $ irule_at Any >>
+  ‘function s s t’ by fs[companion_def] >>
+  simp[function_in] >>
+  metis_tac[companion_idem]
+QED
+
+(*
+ * parameterized formalization following the cawu paper with 2nd order lattice
+ *)
+
+Definition endo_def:
+  endo (s,r) f = (monotonic (s,r) f /\ !x. if s x then s (f x) else f x = @y. ~(s y))
+End
+
+Definition endo_lift_def:
+  endo_lift (s,r) = (endo (s,r) , lift_rel (s,r))
+End
+
+Theorem endo_in:
+  endo (s,r) t /\ s x ==> s (t x)
+Proof
+  rw[endo_def] >> metis_tac[]
+QED
+
+(* this is one reason why we need choose instead of ARB (which can be in s) *)
+Theorem endo_comp:
+  endo (s,r) f /\ endo (s,r) g ==> endo (s,r) (f o g)
+Proof
+  rw[endo_def] >-
+   (metis_tac[monotonic_comp, function_def]) >>
+  rw[] >> metis_tac[]
+QED
+
+Theorem endo_poset:
+  poset (s,r) ==> poset (endo_lift (s,r))
+Proof
+  rw[poset_def, endo_lift_def, lift_rel, endo_def]
+  >- (qexists_tac ‘λx. if s x then x else @y. ~s y’ >> rw[monotonic_def])
+  >- (metis_tac[])
+  >- (rw[FUN_EQ_THM] >> metis_tac[])
+  >- (metis_tac[])
+QED
+
+Definition B_join_def:
+  B_join (s,r) b B =
+  (function (endo (s,r)) (endo (s,r)) B /\ monotonic (endo_lift (s,r)) B /\
+   !g x. lub (s,r) { f x | f | endo (s,r) f /\ lift_rel (s,r) (f o b) (b o g) }
+             (B g x))
+End
+
+Theorem compatible_B_functional_postfix:
+  poset (s,r) /\ endo (s,r) b /\
+  B_join (s,r) b B /\
+  endo (s,r) f ==>
+  (lift_rel (s,r) f (B f) <=> lift_rel (s,r) (f o b) (b o f))
+Proof
+  reverse (rw[B_join_def, EQ_IMP_THM]) >-
+   (fs[lub_def, lift_rel] >> metis_tac[endo_in]) >>
+  (* look pointwise since the predicate is pointwise *)
+  subgoal ‘lift_rel (s,r) (B f o b) (b o f)’ >-
+   (fs[lub_def] >> rw[lift_rel] >>
+    first_x_assum $ qspecl_then [‘f’, ‘b x’] strip_assume_tac >>
+    first_x_assum irule >> rw[SF SFY_ss, endo_in] >>
+    fs[lift_rel]) >>
+  fs[lift_rel] >> rw[endo_in] >>
+  drule_then irule poset_trans >> rw[SF SFY_ss, endo_in] >>
+  fs[endo_lift_def] >>
+  metis_tac[endo_in, monotonic_def, function_def]
+QED
+
+Theorem endo_function:
+  endo (s,r) f ==> function s s f
+Proof
+  metis_tac[endo_def, function_def]
+QED
+
+Theorem B_greatest_fixpoint_is_companion:
+  poset (s,r) /\ endo (s,r) b /\
+  endo (s,r) t /\ companion (s,r) b t /\
+  B_join (s,r) b B
+  ==> gfp (endo_lift (s,r)) B t
+Proof
+  rw[EQ_IMP_THM] >>
+  drule endo_poset >> rw[] >>
+  fs[endo_lift_def] >>
+  qabbrev_tac ‘t' = (λx. if s x then t x else @y. ~s y)’ >>
+  subgoal ‘lub (endo (s,r),lift_rel (s,r)) {f | lift_rel (s,r) f (B f)} t'’ >-
+   (‘endo (s,r) t'’
+      by fs[Abbr ‘t'’, endo_def, monotonic_def, companion_def, function_def] >>
+    ‘compatible (s,r) b t’ by
+      metis_tac[compatible_companion, function_def, endo_def] >>
+     fs[companion_def, lub_def] >> rw[] >-
+     (rw[lift_rel] >>
+      last_x_assum $ qspec_then ‘x’ strip_assume_tac >>
+      fs[Abbr ‘t'’] >>
+      first_x_assum irule >> rw[SF SFY_ss, endo_in] >>
+      qexists_tac ‘y’ >> rw[compatible_def] >-
+       (metis_tac[endo_in, function_def]) >-
+       (fs[endo_def]) >>
+      metis_tac[compatible_B_functional_postfix]) >>
+    pop_assum irule >> rw[] >>
+    ‘lift_rel (s,r) (t' o b) (b o t')’
+      suffices_by metis_tac[compatible_B_functional_postfix] >>
+    fs[compatible_def, lift_rel, Abbr ‘t'’] >>
+    rw[] >>
+    metis_tac[endo_in]) >>
+  subgoal ‘lift_rel (s,r) (t' o b) (b o t')’ >-
+   (drule_then irule (iffLR compatible_B_functional_postfix) >>
+    fs[lub_def] >>
+    qexists_tac ‘B’ >> rw[] >>
+    first_x_assum irule >>
+    reverse conj_tac >- (fs[B_join_def, function_def, endo_lift_def]) >>
+    rw[] >>
+    fs[B_join_def, endo_lift_def] >>
+    ‘lift_rel (s,r) y t'’ by metis_tac[] >>
+    drule_then irule poset_trans >>
+    fs[function_def] >>
+    qexists_tac ‘B y’ >> rw[] >>
+    ‘monotonic (endo (s,r),lift_rel (s,r)) B’ by fs[endo_def] >>
+    fs[monotonic_def]) >>
+  subgoal ‘compatible (s,r) b t’ >-
+   (drule_then irule compatible_companion >>
+    fs[endo_def, function_def] >> metis_tac[]) >>
+  drule_all compatible_B_functional_postfix >> rw[] >>
+  (* argument: gfp B = lub of postfix points = lub of compat functions *)
+  irule lub_is_gfp >> rw[] >-
+   (metis_tac[endo_def, function_def, B_join_def, endo_lift_def]) >-
+   (fs[B_join_def, endo_lift_def, endo_def]) >>
+  ‘t = t'’ suffices_by metis_tac[] >>
+  drule_then irule poset_antisym >>
+  fs[B_join_def, companion_def, lub_def] >>
+  rw[] >-
+   (last_x_assum $ drule_then irule >> fs[compatible_def]) >>
+  rw[lift_rel] >>
+  last_x_assum $ qspec_then ‘x’ strip_assume_tac >>
+  first_x_assum irule >>
+  rw[SF SFY_ss, endo_in] >>
+  qexists_tac ‘t'’ >>
+  fs[compatible_def, SF SFY_ss, endo_function, endo_def]
+QED
+
+Theorem t_below_Tf:
+  poset (s,r) /\ endo (s,r) b /\
+  endo (s,r) t /\ companion (s,r) b t /\
+  B_join (s,r) b B /\
+  bottom (endo_lift (s,r)) bot /\
+  companion (endo_lift (s,r)) B T' /\
+  endo (s,r) f
+  ==> lift_rel (s,r) t (T' f)
+Proof
+  rw[] >>
+  drule endo_poset >>
+  drule_all B_greatest_fixpoint_is_companion >> rw[] >>
+  fs[endo_lift_def] >>
+  subgoal ‘T' bot = t’ >-
+   (irule companion_bot_gfp >>
+    qexistsl_tac [‘B’, ‘lift_rel (s,r)’, ‘endo (s,r)’] >>
+    fs[SRULE [endo_lift_def] endo_poset, B_join_def, endo_lift_def]) >>
+  subgoal ‘monotonic (endo (s,r),lift_rel (s,r)) T'’ >-
+   (irule companion_mono >> fs[function_def] >>
+    qexists_tac ‘B’ >> fs[B_join_def, endo_lift_def, function_def]) >>
+  fs[monotonic_def] >>
+  metis_tac[bottom_def]
+QED
+
+Theorem lift_rel_comp:
+  poset (s,r) /\
+  function s s g /\ function s s f /\ function s s f' /\ function s s g' /\
+  monotonic (s,r) f /\ monotonic (s,r) f' /\
+  lift_rel (s,r) f f' /\ lift_rel (s,r) g g'
+  ==> lift_rel (s,r) (f o g) (f' o g')
+Proof
+  rw[lift_rel, function_def] >>
+  drule_then irule poset_trans >> rw[] >>
+  metis_tac[monotonic_def, poset_trans]
+QED
+
+Theorem Bf_compatible_f:
+  poset (s,r) /\ endo (s,r) b /\ endo (s,r) f /\
+  B_join (s,r) b B
+  ==> lift_rel (s,r) (B f o b) (b o f)
+Proof
+  rw[B_join_def, endo_lift_def, lift_rel, lub_def] >>
+  first_x_assum $ qspecl_then [‘f’, ‘b x’] strip_assume_tac >>
+  pop_assum irule >> pop_assum kall_tac >> rw[] >>
+  metis_tac[endo_in]
+QED
+
+Theorem doubling_compatible_B:
+  poset (s,r) /\ endo (s,r) b /\
+  B_join (s,r) b B
+  ==> compatible (endo_lift (s,r)) B (λf. f o f)
+Proof
+  rw[compatible_def, endo_lift_def] >-
+   (rw[function_def, endo_def] >-
+     (irule monotonic_comp >> metis_tac[function_def]) >- (metis_tac[])) >-
+   (fs[monotonic_def, B_join_def, endo_lift_def] >> rw[] >>
+    metis_tac[lift_rel_comp, endo_def, function_def]) >>
+  rw[lift_rel] >>
+  rename1 ‘r (B f (B f y)) _’ >>
+  drule_all Bf_compatible_f >> rw[] >>
+  fs[lift_rel, B_join_def, endo_lift_def, lub_def] >> rw[] >>
+  first_x_assum $ qspecl_then [‘f o f’, ‘y’] strip_assume_tac >>
+  first_x_assum irule >> pop_assum kall_tac >> rw[] >-
+   (metis_tac[function_def, endo_def]) >>
+  qexists_tac ‘B f o B f’ >> rw[] >-
+   (metis_tac[function_def, endo_comp]) >>
+  drule_then irule poset_trans >> rw[] >-
+   (metis_tac[endo_in, function_in]) >- (metis_tac[endo_in]) >>
+  qexists_tac ‘B f (b (f x))’ >> rw[] >- (metis_tac[endo_in, function_in]) >-
+   (‘monotonic (s,r) (B f)’ by metis_tac[function_def, endo_def] >>
+    fs[monotonic_def] >> metis_tac[endo_def, function_def]) >>
+  metis_tac[endo_def, function_def]
+QED
+
+Theorem Tf_idem:
+  poset (s,r) /\ endo (s,r) b /\
+  B_join (s,r) b B /\
+  endo (s,r) t /\ companion (s,r) b t /\
+  companion (endo_lift (s,r)) B T' /\
+  bottom (endo_lift (s,r)) bot /\
+  endo (s,r) f
+  ==> T' f o T' f = T' f
+Proof
+  rw[endo_lift_def] >>
+  drule endo_poset >> rw[] >>
+  irule poset_antisym >>
+  qexistsl_tac [‘lift_rel (s,r)’, ‘endo (s,r)’] >> rw[] >-
+   (metis_tac[companion_def, function_def, endo_comp, endo_def]) >-
+   (metis_tac[companion_def, function_def, endo_comp, endo_def]) >-
+   (fs[endo_lift_def])
+  >- (irule poset_trans >>
+      qexistsl_tac [‘endo (s,r)’, ‘T' (T' f)’] >>
+      fs[B_join_def, endo_lift_def, function_def] >>
+      rw[] >-
+       (metis_tac[endo_comp, companion_def, function_def]) >-
+       (metis_tac[companion_def, function_def]) >-
+       (metis_tac[companion_def, function_def]) >-
+       (‘lift_rel (endo (s,r),lift_rel (s,r)) ((λf. f o f) o T') (T' o T')’
+          suffices_by fs[lift_rel] >>
+        irule lift_rel_comp >> fs[] >>
+        ‘function (endo (s,r)) (endo (s,r)) T'’ by metis_tac[companion_def] >>
+        rw[] >-
+         (rw[monotonic_def] >>
+          irule lift_rel_comp >> metis_tac[endo_def, function_def]) >-
+         (irule companion_mono >> metis_tac[function_def]) >-
+         (rw[function_def, endo_comp]) >-
+         (irule compatible_below_companion >> rw[] >>
+          qexists_tac ‘B’ >> rw[GSYM endo_lift_def] >>
+          irule doubling_compatible_B >>
+          rw[B_join_def, endo_lift_def] >> metis_tac[function_def]) >-
+         (rw[lift_rel] >> metis_tac[poset_refl, endo_in, function_def])) >-
+       (‘T' (T' f) = T' f’
+          suffices_by metis_tac[poset_refl, companion_def, function_def] >>
+        irule companion_idem >>
+        qexistsl_tac [‘B’, ‘lift_rel (s,r)’, ‘endo (s,r)’] >>
+        metis_tac[function_def, endo_def])) >>
+  (* Tf o id <= Tf o t <= Tf o Tf *)
+  ‘lift_rel (s,r) (T' f o I) (T' f o T' f)’ suffices_by rw[] >>
+  irule lift_rel_comp >>
+  ‘function s s (T' f)’ by metis_tac[function_def, companion_def, endo_def] >>
+  ‘monotonic (s,r) (T' f)’ by metis_tac[function_def, companion_def, endo_def] >>
+  rw[] >-
+   (fs[function_def]) >-
+   (rw[lift_rel] >> metis_tac[poset_refl, companion_def, function_def, endo_def]) >-
+   (drule_all (SRULE [endo_lift_def] t_below_Tf) >>
+    rw[lift_rel] >>
+    drule_then irule poset_trans >> rw[] >-
+     (metis_tac[companion_def, function_def, endo_def]) >>
+    qexists_tac ‘t x’ >> rw[SF SFY_ss, endo_in] >>
+    drule_then irule companion_gt >>
+    metis_tac[function_def, endo_def])
+QED
+
+(* only needs finite lubs aside from t, B and T, completeness is just convenient
+   maybe somehow B_join and the higher companion forces the boundedness?
+ *)
+Theorem param_coind:
+  complete (s,r) /\ complete (endo_lift (s,r)) /\
+  poset (s,r) /\ endo (s,r) b /\
+  companion (s,r) b t /\ endo (s,r) t /\
+  B_join (s,r) b B /\ companion (endo_lift (s,r)) B T' /\
+  gfp (s,r) b gfix /\
+  s x /\ s y /\
+  lub (s,r) { x; y } xy
+  ==> r y (b (t xy)) ==> r y (t x)
+Proof
+  rw[] >>
+  ‘monotonic (s,r) t’ by metis_tac[companion_mono, lub_def, endo_def] >>
+  ‘monotonic (s,r) b’ by metis_tac[function_def, endo_def] >>
+  ‘?bot. lub (s,r) {} bot’ by metis_tac[complete_def] >>
+  reverse (subgoal ‘lift_rel (s,r)
+                    (λz. if s z then (if r x z then y else bot) else @y. ~s y)
+                    t’) >-
+   (fs[lift_rel] >>
+    pop_assum $ qspec_then ‘x’ strip_assume_tac >>
+    Cases_on ‘r x x’ >> metis_tac[poset_refl]) >>
+  qmatch_goalsub_abbrev_tac ‘lift_rel _ f _’ >>
+  subgoal ‘endo (s,r) f’ >-
+   (rw[endo_def, Abbr ‘f’] >-
+     (rw[monotonic_def] >>
+      Cases_on ‘r x z’ >-
+       (metis_tac[poset_refl, poset_trans]) >>
+      fs[lub_def] >> metis_tac[]) >>
+    Cases_on ‘r x z’ >> fs[lub_def] >> metis_tac[]) >>
+  drule_all B_greatest_fixpoint_is_companion >>
+  rw[endo_lift_def] >>
+  irule companion_coinduct >>
+  qexistsl_tac [‘B’, ‘endo (s,r)’, ‘T'’] >> rw[] >-
+   (* begin *)
+   (metis_tac[endo_poset, endo_lift_def]) >-
+   (‘?fxl. lub (s,r) { f x ; x } fxl’ by metis_tac[complete_def] >>
+    subgoal ‘xy = fxl’ >-
+     (drule_then irule lub_unique >>
+      ‘y = f x’ by metis_tac[Abbr ‘f’, poset_refl] >> fs[] >>
+      ‘{x; f x} = {f x; x}’ by rw[SET_EQ_SUBSET, SUBSET_DEF] >>
+      fs[] >> metis_tac[]) >>
+    drule_then strip_assume_tac (iffLR B_join_def) >>
+    fs[endo_lift_def] >>
+    rw[lift_rel] >>
+    last_x_assum $ qspecl_then [‘T' f’, ‘x'’] strip_assume_tac >>
+    pop_assum mp_tac >>
+    rw[lub_def] >>
+    first_x_assum irule >> pop_assum kall_tac >>
+    conj_tac >- (fs[Abbr ‘f’] >> Cases_on ‘r x x'’ >> fs[lub_def]) >>
+    qexists_tac ‘f’ >> rw[] >> ntac 2 (pop_assum kall_tac) >>
+    rw[lift_rel] >>
+    reverse (Cases_on ‘r x (b x')’) >-
+     (reverse (rw[Abbr ‘f’, endo_in]) >- (metis_tac[endo_in]) >>
+      fs[lub_def] >>
+      ‘s (T' (λz. if s z then if r x z then y else bot else @y. ~s y) x')’
+        suffices_by metis_tac[endo_in] >>
+      fs[companion_def] >>
+      metis_tac[function_def, endo_in]) >>
+    subgoal ‘f (b x') = y’ >- (fs[Abbr ‘f’] >> metis_tac[endo_in]) >>
+    rfs[] >> pop_assum kall_tac >>
+    drule_then irule poset_trans >>
+    ‘s (b (T' f x'))’ by metis_tac[endo_in, companion_def, function_def] >>
+    rw[] >>
+    qexists_tac ‘b (t fxl)’ >> rw[endo_in] >- (metis_tac[lub_def, endo_in]) >>
+    drule_then irule poset_trans >> rw[] >- (metis_tac[lub_def, endo_in]) >>
+    ‘?fbxl. lub (s,r) { f (b x') ; b x' } fbxl’ by metis_tac[complete_def] >>
+    qexists_tac ‘b (t fbxl)’ >> rw[] >-
+     (* cases *)
+     (metis_tac[endo_in, lub_def]) >-
+     (‘r (t fxl) (t fbxl)’ suffices_by metis_tac[monotonic_def, lub_def,
+                                                 endo_def, endo_in] >>
+      ‘r fxl fbxl’ suffices_by metis_tac[companion_mono, monotonic_def, lub_def,
+                                         function_def, endo_def] >>
+      fs[lub_def] >>
+      last_x_assum irule >> rw[] >-
+       (‘r (b x') fbxl’ by metis_tac[endo_in] >>
+        drule_then irule poset_trans >>
+        pop_assum $ irule_at Any >>
+        metis_tac[endo_in]) >-
+       (‘y = f x’ by metis_tac[Abbr ‘f’, poset_refl] >> fs[] >>
+        ‘r (f (b x')) fbxl’ by metis_tac[endo_in] >>
+        ‘monotonic (s,r) f’ by fs[endo_def] >>
+        metis_tac[monotonic_def, poset_trans, endo_in])) >>
+    subgoal ‘?fbl. !X. lub (s,r) { f (b X) ; b X } (fbl X)’ >-
+     (rw[GSYM SKOLEM_THM] >> metis_tac[complete_def]) >>
+    ‘fbxl = fbl x'’ by metis_tac[lub_unique] >> fs[] >>
+    ‘r (t (fbl x')) (T' f x')’ suffices_by metis_tac[monotonic_def, lub_def,
+                                                     endo_def, endo_in] >>
+    ‘lift_rel (s,r) (t o fbl) (T' f)’ suffices_by
+      metis_tac[combinTheory.o_DEF, lift_rel] >>
+    subgoal ‘bottom (endo_lift (s,r)) (λx. if s x then bot else @y. ~s y)’ >-
+     (rw[bottom_def, endo_lift_def] >-
+       (rw[endo_def, monotonic_def] >-
+          (metis_tac[poset_refl, lub_def]) >-
+          (metis_tac[lub_def])) >-
+        (rw[lift_rel, lub_def] >>
+         fs[lub_def] >> metis_tac[endo_def])) >>
+    subgoal ‘T' f o T' f = T' f’ >-
+     (drule_then irule Tf_idem >> rw[] >- (metis_tac[]) >>
+      qexistsl_tac [‘B’, ‘b’, ‘t’] >> rw[endo_lift_def]) >>
+    ‘lift_rel (s,r) (t o fbl) (T' f o T' f)’ suffices_by metis_tac[] >>
+    subgoal ‘lift_rel (s,r) t (T' f)’ >-
+     (drule_then irule t_below_Tf >> rw[] >- (metis_tac[]) >>
+      qexistsl_tac [‘B’, ‘b’] >> rw[endo_lift_def]) >>
+    irule lift_rel_comp >> rw[] >-
+     (metis_tac[endo_def, companion_def, function_def]) >-
+     (metis_tac[endo_def, function_def]) >-
+     (metis_tac[endo_def, companion_def, function_def]) >-
+     (metis_tac[function_def, lub_def]) >-
+     (metis_tac[endo_def, companion_def, function_def]) >-
+     (‘!X. s (fbl X) /\ (!y. s y /\ (y = f (b X) \/ y = b X) ==> r y (fbl X)) /\
+           !z. s z /\ (!y. s y /\ (y = f (b X) \/ y = b X) ==> r y z) ==>
+               r (fbl X) z’ by fs[lub_def] >>
+      rw[lift_rel] >>
+      ‘r (t x'') (T' f x'')’ by fs[lift_rel] >>
+      first_x_assum $ qspec_then ‘x''’ strip_assume_tac >>
+      first_x_assum irule >> pop_assum kall_tac >>
+      rw[] >-
+       (metis_tac[companion_def, function_def, endo_def]) >-
+       (‘lift_rel (s,r) (f o b) (T' f o T' f)’
+          suffices_by metis_tac[lift_rel, combinTheory.o_DEF] >>
+        irule lift_rel_comp >> rw[SF SFY_ss, endo_function] >-
+         (fs[endo_def]) >-
+         (metis_tac[companion_def, function_def, endo_def]) >-
+         (metis_tac[companion_def, function_def, endo_def]) >-
+         (metis_tac[companion_def, function_def, endo_def]) >-
+         (irule companion_gt >>
+          qexistsl_tac [‘B’, ‘endo (s,r)’] >> rw[] >>
+          metis_tac[endo_poset, endo_lift_def]) >-
+         (rw[lift_rel] >>
+          drule_then irule poset_trans >>
+          rw[SF SFY_ss, endo_in, endo_function] >-
+           (metis_tac[companion_def, function_def, endo_def]) >>
+          qexists_tac ‘t x'³'’ >> rw[SF SFY_ss, endo_in] >-
+           (‘lift_rel (s,r) b t’ suffices_by rw[lift_rel] >>
+            drule_then irule compatible_below_companion >>
+            metis_tac[compatible_self, function_def, endo_def, lift_rel]) >>
+          rfs[lift_rel])) >-
+       (drule_then irule poset_trans >> rw[] >-
+         (metis_tac[companion_def, function_def, endo_def]) >>
+        qexists_tac ‘t x''’ >> rw[] >- (metis_tac[companion_def, function_def]) >>
+        metis_tac[compatible_below_companion, compatible_self,
+                  function_def, endo_def, lift_rel]))) >-
+   (fs[B_join_def, endo_def, endo_lift_def]) >-
+   (fs[endo_lift_def]) >-
+   (fs[B_join_def, endo_lift_def])
+QED
+
+val _ = export_theory();

--- a/src/coalgebras/companionScript.sml
+++ b/src/coalgebras/companionScript.sml
@@ -140,7 +140,7 @@ Proof
   metis_tac[function_in]
 QED
 
-Theorem companion_gt:
+Theorem companion_expansive:
   poset (s,r) /\ function s s b /\ monotonic (s,r) b /\
   companion (s,r) b t /\
   s x ==> r x (t x)
@@ -166,7 +166,7 @@ Proof
     rw[function_def, GSYM combinTheory.o_DEF] >>
     irule compatible_compose >>
     rw[compatible_companion]) >-
-   (metis_tac[companion_def, function_def, companion_gt])
+   (metis_tac[companion_def, function_def, companion_expansive])
 QED
 
 Theorem companion_bot_gfp:
@@ -209,7 +209,7 @@ Proof
   drule_then match_mp_tac poset_trans >>
   qexists_tac ‘t x’ >> rw[function_in]
   >- (fs[gfp_def])
-  >- (ho_match_mp_tac companion_gt >> rw[]) >>
+  >- (ho_match_mp_tac companion_expansive >> rw[]) >>
   match_mp_tac gfp_coinduct >>
   rw[function_in] >>
   drule_all compatible_companion >> strip_tac >>
@@ -239,7 +239,7 @@ Proof
   irule gfp_coinduct >>
   qexistsl_tac [‘(b o t)’, ‘s’] >>
   fs[gfp_def] >>
-  metis_tac[monotonic_def, function_def, companion_gt]
+  metis_tac[monotonic_def, function_def, companion_expansive]
 QED
 
 (*
@@ -264,7 +264,7 @@ Proof
   ‘function s s t’ by fs[companion_def] >>
   drule_then match_mp_tac poset_trans >>
   qexists_tac ‘x’ >> rw[function_in] >>
-  metis_tac[companion_gt]
+  metis_tac[companion_expansive]
 QED
 
 Theorem param_coind_upto_f:
@@ -546,7 +546,7 @@ Proof
     drule_then irule poset_trans >> rw[] >-
      (metis_tac[companion_def, function_def, endo_def]) >>
     qexists_tac ‘t x’ >> rw[SF SFY_ss, endo_in] >>
-    drule_then irule companion_gt >>
+    drule_then irule companion_expansive >>
     metis_tac[function_def, endo_def])
 QED
 
@@ -678,7 +678,7 @@ Proof
          (metis_tac[companion_def, function_def, endo_def]) >-
          (metis_tac[companion_def, function_def, endo_def]) >-
          (metis_tac[companion_def, function_def, endo_def]) >-
-         (irule companion_gt >>
+         (irule companion_expansive >>
           qexistsl_tac [‘B’, ‘endo (s,r)’] >> rw[] >>
           metis_tac[endo_poset, endo_lift_def]) >-
          (rw[lift_rel] >>

--- a/src/coalgebras/companionScript.sml
+++ b/src/coalgebras/companionScript.sml
@@ -1,6 +1,6 @@
 (*
   This development is based on Damien Pous' "Coinduction All the Way Up,
-  including the derivation of parameterized coinduction system.
+  including the derivation of parameterized coinduction
 *)
 open HolKernel Parse boolLib bossLib;
 open pred_setTheory;
@@ -780,7 +780,7 @@ Proof
 QED
 
 Theorem set_gfp_sub_companion:
-  monotone b ==> gfp b ⊆ set_companion b x
+  monotone b ==> gfp b SUBSET set_companion b x
 Proof
   rw[] >>
   irule set_compatible_enhance >> rw[] >>

--- a/src/coalgebras/itreeTauScript.sml
+++ b/src/coalgebras/itreeTauScript.sml
@@ -919,8 +919,8 @@ Proof
   metis_tac[itree_wbisim_coind_upto_equiv]
 QED
 
-(* more compositional variant using the enhanced functional (bt)
- * proof: x < gfp \/ btx < b(K gfp \/ t)x < btx *)
+(* more compositional variant using the enhanced functional (bt) *)
+(* proof: x < gfp \/ btx < b(K gfp \/ t)x < btx *)
 Theorem itree_wbisim_coind_upto':
   !R. UNCURRY R SUBSET
               UNCURRY itree_wbisim UNION

--- a/src/coalgebras/itreeTauScript.sml
+++ b/src/coalgebras/itreeTauScript.sml
@@ -1270,46 +1270,25 @@ Proof
   metis_tac[after_taus_cases, CURRY_DEF]
 QED
 
-(* example: compatibility can be used like so to get the same as below *)
-(* Theorem itree_coind_upto_taus: *)
-(*   !R. *)
-(*     UNCURRY R SUBSET *)
-(*             UNCURRY itree_wbisim UNION *)
-(*             wbisim_functional (upto_taus_func (UNCURRY R) UNION *)
-(*                                               UNCURRY itree_wbisim) *)
-(*     ==> UNCURRY R SUBSET UNCURRY itree_wbisim *)
-(* Proof *)
-(*   rw[] >> *)
-(*   irule itree_wbisim_coind_upto' >> *)
-(*   dxrule_then irule SUBSET_TRANS >> *)
-(*   rw[UNION_SUBSET] >> *)
-(*   irule wbisim_functional_cancel >> rw[] >- *)
-(*    (irule set_compatible_enhance >> rw[] >> *)
-(*     metis_tac[upto_taus_compatible, SUBSET_REFL]) >> *)
-(*   metis_tac[set_gfp_sub_companion,wbisim_functional_mono,wbisim_functional_gfp]*)
-(* QED *)
-
-Theorem itree_coind_after_taus:
-  !R. (!t t'.
-         R t t' ==>
-         (?t2 t3.
-           t = Tau t2 /\ t' = Tau t3 /\
-             (after_taus R t2 t3 \/ itree_wbisim t2 t3)) \/
-         (?e k k'.
-            strip_tau t (Vis e k) /\ strip_tau t' (Vis e k') /\
-            !r. after_taus R (k r) (k' r) \/ itree_wbisim (k r) (k' r)) \/
-         (?r. strip_tau t (Ret r) /\ strip_tau t' (Ret r)) \/
-         itree_wbisim t t') ==>
-      !t t'. R t t' ==> itree_wbisim t t'
+(* example: compatibility can be used like so *)
+Theorem itree_coind_upto_taus:
+  !R.
+    UNCURRY R SUBSET
+            UNCURRY itree_wbisim UNION
+            wbisim_functional (upto_taus_func (UNCURRY R) UNION
+                                              UNCURRY itree_wbisim)
+    ==> UNCURRY R SUBSET UNCURRY itree_wbisim
 Proof
-  rpt strip_tac >>
-  irule itree_wbisim_coind_upto >>
-  qexists ‘after_taus R’ >>
-  reverse conj_tac
-  >- rw[after_taus_rel] >>
-  Induct_on ‘after_taus’ >>
   rw[] >>
-  metis_tac[after_taus_rules]
+  irule itree_wbisim_coind_upto' >>
+  dxrule_then irule SUBSET_TRANS >>
+  rw[UNION_SUBSET] >>
+  irule SUBSET_TRANS >>
+  irule_at (Pos last) (cj 2 SUBSET_UNION) >>
+  irule wbisim_functional_cancel >> rw[] >-
+   (irule set_compatible_enhance >> rw[] >>
+    metis_tac[upto_taus_compatible, SUBSET_REFL]) >>
+  metis_tac[set_gfp_sub_companion,wbisim_functional_mono,wbisim_functional_gfp]
 QED
 
 (* misc *)

--- a/src/coretypes/posetScript.sml
+++ b/src/coretypes/posetScript.sml
@@ -39,6 +39,11 @@ val function_def = new_definition
   ("function_def",
    ``function a b (f : 'a -> 'b) = !x. a x ==> b (f x)``);
 
+val function_in = store_thm
+  ("function_in",
+   “function s s t /\ s x ==> s (t x)”,
+   RW_TAC (srw_ss()) [function_def]);
+
 (* ------------------------------------------------------------------------- *)
 (* A HOL type of partial orders                                              *)
 (* ------------------------------------------------------------------------- *)
@@ -266,6 +271,13 @@ val continuous_def = new_definition
   ("continuous_def",
    “continuous (p : 'a poset) f <=> up_continuous p f /\ down_continuous p f”);
 
+
+val monotonic_comp = store_thm
+  ("monotonic_comp",
+   ``monotonic (s,r) f /\ monotonic (s,r) g /\ function s s g
+     ==> monotonic (s,r) (f o g)``,
+   RW_TAC (srw_ss()) [monotonic_def, function_def]);
+
 (* ------------------------------------------------------------------------- *)
 (* Least and greatest fixed points.                                          *)
 (* ------------------------------------------------------------------------- *)
@@ -299,6 +311,18 @@ val gfp_unique = store_thm
    >> Know `?s r. p = (s,r)` >- pair_cases_tac
    >> STRIP_TAC
    >> RW_TAC bool_ss [poset_def, gfp_def]);
+
+val lfp_induct = store_thm
+  ("lfp_induct",
+   “lfp (s,r) b lfix /\ s x /\ r (b x) x
+    ==> r lfix x”,
+   RW_TAC bool_ss [lfp_def]);
+
+val gfp_coinduct = store_thm
+  ("gfp_coinduct",
+   “gfp (s,r) b gfix /\ s x /\ r x (b x)
+   ==> r x gfix”,
+   RW_TAC bool_ss [gfp_def]);
 
 (* ------------------------------------------------------------------------- *)
 (* The Knaster-Tarski theorem                                                *)


### PR DESCRIPTION
- companionTheory has the main development based on "Coinduction All the Way Up", giving a way to compose extensions to coinduction principles and also extend the relation on the fly
  - more examples [here](https://github.com/Plisp/proofs/blob/main/HOL/uptoScript.sml#L1265)
- adapted some coinduction schemas in itreeTau to this new style
- added a couple common theorems to posetTheory

I wonder if there could be some toggle that automatically generates the associated functional from a Coinductive definition and proves its monotonicity / coincidence with the fixpoint.