### PR TITLE
[lambda] lameta_complete.equivalent2, etc.

### DIFF
--- a/examples/lambda/barendregt/boehmScript.sml
+++ b/examples/lambda/barendregt/boehmScript.sml
@@ -1,8 +1,8 @@
 (* ========================================================================== *)
 (* FILE    : boehmScript.sml (aka chap10Script.sml)                           *)
-(* TITLE   : (Effective) Böhm Trees (Barendregt 1984 [1], Chapter 10)     UOK *)
+(* TITLE   : (Effective) Böhm Trees (Barendregt 1984 [1], Chapter 10)         *)
 (*                                                                            *)
-(* AUTHORS : 2023-2024 The Australian National University (Chun TIAN)         *)
+(* AUTHORS : 2023-2024 The Australian National University (Chun Tian)         *)
 (* ========================================================================== *)
 
 open HolKernel Parse boolLib bossLib;
@@ -48,7 +48,7 @@ Overload FV  = “supp term_pmact”
 Overload VAR = “term$VAR”
 
 (*---------------------------------------------------------------------------*
- *  Boehm Trees (and subterms) - name after Corrado_Böhm [2]             UOK *
+ *  Boehm Trees (and subterms) - name after Corrado_Böhm [2]                 *
  *---------------------------------------------------------------------------*)
 
 (* The type of Boehm trees:
@@ -274,7 +274,7 @@ Proof
  >> ‘DISJOINT (set vs) (FV M0)’ by METIS_TAC [subterm_disjoint_lemma']
  >> qabbrev_tac ‘M1 = principle_hnf (M0 @* MAP VAR vs)’
  >> Q_TAC (HNF_TAC (“M0 :term”, “vs :string list”,
-                    “y  :string”, “args :term list”)) ‘M1’
+                    “y :string”, “args :term list”)) ‘M1’
  >> ‘TAKE n vs = vs’ by rw []
  >> POP_ASSUM (rfs o wrap)
 QED
@@ -444,7 +444,7 @@ Proof
  >> Q_TAC (RNEWS_TAC (“vs :string list”, “r :num”, “n :num”)) ‘X’
  >> ‘DISJOINT (set vs) (FV M0)’ by METIS_TAC [subterm_disjoint_lemma']
  >> Q_TAC (HNF_TAC (“M0 :term”, “vs :string list”,
-                    “y  :string”, “args :term list”)) ‘M1’
+                    “y :string”, “args :term list”)) ‘M1’
  >> ‘TAKE n vs = vs’ by rw []
  >> POP_ASSUM (rfs o wrap)
  >> ‘Ms = args’ by rw [Abbr ‘Ms’]
@@ -643,7 +643,7 @@ Proof
  >> ‘DISJOINT (set vs) (FV M0)’ by METIS_TAC [subterm_disjoint_lemma']
  >> qabbrev_tac ‘M1 = principle_hnf (M0 @* MAP VAR vs)’
  >> Q_TAC (HNF_TAC (“M0 :term”, “vs :string list”,
-                    “y  :string”, “args :term list”)) ‘M1’
+                    “y :string”, “args :term list”)) ‘M1’
  >> ‘TAKE n vs = vs’ by rw []
  >> POP_ASSUM (rfs o wrap)
  >> Know ‘solvable (M0 @* MAP VAR vs)’
@@ -954,7 +954,7 @@ Proof
  >> ‘DISJOINT (set vs) (FV M0)’ by METIS_TAC [subterm_disjoint_lemma']
  >> qabbrev_tac ‘M1 = principle_hnf (M0 @* MAP VAR vs)’
  >> Q_TAC (HNF_TAC (“M0 :term”, “vs :string list”,
-                    “y  :string”, “args :term list”)) ‘M1’
+                    “y :string”, “args :term list”)) ‘M1’
  >> ‘TAKE n vs = vs’ by rw []
  >> POP_ASSUM (rfs o wrap)
  >> qabbrev_tac ‘m = LENGTH args’
@@ -974,14 +974,7 @@ Proof
     rw [ltree_paths_alt, BT_ltree_el_eq_none]
 QED
 
-Theorem subterm_imp_ltree_paths :
-    !p X M r. FINITE X /\ FV M SUBSET X UNION RANK r /\
-              subterm X M p r <> NONE ==> p IN ltree_paths (BT' X M r)
-Proof
-    PROVE_TAC [BT_ltree_paths_thm]
-QED
-
-(* p <> [] is required because ‘[] IN ltree_paths (BT' X M r)’ always holds. *)
+(* NOTE: p <> [] is required as ‘[] IN ltree_paths (BT' X M r)’ always holds. *)
 Theorem ltree_paths_imp_solvable :
     !p X M r. FINITE X /\ FV M SUBSET X UNION RANK r /\ p <> [] /\
               p IN ltree_paths (BT' X M r) ==> solvable M
@@ -1035,7 +1028,7 @@ Proof
  >> ‘DISJOINT (set vs) (FV M0)’ by METIS_TAC [subterm_disjoint_lemma']
  >> qunabbrev_tac ‘y’
  >> Q_TAC (HNF_TAC (“M0 :term”, “vs :string list”,
-                    “y  :string”, “args :term list”)) ‘M1’
+                    “y :string”, “args :term list”)) ‘M1’
  >> ‘TAKE n vs = vs’ by rw []
  >> POP_ASSUM (rfs o wrap)
  >> simp [ltree_lookup, LNTH_fromList, EL_MAP, GSYM BT_def]
@@ -1076,7 +1069,7 @@ Proof
      qexistsl_tac [‘X’, ‘M’, ‘r’, ‘n’] >> simp [])
  >> DISCH_TAC
  >> Q_TAC (HNF_TAC (“M0 :term”, “vs :string list”,
-                    “y  :string”, “args :term list”)) ‘M1’
+                    “y :string”, “args :term list”)) ‘M1’
  >> ‘TAKE n vs = vs’ by rw []
  >> POP_ASSUM (rfs o wrap)
  >> ‘Ms = args’ by rw [Abbr ‘Ms’]
@@ -1142,7 +1135,7 @@ Theorem subterm_solvable_lemma :
             (!q. q <<= FRONT p ==> solvable (subterm' X M q r))
 Proof
     rpt GEN_TAC >> STRIP_TAC
- >> ‘p IN ltree_paths (BT' X M r)’ by PROVE_TAC [subterm_imp_ltree_paths]
+ >> ‘p IN ltree_paths (BT' X M r)’ by PROVE_TAC [BT_ltree_paths_thm]
  >> CONJ_ASM1_TAC
  >- (Q.X_GEN_TAC ‘q’ >> DISCH_TAC \\
      CCONTR_TAC \\
@@ -1210,7 +1203,7 @@ Theorem BT_subterm_thm :
             od = SOME T
 Proof
     rpt STRIP_TAC
- >> ‘p IN ltree_paths (BT' X M r)’ by PROVE_TAC [subterm_imp_ltree_paths]
+ >> ‘p IN ltree_paths (BT' X M r)’ by PROVE_TAC [BT_ltree_paths_thm]
  >> Know ‘solvable M’
  >- (Cases_on ‘p = []’ >- fs [] \\
     ‘!q. q <<= FRONT p ==> solvable (subterm' X M q r)’
@@ -1336,7 +1329,7 @@ Proof
  >> DISCH_TAC
  >> qunabbrev_tac ‘y’
  >> Q_TAC (HNF_TAC (“M0 :term”, “vs :string list”,
-                    “y  :string”, “args :term list”)) ‘M1’
+                    “y :string”, “args :term list”)) ‘M1’
  >> ‘TAKE n vs = vs’ by rw []
  >> POP_ASSUM (rfs o wrap)
  >> Cases_on ‘h < m’ >> simp []
@@ -1390,7 +1383,7 @@ Proof
  >> DISCH_TAC
  >> qunabbrev_tac ‘y’
  >> Q_TAC (HNF_TAC (“M0 :term”, “vs :string list”,
-                    “y  :string”, “args :term list”)) ‘M1’
+                    “y :string”, “args :term list”)) ‘M1’
  >> ‘TAKE n vs = vs’ by rw []
  >> POP_ASSUM (rfs o wrap)
  >> Cases_on ‘h < m’ >> simp []
@@ -1445,7 +1438,7 @@ Proof
  >> ‘DISJOINT (set vs) (FV M0) /\ DISJOINT (set vs) (FV M0')’
       by METIS_TAC [subterm_disjoint_lemma']
  >> Q_TAC (HNF_TAC (“M0 :term”, “vs :string list”,
-                    “y  :string”, “args :term list”)) ‘M1’
+                    “y :string”, “args :term list”)) ‘M1’
  >> Q_TAC (HNF_TAC (“M0':term”, “vs :string list”,
                     “y' :string”, “args':term list”)) ‘M1'’
  >> ‘TAKE n vs = vs’ by rw []
@@ -1514,7 +1507,7 @@ Proof
       by METIS_TAC [subterm_disjoint_lemma']
  (* NOTE: the next two HNF_TAC will refine M1 and M1' *)
  >> Q_TAC (HNF_TAC (“M0 :term”, “vs :string list”,
-                    “y  :string”, “args :term list”)) ‘M1’
+                    “y :string”, “args :term list”)) ‘M1’
  >> Q_TAC (HNF_TAC (“M0':term”, “vs :string list”,
                     “y' :string”, “args':term list”)) ‘M1'’
  >> ‘TAKE n vs = vs’ by rw []
@@ -2233,7 +2226,7 @@ Proof
  >> Rewr'
  >> ‘DISJOINT (set vs) (FV M0)’ by METIS_TAC [subterm_disjoint_lemma']
  >> Q_TAC (HNF_TAC (“M0 :term”, “vs :string list”,
-                    “y  :string”, “args :term list”)) ‘M1’
+                    “y :string”, “args :term list”)) ‘M1’
  >> ‘TAKE n vs = vs’ by rw [] >> POP_ASSUM (rfs o wrap)
  >> Know ‘principle_hnf (tpm pi (LAMl vs (VAR y @* args) @* MAP VAR vs)) =
           tpm pi (principle_hnf (LAMl vs (VAR y @* args) @* MAP VAR vs))’
@@ -2308,7 +2301,7 @@ Proof
  >> ‘DISJOINT (set vs) (FV M0)’ by METIS_TAC [subterm_disjoint_lemma']
  >> qunabbrevl_tac [‘y’, ‘y'’]
  >> Q_TAC (HNF_TAC (“M0 :term”, “vs :string list”,
-                    “y  :string”, “args :term list”)) ‘M1’
+                    “y :string”, “args :term list”)) ‘M1’
  >> ‘TAKE n vs = vs’ by rw [] >> POP_ASSUM (rfs o wrap)
  >> simp [Abbr ‘M1'’, Abbr ‘Ms’, Abbr ‘Ms'’, Abbr ‘l’, Abbr ‘l'’]
  >> Know ‘principle_hnf (tpm pi (LAMl vs (VAR y @* args) @* MAP VAR vs)) =
@@ -3587,7 +3580,7 @@ Proof
      simp [hnf_children_size_LAMl, GSYM appstar_APPEND])
  (* stage work *)
  >> rpt GEN_TAC >> STRIP_TAC
- >> ‘p IN ltree_paths (BT' X M r)’ by PROVE_TAC [subterm_imp_ltree_paths]
+ >> ‘p IN ltree_paths (BT' X M r)’ by PROVE_TAC [BT_ltree_paths_thm]
  (* re-define P as abbreviations *)
  >> Q.PAT_X_ASSUM ‘P = permutator d’ (FULL_SIMP_TAC std_ss o wrap)
  >> qabbrev_tac ‘P = permutator d’
@@ -3734,8 +3727,8 @@ Proof
              SET_TAC []) \\
          fs [Abbr ‘m’, Abbr ‘args'’] \\
       (* remaining goal: h::q IN ltree_paths (BT' X ([P/v] M) r) *)
-         MATCH_MP_TAC subterm_imp_ltree_paths >> art [] \\
-         CONJ_TAC
+         irule (iffRL BT_ltree_paths_thm) >> art [] \\
+         reverse CONJ_TAC
          >- (rw [FV_SUB] \\
              MATCH_MP_TAC SUBSET_TRANS >> Q.EXISTS_TAC ‘FV M’ >> art [] \\
              SET_TAC []) \\
@@ -3906,7 +3899,7 @@ Proof
      >- (MATCH_MP_TAC LESS_LESS_EQ_TRANS \\
          Q.EXISTS_TAC ‘m’ >> art [] \\
          simp [Abbr ‘m'’, Abbr ‘Ms’, hnf_children_hnf]) \\
-     MATCH_MP_TAC subterm_imp_ltree_paths >> simp [] \\
+     irule (iffRL BT_ltree_paths_thm) >> simp [] \\
      simp [subterm_of_solvables, appstar_APPEND] \\
      simp [GSYM appstar_APPEND, hnf_children_hnf] \\
      Know ‘EL h (args' ++ ls) = EL h args'’
@@ -3975,7 +3968,7 @@ Proof
      simp [])
  >> DISCH_TAC
  >> ‘q IN ltree_paths (BT' X (EL h args) (SUC r))’
-      by PROVE_TAC [subterm_imp_ltree_paths]
+      by PROVE_TAC [BT_ltree_paths_thm]
  >> simp [] >> DISCH_THEN K_TAC
  (* applying SUBSET_MAX_SET *)
  >> MATCH_MP_TAC SUBSET_MAX_SET
@@ -4143,7 +4136,7 @@ Proof
  >> Induct_on ‘q’ >- rw []
  >> rpt GEN_TAC
  >> STRIP_TAC
- >> ‘p IN ltree_paths (BT' X M r)’ by PROVE_TAC [subterm_imp_ltree_paths]
+ >> ‘p IN ltree_paths (BT' X M r)’ by PROVE_TAC [BT_ltree_paths_thm]
  >> qabbrev_tac ‘P = VAR v'’
  >> qabbrev_tac ‘Y = X UNION RANK r’
  >> Cases_on ‘p = []’ >- fs []
@@ -5000,7 +4993,7 @@ Theorem Boehm_transform_exists_lemma :
                   subterm' X (apply pi M) q r = [P/v] (subterm' X M q r)
 Proof
     rpt STRIP_TAC
- >> ‘p IN ltree_paths (BT' X M r)’ by PROVE_TAC [subterm_imp_ltree_paths]
+ >> ‘p IN ltree_paths (BT' X M r)’ by PROVE_TAC [BT_ltree_paths_thm]
  >> ‘(!q. q <<= p ==> subterm X M q r <> NONE) /\
       !q. q <<= FRONT p ==> solvable (subterm' X M q r)’
        by (MATCH_MP_TAC subterm_solvable_lemma >> art [])
@@ -5391,7 +5384,7 @@ Proof
  >> Know ‘hnf_headvar M1 IN X UNION RANK (SUC r)’
  >- (MATCH_MP_TAC subterm_headvar_lemma \\
      qexistsl_tac [‘M’, ‘M0’, ‘n’, ‘vs’] >> simp [])
- >> ASM_SIMP_TAC std_ss [hnf_head_hnf, THE_VAR_thm]
+ >> ASM_SIMP_TAC std_ss [hnf_head_hnf, var_name_thm]
  >> DISCH_TAC (* y IN X UNION RANK (SUC r) *)
  (* applying subterm_subst_permutator_cong *)
  >> MATCH_MP_TAC subterm_subst_permutator_cong'
@@ -5418,8 +5411,7 @@ Proof
      MATCH_MP_TAC subterm_induction_lemma' \\
      qexistsl_tac [‘M’, ‘M0’, ‘n’, ‘m’, ‘vs’, ‘M1’] >> simp [])
  >> DISCH_TAC
- >> ‘t IN ltree_paths (BT' X N (SUC r))’
-       by PROVE_TAC [subterm_imp_ltree_paths]
+ >> ‘t IN ltree_paths (BT' X N (SUC r))’ by PROVE_TAC [BT_ltree_paths_thm]
  >> simp [] >> DISCH_THEN K_TAC
  (* applying SUBSET_MAX_SET *)
  >> MATCH_MP_TAC SUBSET_MAX_SET
@@ -5447,15 +5439,7 @@ Proof
  >> simp []
 QED
 
-(* Proposition 10.3.7 (i) [1, p.248] (Boehm out lemma)
-
-   NOTE: This time the case ‘p = []’ can be included, but it's a trvial case.
-
-   NOTE: The original lemma in textbook requires ‘p IN ltree_paths (BT X M)’,
-   but this seems wrong, as ‘subterm X M p’ may not be defined if only ‘p’ is
-   valid path (i.e. the subterm could be a bottom (\bot) as the result of un-
-   solvable terms).
- *)
+(* Proposition 10.3.7 (i) [1, p.248] (Boehm out lemma) *)
 Theorem Boehm_out_lemma :
     !X p M r. FINITE X /\ FV M SUBSET X UNION RANK r /\
               subterm X M p r <> NONE ==>
@@ -5799,7 +5783,7 @@ Proof
  >> DISCH_TAC
  >> Know ‘!i. i < k ==> p IN ltree_paths (BT' X (M i) r)’
  >- (rpt STRIP_TAC \\
-     MATCH_MP_TAC subterm_imp_ltree_paths >> rw [])
+     irule (iffRL BT_ltree_paths_thm) >> rw [])
  >> DISCH_TAC
  (* define M0 *)
  >> qabbrev_tac ‘M0 = \i. principle_hnf (M i)’
@@ -9991,9 +9975,6 @@ val _ = html_theory "boehm";
 
  [1] Barendregt, H.P.: The lambda calculus, its syntax and semantics.
      College Publications, London (1984).
- [2] https://en.wikipedia.org/wiki/Corrado_Böhm (UOK)
- [3] Böhm, C.: Alcune proprietà delle forme β-η-normali nel λ-K-calcolo. (UOK)
-     Pubblicazioni dell'IAC 696, 1-19 (1968)
-     English translation: "Some properties of beta-eta-normal forms in the
-     lambda-K-calculus".
+ [2] https://en.wikipedia.org/wiki/Corrado_Böhm
+
  *)

--- a/examples/lambda/barendregt/chap11_1Script.sml
+++ b/examples/lambda/barendregt/chap11_1Script.sml
@@ -8,8 +8,6 @@ open nomsetTheory labelledTermsTheory termTheory horeductionTheory chap3Theory
 
 val _ = new_theory "chap11_1";
 
-fun Store_Thm(n,t,tac) = store_thm(n,t,tac) before export_rewrites [n]
-
 (* ----------------------------------------------------------------------
     phi function for reducing all labelled redexes
    ---------------------------------------------------------------------- *)
@@ -34,11 +32,12 @@ val FV_phi = store_thm(
     FULL_SIMP_TAC (srw_ss()) [FV_SUB] THEN METIS_TAC [IN_UNION, IN_DELETE]
   ]);
 
-val NOT_IN_lSUB_I = Store_Thm(
-  "NOT_IN_lSUB_I",
-  ``∀M:lterm. v ∉ FV N ∧ v ≠ u ∧ v ∉ FV M ==> v ∉ FV ([N/u]M)``,
+Theorem NOT_IN_lSUB_I[simp] :
+    ∀M:lterm. v ∉ FV N ∧ v ≠ u ∧ v ∉ FV M ==> v ∉ FV ([N/u]M)
+Proof
   HO_MATCH_MP_TAC lterm_bvc_induction THEN Q.EXISTS_TAC `FV N ∪ {u;v}` THEN
-  SRW_TAC [][lSUB_VAR]);
+  SRW_TAC [][lSUB_VAR]
+QED
 
 val phi_vsubst_commutes = store_thm(
   "phi_vsubst_commutes",
@@ -63,10 +62,11 @@ val (strip_label_thm,_) = define_recursive_term_function
    (strip_label (LAMi n v M N) = (LAM v (strip_label M) @@ strip_label N))`
 val _ = export_rewrites ["strip_label_thm"]
 
-val FV_strip_label = Store_Thm(
-  "FV_strip_label",
-  ``!M. FV (strip_label M) = FV M``,
-  HO_MATCH_MP_TAC simple_lterm_induction THEN SRW_TAC [][]);
+Theorem FV_strip_label[simp] :
+    !M. FV (strip_label M) = FV M
+Proof
+  HO_MATCH_MP_TAC simple_lterm_induction THEN SRW_TAC [][]
+QED
 
 val strip_label_vsubst_commutes = store_thm(
   "strip_label_vsubst_commutes",
@@ -119,10 +119,11 @@ val _ = export_rewrites ["null_labelling_thm"]
 
 val _ = diminish_srw_ss ["alphas"]
 
-val FV_null_labelling = Store_Thm(
-  "FV_null_labelling",
-  ``!M. FV (null_labelling M) = FV M``,
-  HO_MATCH_MP_TAC simple_induction THEN SRW_TAC [][]);
+Theorem FV_null_labelling[simp] :
+    !M. FV (null_labelling M) = FV M
+Proof
+  HO_MATCH_MP_TAC simple_induction THEN SRW_TAC [][]
+QED
 
 val null_labelling_subst = store_thm(
   "null_labelling_subst",
@@ -130,15 +131,17 @@ val null_labelling_subst = store_thm(
   HO_MATCH_MP_TAC nc_INDUCTION2 THEN Q.EXISTS_TAC `v INSERT FV N` THEN
   SRW_TAC [][SUB_THM, SUB_VAR]);
 
-val strip_null_labelling = Store_Thm(
-  "strip_null_labelling",
-  ``!M. strip_label (null_labelling M) = M``,
-  HO_MATCH_MP_TAC simple_induction THEN SRW_TAC [][]);
+Theorem strip_null_labelling[simp] :
+    !M. strip_label (null_labelling M) = M
+Proof
+  HO_MATCH_MP_TAC simple_induction THEN SRW_TAC [][]
+QED
 
-val phi_null_labelling = Store_Thm(
-  "phi_null_labelling",
-  ``!M. phi (null_labelling M) = M``,
-  HO_MATCH_MP_TAC simple_induction THEN SRW_TAC [][]);
+Theorem phi_null_labelling[simp] :
+    !M. phi (null_labelling M) = M
+Proof
+  HO_MATCH_MP_TAC simple_induction THEN SRW_TAC [][]
+QED
 
 (* ----------------------------------------------------------------------
     substitution lemma
@@ -530,9 +533,13 @@ val strip_lemma = store_thm(
   `reduction beta N (phi Ntilde)` by PROVE_TAC [lemma11_1_8] THEN
   PROVE_TAC []);
 
-val beta_CR_2 = store_thm(
-  "beta_CR_2",
-  ``CR beta``,
+(* Theorem 11.1.10 [1, p. 282] (the 2nd version)
+
+   NOTE: cf. chap2Theory.beta_CR and finite_developmentsTheory.corollary11_2_29.
+ *)
+Theorem beta_CR_2 :
+    CR beta
+Proof
   SIMP_TAC (srw_ss())[CR_def, diamond_property_def] THEN
   Q_TAC SUFF_TAC
         `!M M1. RTC (compat_closure beta) M M1 ==>
@@ -540,6 +547,14 @@ val beta_CR_2 = store_thm(
                      ?M3. reduction beta M1 M3 /\ reduction beta M2 M3`
         THEN1 PROVE_TAC [] THEN
   HO_MATCH_MP_TAC relationTheory.RTC_INDUCT THEN
-  PROVE_TAC [reduction_rules, strip_lemma]);
+  PROVE_TAC [reduction_rules, strip_lemma]
+QED
 
-val _ = export_theory()
+val _ = export_theory();
+val _ = html_theory "chap11_1";
+
+(* References:
+
+   [1] Barendregt, H.P.: The Lambda Calculus, Its Syntax and Semantics.
+       College Publications, London (1984).
+ *)

--- a/examples/lambda/barendregt/chap2Script.sml
+++ b/examples/lambda/barendregt/chap2Script.sml
@@ -722,6 +722,7 @@ Proof
   SRW_TAC [][SUB_THM, SUB_VAR]
 QED
 
+(* cf. LAMl_ALPHA_tpm *)
 Theorem EQ_LAML_bodies_permute:
   ∀us vs M N. (LAMl us M = LAMl vs N) ∧ ¬is_abs M ∧ ¬is_abs N ⇒
               ∃pi. N = tpm pi M
@@ -757,25 +758,6 @@ Proof
     Q.X_GEN_TAC ‘t’
  >> Q.SPEC_THEN ‘t’ STRUCT_CASES_TAC term_CASES
  >> SRW_TAC [][]
-QED
-
-(* accessor for retrieving ‘y’ from ‘VAR y’ *)
-local
-    val th1 = prove (“!t. is_var t ==> ?y. t = VAR y”, rw [is_var_cases]);
-    val th2 = SIMP_RULE std_ss [GSYM RIGHT_EXISTS_IMP_THM, SKOLEM_THM] th1;
-in
-   (* |- !t. is_var t ==> t = VAR (THE_VAR t) *)
-    val THE_VAR_def = new_specification ("THE_VAR_def", ["THE_VAR"], th2);
-end;
-
-Theorem THE_VAR_thm[simp] :
-    !y. THE_VAR (VAR y) = y
-Proof
-    rpt STRIP_TAC
- >> qabbrev_tac ‘t = (VAR y :term)’ >> simp []
- >> ‘is_var t’ by rw [Abbr ‘t’]
- >> Suff ‘VAR (THE_VAR t) = (VAR y :term)’ >- rw []
- >> ASM_SIMP_TAC std_ss [GSYM THE_VAR_def]
 QED
 
 Theorem term_cases :
@@ -1642,11 +1624,18 @@ Definition solvable_def :
     solvable (M :term) = ?M' Ns. M' IN closures M /\ M' @* Ns == I
 End
 
+Theorem closures_alt_closed :
+    !M. closed M ==> closures M = {M}
+Proof
+    rw [closures_def, closed_def]
+ >> rw [Once EXTENSION]
+QED
+
 (* 8.3.1 (i) [1, p.171] *)
 Theorem solvable_alt_closed :
     !M. closed M ==> (solvable M <=> ?Ns. M @* Ns == I)
 Proof
-    rw [solvable_def, closed_def]
+    rw [solvable_def, closures_alt_closed]
 QED
 
 (* 8.3.1 (iii) [1, p.171] *)

--- a/examples/lambda/barendregt/chap3Script.sml
+++ b/examples/lambda/barendregt/chap3Script.sml
@@ -603,10 +603,16 @@ Proof
   simp[GSYM TC_RC_EQNS, theorem3_17]
 QED
 
-val beta_CR = store_thm(
-  "beta_CR",
-  ``CR beta``,
-  PROVE_TAC [CR_def, lemma3_16, theorem3_17, diamond_TC]);
+(* Theorem 3.2.8 [1, p.62] (1st version)
+
+   NOTE: This is the short proof due to Tait and Martin-Löf.
+   cf. chap11_1Theory.beta_CR_2 and finite_developmentsTheory.corollary11_2_29.
+ *)
+Theorem beta_CR :
+    CR beta
+Proof
+  PROVE_TAC [CR_def, lemma3_16, theorem3_17, diamond_TC]
+QED
 
 val betaCR_square = store_thm(
   "betaCR_square",

--- a/examples/lambda/barendregt/finite_developmentsScript.sml
+++ b/examples/lambda/barendregt/finite_developmentsScript.sml
@@ -4085,6 +4085,10 @@ val lemma11_2_28ii = store_thm(
     Q.EXISTS_TAC `residuals s2 FS1`
   ] THEN PROVE_TAC [Cpl_complete_development]);
 
+(* Corollary 11.2.29 [1, p. 293] (the 3rd version)
+
+   NOTE: cf. chap2Theory.beta_CR and chap11_1Theory.beta_CR_2
+ *)
 val corollary11_2_29 = store_thm(
   "corollary11_2_29",
   ``CR beta``,
@@ -4092,3 +4096,10 @@ val corollary11_2_29 = store_thm(
              relationTheory.diamond_TC_diamond]);
 
 val _ = export_theory();
+val _ = html_theory "finite_developments";
+
+(* References:
+
+   [1] Barendregt, H.P.: The Lambda Calculus, Its Syntax and Semantics.
+       College Publications, London (1984).
+ *)

--- a/examples/lambda/barendregt/head_reductionScript.sml
+++ b/examples/lambda/barendregt/head_reductionScript.sml
@@ -13,12 +13,16 @@ open boolSimps relationTheory pred_setTheory listTheory finite_mapTheory
      hurdUtils pairTheory;
 
 open termTheory appFOLDLTheory chap2Theory chap3Theory nomsetTheory binderLib
-     horeductionTheory term_posnsTheory finite_developmentsTheory
-     basic_swapTheory NEWLib;
+     horeductionTheory term_posnsTheory finite_developmentsTheory NEWLib
+     basic_swapTheory;
 
 val _ = new_theory "head_reduction"
 
 val _ = hide "Y";
+
+(* Disable some conflicting overloads from labelledTermsTheory *)
+Overload FV  = “supp term_pmact”
+Overload VAR = “term$VAR”
 
 Inductive hreduce1 :
 [~BETA:]
@@ -1655,7 +1659,21 @@ Theorem hnf_head_VAR[simp] =
     (cj 2 hnf_head_hnf) |> Q.GEN ‘args’ |> Q.SPEC ‘[]’
                         |> REWRITE_RULE [appstar_empty]
 
-Overload hnf_headvar = “\t. THE_VAR (hnf_head t)”
+Definition var_name_def :
+    var_name t = @s. VAR s = t
+End
+
+Theorem var_name_thm[simp] :
+    var_name (VAR s) = s
+Proof
+    REWRITE_TAC [var_name_def]
+ >> SELECT_ELIM_TAC
+ >> CONJ_TAC
+ >- (Q.EXISTS_TAC ‘s’ >> art [])
+ >> rw []
+QED
+
+Overload hnf_headvar = “\t. var_name (hnf_head t)”
 
 (* hnf_children retrives the ‘args’ part of absfree hnf *)
 Definition hnf_children_def :

--- a/examples/lambda/barendregt/standardisationScript.sml
+++ b/examples/lambda/barendregt/standardisationScript.sml
@@ -1663,11 +1663,16 @@ val standard_reduction_under_LAMl = prove(
     METIS_TAC [standard_reduction_under_LAM]
   ]);
 
-val standardisation_theorem = store_thm(
-  "standardisation_theorem",
-  ``!M N. reduction beta M N ==>
+(* Theorem 11.4.7 [1, p.300]
+
+   NOTE: both this theorem and the next Corollary 11.4.8 are proved by Lemma
+   11.4.6 (Main Lemma).
+ *)
+Theorem standardisation_theorem :
+    !M N. reduction beta M N ==>
           ?s. (first s = M) /\ finite s /\ (last s = N) /\
-              standard_reduction s``,
+              standard_reduction s
+Proof
   CONV_TAC SWAP_VARS_CONV THEN GEN_TAC THEN completeInduct_on `size N` THEN
   FULL_SIMP_TAC (srw_ss()) [GSYM RIGHT_FORALL_IMP_THM] THEN
   SRW_TAC [][] THEN
@@ -1736,7 +1741,8 @@ val standardisation_theorem = store_thm(
            ASM_REWRITE_TAC []) THEN
     Q.EXISTS_TAC `plink hr sr2` THEN
     SRW_TAC [][head_standard_is_standard]
-  ]);
+  ]
+QED
 
 val hnf_preserved = store_thm(
   "hnf_preserved",
@@ -1758,10 +1764,10 @@ val hnf_reflected_over_ireduction = store_thm(
   SRW_TAC [][hnf_no_head_redex, i_reduce1_def] THEN
   METIS_TAC [lemma11_4_3ii]);
 
-(* NOTE: This is also Theorem 8.3.11 [1, p.174] *)
-val corollary11_4_8 = store_thm(
-  "corollary11_4_8",
-  ``!M. has_hnf M = finite (head_reduction_path M)``,
+(* Corollary 11.4.8 [1, p.299] (also Theorem 8.3.11 [1, p.174]) *)
+Theorem corollary11_4_8 :
+    !M. has_hnf M = finite (head_reduction_path M)
+Proof
   GEN_TAC THEN EQ_TAC THENL [
     SRW_TAC [][has_hnf_def] THEN
     `?Z. reduction beta M Z /\ reduction beta N Z`
@@ -1780,7 +1786,8 @@ val corollary11_4_8 = store_thm(
     Q.EXISTS_TAC `last (head_reduction_path M)` THEN
     METIS_TAC [head_reduces_reduction_beta, conversion_rules,
                head_reduces_def]
-  ]);
+  ]
+QED
 
 (* named by analogy with has_bnf_thm in chap3Theory *)
 val has_hnf_thm = store_thm(
@@ -2011,7 +2018,8 @@ Proof
            rw [Abbr ‘l0’, EL_MAP] ]) \\
      (* Case 1.2: all APP, some LAM:
 
-        M @@ N -h-> M1 @@ N -h->* (M2 = LAM v M') @@ N [EL n l] -h-> [N/v] M2' -h->* hnf
+        M @@ N -h-> M1 @@ N -h->* (M2 = LAM v M') @@ N [EL n l]
+                            -h-> [N/v] M2' -h->* hnf
       *)
      FULL_SIMP_TAC std_ss [NOT_EVERY_EXISTS_FIRST] \\
      Q.PAT_X_ASSUM ‘EVERY is_comb l’ (STRIP_ASSUME_TAC o (REWRITE_RULE [EVERY_EL])) \\
@@ -2062,7 +2070,8 @@ Proof
     ‘has_hnf M2’ by METIS_TAC [has_hnf_LAM_E] \\
      Cases_on ‘n = 0’ >- gs [] \\
   (* constructing a new head reduction list *)
-     rw [Once corollary11_4_8, Once finite_head_reduction_path_to_list_last_has_hnf] \\
+     rw [Once corollary11_4_8,
+         Once finite_head_reduction_path_to_list_last_has_hnf] \\
      qabbrev_tac ‘l0 = MAP rator l’ \\
     ‘(LENGTH l0 = LENGTH l) /\ l0 <> []’ by rw [Abbr ‘l0’] \\
     ‘0 < LENGTH l /\ 0 < LENGTH l0’ by rw [GSYM NOT_NIL_EQ_LENGTH_NOT_0] \\


### PR DESCRIPTION
Hi,

I mainly did some cleanups to the lambda code base, added some comments (e.g. there are totally 3 proofs of the beta-CR theorem), and (more importantly) I added a few new lemmas which is currently used in the ongoing paper.

In `lameta_completeTheory`, there was the `equivalent M N` relation for two λ-terms invented long time ago. In this definition, the excluded set is fixed to `FV M UNION FV N` and the rank is fixed to 0, and the already proved separability lemmas used this definition.  But the connection between `equivalent` and `subtree_equiv` indicates that it's better (easier for some proofs) to have another version with explicit excluded set and rank. The bridging theorem is proved as the following two:
```
[equivalent2_thm]
⊢ ∀X M N r.
    FINITE X ∧ 0 < r ∧ FV M ⊆ X ∪ RANK r ∧ FV N ⊆ X ∪ RANK r ⇒
    (equivalent2 X M N r ⇔ equivalent M N)

[equivalent_alt_equivalent2]
⊢ ∀M N. equivalent M N ⇔ equivalent2 (FV M ∪ FV N) M N 0
```
In this way, recent proofs and old proofs are connected. Not an elegant solution (to have two definitions for the same concept) but the efforts are minimal in this way.

--Chun