### PR TITLE
fix for DataSize error for finite_map

### DIFF
--- a/src/datatype/DataSize.sml
+++ b/src/datatype/DataSize.sml
@@ -202,8 +202,8 @@ fun size_def_to_comb (db : TypeBasePure.typeBase) opt_ind_rec size_def =
         val th1 = prove (eqs,
                 ho_match_mp_tac ind
                 \\ REWRITE_TAC (size_def' :: aux_size_eqs @ aux_size_rules @ useful_ths)
+                \\ rpt (CHANGED_TAC BETA_TAC)
                 \\ rpt strip_tac
-                \\ BETA_TAC
                 \\ ASSUM_LIST REWRITE_TAC)
         val th2 = prove (list_mk_conj aux_eqs, REWRITE_TAC [FUN_EQ_THM, th1])
       in SOME th2 end

--- a/src/datatype/selftest.sml
+++ b/src/datatype/selftest.sml
@@ -498,29 +498,34 @@ val _ = OK()
 
 val _ = tprint "Test for lambdas in supplied sizes (github issue #1400)";
 
-Hol_datatype `list_syn = L of (('a # 'b) list)`;
+val _ = quiet_warnings (fn () => let in
+  Hol_datatype `list_syn = L of (('a # 'b) list)`;
+  Defn.Hol_defn "list_syn_size_v1_def"
+    `list_syn_size_v1 (f : ('a # 'b) -> num$num) = (\x : ('a, 'b) list_syn. 0)`;
+  ()
+  end) ()
 
-Hol_defn "list_syn_size_v1_def"
-  `list_syn_size_v1 (f : ('a # 'b) -> num) = (\x : ('a, 'b) list_syn. 0)`;
-
-Hol_defn "list_syn_size_v2_def"
+val size_v2_defn = Defn.Hol_defn "list_syn_size_v2_def"
   `list_syn_size_v2 = (\x_sz y_sz. list_syn_size_v1 (\k. x_sz (FST k) + y_sz (SND k)))`;
+val size_v2_def = hd (Defn.eqns_of size_v2_defn);
 
 (* coerce a non-standard size term *)
 val _ = TypeBase.export [
     TypeBasePure.mk_nondatatype_info (
-      “: ('a, 'b) list_syn”,
+      ``: ('a, 'b) list_syn``,
       {encode = NONE,
-       size = SOME (``\(xsize : 'a -> num) (ysize : 'b -> num).
+       size = SOME (``\(xsize : 'a -> num$num) (ysize : 'b -> num$num).
                 list_syn_size_v2 (\x : 'a. 0) (\y. ysize y + 1)``,
-            fetch "-" "list_syn_size_v2_def"),
+            size_v2_def),
        induction = NONE,
        nchotomy = NONE}
       )
   ]
 
 (* test the type with the non-standard size can be used in a size eq proof *)
-Hol_datatype `t1 = T1 of (((num, num) list_syn # t2) list)
+val _ = Hol_datatype `t1 = T1 of (((num, num) list_syn # t2) list)
     ;  t2 = T2 of t1`;
+
+val _ = OK ()
 
 val _ = Process.exit Process.success;

--- a/src/datatype/selftest.sml
+++ b/src/datatype/selftest.sml
@@ -496,4 +496,31 @@ val _ = quiet_warnings (fn () =>
            ) () handle _ => die "FAILED!"
 val _ = OK()
 
+val _ = tprint "Test for lambdas in supplied sizes (github issue #1400)";
+
+Hol_datatype `list_syn = L of (('a # 'b) list)`;
+
+Hol_defn "list_syn_size_v1_def"
+  `list_syn_size_v1 (f : ('a # 'b) -> num) = (\x : ('a, 'b) list_syn. 0)`;
+
+Hol_defn "list_syn_size_v2_def"
+  `list_syn_size_v2 = (\x_sz y_sz. list_syn_size_v1 (\k. x_sz (FST k) + y_sz (SND k)))`;
+
+(* coerce a non-standard size term *)
+val _ = TypeBase.export [
+    TypeBasePure.mk_nondatatype_info (
+      “: ('a, 'b) list_syn”,
+      {encode = NONE,
+       size = SOME (``\(xsize : 'a -> num) (ysize : 'b -> num).
+                list_syn_size_v2 (\x : 'a. 0) (\y. ysize y + 1)``,
+            fetch "-" "list_syn_size_v2_def"),
+       induction = NONE,
+       nchotomy = NONE}
+      )
+  ]
+
+(* test the type with the non-standard size can be used in a size eq proof *)
+Hol_datatype `t1 = T1 of (((num, num) list_syn # t2) list)
+    ;  t2 = T2 of t1`;
+
 val _ = Process.exit Process.success;


### PR DESCRIPTION
[github issue #1400]

A proof of type-size equivalence fails when the finite_map type is present, because the size installed for finite_map contains a lambda and causes a BETA_TAC to apply to the wrong thing. This simple fix seems to solve the problem.

The breaking example depends on the finite_map type, and probably can't be easily added to the self-test.