### PR TITLE
[probability] indep_functions_of_vars, etc.

### DIFF
--- a/examples/probability/stochastic_processScript.sml
+++ b/examples/probability/stochastic_processScript.sml
@@ -1774,7 +1774,7 @@ QED
 
 (* |- !sp A f J.
         (!i. i IN J ==> sigma_algebra (A i)) /\
-        (!i. f i IN (sp -> space (A i))) ==>
+        (!i. i IN J ==> f i IN (sp -> space (A i))) ==>
         !i. i IN J ==> f i IN measurable (sigma sp A f J) (A i)
  *)
 val lemma =
@@ -1783,9 +1783,9 @@ val lemma =
                                     |> INST_TYPE [“:'index” |-> “:num”]
                                     |> INST_TYPE [“:'temp” |-> “:'a”];
 
-Theorem sigma_lists_simultaneously_measurable :
+Theorem sigma_lists_simultaneously_measurable[local] :
     !B N. sigma_algebra B /\
-         (!i. (EL i) IN (rectangle (\n. space B) N -> space B)) ==>
+         (!i. i < N ==> (EL i) IN (rectangle (\n. space B) N -> space B)) ==>
           !i. i < N ==> (EL i) IN measurable (sigma_lists B N) B
 Proof
     rw [sigma_lists_def]
@@ -1799,6 +1799,17 @@ Theorem IN_MEASURABLE_BOREL_EL =
         SRULE [SPACE_BOREL, SIGMA_ALGEBRA_BOREL, IN_FUNSET, GSYM Borel_lists_def]
               (ISPEC “Borel” sigma_lists_simultaneously_measurable)
 
+(* cf. sigma_algebraTheory.MEASURABLE_FST and MEASURABLE_SND *)
+Theorem MEASURABLE_EL :
+    !B N. sigma_algebra B ==>
+          !i. i < N ==> (EL i) IN measurable (sigma_lists B N) B
+Proof
+    NTAC 3 STRIP_TAC
+ >> MATCH_MP_TAC sigma_lists_simultaneously_measurable >> art []
+ >> rw [IN_FUNSET, IN_list_rectangle]
+QED
+
+(* cf. sigma_algebraTheory.MEASURABLE_FST *)
 Theorem IN_MEASURABLE_BOREL_HD :
     !N. 0 < N ==> HD IN Borel_measurable (Borel_lists N)
 Proof

--- a/examples/probability/stochastic_processScript.sml
+++ b/examples/probability/stochastic_processScript.sml
@@ -1,7 +1,7 @@
 (* ========================================================================= *)
 (* stochastic_processScript.sml: Theory of General Stochastic Processes      *)
 (*                                                                           *)
-(* Author: Chun Tian (binghe) <binghe.lisp@gmail.com> (2021 - 2024)          *)
+(* Author: Chun Tian (binghe) <binghe.lisp@gmail.com> (2021 - 2025)          *)
 (* ========================================================================= *)
 
 open HolKernel Parse boolLib bossLib;
@@ -9,11 +9,11 @@ open HolKernel Parse boolLib bossLib;
 open combinTheory arithmeticTheory pred_setTheory pred_setLib numLib hurdUtils
      posetTheory listTheory fcpTheory fcpLib topologyTheory;
 
-open realTheory realLib iterateTheory real_sigmaTheory real_topologyTheory;
+open realTheory realLib iterateTheory real_sigmaTheory real_topologyTheory
+     extreal_baseTheory extrealTheory;
 
-open util_probTheory sigma_algebraTheory extrealTheory real_borelTheory
-     measureTheory borelTheory lebesgueTheory martingaleTheory
-     probabilityTheory;
+open util_probTheory sigma_algebraTheory real_borelTheory borelTheory
+     measureTheory lebesgueTheory martingaleTheory probabilityTheory;
 
 val _ = new_theory "stochastic_process";
 
@@ -34,6 +34,8 @@ val _ = intLib.deprecate_int ();
 val _ = ratLib.deprecate_rat ();
 
 val _ = hide "S";
+
+Overload sum_list = “FOLDR $+ (0 :extreal)”
 
 (* ------------------------------------------------------------------------- *)
 (*  General filtration/martingale with poset indexes (Chapter 25 of [9])     *)
@@ -302,12 +304,14 @@ Proof
        [ (* goal 2.1 (of 2) *)
          rename1 ‘x ' i IN space B’ \\
          Cases_on ‘i = n’
-         >- (Q.PAT_X_ASSUM ‘!i. i < dimindex (:'N) ==> x ' i IN h i’ (MP_TAC o (Q.SPEC ‘n’)) \\
-             rw [] \\
+         >- (Q.PAT_X_ASSUM ‘!i. i < dimindex (:'N) ==> x ' i IN h i’
+               (MP_TAC o (Q.SPEC ‘n’)) >> rw [] \\
              FULL_SIMP_TAC std_ss [subset_class_def] \\
              METIS_TAC [SUBSET_DEF]) \\
-         Q.PAT_X_ASSUM ‘!i. i < dimindex (:'N) /\ i <> n ==> P’ (MP_TAC o (Q.SPEC ‘i’)) \\
-         Q.PAT_X_ASSUM ‘!i. i < dimindex (:'N) ==> x ' i IN h i’ (MP_TAC o (Q.SPEC ‘i’)) \\
+         Q.PAT_X_ASSUM ‘!i. i < dimindex (:'N) /\ i <> n ==> P’
+           (MP_TAC o (Q.SPEC ‘i’)) \\
+         Q.PAT_X_ASSUM ‘!i. i < dimindex (:'N) ==> x ' i IN h i’
+           (MP_TAC o (Q.SPEC ‘i’)) \\
          rw [] >> fs [],
          (* goal 2.2 (of 2) *)
          Cases_on ‘i = n’ >> rw [] ] ])
@@ -336,7 +340,8 @@ Proof
  >- (rw [Abbr ‘prod’, SUBSET_DEF] \\
      Know ‘rectangle h (:'N) =
            BIGINTER (IMAGE (\n. {v | v ' n IN h n /\
-                                     !i. i < dimindex (:'N) /\ i <> n ==> v ' i IN space B})
+                                     !i. i < dimindex (:'N) /\ i <> n ==>
+                                         v ' i IN space B})
                            (count (dimindex(:'N))))’
      >- (rw [fcp_rectangle_def, Once EXTENSION, IN_BIGINTER_IMAGE] \\
          EQ_TAC >> rw [] \\
@@ -349,8 +354,9 @@ Proof
                          v ' i IN h i /\
                         !j. j < dimindex (:'N) /\ j <> i ==> v ' j IN space B}’ \\
      Suff ‘A IN sts’ >- PROVE_TAC [SUBSET_DEF] \\
-     Q.PAT_X_ASSUM ‘sigma_algebra (sigma (rectangle (\n. space B) (:'N)) sts)’      K_TAC \\
-     Q.PAT_X_ASSUM ‘sts SUBSET subsets (sigma (rectangle (\n. space B) (:'N)) sts)’ K_TAC \\
+     Q.PAT_X_ASSUM ‘sigma_algebra (sigma (rectangle (\n. space B) (:'N)) sts)’ K_TAC \\
+     Q.PAT_X_ASSUM ‘sts SUBSET
+                    subsets (sigma (rectangle (\n. space B) (:'N)) sts)’ K_TAC \\
      rw [Abbr ‘A’, Abbr ‘sts’, IN_BIGUNION_IMAGE] \\
      rename1 ‘n < dimindex(:'N)’ \\
      Q.EXISTS_TAC ‘n’ >> rw [] \\
@@ -851,10 +857,10 @@ Proof
                               (subsets B))
                    (count N))’
  >> Q.ABBREV_TAC
-   ‘sts = BIGUNION (IMAGE (\n. {rectangle h N | h |
-                                                h n IN subsets B /\
-                                                !i. i < N /\ i <> n ==> h i = space B})
-                          (count N))’
+   ‘sts = BIGUNION
+            (IMAGE (\n. {rectangle h N | h | h n IN subsets B /\
+                                             !i. i < N /\ i <> n ==> h i = space B})
+                   (count N))’
  >> Know ‘src = sts’
  >- (rw [Abbr ‘src’, Abbr ‘sts’, Once EXTENSION, PREIMAGE_def] \\
      EQ_TAC >> rw [] >| (* 2 subgoals *)
@@ -887,8 +893,8 @@ Proof
        [ (* goal 2.1 (of 2) *)
          rename1 ‘EL i x IN space B’ \\
          Cases_on ‘i = n’
-         >- (Q.PAT_X_ASSUM ‘!i. i < LENGTH x ==> EL i x IN h i’ (MP_TAC o (Q.SPEC ‘n’)) \\
-             rw [] \\
+         >- (Q.PAT_X_ASSUM ‘!i. i < LENGTH x ==> EL i x IN h i’
+               (MP_TAC o (Q.SPEC ‘n’)) >> rw [] \\
              FULL_SIMP_TAC std_ss [subset_class_def] \\
              METIS_TAC [SUBSET_DEF]) \\
          Q.PAT_X_ASSUM ‘!i. i < LENGTH x /\ i <> n ==> P’ (MP_TAC o (Q.SPEC ‘i’)) \\
@@ -993,6 +999,135 @@ Proof
  >> fs [sigma_algebra_def, algebra_def]
 QED
 
+Definition wrap_def :
+    wrap e = [e]
+End
+
+Theorem IMAGE_wrap_univ :
+    IMAGE wrap univ(:'a) = {v | LENGTH v = 1}
+Proof
+    rw [Once EXTENSION, wrap_def]
+ >> EQ_TAC >> rw []
+ >- simp []
+ >> Cases_on ‘x’ >> fs []
+QED
+
+Theorem LENGTH_wrap[simp] :
+    LENGTH (wrap e) = 1
+Proof
+    rw [wrap_def]
+QED
+
+Definition unwrap_def :
+    unwrap = EL 0
+End
+
+Theorem unwrap_wrap[simp] :
+    unwrap (wrap x) = x
+Proof
+    rw [wrap_def, unwrap_def]
+QED
+
+Theorem wrap_unwrap :
+    !x. LENGTH x = 1 ==> wrap (unwrap x) = x
+Proof
+    rw [wrap_def, unwrap_def]
+QED
+
+Theorem IMAGE_unwrap_wrap[simp] :
+    IMAGE unwrap (IMAGE wrap s) = s
+Proof
+    rw [Once EXTENSION]
+ >> EQ_TAC >> rw [] >- simp []
+ >> Q.EXISTS_TAC ‘wrap x’ >> simp []
+ >> Q.EXISTS_TAC ‘x’ >> art []
+QED
+
+Theorem IMAGE_wrap_unwrap :
+    !s. (!e. e IN s ==> LENGTH e = 1) ==> IMAGE wrap (IMAGE unwrap s) = s
+Proof
+    rpt STRIP_TAC
+ >> rw [Once EXTENSION]
+ >> EQ_TAC >> rw []
+ >- (rename1 ‘wrap (unwrap y) IN s’ \\
+     Suff ‘wrap (unwrap y) = y’ >- rw [] \\
+     MATCH_MP_TAC wrap_unwrap >> rw [])
+ >> ‘LENGTH x = 1’ by PROVE_TAC []
+ >> Q.EXISTS_TAC ‘unwrap x’ >> rw [wrap_unwrap]
+ >> Q.EXISTS_TAC ‘x’ >> art []
+QED
+
+Theorem sigma_lists_1 :
+    !b. sigma_algebra b ==>
+        sigma_lists b 1 = (IMAGE wrap (space b), IMAGE (IMAGE wrap) (subsets b))
+Proof
+    rw [sigma_lists_alt_sigma_algebra, list_rectangle_1]
+ >> qmatch_abbrev_tac ‘_ = (sp,sts)’
+ >> Know ‘IMAGE (\e. [e]) (space b) = sp’
+ >- rw [Abbr ‘sp’, wrap_def, Once EXTENSION]
+ >> Rewr'
+ >> Know ‘{IMAGE (\e. [e]) (h (0 :num)) | h 0 IN subsets b} = sts’
+ >- (rw [Abbr ‘sts’, wrap_def, Once EXTENSION] \\
+     EQ_TAC >> rw [] >| (* 2 subgoals *)
+     [ (* goal 1 (of 2) *)
+       Q.EXISTS_TAC ‘h 0’ \\
+       rw [Once EXTENSION, wrap_def],
+       (* goal 2 (of 2) *)
+       rename1 ‘s IN subsets b’ \\
+       Q.EXISTS_TAC ‘\x. s’ \\
+       rw [Once EXTENSION, wrap_def] ])
+ >> Rewr'
+ >> MATCH_MP_TAC (SRULE [] (Q.SPEC ‘(sp,sts)’ SIGMA_STABLE))
+ >> rw [Abbr ‘sp’, Abbr ‘sts’, sigma_algebra_alt_pow]
+ >| [ (* goal 1 (of 4) *)
+      rw [SUBSET_DEF, IN_POW] \\
+      rename1 ‘s IN subsets b’ \\
+      rename1 ‘s' IN IMAGE wrap s’ \\
+      POP_ASSUM MP_TAC >> rw [wrap_def] \\
+      fs [sigma_algebra_def, algebra_def, subset_class_def] \\
+      Q.PAT_X_ASSUM ‘!x. x IN subsets b ==> x SUBSET space b’
+        (MP_TAC o Q.SPEC ‘s’) >> rw [SUBSET_DEF],
+      (* goal 2 (of 4) *)
+      MATCH_MP_TAC SIGMA_ALGEBRA_EMPTY >> art [],
+      (* goal 3 (of 4) *)
+      Q.EXISTS_TAC ‘space b DIFF x’ \\
+      reverse CONJ_TAC >- (MATCH_MP_TAC SIGMA_ALGEBRA_COMPL >> art []) \\
+      rw [Once EXTENSION, wrap_def] \\
+      EQ_TAC >> rw [] >> art [],
+      (* goal 4 (of 4) *)
+      POP_ASSUM MP_TAC \\
+      rw [SUBSET_DEF, wrap_def] \\
+      Q.EXISTS_TAC ‘BIGUNION (IMAGE (\i. IMAGE unwrap (A i)) UNIV)’ \\
+      reverse CONJ_TAC
+      >- (MATCH_MP_TAC SIGMA_ALGEBRA_ENUM >> rw [IN_FUNSET] \\
+          POP_ASSUM (MP_TAC o Q.SPEC ‘A (i :num)’) \\
+          impl_tac >- (Q.EXISTS_TAC ‘i’ >> REWRITE_TAC []) \\
+          rw [] \\
+          rename1 ‘A i = IMAGE wrap s’ \\
+          Q.PAT_X_ASSUM ‘A i = IMAGE wrap s’ (REWRITE_TAC o wrap) \\
+          simp []) \\
+      rw [Once EXTENSION, IN_BIGUNION_IMAGE] \\
+      EQ_TAC >> rw []
+      >- (Q.PAT_X_ASSUM ‘!x. P’ (MP_TAC o Q.SPEC ‘A (i :num)’) \\
+          impl_tac >- (Q.EXISTS_TAC ‘i’ >> REWRITE_TAC []) \\
+          rw [] >> rename1 ‘s IN subsets b’ \\
+          Q.EXISTS_TAC ‘unwrap x’ \\
+          CONJ_TAC
+          >- (ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
+              MATCH_MP_TAC wrap_unwrap \\
+              Q.PAT_X_ASSUM ‘A i = IMAGE wrap s’ (fs o wrap)) \\
+          qexistsl_tac [‘i’, ‘x’] >> art []) \\
+      rename1 ‘s IN A i’ \\
+      Q.EXISTS_TAC ‘A i’ \\
+      reverse CONJ_TAC >- (Q.EXISTS_TAC ‘i’ >> REWRITE_TAC []) \\
+      Suff ‘wrap (unwrap s) = s’ >- rw [] \\
+      MATCH_MP_TAC wrap_unwrap \\
+      Q.PAT_X_ASSUM ‘!x. P’ (MP_TAC o Q.SPEC ‘A (i :num)’) \\
+      impl_tac >- (Q.EXISTS_TAC ‘i’ >> REWRITE_TAC []) \\
+      rw [] >> rename1 ‘t IN subsets b’ \\
+      Q.PAT_X_ASSUM ‘A i = IMAGE wrap t’ (fs o wrap) ]
+QED
+
 (* NOTE: This is a difficult result. It gives another alternative definition of
    sigma_lists using the very 1-dimensional generator. --Chun Tian, 25 ago 2024
  *)
@@ -1050,8 +1185,8 @@ Proof
        [ (* goal 2.1 (of 2) *)
          rename1 ‘EL i x IN sp’ \\
          Cases_on ‘i = n’
-         >- (Q.PAT_X_ASSUM ‘!i. i < LENGTH x ==> EL i x IN h i’ (MP_TAC o (Q.SPEC ‘n’)) \\
-             rw [] \\
+         >- (Q.PAT_X_ASSUM ‘!i. i < LENGTH x ==> EL i x IN h i’
+               (MP_TAC o (Q.SPEC ‘n’)) >> rw [] \\
              qabbrev_tac ‘a = sigma sp sts’ \\
             ‘sigma_algebra a’ by rw [Abbr ‘a’, SIGMA_ALGEBRA_SIGMA] \\
             ‘space a = sp’ by rw [Abbr ‘a’, SPACE_SIGMA] \\
@@ -1089,7 +1224,8 @@ Proof
  >> ‘src' SUBSET subsets (sigma (rectangle (\n. sp) N) src')’
        by PROVE_TAC [SIGMA_SUBSET_SUBSETS]
  (* ‘prod’ further eliminates ‘BIGUNION IMAGE ...’ *)
- >> Q.ABBREV_TAC ‘prod = {rectangle h N | h | !i. i < N ==> h i IN subsets (sigma sp sts)}’
+ >> Q.ABBREV_TAC ‘prod = {rectangle h N | h |
+                          !i. i < N ==> h i IN subsets (sigma sp sts)}’
  >> Know ‘prod SUBSET subsets (sigma (rectangle (\n. sp) N) src')’
  >- (rw [Abbr ‘prod’, SUBSET_DEF] \\
      Know ‘rectangle h N =
@@ -1231,10 +1367,11 @@ Proof
  >> qabbrev_tac ‘N = SUC n’
  >> qabbrev_tac ‘Z = rectangle (\n. sp) N’
  >> qabbrev_tac ‘S = {rectangle h N | h | !i. i < N ==> h i IN sts}’
- >> qabbrev_tac ‘B = {rectangle h N | h | !i. i < N ==> h i IN subsets (sigma sp sts)}’
+ >> qabbrev_tac ‘B = {rectangle h N | h |
+                      !i. i < N ==> h i IN subsets (sigma sp sts)}’
  >> qabbrev_tac ‘a = sigma sp sts’
  >> Know ‘{rectangle h (SUC N) | h | !i. i < SUC N ==> h i IN subsets a} =
-          cons_prod (subsets a) B’
+           cons_prod (subsets a) B’
  >- (rw [cons_prod_def, cons_cross_def, Once EXTENSION] \\
      EQ_TAC >> rw [list_rectangle_def, Once EXTENSION] >| (* 2 subgoals *)
      [ (* goal 1 (of 2) *)
@@ -1247,8 +1384,8 @@ Proof
              Cases_on ‘v’ >> fs [] \\
              CONJ_TAC >- (POP_ASSUM (MP_TAC o Q.SPEC ‘0’) >> simp []) \\
              rpt STRIP_TAC \\
-             Q.PAT_X_ASSUM ‘!i. i < SUC N ==> EL i _ IN h i’ (MP_TAC o Q.SPEC ‘SUC i’) \\
-             simp [],
+             Q.PAT_X_ASSUM ‘!i. i < SUC N ==> EL i _ IN h i’
+               (MP_TAC o Q.SPEC ‘SUC i’) >> simp [],
              (* goal 1.2 (of 3) *)
              rw [],
              (* goal 1.3 (of 3) *)
@@ -1322,7 +1459,8 @@ Proof
      qunabbrevl_tac [‘t’, ‘a’] \\
   (* preparing for cons_sigma_of_generator *)
      Know ‘Z' = cons_cross sp Z’
-     >- (rw [Abbr ‘Z'’, Abbr ‘Z’, cons_cross_def, Once EXTENSION, IN_list_rectangle] \\
+     >- (rw [Abbr ‘Z'’, Abbr ‘Z’, cons_cross_def, Once EXTENSION,
+             IN_list_rectangle] \\
          EQ_TAC >> rw [] >| (* 3 subgoals *)
          [ (* goal 1 (of 3) *)
            Cases_on ‘x’ >> fs [] \\
@@ -1513,9 +1651,8 @@ Proof
  >> Q.EXISTS_TAC ‘PosInf’ >> rw []
 QED
 
-(* |- !h N.
-        (!i. i < N ==> h i IN subsets Borel) /\ 0 < N ==>
-        rectangle h N IN subsets (Borel_lists N)
+(* |- !h N. (!i. i < N ==> h i IN subsets Borel) /\ 0 < N ==>
+            rectangle h N IN subsets (Borel_lists N)
  *)
 Theorem list_rectangle_IN_Borel_lists =
     REWRITE_RULE [SIGMA_ALGEBRA_BOREL, GSYM Borel_lists_def]
@@ -1628,6 +1765,13 @@ Proof
  >> rw [SIGMA_ALGEBRA_BOREL]
 QED
 
+Theorem Borel_lists_1 :
+    Borel_lists 1 = (IMAGE wrap univ(:extreal),
+                     IMAGE (IMAGE wrap) (subsets Borel))
+Proof
+    rw [Borel_lists_def, sigma_lists_1, SIGMA_ALGEBRA_BOREL, SPACE_BOREL]
+QED
+
 (* |- !sp A f J.
         (!i. i IN J ==> sigma_algebra (A i)) /\
         (!i. f i IN (sp -> space (A i))) ==>
@@ -1654,6 +1798,742 @@ QED
 Theorem IN_MEASURABLE_BOREL_EL =
         SRULE [SPACE_BOREL, SIGMA_ALGEBRA_BOREL, IN_FUNSET, GSYM Borel_lists_def]
               (ISPEC “Borel” sigma_lists_simultaneously_measurable)
+
+Theorem IN_MEASURABLE_BOREL_HD :
+    !N. 0 < N ==> HD IN Borel_measurable (Borel_lists N)
+Proof
+    rpt STRIP_TAC
+ >> MP_TAC (Q.SPECL [‘N’, ‘0’] IN_MEASURABLE_BOREL_EL) >> rw []
+QED
+
+(* NOTE: “(\x. MAP (\i. f i x) l)” is essentially a random vector. This theorem
+   could be further generalised to “sigma_lists B n” but not necessary for now.
+
+   cf. IN_MEASURABLE_BOREL_2D_VECTOR
+ *)
+Theorem IN_MEASURABLE_BOREL_LISTS :
+    !a f l n. sigma_algebra a /\ LENGTH (l :'index list) = n /\ 0 < n /\
+             (!i. MEM i l ==> f i IN measurable a Borel) ==>
+             (\x. MAP (\i. f i x) l) IN measurable a (Borel_lists n)
+Proof
+    rw [IN_MEASURABLE, space_Borel_lists, IN_FUNSET, SPACE_BOREL]
+ >> qabbrev_tac ‘n = LENGTH l’
+ >> Q.PAT_X_ASSUM ‘s IN subsets (Borel_lists n)’ MP_TAC
+ >> qabbrev_tac
+      ‘P = \s. s IN subsets (Borel_lists n) /\
+               PREIMAGE (\x. MAP (\i. f i x) l) s INTER space a IN subsets a’
+ >> Suff ‘subsets (Borel_lists n) SUBSET P’
+ >- rw [SUBSET_DEF, IN_APP, Abbr ‘P’]
+ >> simp [Borel_lists_alt_sigma]
+ >> qmatch_abbrev_tac ‘subsets (sigma sp sts) SUBSET P’
+ >> qabbrev_tac ‘b = (sp,P)’
+ >> ‘P = subsets b’ by rw [Abbr ‘b’] >> POP_ORW
+ >> ‘sp = space b’  by rw [Abbr ‘b’] >> POP_ORW
+ >> MATCH_MP_TAC SIGMA_SUBSET
+ >> reverse CONJ_TAC
+ >- (rw [Abbr ‘b’, Abbr ‘P’, Abbr ‘sts’, SUBSET_DEF, Borel_lists_alt_sigma]
+     >- (MATCH_MP_TAC IN_SIGMA >> rw [] \\
+         Q.EXISTS_TAC ‘h’ >> art []) \\
+     qmatch_abbrev_tac ‘PREIMAGE g (rectangle h n) INTER space a IN subsets a’ \\
+     MP_TAC (Q.SPECL [‘g’, ‘h’, ‘n’]
+                     (INST_TYPE [beta |-> “:extreal”] PREIMAGE_list_rectangle)) \\
+     simp [Abbr ‘g’, BIGINTER_OVER_INTER_L] \\
+     DISCH_THEN K_TAC (* already used *) \\
+     MATCH_MP_TAC SIGMA_ALGEBRA_FINITE_INTER >> rw [EL_MAP] \\
+    ‘(\x. f (EL i l) x) = f (EL i l)’ by rw [FUN_EQ_THM] >> POP_ORW \\
+     FIRST_X_ASSUM irule >> rw [EL_MEM])
+ (* stage work *)
+ >> rw [Abbr ‘b’, Abbr ‘P’, sigma_algebra_alt_pow] (* 7 subgoals *)
+ >| [ (* goal 1 (of 7) *)
+      rw [Abbr ‘sp’, SUBSET_DEF, IN_POW] \\
+      MP_TAC (Q.SPEC ‘n’ sigma_algebra_Borel_lists) \\
+      rw [sigma_algebra_def, algebra_def, subset_class_def, space_Borel_lists] \\
+      Q.PAT_X_ASSUM ‘!x. x IN subsets (Borel_lists n) ==>
+                         x SUBSET {v | LENGTH v = n}’ (MP_TAC o Q.SPEC ‘x’) \\
+      rw [SUBSET_DEF],
+      (* goal 2 (of 7) *)
+      MATCH_MP_TAC SIGMA_ALGEBRA_EMPTY \\
+      REWRITE_TAC [sigma_algebra_Borel_lists],
+      (* goal 3 (of 7) *)
+      MATCH_MP_TAC SIGMA_ALGEBRA_EMPTY >> art [],
+      (* goal 4 (of 7) *)
+      simp [Abbr ‘sp’, GSYM space_Borel_lists] \\
+      MATCH_MP_TAC SIGMA_ALGEBRA_COMPL \\
+      rw [sigma_algebra_Borel_lists],
+      (* goal 5 (of 7) *)
+      rw [PREIMAGE_DIFF] \\
+      qmatch_abbrev_tac ‘(X DIFF A) INTER space a IN subsets a’ \\
+     ‘(X DIFF A) INTER space a = (X INTER space a) DIFF (A INTER space a)’
+        by SET_TAC [] >> POP_ORW \\
+      Know ‘X INTER space a = space a’
+      >- (Suff ‘space a SUBSET X’ >- SET_TAC [] \\
+          rw [SUBSET_DEF, Abbr ‘X’, IN_PREIMAGE, Abbr ‘sp’]) >> Rewr' \\
+      MATCH_MP_TAC SIGMA_ALGEBRA_COMPL >> art [],
+      (* goal 6 (of 7) *)
+     ‘BIGUNION {A i | i | T} = BIGUNION (IMAGE A UNIV)’ by rw [Once EXTENSION] \\
+      POP_ORW \\
+      MATCH_MP_TAC SIGMA_ALGEBRA_ENUM \\
+      POP_ASSUM MP_TAC \\
+      rw [sigma_algebra_Borel_lists, IN_FUNSET, SUBSET_DEF] \\
+      POP_ASSUM (MP_TAC o Q.SPEC ‘A (x :num)’) \\
+      impl_tac >- (Q.EXISTS_TAC ‘x’ >> art []) >> rw [],
+      (* goal 7 (of 7) *)
+     ‘BIGUNION {A i | i | T} = BIGUNION (IMAGE A UNIV)’ by rw [Once EXTENSION] \\
+      POP_ORW \\
+      simp [PREIMAGE_BIGUNION, IMAGE_IMAGE, o_DEF, BIGUNION_OVER_INTER_L] \\
+      MATCH_MP_TAC SIGMA_ALGEBRA_ENUM >> simp [IN_FUNSET] \\
+      Q.X_GEN_TAC ‘i’ \\
+      POP_ASSUM MP_TAC \\
+      rw [SUBSET_DEF] \\
+      POP_ASSUM (MP_TAC o Q.SPEC ‘A (i :num)’) \\
+      impl_tac >- (Q.EXISTS_TAC ‘i’ >> art []) >> rw [] ]
+QED
+
+Theorem IN_MEASURABLE_BOREL_TL :
+    !N. 0 < N ==> TL IN measurable (Borel_lists (SUC N)) (Borel_lists N)
+Proof
+    rw [IN_MEASURABLE, IN_FUNSET, space_Borel_lists]
+ >- (Cases_on ‘x’ >> fs [])
+ >> POP_ASSUM MP_TAC
+ >> qabbrev_tac ‘P = \s. s IN subsets (Borel_lists N) /\
+                         PREIMAGE TL s INTER {v :extreal list | LENGTH v = SUC N} IN
+                         subsets (Borel_lists (SUC N))’
+ >> Suff ‘subsets (Borel_lists N) SUBSET P’
+ >- simp [SUBSET_DEF, Abbr ‘P’, IN_APP]
+ >> simp [Borel_lists_alt_sigma]
+ >> qmatch_abbrev_tac ‘subsets (sigma sp sts) SUBSET P’
+ >> qabbrev_tac ‘b = (sp,P)’
+ >> ‘P = subsets b’ by rw [Abbr ‘b’] >> POP_ORW
+ >> ‘sp = space b’  by rw [Abbr ‘b’] >> POP_ORW
+ >> MATCH_MP_TAC SIGMA_SUBSET
+ >> simp [Abbr ‘b’]
+ >> reverse CONJ_TAC
+ >- (rw [Abbr ‘sts’, Abbr ‘P’, SUBSET_DEF]
+     >- (simp [Borel_lists_alt_sigma] \\
+         MATCH_MP_TAC IN_SIGMA >> rw [] \\
+         Q.EXISTS_TAC ‘h’ >> simp []) \\
+     rw [Borel_lists_alt_sigma, PREIMAGE_def] \\
+     MATCH_MP_TAC IN_SIGMA >> rw [] \\
+     Q.EXISTS_TAC ‘\i. if i = 0 then UNIV else h (i - 1)’ \\
+     CONJ_TAC
+     >- (rw [Once EXTENSION] \\
+         EQ_TAC >> rw [IN_list_rectangle] >| (* 3 subgoals *)
+         [ (* goal 1 (of 3) *)
+           Cases_on ‘i’ >> fs [] \\
+           Cases_on ‘x’ >> fs [],
+           (* goal 2 (of 3) *)
+           Cases_on ‘x’ >> fs [],
+           (* goal 3 (of 3) *)
+           Cases_on ‘x’ >> fs [] \\
+           Q.PAT_X_ASSUM ‘!i. i < SUC N ==> P’ (MP_TAC o Q.SPEC ‘SUC i’) \\
+           simp [] ]) \\
+     rw [] \\
+     REWRITE_TAC [GSYM SPACE_BOREL] \\
+     MATCH_MP_TAC SIGMA_ALGEBRA_SPACE \\
+     rw [SIGMA_ALGEBRA_BOREL])
+ (* stage work *)
+ >> rw [sigma_algebra_alt_pow, Abbr ‘P’] (* 7 subgoals *)
+ >| [ (* goal 1 (of 7) *)
+       rw [SUBSET_DEF, IN_POW] \\
+       POP_ASSUM MP_TAC \\
+       Suff ‘x SUBSET sp’ >- rw [SUBSET_DEF] \\
+       MP_TAC (Q.SPEC ‘N’ sigma_algebra_Borel_lists) \\
+       rw [sigma_algebra_def, algebra_def, subset_class_def, space_Borel_lists],
+       (* goal 2 (of 7) *)
+       MATCH_MP_TAC SIGMA_ALGEBRA_EMPTY \\
+       rw [sigma_algebra_Borel_lists],
+       (* goal 3 (of 7) *)
+       MATCH_MP_TAC SIGMA_ALGEBRA_EMPTY \\
+       rw [sigma_algebra_Borel_lists],
+       (* goal 4 (of 7) *)
+       simp [Abbr ‘sp’, GSYM space_Borel_lists] \\
+       MATCH_MP_TAC SIGMA_ALGEBRA_COMPL \\
+       rw [sigma_algebra_Borel_lists],
+       (* goal 5 (of 7) *)
+       simp [PREIMAGE_DIFF] \\
+       qmatch_abbrev_tac ‘(A DIFF B) INTER Z IN _’ \\
+      ‘(A DIFF B) INTER Z = (A INTER Z) DIFF (B INTER Z)’ by SET_TAC [] \\
+       POP_ORW \\
+       Know ‘A INTER Z = space (Borel_lists (SUC N))’
+       >- (simp [space_Borel_lists] \\
+           Suff ‘Z SUBSET A’ >- SET_TAC [] \\
+           rw [Abbr ‘Z’, Abbr ‘A’, SUBSET_DEF, IN_PREIMAGE, Abbr ‘sp’] \\
+           Cases_on ‘x’ >> fs []) >> Rewr' \\
+       MATCH_MP_TAC SIGMA_ALGEBRA_COMPL \\
+       rw [sigma_algebra_Borel_lists],
+       (* goal 6 (of 7) *)
+      ‘{A i | i | T} = IMAGE A UNIV’ by rw [Once EXTENSION] >> POP_ORW \\
+       MATCH_MP_TAC SIGMA_ALGEBRA_ENUM \\
+       rw [sigma_algebra_Borel_lists, IN_FUNSET] \\
+       POP_ASSUM MP_TAC >> rw [SUBSET_DEF] \\
+       POP_ASSUM (MP_TAC o Q.SPEC ‘A (x :num)’) \\
+       impl_tac >- (Q.EXISTS_TAC ‘x’ >> art []) \\
+       simp [],
+       (* goal 7 (of 7) *)
+      ‘{A i | i | T} = IMAGE A UNIV’ by rw [Once EXTENSION] >> POP_ORW \\
+       simp [PREIMAGE_BIGUNION, IMAGE_IMAGE, o_DEF, BIGUNION_OVER_INTER_L] \\
+       MATCH_MP_TAC SIGMA_ALGEBRA_ENUM \\
+       rw [sigma_algebra_Borel_lists, IN_FUNSET] \\
+       POP_ASSUM MP_TAC >> rw [SUBSET_DEF] \\
+       POP_ASSUM (MP_TAC o Q.SPEC ‘A (x :num)’) \\
+       impl_tac >- (Q.EXISTS_TAC ‘x’ >> art []) \\
+       simp [] ]
+QED
+
+(* cf. IN_MEASURABLE_BOREL_ADD' and IN_MEASURABLE_BOREL_2D_VECTOR, and
+       IN_MEASURABLE_BOREL_LISTS.
+ *)
+Theorem IN_MEASURABLE_BOREL_SUM_LIST :
+    !N. 0 < N ==> FOLDR $+ 0 IN measurable (Borel_lists N) Borel
+Proof
+    Induct_on ‘N’ >- rw []
+ >> Cases_on ‘N’ >> rw []
+ >- (fs [Borel_lists_1] \\
+     rw [IN_MEASURABLE, IN_FUNSET, SPACE_BOREL, IMAGE_wrap_univ] \\
+     Q.EXISTS_TAC ‘s’ >> art [] \\
+     rw [Once EXTENSION, PREIMAGE_def, wrap_def] \\
+     EQ_TAC >> rw [] >> rw [FOLDR] (* only 1 goal left *)\\
+     Cases_on ‘x’ >> fs [])
+ >> qabbrev_tac ‘N = SUC n’
+ >> ‘0 < N’ by rw [Abbr ‘N’]
+ >> Know ‘FOLDR $+ 0 = \s. if s = [] then 0
+                           else HD s + FOLDR $+ 0 (TL s)’
+ >- (rw [FUN_EQ_THM] \\
+     Cases_on ‘s’ >> simp [])
+ >> Rewr'
+ >> Know ‘(\s. if s = [] then 0 else HD s + FOLDR $+ 0 (TL s)) IN
+             Borel_measurable (Borel_lists (SUC N)) <=>
+          (\s. HD s + FOLDR $+ 0 (TL s)) IN
+             Borel_measurable (Borel_lists (SUC N))’
+ >- (MATCH_MP_TAC IN_MEASURABLE_BOREL_EQ_SYM \\
+     rw [space_Borel_lists])
+ >> Rewr'
+ >> MATCH_MP_TAC IN_MEASURABLE_BOREL_ADD'
+ >> simp [sigma_algebra_Borel_lists, space_Borel_lists]
+ >> qexistsl_tac [‘HD’, ‘FOLDR $+ 0 o TL’]
+ >> simp [IN_MEASURABLE_BOREL_HD]
+ >> MATCH_MP_TAC MEASURABLE_COMP
+ >> Q.EXISTS_TAC ‘Borel_lists N’ >> simp []
+ >> MATCH_MP_TAC IN_MEASURABLE_BOREL_TL >> art []
+QED
+
+Theorem IN_MEASURABLE_BOREL_SUM_LIST_LIST :
+    !a f l. sigma_algebra a /\ 0 < LENGTH l /\
+           (!i. MEM i l ==> f i IN measurable a Borel) ==>
+           (\x. FOLDR $+ 0 (MAP (\i. f i x) l)) IN measurable a Borel
+Proof
+    rpt STRIP_TAC
+ >> ‘(\x. FOLDR $+ 0 (MAP (\i. f i x) l)) =
+     (FOLDR $+ 0) o (\x. MAP (\i. f i x) l)’ by rw [o_DEF, FUN_EQ_THM]
+ >> POP_ORW
+ >> MATCH_MP_TAC MEASURABLE_COMP
+ >> qabbrev_tac ‘n = LENGTH l’
+ >> Q.EXISTS_TAC ‘Borel_lists n’
+ >> rw [IN_MEASURABLE_BOREL_LISTS]
+ >> irule IN_MEASURABLE_BOREL_SUM_LIST >> art []
+QED
+
+(* ------------------------------------------------------------------------- *)
+(*  Independence of functions of independent r.v.'s                          *)
+(*                                                                           *)
+(*  By "functions", here we mean those who taking lists of numbers returning *)
+(*  single numbers. Lengths of input lists are "dimensions" of functions.    *)
+(* ------------------------------------------------------------------------- *)
+
+(* Theorem 3.3.2 [2, p.54] (for only two group of r.v.'s)
+   See also Problem 2.5.7 of [4, p.217].
+
+   NOTE: This is a generalization of [indep_functions_of_four_vars] for two
+   disjoint lists of (total) independent r.v.'s.
+ *)
+Theorem indep_functions_of_vars_lemma[local] :
+    !p. prob_space p /\ ALL_DISTINCT (l1 ++ (l2 :'index list)) /\
+       (!n. MEM n (l1 ++ l2) ==> random_variable (X n) p Borel) /\
+        LENGTH l1 = n1 /\ LENGTH l2 = n2 /\ 0 < n1 /\ 0 < n2 /\
+        indep_vars p X (\n. Borel) (set (l1 ++ l2)) ==>
+        !A. A IN subsets (Borel_lists n1) ==>
+            !B. B IN subsets (Borel_lists n2) ==>
+                indep p (PREIMAGE (\x. MAP (\n. X n x) l1) A INTER p_space p)
+                        (PREIMAGE (\x. MAP (\n. X n x) l2) B INTER p_space p)
+Proof
+    NTAC 2 STRIP_TAC
+ >> qabbrev_tac
+   ‘P = \A. A IN subsets (Borel_lists n1) /\
+            !B. B IN subsets (Borel_lists n2) ==>
+                indep p (PREIMAGE (\x. MAP (\n. X n x) l1) A INTER p_space p)
+                        (PREIMAGE (\x. MAP (\n. X n x) l2) B INTER p_space p)’
+ >> Suff ‘subsets (Borel_lists n1) SUBSET P’
+ >- rw [SUBSET_DEF, IN_APP, Abbr ‘P’]
+ >> simp [Borel_lists_alt_sigma]
+ >> qmatch_abbrev_tac ‘subsets (sigma sp sts) SUBSET P’
+ >> qabbrev_tac ‘b = (sp,P)’
+ >> ‘P = subsets b’ by rw [Abbr ‘b’] >> POP_ORW
+ >> ‘sp = space b’ by rw [Abbr ‘b’] >> POP_ORW
+ >> MATCH_MP_TAC SIGMA_PROPERTY_DYNKIN
+ >> CONJ_TAC (* subset_class (space b) sts *)
+ >- (rw [subset_class_def, Abbr ‘b’, Abbr ‘sp’, space_Borel_lists, SPACE_BOREL] \\
+     POP_ASSUM MP_TAC >> rw [SUBSET_DEF, Abbr ‘sts’] \\
+     POP_ASSUM MP_TAC >> rw [IN_list_rectangle])
+ >> CONJ_TAC (* !s t. s IN sts /\ t IN sts ==> s INTER t IN sts *)
+ >- (rw [Abbr ‘sts’] \\
+     rw [Once EXTENSION, list_rectangle_def] \\
+     qabbrev_tac ‘n1 = LENGTH l1’ \\
+     Q.EXISTS_TAC ‘\i. h i INTER h' i’ \\
+     CONJ_TAC >- (rw [] >> EQ_TAC >> rw []) \\
+     rw [] >> MATCH_MP_TAC SIGMA_ALGEBRA_INTER >> rw [SIGMA_ALGEBRA_BOREL])
+ >> fs [Abbr ‘b’]
+ >> reverse CONJ_TAC
+ >- (rw [dynkin_system_def] >| (* 4 subgoals *)
+     [ (* goal 1 (of 4) *)
+       rw [Abbr ‘sp’, Abbr ‘P’, subset_class_def, SUBSET_DEF, space_Borel_lists] \\
+       qabbrev_tac ‘n1 = LENGTH l1’ \\
+       MP_TAC (Q.SPEC ‘n1’ sigma_algebra_Borel_lists) \\
+       rw [sigma_algebra_def, algebra_def, space_Borel_lists, subset_class_def] \\
+       Q.PAT_X_ASSUM ‘!x. x IN subsets (Borel_lists n1) ==>
+                          x SUBSET {v | LENGTH v = n1}’ (MP_TAC o Q.SPEC ‘x’) \\
+       rw [SUBSET_DEF],
+       (* goal 2 (of 4): sp IN P *)
+       simp [Abbr ‘sp’, Abbr ‘P’, GSYM space_Borel_lists] \\
+       qabbrev_tac ‘n1 = LENGTH l1’ \\
+       CONJ_TAC
+       >- (MATCH_MP_TAC SIGMA_ALGEBRA_SPACE \\
+           REWRITE_TAC [sigma_algebra_Borel_lists]) \\
+       rw [space_Borel_lists] \\
+       qabbrev_tac ‘sp = {(v :extreal list) | LENGTH v = n1}’ \\
+       Know ‘PREIMAGE (\x. MAP (\n. X n x) l1) sp INTER p_space p = p_space p’
+       >- (qmatch_abbrev_tac ‘s INTER p_space p = p_space p’ \\
+           Suff ‘p_space p SUBSET s’ >- SET_TAC [] \\
+           rw [Abbr ‘s’, IN_PREIMAGE, SUBSET_DEF, Abbr ‘sp’]) >> Rewr' \\
+       MATCH_MP_TAC INDEP_SPACE >> art [] \\
+       qabbrev_tac ‘n2 = LENGTH l2’ \\
+    (* applying IN_MEASURABLE_BOREL_LISTS *)
+       qabbrev_tac ‘a = (p_space p,events p)’ \\
+      ‘sigma_algebra a’ by METIS_TAC [EVENTS_SIGMA_ALGEBRA] \\
+       MP_TAC (Q.SPECL [‘a’, ‘X’, ‘l2’, ‘n2’] IN_MEASURABLE_BOREL_LISTS) \\
+       simp [] \\
+       impl_tac >- (rpt STRIP_TAC \\
+                    fs [random_variable_def] \\
+                    FIRST_X_ASSUM MATCH_MP_TAC \\
+                    Q.PAT_X_ASSUM ‘set l2 SUBSET J’ MP_TAC \\
+                    rw [SUBSET_DEF]) \\
+       rw [IN_MEASURABLE, SPACE_BOREL, IN_FUNSET, Abbr ‘a’],
+       (* goal 3 (of 4): sp DIFF s IN P *)
+       POP_ASSUM MP_TAC \\
+       rw [Abbr ‘sp’, Abbr ‘P’, GSYM space_Borel_lists]
+       >- (MATCH_MP_TAC SIGMA_ALGEBRA_COMPL \\
+           simp [sigma_algebra_Borel_lists]) \\
+       qabbrev_tac ‘n1 = LENGTH l1’ \\
+       qabbrev_tac ‘n2 = LENGTH l2’ \\
+       simp [space_Borel_lists, PREIMAGE_DIFF] \\
+       Q.PAT_X_ASSUM ‘!B. B IN subsets (Borel_lists n2) ==> _’
+                     (MP_TAC o Q.SPEC ‘B’) >> rw [] \\
+       qmatch_abbrev_tac ‘indep p ((Z DIFF A) INTER sp) b’ \\
+      ‘(Z DIFF A) INTER sp = (Z INTER sp) DIFF (A INTER sp)’ by SET_TAC [] \\
+       POP_ORW \\
+       Know ‘Z INTER sp = sp’
+       >- (Suff ‘sp SUBSET Z’ >- SET_TAC [] \\
+           rw [Abbr ‘sp’, Abbr ‘Z’, IN_PREIMAGE, SUBSET_DEF]) >> Rewr' \\
+       qunabbrev_tac ‘sp’ \\
+       MATCH_MP_TAC INDEP_COMPL' >> art [],
+       (* goal 4 (of 4) *)
+       Q.PAT_X_ASSUM ‘f IN (UNIV -> P)’ MP_TAC \\
+       rw [Abbr ‘P’, IN_FUNSET]
+       >- (MATCH_MP_TAC SIGMA_ALGEBRA_ENUM \\
+           rw [sigma_algebra_Borel_lists, IN_FUNSET]) \\
+       simp [PREIMAGE_BIGUNION, IMAGE_IMAGE, o_DEF, BIGUNION_OVER_INTER_L] \\
+       MATCH_MP_TAC INDEP_COUNTABLE_DUNION' \\
+       simp [disjoint_family_def] \\
+       CONJ_TAC
+       >- (qabbrev_tac ‘n2 = LENGTH l2’ \\
+        (* applying IN_MEASURABLE_BOREL_LISTS *)
+           qabbrev_tac ‘a = (p_space p,events p)’ \\
+          ‘sigma_algebra a’ by METIS_TAC [EVENTS_SIGMA_ALGEBRA] \\
+           MP_TAC (Q.SPECL [‘a’, ‘X’, ‘l2’, ‘n2’] IN_MEASURABLE_BOREL_LISTS) \\
+           simp [] \\
+           impl_tac >- (rpt STRIP_TAC \\
+                        fs [random_variable_def] \\
+                        FIRST_X_ASSUM MATCH_MP_TAC \\
+                        Q.PAT_X_ASSUM ‘set l2 SUBSET J’ MP_TAC \\
+                        rw [SUBSET_DEF]) \\
+           rw [IN_MEASURABLE, SPACE_BOREL, IN_FUNSET, Abbr ‘a’]) \\
+       qx_genl_tac [‘i’, ‘j’] >> DISCH_TAC \\
+       MATCH_MP_TAC DISJOINT_RESTRICT_L \\
+       MATCH_MP_TAC PREIMAGE_DISJOINT \\
+       FIRST_X_ASSUM MATCH_MP_TAC >> art [] ])
+ (* stage work *)
+ >> simp [SUBSET_DEF, Abbr ‘sts’, Abbr ‘P’]
+ >> NTAC 2 STRIP_TAC
+ >> Q.PAT_X_ASSUM ‘x = rectangle h n1’ (REWRITE_TAC o wrap)
+ >> CONJ_TAC
+ >- (simp [Borel_lists_alt_sigma] \\
+     MATCH_MP_TAC IN_SIGMA >> rw [IN_list_rectangle] \\
+     Q.EXISTS_TAC ‘h’ >> art [])
+ (* stage work *)
+ >> qabbrev_tac ‘r = rectangle h n1’
+ >> qabbrev_tac
+     ‘P = \B. B IN subsets (Borel_lists n2) /\
+              indep p (PREIMAGE (\x. MAP (\n. X n x) l1) r INTER p_space p)
+                      (PREIMAGE (\x. MAP (\n. X n x) l2) B INTER p_space p)’
+ >> Suff ‘subsets (Borel_lists n2) SUBSET P’
+ >- rw [SUBSET_DEF, IN_APP, Abbr ‘P’]
+ >> simp [Borel_lists_alt_sigma]
+ >> qunabbrev_tac ‘sp’
+ >> qmatch_abbrev_tac ‘subsets (sigma sp sts) SUBSET P’
+ >> qabbrev_tac ‘b = (sp,P)’
+ >> ‘P = subsets b’ by rw [Abbr ‘b’] >> POP_ORW
+ >> ‘sp = space b’ by rw [Abbr ‘b’] >> POP_ORW
+ >> MATCH_MP_TAC SIGMA_PROPERTY_DYNKIN
+ >> CONJ_TAC (* subset_class (space b) sts *)
+ >- (rw [subset_class_def, Abbr ‘b’, Abbr ‘sp’, space_Borel_lists, SPACE_BOREL] \\
+     POP_ASSUM MP_TAC >> rw [SUBSET_DEF, Abbr ‘sts’] \\
+     POP_ASSUM MP_TAC >> rw [IN_list_rectangle])
+ >> CONJ_TAC (* !s t. s IN sts /\ t IN sts ==> s INTER t IN sts *)
+ >- (rw [Abbr ‘sts’] \\
+     rw [Once EXTENSION, list_rectangle_def] \\
+     qabbrev_tac ‘n2 = LENGTH l2’ \\
+     rename1 ‘!i. i < n2 ==> h2 i IN subsets Borel’ \\
+     Q.EXISTS_TAC ‘\i. h' i INTER h2 i’ \\
+     CONJ_TAC >- (rw [] >> EQ_TAC >> rw []) \\
+     rw [] >> MATCH_MP_TAC SIGMA_ALGEBRA_INTER >> rw [SIGMA_ALGEBRA_BOREL])
+ >> fs [Abbr ‘b’]
+ >> reverse CONJ_TAC
+ >- (rw [dynkin_system_def] >| (* 4 subgoals *)
+     [ (* goal 1 (of 4) *)
+       rw [Abbr ‘sp’, Abbr ‘P’, subset_class_def, SUBSET_DEF, space_Borel_lists] \\
+       qabbrev_tac ‘n2 = LENGTH l2’ \\
+       MP_TAC (Q.SPEC ‘n2’ sigma_algebra_Borel_lists) \\
+       rw [sigma_algebra_def, algebra_def, space_Borel_lists, subset_class_def] \\
+       Q.PAT_X_ASSUM ‘!x. x IN subsets (Borel_lists n2) ==>
+                          x SUBSET {v | LENGTH v = n2}’ (MP_TAC o Q.SPEC ‘x’) \\
+       rw [SUBSET_DEF],
+       (* goal 2 (of 4): sp IN P *)
+       simp [Abbr ‘sp’, Abbr ‘P’, GSYM space_Borel_lists] \\
+       qabbrev_tac ‘n2 = LENGTH l2’ \\
+       CONJ_TAC
+       >- (MATCH_MP_TAC SIGMA_ALGEBRA_SPACE \\
+           REWRITE_TAC [sigma_algebra_Borel_lists]) \\
+       rw [space_Borel_lists] \\
+       qabbrev_tac ‘sp = {(v :extreal list) | LENGTH v = n2}’ \\
+       Know ‘PREIMAGE (\x. MAP (\n. X n x) l2) sp INTER p_space p = p_space p’
+       >- (qmatch_abbrev_tac ‘s INTER p_space p = p_space p’ \\
+           Suff ‘p_space p SUBSET s’ >- SET_TAC [] \\
+           rw [Abbr ‘s’, IN_PREIMAGE, SUBSET_DEF, Abbr ‘sp’]) >> Rewr' \\
+       MATCH_MP_TAC INDEP_SPACE' >> art [] \\
+       qabbrev_tac ‘n1 = LENGTH l1’ \\
+    (* applying PREIMAGE_list_rectangle *)
+       qmatch_abbrev_tac ‘PREIMAGE g r INTER p_space p IN events p’ \\
+       qunabbrev_tac ‘r’ \\
+       MP_TAC (Q.SPECL [‘g’, ‘h’, ‘n1’]
+                       (INST_TYPE [beta |-> “:extreal”] PREIMAGE_list_rectangle)) \\
+       simp [Abbr ‘g’, BIGINTER_OVER_INTER_L] \\
+       DISCH_THEN K_TAC (* already used *) \\
+       MATCH_MP_TAC EVENTS_BIGINTER_FN \\
+       rw [SUBSET_DEF] \\
+       rw [EL_MAP] \\
+      ‘(\x. X (EL n l1) x) = X (EL n l1)’ by rw [FUN_EQ_THM] >> POP_ORW \\
+       fs [random_variable_def, IN_MEASURABLE, IN_FUNSET, SPACE_BOREL] \\
+       FIRST_X_ASSUM irule >> simp [EL_MEM],
+       (* goal 3 (of 4): sp DIFF s IN P *)
+       POP_ASSUM MP_TAC \\
+       rw [Abbr ‘sp’, Abbr ‘P’, GSYM space_Borel_lists]
+       >- (MATCH_MP_TAC SIGMA_ALGEBRA_COMPL \\
+           simp [sigma_algebra_Borel_lists]) \\
+       qabbrev_tac ‘n1 = LENGTH l1’ \\
+       qabbrev_tac ‘n2 = LENGTH l2’ \\
+       simp [space_Borel_lists, PREIMAGE_DIFF] \\
+       qmatch_abbrev_tac ‘indep p b ((Z DIFF A) INTER sp)’ \\
+      ‘(Z DIFF A) INTER sp = (Z INTER sp) DIFF (A INTER sp)’ by SET_TAC [] \\
+       POP_ORW \\
+       Know ‘Z INTER sp = sp’
+       >- (Suff ‘sp SUBSET Z’ >- SET_TAC [] \\
+           rw [Abbr ‘sp’, Abbr ‘Z’, IN_PREIMAGE, SUBSET_DEF]) >> Rewr' \\
+       qunabbrev_tac ‘sp’ \\
+       MATCH_MP_TAC INDEP_COMPL >> art [],
+       (* goal 4 (of 4) *)
+       Q.PAT_X_ASSUM ‘f IN (UNIV -> P)’ MP_TAC \\
+       rw [Abbr ‘P’, IN_FUNSET]
+       >- (MATCH_MP_TAC SIGMA_ALGEBRA_ENUM \\
+           rw [sigma_algebra_Borel_lists, IN_FUNSET]) \\
+       simp [PREIMAGE_BIGUNION, IMAGE_IMAGE, o_DEF, BIGUNION_OVER_INTER_L] \\
+       MATCH_MP_TAC INDEP_COUNTABLE_DUNION \\
+       simp [disjoint_family_def] \\
+       CONJ_TAC
+       >- (qabbrev_tac ‘n1 = LENGTH l1’ \\
+           qmatch_abbrev_tac ‘PREIMAGE g r INTER p_space p IN events p’ \\
+           qunabbrev_tac ‘r’ \\
+           MP_TAC (Q.SPECL [‘g’, ‘h’, ‘n1’]
+                     (INST_TYPE [beta |-> “:extreal”] PREIMAGE_list_rectangle)) \\
+           simp [Abbr ‘g’, BIGINTER_OVER_INTER_L] \\
+           DISCH_THEN K_TAC (* already used *) \\
+           MATCH_MP_TAC EVENTS_BIGINTER_FN \\
+           rw [SUBSET_DEF] \\
+           rw [EL_MAP] \\
+          ‘(\x. X (EL n l1) x) = X (EL n l1)’ by rw [FUN_EQ_THM] >> POP_ORW \\
+           fs [random_variable_def, IN_MEASURABLE, IN_FUNSET, SPACE_BOREL] \\
+           FIRST_X_ASSUM irule >> simp [EL_MEM]) \\
+       qx_genl_tac [‘i’, ‘j’] >> DISCH_TAC \\
+       MATCH_MP_TAC DISJOINT_RESTRICT_L \\
+       MATCH_MP_TAC PREIMAGE_DISJOINT \\
+       FIRST_X_ASSUM MATCH_MP_TAC >> art [] ])
+ (* stage work *)
+ >> simp [SUBSET_DEF, Abbr ‘sts’, Abbr ‘P’]
+ >> NTAC 2 STRIP_TAC
+ >> Q.PAT_X_ASSUM ‘x = rectangle h' n2’ (REWRITE_TAC o wrap)
+ >> CONJ_TAC
+ >- (simp [Borel_lists_alt_sigma] \\
+     MATCH_MP_TAC IN_SIGMA >> rw [IN_list_rectangle] \\
+     Q.EXISTS_TAC ‘h'’ >> art [])
+ >> qunabbrev_tac ‘r’
+ >> qmatch_abbrev_tac
+     ‘indep p (PREIMAGE f (rectangle h  n1) INTER p_space p)
+              (PREIMAGE g (rectangle h' n2) INTER p_space p)’
+ >> MP_TAC (Q.SPECL [‘f’, ‘h’, ‘n1’]
+                    (INST_TYPE [beta |-> “:extreal”] PREIMAGE_list_rectangle))
+ >> simp [Abbr ‘f’, BIGINTER_OVER_INTER_L]
+ >> DISCH_THEN K_TAC
+ >> MP_TAC (Q.SPECL [‘g’, ‘h'’, ‘n2’]
+                    (INST_TYPE [beta |-> “:extreal”] PREIMAGE_list_rectangle))
+ >> simp [Abbr ‘g’, BIGINTER_OVER_INTER_L]
+ >> DISCH_THEN K_TAC
+ >> rw [indep_def]
+ >- (MATCH_MP_TAC EVENTS_BIGINTER_FN \\
+     qabbrev_tac ‘n1 = LENGTH l1’ \\
+     rw [SUBSET_DEF] >> rw [EL_MAP] \\
+    ‘(\x. X (EL n l1) x) = X (EL n l1)’ by rw [FUN_EQ_THM] >> POP_ORW \\
+     fs [random_variable_def, IN_MEASURABLE, IN_FUNSET, SPACE_BOREL] \\
+     FIRST_X_ASSUM irule >> simp [EL_MEM])
+ >- (MATCH_MP_TAC EVENTS_BIGINTER_FN \\
+     qabbrev_tac ‘n2 = LENGTH l2’ \\
+     rw [SUBSET_DEF] >> rw [EL_MAP] \\
+    ‘(\x. X (EL n l2) x) = X (EL n l2)’ by rw [FUN_EQ_THM] >> POP_ORW \\
+     fs [random_variable_def, IN_MEASURABLE, IN_FUNSET, SPACE_BOREL] \\
+     FIRST_X_ASSUM irule >> simp [EL_MEM])
+ (* stage work *)
+ >> qabbrev_tac ‘f = \n x. EL n (MAP (\n. (X :'index -> 'a -> extreal) n x) l1)’
+ >> qabbrev_tac ‘g = \n x. EL n (MAP (\n. (X :'index -> 'a -> extreal) n x) l2)’
+ >> simp []
+ >> ‘!n. (\x. f n x) = f n’ by rw [FUN_EQ_THM] >> POP_ORW
+ >> ‘!n. (\x. g n x) = g n’ by rw [FUN_EQ_THM] >> POP_ORW
+ >> qabbrev_tac ‘n1 = LENGTH l1’
+ >> qabbrev_tac ‘n2 = LENGTH l2’
+ >> Know ‘IMAGE (\i. EL i l1) (count n1) = set l1’
+ >- (rw [Once EXTENSION, MEM_EL] >> METIS_TAC [])
+ >> DISCH_TAC
+ >> Know ‘IMAGE (\i. EL i l2) (count n2) = set l2’
+ >- (rw [Once EXTENSION, MEM_EL] >> METIS_TAC [])
+ >> DISCH_TAC
+ >> qabbrev_tac ‘g1 = \i. EL i l1’
+ >> qabbrev_tac ‘g2 = \i. EL i l2’
+ (* applying IMAGE_IMAGE *)
+ >> qabbrev_tac ‘f1 = \e. {x | x IN p_space p /\ X e x IN h  (THE (INDEX_OF e l1))}’
+ >> qabbrev_tac ‘f2 = \e. {x | x IN p_space p /\ X e x IN h' (THE (INDEX_OF e l2))}’
+ (* applying ALL_DISTINCT_INDEX_OF_EL *)
+ >> FULL_SIMP_TAC std_ss [ALL_DISTINCT_APPEND']
+ >> Know ‘!i. i < n1 ==> INDEX_OF (EL i l1) l1 = SOME i’
+ >- (rpt STRIP_TAC \\
+     MATCH_MP_TAC ALL_DISTINCT_INDEX_OF_EL >> simp [])
+ >> DISCH_TAC
+ >> Know ‘!i. i < n2 ==> INDEX_OF (EL i l2) l2 = SOME i’
+ >- (rpt STRIP_TAC \\
+     MATCH_MP_TAC ALL_DISTINCT_INDEX_OF_EL >> simp [])
+ >> DISCH_TAC
+ >> Know ‘IMAGE (\n. PREIMAGE (f n) (h n) INTER p_space p) (count n1) =
+          IMAGE (f1 o g1) (count n1)’
+ >- (rw [o_DEF, Abbr ‘g1’, Abbr ‘f1’, PREIMAGE_def, Abbr ‘f’, Once EXTENSION] \\
+     EQ_TAC >> rw [] >| (* 2 subgoals *)
+     [ (* goal 1 (of 2) *)
+       Q.EXISTS_TAC ‘n’ >> art [] \\
+       rw [Once EXTENSION] \\
+       EQ_TAC >> rw [EL_MAP],
+       (* goal 2 (of 2) *)
+       rename1 ‘i < n1’ \\
+       Q.EXISTS_TAC ‘i’ >> art [] \\
+       rw [Once EXTENSION] \\
+       EQ_TAC >> rw [EL_MAP] ])
+ >> Rewr'
+ >> Know ‘IMAGE (\n. PREIMAGE (g n) (h' n) INTER p_space p) (count n2) =
+          IMAGE (f2 o g2) (count n2)’
+ >- (rw [o_DEF, Abbr ‘g2’, Abbr ‘f2’, PREIMAGE_def, Abbr ‘g’, Once EXTENSION] \\
+     EQ_TAC >> rw [] >| (* 2 subgoals *)
+     [ (* goal 1 (of 2) *)
+       Q.EXISTS_TAC ‘n’ >> art [] \\
+       rw [Once EXTENSION] \\
+       EQ_TAC >> rw [EL_MAP],
+       (* goal 2 (of 2) *)
+       rename1 ‘i < n2’ \\
+       Q.EXISTS_TAC ‘i’ >> art [] \\
+       rw [Once EXTENSION] \\
+       EQ_TAC >> rw [EL_MAP] ])
+ >> Rewr'
+ >> simp [GSYM IMAGE_IMAGE]
+ (* stage work *)
+ >> qabbrev_tac ‘E1 = \e. h  (THE (INDEX_OF e l1))’
+ >> qabbrev_tac ‘E2 = \e. h' (THE (INDEX_OF e l2))’
+ >> Know ‘IMAGE f1 (set l1) =
+          IMAGE (\e. PREIMAGE (X e) (E1 e) INTER p_space p) (set l1)’
+ >- (rw [Once EXTENSION, Abbr ‘f1’, PREIMAGE_def] \\
+     EQ_TAC >> rw [] >| (* 2 subgoals *)
+     [ (* goal 1 (of 2) *)
+       Q.EXISTS_TAC ‘e’ >> art [] \\
+       rw [Once EXTENSION] >> rw [Once CONJ_SYM],
+       (* goal 2 (of 2) *)
+       Q.EXISTS_TAC ‘e’ >> art [] \\
+       rw [Once EXTENSION] >> rw [Once CONJ_SYM] ])
+ >> Rewr'
+ >> Know ‘IMAGE f2 (set l2) =
+          IMAGE (\e. PREIMAGE (X e) (E2 e) INTER p_space p) (set l2)’
+ >- (rw [Once EXTENSION, Abbr ‘f2’, PREIMAGE_def] \\
+     EQ_TAC >> rw [] >| (* 2 subgoals *)
+     [ (* goal 1 (of 2) *)
+       Q.EXISTS_TAC ‘e’ >> art [] \\
+       rw [Once EXTENSION] >> rw [Once CONJ_SYM],
+       (* goal 2 (of 2) *)
+       Q.EXISTS_TAC ‘e’ >> art [] \\
+       rw [Once EXTENSION] >> rw [Once CONJ_SYM] ])
+ >> Rewr'
+ (* applying indep_vars_def *)
+ >> fs [indep_vars_def]
+ >> Know ‘prob p
+            (BIGINTER (IMAGE (\n. PREIMAGE (X n) (E1 n) INTER p_space p) (set l1))) =
+          PI (prob p o (\n. PREIMAGE (X n) (E1 n) INTER p_space p)) (set l1)’
+ >- (FIRST_X_ASSUM MATCH_MP_TAC \\
+     simp [GSYM LENGTH_NON_NIL, IN_DFUNSET] \\
+     rw [MEM_EL, Abbr ‘E1’, Abbr ‘g1’] >> simp [])
+ >> Rewr'
+ >> Know ‘prob p
+            (BIGINTER (IMAGE (\n. PREIMAGE (X n) (E2 n) INTER p_space p) (set l2))) =
+          PI (prob p o (\n. PREIMAGE (X n) (E2 n) INTER p_space p)) (set l2)’
+ >- (FIRST_X_ASSUM MATCH_MP_TAC \\
+     simp [GSYM LENGTH_NON_NIL, IN_DFUNSET] \\
+     rw [MEM_EL, Abbr ‘E2’, Abbr ‘g2’] >> simp [])
+ >> Rewr'
+ >> Know ‘!e. MEM e l1 ==> ~MEM e l2’
+ >- (Q.PAT_X_ASSUM ‘DISJOINT (set l1) (set l2)’ MP_TAC \\
+     rw [DISJOINT_ALT])
+ >> DISCH_TAC
+ >> Know ‘!e. MEM e l2 ==> ~MEM e l1’
+ >- (Q.PAT_X_ASSUM ‘DISJOINT (set l1) (set l2)’ MP_TAC \\
+     rw [DISJOINT_ALT'])
+ >> DISCH_TAC
+ (* stage work *)
+ >> qabbrev_tac ‘E = \e. if MEM e l1 then E1 e else E2 e’
+ >> Know ‘BIGINTER
+            (IMAGE (\e. PREIMAGE (X e) (E1 e) INTER p_space p) (set l1)) INTER
+          BIGINTER
+            (IMAGE (\e. PREIMAGE (X e) (E2 e) INTER p_space p) (set l2)) =
+          BIGINTER
+            (IMAGE (\e. PREIMAGE (X e) (E e) INTER p_space p) (set l1 UNION set l2))’
+ >- (rw [Once EXTENSION, IN_BIGINTER_IMAGE] \\
+     EQ_TAC >> rw [Abbr ‘E’] >| (* 8 subgoals *)
+     [ (* goal 1 (of 8) *)
+       simp [],
+       (* goal 2 (of 8) *)
+       Q.PAT_X_ASSUM ‘!e. MEM e l1 ==> X e x IN E1 e /\ x IN p_space p’
+         (MP_TAC o Q.SPEC ‘e’) >> rw [],
+       (* goal 3 (of 8) *)
+       simp [],
+       (* goal 4 (of 8) *)
+       Q.PAT_X_ASSUM ‘!e. MEM e l2 ==> X e x IN E2 e /\ x IN p_space p’
+         (MP_TAC o Q.SPEC ‘e’) >> rw [],
+       (* goal 5 (of 8) *)
+       Q.PAT_X_ASSUM ‘!e. MEM e l1 \/ MEM e l2 ==> _’ (MP_TAC o Q.SPEC ‘e’) \\
+       simp [],
+       (* goal 6 (of 8) *)
+       Q.PAT_X_ASSUM ‘!e. MEM e l1 \/ MEM e l2 ==> _’ (MP_TAC o Q.SPEC ‘e’) \\
+       simp [],
+       (* goal 7 (of 8) *)
+       Q.PAT_X_ASSUM ‘!e. MEM e l1 \/ MEM e l2 ==> _’ (MP_TAC o Q.SPEC ‘e’) \\
+       simp [],
+       (* goal 8 (of 8) *)
+       Q.PAT_X_ASSUM ‘!e. MEM e l1 \/ MEM e l2 ==> _’ (MP_TAC o Q.SPEC ‘e’) \\
+       simp [] ])
+ >> Rewr'
+ >> Know ‘prob p (BIGINTER (IMAGE (\n. PREIMAGE (X n) (E n) INTER p_space p)
+                                  (set l1 UNION set l2))) =
+          PI (prob p o (\n. PREIMAGE (X n) (E n) INTER p_space p))
+             (set l1 UNION set l2)’
+ >- (FIRST_X_ASSUM MATCH_MP_TAC \\
+     simp [GSYM LENGTH_NON_NIL, IN_DFUNSET] \\
+     rw [MEM_EL, Abbr ‘E’, Abbr ‘E1’, Abbr ‘E2’, Abbr ‘g1’, Abbr ‘g2’] \\
+     simp [])
+ >> Rewr'
+ >> Know ‘PI (prob p o (\n. PREIMAGE (X n) (E n) INTER p_space p))
+             (set l1 UNION set l2) =
+          PI (prob p o (\n. PREIMAGE (X n) (E n) INTER p_space p)) (set l1) *
+          PI (prob p o (\n. PREIMAGE (X n) (E n) INTER p_space p)) (set l2)’
+ >- (MATCH_MP_TAC EXTREAL_PROD_IMAGE_DISJOINT_UNION >> simp [])
+ >> Rewr'
+ >> Know ‘PI (prob p o (\n. PREIMAGE (X n) (E n) INTER p_space p)) (set l1) =
+          PI (prob p o (\n. PREIMAGE (X n) (E1 n) INTER p_space p)) (set l1)’
+ >- (MATCH_MP_TAC EXTREAL_PROD_IMAGE_EQ \\
+     rw [Abbr ‘E’])
+ >> Rewr'
+ >> Know ‘PI (prob p o (\n. PREIMAGE (X n) (E n) INTER p_space p)) (set l2) =
+          PI (prob p o (\n. PREIMAGE (X n) (E2 n) INTER p_space p)) (set l2)’
+ >- (MATCH_MP_TAC EXTREAL_PROD_IMAGE_EQ \\
+     rw [Abbr ‘E’])
+ >> Rewr
+QED
+
+Theorem indep_functions_of_vars :
+    !p X (l1 :'index list) l2 n1 n2 f g.
+        prob_space p /\ ALL_DISTINCT (l1 ++ l2) /\
+       (!n. MEM n (l1 ++ l2) ==> random_variable (X n) p Borel) /\
+        LENGTH l1 = n1 /\ LENGTH l2 = n2 /\ 0 < n1 /\ 0 < n2 /\
+        f IN measurable (Borel_lists n1) Borel /\
+        g IN measurable (Borel_lists n2) Borel /\
+        indep_vars p X (\n. Borel) (set (l1 ++ l2)) ==>
+        indep_vars p (\x. f (MAP (\n. X n x) l1))
+                     (\x. g (MAP (\n. X n x) l2)) Borel Borel
+Proof
+    rw [indep_rv_def, IN_MEASURABLE, IN_FUNSET, space_Borel_lists, SPACE_BOREL]
+ >> qabbrev_tac ‘n1 = LENGTH l1’
+ >> qabbrev_tac ‘n2 = LENGTH l2’
+ >> ‘(\x. f (MAP (\n. X n x) l1)) = f o (\x. MAP (\n. X n x) l1)’ by rw [o_DEF]
+ >> POP_ORW
+ >> ‘(\x. g (MAP (\n. X n x) l2)) = g o (\x. MAP (\n. X n x) l2)’ by rw [o_DEF]
+ >> POP_ORW
+ >> simp [PREIMAGE_o, GSYM PREIMAGE_ALT]
+ >> qabbrev_tac ‘L1 = (\x. MAP (\n. X n x) l1)’
+ >> qabbrev_tac ‘L2 = (\x. MAP (\n. X n x) l2)’
+ >> qabbrev_tac ‘A = PREIMAGE f a’
+ >> qabbrev_tac ‘B = PREIMAGE g b’
+ >> Know ‘PREIMAGE L1 A INTER p_space p =
+          PREIMAGE L1 (A INTER {v | LENGTH v = n1}) INTER p_space p’
+ >- (rw [Once EXTENSION, IN_PREIMAGE] \\
+     simp [Abbr ‘L1’])
+ >> Rewr'
+ >> Know ‘PREIMAGE L2 B INTER p_space p =
+          PREIMAGE L2 (B INTER {v | LENGTH v = n2}) INTER p_space p’
+ >- (rw [Once EXTENSION, IN_PREIMAGE] \\
+     simp [Abbr ‘L2’])
+ >> Rewr'
+ >> qabbrev_tac ‘A' = A INTER {v | LENGTH v = n1}’
+ >> qabbrev_tac ‘B' = B INTER {v | LENGTH v = n2}’
+ >> qunabbrevl_tac [‘A’, ‘B’]
+ >> ‘A' IN subsets (Borel_lists n1) /\ B' IN subsets (Borel_lists n2)’
+      by METIS_TAC []
+ >> qunabbrevl_tac [‘L1’, ‘L2’]
+ >> irule indep_functions_of_vars_lemma
+ >> simp [MEM_APPEND]
+ >> rpt STRIP_TAC
+ >> FIRST_X_ASSUM MATCH_MP_TAC >> art []
+QED
+
+Theorem indep_sum_list_of_vars :
+    !p X (l1 :'index list) l2 n1 n2 f g.
+        prob_space p /\ ALL_DISTINCT (l1 ++ l2) /\
+       (!n. MEM n (l1 ++ l2) ==> random_variable (X n) p Borel) /\
+        LENGTH l1 = n1 /\ LENGTH l2 = n2 /\ 0 < n1 /\ 0 < n2 /\
+        indep_vars p X (\n. Borel) (set (l1 ++ l2)) ==>
+        indep_vars p (\x. FOLDR $+ 0 (MAP (\n. X n x) l1))
+                     (\x. FOLDR $+ 0 (MAP (\n. X n x) l2)) Borel Borel
+Proof
+    rpt STRIP_TAC
+ >> HO_MATCH_MP_TAC indep_functions_of_vars
+ >> qexistsl_tac [‘n1’, ‘n2’]
+ >> simp [IN_MEASURABLE_BOREL_SUM_LIST]
+QED
 
 (* ------------------------------------------------------------------------- *)
 (*  Infinite-dimensional Borel space [4, p.178]                              *)
@@ -1751,32 +2631,27 @@ Proof
  >> reverse EQ_TAC >- rw []
  >> rw [cylinder2rect_def, Once EXTENSION]
  >> CCONTR_TAC
- >> ‘s <> t <=> s DIFF t <> {} \/ t DIFF s <> {}’ by SET_TAC []
- >> POP_ASSUM (FULL_SIMP_TAC pure_ss o wrap)
- >| [ (* goal 1 (of 2) *)
-      fs [GSYM MEMBER_NOT_EMPTY] \\
-      fs [cylinder2rect_def] \\
-      Q.PAT_X_ASSUM ‘!x. P <=> Q’ (MP_TAC o Q.SPEC ‘GENLIST x N’) \\
-      Know ‘?f'. GENLIST x N = GENLIST f' N /\ f' IN s’
-      >- (Q.EXISTS_TAC ‘x’ >> art []) >> simp [] \\
-      DISCH_THEN K_TAC \\
-      Q.X_GEN_TAC ‘g’ >> rpt STRIP_TAC \\
-      Q.PAT_X_ASSUM ‘!f. (?f'. GENLIST f N = GENLIST f' N /\ f' IN t) ==> f IN t’
-         (MP_TAC o Q.SPEC ‘x’) \\
-      impl_tac >- (Q.EXISTS_TAC ‘g’ >> art []) >> rw [],
-      (* goal 2 (of 2) *)
-      fs [GSYM MEMBER_NOT_EMPTY, cylinder2rect_def] \\
-      Q.PAT_X_ASSUM ‘!x. P <=> Q’ (MP_TAC o SYM o Q.SPEC ‘GENLIST x N’) \\
-      Know ‘?f'. GENLIST x N = GENLIST f' N /\ f' IN t’
-      >- (Q.EXISTS_TAC ‘x’ >> art []) >> simp [] \\
-      DISCH_THEN K_TAC \\
-      Q.X_GEN_TAC ‘g’ >> rpt STRIP_TAC \\
-      Q.PAT_X_ASSUM ‘!f. (?f'. GENLIST f N = GENLIST f' N /\ f' IN t) ==> f IN t’
-         (MP_TAC o Q.SPEC ‘g’) \\
-      impl_tac >- (Q.EXISTS_TAC ‘x’ >> art []) >> DISCH_TAC \\
-      Q.PAT_X_ASSUM ‘!f. (?f'. GENLIST f N = GENLIST f' N /\ f' IN t) ==> f IN s’
-         (MP_TAC o Q.SPEC ‘x’) \\
-      impl_tac >- (Q.EXISTS_TAC ‘g’ >> art []) >> rw [] ]
+ >> rpt (Q.PAT_X_ASSUM ‘!f. P’ MP_TAC)
+ (* applying wlog_tac *)
+ >> wlog_tac ‘s DIFF t <> {}’ [‘s’, ‘t’]
+ >- (‘t DIFF s <> {}’ by ASM_SET_TAC [] \\
+     Q.PAT_X_ASSUM ‘!s t N. P’ (MP_TAC o Q.SPECL [‘t’, ‘s’, ‘N’]) \\
+     rw [] >> gs [] \\
+     Q.EXISTS_TAC ‘x’ >> rw [])
+ >> rpt STRIP_TAC
+ (* stage work *)
+ >> fs [GSYM MEMBER_NOT_EMPTY]
+ >> fs [cylinder2rect_def]
+ >> Q.PAT_X_ASSUM ‘!x. P <=> Q’ (MP_TAC o Q.SPEC ‘GENLIST x N’)
+ >> Know ‘?f'. GENLIST x N = GENLIST f' N /\ f' IN s’
+ >- (Q.EXISTS_TAC ‘x’ >> art [])
+ >> simp []
+ >> DISCH_THEN K_TAC
+ >> Q.X_GEN_TAC ‘g’ >> rpt STRIP_TAC
+ >> Q.PAT_X_ASSUM ‘!f. (?f'. GENLIST f N = GENLIST f' N /\ f' IN t) ==> f IN t’
+       (MP_TAC o Q.SPEC ‘x’)
+ >> impl_tac >- (Q.EXISTS_TAC ‘g’ >> art [])
+ >> rw []
 QED
 
 (* NOTE: The choice of this particular generator {x | x <= c} is necessary, as
@@ -1859,10 +2734,13 @@ Proof
  >> REWRITE_TAC [Borel_inf_SUBSET_inf1, Borel_inf1_SUBSET_inf2]
 QED
 
-(* NOTE: The extra condition ‘is_cylinder c N’ is beyond the textbook [4, p.179] *)
+(* NOTE: The extra condition ‘is_cylinder c N’ is beyond the textbook [4, p.179].
+   This definition is local, shouldn't be used outside of the present theory.
+ *)
 Definition Borel_lists' :
-    Borel_lists' N = ({v :extreal list | LENGTH v = N},
-                      {cylinder2rect c N | c | c IN subsets Borel_inf /\ is_cylinder c N})
+    Borel_lists' N =
+      ({v :extreal list | LENGTH v = N},
+       {cylinder2rect c N | c | c IN subsets Borel_inf /\ is_cylinder c N})
 End
 
 (* NOTE: This proof depends on the hard work of Borel_lists_alt_sigma_generator *)
@@ -1902,7 +2780,8 @@ Proof
      rw [Once EXTENSION, cylinder2rect_def] >> fs [])
  (* stage work *)
  >> rfs [Borel_lists_alt_sigma_generator]
- >> qabbrev_tac ‘sts = {B | B SUBSET sp /\ {f | GENLIST f N IN B} IN subsets Borel_inf}’
+ >> qabbrev_tac ‘sts = {B | B SUBSET sp /\
+                            {f | GENLIST f N IN B} IN subsets Borel_inf}’
  >> Suff ‘B IN sts’ >- rw [Abbr ‘sts’, SUBSET_DEF]
  >> ASSUME_TAC sigma_algebra_Borel_inf
  >> Know ‘algebra (sp,sts)’
@@ -2020,12 +2899,14 @@ val _ = html_theory "stochastic_process";
 
   [1] Kolmogorov, A.N.: Foundations of the Theory of Probability (Grundbegriffe der
       Wahrscheinlichkeitsrechnung). Chelsea Publishing Company, New York. (1950).
-  [2] Chung, K.L.: A Course in Probability Theory, Third Edition. Academic Press (2001).
+  [2] Chung, K.L.: A Course in Probability Theory, Third Edition.
+      Academic Press (2001).
   [3] Rosenthal, J.S.: A First Look at Rigorous Probability Theory (Second Editoin).
       World Scientific Publishing Company (2006).
   [4] Shiryaev, A.N.: Probability-1. Springer-Verlag New York (2016).
   [5] Shiryaev, A.N.: Probability-2. Springer-Verlag New York (2019).
-  [6] Billingsley, P.: Probability and Measure (3rd Edition). Wiley-Interscience (1995).
+  [6] Billingsley, P.: Probability and Measure (3rd Edition).
+      Wiley-Interscience (1995).
   [7] Cinlar, E.: Probability and Stochastics. Springer (2011).
   [8] J.L. Doob (1953), Stochastic processes (2nd ed.). John Wiley & Sons, New York.
   [9] Schilling, R.L.: Measures, Integrals and Martingales (Second Edition).

--- a/src/probability/borelScript.sml
+++ b/src/probability/borelScript.sml
@@ -2035,6 +2035,20 @@ Proof
  >> FIRST_X_ASSUM MATCH_MP_TAC >> art []
 QED
 
+Theorem IN_MEASURABLE_BOREL_EQ_SYM :
+    !a f g. (!x. x IN space a ==> (f x = g x)) ==>
+            (f IN measurable a Borel <=> g IN measurable a Borel)
+Proof
+    rpt STRIP_TAC
+ >> EQ_TAC >> STRIP_TAC
+ >| [ (* goal 1 (of 2) *)
+      MATCH_MP_TAC IN_MEASURABLE_BOREL_EQ' \\
+      Q.EXISTS_TAC ‘f’ >> rw [],
+      (* goal 2 (of 2) *)
+      MATCH_MP_TAC IN_MEASURABLE_BOREL_EQ' \\
+      Q.EXISTS_TAC ‘g’ >> rw [] ]
+QED
+
 (* changed quantifier orders (was: f g m) for applications in martingaleTheory *)
 Theorem IN_MEASURABLE_BOREL_EQ :
     !m f g. (!x. x IN m_space m ==> (f x = g x)) /\
@@ -7485,8 +7499,8 @@ QED
 
 (* NOTE: ‘Borel’ here can be generalized to any sigma_algebra
 
-   cf. stochastic_processTheory.random_variable_sigma_of_dimension for a generalization
-       of this theorem to arbitrary finite dimensions.
+   cf. stochastic_processTheory.random_variable_sigma_of_dimension for a
+   generalization of this theorem to arbitrary finite dimensions.
  *)
 Theorem IN_MEASURABLE_BOREL_2D_VECTOR :
     !a X Y. sigma_algebra a /\
@@ -7511,8 +7525,7 @@ Proof
     ‘PREIMAGE X t INTER PREIMAGE Y u INTER space a =
        (PREIMAGE X t INTER space a) INTER (PREIMAGE Y u INTER space a)’
       by SET_TAC [] >> POP_ORW \\
-     MATCH_MP_TAC SIGMA_ALGEBRA_INTER \\
-     fs [IN_MEASURABLE])
+     MATCH_MP_TAC SIGMA_ALGEBRA_INTER >> fs [IN_MEASURABLE])
  >> DISCH_TAC
  (* applying SIGMA_SUBSET *)
  >> Know ‘subsets (sigma (space a)
@@ -7643,9 +7656,11 @@ Proof
      [ (* goal 1 (of 6) *)
        Cases_on ‘q’ >> Cases_on ‘r’ >> Cases_on ‘0 < r'’ \\
        rw [extreal_mul_def, extreal_of_num_def, extreal_lt_eq, lt_infty, le_infty] \\
-       fs [extreal_mul_def, lt_infty, le_infty, extreal_of_num_def] >| (* 10 subgoals *)
+       fs [extreal_mul_def, lt_infty, le_infty,
+           extreal_of_num_def] >| (* 10 subgoals *)
        [ (* goal 1 (of 10) *)
-        ‘r' <> 0’ by PROVE_TAC [REAL_LT_IMP_NE] >> fs [le_infty, lt_infty, extreal_of_num_def],
+        ‘r' <> 0’ by PROVE_TAC [REAL_LT_IMP_NE] \\
+         fs [le_infty, lt_infty, extreal_of_num_def],
          (* goal 2 (of 10) *)
         ‘r' = 0 \/ (r' <> 0 /\ r' < 0)’ by PROVE_TAC [REAL_LT_TOTAL]
          >- fs [real_lte, extreal_lt_eq, extreal_le_eq] \\

--- a/src/probability/sigma_algebraScript.sml
+++ b/src/probability/sigma_algebraScript.sml
@@ -3396,7 +3396,7 @@ QED
 Theorem SIGMA_SIMULTANEOUSLY_MEASURABLE :
     !sp A f (J :'index set).
             (!i. i IN J ==> sigma_algebra (A i)) /\
-            (!i. f i IN (sp -> space (A i))) ==>
+            (!i. i IN J ==> f i IN (sp -> space (A i))) ==>
              !i. i IN J ==> f i IN measurable (sigma sp A f J) (A i)
 Proof
     RW_TAC std_ss [IN_FUNSET, SPACE_SIGMA, sigma_functions_def, IN_MEASURABLE]


### PR DESCRIPTION
Hi,

Given two disjoint lists of (totally independent) random variables (actually two disjoint index lists l1 and l2 of `X(n)`), and two the functions f and g measurable from multi-dimensional Borel spaces to one (the dimensions match the number of r.v.'s in the lists). Then the two composed r.v.'s `f(X .. l1)` and `g(X .. l2)` are independent r.v.s'. The proof is similar with `indep_functions_of_four_vars` (in PR #1404) but the statements of this theorem (where the involved dimensions are parameters) was a long puzzle to me, until the list-based Borel spaces (#1288) were introduced:

```
[indep_functions_of_vars] (stochastic_processTheory)
⊢ ∀p X l1 l2 n1 n2 f g.
    prob_space p ∧ ALL_DISTINCT (l1 ⧺ l2) ∧
    (∀n. MEM n (l1 ⧺ l2) ⇒ random_variable (X n) p Borel) ∧ LENGTH l1 = n1 ∧
    LENGTH l2 = n2 ∧ 0 < n1 ∧ 0 < n2 ∧ f ∈ Borel_measurable (Borel_lists n1) ∧
    g ∈ Borel_measurable (Borel_lists n2) ∧
    indep_vars p X (λn. Borel) (set (l1 ⧺ l2)) ⇒
    indep_vars p (λx. f (MAP (λn. X n x) l1)) (λx. g (MAP (λn. X n x) l2))
      Borel Borel

[IN_MEASURABLE_BOREL_LISTS]
⊢ ∀a f l n.
    sigma_algebra a ∧ LENGTH l = n ∧ 0 < n ∧
    (∀i. MEM i l ⇒ f i ∈ Borel_measurable a) ⇒
    (λx. MAP (λi. f i x) l) ∈ measurable a (Borel_lists n)
```

As an application, if both `f` and `g` are just summations, the following theorem holds:

```
[indep_sum_list_of_vars]
⊢ ∀p X l1 l2 n1 n2 f g.
    prob_space p ∧ ALL_DISTINCT (l1 ⧺ l2) ∧
    (∀n. MEM n (l1 ⧺ l2) ⇒ random_variable (X n) p Borel) ∧ LENGTH l1 = n1 ∧
    LENGTH l2 = n2 ∧ 0 < n1 ∧ 0 < n2 ∧
    indep_vars p X (λn. Borel) (set (l1 ⧺ l2)) ⇒
    indep_vars p (λx. sum_list (MAP (λn. X n x) l1))
      (λx. sum_list (MAP (λn. X n x) l2)) Borel Borel
```
where `sum_list` is a (local) overload to `FOLDR $+ (0 :extreal)`. This theorem has important applications in future work.

--Chun