### PR TITLE
Insertion and deletion operators on ltrees

### DIFF
--- a/examples/lambda/barendregt/boehmScript.sml
+++ b/examples/lambda/barendregt/boehmScript.sml
@@ -971,7 +971,7 @@ Theorem BT_ltree_paths_thm :
     !X M p r. FINITE X /\ FV M SUBSET X UNION RANK r ==>
              (p IN ltree_paths (BT' X M r) <=> subterm X M p r <> NONE)
 Proof
-    rw [ltree_paths_alt, BT_ltree_el_eq_none]
+    rw [ltree_paths_alt_ltree_el, BT_ltree_el_eq_none]
 QED
 
 (* NOTE: p <> [] is required as ‘[] IN ltree_paths (BT' X M r)’ always holds. *)

--- a/examples/lambda/barendregt/lameta_completeScript.sml
+++ b/examples/lambda/barendregt/lameta_completeScript.sml
@@ -1249,7 +1249,7 @@ Proof
          MATCH_MP_TAC BT_of_principle_hnf >> simp []) >> Rewr' \\
      Q.PAT_X_ASSUM ‘M1 0 = _’ (REWRITE_TAC o wrap) \\
      simp [BT_def, Once ltree_unfold, BT_generator_def, LMAP_fromList,
-           ltree_paths_alt, ltree_el_def] \\
+           ltree_paths_alt_ltree_el, ltree_el_def] \\
      simp [GSYM BT_def, LNTH_fromList, MAP_MAP_o] \\
      Cases_on ‘h < m’ >> rw [])
  >> DISCH_TAC
@@ -1365,7 +1365,7 @@ Proof
     ‘!i. principle_hnf (VAR y @* f i) = VAR y @* f i’ by rw [] \\
      Q_TAC (UNBETA_TAC [BT_def, Once ltree_unfold, BT_generator_def])
            ‘BT' X (M1 (n :num)) r’ \\
-     simp [LMAP_fromList, ltree_paths_alt, ltree_el_def, GSYM BT_def] \\
+     simp [LMAP_fromList, ltree_paths_alt_ltree_el, ltree_el_def, GSYM BT_def] \\
      simp [Abbr ‘M0’, GSYM appstar_APPEND, LNTH_fromList, EL_MAP,
            Abbr ‘y'’, Abbr ‘Ms'’, Abbr ‘n'’, Abbr ‘l’, Abbr ‘M1'’, Abbr ‘vs’])
  >> DISCH_TAC

--- a/src/coalgebras/llistScript.sml
+++ b/src/coalgebras/llistScript.sml
@@ -2164,8 +2164,9 @@ val toList_LAPPEND_APPEND = Q.store_thm("toList_LAPPEND_APPEND",
   fs[LTAKE_LAPPEND2,Abbr`n`] >>
   simp[toList]);
 
-val LNTH_LLENGTH_NONE = Q.store_thm("LNTH_LLENGTH_NONE",
-  `(LLENGTH l = SOME x) /\ x <= n ==> (LNTH n l = NONE)`,
+Theorem LNTH_LLENGTH_NONE :
+    !x n l. (LLENGTH l = SOME x) /\ x <= n ==> (LNTH n l = NONE)
+Proof
   rw[LESS_OR_EQ] >- (
     metis_tac[LTAKE_LLENGTH_NONE,LTAKE_EQ_NONE_LNTH] ) >>
   `LFINITE l` by metis_tac[NOT_LFINITE_NO_LENGTH,NOT_NONE_SOME] >>
@@ -2175,7 +2176,8 @@ val LNTH_LLENGTH_NONE = Q.store_thm("LNTH_LLENGTH_NONE",
   simp[] >>
   CASE_TAC >> simp[] >>
   CASE_TAC >> simp[] >>
-  metis_tac[LTAKE_EQ_NONE_LNTH,NOT_NONE_SOME])
+  metis_tac[LTAKE_EQ_NONE_LNTH,NOT_NONE_SOME]
+QED
 
 val LNTH_NONE_MONO = Q.store_thm ("LNTH_NONE_MONO",
   `!m n l.
@@ -2190,7 +2192,7 @@ val LNTH_NONE_MONO = Q.store_thm ("LNTH_NONE_MONO",
   `~(m < z)` by metis_tac[LTAKE_LNTH_EL,NOT_SOME_NONE] >>
   rw[] >> decide_tac);
 
-(* cf. This is just another version of lnth_some_down_closed *)
+(* NOTE: this is just another version of lnth_some_down_closed *)
 Theorem LNTH_IS_SOME_MONO :
    !m n l.
      IS_SOME (LNTH n l) /\ m <= n
@@ -2200,6 +2202,42 @@ Proof
     rw [IS_SOME_EXISTS]
  >> MATCH_MP_TAC lnth_some_down_closed
  >> qexistsl_tac [‘x’, ‘n’] >> rw []
+QED
+
+val LFINITE_strongind = DB.fetch "-" "LFINITE_strongind";
+
+Theorem LNTH_IS_SOME_lemma[local] :
+    !ll. LFINITE ll ==> !n. n < THE (LLENGTH ll) ==> IS_SOME (LNTH n ll)
+Proof
+    HO_MATCH_MP_TAC LFINITE_strongind >> rw []
+ >> gs [LFINITE_LLENGTH]
+ >> Cases_on ‘n’ >> rw [LNTH_THM]
+QED
+
+Theorem LNTH_IS_SOME :
+    !n ll. IS_SOME (LNTH n ll) <=> (LFINITE ll ==> n < THE (LLENGTH ll))
+Proof
+    rpt GEN_TAC
+ >> reverse EQ_TAC
+ >- (rpt STRIP_TAC \\
+     reverse (Cases_on ‘LFINITE ll’)
+     >- (fs [LFINITE_LNTH_NONE] \\
+         POP_ASSUM (MP_TAC o Q.SPEC ‘n’) \\
+         rw [IS_SOME_EQ_NOT_NONE]) \\
+     irule LNTH_IS_SOME_lemma >> simp [])
+ >> rw [LFINITE_LLENGTH] >> rw []
+ >> rename1 ‘i < N’
+ >> fs [IS_SOME_EXISTS]
+ >> CCONTR_TAC
+ >> ‘N <= i’ by rw []
+ >> ‘LNTH i ll = NONE’ by PROVE_TAC [LNTH_LLENGTH_NONE]
+ >> fs []
+QED
+
+Theorem LFINITE_LNTH_IS_SOME :
+    !n ll. LFINITE ll ==> (IS_SOME (LNTH n ll) <=> n < THE (LLENGTH ll))
+Proof
+    rw [LNTH_IS_SOME]
 QED
 
 (* ------------------------------------------------------------------------ *)

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -3945,6 +3945,13 @@ val SHORTLEX_total = store_thm(
   MAP_EVERY Cases_on [‘LENGTH l1 < LENGTH l2’, ‘h1 = h2’, ‘l1 = l2’] >>
   simp[] >> metis_tac[arithmeticTheory.LESS_LESS_CASES]);
 
+Theorem SHORTLEX_irreflexive :
+    !R. irreflexive R ==> irreflexive (SHORTLEX R)
+Proof
+    rw [irreflexive_def]
+ >> Induct_on ‘x’ >> rw [SHORTLEX_def]
+QED
+
 val WF_SHORTLEX_same_lengths = Q.store_thm(
   "WF_SHORTLEX_same_lengths",
   ‘WF R ==>
@@ -4018,6 +4025,14 @@ val WF_SHORTLEX = Q.store_thm(
   ‘LENGTH bb <= LENGTH a0’ by metis_tac[SHORTLEX_LENGTH_LE] >>
   ‘LENGTH a0 = LENGTH a’ by metis_tac[] >>
   full_simp_tac (srw_ss() ++ numSimps.ARITH_ss) []);
+
+Theorem SHORTLEX_SNOC :
+    !R l h1 h2. R h1 h2 ==> SHORTLEX R (SNOC h1 l) (SNOC h2 l)
+Proof
+    Q.X_GEN_TAC ‘R’
+ >> HO_MATCH_MP_TAC list_induction
+ >> rw []
+QED
 
 val LLEX_def = Define‘
   (LLEX R [] l2 <=> l2 <> []) /\

--- a/src/pred_set/src/set_relationScript.sml
+++ b/src/pred_set/src/set_relationScript.sml
@@ -1091,6 +1091,15 @@ Proof
   THEN PROVE_TAC [FINITE_WF_noloops]
 QED
 
+Theorem WF_acyclic :
+    !r. WF (reln_to_rel r) ==> acyclic r
+Proof
+    rpt STRIP_TAC
+ >> SRW_TAC [][acyclic_def, tc_to_rel_conv, in_rel_to_reln]
+ >> Q.ABBREV_TAC ‘R = reln_to_rel r’
+ >> METIS_TAC [WF_noloops]
+QED
+
 (* ------------------------------------------------------------------------ *)
 (* Minimal and maximal elements                                             *)
 (* ------------------------------------------------------------------------ *)


### PR DESCRIPTION
Hi,

The `ltreeTheory` provides a general coinductive datatype for representing potential infinite depth and width trees. Using `ltree_lookup` and `ltree_el`, one can access any ltree subtree or just single node of any path (as `:num list`) of the ltree. But currently there's no way to insert another ltree into the leaf of an existing ltree as a subtree, or to remove one subtree from an existing ltree and get the remaining part. This PR adds two new function `ltree_insert` and `ltree_delete` for these purposes.

However, these operations have limitations: they only operate at the *right most* children of any ltree node. This is because, if a new subtree were added/deleted at the right most position, all other ltree nodes can still be accessed using their original paths. Otherwise, the related shifting process of paths makes things tricky.  (Fortunately, these operations are enough for me, because the η-reduction process of Böhm trees corresponds to the deletion of rightmost children of involved tree nodes.)

Since the insert and delete operations target at the right most children of certain ltree node, these operations do NOT take the path of the actual insertion/deletion node (as arguments) but their parent node(path):

The function `ltree_delete f t p` deletes the right most child of the ltree `t` at path `p`, and if the deletion succeed (the children list is not infinite, and there's at least one child), the ltree node data `d` at path `p` will be modified to `f(d)`. This is the formal definition:
```
   [ltree_delete_def]  Definition
      ⊢ ∀f t p.
          ltree_delete f t p =
          gen_ltree
            (λns.
                 (let
                    (d,len) = THE (ltree_el t ns);
                    m = THE len
                  in
                    if ns = p ∧ len ≠ NONE ∧ 0 < m then (f d,SOME (m − 1))
                    else (d,len)))
```

On the other hand, `ltree_insert f t p t0` inserts a new subtree `t0` as the right most child into the ltree `t` at the parent path `p`. And if the insertion succeeds (the existing children list must not be infinite), the parent node `d` at `p` is modified by the function `f(d)`:
```
   [ltree_insert_def]  Definition      
      ⊢ ∀f t p t0.
          ltree_insert f t p t0 =
          gen_ltree
            (λns.
                 if ltree_el t ns ≠ NONE then
                   (let
                      (d,len) = THE (ltree_el t ns);
                      m = THE len
                    in
                      if ns = p ∧ len ≠ NONE then (f d,SOME (m + 1))
                      else (d,len))
                 else THE (ltree_el t0 (DROP (LENGTH p + 1) ns)))
```

These definitions involve a lot of cases (I don't see shorter ways), and you can imagine it's hard to prove their properties (the proofs in this PR almost doubled the size of `ltreeScript.sml`).

The following theorems show that the set of ltree paths after deletion is indeed the original tree removing just the deleted subtree (and the deletion point, i.e. the parent path, is still there):
```
   [ltree_delete_path_stable]  Theorem      
      ⊢ ∀f p t. p ∈ ltree_paths t ⇒ p ∈ ltree_paths (ltree_delete f t p)
   
   [ltree_delete_paths]  Theorem      
      ⊢ ∀f p t a n.
          ltree_el t p = SOME (a,SOME (SUC n)) ⇒
          ltree_paths (ltree_delete f t p) =
          ltree_paths t DIFF
          IMAGE (λq. SNOC n p ⧺ q)
            (ltree_paths (THE (ltree_lookup t (SNOC n p))))
```

The following theorem shows that, if you delete a subtree and then insert it back, you can get the original ltree. Note that, `ltree_insert'` and `ltree_delete'` are overloads ignoring the modifier function (let `f = I`):

```
   [ltree_insert_delete']  Theorem      
      ⊢ ∀n p t t0.
          ltree_lookup t (SNOC n p) = SOME t0 ∧
          ltree_branching t p = SOME (SUC n) ⇒
          ltree_insert' (ltree_delete' t p) p t0 = t

Overload ltree_delete' = “ltree_delete I”
Overload ltree_insert' = “ltree_insert I”
```

Furthermore, if you insert a finite ltree into a finite ltree, the resulting ltree is (of course) still finite:
```
   [ltree_finite_insert]  Theorem      
      ⊢ ∀f p t t0 d len.
          ltree_finite t ∧ ltree_el t p = SOME (d,len) ∧ ltree_finite t0 ⇒
          ltree_finite (ltree_insert f t p t0)
```

Finally, using all results above (a bit surprisingly), I have proved the following relationship between `ltree_finite` and `ltree_paths`: (In previous PR only the easy direction was proved)
```
   [ltree_finite_alt_ltree_paths]  Theorem      
      ⊢ ∀t. ltree_finite t ⇔ FINITE (ltree_paths t)
```

Let's hope this `ltreeTheory` will become the foundation of all tree-like structures of formalisations in HOL4....

--Chun