### PR TITLE
Improved support of mutually (recursive) nominal datatypes

### DIFF
--- a/examples/CCS/CCSScript.sml
+++ b/examples/CCS/CCSScript.sml
@@ -304,20 +304,19 @@ val APPLY_RELAB_THM = save_thm (
                   (Q.SPEC `labl` IS_RELABELING))));
 
 (******************************************************************************)
-(*                                                                            *)
 (*             Syntax of pure CCS (general formalization)                     *)
-(*                                                                            *)
 (******************************************************************************)
 
-(* The (equivalent) old way (no alpha conversion)
-Datatype: CCS = nil
-              | var string
+(* The nominal datatype with alpha conversion on recursion variables
+Nominal_datatype :
+          CCS = nil
+              | var name
               | prefix ('a Action) CCS
               | sum CCS CCS
               | par CCS CCS
               | restr ('a Label set) CCS
               | relab CCS ('a Relabeling)
-              | rec string CCS
+              | rec ''name CCS
 End
  *)
 
@@ -345,19 +344,20 @@ val lp =
               tns = [] /\ uns = [0;0] \/                          (* 3. par *)
      n = 0 /\ ISR d /\ ISR (OUTR d) /\ ISR (OUTR (OUTR d)) /\
               ISL (OUTR (OUTR (OUTR d))) /\
-              tns = [] /\ uns = [0] \/                          (* 4. restr *)
+              tns = [] /\ uns = [0] \/                            (* 4. restr *)
      n = 0 /\ ISR d /\ ISR (OUTR d) /\ ISR (OUTR (OUTR d)) /\
               ISR (OUTR (OUTR (OUTR d))) /\
               ISL (OUTR (OUTR (OUTR (OUTR d)))) /\
-              tns = [] ∧ uns = [0] \/                           (* 5. relab *)
+              tns = [] /\ uns = [0] \/                            (* 5. relab *)
      n = 0 /\ ISR d /\ ISR (OUTR d) /\ ISR (OUTR (OUTR d)) /\
               ISR (OUTR (OUTR (OUTR d))) /\
               ISR (OUTR (OUTR (OUTR (OUTR d)))) /\
-              tns = [0] /\ uns = [])”;                          (* 6. rec *)
+              tns = [0] /\ uns = []                               (* 6. rec *)
+    )”;
 
 val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
      termP, absrep_id, repabs_pseudo_id, term_REP_t, term_ABS_t, newty, ...} =
-    new_type_step1 tyname 0 {vp = vp, lp = lp};
+    new_type_step1 tyname 0 [] {vp = vp, lp = lp};
 
 (* ----------------------------------------------------------------------
     CCS operators

--- a/examples/formal-languages/pi-calculus/Holmakefile
+++ b/examples/formal-languages/pi-calculus/Holmakefile
@@ -1,0 +1,1 @@
+INCLUDES = $(HOLDIR)/examples/lambda/basics

--- a/examples/formal-languages/pi-calculus/pi_agentScript.sml
+++ b/examples/formal-languages/pi-calculus/pi_agentScript.sml
@@ -1,0 +1,830 @@
+(* ========================================================================== *)
+(* FILE          : pi_agentScript.sml                                         *)
+(* DESCRIPTION   : Nominal type for process (agent) of pi-calculus            *)
+(*                                                                            *)
+(* Copyright 2025  The Australian National University (Author: Chun Tian)     *)
+(* ========================================================================== *)
+
+open HolKernel Parse boolLib bossLib;
+
+open pred_setTheory generic_termsTheory binderLib nomsetTheory nomdatatype;
+
+val _ = new_theory "pi_agent";
+
+(* ----------------------------------------------------------------------
+   Pi-calculus as a nominal datatype in HOL4
+
+   HOL4 syntax ('free and 'bound are special type variables (alias of string)
+
+   Nominal_datatype :
+
+           name = Name string
+
+           pi   = Nil                      (* 0 *)
+                | Tau pi                   (* tau.P *)
+                | Input name ''name pi     (* a(x).P *)
+                | Output name name pi      (* {a}b.P *)
+                | Match name name pi       (* [a == b] P *)
+                | Mismatch name name pi    (* [a <> b] P *)
+                | Sum pi pi                (* P + Q *)
+                | Par pi pi                (* P | Q *)
+                | Res ''name pi            (* nu x. P *)
+
+       residual = TauR pi
+                | InputR name ''name pi      (* (Bound) input *)
+                | BoundOutput name ''name pi (* Bound output *)
+                | FreeOutput name name pi    (* Free output *)
+   End
+
+   NOTE: Replication ("!") is not need so far.
+   ---------------------------------------------------------------------- *)
+
+val tyname0 = "name";
+val tyname1 = "pi";
+val tyname2 = "residual";
+
+(* "Name" is under GVAR (of type 0); There's an extra "Var" under type 1 *)
+val gvar_rep_t = “:unit”;
+val u_tm = mk_var("u", gvar_rep_t);
+val vp = “(\n ^u_tm. n = 0)”;
+
+(* other operators (type 1) are under GLAM (of type 1) *)
+val glam_rep_t = “:unit + unit + unit + unit + unit + unit + unit + unit + unit”;
+val d_tm = mk_var("d", glam_rep_t);
+val lp =
+  “(\n ^d_tm tns uns.
+     n = 1 /\ ISL d /\                                        (* 1. nil *)
+              tns = [] ∧ uns = [] \/
+     n = 1 /\ ISR d /\ ISL (OUTR d) /\                        (* 2. tau prefix *)
+              tns = [] /\ uns = [1] \/
+     n = 1 /\ ISR d /\ ISR (OUTR d) /\ ISL (OUTR (OUTR d)) /\ (* 3. input prefix *)
+              tns = [1] /\ uns = [0] \/
+     n = 1 /\ ISR d /\ ISR (OUTR d) /\ ISR (OUTR (OUTR d)) /\ (* 4. output prefix *)
+              ISL (OUTR (OUTR (OUTR d))) /\
+              tns = [] /\ uns = [0; 0; 1] \/
+     n = 1 /\ ISR d /\ ISR (OUTR d) /\ ISR (OUTR (OUTR d)) /\ (* 5. smatch *)
+              ISR (OUTR (OUTR (OUTR d))) /\
+              ISL (OUTR (OUTR (OUTR (OUTR d)))) /\
+              tns = [] /\ uns = [0; 0; 1] \/
+     n = 1 /\ ISR d /\ ISR (OUTR d) /\ ISR (OUTR (OUTR d)) /\ (* 6. mismatch *)
+              ISR (OUTR (OUTR (OUTR d))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR d)))) /\
+              ISL (OUTR (OUTR (OUTR (OUTR (OUTR d))))) /\
+              tns = [] /\ uns = [0; 0; 1] \/
+     n = 1 /\ ISR d /\ ISR (OUTR d) /\ ISR (OUTR (OUTR d)) /\ (* 7. summation *)
+              ISR (OUTR (OUTR (OUTR d))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR d)))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR d))))) /\
+              ISL (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d)))))) /\
+              tns = [] /\ uns = [1; 1] \/
+     n = 1 /\ ISR d /\ ISR (OUTR d) /\ ISR (OUTR (OUTR d)) /\ (* 8. parallel *)
+              ISR (OUTR (OUTR (OUTR d))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR d)))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR d))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d)))))) /\
+              ISL (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d))))))) /\
+              tns = [] /\ uns = [1; 1] \/
+     n = 1 /\ ISR d /\ ISR (OUTR d) /\ ISR (OUTR (OUTR d)) /\ (* 9. restriction *)
+              ISR (OUTR (OUTR (OUTR d))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR d)))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR d))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d)))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d))))))) /\
+              tns = [1] /\ uns = [] \/
+     n = 2 /\ ISL d /\                                        (* tau residual *)
+              tns = [] ∧ uns = [1] \/
+     n = 2 /\ ISR d /\ ISL (OUTR d) /\                        (* bound output *)
+              tns = [1] /\ uns = [0] \/
+     n = 2 /\ ISR d /\ ISR (OUTR d) /\ ISL (OUTR (OUTR d)) /\ (* input residual *)
+              tns = [1] /\ uns = [0] \/
+     n = 2 /\ ISR d /\ ISR (OUTR d) /\ ISR (OUTR (OUTR d)) /\ (* free output *)
+              ISL (OUTR (OUTR (OUTR d))) /\
+              tns = [] /\ uns = [0; 0; 1]
+    )”;
+
+(* type 0 (:name) *)
+val {term_ABS_pseudo11 = term_ABS_pseudo11_0,
+     term_REP_11 = term_REP_11_0,
+     genind_term_REP = genind_term_REP0,
+     genind_exists = genind_exists0,
+     termP = termP0,
+     absrep_id = absrep_id0,
+     repabs_pseudo_id = repabs_pseudo_id0,
+     term_REP_t = term_REP_t0,
+     term_ABS_t = term_ABS_t0,
+     newty = newty0, ...} = new_type_step1 tyname0 0 [] {vp = vp, lp = lp};
+
+(* type 1 (:pi) *)
+val {term_ABS_pseudo11 = term_ABS_pseudo11_1,
+     term_REP_11 = term_REP_11_1,
+     genind_term_REP = genind_term_REP1,
+     genind_exists = genind_exists1,
+     termP = termP1,
+     absrep_id = absrep_id1,
+     repabs_pseudo_id = repabs_pseudo_id1,
+     term_REP_t = term_REP_t1,
+     term_ABS_t = term_ABS_t1,
+     newty = newty1, ...} = new_type_step1 tyname1 1 [] {vp = vp, lp = lp};
+
+(* type 2 (:residual) *)
+val {term_ABS_pseudo11 = term_ABS_pseudo11_2,
+     term_REP_11 = term_REP_11_2,
+     genind_term_REP = genind_term_REP2,
+     genind_exists = genind_exists2,
+     termP = termP2,
+     absrep_id = absrep_id2,
+     repabs_pseudo_id = repabs_pseudo_id2,
+     term_REP_t = term_REP_t2,
+     term_ABS_t = term_ABS_t2,
+     newty = newty2, ...} =
+     new_type_step1 tyname2 2 [genind_exists0, genind_exists1] {vp = vp, lp = lp};
+
+(* ----------------------------------------------------------------------
+    Pi-calculus operators
+   ---------------------------------------------------------------------- *)
+
+val [gvar,glam] = genind_rules |> SPEC_ALL |> CONJUNCTS;
+
+(* "Name" of type 0 (:name) *)
+val Name_t = mk_var("Name", “:string -> ^newty0”);
+val Name_def = new_definition(
+   "Name_def", “^Name_t s = ^term_ABS_t0 (GVAR s ())”);
+val Name_termP = prove(
+    mk_comb(termP0, Name_def |> SPEC_ALL |> concl |> rhs |> rand),
+    srw_tac [][genind_rules]);
+val Name_t = defined_const Name_def;
+
+(* Nil *)
+val Nil_t = mk_var("Nil", “:^newty1”);
+val Nil_def = new_definition(
+   "Nil_def",
+  “^Nil_t = ^term_ABS_t1 (GLAM ARB (INL ()) [] [])”);
+val Nil_termP = prove(
+   “^termP1 (GLAM x (INL ()) [] [])”,
+    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
+val Nil_t = defined_const Nil_def;
+val Nil_def' = prove(
+  “^term_ABS_t1 (GLAM v (INL ()) [] []) = ^Nil_t”,
+    srw_tac [][Nil_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Nil_termP]);
+
+(* Tau prefix *)
+val Tau_t = mk_var("Tau", “:^newty1 -> ^newty1”);
+val Tau_def = new_definition(
+   "Tau_def",
+  “^Tau_t P = ^term_ABS_t1 (GLAM ARB (INR (INL ())) [] [^term_REP_t1 P])”);
+val Tau_termP = prove(
+   “^termP1 (GLAM x (INR (INL ())) [] [^term_REP_t1 P])”,
+    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
+val Tau_t = defined_const Tau_def;
+val Tau_def' = prove(
+  “^term_ABS_t1 (GLAM v (INR (INL ())) [] [^term_REP_t1 P]) = ^Tau_t P”,
+    srw_tac [][Tau_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Tau_termP]);
+
+(* Input prefix *)
+val Input_t = mk_var("Input", “:^newty0 -> string -> ^newty1 -> ^newty1”);
+val Input_def = new_definition(
+   "Input_def",
+  “^Input_t a x P = ^term_ABS_t1 (GLAM x (INR (INR (INL ())))
+                                         [^term_REP_t1 P]
+                                         [^term_REP_t0 a])”);
+val Input_termP = prove(
+    mk_comb(termP1, Input_def |> SPEC_ALL |> concl |> rhs |> rand),
+    match_mp_tac glam >> srw_tac [][genind_term_REP0, genind_term_REP1]);
+val Input_t = defined_const Input_def;
+
+(* Output prefix *)
+val Output_t = mk_var("Output", “:^newty0 -> ^newty0 -> ^newty1 -> ^newty1”);
+val Output_def = new_definition(
+   "Output_def",
+  “^Output_t a b P = ^term_ABS_t1 (GLAM ARB (INR (INR (INR (INL ())))) []
+                                            [^term_REP_t0 a;
+                                             ^term_REP_t0 b;
+                                             ^term_REP_t1 P])”);
+val Output_termP = prove(
+   “^termP1 (GLAM x (INR (INR (INR (INL ())))) []
+                                            [^term_REP_t0 a;
+                                             ^term_REP_t0 b;
+                                             ^term_REP_t1 P])”,
+    match_mp_tac glam >> srw_tac [][genind_term_REP0,genind_term_REP1]);
+val Output_t = defined_const Output_def;
+val Output_def' = prove(
+  “^term_ABS_t1 (GLAM v (INR (INR (INR (INL ())))) []
+                                            [^term_REP_t0 a;
+                                             ^term_REP_t0 b;
+                                             ^term_REP_t1 P]) = ^Output_t a b P”,
+    srw_tac [][Output_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Output_termP]);
+
+(* Match *)
+val Match_t = mk_var("Match", “:^newty0 -> ^newty0 -> ^newty1 -> ^newty1”);
+val Match_def = new_definition(
+   "Match_def",
+  “^Match_t a b P = ^term_ABS_t1 (GLAM ARB (INR (INR (INR (INR (INL ()))))) []
+                                           [^term_REP_t0 a;
+                                            ^term_REP_t0 b;
+                                            ^term_REP_t1 P])”);
+val Match_termP = prove(
+   “^termP1 (GLAM x (INR (INR (INR (INR (INL ()))))) []
+                                           [^term_REP_t0 a;
+                                            ^term_REP_t0 b;
+                                            ^term_REP_t1 P])”,
+    match_mp_tac glam >> srw_tac [][genind_term_REP0,genind_term_REP1]);
+val Match_t = defined_const Match_def;
+val Match_def' = prove(
+  “^term_ABS_t1 (GLAM v (INR (INR (INR (INR (INL ()))))) []
+                                           [^term_REP_t0 a;
+                                            ^term_REP_t0 b;
+                                            ^term_REP_t1 P]) = ^Match_t a b P”,
+    srw_tac [][Match_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Match_termP]);
+
+(* Mismatch *)
+val Mismatch_t = mk_var("Mismatch", “:^newty0 -> ^newty0 -> ^newty1 -> ^newty1”);
+val Mismatch_def = new_definition(
+   "Mismatch_def",
+  “^Mismatch_t a b P =
+   ^term_ABS_t1 (GLAM ARB (INR (INR (INR (INR (INR (INL ())))))) []
+                          [^term_REP_t0 a;
+                           ^term_REP_t0 b;
+                           ^term_REP_t1 P])”);
+val Mismatch_termP = prove(
+   “^termP1 (GLAM x (INR (INR (INR (INR (INR (INL ())))))) []
+                          [^term_REP_t0 a;
+                           ^term_REP_t0 b;
+                           ^term_REP_t1 P])”,
+    match_mp_tac glam >> srw_tac [][genind_term_REP0,genind_term_REP1]);
+val Mismatch_t = defined_const Mismatch_def;
+val Mismatch_def' = prove(
+  “^term_ABS_t1 (GLAM v (INR (INR (INR (INR (INR (INL ())))))) []
+                          [^term_REP_t0 a;
+                           ^term_REP_t0 b;
+                           ^term_REP_t1 P]) = ^Mismatch_t a b P”,
+    srw_tac [][Mismatch_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Mismatch_termP]);
+
+(* Sum (Choice) *)
+val Sum_t = mk_var("Sum", “:^newty1 -> ^newty1 -> ^newty1”);
+val Sum_def = new_definition(
+   "Sum_def",
+  “^Sum_t P Q =
+   ^term_ABS_t1 (GLAM ARB (INR (INR (INR (INR (INR (INR (INL ()))))))) []
+                          [^term_REP_t1 P;
+                           ^term_REP_t1 Q])”);
+val Sum_termP = prove(
+   “^termP1 (GLAM x (INR (INR (INR (INR (INR (INR (INL ()))))))) []
+                          [^term_REP_t1 P;
+                           ^term_REP_t1 Q])”,
+    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
+val Sum_t = defined_const Sum_def;
+val Sum_def' = prove(
+  “^term_ABS_t1 (GLAM v (INR (INR (INR (INR (INR (INR (INL ()))))))) []
+                          [^term_REP_t1 P;
+                           ^term_REP_t1 Q]) = ^Sum_t P Q”,
+    srw_tac [][Sum_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Sum_termP]);
+
+(* Parallel Composition *)
+val Par_t = mk_var("Par", “:^newty1 -> ^newty1 -> ^newty1”);
+val Par_def = new_definition(
+   "Par_def",
+  “^Par_t P Q =
+   ^term_ABS_t1 (GLAM ARB (INR (INR (INR (INR (INR (INR (INR (INL ())))))))) []
+                          [^term_REP_t1 P;
+                           ^term_REP_t1 Q])”);
+val Par_termP = prove(
+   “^termP1 (GLAM x (INR (INR (INR (INR (INR (INR (INR (INL ())))))))) []
+                          [^term_REP_t1 P;
+                           ^term_REP_t1 Q])”,
+    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
+val Par_t = defined_const Par_def;
+val Par_def' = prove(
+  “^term_ABS_t1 (GLAM v (INR (INR (INR (INR (INR (INR (INR (INL ())))))))) []
+                          [^term_REP_t1 P;
+                           ^term_REP_t1 Q]) = ^Par_t P Q”,
+    srw_tac [][Par_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Par_termP]);
+
+(* Restriction *)
+val Res_t = mk_var("Res", “:string -> ^newty1 -> ^newty1”);
+val Res_def = new_definition(
+   "Res_def",
+  “^Res_t v P =
+   ^term_ABS_t1 (GLAM v (INR (INR (INR (INR (INR (INR (INR (INR ()))))))))
+                        [^term_REP_t1 P] [])”);
+val Res_tm = Res_def |> concl |> strip_forall |> snd |> rhs |> rand;
+val Res_termP = prove(
+    mk_comb (termP1, Res_tm),
+    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
+val Res_t = defined_const Res_def;
+
+(* TauR *)
+val TauR_t = mk_var("TauR", “:^newty1 -> ^newty2”);
+val TauR_def = new_definition(
+   "TauR_def",
+  “^TauR_t P = ^term_ABS_t2 (GLAM ARB (INL ()) [] [^term_REP_t1 P])”);
+val TauR_tm = TauR_def |> concl |> strip_forall |> snd |> rhs |> rand;
+val TauR_termP = prove(
+   “^termP2 (GLAM x (INL ()) [] [^term_REP_t1 P])”,
+    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
+val TauR_t = defined_const TauR_def;
+val TauR_def' = prove(
+  “^term_ABS_t2 (GLAM v (INL ()) [] [^term_REP_t1 P]) = ^TauR_t P”,
+    srw_tac [][TauR_def, GLAM_NIL_EQ, term_ABS_pseudo11_2, TauR_termP]);
+
+(* Bound output (residual) *)
+val BoundOutput_t =
+    mk_var("BoundOutput", “:^newty0 -> string -> ^newty1 -> ^newty2”);
+val BoundOutput_def = new_definition(
+   "BoundOutput_def",
+  “^BoundOutput_t a x P = ^term_ABS_t2 (GLAM x (INR (INL ()))
+                                               [^term_REP_t1 P]
+                                               [^term_REP_t0 a])”);
+val BoundOutput_termP = prove(
+    mk_comb(termP2, BoundOutput_def |> SPEC_ALL |> concl |> rhs |> rand),
+    match_mp_tac glam >> srw_tac [][genind_term_REP0, genind_term_REP1]);
+val BoundOutput_t = defined_const BoundOutput_def;
+
+(* Input residual *)
+val InputR_t = mk_var("InputR",
+                             “:^newty0 -> string -> ^newty1 -> ^newty2”);
+val InputR_def = new_definition(
+   "InputR_def",
+  “^InputR_t a x P = ^term_ABS_t2 (GLAM x (INR (INR (INL ())))
+                                                 [^term_REP_t1 P]
+                                                 [^term_REP_t0 a])”);
+val InputR_termP = prove(
+    mk_comb(termP2, InputR_def |> SPEC_ALL |> concl |> rhs |> rand),
+    match_mp_tac glam >> srw_tac [][genind_term_REP0, genind_term_REP1]);
+val InputR_t = defined_const InputR_def;
+
+(* Free output (residual) *)
+val FreeOutput_t =
+    mk_var("FreeOutput", “:^newty0 -> ^newty0 -> ^newty1 -> ^newty2”);
+val FreeOutput_def = new_definition(
+   "FreeOutput_def",
+  “^FreeOutput_t a b P = ^term_ABS_t2 (GLAM ARB (INR (INR (INR (INL ())))) []
+                                            [^term_REP_t0 a;
+                                             ^term_REP_t0 b;
+                                             ^term_REP_t1 P])”);
+val FreeOutput_termP = prove(
+   “^termP2 (GLAM x (INR (INR (INR (INL ())))) []
+                                            [^term_REP_t0 a;
+                                             ^term_REP_t0 b;
+                                             ^term_REP_t1 P])”,
+    match_mp_tac glam >> srw_tac [][genind_term_REP0, genind_term_REP1]);
+val FreeOutput_t = defined_const FreeOutput_def;
+val FreeOutput_def' = prove(
+  “^term_ABS_t2 (GLAM v (INR (INR (INR (INL ())))) []
+                                            [^term_REP_t0 a;
+                                             ^term_REP_t0 b;
+                                             ^term_REP_t1 P]) = ^FreeOutput_t a b P”,
+    srw_tac [][FreeOutput_def, GLAM_NIL_EQ, term_ABS_pseudo11_2,
+               FreeOutput_termP]);
+
+(* ----------------------------------------------------------------------
+    npm - permutation of pi-calculus names
+   ---------------------------------------------------------------------- *)
+
+val ncons_info = [{con_termP = Name_termP, con_def = Name_def}];
+val npm_name_pfx = "n";
+
+val {tpm_thm = npm_thm,
+     term_REP_tpm = term_REP_npm,
+     t_pmact_t = n_pmact_t,
+     tpm_t = npm_t} =
+    define_permutation {name_pfx = npm_name_pfx, name = tyname0,
+                        term_REP_t = term_REP_t0,
+                        term_ABS_t = term_ABS_t0,
+                        absrep_id = absrep_id0,
+                        repabs_pseudo_id = repabs_pseudo_id0,
+                        cons_info = ncons_info,
+                        newty = newty0,
+                        genind_term_REP = genind_term_REP0};
+
+Theorem npm_eqr :
+    t = npm pi u <=> npm (REVERSE pi) t = (u :name)
+Proof
+    METIS_TAC [pmact_inverse]
+QED
+
+Theorem npm_eql :
+    npm pi t = u <=> t = npm (REVERSE pi) (u :name)
+Proof
+    simp[npm_eqr]
+QED
+
+Theorem npm_CONS :
+    npm ((x,y)::pi) (t :name) = npm [(x,y)] (npm pi t)
+Proof
+  SRW_TAC [][GSYM pmact_decompose]
+QED
+
+(* ----------------------------------------------------------------------
+    tpm - permutation of pi-calculus binding variables
+   ---------------------------------------------------------------------- *)
+
+val cons_info =
+    [{con_termP = Nil_termP,      con_def = SYM Nil_def'},
+     {con_termP = Tau_termP,      con_def = SYM Tau_def'},
+     {con_termP = Input_termP,    con_def = Input_def},
+     {con_termP = Output_termP,   con_def = SYM Output_def'},
+     {con_termP = Match_termP,    con_def = SYM Match_def'},
+     {con_termP = Mismatch_termP, con_def = SYM Mismatch_def'},
+     {con_termP = Sum_termP,      con_def = SYM Sum_def'},
+     {con_termP = Par_termP,      con_def = SYM Par_def'},
+     {con_termP = Res_termP,      con_def = Res_def}];
+
+val tpm_name_pfx = "t";
+val {tpm_thm, term_REP_tpm, t_pmact_t, tpm_t} =
+    define_permutation {name_pfx = tpm_name_pfx, name = tyname1,
+                        term_REP_t = term_REP_t1,
+                        term_ABS_t = term_ABS_t1,
+                        absrep_id = absrep_id1,
+                        repabs_pseudo_id = repabs_pseudo_id1,
+                        cons_info = cons_info,
+                        newty = newty1,
+                        genind_term_REP = genind_term_REP1};
+
+Theorem tpm_thm[allow_rebind] =
+        tpm_thm |> REWRITE_RULE [GSYM term_REP_npm, GSYM Input_def, Output_def',
+                                 Match_def', Mismatch_def'];
+
+Theorem tpm_eqr :
+    t = tpm pi u <=> tpm (REVERSE pi) t = (u :pi)
+Proof
+    METIS_TAC [pmact_inverse]
+QED
+
+Theorem tpm_eql :
+    tpm pi t = u <=> t = tpm (REVERSE pi) (u :pi)
+Proof
+    simp[tpm_eqr]
+QED
+
+Theorem tpm_CONS :
+    tpm ((x,y)::pi) (t :pi) = tpm [(x,y)] (tpm pi t)
+Proof
+  SRW_TAC [][GSYM pmact_decompose]
+QED
+
+(* ----------------------------------------------------------------------
+    rpm - permutation of pi-calculus residuals
+   ---------------------------------------------------------------------- *)
+
+val rcons_info =
+    [{con_termP = TauR_termP,        con_def = SYM TauR_def'},
+     {con_termP = BoundOutput_termP, con_def = BoundOutput_def},
+     {con_termP = InputR_termP,      con_def = InputR_def},
+     {con_termP = FreeOutput_termP,  con_def = SYM FreeOutput_def'}];
+
+val rpm_name_pfx = "r";
+
+val {tpm_thm = rpm_thm,
+     term_REP_tpm = term_REP_rpm,
+     t_pmact_t = r_pmact_t,
+     tpm_t = rpm_t} =
+    define_permutation {name_pfx = rpm_name_pfx, name = tyname2,
+                        term_REP_t = term_REP_t2,
+                        term_ABS_t = term_ABS_t2,
+                        absrep_id = absrep_id2,
+                        repabs_pseudo_id = repabs_pseudo_id2,
+                        cons_info = rcons_info,
+                        newty = newty2,
+                        genind_term_REP = genind_term_REP2};
+
+Theorem rpm_thm[allow_rebind] =
+        rpm_thm |> REWRITE_RULE [GSYM term_REP_npm, GSYM term_REP_tpm, TauR_def',
+                                 GSYM BoundOutput_def, GSYM InputR_def, FreeOutput_def']
+
+Theorem rpm_eqr :
+    t = rpm pi u <=> rpm (REVERSE pi) t = (u :residual)
+Proof
+    METIS_TAC [pmact_inverse]
+QED
+
+Theorem rpm_eql :
+    rpm pi t = u <=> t = rpm (REVERSE pi) (u :residual)
+Proof
+    simp[rpm_eqr]
+QED
+
+Theorem rpm_CONS :
+    rpm ((x,y)::pi) (t :residual) = rpm [(x,y)] (rpm pi t)
+Proof
+  SRW_TAC [][GSYM pmact_decompose]
+QED
+
+(* ----------------------------------------------------------------------
+    support (supp) and FV (for type :name)
+   ---------------------------------------------------------------------- *)
+
+val name_REP_eqv = prove(
+   “support (fn_pmact ^n_pmact_t gt_pmact) ^term_REP_t0 {}”,
+    srw_tac [][support_def, fnpm_def, FUN_EQ_THM, term_REP_npm, pmact_sing_inv]);
+
+val supp_name_REP = prove(
+   “supp (fn_pmact ^n_pmact_t gt_pmact) ^term_REP_t0 = {}”,
+    REWRITE_TAC [GSYM SUBSET_EMPTY]
+ >> MATCH_MP_TAC (GEN_ALL supp_smallest)
+ >> srw_tac [][name_REP_eqv]);
+
+val npm_def' =
+    term_REP_npm |> AP_TERM term_ABS_t0 |> PURE_REWRITE_RULE [absrep_id0];
+
+val t = mk_var("t", newty0);
+
+val supp_npm_support = prove(
+   “support ^n_pmact_t ^t (supp gt_pmact (^term_REP_t0 ^t))”,
+    srw_tac [][support_def, npm_def', supp_fresh, absrep_id0]);
+
+val supp_npm_apart = prove(
+   “x IN supp gt_pmact (^term_REP_t0 ^t) /\ y NOTIN supp gt_pmact (^term_REP_t0 ^t)
+    ==> ^npm_t [(x,y)] ^t <> ^t”,
+    srw_tac [][npm_def']
+ >> DISCH_THEN (MP_TAC o AP_TERM term_REP_t0)
+ >> srw_tac [][repabs_pseudo_id0, genind_gtpm_eqn, genind_term_REP0, supp_apart]);
+
+val supp_npm = prove(
+   “supp ^n_pmact_t ^t = supp gt_pmact (^term_REP_t0 ^t)”,
+    match_mp_tac (GEN_ALL supp_unique_apart)
+ >> srw_tac [][supp_npm_support, supp_npm_apart, FINITE_GFV]);
+
+val _ = overload_on ("FV", “supp ^n_pmact_t”);
+val _ = overload_on ("#", “\v (P :name). v NOTIN FV P”);
+
+Theorem FINITE_FV_name[simp] :
+    FINITE (FV (n :name))
+Proof
+    srw_tac [][supp_npm, FINITE_GFV]
+QED
+
+Theorem FV_EMPTY_name :
+    FV n = {} <=> !v. v NOTIN FV (n :name)
+Proof
+    SIMP_TAC (srw_ss()) [EXTENSION]
+QED
+
+fun nsupp_clause {con_termP, con_def} = let
+  val t = mk_comb(“supp ^n_pmact_t”, lhand (concl (SPEC_ALL con_def)))
+in
+  t |> REWRITE_CONV [supp_npm, con_def, MATCH_MP repabs_pseudo_id0 con_termP,
+                     GFV_thm]
+    |> REWRITE_RULE [supp_listpm, EMPTY_DELETE, UNION_EMPTY]
+    |> REWRITE_RULE [GSYM supp_npm]
+    |> GEN_ALL
+end
+
+Theorem FV_name_thm[simp] = LIST_CONJ (map nsupp_clause ncons_info)
+
+Theorem FV_npm[simp] = “x IN FV (npm p (n :name))”
+                       |> REWRITE_CONV [perm_supp, pmact_IN]
+                       |> GEN_ALL
+
+(* ----------------------------------------------------------------------
+    support (supp) and FV (for type :pi)
+   ---------------------------------------------------------------------- *)
+
+val term_REP_eqv = prove(
+   “support (fn_pmact ^t_pmact_t gt_pmact) ^term_REP_t1 {}”,
+    srw_tac [][support_def, fnpm_def, FUN_EQ_THM, term_REP_tpm, pmact_sing_inv]);
+
+val supp_term_REP = prove(
+   “supp (fn_pmact ^t_pmact_t gt_pmact) ^term_REP_t1 = {}”,
+    REWRITE_TAC [GSYM SUBSET_EMPTY]
+ >> MATCH_MP_TAC (GEN_ALL supp_smallest)
+ >> srw_tac [][term_REP_eqv]);
+
+val tpm_def' =
+    term_REP_tpm |> AP_TERM term_ABS_t1 |> PURE_REWRITE_RULE [absrep_id1];
+
+val t = mk_var("t", newty1);
+
+val supp_tpm_support = prove(
+   “support ^t_pmact_t ^t (supp gt_pmact (^term_REP_t1 ^t))”,
+    srw_tac [][support_def, tpm_def', supp_fresh, absrep_id1]);
+
+val supp_tpm_apart = prove(
+   “x IN supp gt_pmact (^term_REP_t1 ^t) /\ y NOTIN supp gt_pmact (^term_REP_t1 ^t)
+    ==> ^tpm_t [(x,y)] ^t <> ^t”,
+    srw_tac [][tpm_def']
+ >> DISCH_THEN (MP_TAC o AP_TERM term_REP_t1)
+ >> srw_tac [][repabs_pseudo_id1, genind_gtpm_eqn, genind_term_REP1, supp_apart]);
+
+val supp_tpm = prove(
+   “supp ^t_pmact_t ^t = supp gt_pmact (^term_REP_t1 ^t)”,
+    match_mp_tac (GEN_ALL supp_unique_apart)
+ >> srw_tac [][supp_tpm_support, supp_tpm_apart, FINITE_GFV]);
+
+val _ = overload_on ("FV", “supp ^t_pmact_t”);
+
+val _ = set_fixity "#" (Infix(NONASSOC, 450));
+val _ = overload_on ("#", “\v (P :pi). v NOTIN FV P”);
+
+Theorem FINITE_FV[simp] :
+    FINITE (FV (t :pi))
+Proof
+    srw_tac [][supp_tpm, FINITE_GFV]
+QED
+
+Theorem FV_EMPTY :
+    FV t = {} <=> !v. v NOTIN FV (t :pi)
+Proof
+    SIMP_TAC (srw_ss()) [EXTENSION]
+QED
+
+fun supp_clause {con_termP, con_def} = let
+  val t = mk_comb(“supp ^t_pmact_t”, lhand (concl (SPEC_ALL con_def)))
+in
+  t |> REWRITE_CONV [supp_tpm, con_def, MATCH_MP repabs_pseudo_id1 con_termP,
+                     GFV_thm]
+    |> REWRITE_RULE [supp_listpm, EMPTY_DELETE, UNION_EMPTY]
+    |> REWRITE_RULE [GSYM supp_tpm, GSYM supp_npm]
+    |> GEN_ALL
+end
+
+Theorem FV_thm[simp] = LIST_CONJ (map supp_clause cons_info)
+
+Theorem FV_tpm[simp] = “x IN FV (tpm p (t :pi))”
+                       |> REWRITE_CONV [perm_supp, pmact_IN]
+                       |> GEN_ALL
+
+(* ----------------------------------------------------------------------
+    support (supp) and FV (for type :residual)
+   ---------------------------------------------------------------------- *)
+
+val residual_REP_eqv = prove(
+   “support (fn_pmact ^r_pmact_t gt_pmact) ^term_REP_t2 {}”,
+    srw_tac [][support_def, fnpm_def, FUN_EQ_THM, term_REP_rpm, pmact_sing_inv]);
+
+val supp_residual_REP = prove(
+   “supp (fn_pmact ^r_pmact_t gt_pmact) ^term_REP_t2 = {}”,
+    REWRITE_TAC [GSYM SUBSET_EMPTY]
+ >> MATCH_MP_TAC (GEN_ALL supp_smallest)
+ >> srw_tac [][residual_REP_eqv]);
+
+val rpm_def' =
+    term_REP_rpm |> AP_TERM term_ABS_t2 |> PURE_REWRITE_RULE [absrep_id2];
+
+val t = mk_var("t", newty2);
+
+val supp_rpm_support = prove(
+   “support ^r_pmact_t ^t (supp gt_pmact (^term_REP_t2 ^t))”,
+    srw_tac [][support_def, rpm_def', supp_fresh, absrep_id2]);
+
+val supp_rpm_apart = prove(
+   “x IN supp gt_pmact (^term_REP_t2 ^t) /\ y NOTIN supp gt_pmact (^term_REP_t2 ^t)
+    ==> ^rpm_t [(x,y)] ^t <> ^t”,
+    srw_tac [][rpm_def']
+ >> DISCH_THEN (MP_TAC o AP_TERM term_REP_t2)
+ >> srw_tac [][repabs_pseudo_id2, genind_gtpm_eqn, genind_term_REP2, supp_apart]);
+
+val supp_rpm = prove(
+   “supp ^r_pmact_t ^t = supp gt_pmact (^term_REP_t2 ^t)”,
+    match_mp_tac (GEN_ALL supp_unique_apart)
+ >> srw_tac [][supp_rpm_support, supp_rpm_apart, FINITE_GFV]);
+
+val _ = overload_on ("FV", “supp ^r_pmact_t”);
+val _ = overload_on ("#", “\v (P :residual). v NOTIN FV P”);
+
+Theorem FINITE_FV_residual[simp] :
+    FINITE (FV (t :residual))
+Proof
+    srw_tac [][supp_rpm, FINITE_GFV]
+QED
+
+Theorem FV_EMPTY_residual :
+    FV t = {} <=> !v. v NOTIN FV (t :residual)
+Proof
+    SIMP_TAC (srw_ss()) [EXTENSION]
+QED
+
+fun rsupp_clause {con_termP, con_def} = let
+  val t = mk_comb(“supp ^r_pmact_t”, lhand (concl (SPEC_ALL con_def)))
+in
+  t |> REWRITE_CONV [supp_rpm, con_def, MATCH_MP repabs_pseudo_id2 con_termP,
+                     GFV_thm]
+    |> REWRITE_RULE [supp_listpm, EMPTY_DELETE, UNION_EMPTY]
+    |> REWRITE_RULE [GSYM supp_tpm, GSYM supp_npm]
+    |> GEN_ALL
+end
+
+Theorem FV_residual_thm[simp] = LIST_CONJ (map rsupp_clause rcons_info)
+
+Theorem FV_rpm[simp] = “x IN FV (rpm p (t :residual))”
+                       |> REWRITE_CONV [perm_supp, pmact_IN]
+                       |> GEN_ALL
+
+(* ----------------------------------------------------------------------
+    term induction
+   ---------------------------------------------------------------------- *)
+
+fun genit th = let
+  val (_, args) = strip_comb (concl th)
+  val (tm, x) = case args of [x,y] => (x,y) | _ => raise Fail "Bind"
+  val ty = type_of tm
+  val t = mk_var("t", ty)
+in
+  th |> INST [tm |-> t] |> GEN x |> GEN t
+end
+
+val LIST_REL_CONS1 = listTheory.LIST_REL_CONS1;
+val LIST_REL_NIL = listTheory.LIST_REL_NIL;
+
+val term_ind =
+    bvc_genind
+        |> INST_TYPE [alpha |-> glam_rep_t, beta |-> gvar_rep_t]
+        |> Q.INST [‘vp’ |-> ‘^vp’, ‘lp’ |-> ‘^lp’]
+        |> SIMP_RULE std_ss [LIST_REL_CONS1, RIGHT_AND_OVER_OR,
+                             LEFT_AND_OVER_OR, DISJ_IMP_THM, LIST_REL_NIL]
+        |> Q.SPECL [‘\n t0 x. n = 1 ==> Q t0 x’, ‘fv’]
+        |> UNDISCH |> Q.SPEC ‘1’ |> DISCH_ALL
+        |> SIMP_RULE (std_ss ++ DNF_ss)
+                     [sumTheory.FORALL_SUM, supp_listpm,
+                      IN_UNION, NOT_IN_EMPTY, oneTheory.FORALL_ONE,
+                      genind_exists0,
+                      genind_exists1,
+                      genind_exists2,
+                      LIST_REL_CONS1, LIST_REL_NIL]
+        |> Q.INST [‘Q’ |-> ‘\t. P (^term_ABS_t1 t)’]
+        |> SIMP_RULE std_ss [absrep_id1,
+                             GSYM Name_def,
+                             Nil_def', Tau_def', GSYM Input_def,
+                             Output_def', Match_def', Mismatch_def',
+                             Sum_def', Par_def', GSYM Res_def]
+        |> SIMP_RULE (srw_ss()) [GSYM supp_tpm, GSYM supp_npm]
+        |> elim_unnecessary_atoms {finite_fv = FINITE_FV}
+                                  [ASSUME “!x:'c. FINITE (fv x:string set)”]
+        |> SPEC_ALL |> UNDISCH
+        |> genit |> DISCH_ALL |> Q.GENL [‘P’, ‘fv’];
+
+fun mkX_ind th = th |> Q.SPECL [‘\t x. Q t’, ‘\x. X’]
+                    |> SIMP_RULE std_ss [] |> Q.GEN ‘X’
+                    |> Q.INST [‘Q’ |-> ‘P’] |> Q.GEN ‘P’;
+
+(* NOTE: not recommended unless in generated theorems *)
+Theorem nc_INDUCTION[local] = mkX_ind term_ind
+
+(* The recommended induction theorem containing correctly namedbinding variables. *)
+Theorem nc_INDUCTION2 :
+    !P X.
+        P Nil /\ (!E. P E ==> P (Tau E)) /\
+        (!a x E. P E /\ x NOTIN X /\ x # a ==> P (Input a x E)) /\
+        (!a b E. P E ==> P (Output a b E)) /\
+        (!a b E. P E ==> P (Match a b E)) /\
+        (!a b E. P E ==> P (Mismatch a b E)) /\
+        (!E E'. P E /\ P E' ==> P (Sum E E')) /\
+        (!E E'. P E /\ P E' ==> P (Par E E')) /\
+        (!x E. P E /\ x NOTIN X ==> P (Res x E)) /\ FINITE X ==> !E. P E
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC nc_INDUCTION
+ >> Q.EXISTS_TAC ‘X’ >> rw []
+QED
+
+(* |- !P. P Nil /\ (!E. P E ==> P (Tau E)) /\
+          (!a x E. P E /\ x # a ==> P (Input a x E)) /\
+          (!a b E. P E ==> P (Output a b E)) /\
+          (!a b E. P E ==> P (Match a b E)) /\
+          (!a b E. P E ==> P (Mismatch a b E)) /\
+          (!E E'. P E /\ P E' ==> P (Sum E E')) /\
+          (!E E'. P E /\ P E' ==> P (Par E E')) /\
+          (!y E. P E ==> P (Res y E)) ==>
+          !E. P E
+ *)
+Theorem simple_induction =
+    nc_INDUCTION2 |> Q.SPECL [‘P’, ‘{}’]
+                  |> REWRITE_RULE [FINITE_EMPTY, NOT_IN_EMPTY]
+                  |> Q.GEN ‘P’
+
+(* |- !u v t1 t2.
+        Res u t1 = Res v t2 <=>
+        u = v /\ t1 = t2 \/ u <> v /\ u # t2 /\ t1 = tpm [(u,v)] t2
+ *)
+Theorem Res_eq_thm =
+  “(Res u t1 = Res v t2 :pi)”
+     |> SIMP_CONV (srw_ss()) [Res_def, Res_termP, term_ABS_pseudo11_1,
+                              GLAM_eq_thm, term_REP_11_1, GSYM term_REP_tpm,
+                              GSYM supp_tpm]
+     |> Q.GENL [‘u’, ‘v’, ‘t1’, ‘t2’]
+
+Theorem Res_tpm_ALPHA :
+    v # (u :pi) ==> Res x u = Res v (tpm [(v,x)] u)
+Proof
+    SRW_TAC [boolSimps.CONJ_ss][Res_eq_thm, pmact_flip_args]
+QED
+
+(* |- !a b x y t1 t2.
+        Input a x t1 = Input b y t2 <=>
+        x = y /\ t1 = t2 /\ a = b \/
+        x <> y /\ x # t2 /\ t1 = tpm [(x,y)] t2 /\ a = b
+ *)
+Theorem Input_eq_thm =
+  “Input a x t1 = Input b y (t2 :pi)”
+     |> SIMP_CONV (srw_ss()) [Input_def, Input_termP, term_ABS_pseudo11_1,
+                              GLAM_eq_thm, term_REP_11_0, term_REP_11_1,
+                              GSYM term_REP_tpm, GSYM supp_tpm]
+     |> Q.GENL [‘a’, ‘b’, ‘x’, ‘y’, ‘t1’, ‘t2’]
+
+Theorem Input_tpm_ALPHA :
+    v # (u :pi) ==> Input a x u = Input a v (tpm [(v,x)] u)
+Proof
+    SRW_TAC [boolSimps.CONJ_ss][Input_eq_thm, pmact_flip_args]
+QED
+
+val _ = export_theory ();
+val _ = html_theory "pi_agent";

--- a/examples/lambda/barendregt/labelledTermsScript.sml
+++ b/examples/lambda/barendregt/labelledTermsScript.sml
@@ -19,7 +19,7 @@ val lp = “(λn (d:unit + unit + num) tns uns.
 
 val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
      termP, absrep_id, repabs_pseudo_id, newty, term_REP_t, term_ABS_t,...} =
-    new_type_step1 tyname 0 {vp=vp, lp = lp}
+    new_type_step1 tyname 0 [] {vp = vp, lp = lp};
 
 val _ = temp_overload_on ("termP", termP)
 

--- a/examples/lambda/basics/Holmakefile
+++ b/examples/lambda/basics/Holmakefile
@@ -4,7 +4,7 @@ INCLUDES = $(patsubst %,$(dprot $(HOLDIR)/src/%),$(SRCDIRS))
 
 EXTRA_CLEANS = $(patsubst %Theory.uo,%Theory.html,$(DEFAULT_TARGETS))
 
-all: $(DEFAULT_TARGETS)
+all: $(DEFAULT_TARGETS) selftest.exe
 .PHONY: all
 
 selftest.exe: selftest.uo

--- a/examples/lambda/basics/ctermScript.sml
+++ b/examples/lambda/basics/ctermScript.sml
@@ -18,7 +18,8 @@ val lp = “(λn (d:unit + unit + 'a) tns uns.
 
 val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
      termP, absrep_id, repabs_pseudo_id, term_REP_t, term_ABS_t, newty, ...} =
-    new_type_step1 tyname 0 {vp=vp, lp = lp}
+    new_type_step1 tyname 0 [] {vp = vp, lp = lp};
+
 val [gvar,glam] = genind_rules |> SPEC_ALL |> CONJUNCTS
 
 val LAM_t = mk_var("LAM", ``:string -> ^newty -> ^newty``)

--- a/examples/lambda/basics/nomdatatype.sig
+++ b/examples/lambda/basics/nomdatatype.sig
@@ -4,7 +4,7 @@ sig
   include Abbrev
   type coninfo = {con_termP : thm, con_def : thm}
 
-  val new_type_step1 : string -> int -> {vp:term,lp:term} ->
+  val new_type_step1 : string -> int -> thm list -> {vp:term,lp:term} ->
                        {term_ABS_pseudo11 : thm,
                         term_REP_11 : thm,
                         term_REP_t : term,

--- a/examples/lambda/basics/nomdatatype.sml
+++ b/examples/lambda/basics/nomdatatype.sml
@@ -120,7 +120,11 @@ fun first2 l =
       (x::y::_) => (x,y)
     | _ => raise Fail "first2: list doesn't have at least two elements"
 
-fun new_type_step1 tyname n {vp, lp} = let
+(* NOTE: In case multiple mutually recursive nominal types are being defined, "witnesses"
+   argument takes a list of [genind_exists] theorems generated from previous calls to the
+   current function, otherwise the proof of term_exists may not succeed.
+ *)
+fun new_type_step1 tyname n witnesses {vp, lp} = let
   val list_mk_icomb = uncurry (List.foldl (mk_icomb o swap))
   val termP =
       list_mk_icomb (genind_t, [vp,lp,numSyntax.mk_numeral (Arbnum.fromInt n)])
@@ -136,7 +140,8 @@ fun new_type_step1 tyname n {vp, lp} = let
             ((* hope type uses GLAM in base-case way *)
              irule_at (Pos hd) (cj 2 genind_rules) THEN
              simpLib.SIMP_TAC (list_ss ++ boolSimps.DNF_ss) [] THEN
-             simpLib.SIMP_TAC list_ss [sumTheory.EXISTS_SUM]))
+             simpLib.SIMP_TAC list_ss [sumTheory.EXISTS_SUM] THEN
+             simpLib.SIMP_TAC list_ss witnesses))
   val {absrep_id, newty, repabs_pseudo_id, termP, termP_exists, termP_term_REP,
        term_ABS_t, term_ABS_pseudo11,
        term_REP_t, term_REP_11} =

--- a/examples/lambda/basics/selftest.sml
+++ b/examples/lambda/basics/selftest.sml
@@ -19,10 +19,10 @@ val lp =
 
 val _ = tprint "Deriving type 0"
 val _ = require (check_result (K true))
-                (new_type_step1 tyname0 0)
+                (new_type_step1 tyname0 0 [])
                 {vp = vp, lp = lp}
 
 val _ = tprint "Deriving type 1"
 val _ = require (check_result (K true))
-                (new_type_step1 tyname1 1)
+                (new_type_step1 tyname1 1 [])
                 {vp = vp, lp = lp}

--- a/examples/lambda/basics/termScript.sml
+++ b/examples/lambda/basics/termScript.sml
@@ -26,7 +26,7 @@ val lp = “(λn (d:unit + unit) tns uns.
 
 val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
      termP, absrep_id, repabs_pseudo_id, term_REP_t, term_ABS_t, newty, ...} =
-    new_type_step1 tyname 0 {vp = vp, lp = lp};
+    new_type_step1 tyname 0 [] {vp = vp, lp = lp};
 
 val [gvar,glam] = genind_rules |> SPEC_ALL |> CONJUNCTS
 


### PR DESCRIPTION
This PR fixes #1418 (@mn200's own work).

In case multiple mutually recursive nominal types are being defined, the newly added "witnesses" argument of the API function `new_type_step1` provides a list of `genind_exists` theorems generated from previous calls to the same function, otherwise the proof of `term_exists` may not succeed.

As a sample application of the improve `nomdatatype` package, I added the initial theory of my ongoing pi-calculus work, in `examples/formal-languages/pi-calculus`.  There are totally 3 nominal types (mutual but not recursive), expressed in future API `Nominal_datatype`:

```
   Nominal_datatype :

           name = Name string

           pi   = Nil                      (* 0 *)
                | Tau pi                   (* tau.P *)
                | Input name ''name pi     (* a(x).P *)
                | Output name name pi      (* {a}b.P *)
                | Match name name pi       (* [a == b] P *)
                | Mismatch name name pi    (* [a <> b] P *)
                | Sum pi pi                (* P + Q *)
                | Par pi pi                (* P | Q *)
                | Res ''name pi            (* nu x. P *)

       residual = TauR pi
                | InputR name ''name pi      (* (Bound) input *)
                | BoundOutput name ''name pi (* Bound output *)
                | FreeOutput name name pi    (* Free output *)
   End
```

Below are the basic tpm and induction theorems for the `:pi` type and the `FV` function for getting free variables:

```
tpm_thm
⊢ (∀pi. tpm pi Nil = Nil) ∧ (∀pi P. tpm pi (Tau P) = Tau (tpm pi P)) ∧
  (∀x pi a P.
     tpm pi (Input a x P) = Input (npm pi a) (lswapstr pi x) (tpm pi P)) ∧
  (∀pi b a P. tpm pi (Output a b P) = Output (npm pi a) (npm pi b) (tpm pi P)) ∧
  (∀pi b a P. tpm pi (Match a b P) = Match (npm pi a) (npm pi b) (tpm pi P)) ∧
  (∀pi b a P.
     tpm pi (Mismatch a b P) = Mismatch (npm pi a) (npm pi b) (tpm pi P)) ∧
  (∀pi Q P. tpm pi (Sum P Q) = Sum (tpm pi P) (tpm pi Q)) ∧
  (∀pi Q P. tpm pi (Par P Q) = Par (tpm pi P) (tpm pi Q)) ∧
  ∀v pi P. tpm pi (Res v P) = Res (lswapstr pi v) (tpm pi P)

FV_thm
⊢ FV Nil = ∅ ∧ (∀P. FV (Tau P) = FV P) ∧
  (∀x a P. FV (Input a x P) = FV P DELETE x ∪ FV a) ∧
  (∀b a P. FV (Output a b P) = FV a ∪ (FV b ∪ FV P)) ∧
  (∀b a P. FV (Match a b P) = FV a ∪ (FV b ∪ FV P)) ∧
  (∀b a P. FV (Mismatch a b P) = FV a ∪ (FV b ∪ FV P)) ∧
  (∀Q P. FV (Sum P Q) = FV P ∪ FV Q) ∧ (∀Q P. FV (Par P Q) = FV P ∪ FV Q) ∧
  ∀v P. FV (Res v P) = FV P DELETE v

nc_INDUCTION2
⊢ ∀P X.
    P Nil ∧ (∀E. P E ⇒ P (Tau E)) ∧
    (∀a x E. P E ∧ x ∉ X ∧ x # a ⇒ P (Input a x E)) ∧
    (∀a b E. P E ⇒ P (Output a b E)) ∧ (∀a b E. P E ⇒ P (Match a b E)) ∧
    (∀a b E. P E ⇒ P (Mismatch a b E)) ∧ (∀E E'. P E ∧ P E' ⇒ P (Sum E E')) ∧
    (∀E E'. P E ∧ P E' ⇒ P (Par E E')) ∧ (∀y E. P E ∧ y ∉ X ⇒ P (Res y E)) ∧
    FINITE X ⇒
    ∀E. P E
```

The following theorems show the (correct) built-in alpha conversion of the `Input` and `Res` constructors:

```
Input_eq_thm
⊢ ∀a b x y t1 t2.
    Input a x t1 = Input b y t2 ⇔
    x = y ∧ t1 = t2 ∧ a = b ∨ x ≠ y ∧ x # t2 ∧ t1 = tpm [(x,y)] t2 ∧ a = b

Input_tpm_ALPHA
⊢ v # u ⇒ Input a x u = Input a v (tpm [(v,x)] u)

Res_eq_thm
⊢ ∀u v t1 t2.
    Res u t1 = Res v t2 ⇔
    u = v ∧ t1 = t2 ∨ u ≠ v ∧ u # t2 ∧ t1 = tpm [(u,v)] t2

Res_tpm_ALPHA
⊢ v # u ⇒ Res x u = Res v (tpm [(v,x)] u)
```