### PR TITLE
[lambda] "completeness" of lambda theory

### DIFF
--- a/examples/lambda/barendregt/head_reductionScript.sml
+++ b/examples/lambda/barendregt/head_reductionScript.sml
@@ -2613,6 +2613,49 @@ Proof
  >> Q.EXISTS_TAC ‘e’ >> art []
 QED
 
+Theorem hnf_children_bnf :
+    !vs y args. ALL_DISTINCT vs /\ bnf (LAMl vs (VAR y @* args)) /\
+                i < LENGTH args ==> bnf (EL i args)
+Proof
+    rpt STRIP_TAC
+ >> qabbrev_tac ‘M1 = VAR y @* args’
+ >> qabbrev_tac ‘N = LAMl vs M1’
+ >> qabbrev_tac ‘n = LENGTH vs’
+ >> qabbrev_tac ‘m = LENGTH args’
+ >> MP_TAC (Q.SPECL [‘N’, ‘FV M1 UNION set vs’] bnf_characterisation_X)
+ >> simp []
+ >> DISCH_THEN (Q.X_CHOOSE_THEN ‘ys’
+                 (Q.X_CHOOSE_THEN ‘v’
+                   (Q.X_CHOOSE_THEN ‘args'’ STRIP_ASSUME_TAC)))
+ >> Know ‘LAMl_size N = n’
+ >- (qunabbrevl_tac [‘N’, ‘M1’] >> simp [])
+ >> DISCH_TAC
+ >> Know ‘LENGTH ys = n’
+ >- (POP_ASSUM (REWRITE_TAC o wrap o SYM) \\
+     Q.PAT_X_ASSUM ‘N = _’ (REWRITE_TAC o wrap) >> simp [])
+ >> DISCH_TAC
+ >> Know ‘hnf_children_size N = m’
+ >- (qunabbrevl_tac [‘N’, ‘M1’] >> simp [])
+ >> DISCH_TAC
+ >> Know ‘LENGTH args' = m’
+ >- (POP_ASSUM (REWRITE_TAC o wrap o SYM) \\
+     Q.PAT_X_ASSUM ‘N = _’ (REWRITE_TAC o wrap) \\
+     simp [])
+ >> DISCH_TAC
+ (* applying LAMl_ALPHA_tpm *)
+ >> Q.PAT_X_ASSUM ‘N = _’ MP_TAC
+ >> Know ‘N = LAMl ys (tpm (ZIP (vs,ys)) M1)’
+ >- (qunabbrev_tac ‘N’ \\
+     MATCH_MP_TAC LAMl_ALPHA_tpm >> simp [Once DISJOINT_SYM])
+ >> Rewr'
+ >> simp [Abbr ‘M1’]
+ >> qabbrev_tac ‘pi = ZIP (vs,ys)’
+ >> simp [Once tpm_eql]
+ >> qabbrev_tac ‘pi' = REVERSE pi’
+ >> rw [tpm_appstar]
+ >> FIRST_X_ASSUM MATCH_MP_TAC >> simp [EL_MEM]
+QED
+
 val _ = export_theory()
 val _ = html_theory "head_reduction";
 

--- a/examples/lambda/barendregt/solvableScript.sml
+++ b/examples/lambda/barendregt/solvableScript.sml
@@ -837,6 +837,14 @@ Proof
  >> gs [is_head_reduction_thm, hnf_no_head_redex]
 QED
 
+Theorem principle_hnf_bnf :
+    !M. bnf M ==> principle_hnf M = M
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC principle_hnf_reduce
+ >> rw [bnf_hnf]
+QED
+
 Theorem principle_hnf_absfree_hnf[simp] :
     principle_hnf (VAR y @* args) = VAR y @* args
 Proof


### PR DESCRIPTION
Hi,

I think I found an better and shorter proof of the completeness proof of lameta (λη) theory. If we assume that two lambda terms have bnf and also have the same set of paths in their Böhm trees, the following "completeness" theorem for just λ-theory can be obtained without using anything related to η-reduction (i.e. even the concepts of "equivalence" can be eliminated):

```
[distinct_bnf_imp_inconsistent] (lameta_completeTheory)
⊢ ∀X M N r.
    FINITE X ∧ FV M ∪ FV N ⊆ X ∪ RANK r ∧ 0 < r ∧
    ltree_paths (BT' X M r) = ltree_paths (BT' X N r) ∧ has_bnf M ∧
    has_bnf N ∧ ¬(M == N) ⇒
    inconsistent (asmlam {(M,N)})

[lambda_complete] (lameta_completeTheory)
⊢ ∀M N.
    has_bnf M ∧ has_bnf N ∧ BT_paths M = BT_paths N ⇒
    M == N ∨ inconsistent (asmlam {(M,N)})
```
(The above 2nd theorem is obtained by fixing `X = FV M UNION FV N` and `r = 1` in the 1st theorem. The set of Böhm tree paths of any term M, denoted by `BT_paths M`, is independent of the choice of `X` and `r`.)

This is the last theorem in the updated `lameta_completeTheory`. And this proof has already used almost everything before, including those very hard proofs. Starting from here, to finally arrive the completeness of lameta (λη) theory, there's the following new method:

Suppose M and N are two "original" lambda terms having bnf (or benf, this is equivalent) and are not βη-equivalent. In general their Böhm trees have different shape. The first step is to "expand" them into M0 and N0 such that `M =η= M0` and `N =η= N0`, and now M0 and N0's Böhm trees have the same shape.  Of course M0 and N0 still have bnfs and they are not β-equivalent (otherwise `M =η= M0 =β= N0 =η= N`, i.e. `M =βη=N` is conflict with the assumption). Now we call the following (fixed) separability theorem on M0 and N0:
```
[separability_thm]
⊢ ∀X M N r.
    FINITE X ∧ FV M ∪ FV N ⊆ X ∪ RANK r ∧ 0 < r ∧
    ltree_paths (BT' X M r) = ltree_paths (BT' X N r) ∧ has_bnf M ∧
    has_bnf N ∧ ¬(M == N) ⇒
    ∀P Q. ∃pi. Boehm_transform pi ∧ apply pi M == P ∧ apply pi N == Q
```
To prove lameta theory is inconsistent with (M,N), for any two arbitrary terms `P` and `Q`, we have (by congruence of η-conversions):
```
apply pi M =η= apply pi M0 =β= P
apply pi N =η= apply pi M0 =β= Q
```
If (M,N) is put into the theory, then (P,Q) must be also in the theory. Thus lameta theory is inconsistent (any two distinct terms can be proved to be equal).

So the only remaining work is my method of "eta" expansions of Böhm trees to an arbitrary larger set of paths. (In case of two terms, we expand them to the union of `BT_paths M` and `BT_paths N`.)
 
--Chun
