### PR TITLE
[lambda] Completeness of lameta (λη)-Theory

### DIFF
--- a/examples/lambda/barendregt/README.md
+++ b/examples/lambda/barendregt/README.md
@@ -1,3 +1,5 @@
+# The Mechanisation of [Barendregt 1984]
+
 chap2Script.sml :
                mechanisation of chapter 2 of Hankin's "Lambda calculi:
                a guide for computer scientists"
@@ -10,9 +12,17 @@ chap11_1Script.sml :
                mechanisation of section 11.1 from Barendregt's "The
                lambda calculus: its syntax and semantics"
 
+horeductionScript.sml :
+head_reductionScript.sml :
+
 term_posnsScript.sml :
                establishes a type for labelling reductions, and
                positions within terms more generally
+
+labelledTermsScript.sml :
+               establishes the type of lambda calculus
+               terms with labelled redexes.  Called $\Lambda'$ in
+               Barendregt.
 
 finite_developmentsScript.sml :
                Barendregt's proof of the finite-ness of developments
@@ -22,11 +32,6 @@ finite_developmentsScript.sml :
 standardisationScript.sml :
                Barendregt's proof of the standardisation theorem, from
                section 11.4.
-
-preltermScript.sml ltermScript.sml :
-               script files that establish the type of lambda calculus
-               terms with labelled redexes.  Called $\Lambda'$ in
-               Barendregt.
 
                     ------------------------------
 
@@ -42,3 +47,27 @@ and
    of terms with permutations"
   Michael Norrish
   In "Higher Order and Symbolic Computation", 19:169-195, 2006.
+
+solvableScript.sml :
+boehmScript.sml :
+lameta_completeScript.sml :
+takahashiS3Script.sml :
+
+These files are new work.
+
+# Coverage of [Barendregt 1984] (and other materials)
+
+| Chapter/Section | Theory                     |
+|---------------- | -------------------------- |
+| 2               | term, chap2                |
+| 3               | horeduction, chap3         |
+| 4               | chap4                      |
+| 8.3             | `head_reduction`, solvable |
+| 10.1,10.3       | boehm                      |
+| 10.4            | `lameta_complete`          |
+| 11.1            | `chap11_1`                 |
+| 11.2            | `finite_developments`      |
+| 11.4            | standardisation            |
+| 15.1            | takahashiS3 [*]            |
+
+[*] The proofs of Chapter 15.1 are done by Takahashi's new methods.

--- a/examples/lambda/barendregt/boehmScript.sml
+++ b/examples/lambda/barendregt/boehmScript.sml
@@ -333,11 +333,6 @@ Proof
  >> qexistsl_tac [‘X’, ‘M’, ‘r’, ‘n’, ‘vs’, ‘M1’] >> simp []
 QED
 
-(* Boehm tree of a single (free) variable ‘VAR y’ *)
-Definition BT_VAR_def :
-    BT_VAR y :boehm_tree = Branch (SOME ([],y)) LNIL
-End
-
 (* Remarks 10.1.3 (iii) [1, p.216]: unsolvable terms all have the same Boehm
    tree (‘bot’). The following overloaded ‘bot’ may be returned by
   ‘THE (ltree_lookup A p)’ when looking up a terminal node of the Boehm tree.

--- a/examples/lambda/barendregt/chap3Script.sml
+++ b/examples/lambda/barendregt/chap3Script.sml
@@ -1621,6 +1621,28 @@ Theorem betastar_TRANS =
         RTC_TRANSITIVE |> Q.ISPEC ‘compat_closure beta’
                        |> REWRITE_RULE [transitive_def]
 
+Theorem lameq_imp_lameta :
+    !M N. M == N ==> lameta M N
+Proof
+    rw [GSYM beta_eta_lameta]
+ >> Know ‘conversion beta RSUBSET conversion (beta RUNION eta)’
+ >- (MATCH_MP_TAC conversion_monotone \\
+     simp [RSUBSET, RUNION])
+ >> rw [RSUBSET]
+ >> POP_ASSUM MATCH_MP_TAC
+ >> rw [GSYM lameq_betaconversion]
+QED
+
+Theorem etaconversion_imp_lameta :
+    !M N. conversion eta M N ==> lameta M N
+Proof
+    rw [GSYM beta_eta_lameta]
+ >> Know ‘conversion eta RSUBSET conversion (beta RUNION eta)’
+ >- (MATCH_MP_TAC conversion_monotone \\
+     simp [RSUBSET, RUNION])
+ >> rw [RSUBSET]
+QED
+
 val _ = export_theory();
 val _ = html_theory "chap3";
 

--- a/examples/lambda/barendregt/head_reductionScript.sml
+++ b/examples/lambda/barendregt/head_reductionScript.sml
@@ -2614,8 +2614,8 @@ Proof
 QED
 
 Theorem hnf_children_bnf :
-    !vs y args. ALL_DISTINCT vs /\ bnf (LAMl vs (VAR y @* args)) /\
-                i < LENGTH args ==> bnf (EL i args)
+    !vs y args i. ALL_DISTINCT vs /\ bnf (LAMl vs (VAR y @* args)) /\
+                  i < LENGTH args ==> bnf (EL i args)
 Proof
     rpt STRIP_TAC
  >> qabbrev_tac ‘M1 = VAR y @* args’
@@ -2627,9 +2627,7 @@ Proof
  >> DISCH_THEN (Q.X_CHOOSE_THEN ‘ys’
                  (Q.X_CHOOSE_THEN ‘v’
                    (Q.X_CHOOSE_THEN ‘args'’ STRIP_ASSUME_TAC)))
- >> Know ‘LAMl_size N = n’
- >- (qunabbrevl_tac [‘N’, ‘M1’] >> simp [])
- >> DISCH_TAC
+ >> ‘LAMl_size N = n’ by simp [Abbr ‘N’, Abbr ‘M1’]
  >> Know ‘LENGTH ys = n’
  >- (POP_ASSUM (REWRITE_TAC o wrap o SYM) \\
      Q.PAT_X_ASSUM ‘N = _’ (REWRITE_TAC o wrap) >> simp [])

--- a/examples/lambda/barendregt/horeductionScript.sml
+++ b/examples/lambda/barendregt/horeductionScript.sml
@@ -1,7 +1,7 @@
 open HolKernel Parse boolLib bossLib;
 
-open binderLib
-open relationTheory nomsetTheory termTheory chap2Theory
+open arithmeticTheory relationTheory listTheory rich_listTheory hurdUtils;
+open binderLib nomsetTheory termTheory chap2Theory appFOLDLTheory;
 
 val _ = new_theory "horeduction";
 
@@ -289,4 +289,57 @@ val can_reduce_reduces = store_thm(
 
 val normal_form_def = Define`normal_form R t = ~can_reduce R t`;
 
+(*---------------------------------------------------------------------------*
+ *  compat_closure and LAMl/appstar
+ *---------------------------------------------------------------------------*)
+
+Theorem compat_closure_LAMl :
+    !vs. compat_closure R x y ==> compat_closure R (LAMl vs x) (LAMl vs y)
+Proof
+    Induct_on ‘vs’ >> rw []
+ >> MATCH_MP_TAC compat_closure_LAM
+ >> FIRST_X_ASSUM MATCH_MP_TAC >> rw []
+QED
+
+Theorem compat_closure_appstar :
+    !args R M N. compat_closure R M N ==> compat_closure R (M @* args) (N @* args)
+Proof
+    Induct_on ‘args’ using SNOC_INDUCT
+ >- rw []
+ >> rw [appstar_SNOC]
+ >> MATCH_MP_TAC compat_closure_APPL
+ >> FIRST_X_ASSUM MATCH_MP_TAC >> art []
+QED
+
+Theorem compat_closure_appstar' :
+    !R args t h m.
+       LENGTH args = m /\ h < m /\ compat_closure R N (EL h args) ==>
+       compat_closure R (t @* GENLIST (\i. if i = h then N else EL i args) m)
+                        (t @* args)
+Proof
+    Q.X_GEN_TAC ‘R’
+ >> Induct_on ‘args’ >- (rw [] >> fs [])
+ >> rw []
+ >> qabbrev_tac ‘t' = t @@ h’
+ >> Cases_on ‘h' = 0’
+ >- (fs [] \\
+     Know ‘GENLIST (\i. if i = 0 then N else EL i (h::args)) (SUC (LENGTH args)) =
+           N::args’
+     >- (rw [LIST_EQ_REWRITE] \\
+        ‘x = 0 \/ 0 < x’ by rw [] >> simp [EL_CONS]) >> Rewr' \\
+     simp [GSYM appstar_CONS, Abbr ‘t'’] \\
+     MATCH_MP_TAC compat_closure_appstar \\
+     MATCH_MP_TAC compat_closure_APPR >> art [])
+ >> Know ‘GENLIST (\i. if i = h' then N else EL i (h::args)) (SUC (LENGTH args)) =
+          h::GENLIST (\i. if i = h' - 1 then N else EL i args) (LENGTH args)’
+ >- (rw [LIST_EQ_REWRITE] \\
+     Cases_on ‘x = h'’ >> simp [EL_CONS] \\
+    ‘x = 0 \/ 0 < x’ by rw [] >> simp [EL_CONS])
+ >> Rewr'
+ >> simp [GSYM appstar_CONS, Abbr ‘t'’]
+ >> FIRST_X_ASSUM MATCH_MP_TAC >> simp []
+ >> fs [EL_CONS, PRE_SUB1]
+QED
+
 val _ = export_theory();
+val _ = html_theory "horeduction";

--- a/examples/lambda/barendregt/takahashiS3Script.sml
+++ b/examples/lambda/barendregt/takahashiS3Script.sml
@@ -785,6 +785,5 @@ Proof
   simp[benf_def] >> metis_tac[RTC_CASES_RTC_TWICE, takahashi_3_7star]
 QED
 
-
-
 val _ = export_theory();
+val _ = html_theory "takahashiS3";

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -3952,6 +3952,41 @@ Proof
  >> Induct_on ‘x’ >> rw [SHORTLEX_def]
 QED
 
+Theorem SHORTLEX_same_lengths :
+    !R h1 h2 t1 t2. LENGTH t1 = LENGTH t2 ==>
+                   (SHORTLEX R (h1::t1) (h2::t2) <=>
+                    R h1 h2 \/ h1 = h2 /\ SHORTLEX R t1 t2)
+Proof
+    rw [SHORTLEX_THM]
+QED
+
+(* NOTE: ‘antisymmetric’ (together with ‘transitive’) is sufficient for using
+   iterateTheory.TOPOLOGICAL_SORT' to sort a list of lists w.r.t. ‘SHORTLEX R’.
+
+   The antecedent ‘irreflexive R’ is necessary.
+ *)
+Theorem SHORTLEX_antisymmetric :
+    !R. irreflexive R /\ antisymmetric R ==> antisymmetric (SHORTLEX R)
+Proof
+    rw [antisymmetric_def, irreflexive_def]
+ >> NTAC 2 (POP_ASSUM MP_TAC)
+ >> qid_spec_tac ‘y’
+ >> qid_spec_tac ‘x’
+ >> Induct_on ‘x’
+ >- rw [SHORTLEX_THM]
+ >> rpt STRIP_TAC
+ >> Cases_on ‘y’ >- fs [SHORTLEX_THM]
+ >> Q.RENAME_TAC [‘h1::t1 = h2::t2’]
+ >> ‘LENGTH (h1::t1) <= LENGTH (h2::t2)’ by PROVE_TAC [SHORTLEX_LENGTH_LE]
+ >> ‘LENGTH (h2::t2) <= LENGTH (h1::t1)’ by PROVE_TAC [SHORTLEX_LENGTH_LE]
+ >> ‘LENGTH (h1::t1) = LENGTH (h2::t2)’ by PROVE_TAC [LESS_EQUAL_ANTISYM]
+ >> FULL_SIMP_TAC arith_ss [LENGTH]
+ >> Q.PAT_X_ASSUM ‘SHORTLEX R (h1::t1) (h2::t2)’ MP_TAC
+ >> Q.PAT_X_ASSUM ‘SHORTLEX R (h2::t2) (h1::t1)’ MP_TAC
+ >> rw [SHORTLEX_same_lengths] (* 5 subgoals *)
+ >> PROVE_TAC []
+QED
+
 val WF_SHORTLEX_same_lengths = Q.store_thm(
   "WF_SHORTLEX_same_lengths",
   ‘WF R ==>


### PR DESCRIPTION
That's it, the completeness of lameta (λη)-theory:

```
[lameta_complete_final] (lameta_completeTheory)
⊢ ∀M N.
    has_benf M ∧ has_benf N ⇒
    lameta M N ∨ inconsistent (conversion (RINSERT (β ∪ᵣ η) M N))
```

No (more) Böhm trees, nor ranked fresh names nor even solvable terms, the theorem is just in the language of `chap2Theory`.

In `ltreeTheory`, the question of sorting a set of ltree paths is answered by a new constant `path_index` and the following theorem (based on `iterateTheory.TOPOLOGICAL_SORT'`, to avoid using `sortingTheory`):

```
    [path_index_thm]  Theorem
      ⊢ ∀s n.
          s HAS_SIZE n ⇒
          BIJ (path_index s) (count n) s ∧
          ∀j k.
            j < n ∧ k < n ⇒
            (ltree_path_lt (path_index s j) (path_index s k) ⇔ j < k)
```
where `ltree_path_lt := SHORTLEX $<` (overload).

The η-expansion of λ-terms w.r.t. a new Boehm trees path, is defined in the following complicated way (based on `ltree_insert`):
```
[BT_expand_def]
⊢ ∀X t p r.
    BT_expand X t p r =
    (let
       s = ltree_paths t;
       r' = LENGTH p + r;
       (d,len) = THE (ltree_el t p);
       (vs,y) = THE d;
       m = THE len;
       n = LENGTH vs;
       vs' = RNEWS r' (SUC n) X;
       v = LAST vs';
       f = OPTION_MAP (λ(vs,y). (SNOC v vs,y))
     in
       ltree_insert f t p (BT_VAR v))
```
But then I managed to prove a chain of lemmas saying, if started with a bnf, the expanded term can do one-step η-reduction back to the original one, and the expanded Böhm tree has just one more new path. But if the original term just `has_bnf`, the expanded term is λη-equivalent to the original one, and the Böhm tree still has one more expected path:
```
[BT_expand_lemma1]
⊢ ∀X M p r B N.
    FINITE X ∧ FV M ⊆ X ∪ RANK r ∧ bnf M ∧ p ∈ ltree_paths (BT' X M r) ∧
    BT_expand X (BT' X M r) p r = B ∧ N = BT_to_term B ⇒
    N -η-> M ∧ BT' X N r = B

[BT_expand_lemma2]
⊢ ∀X M p r B N.
    FINITE X ∧ FV M ⊆ X ∪ RANK r ∧ has_bnf M ∧ p ∈ ltree_paths (BT' X M r) ∧
    BT_expand X (BT' X M r) p r = B ∧ N = BT_to_term B ⇒
    lameta M N ∧ has_bnf N ∧ FV N ⊆ X ∪ RANK r ∧ BT' X N r = B

[ltree_paths_BT_expand']
⊢ ∀X M p r vs y m.
    FINITE X ∧ FV M ⊆ X ∪ RANK r ∧ has_bnf M ∧ p ∈ ltree_paths (BT' X M r) ∧
    ltree_el (BT' X M r) p = SOME (SOME (vs,y),SOME m) ⇒
    ltree_paths (BT_expand X (BT' X M r) p r) =
    SNOC m p INSERT ltree_paths (BT' X M r)
```

The repeated proceess of the above expansion until the Böhm tree is big enough, I call it "η-expansion up to", based on list folding and the `path_index` sorting function:
```
[eta_expand_upto_def]
⊢ ∀X M r paths.
    eta_expand_upto X M r paths =
    (let
       s = paths DIFF ltree_paths (BT' X M r);
       n = CARD s;
       l = GENLIST (path_index s) n;
       f e p = eta_expand1 X e (FRONT p) r
     in
       FOLDL f M l)
```
where `eta_expand1 := BT_to_term o BT_expand` (overload, avoiding name conflicts with `takahashiS3Theory` which has `eta_expand`).

Finally, I proved the following theorem connecting the original term directly to the final expaned term:
```
[eta_expand_upto_thm
⊢ ∀X M M0 r paths.
    FINITE X ∧ FV M ⊆ X ∪ RANK r ∧ has_bnf M ∧
    ltree_paths (BT' X M r) ⊆ paths ∧ FINITE paths ∧ parent_inclusive paths ∧
    sibling_inclusive paths ∧ M0 = eta_expand_upto X M r paths ⇒
    FV M0 ⊆ X ∪ RANK r ∧ has_bnf M0 ∧ ltree_paths (BT' X M0 r) = paths ∧
    lameta M M0
```

Not easy... and it's now only 21 hours before the ITP abstract deadline:)

Chun