### PR TITLE
[probability] existence_of_multidimensional_prob_space

### DIFF
--- a/examples/probability/stochastic_processScript.sml
+++ b/examples/probability/stochastic_processScript.sml
@@ -2248,6 +2248,51 @@ Proof
  >> Q.EXISTS_TAC ‘h o SUC’ >> rw []
 QED
 
+(* Another version with both E and h as universal quantifier *)
+Theorem existence_of_multidimensional_prob_space' :
+    !p N. prob_space p /\ 0 < N ==>
+         ?pp. prob_space pp /\
+             !E h. E = rectangle h N /\ (!i. i < N ==> h i IN events p) ==>
+                   E IN events pp /\ prob pp E = PI (prob p o h) (count N)
+Proof
+    rpt STRIP_TAC
+ >> drule_all_then STRIP_ASSUME_TAC existence_of_multidimensional_prob_space
+ >> Q.EXISTS_TAC ‘pp’ >> art []
+ >> rpt GEN_TAC
+ >> STRIP_TAC
+ >> Q.PAT_X_ASSUM ‘!E. _ ==> E IN events pp /\ _’ (MP_TAC o Q.SPEC ‘E’)
+ >> impl_tac
+ >- (Q.EXISTS_TAC ‘h’ >> rw [])
+ >> rw []
+ >> Cases_on ‘!i. i < N ==> h i <> {}’
+ >- (MATCH_MP_TAC EXTREAL_PROD_IMAGE_EQ \\
+     Q.X_GEN_TAC ‘i’ >> rw [o_DEF] \\
+     AP_TERM_TAC \\
+     rw [Once EXTENSION, IN_list_rectangle] \\
+     EQ_TAC >> rw [] >> rw [] \\
+     Know ‘!j. j < N /\ j <> i ==> ?y. y IN h j’
+     >- (rpt STRIP_TAC \\
+         rw [MEMBER_NOT_EMPTY]) \\
+     simp [EXT_SKOLEM_THM'] >> STRIP_TAC \\
+     Q.EXISTS_TAC ‘GENLIST (\j. if j = i then x else f j) N’ \\
+     simp [] \\
+     Q.X_GEN_TAC ‘j’ >> rw [])
+ >> fs []
+ >> qabbrev_tac ‘s = count N DELETE i’
+ >> ‘i IN count N’ by rw []
+ >> ‘count N = i INSERT s’ by ASM_SET_TAC []
+ >> POP_ORW
+ >> qmatch_abbrev_tac ‘PI f (i INSERT s) = PI g (i INSERT s)’
+ >> ‘s DELETE i = s’ by ASM_SET_TAC []
+ >> ‘FINITE s’ by rw [Abbr ‘s’]
+ >> simp [EXTREAL_PROD_IMAGE_PROPERTY]
+ >> Suff ‘f i = 0 /\ g i = 0’ >- rw []
+ >> simp [Abbr ‘f’, Abbr ‘g’, PROB_EMPTY]
+ >> Suff ‘IMAGE (EL i) (rectangle h N) = h i’ >- rw [PROB_EMPTY]
+ >> rw [Once EXTENSION, IN_list_rectangle]
+ >> Q.EXISTS_TAC ‘i’ >> rw [NOT_IN_EMPTY]
+QED
+
 (* ------------------------------------------------------------------------- *)
 (*  Independence of functions of independent r.v.'s                          *)
 (*                                                                           *)

--- a/src/probability/probabilityScript.sml
+++ b/src/probability/probabilityScript.sml
@@ -149,6 +149,12 @@ val uniform_distribution_def = Define
 (*  Basic probability theorems                                               *)
 (* ------------------------------------------------------------------------- *)
 
+Theorem PROB_SPACE_REDUCE :
+    !p. (p_space p,events p,prob p) = p
+Proof
+    RW_TAC std_ss [p_space_def, events_def, prob_def, MEASURE_SPACE_REDUCE]
+QED
+
 val POSITIVE_PROB = store_thm
   ("POSITIVE_PROB",
   ``!p. positive p <=> (prob p {} = 0) /\ !s. s IN events p ==> 0 <= prob p s``,
@@ -3641,7 +3647,7 @@ Proof
  >> Know `{i; j} <> {}` >- SET_TAC []
  >> Know `FINITE {i; j}` >- PROVE_TAC [FINITE_INSERT, FINITE_SING]
  >> Know `BIGINTER (IMAGE E {i; j}) = E i INTER E j`
- >- (RW_TAC std_ss [Once EXTENSION, IN_BIGINTER_IMAGE, IN_SING, IN_INSERT, IN_INTER] \\
+ >- (rw [Once EXTENSION, IN_BIGINTER_IMAGE] \\
      METIS_TAC [])
  >> RW_TAC std_ss []
  >> `!i. prob p (E i) = (prob p o E) i` by PROVE_TAC [o_DEF] >> POP_ORW
@@ -3664,7 +3670,7 @@ Proof
  >> Know `{i; j} <> {}` >- SET_TAC []
  >> Know `FINITE {i; j}` >- PROVE_TAC [FINITE_INSERT, FINITE_SING]
  >> Know `!E. BIGINTER (IMAGE E {i; j}) = E i INTER E j`
- >- (RW_TAC std_ss [Once EXTENSION, IN_BIGINTER_IMAGE, IN_SING, IN_INSERT, IN_INTER] \\
+ >- (rw [Once EXTENSION, IN_BIGINTER_IMAGE] \\
      METIS_TAC [])
  >> Know `!E. PI (prob p o E) {i; j} = prob p (E i) * prob p (E j)`
  >- (GEN_TAC \\

--- a/src/probability/sigma_algebraScript.sml
+++ b/src/probability/sigma_algebraScript.sml
@@ -3773,6 +3773,123 @@ Proof
  >> FIRST_X_ASSUM MATCH_MP_TAC >> art []
 QED
 
+Theorem IMAGE_SIGMA_ALGEBRA :
+    !sp sts f. sigma_algebra (sp,sts) /\ BIJ f sp (IMAGE f sp) ==>
+               sigma_algebra (IMAGE f sp,IMAGE (IMAGE f) sts)
+Proof
+    rw [sigma_algebra_alt_pow]
+ >| [ (* goal 1 (of 3) *)
+      rw [SUBSET_DEF, IN_POW] \\
+      rename1 ‘y IN IMAGE f s’ >> fs [IN_IMAGE] \\
+      Q.EXISTS_TAC ‘x’ >> art [] \\
+      Q.PAT_X_ASSUM ‘sts SUBSET POW sp’ MP_TAC \\
+      rw [SUBSET_DEF, IN_POW] \\
+      POP_ASSUM irule \\
+      Q.EXISTS_TAC ‘s’ >> art [],
+      (* goal 2 (of 3) *)
+      rename1 ‘s IN sts’ \\
+      Q.EXISTS_TAC ‘sp DIFF s’ \\
+      reverse CONJ_TAC >- (FIRST_X_ASSUM MATCH_MP_TAC >> art []) \\
+      rw [Once EXTENSION] \\
+      EQ_TAC >> rw [] >| (* 3 subgoals *)
+      [ (* goal 2.1 (of 3) *)
+        rename1 ‘y IN sp’ \\
+        Q.EXISTS_TAC ‘y’ >> art [] \\
+        POP_ASSUM MATCH_MP_TAC >> art [],
+        (* goal 2.2 (of 3) *)
+        rename1 ‘y IN sp’ \\
+        Q.EXISTS_TAC ‘y’ >> art [],
+        (* goal 2.3 (of 3) *)
+        rename1 ‘f x = f y’ \\
+        Q.PAT_X_ASSUM ‘BIJ f sp _’ MP_TAC \\
+        simp [BIJ_ALT, IN_FUNSET, EXISTS_UNIQUE_ALT] \\
+        DISCH_THEN (MP_TAC o Q.SPEC ‘f x’) \\
+        impl_tac >- (Q.EXISTS_TAC ‘y’ >> art []) \\
+        DISCH_THEN (Q.X_CHOOSE_THEN ‘z’ STRIP_ASSUME_TAC) \\
+        CCONTR_TAC >> fs [] \\
+        Suff ‘x IN sp’ >- METIS_TAC [] \\
+        Q.PAT_X_ASSUM ‘sts SUBSET POW sp’ MP_TAC \\
+        rw [SUBSET_DEF, IN_POW] \\
+        POP_ASSUM irule \\
+        Q.EXISTS_TAC ‘s’ >> art [] ],
+      (* goal 3 (of 3) *)
+      Know ‘BIGUNION {A i | i | T} = BIGUNION (IMAGE A UNIV)’
+      >- (rw [Once EXTENSION, IN_BIGUNION_IMAGE] \\
+          EQ_TAC >> rw [] >- (Q.EXISTS_TAC ‘i’ >> art []) \\
+          rename1 ‘x IN A i’ \\
+          Q.EXISTS_TAC ‘A i’ >> art [] \\
+          Q.EXISTS_TAC ‘i’ >> art []) >> Rewr' \\
+      POP_ASSUM MP_TAC >> rw [SUBSET_DEF] \\
+      IMP_RES_TAC BIJ_INV \\
+      Q.EXISTS_TAC ‘BIGUNION (IMAGE (IMAGE g o A) UNIV)’ \\
+      simp [IMAGE_BIGUNION, IMAGE_IMAGE] \\
+      CONJ_TAC
+      >- (AP_TERM_TAC >> AP_THM_TAC >> AP_TERM_TAC \\
+          rw [Once EXTENSION, o_DEF, FUN_EQ_THM] \\
+          reverse EQ_TAC >> rw []
+          >- (rename1 ‘f (g y) IN A i’ \\
+              fs [o_DEF] \\
+              Suff ‘f (g y) = y’ >- rw [] \\
+              FIRST_ASSUM MATCH_MP_TAC \\
+              Q.PAT_X_ASSUM ‘!x. _ ==> ?x. _’ (MP_TAC o Q.SPEC ‘A (i :num)’) \\
+              impl_tac >- (Q.EXISTS_TAC ‘i’ >> art []) \\
+              DISCH_THEN (Q.X_CHOOSE_THEN ‘j’ STRIP_ASSUME_TAC) \\
+              Q.PAT_X_ASSUM ‘A i = IMAGE f j’ (fs o wrap) \\
+              Q.EXISTS_TAC ‘x’ >> art [] \\
+              Q.PAT_X_ASSUM ‘sts SUBSET POW sp’ MP_TAC \\
+              rw [SUBSET_DEF, IN_POW] \\
+              POP_ASSUM irule \\
+              Q.EXISTS_TAC ‘j’ >> art []) \\
+          rename1 ‘y IN A i’ \\
+          fs [o_DEF] \\
+          Q.EXISTS_TAC ‘g y’ \\
+          reverse CONJ_TAC >- (Q.EXISTS_TAC ‘y’ >> art []) \\
+          ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
+          FIRST_ASSUM MATCH_MP_TAC \\
+          Q.PAT_X_ASSUM ‘!x. _ ==> ?x. _’ (MP_TAC o Q.SPEC ‘A (i :num)’) \\
+          impl_tac >- (Q.EXISTS_TAC ‘i’ >> art []) \\
+          DISCH_THEN (Q.X_CHOOSE_THEN ‘j’ STRIP_ASSUME_TAC) \\
+          Q.PAT_X_ASSUM ‘A i = IMAGE f j’ (fs o wrap) \\
+          Q.EXISTS_TAC ‘x’ >> art [] \\
+          Q.PAT_X_ASSUM ‘sts SUBSET POW sp’ MP_TAC \\
+          rw [SUBSET_DEF, IN_POW] \\
+          POP_ASSUM irule \\
+          Q.EXISTS_TAC ‘j’ >> art []) \\
+      qabbrev_tac ‘B = IMAGE g o A’ \\
+      Know ‘BIGUNION {B i | i | T} = BIGUNION (IMAGE B UNIV)’
+      >- (rw [Once EXTENSION, IN_BIGUNION_IMAGE] \\
+          EQ_TAC >> rw [] >- (Q.EXISTS_TAC ‘i’ >> art []) \\
+          rename1 ‘x IN B i’ \\
+          Q.EXISTS_TAC ‘B i’ >> art [] \\
+          Q.EXISTS_TAC ‘i’ >> art []) \\
+      DISCH_THEN (REWRITE_TAC o wrap o SYM) \\
+      FIRST_X_ASSUM MATCH_MP_TAC \\
+      rw [Abbr ‘B’, SUBSET_DEF] \\
+      rename1 ‘IMAGE g (A i) IN sts’ \\
+      Q.PAT_X_ASSUM ‘!x. _ ==> ?x. _’ (MP_TAC o Q.SPEC ‘A (i :num)’) \\
+      impl_tac >- (Q.EXISTS_TAC ‘i’ >> art []) \\
+      DISCH_THEN (Q.X_CHOOSE_THEN ‘s’ STRIP_ASSUME_TAC) \\
+      Q.PAT_X_ASSUM ‘A i = IMAGE f s’ (fs o wrap) \\
+      Suff ‘IMAGE g (IMAGE f s) = s’ >- rw [] \\
+      rw [Once EXTENSION] \\
+      reverse EQ_TAC >> rw []
+      >- (Q.EXISTS_TAC ‘f x’ \\
+          reverse CONJ_TAC >- (Q.EXISTS_TAC ‘x’ >> art []) \\
+          ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
+          FIRST_X_ASSUM MATCH_MP_TAC \\
+          Q.PAT_X_ASSUM ‘sts SUBSET POW sp’ MP_TAC \\
+          rw [SUBSET_DEF, IN_POW] \\
+          POP_ASSUM irule \\
+          Q.EXISTS_TAC ‘s’ >> art []) \\
+      rename1 ‘g (f y) IN s’ \\
+      Suff ‘g (f y) = y’ >- rw [] \\
+      FIRST_X_ASSUM MATCH_MP_TAC \\
+      Q.PAT_X_ASSUM ‘sts SUBSET POW sp’ MP_TAC \\
+      rw [SUBSET_DEF, IN_POW] \\
+      POP_ASSUM irule \\
+      Q.EXISTS_TAC ‘s’ >> art [] ]
+QED
+
 (* Lemma 2.2.5 of [9, p.177] (moving INTER outside of the sigma generator) *)
 Theorem SIGMA_RESTRICT :
     !sp sts B. subset_class sp sts /\ B SUBSET sp ==>


### PR DESCRIPTION
Hi,

The product measure spaces constructed from existing probability spaces (pspace), is still a pspace. This PR adds a simple list-based version, which constructs a product pspace from N-copies of the same pspace:
```
existence_of_multidimensional_prob_space (stochastic_processTheory)
⊢ ∀p N.
    prob_space p ∧ 0 < N ⇒
    ∃pp.
      prob_space pp ∧
      ∀E. (∃h. E = rectangle h N ∧ ∀i. i < N ⇒ h i ∈ events p) ⇒
          E ∈ events pp ∧
          prob pp E = ∏ (λi. prob p (IMAGE (EL i) E)) (count N)
```

An application of this theorem leads to the construction of finite number of independent r.v.'s having desired distributions, needed in the proof of central limit theorem (CLT).

--Chun