### PR TITLE
HOL keywords don't stop open unless they are col 0

### DIFF
--- a/tools/Holmake/HolLex
+++ b/tools/Holmake/HolLex
@@ -445,7 +445,11 @@ ProofLine = {newline}"Proof"({ws}*"["{optallws}{defn_attribute_list}{optallws}"]
   | _ => raise Unreachable
 );
 <opens>({ws}|{newline})+ => (continue());
-<opens>({holstartkeyword}|{declforms}) => (
+<opens>^{holstartkeyword} => (
+  yybufpos := !yybufpos - (yyend - yypos); (* unread token *)
+  OpenEnd yypos
+);
+<opens>{declforms} => (
   yybufpos := !yybufpos - (yyend - yypos); (* unread token *)
   OpenEnd yypos
 );


### PR DESCRIPTION
Otherwise `open Overload` breaks.