### PR TITLE
Porting "Formalization of Normal Random Variables"

### DIFF
--- a/Manual/Description/math.stex
+++ b/Manual/Description/math.stex
@@ -761,9 +761,9 @@ filtering out $\pm\infty$.
 It can be proven that \holtxt{ext_lborel} is indeed a $\sigma$-finite measure space:
 \begin{hol}
 \begin{alltt}
-##thm MEASURE_SPACE_LBOREL
+##thm measure_space_ext_lborel
 
-##thm SIGMA_FINITE_LBOREL
+##thm sigma_finite_ext_lborel
 \end{alltt}
 \end{hol}
 

--- a/examples/probability/distributionScript.sml
+++ b/examples/probability/distributionScript.sml
@@ -1,5 +1,5 @@
 (* ========================================================================= *)
-(*   Probability Density Function Theory (normal_rvTheory)                   *)
+(*   Probability Density Function Theory (former normal_rvTheory) [1]        *)
 (*                                                                           *)
 (*        (c) Copyright 2015,                                                *)
 (*                       Muhammad Qasim,                                     *)
@@ -14,7 +14,7 @@
 open HolKernel Parse boolLib bossLib;
 
 open combinTheory arithmeticTheory numLib logrootTheory hurdUtils pred_setLib
-     pred_setTheory topologyTheory pairTheory tautLib;
+     pred_setTheory topologyTheory pairTheory tautLib jrhUtils;
 
 open realTheory realLib seqTheory transcTheory real_sigmaTheory iterateTheory
      real_topologyTheory derivativeTheory;
@@ -23,6 +23,290 @@ open sigma_algebraTheory extreal_baseTheory extrealTheory real_borelTheory
      measureTheory borelTheory lebesgueTheory martingaleTheory probabilityTheory;
 
 val _ = new_theory "distribution"; (* was: "normal_rv" *)
+
+val DISC_RW_KILL = DISCH_TAC THEN ONCE_ASM_REWRITE_TAC [] THEN
+                   POP_ASSUM K_TAC;
+
+fun ASSERT_TAC tm = SUBGOAL_THEN tm STRIP_ASSUME_TAC;
+fun METIS ths tm = prove(tm,METIS_TAC ths);
+
+(* ------------------------------------------------------------------------- *)
+(*  Various alternative definitions of distributions                         *)
+(* ------------------------------------------------------------------------- *)
+
+(* NOTE: This definition is dedicated for r.v.'s of ‘:'a -> real’ *)
+Definition measurable_distr :
+    measurable_distr p X =
+      (\s. if s IN subsets borel then distribution p X s else 0)
+End
+
+(* |- !p X s.
+        measurable_distr p X s =
+        if s IN subsets borel then distribution p X s else 0
+ *)
+Theorem measurable_distr_def :
+    !p X s. measurable_distr p X s =
+            if s IN measurable_sets lborel then distribution p X s else 0
+Proof
+    rw [FUN_EQ_THM, sets_lborel, measurable_distr]
+QED
+
+Theorem distr_of_lborel :
+    !p X. distr_of p lborel X =
+            (m_space lborel, measurable_sets lborel, measurable_distr p X)
+Proof
+    rw [distr_of, measurable_distr, m_space_lborel, sets_lborel, FUN_EQ_THM,
+        distribution_def, p_space_def, prob_def]
+QED
+
+(* NOTE: The new, shorter proof is based on pos_fn_integral_distr *)
+Theorem lebesgue_real_affine :
+    !c t. c <> 0 ==>
+          measure_of lborel =
+          measure_of
+           (density
+             (distr_of lborel (space borel, subsets borel, (\x. 0)) (\x. t + c * x))
+             (\z. Normal (abs c)))
+Proof
+    RW_TAC std_ss []
+ >> ASSUME_TAC sigma_algebra_borel
+ >> MATCH_MP_TAC lborel_eqI
+ >> qabbrev_tac ‘h = (\x :real. t + c * x)’
+ >> Know ‘h IN measurable borel borel’
+ >- (qunabbrev_tac ‘h’ \\
+     MATCH_MP_TAC in_borel_measurable_add \\
+     qexistsl_tac [‘\x. t’, ‘\x. c * x’] >> rw []
+     >- (MATCH_MP_TAC in_borel_measurable_const \\
+         Q.EXISTS_TAC ‘t’ >> rw []) \\
+     MATCH_MP_TAC in_borel_measurable_cmul \\
+     qexistsl_tac [‘\x. x’, ‘c’] >> simp [] \\
+     REWRITE_TAC [in_borel_measurable_I])
+ >> DISCH_TAC
+ >> Know ‘measure_space (distr_of lborel (space borel,subsets borel,(\x. 0)) h)’
+ >- (MATCH_MP_TAC measure_space_distr_of \\
+     simp [lborel_def, measure_space_trivial'])
+ >> DISCH_TAC
+ >> reverse CONJ_TAC
+ >- (reverse CONJ_TAC
+     >- METIS_TAC [density_def, distr_of, measurable_sets_def] \\
+     MATCH_MP_TAC measure_space_density >> simp [] \\
+     MATCH_MP_TAC IN_MEASURABLE_BOREL_CONST \\
+     Q.EXISTS_TAC `Normal (abs c)` \\
+     simp [SPACE, distr_of, sigma_algebra_borel])
+ >> Know ‘measure_space (space borel,subsets borel,distr lborel h)’
+ >- (MATCH_MP_TAC measure_space_distr >> rw [lborel_def])
+ >> DISCH_TAC
+ (* stage work *)
+ >> rw [distr_of_alt_distr, space_lborel, density]
+ >> qmatch_abbrev_tac ‘pos_fn_integral (space borel,subsets borel,f) g = _’
+ >> Know ‘!x. 0 <= g x’
+ >- (rw [space_borel, Abbr ‘g’] \\
+     MATCH_MP_TAC le_mul >> rw [INDICATOR_FN_POS])
+ >> DISCH_TAC
+ >> Know ‘g IN Borel_measurable borel’
+ >- (qunabbrev_tac ‘g’ \\
+     HO_MATCH_MP_TAC IN_MEASURABLE_BOREL_CMUL_INDICATOR \\
+     rw [CLOSED_interval, borel_measurable_sets])
+ >> DISCH_TAC
+ >> Know ‘pos_fn_integral (space borel,subsets borel,f) g =
+          pos_fn_integral (space borel,subsets borel,distr lborel h) g’
+ >- (MATCH_MP_TAC pos_fn_integral_cong_measure >> simp [Abbr ‘f’] \\
+     fs [distr_of_alt_distr])
+ >> Rewr'
+ >> Know ‘pos_fn_integral (space borel,subsets borel,distr lborel h) g =
+          pos_fn_integral lborel (g o h)’
+ >- (MATCH_MP_TAC pos_fn_integral_distr \\
+     rw [lborel_def, SPACE, m_space_lborel, sets_lborel])
+ >> Rewr'
+ >> NTAC 2 (POP_ASSUM K_TAC)
+ >> Q.PAT_X_ASSUM ‘h IN borel_measurable borel’ K_TAC
+ >> rpt (Q.PAT_X_ASSUM ‘measure_space _’ K_TAC)
+ >> simp [Abbr ‘g’, Abbr ‘h’, o_DEF, Abbr ‘f’]
+ >> qabbrev_tac ‘s = interval [a,b]’
+ >> qabbrev_tac ‘f = \x. indicator_fn s (t + c * x)’
+ >> simp []
+ >> Know ‘pos_fn_integral lborel (\x. Normal (abs c) * f x) =
+          Normal (abs c) * pos_fn_integral lborel f’
+ >- (MATCH_MP_TAC pos_fn_integral_cmul \\
+     rw [abs_pos, lborel_def, Abbr ‘f’, INDICATOR_FN_POS])
+ >> Rewr'
+ (* applying pos_fn_integral_indicator *)
+ >> Cases_on ‘0 < c’
+ >- (qabbrev_tac ‘s' = interval [(a - t) / c, (b - t) / c]’ \\
+     Know ‘f = indicator_fn s'’
+     >- (rw [FUN_EQ_THM, Abbr ‘f’] \\
+         simp [indicator_fn_def, Abbr ‘s’, Abbr ‘s'’, CLOSED_interval] \\
+         simp [REAL_ARITH “a <= t + c * x <=> a - t <= c * (x :real)”,
+               REAL_ARITH “t + c * x <= b <=> c * x <= b - (t :real)”]) >> Rewr' \\
+     Know ‘pos_fn_integral lborel (indicator_fn s') = measure lborel s'’
+     >- (MATCH_MP_TAC pos_fn_integral_indicator \\
+         rw [lborel_def, Abbr ‘s'’, CLOSED_interval] \\
+         Know ‘!x. a - t <= c * x <=> (a - t) / c <= x’
+         >- (Q.X_GEN_TAC ‘x’ \\
+             REWRITE_TAC [Once EQ_SYM_EQ, Once REAL_MUL_COMM] \\
+             MATCH_MP_TAC REAL_LE_LDIV_EQ >> art []) >> Rewr' \\
+         Know ‘!x. c * x <= b - t <=> x <= (b - t) / c’
+         >- (Q.X_GEN_TAC ‘x’ \\
+             REWRITE_TAC [Once EQ_SYM_EQ, Once REAL_MUL_COMM] \\
+             MATCH_MP_TAC REAL_LE_RDIV_EQ >> art []) >> Rewr' \\
+         SIMP_TAC std_ss [borel_measurable_sets, sets_lborel]) >> Rewr' \\
+     simp [CONTENT_CLOSED_INTERVAL_CASES, Abbr ‘s’] \\
+     qabbrev_tac ‘a' = (a - t) / c’ \\
+     qabbrev_tac ‘b' = (b - t) / c’ \\
+     Know ‘a <= b <=> a' <= b'’
+     >- (simp [Abbr ‘a'’, Abbr ‘b'’, real_div] \\
+         REAL_ARITH_TAC) >> DISCH_TAC \\
+     Cases_on ‘a <= b’
+     >- (fs [Abbr ‘s'’, lambda_closed_interval] \\
+         simp [extreal_mul_eq, Abbr ‘b'’, Abbr ‘a'’] \\
+        ‘abs c = c’ by METIS_TAC [ABS_REFL, REAL_LT_IMP_LE] >> POP_ORW \\
+         simp [REAL_DIV_SUB] >> REAL_ARITH_TAC) \\
+     fs [] \\
+    ‘s' = {}’ by rw [Abbr ‘s'’, GSYM INTERVAL_EQ_EMPTY, real_lt] \\
+     simp [lambda_empty])
+ >> Know ‘c < 0’
+ >- (simp [REAL_LT_LE] >> fs [real_lt])
+ >> POP_ASSUM K_TAC
+ >> DISCH_TAC
+ >> qabbrev_tac ‘s' = interval [(b - t) / c, (a - t) / c]’
+ >> Know ‘f = indicator_fn s'’
+ >- (rw [FUN_EQ_THM, Abbr ‘f’] \\
+     simp [indicator_fn_def, Abbr ‘s’, Abbr ‘s'’, CLOSED_interval] \\
+     REWRITE_TAC [Once CONJ_COMM] \\
+     simp [REAL_ARITH “a <= t + c * x <=> a - t <= c * (x :real)”,
+           REAL_ARITH “t + c * x <= b <=> c * x <= b - (t :real)”])
+ >> Rewr'
+ >> Know ‘pos_fn_integral lborel (indicator_fn s') = measure lborel s'’
+ >- (MATCH_MP_TAC pos_fn_integral_indicator \\
+     rw [lborel_def, Abbr ‘s'’, CLOSED_interval] \\
+     Know ‘!x. a - t <= c * x <=> x <= (a - t) / c’
+     >- (Q.X_GEN_TAC ‘x’ \\
+         REWRITE_TAC [Once EQ_SYM_EQ, Once REAL_MUL_COMM] \\
+         MATCH_MP_TAC REAL_LE_LDIV_EQ_NEG >> art []) >> Rewr' \\
+     Know ‘!x. c * x <= b - t <=> (b - t) / c <= x’
+     >- (Q.X_GEN_TAC ‘x’ \\
+         REWRITE_TAC [Once EQ_SYM_EQ, Once REAL_MUL_COMM] \\
+         MATCH_MP_TAC REAL_LE_RDIV_EQ_NEG >> art []) >> Rewr' \\
+     SIMP_TAC std_ss [borel_measurable_sets, sets_lborel])
+ >> Rewr'
+ >> simp [CONTENT_CLOSED_INTERVAL_CASES, Abbr ‘s’]
+ >> qabbrev_tac ‘a' = (a - t) / c’
+ >> qabbrev_tac ‘b' = (b - t) / c’
+ >> Know ‘a <= b <=> b' <= a'’
+ >- (simp [Abbr ‘a'’, Abbr ‘b'’, real_div] \\
+     REAL_ARITH_TAC) >> DISCH_TAC
+ >> Cases_on ‘a <= b’
+ >- (fs [Abbr ‘s'’, lambda_closed_interval] \\
+     simp [extreal_mul_eq, Abbr ‘b'’, Abbr ‘a'’] \\
+    ‘abs c = -c’ by METIS_TAC [ABS_EQ_NEG] >> POP_ORW \\
+     simp [REAL_DIV_SUB] >> REAL_ARITH_TAC)
+ >> fs []
+ >> ‘s' = {}’ by rw [Abbr ‘s'’, GSYM INTERVAL_EQ_EMPTY, real_lt]
+ >> simp [lambda_empty]
+QED
+
+(* NOTE: New proof by pos_fn_integral_density_reduce and pos_fn_integral_distr *)
+Theorem lebesgue_pos_integral_real_affine :
+    !f c t. c <> 0 /\ f IN measurable borel Borel ==>
+           (pos_fn_integral lborel (\x. max 0 (f x)) =
+            Normal (abs c) * pos_fn_integral lborel (\x. max 0 (f (t + c * x))))
+Proof
+    RW_TAC std_ss []
+ >> ‘measure_space lborel’ by rw [lborel_def]
+ >> ‘measure_space (measure_of lborel)’ by rw [measure_of_measure_space]
+ >> Know ‘pos_fn_integral lborel (\x. max 0 (f x)) =
+          pos_fn_integral (measure_of lborel) (\x. max 0 (f x))’
+ >- (MATCH_MP_TAC pos_fn_integral_cong_measure' \\
+     rw [measure_space_eq_measure_of, le_max])
+ >> Rewr'
+ >> MP_TAC (Q.SPECL [‘c’, ‘t’] lebesgue_real_affine) >> art []
+ >> Rewr'
+ >> qmatch_abbrev_tac ‘pos_fn_integral (measure_of M) g = _’
+ >> qabbrev_tac ‘h = (\x :real. t + c * x)’
+ >> Know ‘h IN measurable borel borel’
+ >- (qunabbrev_tac ‘h’ \\
+     MATCH_MP_TAC in_borel_measurable_add \\
+     ASSUME_TAC sigma_algebra_borel \\
+     qexistsl_tac [‘\x. t’, ‘\x. c * x’] >> rw []
+     >- (MATCH_MP_TAC in_borel_measurable_const \\
+         Q.EXISTS_TAC ‘t’ >> rw []) \\
+     MATCH_MP_TAC in_borel_measurable_cmul \\
+     qexistsl_tac [‘\x. x’, ‘c’] >> simp [] \\
+     REWRITE_TAC [in_borel_measurable_I])
+ >> DISCH_TAC
+ >> Know ‘measure_space M’
+ >- (qunabbrev_tac ‘M’ \\
+     MATCH_MP_TAC measure_space_density \\
+     ASSUME_TAC sigma_algebra_borel \\
+     CONJ_TAC
+     >- (MATCH_MP_TAC measure_space_distr_of \\
+         rw [lborel_def, measure_space_trivial']) \\
+     rw [distr_of] \\
+     HO_MATCH_MP_TAC (REWRITE_RULE [o_DEF] IN_MEASURABLE_BOREL_IMP_BOREL') >> rw [] \\
+     MATCH_MP_TAC in_borel_measurable_const \\
+     Q.EXISTS_TAC ‘abs c’ >> rw [])
+ >> DISCH_TAC
+ >> ‘measure_space (measure_of M)’ by rw [measure_of_measure_space]
+ >> Know ‘pos_fn_integral (measure_of M) g = pos_fn_integral M g’
+ >- (MATCH_MP_TAC pos_fn_integral_cong_measure' \\
+     rw [measure_space_eq_measure_of', le_max, Abbr ‘g’])
+ >> Rewr'
+ (* applying pos_fn_integral_density_reduce *)
+ >> qunabbrev_tac ‘M’
+ >> qmatch_abbrev_tac ‘pos_fn_integral (density N ff) _ = _’
+ >> Know ‘measure_space N’
+ >- (qunabbrev_tac ‘N’ \\
+     MATCH_MP_TAC measure_space_distr_of \\
+     rw [measure_space_trivial', lborel_def, sigma_algebra_borel])
+ >> DISCH_TAC
+ >> Know ‘ff IN Borel_measurable (measurable_space N)’
+ >- (qunabbrev_tac ‘ff’ \\
+     MATCH_MP_TAC IN_MEASURABLE_BOREL_CONST \\
+     Q.EXISTS_TAC ‘Normal (abs c)’ >> rw [Abbr ‘N’, distr_of])
+ >> DISCH_TAC
+ >> Know ‘g IN Borel_measurable (measurable_space N)’
+ >- (‘g = fn_plus f’ by rw [FUN_EQ_THM, Abbr ‘g’, FN_PLUS_ALT, Once max_comm] \\
+     POP_ORW \\
+     MATCH_MP_TAC IN_MEASURABLE_BOREL_FN_PLUS \\
+     rw [Abbr ‘N’, distr_of])
+ >> DISCH_TAC
+ >> Know ‘pos_fn_integral (density N ff) g = pos_fn_integral N (\x. ff x * g x)’
+ >- (MATCH_MP_TAC pos_fn_integral_density_reduce >> art [] \\
+     rw [Abbr ‘ff’, abs_pos] \\
+     rw [Abbr ‘g’, le_max])
+ >> Rewr'
+ >> simp [Abbr ‘ff’]
+ >> Know ‘pos_fn_integral N (\x. Normal (abs c) * g x) =
+          Normal (abs c) * pos_fn_integral N g’
+ >- (MATCH_MP_TAC pos_fn_integral_cmul >> rw [abs_pos] \\
+     rw [Abbr ‘g’, le_max])
+ >> Rewr'
+ >> Suff ‘pos_fn_integral N g = pos_fn_integral lborel (\x. g (h x))’ >- rw []
+ >> qunabbrev_tac ‘N’
+ >> qmatch_abbrev_tac ‘pos_fn_integral (distr_of lborel N _) _ = _’
+ >> Suff ‘pos_fn_integral (distr_of lborel N h) g =
+          pos_fn_integral lborel (g o h)’ >- rw [o_DEF]
+ >> MATCH_MP_TAC pos_fn_integral_distr_of
+ >> simp [lborel_def, Abbr ‘N’, measure_space_trivial', sigma_algebra_borel]
+ >> reverse CONJ_TAC >- rw [Abbr ‘g’, le_max]
+ >> ‘g = fn_plus f’ by rw [FUN_EQ_THM, Abbr ‘g’, FN_PLUS_ALT, Once max_comm]
+ >> POP_ORW
+ >> MATCH_MP_TAC IN_MEASURABLE_BOREL_FN_PLUS
+ >> rw [sigma_algebra_borel]
+QED
+
+(* NOTE: "modern" version without using “max” *)
+Theorem lebesgue_pos_integral_real_affine' :
+    !f c t. c <> 0 /\ f IN measurable borel Borel /\ (!x. 0 <= f x) ==>
+            pos_fn_integral lborel f =
+            Normal (abs c) * pos_fn_integral lborel (\x. f (t + c * x))
+Proof
+    rpt STRIP_TAC
+ >> ‘f = \x. max 0 (f x)’ by rw [FUN_EQ_THM, max_0_reduce]
+ >> POP_ORW
+ >> simp []
+ >> MATCH_MP_TAC lebesgue_pos_integral_real_affine >> art []
+QED
 
 (* See, e.g., [3, p.117] or [4, p.375]
 
@@ -39,40 +323,18 @@ End
 
 Overload "-->" = “weak_converge”
 
-Theorem real_in_borel_measurable :
-    real IN borel_measurable Borel
-Proof
-    rw [in_borel_measurable_le, SIGMA_ALGEBRA_BOREL, SPACE_BOREL, IN_FUNSET]
- >> Cases_on ‘0 <= a’
- >- (Know ‘{w | real w <= a} = {x | x <= Normal a} UNION {PosInf}’
-     >- (rw [Once EXTENSION] \\
-         Cases_on ‘x = PosInf’ >- rw [real_def] \\
-         Cases_on ‘x = NegInf’ >- rw [real_def] \\
-        ‘?r. x = Normal r’ by METIS_TAC [extreal_cases] >> rw []) >> Rewr' \\
-     MATCH_MP_TAC SIGMA_ALGEBRA_UNION \\
-     rw [SIGMA_ALGEBRA_BOREL, BOREL_MEASURABLE_SETS_RC])
- >> fs [GSYM real_lt]
- (* stage work *)
- >> Know ‘{w | real w <= a} = {x | x <= Normal a} DIFF {NegInf}’
- >- (rw [Once EXTENSION] \\
-     Cases_on ‘x = PosInf’ >- rw [real_def, GSYM real_lt] \\
-     Cases_on ‘x = NegInf’ >- rw [real_def, GSYM real_lt] \\
-    ‘?r. x = Normal r’ by METIS_TAC [extreal_cases] >> rw [])
- >> Rewr'
- >> MATCH_MP_TAC SIGMA_ALGEBRA_DIFF
- >> rw [SIGMA_ALGEBRA_BOREL, BOREL_MEASURABLE_SETS_RC]
-QED
-
 (* some shared tactics for the next two theorems *)
 val converge_in_dist_tactic1 =
     qabbrev_tac ‘f = Normal o g o real’ \\
-    Know ‘!n. integral (space Borel,subsets Borel,distr p (X n)) f = integral p (f o X n)’
+    Know ‘!n. integral (space Borel,subsets Borel,distr p (X n)) f =
+              integral p (f o X n)’
     >- (Q.X_GEN_TAC ‘n’ \\
         MATCH_MP_TAC (cj 1 integral_distr) \\
         simp [SIGMA_ALGEBRA_BOREL, Abbr ‘f’] \\
         MATCH_MP_TAC IN_MEASURABLE_BOREL_IMP_BOREL' \\
         simp [SIGMA_ALGEBRA_BOREL] \\
-       ‘g IN borel_measurable borel’ by PROVE_TAC [in_borel_measurable_continuous_on] \\
+       ‘g IN borel_measurable borel’
+          by PROVE_TAC [in_borel_measurable_continuous_on] \\
         MATCH_MP_TAC MEASURABLE_COMP \\
         Q.EXISTS_TAC ‘borel’ >> rw [real_in_borel_measurable]) >> Rewr' \\
     Know ‘!n. integral (space Borel,subsets Borel,distr p Y) f = integral p (f o Y)’
@@ -80,7 +342,8 @@ val converge_in_dist_tactic1 =
         simp [SIGMA_ALGEBRA_BOREL, Abbr ‘f’] \\
         MATCH_MP_TAC IN_MEASURABLE_BOREL_IMP_BOREL' \\
         simp [SIGMA_ALGEBRA_BOREL] \\
-       ‘g IN borel_measurable borel’ by PROVE_TAC [in_borel_measurable_continuous_on] \\
+       ‘g IN borel_measurable borel’
+          by PROVE_TAC [in_borel_measurable_continuous_on] \\
         MATCH_MP_TAC MEASURABLE_COMP \\
         Q.EXISTS_TAC ‘borel’ >> rw [real_in_borel_measurable]) >> Rewr' \\
     simp [Abbr ‘f’];
@@ -91,13 +354,15 @@ val converge_in_dist_tactic2 =
    ‘Normal o f o real o Y = g o Y’ by METIS_TAC [o_ASSOC] >> POP_ORW \\
     Q.PAT_X_ASSUM ‘!g. bounded (IMAGE g UNIV) /\ _ ==> _’ (MP_TAC o Q.SPEC ‘f’) \\
     simp [] \\
-    Know ‘!n. integral (space Borel,subsets Borel,distr p (X n)) g = integral p (g o X n)’
+    Know ‘!n. integral (space Borel,subsets Borel,distr p (X n)) g =
+              integral p (g o X n)’
     >- (Q.X_GEN_TAC ‘n’ \\
         MATCH_MP_TAC (cj 1 integral_distr) \\
         simp [SIGMA_ALGEBRA_BOREL, Abbr ‘g’] \\
         MATCH_MP_TAC IN_MEASURABLE_BOREL_IMP_BOREL' \\
         simp [SIGMA_ALGEBRA_BOREL] \\
-       ‘f IN borel_measurable borel’ by PROVE_TAC [in_borel_measurable_continuous_on] \\
+       ‘f IN borel_measurable borel’
+          by PROVE_TAC [in_borel_measurable_continuous_on] \\
         MATCH_MP_TAC MEASURABLE_COMP \\
         Q.EXISTS_TAC ‘borel’ >> rw [real_in_borel_measurable]) >> Rewr' \\
     Know ‘!n. integral (space Borel,subsets Borel,distr p Y) g = integral p (g o Y)’
@@ -105,7 +370,8 @@ val converge_in_dist_tactic2 =
         simp [SIGMA_ALGEBRA_BOREL, Abbr ‘g’] \\
         MATCH_MP_TAC IN_MEASURABLE_BOREL_IMP_BOREL' \\
         simp [SIGMA_ALGEBRA_BOREL] \\
-       ‘f IN borel_measurable borel’ by PROVE_TAC [in_borel_measurable_continuous_on] \\
+       ‘f IN borel_measurable borel’
+          by PROVE_TAC [in_borel_measurable_continuous_on] \\
         MATCH_MP_TAC MEASURABLE_COMP \\
         Q.EXISTS_TAC ‘borel’ >> rw [real_in_borel_measurable]) >> Rewr;
 
@@ -146,7 +412,7 @@ Proof
 QED
 
 (* ------------------------------------------------------------------------- *)
-(*  PDF                                                                      *)
+(*  PDF (for r.v.'s of type :'a -> real, aka old style r.v.'s)               *)
 (* ------------------------------------------------------------------------- *)
 
 (* This definition comes from HVG's original work (real-based)
@@ -175,44 +441,67 @@ Proof
  >> SELECT_ELIM_TAC >> METIS_TAC []
 QED
 
-Theorem EXPECTATION_PDF_1 : (* was: INTEGRAL_PDF_1 *)
+Theorem EXPECTATION_PDF[local] :
     !p X. prob_space p /\ random_variable X p borel /\
           distribution p X << lborel ==>
+          PDF p X IN Borel_measurable borel /\
           expectation lborel (PDF p X) = 1
 Proof
-    rpt STRIP_TAC
+    rpt GEN_TAC >> STRIP_TAC
  >> `prob_space (space borel, subsets borel, distribution p X)`
        by PROVE_TAC [distribution_prob_space, sigma_algebra_borel]
  >> NTAC 2 (POP_ASSUM MP_TAC) >> KILL_TAC
- >> RW_TAC std_ss [prob_space_def, p_space_def, m_space_def, measure_def,
-                   expectation_def]
+ >> simp [prob_space_def, p_space_def, m_space_def, measure_def, expectation_def]
+ >> NTAC 2 STRIP_TAC
  >> ASSUME_TAC sigma_finite_lborel
  >> ASSUME_TAC measure_space_lborel
  >> MP_TAC (ISPECL [“lborel”, “distribution (p :'a m_space) (X :'a -> real)”]
                    Radon_Nikodym')
- >> RW_TAC std_ss [m_space_lborel, sets_lborel, m_space_def, measure_def,
-                   space_borel, IN_UNIV]
+ >> simp [m_space_lborel, sets_lborel, m_space_def, measure_def]
+ >> STRIP_TAC
  >> fs [PDF_def, RN_deriv_def, m_space_def, measurable_sets_def,
-        m_space_lborel, sets_lborel, space_borel]
+        m_space_lborel, sets_lborel]
  >> SELECT_ELIM_TAC
  >> CONJ_TAC >- METIS_TAC []
  >> Q.X_GEN_TAC `g`
- >> RW_TAC std_ss [density_measure_def]
+ >> simp [density_measure_def]
+ >> STRIP_TAC
  >> POP_ASSUM (MP_TAC o Q.SPEC `space borel`)
- >> Know `space borel IN subsets borel`
+ >> impl_tac (* `space borel IN subsets borel` *)
  >- (`sigma_algebra borel` by PROVE_TAC [sigma_algebra_borel] \\
      PROVE_TAC [sigma_algebra_def, ALGEBRA_SPACE])
- >> RW_TAC std_ss []
+ >> DISCH_TAC
  >> Know `integral lborel g = pos_fn_integral lborel g`
- >- (MATCH_MP_TAC integral_pos_fn >> art [])
+ >- (MATCH_MP_TAC integral_pos_fn >> art [] \\
+     fs [space_borel])
  >> Rewr'
- >> Know `pos_fn_integral lborel g =
+ >> Suff `pos_fn_integral lborel g =
           pos_fn_integral lborel (\x. g x * indicator_fn (space borel) x)`
- >- (MATCH_MP_TAC pos_fn_integral_cong \\
-     rw [m_space_lborel, indicator_fn_def, mul_rone, mul_rzero, le_refl])
- >> Rewr'
- >> POP_ORW >> rw [space_borel]
+ >- rw []
+ >> MATCH_MP_TAC pos_fn_integral_cong
+ >> rw [m_space_lborel, indicator_fn_def, mul_rone, mul_rzero, le_refl]
 QED
+
+(* |- !p X.
+        prob_space p /\ random_variable X p borel /\
+        distribution p X << lborel ==>
+        expectation lborel (PDF p X) = 1
+ *)
+Theorem EXPECTATION_PDF_1 = cj 2 EXPECTATION_PDF
+
+(* |- !p X.
+        prob_space p /\ random_variable X p borel /\
+        distribution p X << lborel ==>
+        integral lborel (PDF p X) = 1
+ *)
+Theorem INTEGRAL_PDF_1 = REWRITE_RULE [expectation_def] EXPECTATION_PDF_1
+
+(* |- !p X.
+        prob_space p /\ random_variable X p borel /\
+        distribution p X << lborel ==>
+        PDF p X IN Borel_measurable borel
+ *)
+Theorem PDF_IN_MEASURABLE_BOREL = cj 1 EXPECTATION_PDF
 
 (* ------------------------------------------------------------------------- *)
 (*  Normal density                                                           *)
@@ -227,6 +516,7 @@ Definition normal_density :
 End
 
 Overload std_normal_density = “normal_density 0 1”
+Overload Normal_density = “\mu sig x. Normal (normal_density mu sig x)”
 
 Theorem std_normal_density_def :
     !x. std_normal_density x = (1 / sqrt (2 * pi)) * exp (-(x pow 2) / 2)
@@ -290,7 +580,8 @@ Proof
  >> rw [normal_density_continuous_on]
 QED
 
-Theorem IN_MEASURABLE_BOREL_normal_density :
+(* NOTE: The o-version looks nice but is not practical in use. *)
+Theorem IN_MEASURABLE_BOREL_normal_density_o[local] :
     !mu sig. Normal o normal_density mu sig IN Borel_measurable borel
 Proof
     rpt GEN_TAC
@@ -298,15 +589,812 @@ Proof
  >> rw [sigma_algebra_borel, in_measurable_borel_normal_density]
 QED
 
+Theorem IN_MEASURABLE_BOREL_normal_density :
+    !mu sig. (\x. Normal (normal_density mu sig x)) IN
+              measurable (m_space lborel, measurable_sets lborel) Borel
+Proof
+    rw [lborel_def, REWRITE_RULE [o_DEF] IN_MEASURABLE_BOREL_normal_density_o]
+QED
+
+(* |- !mu sig.
+        (\x. Normal (normal_density mu sig x)) IN Borel_measurable borel
+ *)
+Theorem IN_MEASURABLE_BOREL_normal_density' =
+        IN_MEASURABLE_BOREL_normal_density |> REWRITE_RULE [lborel_def]
+
+Definition normal_pmeasure :
+    normal_pmeasure mu sig =
+    (\A. if A IN measurable_sets lborel then
+            pos_fn_integral lborel
+             (\x. Normal (normal_density mu sig x) * indicator_fn A x)
+         else 0)
+End
+
+(* |- !mu sig A.
+        normal_pmeasure mu sig A =
+        if A IN measurable_sets lborel then
+          pos_fn_integral lborel
+            (\x. Normal (normal_density mu sig x) * indicator_fn A x)
+        else 0
+ *)
+Theorem normal_pmeasure_def = SIMP_RULE std_ss [FUN_EQ_THM] normal_pmeasure
+
+Theorem normal_pmeasure_alt_density_measure :
+    !mu sig s. normal_pmeasure mu sig s =
+               if s IN measurable_sets lborel then
+                  density_measure lborel (Normal o normal_density mu sig) s
+               else
+                  0
+Proof
+    rw [normal_pmeasure_def, density_measure_def, o_DEF]
+QED
+
+(* NOTE: The old (bad) statements, the new proof based on pos_fn_integral_eq_0 *)
+Theorem null_sets_density_iff[local] :
+    !f A M. measure_space M /\ (!x. x IN m_space M ==> 0 <= f x) /\
+            f IN measurable (m_space M, measurable_sets M) Borel ==>
+    ((A IN measurable_sets M /\
+      measure ((m_space M,measurable_sets M,
+        (\A.
+           if A IN measurable_sets M then
+             pos_fn_integral M (\x. f x * indicator_fn A x)
+           else 0))) A = 0) <=>
+     (A IN measurable_sets M /\ AE x::M. x IN A ==> f x <= 0))
+Proof
+    RW_TAC std_ss []
+ >> MATCH_MP_TAC (TAUT `(a ==> (b <=> c)) ==> (a /\ b <=> a /\ c)`)
+ >> DISCH_TAC
+ (* below are new proofs *)
+ >> simp [measure_def]
+ >> qmatch_abbrev_tac ‘pos_fn_integral M g = 0 <=> _’
+ (* applying pos_fn_integral_eq_0 *)
+ >> MP_TAC (Q.SPECL [‘M’, ‘g’] pos_fn_integral_eq_0) >> art []
+ >> Know ‘!x. x IN m_space M ==> 0 <= g x’
+ >- (rw [Abbr ‘g’] \\
+     MATCH_MP_TAC le_mul >> rw [INDICATOR_FN_POS])
+ >> DISCH_TAC
+ >> Know ‘g IN Borel_measurable (measurable_space M)’
+ >- (fs [Abbr ‘g’] \\
+     MATCH_MP_TAC IN_MEASURABLE_BOREL_MUL_INDICATOR \\
+     rw [subsets_def])
+ >> DISCH_TAC
+ >> simp []
+ >> DISCH_THEN K_TAC
+ >> qmatch_abbrev_tac ‘measure M N = 0 <=> _’
+ >> Know ‘N IN measurable_sets M’
+ >- (qunabbrev_tac ‘N’ \\
+    ‘{x | x IN m_space M /\ g x <> 0} = {x | g x <> 0} INTER m_space M’
+      by SET_TAC [] >> POP_ORW \\
+     simp [IN_MEASURABLE_BOREL_ALL_MEASURE])
+ >> DISCH_TAC
+ >> EQ_TAC
+ >- (rw [AE_ALT, null_set_def] \\
+     Q.EXISTS_TAC ‘N’ >> art [] \\
+     NTAC 2 (POP_ASSUM K_TAC) \\
+     rw [SUBSET_DEF, Abbr ‘N’, Abbr ‘g’, GSYM extreal_lt_def]
+     >- PROVE_TAC [lt_imp_ne] \\
+     rw [indicator_fn_def])
+ >> rw [AE_ALT, GSYM IN_NULL_SET, GSYM extreal_lt_def]
+ >> POP_ASSUM MP_TAC
+ >> ‘{x | x IN m_space M /\ x IN A /\ 0 < f x} =
+     {x | 0 < f x} INTER m_space M INTER A’ by SET_TAC [] >> POP_ORW
+ >> qmatch_abbrev_tac ‘P INTER A SUBSET N' ==> _’
+ >> DISCH_TAC
+ >> Know ‘P INTER A IN measurable_sets M’
+ >- (MATCH_MP_TAC MEASURE_SPACE_INTER >> art [] \\
+     qunabbrev_tac ‘P’ \\
+     simp [IN_MEASURABLE_BOREL_ALL_MEASURE])
+ >> DISCH_TAC
+ (* applying NULL_SET_MONO *)
+ >> Know ‘P INTER A IN null_set M’ >- PROVE_TAC [NULL_SET_MONO]
+ >> rw [IN_NULL_SET, null_set_def]
+ >> Suff ‘N = P INTER A’ >- rw []
+ >> rw [Once EXTENSION, Abbr ‘N’, Abbr ‘P’, Abbr ‘g’, indicator_fn_def]
+ >> reverse EQ_TAC >> rw [] >- PROVE_TAC [lt_imp_ne]
+ >> Q.PAT_X_ASSUM ‘!x. x IN m_space M ==> 0 <= f x’ drule
+ >> simp [le_lt]
+QED
+
+Theorem normal_measure_abs_continuous :
+    !mu sig. measure_absolutely_continuous (normal_pmeasure mu sig) lborel
+Proof
+    RW_TAC std_ss []
+ >> SIMP_TAC std_ss [measure_absolutely_continuous_def]
+ >> RW_TAC std_ss [measurable_sets_def, measure_def]
+ >> ONCE_REWRITE_TAC [normal_pmeasure]
+ >> Q.ABBREV_TAC `f = (\x. Normal (normal_density mu sig x))`
+ >> simp []
+ >> rename1 ‘lambda A = 0’
+ >> Suff `A IN measurable_sets lborel /\
+   (measure (m_space lborel, measurable_sets lborel,
+    (\A. if A IN measurable_sets lborel then
+          pos_fn_integral lborel (\x. f x * indicator_fn A x)
+         else 0)) A = 0)`
+ >- (RW_TAC std_ss [measure_def])
+ >> Suff `measure_space lborel /\ (!x. x IN m_space lborel ==> 0 <= f x) /\
+          f IN measurable (m_space lborel,measurable_sets lborel) Borel`
+ >- (DISCH_THEN (MP_TAC o MATCH_MP null_sets_density_iff) \\
+     DISCH_THEN (MP_TAC o Q.SPEC `A`) >> DISC_RW_KILL \\
+     fs [sets_lborel] \\
+     rw [AE_ALT, null_set_def, GSYM extreal_lt_def, space_lborel, sets_lborel] \\
+     Q.EXISTS_TAC ‘A’ >> art [] \\
+     rw [SUBSET_DEF])
+ (* stage work *)
+ >> simp [space_lborel]
+ >> `(!x. 0 <= f x)`
+     by METIS_TAC [normal_density_nonneg, extreal_of_num_def, extreal_le_def]
+ >> ASM_SIMP_TAC std_ss [lborel_def]
+ >> Q.UNABBREV_TAC `f`
+ >> SIMP_TAC std_ss [IN_MEASURABLE_BOREL_normal_density, GSYM space_lborel]
+QED
+
+(* NOTE: This shorter new proof is based on measure_space_density *)
+Theorem normal_measure_space :
+    !mu sig. measure_space (space borel,subsets borel,normal_pmeasure mu sig)
+Proof
+    rpt GEN_TAC
+ >> qabbrev_tac ‘f = Normal o normal_density mu sig’
+ >> Know ‘measure_space (space borel,subsets borel,normal_pmeasure mu sig) <=>
+          measure_space (density lborel f)’
+ >- (simp [density_def, space_lborel, sets_lborel, space_borel] \\
+     MATCH_MP_TAC measure_space_cong \\
+     rw [GSYM sets_lborel, normal_pmeasure_alt_density_measure])
+ >> Rewr'
+ >> MATCH_MP_TAC measure_space_density
+ >> simp [lborel_def, Abbr ‘f’, o_DEF, IN_MEASURABLE_BOREL_normal_density',
+          space_lborel, normal_density_nonneg]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(*  Normal random variable                                                   *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem PDF_ALT :
+    !p X. PDF p X = RN_deriv (measurable_distr p X) lborel
+Proof
+    rw [PDF_def, RN_deriv_def]
+ >> Suff ‘!f. (!s. s IN measurable_sets lborel ==>
+                (f * lborel) s = distribution p X s) <=>
+              (!s. s IN measurable_sets lborel ==>
+                (f * lborel) s = measurable_distr p X s)’
+ >- Rewr
+ >> Q.X_GEN_TAC ‘f’
+ >> EQ_TAC >> rw [measurable_distr_def]
+QED
+
+Theorem distribution_alt_measurable_distr :
+    !p X s. s IN measurable_sets lborel ==>
+            distribution p X s = measurable_distr p X s
+Proof
+    rw [measurable_distr_def]
+QED
+
+Theorem measurable_distr_abs_continuous_alt :
+    !p X. measurable_distr p X << lborel <=> distribution p X << lborel
+Proof
+    rw [measurable_distr, measure_absolutely_continuous_def, sets_lborel]
+QED
+
+(* |- !p X.
+        prob_space p /\ random_variable X p borel /\
+        measurable_distr p X << lborel ==>
+        PDF p X IN Borel_measurable borel
+ *)
+Theorem PDF_IN_MEASURABLE_BOREL' =
+        PDF_IN_MEASURABLE_BOREL
+     |> REWRITE_RULE [GSYM measurable_distr_abs_continuous_alt]
+
+(* |- !p X.
+        prob_space p /\ random_variable X p borel /\
+        measurable_distr p X << lborel ==> !x. 0 <= PDF p X x
+ *)
+Theorem PDF_LE_POS' =
+        PDF_LE_POS |> REWRITE_RULE [GSYM measurable_distr_abs_continuous_alt]
+
+Definition normal_rv :
+    normal_rv X p mu sig =
+      (random_variable X p borel /\
+       measurable_distr p X = normal_pmeasure mu sig)
+End
+
+Theorem normal_rv_def :
+    !p X mu sig. normal_rv (X :'a -> real) p mu sig <=>
+                 random_variable X p borel /\
+                 !s. s IN subsets borel ==>
+                     distribution p X s = normal_pmeasure mu sig s
+Proof
+    rw [normal_rv, measurable_distr]
+ >> EQ_TAC >> rw [FUN_EQ_THM]
+ >- (Q.PAT_X_ASSUM ‘!s. P’ (MP_TAC o Q.SPEC ‘s’) >> rw [])
+ >> Cases_on ‘s IN subsets borel’ >> rw []
+ >> rw [normal_pmeasure]
+ >> fs [sets_lborel]
+QED
+
+Theorem normal_pdf_nonneg :
+    !X p mu sig. prob_space p /\ normal_rv X p mu sig ==>
+                 !x. 0 <= PDF p (X:'a->real) x
+Proof
+    RW_TAC std_ss [normal_rv]
+ >> MATCH_MP_TAC PDF_LE_POS
+ >> FULL_SIMP_TAC std_ss [random_variable_def, prob_space_def]
+ >> REWRITE_TAC [GSYM measurable_distr_abs_continuous_alt]
+ >> METIS_TAC [normal_measure_abs_continuous, normal_measure_space]
+QED
+
+Theorem normal_pdf_integral_eq_1 :
+    !X p mu sig. prob_space p /\ normal_rv X p mu sig ==>
+                 integral lborel (PDF p X) = 1
+Proof
+    RW_TAC std_ss [normal_rv]
+ >> MATCH_MP_TAC INTEGRAL_PDF_1 >> art []
+ >> rw [GSYM measurable_distr_abs_continuous_alt, normal_measure_abs_continuous]
+QED
+
+Theorem normal_pdf_pos_fn_integral_eq_1 :
+    !X p mu sig. prob_space p /\ normal_rv X p mu sig ==>
+                 pos_fn_integral lborel (PDF p X) = 1
+Proof
+    rpt STRIP_TAC
+ >> Suff ‘pos_fn_integral lborel (PDF p X) = integral lborel (PDF p X)’
+ >- (Rewr' \\
+     MATCH_MP_TAC normal_pdf_integral_eq_1 >> art [] \\
+     qexistsl_tac [‘mu’, ‘sig’] >> art [])
+ >> ONCE_REWRITE_TAC [EQ_SYM_EQ]
+ >> MATCH_MP_TAC integral_pos_fn >> rw [lborel_def, space_lborel]
+ >> irule normal_pdf_nonneg >> art []
+ >> qexistsl_tac [‘mu’, ‘sig’] >> art []
+QED
+
+Theorem integral_normal_pdf_eq_density :
+    !X p mu sig A. normal_rv X p mu sig /\ A IN measurable_sets lborel ==>
+       (pos_fn_integral lborel (\x. PDF p X x * indicator_fn A x) =
+        pos_fn_integral lborel
+         (\x. Normal (normal_density mu sig x) * indicator_fn A x))
+Proof
+    RW_TAC std_ss [normal_rv, PDF_ALT, RN_deriv_def]
+ >> SELECT_ELIM_TAC
+ >> RW_TAC std_ss [measure_def, normal_pmeasure, density_measure_def]
+ >> Q.EXISTS_TAC `(\x. Normal (normal_density mu sig x))`
+ >> rw [normal_density_nonneg, IN_MEASURABLE_BOREL_normal_density]
+QED
+
+Theorem integral_normal_pdf_eq_density' :
+    !X p mu sig f. prob_space p /\ normal_rv X p mu sig /\ (!x. 0 <= f x) /\
+       f IN measurable (m_space lborel, measurable_sets lborel) Borel ==>
+       (pos_fn_integral lborel (\x. f x * PDF p X x) =
+        pos_fn_integral lborel
+         (\x. f x * Normal (normal_density mu sig x)))
+Proof
+    RW_TAC std_ss [normal_rv, PDF_ALT]
+ >> ONCE_REWRITE_TAC [EQ_SYM_EQ]
+ >> qabbrev_tac ‘g = normal_pmeasure mu sig / lborel’
+ >> Know ‘!x. 0 <= g x’
+ >- (rw [Abbr ‘g’] \\
+     Q.PAT_ASSUM ‘_ = normal_pmeasure mu sig’ (REWRITE_TAC o wrap o SYM) \\
+     irule (REWRITE_RULE [PDF_ALT] PDF_LE_POS) >> art [] \\
+     REWRITE_TAC [GSYM measurable_distr_abs_continuous_alt] \\
+     simp [normal_measure_abs_continuous])
+ >> DISCH_TAC
+ >> Know ‘g IN Borel_measurable borel’
+ >- (qunabbrev_tac ‘g’ \\
+     Q.PAT_ASSUM ‘_ = normal_pmeasure mu sig’ (REWRITE_TAC o wrap o SYM) \\
+     MATCH_MP_TAC (REWRITE_RULE [PDF_ALT] PDF_IN_MEASURABLE_BOREL') \\
+     simp [normal_measure_abs_continuous])
+ >> DISCH_TAC
+ >> Know ‘pos_fn_integral lborel (\x. f x *
+           (RN_deriv' lborel (space borel,subsets borel,normal_pmeasure mu sig)) x) =
+          pos_fn_integral (density lborel
+           (RN_deriv' lborel (space borel,subsets borel,normal_pmeasure mu sig))) f’
+ >- (simp [] \\
+     ONCE_REWRITE_TAC [mul_comm] \\
+     Know ‘g^+ IN Borel_measurable borel’
+     >- (MATCH_MP_TAC IN_MEASURABLE_BOREL_FN_PLUS \\
+         rw [sigma_algebra_borel]) >> DISCH_TAC \\
+     ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
+    ‘!x. 0 <= g^+ x’ by rw [FN_PLUS_POS] \\
+     Know ‘density lborel g = density lborel g^+’
+     >- (MATCH_MP_TAC density_eq >> simp [lborel_def]) >> Rewr' \\
+     Know ‘pos_fn_integral lborel (\x. g x * f x) =
+           pos_fn_integral lborel (\x. g^+ x * f x)’
+     >- (MATCH_MP_TAC pos_fn_integral_cong \\
+         simp [lborel_def, space_lborel] \\
+         Q.X_GEN_TAC ‘x’ >> MATCH_MP_TAC le_mul >> simp []) >> Rewr' \\
+     MATCH_MP_TAC pos_fn_integral_density \\
+     simp [lborel_def] \\
+     MATCH_MP_TAC AE_T >> simp [lborel_def])
+ >> simp []
+ >> DISCH_THEN K_TAC
+ >> Know ‘pos_fn_integral (density lborel g) f =
+          pos_fn_integral (density_of lborel g) f’
+ >- (ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
+     MATCH_MP_TAC pos_fn_integral_density_of >> rw [lborel_def])
+ >> Rewr'
+ >> Q.ABBREV_TAC `N = (space borel,subsets borel,normal_pmeasure mu sig)`
+ >> ‘measure_space N’ by PROVE_TAC [normal_measure_space]
+ >> Q_TAC SUFF_TAC
+       `pos_fn_integral lborel (\x. f x * Normal (normal_density mu sig x)) =
+        pos_fn_integral N f`
+ >- (DISC_RW_KILL THEN
+     simp [Abbr ‘g’] \\
+     MP_TAC (Q.SPECL [‘lborel’, ‘N’, ‘f’]
+               (INST_TYPE [alpha |-> “:real”] RN_deriv_positive_integral)) \\
+     simp [sigma_finite_lborel, sigma_finite_measure_space_def, lborel_def] \\
+     simp [Abbr ‘N’, normal_measure_abs_continuous, sets_lborel])
+ >> fs [Abbr ‘g’]
+ (* stage work *)
+ >> ONCE_REWRITE_TAC [METIS [] ``Normal (normal_density mu sig x) =
+                            (\x. Normal (normal_density mu sig x)) x``]
+ >> Q.ABBREV_TAC `g = (\x. Normal (normal_density mu sig x))`
+ >> ONCE_REWRITE_TAC [EQ_SYM_EQ] >> ONCE_REWRITE_TAC [mul_comm]
+ >> `!x. 0 <= g x`
+       by (Q.UNABBREV_TAC `g` \\
+           SIMP_TAC std_ss [extreal_of_num_def, extreal_le_def] \\
+           METIS_TAC [normal_density_nonneg])
+ >> Know ‘N = density_of lborel g’
+ >- (simp [Abbr ‘N’, density_of, m_space_lborel, sets_lborel] \\
+     rw [normal_pmeasure, sets_lborel, FUN_EQ_THM] \\
+     Cases_on ‘A IN subsets borel’ >> rw [] \\
+     qabbrev_tac ‘h = \x. g x * indicator_fn A x’ >> simp [] \\
+     ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
+     MATCH_MP_TAC pos_fn_integral_max_0 \\
+     rw [Abbr ‘h’, lborel_def] \\
+     MATCH_MP_TAC le_mul >> rw [INDICATOR_FN_POS] \\
+     simp [extreal_of_num_def, Abbr ‘g’])
+ >> Rewr'
+ >> ‘g IN Borel_measurable (measurable_space lborel)’
+      by rw [Abbr ‘g’, IN_MEASURABLE_BOREL_normal_density]
+ >> Know ‘pos_fn_integral (density_of lborel g) f =
+          pos_fn_integral (density lborel g) f’
+ >- (MATCH_MP_TAC pos_fn_integral_density_of >> rw [lborel_def])
+ >> Rewr'
+ >> MATCH_MP_TAC pos_fn_integral_density_reduce
+ >> rw [lborel_def]
+QED
+
+Theorem integral_normal_pdf_symmetry :
+    !X p mu sig. prob_space p /\ normal_rv X p mu sig ==>
+      (pos_fn_integral lborel (\x. PDF p X x * indicator_fn {x | x <= mu} x) =
+       pos_fn_integral lborel (\x. PDF p X x * indicator_fn {x | mu <= x} x))
+Proof
+    RW_TAC std_ss []
+ >> `{x | x <= mu} IN measurable_sets lborel /\
+     {x | mu <= x} IN measurable_sets lborel`
+       by simp [borel_measurable_sets, sets_lborel]
+ >> `pos_fn_integral lborel (\x. PDF p X x * indicator_fn {x | x <= mu} x) =
+     pos_fn_integral lborel
+       (\x. Normal (normal_density mu sig x) * indicator_fn {x | x <= mu} x)`
+       by METIS_TAC [integral_normal_pdf_eq_density]
+ >> `pos_fn_integral lborel (\x. PDF p X x * indicator_fn {x | mu <= x} x) =
+     pos_fn_integral lborel
+       (\x. Normal (normal_density mu sig x) * indicator_fn {x | mu <= x} x)`
+       by METIS_TAC [integral_normal_pdf_eq_density]
+ >> NTAC 2 (POP_ORW)
+ >> Q.ABBREV_TAC ‘f = \x. Normal (normal_density mu sig x) *
+                          indicator_fn {x | x <= mu} x’
+ >> Know ‘!x. 0 <= f x’
+ >- (rw [Abbr ‘f’] \\
+     MATCH_MP_TAC le_mul >> rw [INDICATOR_FN_POS, normal_density_nonneg])
+ >> DISCH_TAC
+ >> Know ‘f IN Borel_measurable borel’
+ >- (qunabbrev_tac ‘f’ \\
+     ASSUME_TAC sigma_algebra_borel \\
+     HO_MATCH_MP_TAC IN_MEASURABLE_BOREL_MUL_INDICATOR \\
+     rw [borel_measurable_sets] \\
+     rw [IN_MEASURABLE_BOREL_normal_density'])
+ >> DISCH_TAC
+ >> Know ‘pos_fn_integral lborel f =
+          Normal (abs (-1)) * pos_fn_integral lborel (\x. f ((2 * mu) + (-1) * x))’
+ >- (MATCH_MP_TAC lebesgue_pos_integral_real_affine' >> rw [])
+ >> Rewr'
+ >> simp [normal_1, Abbr ‘f’]
+ >> SIMP_TAC std_ss [indicator_fn_def, GSYM real_sub]
+ >> SIMP_TAC real_ss [GSPECIFICATION,
+                      REAL_ARITH ``2 * mu - x <= mu <=> mu <= x:real``]
+ >> AP_TERM_TAC >> ABS_TAC >> AP_THM_TAC >> AP_TERM_TAC
+ >> SIMP_TAC std_ss [extreal_11, normal_density]
+ >> ONCE_REWRITE_TAC [REAL_ARITH ``2 * mu = mu + mu:real``]
+ >> Suff `(mu + mu - x - mu) pow 2 = (x - mu) pow 2` >- METIS_TAC []
+ >> SIMP_TAC std_ss [POW_2] >> REAL_ARITH_TAC
+QED
+
+Theorem integral_normal_pdf_symmetry' :
+    !X p mu sig a. prob_space p /\ normal_rv X p mu sig ==>
+       pos_fn_integral lborel
+         (\x. PDF p X x * indicator_fn {x | mu - a <= x /\ x <= mu} x) =
+       pos_fn_integral lborel
+         (\x. PDF p X x * indicator_fn {x | mu <= x /\ x <= mu + a} x)
+Proof
+    RW_TAC std_ss []
+ >> ‘{x | mu - a <= x /\ x <= mu} IN measurable_sets lborel /\
+     {x | mu <= x /\ x <= mu + a} IN measurable_sets lborel’
+       by rw [sets_lborel, borel_measurable_sets]
+ >> ‘pos_fn_integral lborel
+       (\x. PDF p X x * indicator_fn {x | mu - a <= x /\ x <= mu} x) =
+     pos_fn_integral lborel
+       (\x. Normal (normal_density mu sig x) *
+            indicator_fn {x | mu - a <= x /\ x <= mu} x)’
+       by METIS_TAC [integral_normal_pdf_eq_density]
+ >> ‘pos_fn_integral lborel
+       (\x. PDF p X x * indicator_fn {x | mu <= x /\ x <= mu + a} x) =
+     pos_fn_integral lborel
+       (\x. Normal (normal_density mu sig x) *
+            indicator_fn {x | mu <= x /\ x <= mu + a} x)’
+       by METIS_TAC [integral_normal_pdf_eq_density]
+ >> NTAC 2 POP_ORW
+ >> Q.ABBREV_TAC ‘f = (\x. Normal (normal_density mu sig x) *
+                           indicator_fn {x | mu - a <= x /\ x <= mu} x)’
+ >> Know ‘!x. 0 <= f x’
+ >- (rw [Abbr ‘f’] \\
+     MATCH_MP_TAC le_mul >> rw [INDICATOR_FN_POS, normal_density_nonneg])
+ >> DISCH_TAC
+ >> Know ‘f IN Borel_measurable borel’
+ >- (qunabbrev_tac ‘f’ \\
+     ASSUME_TAC sigma_algebra_borel \\
+     HO_MATCH_MP_TAC IN_MEASURABLE_BOREL_MUL_INDICATOR \\
+     rw [borel_measurable_sets] \\
+     rw [IN_MEASURABLE_BOREL_normal_density'])
+ >> DISCH_TAC
+ >> Know ‘pos_fn_integral lborel f =
+          Normal (abs (-1)) *
+          pos_fn_integral lborel (\x. f ((2 * mu) + (-1) * x))’
+ >- (MATCH_MP_TAC lebesgue_pos_integral_real_affine' >> rw [])
+ >> Rewr'
+ >> simp [normal_1, Abbr ‘f’]
+ >> SIMP_TAC std_ss [indicator_fn_def, GSYM real_sub]
+ >> SIMP_TAC real_ss [GSPECIFICATION,
+                      REAL_ARITH ``2 * mu - x <= mu <=> mu <= x:real``,
+                      REAL_ARITH ``mu - a <= 2 * mu - x <=> x <= mu + a:real``]
+ >> GEN_REWR_TAC (LAND_CONV o ONCE_DEPTH_CONV) [CONJ_COMM]
+ >> AP_TERM_TAC >> ABS_TAC >> AP_THM_TAC >> AP_TERM_TAC
+ >> SIMP_TAC std_ss [extreal_11, normal_density]
+ >> ONCE_REWRITE_TAC [REAL_ARITH ``2 * mu = mu + mu:real``]
+ >> Suff `(mu + mu - x - mu) pow 2 = (x - mu) pow 2` >- METIS_TAC []
+ >> SIMP_TAC std_ss [POW_2] >> REAL_ARITH_TAC
+QED
+
+Theorem integral_normal_pdf_half1 :
+    !X p mu sig A. prob_space p /\ normal_rv X p mu sig /\ A = {x | x <= mu} ==>
+         pos_fn_integral lborel (\x. PDF p X x * indicator_fn A x) = 1 / 2
+Proof
+    RW_TAC std_ss []
+ >> ‘{x | x <= mu} IN measurable_sets lborel /\
+     {x | mu <= x} IN measurable_sets lborel’
+       by rw [sets_lborel, borel_measurable_sets]
+ >> drule_all_then STRIP_ASSUME_TAC normal_pdf_pos_fn_integral_eq_1
+ >> ‘UNIV IN measurable_sets lborel’ by rw [sets_lborel, space_in_borel]
+ >> ‘pos_fn_integral lborel (\x. PDF p X x * indicator_fn UNIV x) =
+     pos_fn_integral lborel
+       (\x. Normal (normal_density mu sig x) * indicator_fn UNIV x)’
+       by METIS_TAC [integral_normal_pdf_eq_density]
+ >> Know ‘UNIV = {x | x <= mu} UNION {x | mu < x}’
+ >- (SIMP_TAC real_ss [EXTENSION, IN_UNIV, IN_UNION, GSPECIFICATION] \\
+     REAL_ARITH_TAC)
+ >> DISCH_TAC
+ >> Know ‘pos_fn_integral lborel
+            (\x. PDF p X x * indicator_fn univ(:real) x) = 1’
+ >- (SIMP_TAC std_ss [indicator_fn_def, IN_UNIV, mul_rone] \\
+     METIS_TAC [ETA_AX])
+ >> Q.ABBREV_TAC ‘f = (\x. Normal (normal_density mu sig x))’ >> fs []
+ >> Q.PAT_X_ASSUM ‘_ = univ(:real)’ (REWRITE_TAC o wrap o SYM)
+ >> ‘!x. 0 <= f x’ by rw [Abbr ‘f’, normal_density_nonneg]
+ >> ‘f IN Borel_measurable borel’
+       by rw [IN_MEASURABLE_BOREL_normal_density', Abbr ‘f’]
+ >> Know ‘pos_fn_integral lborel
+            (\x. f x * indicator_fn ({x | x <= mu} UNION {x | mu < x}) x) =
+          pos_fn_integral lborel (\x. f x * indicator_fn ({x | x <= mu}) x) +
+          pos_fn_integral lborel (\x. f x * indicator_fn ({x | mu < x}) x)’
+ >- (MATCH_MP_TAC pos_fn_integral_disjoint_sets \\
+     rw [lborel_def, sets_lborel, borel_measurable_sets] \\
+     rw [DISJOINT_ALT, real_lt])
+ >> Rewr'
+ >> Suff ‘pos_fn_integral lborel (\x. f x * indicator_fn {x | mu < x} x) =
+          pos_fn_integral lborel (\x. f x * indicator_fn {x | mu <= x} x)’
+ >- (DISCH_THEN (fn th => GEN_REWR_TAC (LAND_CONV o ONCE_DEPTH_CONV) [th]) \\
+     SIMP_TAC std_ss [Abbr ‘f’] \\
+     drule_all integral_normal_pdf_symmetry \\
+    ‘pos_fn_integral lborel (\x. PDF p X x * indicator_fn {x | x <= mu} x) =
+     pos_fn_integral lborel
+        (\x. Normal (normal_density mu sig x) * indicator_fn {x | x <= mu} x)’
+       by METIS_TAC [integral_normal_pdf_eq_density] >> POP_ORW \\
+    ‘pos_fn_integral lborel (\x. PDF p X x * indicator_fn {x | mu <= x} x) =
+     pos_fn_integral lborel
+        (\x. Normal (normal_density mu sig x) * indicator_fn {x | mu <= x} x)’
+       by METIS_TAC [integral_normal_pdf_eq_density] >> POP_ORW \\
+     Rewr' \\
+     SIMP_TAC std_ss [extreal_double] >> DISCH_TAC \\
+     qmatch_abbrev_tac ‘z = 1 / (2 :extreal)’ \\
+     SIMP_TAC real_ss [eq_rdiv, extreal_of_num_def] \\
+     SIMP_TAC std_ss [GSYM extreal_of_num_def] \\
+     simp [Once mul_comm])
+ >> Know ‘{x | mu <= x} = {x | mu < x} UNION {mu}’
+ >- (SIMP_TAC std_ss [EXTENSION, IN_UNION, GSPECIFICATION, IN_SING] \\
+     REAL_ARITH_TAC)
+ >> Rewr'
+ >> Know ‘pos_fn_integral lborel
+             (\x. f x * indicator_fn ({x | mu < x} UNION {mu}) x) =
+          pos_fn_integral lborel (\x. f x * indicator_fn ({x | mu < x}) x) +
+          pos_fn_integral lborel (\x. f x * indicator_fn ({mu}) x)’
+ >- (MATCH_MP_TAC pos_fn_integral_disjoint_sets \\
+     rw [lborel_def, sets_lborel, borel_measurable_sets])
+ >> Rewr'
+ >> Suff ‘pos_fn_integral lborel (\x. f x * indicator_fn {mu} x) = 0’
+ >- rw []
+ >> Know ‘(\x. f x * indicator_fn {mu} x) = (\x. f mu * indicator_fn {mu} x)’
+ >- (ABS_TAC >> SIMP_TAC std_ss [indicator_fn_def, IN_SING] \\
+     COND_CASES_TAC >> ASM_SIMP_TAC std_ss [mul_rone, mul_rzero])
+ >> Rewr'
+ >> SIMP_TAC std_ss [Abbr ‘f’]
+ >> Know ‘pos_fn_integral lborel
+            (\x. Normal (normal_density mu sig mu) * indicator_fn {mu} x) =
+          Normal (normal_density mu sig mu) * measure lborel {mu}’
+ >- (MATCH_MP_TAC pos_fn_integral_cmul_indicator \\
+     SIMP_TAC std_ss [normal_density_nonneg, measure_space_lborel] \\
+     rw [sets_lborel, borel_measurable_sets])
+ >> Rewr'
+ >> rw [lambda_sing]
+QED
+
+Theorem integral_normal_pdf_split :
+    !X p mu sig. prob_space p /\ normal_rv X p mu sig ==>
+       pos_fn_integral lborel (PDF p X) =
+       pos_fn_integral lborel (\x. PDF p X x * indicator_fn {x | x <= mu} x) +
+       pos_fn_integral lborel (\x. PDF p X x * indicator_fn {x | mu <= x} x)
+Proof
+    RW_TAC std_ss []
+ >> drule_all_then STRIP_ASSUME_TAC normal_pdf_pos_fn_integral_eq_1
+ >> POP_ORW
+ >> qmatch_abbrev_tac ‘1 = a + (b :extreal)’
+ >> Know ‘a = b’
+ >- (qunabbrevl_tac [‘a’, ‘b’] \\
+     MATCH_MP_TAC integral_normal_pdf_symmetry \\
+     Q.EXISTS_TAC ‘sig’ >> art [])
+ >> DISCH_TAC
+ >> Know ‘a = 1 / 2’
+ >- (qunabbrev_tac ‘a’ \\
+     MATCH_MP_TAC integral_normal_pdf_half1 \\
+     qexistsl_tac [‘mu’, ‘sig’] >> art [])
+ >> DISCH_TAC
+ >> Q.PAT_X_ASSUM ‘a = b’ (REWRITE_TAC o wrap o SYM)
+ >> POP_ORW >> simp [half_double]
+QED
+
+Theorem integral_normal_pdf_half2 :
+    !X p mu sig A. prob_space p /\ normal_rv X p mu sig /\ A = {x | mu <= x} ==>
+         pos_fn_integral lborel (\x. PDF p X x * indicator_fn A x) = 1 / 2
+Proof
+    RW_TAC std_ss []
+ >> drule_all_then STRIP_ASSUME_TAC normal_pdf_pos_fn_integral_eq_1
+ >> drule_all integral_normal_pdf_split
+ >> `pos_fn_integral lborel (\x. PDF p X x * indicator_fn {x | x <= mu} x) = 1 / 2`
+      by METIS_TAC [integral_normal_pdf_half1]
+ >> ASM_REWRITE_TAC []
+ >> Suff `1 = 1 / 2 + 1 / (2 :extreal)`
+ >- (DISCH_THEN (fn th => GEN_REWR_TAC (LAND_CONV o LAND_CONV) [th]) \\
+    `1 / 2 <> PosInf`
+       by SIMP_TAC real_ss [lt_infty, extreal_of_num_def, extreal_div_eq] \\
+    `1 / 2 <> NegInf`
+       by SIMP_TAC real_ss [lt_infty, extreal_of_num_def, extreal_div_eq] \\
+     METIS_TAC [EXTREAL_EQ_LADD])
+ >> simp [half_double]
+QED
+
+Theorem normal_rv_affine :
+    !X p mu sig Y b.
+       prob_space p /\ normal_rv X p mu sig /\ (!x. Y x = X x + b) ==>
+       normal_rv Y p (mu + b) (sig)
+Proof
+    RW_TAC std_ss [normal_rv]
+ >- (fs [random_variable_def, p_space_def, events_def, prob_space_def] \\
+    ‘sigma_algebra (measurable_space p)’
+       by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA] \\
+     MATCH_MP_TAC in_borel_measurable_add \\
+     qexistsl_tac [‘X’, ‘\x. b’] >> simp [] \\
+     MATCH_MP_TAC in_borel_measurable_const \\
+     Q.EXISTS_TAC ‘b’ >> simp [])
+ >> FULL_SIMP_TAC std_ss [measurable_distr, distribution_def, normal_pmeasure]
+ >> FULL_SIMP_TAC std_ss [FUN_EQ_THM]
+ >> GEN_TAC
+ >> ‘A IN subsets borel <=> A IN measurable_sets lborel’ by rw [sets_lborel]
+ >> POP_ASSUM MP_TAC >> RW_TAC std_ss []
+ >> Know ‘PREIMAGE Y A = PREIMAGE X {x | x + b IN A}’
+ >- (SIMP_TAC std_ss [PREIMAGE_def] >> ASM_SET_TAC [])
+ >> Rewr'
+ >> Know ‘{x | x + b IN A} IN subsets borel’
+ >- (FULL_SIMP_TAC std_ss [measurable_sets_def] \\
+    ‘{x | x + b IN A} = PREIMAGE (\x. x + b) A’ by
+       (SIMP_TAC std_ss [PREIMAGE_def] >> SET_TAC []) \\
+     POP_ASSUM (fn th => REWRITE_TAC [th]) \\
+     Suff ‘(\x. x + b) IN borel_measurable borel’
+     >- rw [IN_MEASURABLE, space_borel] \\
+     ASSUME_TAC sigma_algebra_borel \\
+     MATCH_MP_TAC in_borel_measurable_add \\
+     qexistsl_tac [‘\x. x’, ‘\x. b’] >> simp [in_borel_measurable_I] \\
+     MATCH_MP_TAC in_borel_measurable_const \\
+     Q.EXISTS_TAC ‘b’ >> rw [])
+ >> DISCH_TAC
+ >> qabbrev_tac ‘s = {x | x + b IN A}’
+ >> qabbrev_tac ‘f = (\x. Normal (normal_density mu sig x) * indicator_fn s x)’
+ >> Know ‘!x. 0 <= f x’
+ >- (rw [Abbr ‘f’] \\
+     MATCH_MP_TAC le_mul \\
+     rw [INDICATOR_FN_POS, normal_density_nonneg])
+ >> DISCH_TAC
+ >> Suff ‘pos_fn_integral lborel
+           (\x. (\x. Normal (normal_density (mu + b) sig x) * indicator_fn A x) x) =
+          Normal (abs 1) * pos_fn_integral lborel (\x. f (-b + 1 * x))’
+ >- (SIMP_TAC std_ss [] >> DISC_RW_KILL \\
+     Suff `pos_fn_integral lborel f =
+           Normal (abs 1) * pos_fn_integral lborel (\x. f (-b + 1 * x))`
+     >- (DISCH_THEN (simp o wrap o SYM) \\
+         qunabbrev_tac ‘f’ \\
+         Q.PAT_X_ASSUM ‘!A. (if A IN subsets borel then _ else 0) = _’
+           (MP_TAC o Q.SPEC ‘s’) \\
+         simp [sets_lborel]) \\
+     MATCH_MP_TAC lebesgue_pos_integral_real_affine' >> rw [] \\
+     Q.UNABBREV_TAC `f` \\
+     HO_MATCH_MP_TAC IN_MEASURABLE_BOREL_MUL_INDICATOR \\
+     rw [sigma_algebra_borel, IN_MEASURABLE_BOREL_normal_density'])
+ >> SIMP_TAC real_ss []
+ >> simp [Abbr ‘f’, normal_1]
+ >> Know ‘!x. indicator_fn s (-b + x) = indicator_fn A x’
+ >- rw [Abbr ‘s’, indicator_fn_def, REAL_ARITH “-b + x + b = x:real”]
+ >> Rewr'
+ >> Know ‘!x. Normal_density (mu + b) sig x =
+              Normal_density mu sig (-b + x)’
+ >- (rw [normal_density] >> DISJ2_TAC \\
+     rw [REAL_ARITH “x - (mu + b) = -b + x - mu:real”])
+ >> Rewr
+QED
+
+Theorem normal_rv_affine' :
+    !X p mu sig Y a b.
+       prob_space p /\ a <> 0 /\ 0 < sig /\
+       normal_rv X p mu sig /\ (!x. Y x = b + a * X x) ==>
+       normal_rv Y p (b + a * mu) (abs a * sig)
+Proof
+    RW_TAC std_ss [normal_rv]
+ >- (fs [random_variable_def, p_space_def, events_def, prob_space_def] \\
+    ‘sigma_algebra (measurable_space p)’
+       by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA] \\
+     MATCH_MP_TAC in_borel_measurable_add \\
+     qexistsl_tac [‘\x. b’, ‘\x. a * X x’] >> simp [] \\
+     CONJ_TAC >- (MATCH_MP_TAC in_borel_measurable_const \\
+                  Q.EXISTS_TAC ‘b’ >> simp []) \\
+     MATCH_MP_TAC in_borel_measurable_cmul \\
+     qexistsl_tac [‘X’, ‘a’] >> simp [])
+ >> FULL_SIMP_TAC std_ss [measurable_distr, distribution_def, PREIMAGE_def]
+ >> FULL_SIMP_TAC std_ss [FUN_EQ_THM]
+ >> GEN_TAC
+ >> ‘{x | b + a * X x IN s} = {x | X x IN {x | b + a * x IN s}}’
+      by SET_TAC []
+ >> POP_ORW
+ >> FIRST_X_ASSUM (MP_TAC o Q.SPEC ‘{x | b + a * x IN s:real->bool}’)
+ >> SIMP_TAC std_ss [normal_pmeasure, sets_lborel]
+ >> Cases_on ‘s IN subsets borel’ >> simp []
+ >> qabbrev_tac ‘A = {x | b + a * x IN s}’
+ >> Know ‘A IN subsets borel’
+ >- (rw [Abbr ‘A’, IN_MEASURABLE] \\
+     ONCE_REWRITE_TAC [SET_RULE ``{x | b + a * x IN s} =
+      {x | (\x. b + a * x) x IN s:real->bool} INTER UNIV``] \\
+     REWRITE_TAC [GSYM PREIMAGE_def, GSYM space_borel] \\
+     Suff ‘(\x. b + a * x) IN borel_measurable borel’
+     >- rw [IN_MEASURABLE, space_borel] \\
+     ASSUME_TAC sigma_algebra_borel \\
+     MATCH_MP_TAC in_borel_measurable_add \\
+     qexistsl_tac [‘\x. b’, ‘\x. a * x’] >> simp [] \\
+     CONJ_TAC >- (MATCH_MP_TAC in_borel_measurable_const \\
+                  Q.EXISTS_TAC ‘b’ >> rw []) \\
+     MATCH_MP_TAC in_borel_measurable_cmul \\
+     qexistsl_tac [‘\x. x’, ‘a’] >> simp [in_borel_measurable_I])
+ >> DISCH_TAC
+ >> ASM_SIMP_TAC std_ss []
+ >> DISCH_THEN K_TAC
+ >> Suff ‘!x. Normal (normal_density mu sig x) * indicator_fn A x =
+              Normal (abs a) *
+              Normal (normal_density (b + a * mu) (abs a * sig) (b + a * x)) *
+              indicator_fn s (b + a * x)’
+ >- (Rewr' \\
+     Know ‘pos_fn_integral lborel
+             (\x. Normal (abs a) *
+                 (\x. Normal (normal_density (b + a * mu) (abs a * sig) (b + a * x)) *
+                      indicator_fn s (b + a * x)) x) =
+           Normal (abs a) *
+           pos_fn_integral lborel
+             (\x. Normal (normal_density (b + a * mu) (abs a * sig) (b + a * x)) *
+                  indicator_fn s (b + a * x))’
+     >- (MATCH_MP_TAC pos_fn_integral_cmul \\
+         rw [measure_space_lborel, space_lborel] \\
+         MATCH_MP_TAC le_mul >> rw [INDICATOR_FN_POS] \\
+         SIMP_TAC std_ss [normal_density_nonneg]) \\
+     SIMP_TAC std_ss [mul_assoc] \\
+     DISCH_THEN K_TAC \\
+     ONCE_REWRITE_TAC [EQ_SYM_EQ] THEN
+     qmatch_abbrev_tac ‘pos_fn_integral lborel f = _’ >> simp [] \\
+     Know ‘!x. 0 <= f x’
+     >- (rw [Abbr ‘f’] \\
+         MATCH_MP_TAC le_mul >> rw [INDICATOR_FN_POS] \\
+         rw [normal_density_nonneg]) >> DISCH_TAC \\
+     MATCH_MP_TAC lebesgue_pos_integral_real_affine' >> art [] \\
+     qunabbrev_tac ‘f’ \\
+     ASSUME_TAC sigma_algebra_borel \\
+     HO_MATCH_MP_TAC IN_MEASURABLE_BOREL_MUL_INDICATOR >> art [] \\
+     rw [IN_MEASURABLE_BOREL_normal_density'])
+ (* stage work *)
+ >> rw [FUN_EQ_THM, indicator_fn_def, GSPECIFICATION, Abbr ‘A’]
+ >> SIMP_TAC std_ss [normal_density]
+ >> ONCE_REWRITE_TAC [REAL_ARITH ``a * (b * c) = (a:real * b:real) * c:real``]
+ >> Know ‘1 / sqrt (2 * pi * sig pow 2) =
+          abs a * (1 / sqrt (2 * pi * (abs a * sig) pow 2))’
+ >- (SIMP_TAC real_ss [real_div, REAL_MUL_ASSOC, POW_2] \\
+     ONCE_REWRITE_TAC [REAL_ARITH ``2 * pi * abs a * sig * abs a * sig =
+       (2:real * pi:real * sig * sig:real) * (abs a * abs a:real)``] \\
+     Know `0 < 2 * pi * sig * sig`
+     >- (ASSUME_TAC PI_POS \\
+         MATCH_MP_TAC REAL_LT_MUL >> ASM_SIMP_TAC real_ss [] \\
+         MATCH_MP_TAC REAL_LT_MUL >> ASM_SIMP_TAC real_ss [] \\
+         MATCH_MP_TAC REAL_LT_MUL >> ASM_SIMP_TAC real_ss []) >> DISCH_TAC \\
+     Know `0 < abs a * abs a`
+     >- (MATCH_MP_TAC REAL_LT_MUL >> ASM_SIMP_TAC std_ss [GSYM ABS_NZ]) \\
+     DISCH_TAC \\
+    `0 <= 2 * pi * sig * sig` by ASM_SIMP_TAC std_ss [REAL_LT_IMP_LE] \\
+    `0 <= abs a * abs a` by ASM_SIMP_TAC std_ss [REAL_LT_IMP_LE] \\
+     ASM_SIMP_TAC std_ss [SQRT_MUL] \\
+    `0 < sqrt (2:real * pi * sig * sig)` by METIS_TAC [SQRT_POS_LT] \\
+    `0 < sqrt (abs a * abs a)` by METIS_TAC [SQRT_POS_LT] \\
+    `sqrt (2:real * pi * sig * sig) <> 0` by METIS_TAC [REAL_LT_IMP_NE] \\
+    `sqrt (abs a * abs a) <> 0` by METIS_TAC [REAL_LT_IMP_NE] \\
+     ASM_SIMP_TAC std_ss [REAL_INV_MUL, GSYM POW_2] \\
+     SIMP_TAC std_ss [POW_2_SQRT, ABS_POS] \\
+     ONCE_REWRITE_TAC [REAL_ARITH ``a * (b * c) = b:real * (a:real * c:real)``] \\
+    `0 < abs a` by FULL_SIMP_TAC std_ss [ABS_NZ] \\
+    `abs a <> 0` by METIS_TAC [REAL_LT_IMP_NE] \\
+     FULL_SIMP_TAC std_ss [REAL_MUL_RINV, REAL_MUL_RID])
+ >> Rewr'
+ >> simp [extreal_mul_eq]
+ >> DISJ2_TAC
+ >> ONCE_REWRITE_TAC [REAL_ARITH ``b + a * x - (b + a * mu) =
+                                   a:real * (x:real - mu:real)``]
+ >> SIMP_TAC real_ss [POW_MUL, real_div, REAL_MUL_ASSOC]
+ >> ONCE_REWRITE_TAC [REAL_MUL_COMM]
+ >> SIMP_TAC std_ss [REAL_MUL_ASSOC]
+ >> AP_TERM_TAC >> AP_TERM_TAC
+ >> ONCE_REWRITE_TAC [REAL_ARITH ``a * b * c = (a:real * b:real) * c:real``]
+ >> AP_THM_TAC >> AP_TERM_TAC
+ >> simp [REAL_POW2_ABS]
+QED
+
+(* NOTE: This is just normal_rv_affine' expanded with normal_rv_def *)
+Theorem normal_distribution_affine :
+    !X p mu sig Y a b.
+       prob_space p /\ a <> 0 /\ 0 < sig /\
+       random_variable X p borel /\
+      (!s. s IN subsets borel ==>
+           distribution p X s = normal_pmeasure mu sig s) /\
+      (!x. Y x = b + a * X x) ==>
+       random_variable Y p borel /\
+       !s. s IN subsets borel ==>
+           distribution p Y s = normal_pmeasure (b + a * mu) (abs a * sig) s
+Proof
+    rpt GEN_TAC >> STRIP_TAC
+ >> ‘normal_rv X p mu sig’ by rw [normal_rv_def]
+ >> Suff ‘normal_rv Y p (b + a * mu) (abs a * sig)’ >- rw [normal_rv_def]
+ >> MATCH_MP_TAC normal_rv_affine'
+ >> Q.EXISTS_TAC ‘X’ >> rw []
+QED
+
 val _ = export_theory ();
 val _ = html_theory "distribution";
 
 (* References:
 
-  [1] Qasim, M.: Formalization of Normal Random Variables, Concordia University (2016).
-  [2] Chung, K.L.: A Course in Probability Theory, Third Edition. Academic Press (2001).
+  [1] Qasim, M.: Formalization of Normal Random Variables,
+      Concordia University (2016).
+  [2] Chung, K.L.: A Course in Probability Theory, Third Edition.
+      Academic Press (2001).
   [3] Rosenthal, J.S.: A First Look at Rigorous Probability Theory (Second Edition).
       World Scientific Publishing Company (2006).
   [4] Shiryaev, A.N.: Probability-1. Springer-Verlag New York (2016).
-
+  [5] Schilling, R.L.: Measures, Integrals and Martingales (2nd Edition).
+      Cambridge University Press (2017).
  *)

--- a/src/probability/README.md
+++ b/src/probability/README.md
@@ -4,8 +4,7 @@ This directory contains HOL4's Measure, Lebesgue Integration and Probability the
 
 ## Preliminaries
 
-     util_probScript.sml          * Utility lemmas needed by other scripts
-     extrealScript.sml            * The theory of extended reals
+     extrealScript.sml            * The (extended) theory of extended reals
 
 ## Measure, Integration and Probability Theory defined on extended reals
 
@@ -19,9 +18,9 @@ This directory contains HOL4's Measure, Lebesgue Integration and Probability the
 
 ## Measure, Integration and Probability Theory defined on reals (obsoleted)
 
-     NOTE: The legacy measure, integration and probability theories based on finite measures
-     are moved to `$(HOLDIR)/examples/probability/legacy`. They are needed when building the
-     two examples in `examples/miller` and `examples/diningcryptos`.
+NOTE: The legacy measure, integration and probability theories based on finite measures
+      are moved to `$(HOLDIR)/examples/probability/legacy`. They are used for building
+      some official examples.
 
 ## Further extensions
 

--- a/src/probability/lebesgueScript.sml
+++ b/src/probability/lebesgueScript.sml
@@ -134,29 +134,6 @@ Definition finite_space_integral_def :
       SIGMA (\r. r * measure m (PREIMAGE f {r} INTER m_space m)) (IMAGE f (m_space m))
 End
 
-(* ------------------------------------------------------------------------- *)
-(* Radon-Nikodym Related Definitions                                         *)
-(* ------------------------------------------------------------------------- *)
-
-(* v is absolutely continuous w.r.t. m, denoted by ``v << m``
-
-   NOTE: the type of `v` is not `:'a m_space` but `:'a measure`, to simplify
-   the statements of Radon-Nikodym theorems as much as possible.
- *)
-val measure_absolutely_continuous_def = Define
-   `measure_absolutely_continuous v m =
-      !s. s IN measurable_sets m /\ (measure m s = 0) ==> (v s = 0)`;
-
-(* "<<" is already used in "src/n-bit/wordsScript.sml", same priority here *)
-val _ = set_fixity "<<" (Infixl 680);
-val _ = Unicode.unicode_version {u = Unicode.UChar.lsl, tmnm = "<<"};
-
-(* aligned with wordsTheory *)
-val _ = TeX_notation {hol = "<<",              TeX = ("\\HOLTokenLsl{}", 2)};
-val _ = TeX_notation {hol = Unicode.UChar.lsl, TeX = ("\\HOLTokenLsl{}", 2)};
-
-val _ = overload_on ("<<", ``measure_absolutely_continuous``);
-
 (* The measure with density (function) f with respect to m, see [1, p.86-87]
    from HVG's lebesgue_measureScript.sml, simplified.
 
@@ -171,6 +148,13 @@ val density_measure_def = Define (* or `f * m` *)
 val density_def = Define (* was: density *)
    `density m f = (m_space m, measurable_sets m, density_measure m f)`;
 
+(* |- !m f.
+        density m f =
+        (m_space m,measurable_sets m,
+         (\s. pos_fn_integral m (\x. f x * indicator_fn s x)))
+ *)
+Theorem density = REWRITE_RULE [density_measure_def] density_def
+
 (* `v = density m f` is denoted by `v = f * m` (cf. "RN_deriv_def" below)
 
    The idea is to syntactically have (`*` is not commutative here):
@@ -178,6 +162,9 @@ val density_def = Define (* was: density *)
       `(f * m = v) <=> (f = v / m)`     or      `v / m * m = v`
  *)
 val _ = overload_on ("*", ``\f m. density_measure m f``);
+
+(* |- !m f s. (f * m) s = pos_fn_integral m (\x. f x * indicator_fn s x) *)
+Theorem density_measure = SIMP_RULE std_ss [FUN_EQ_THM] density_measure_def
 
 (* Theorem 7.6 [1, p.55]: let M, N be measurable spaces and f : M -> N be an
    M/N-measurable map. For every `u` on `(m_space M,measurable_sets M)`,
@@ -233,8 +220,10 @@ Theorem pos_simple_fn_integral_present :
        g (s':num->bool) b y.
        measure_space m /\ pos_simple_fn m f s a x /\ pos_simple_fn m g s' b y ==>
        ?z z' c (k:num->bool).
-          (!t. t IN m_space m ==> (f t = SIGMA (\i. Normal (z  i) * (indicator_fn (c i) t)) k)) /\
-          (!t. t IN m_space m ==> (g t = SIGMA (\i. Normal (z' i) * (indicator_fn (c i) t)) k)) /\
+          (!t. t IN m_space m ==>
+               f t = SIGMA (\i. Normal (z  i) * indicator_fn (c i) t) k) /\
+          (!t. t IN m_space m ==>
+               g t = SIGMA (\i. Normal (z' i) * indicator_fn (c i) t) k) /\
           (pos_simple_fn_integral m s  a x = pos_simple_fn_integral m k c z) /\
           (pos_simple_fn_integral m s' b y = pos_simple_fn_integral m k c z') /\
            FINITE k /\ (!i. i IN k ==> 0 <= z i) /\ (!i. i IN k ==> 0 <= z' i) /\
@@ -244,14 +233,14 @@ Theorem pos_simple_fn_integral_present :
 Proof
     rpt STRIP_TAC
  >> `?p n. BIJ p (count n) (s CROSS s')`
-        by FULL_SIMP_TAC std_ss [GSYM FINITE_BIJ_COUNT, pos_simple_fn_def, FINITE_CROSS]
+        by FULL_SIMP_TAC std_ss [GSYM FINITE_BIJ_COUNT, pos_simple_fn_def,
+                                 FINITE_CROSS]
  >> `?p'. BIJ p' (s CROSS s') (count n) /\
           (!x. x IN (count n) ==> ((p' o p) x = x)) /\
           (!x. x IN (s CROSS s') ==> ((p o p') x = x))`
         by (MATCH_MP_TAC BIJ_INV >> RW_TAC std_ss [])
  >> qexistsl_tac [`x o FST o p`, `y o SND o p`,
-                  `(\(i,j). a i INTER b j) o p`,
-                  `IMAGE p' (s CROSS s')`]
+                  `(\(i,j). a i INTER b j) o p`, `IMAGE p' (s CROSS s')`]
  >> Q.ABBREV_TAC `G = IMAGE (\i j. p' (i,j)) s'`
  >> Q.ABBREV_TAC `H = IMAGE (\j i. p' (i,j)) s`
  >> CONJ_TAC
@@ -290,48 +279,58 @@ Proof
                 EXTREAL_SUM_IMAGE_CMUL \\
              FULL_SIMP_TAC std_ss []) >> POP_ORW \\
     `FINITE (s CROSS s')` by RW_TAC std_ss [FINITE_CROSS] \\
-    `INJ p' (s CROSS s') (IMAGE p' (s CROSS s'))` by METIS_TAC [INJ_IMAGE_BIJ, BIJ_DEF] \\
-     (MP_TAC o Q.SPEC `(\i:num. Normal (x (FST (p i))) *
-                                indicator_fn ((\(i:num,j:num). a i INTER b j) (p i)) t)`
-             o UNDISCH o Q.SPEC `p'` o UNDISCH o Q.SPEC `s CROSS s'`
-             o INST_TYPE [alpha |-> ``:num#num``, beta |-> ``:num``]) EXTREAL_SUM_IMAGE_IMAGE \\
-    `!x'. Normal (x (FST (p x'))) * indicator_fn ((\(i,j). a i INTER b j) (p x')) t <> NegInf`
-          by METIS_TAC [indicator_fn_def, mul_rzero, mul_rone, extreal_not_infty,
-                        extreal_of_num_def] \\
+    `INJ p' (s CROSS s') (IMAGE p' (s CROSS s'))`
+       by METIS_TAC [INJ_IMAGE_BIJ, BIJ_DEF] \\
+    (MP_TAC o Q.SPEC `\i:num. Normal (x (FST (p i))) *
+                            indicator_fn ((\(i:num,j:num). a i INTER b j) (p i)) t`
+            o UNDISCH o Q.SPEC `p'` o UNDISCH o Q.SPEC `s CROSS s'`
+            o INST_TYPE [alpha |-> ``:num#num``, beta |-> ``:num``])
+              EXTREAL_SUM_IMAGE_IMAGE \\
+    `!x'. Normal (x (FST (p x'))) *
+          indicator_fn ((\(i,j). a i INTER b j) (p x')) t <> NegInf`
+       by METIS_TAC [indicator_fn_def, mul_rzero, mul_rone, extreal_not_infty,
+                     extreal_of_num_def] \\
      RW_TAC std_ss [] \\
     `!x'. ((\i. Normal (x (FST (p i))) *
                 indicator_fn ((\(i,j). a i INTER b j) (p i)) t) o p') x' <> NegInf`
           by (RW_TAC std_ss [indicator_fn_def, mul_rzero, mul_rone] \\
               METIS_TAC [extreal_not_infty, extreal_of_num_def]) \\
-     (MP_TAC o Q.SPEC `((\i. Normal (x (FST ((p :num -> num # num) i))) *
-                             indicator_fn ((\(i,j). a i INTER b j) (p i)) t) o p')`
-             o UNDISCH o Q.ISPEC `(s :num set) CROSS (s' :num set)`) EXTREAL_SUM_IMAGE_IN_IF \\
+    (MP_TAC o Q.SPEC `((\i. Normal (x (FST ((p :num -> num # num) i))) *
+                            indicator_fn ((\(i,j). a i INTER b j) (p i)) t) o p')`
+            o UNDISCH o Q.ISPEC `(s :num set) CROSS (s' :num set)`)
+              EXTREAL_SUM_IMAGE_IN_IF \\
      RW_TAC std_ss [] \\
-    `(\x'.if x' IN s CROSS s' then
-             Normal (x (FST x')) * indicator_fn ((\(i,j). a i INTER b j) x') t
-          else 0) =
-     (\x'. (if x' IN s CROSS s' then
-               (\x'. Normal (x (FST x')) * indicator_fn ((\(i,j). a i INTER b j) x') t) x'
-            else 0))` by METIS_TAC [] >> POP_ORW \\
-    `!x'. (\x'. Normal (x (FST x')) * indicator_fn ((\(i,j). a i INTER b j) x') t) x' <> NegInf`
-          by (RW_TAC std_ss [indicator_fn_def, mul_rzero, mul_rone] \\
-              METIS_TAC [extreal_not_infty, extreal_of_num_def]) \\
-     (MP_TAC o Q.SPEC `(\x'. Normal (x (FST x')) * indicator_fn ((\(i,j). a i INTER b j) x') t)`
-             o UNDISCH o Q.ISPEC `(s :num set) CROSS (s' :num set)`)
+    `(\x'. if x' IN s CROSS s' then
+              Normal (x (FST x')) * indicator_fn ((\(i,j). a i INTER b j) x') t
+           else 0) =
+     (\x'. if x' IN s CROSS s' then
+              (\x'. Normal (x (FST x')) *
+                    indicator_fn ((\(i,j). a i INTER b j) x') t) x'
+           else 0)` by METIS_TAC [] >> POP_ORW \\
+    `!x'. (\x'. Normal (x (FST x')) *
+                indicator_fn ((\(i,j). a i INTER b j) x') t) x' <> NegInf`
+       by (RW_TAC std_ss [indicator_fn_def, mul_rzero, mul_rone] \\
+           METIS_TAC [extreal_not_infty, extreal_of_num_def]) \\
+    (MP_TAC o Q.SPEC `(\x'. Normal (x (FST x')) *
+                            indicator_fn ((\(i,j). a i INTER b j) x') t)`
+            o UNDISCH o Q.ISPEC `(s :num set) CROSS (s' :num set)`)
        (GSYM EXTREAL_SUM_IMAGE_IN_IF) \\
      RW_TAC std_ss [] \\
-    `!x'. NegInf <> (\i:num. SIGMA (\j:num. Normal (x i) * indicator_fn (a i INTER b j) t) s') x'`
-          by (RW_TAC std_ss [] \\
-             `!j. (\j. Normal (x x') * indicator_fn (a x' INTER b j) t) j <> NegInf`
-                  by (RW_TAC std_ss [indicator_fn_def, mul_rzero, mul_rone] \\
-                      METIS_TAC [extreal_of_num_def, extreal_not_infty]) \\
-              FULL_SIMP_TAC std_ss [EXTREAL_SUM_IMAGE_NOT_INFTY]) \\
-     (MP_TAC o Q.SPEC `(\i:num. SIGMA (\j:num. Normal (x i) * indicator_fn (a i INTER b j) t) s')`
-             o UNDISCH o Q.ISPEC `(s :num -> bool)`) (GSYM EXTREAL_SUM_IMAGE_IN_IF) \\
+    `!x'. NegInf <> (\i:num. SIGMA (\j:num. Normal (x i) *
+                             indicator_fn (a i INTER b j) t) s') x'`
+       by (RW_TAC std_ss [] \\
+          `!j. (\j. Normal (x x') * indicator_fn (a x' INTER b j) t) j <> NegInf`
+              by (RW_TAC std_ss [indicator_fn_def, mul_rzero, mul_rone] \\
+                  METIS_TAC [extreal_of_num_def, extreal_not_infty]) \\
+          FULL_SIMP_TAC std_ss [EXTREAL_SUM_IMAGE_NOT_INFTY]) \\
+    (MP_TAC o Q.SPEC `(\i:num. SIGMA (\j:num. Normal (x i) *
+                               indicator_fn (a i INTER b j) t) s')`
+            o UNDISCH o Q.ISPEC `(s :num -> bool)`) (GSYM EXTREAL_SUM_IMAGE_IN_IF) \\
      RW_TAC std_ss [] \\
-     (MP_TAC o Q.ISPECL [`s:num->bool`,`s':num->bool`]) EXTREAL_SUM_IMAGE_SUM_IMAGE \\
+    (MP_TAC o Q.ISPECL [`s:num->bool`,`s':num->bool`]) EXTREAL_SUM_IMAGE_SUM_IMAGE \\
      RW_TAC std_ss [] \\
-     POP_ASSUM (MP_TAC o Q.SPEC `(\i j. Normal (x i) * indicator_fn (a i INTER b j) t)`) \\
+     POP_ASSUM (MP_TAC o
+                Q.SPEC `(\i j. Normal (x i) * indicator_fn (a i INTER b j) t)`) \\
     `!x'. Normal (x (FST x')) * indicator_fn (a (FST x') INTER b (SND x')) t <> NegInf`
           by (RW_TAC std_ss [indicator_fn_def, mul_rzero, mul_rone] \\
               METIS_TAC [extreal_of_num_def, extreal_not_infty]) \\
@@ -369,16 +368,19 @@ Proof
              RW_TAC std_ss [MEASURE_SPACE_SUBSET_MSPACE]) >> POP_ORW \\
     `!(x:num) (i:num). Normal (y i) * SIGMA (\j. indicator_fn (a j INTER b i) t) s =
                        SIGMA (\j. Normal (y i) * indicator_fn (a j INTER b i) t) s`
-         by (RW_TAC std_ss [] \\
-            `!j. (\j. indicator_fn (a j INTER b i) t) j <> NegInf`
-                 by RW_TAC std_ss [indicator_fn_def, extreal_of_num_def, extreal_not_infty] \\
-             FULL_SIMP_TAC std_ss [GSYM EXTREAL_SUM_IMAGE_CMUL]) >> POP_ORW \\
+        by (RW_TAC std_ss [] \\
+          `!j. (\j. indicator_fn (a j INTER b i) t) j <> NegInf`
+              by RW_TAC std_ss [indicator_fn_def, extreal_of_num_def,
+                                extreal_not_infty] \\
+            FULL_SIMP_TAC std_ss [GSYM EXTREAL_SUM_IMAGE_CMUL]) >> POP_ORW \\
     `FINITE (s CROSS s')` by RW_TAC std_ss [FINITE_CROSS] \\
-    `INJ p' (s CROSS s') (IMAGE p' (s CROSS s'))` by METIS_TAC [INJ_IMAGE_BIJ, BIJ_DEF] \\
-     (MP_TAC o Q.SPEC `(\i:num. Normal (y (SND (p i))) *
-                                indicator_fn ((\(i:num,j:num). a i INTER b j) (p i)) t)`
-             o UNDISCH o Q.SPEC `p'` o UNDISCH o Q.SPEC `s CROSS s'`
-             o INST_TYPE [alpha |-> ``:num#num``, beta |-> ``:num``]) EXTREAL_SUM_IMAGE_IMAGE \\
+    `INJ p' (s CROSS s') (IMAGE p' (s CROSS s'))`
+        by METIS_TAC [INJ_IMAGE_BIJ, BIJ_DEF] \\
+    (MP_TAC o Q.SPEC `(\i:num. Normal (y (SND (p i))) *
+                               indicator_fn ((\(i:num,j:num). a i INTER b j) (p i)) t)`
+            o UNDISCH o Q.SPEC `p'` o UNDISCH o Q.SPEC `s CROSS s'`
+            o INST_TYPE [alpha |-> ``:num#num``, beta |-> ``:num``])
+              EXTREAL_SUM_IMAGE_IMAGE \\
     `!x. (\i. Normal (y (SND (p i))) *
               indicator_fn ((\(i,j). a i INTER b j) (p i)) t) x <> NegInf`
          by METIS_TAC [indicator_fn_def, mul_rzero, mul_rone, extreal_not_infty,
@@ -388,34 +390,42 @@ Proof
                 indicator_fn ((\(i,j). a i INTER b j) (p i)) t) o p') x' <> NegInf`
          by (RW_TAC std_ss [indicator_fn_def, mul_rzero, mul_rone] \\
              METIS_TAC [extreal_not_infty, extreal_of_num_def]) \\
-     (MP_TAC o Q.SPEC `((\i. Normal (y (SND ((p :num -> num # num) i))) *
-                             indicator_fn ((\(i,j). a i INTER b j) (p i)) t) o p')`
-             o UNDISCH o Q.ISPEC `(s :num set) CROSS (s' :num set)`) EXTREAL_SUM_IMAGE_IN_IF \\
+    (MP_TAC o Q.SPEC `(\i. Normal (y (SND ((p :num -> num # num) i))) *
+                           indicator_fn ((\(i,j). a i INTER b j) (p i)) t) o p'`
+            o UNDISCH o Q.ISPEC `(s :num set) CROSS (s' :num set)`)
+              EXTREAL_SUM_IMAGE_IN_IF \\
      RW_TAC std_ss [] \\
-    `(\x'.if x' IN s CROSS s' then
-             Normal (y (SND x')) * indicator_fn ((\(i,j). a i INTER b j) x') t else 0) =
-     (\x'. (if x' IN s CROSS s' then
-             (\x'. Normal (y (SND x')) * indicator_fn ((\(i,j). a i INTER b j) x') t) x'
-            else 0))` by METIS_TAC [] >> POP_ORW \\
-    `!x'. (\x'. Normal (y (SND x')) * indicator_fn ((\(i,j). a i INTER b j) x') t) x' <> NegInf`
+    `(\x'. if x' IN s CROSS s' then
+              Normal (y (SND x')) * indicator_fn ((\(i,j). a i INTER b j) x') t
+           else 0) =
+     (\x'. if x' IN s CROSS s' then
+             (\x'. Normal (y (SND x')) *
+                   indicator_fn ((\(i,j). a i INTER b j) x') t) x'
+           else 0)` by METIS_TAC [] >> POP_ORW \\
+    `!x'. (\x'. Normal (y (SND x')) *
+                indicator_fn ((\(i,j). a i INTER b j) x') t) x' <> NegInf`
          by (RW_TAC std_ss [indicator_fn_def, mul_rzero, mul_rone] \\
              METIS_TAC [extreal_not_infty, extreal_of_num_def]) \\
-     (MP_TAC o Q.SPEC `(\x'. Normal (y (SND x')) * indicator_fn ((\(i,j). a i INTER b j) x') t)`
-             o UNDISCH o Q.ISPEC `(s :num set) CROSS (s' :num set)`)
+    (MP_TAC o Q.SPEC `(\x'. Normal (y (SND x')) *
+                            indicator_fn ((\(i,j). a i INTER b j) x') t)`
+            o UNDISCH o Q.ISPEC `(s :num set) CROSS (s' :num set)`)
         (GSYM EXTREAL_SUM_IMAGE_IN_IF) \\
      RW_TAC std_ss [] \\
-    `!x'. NegInf <> (\x:num. SIGMA (\j:num. Normal (y x) * indicator_fn (a j INTER b x) t) s) x'`
+    `!x'. NegInf <> (\x:num. SIGMA (\j:num. Normal (y x) *
+                                            indicator_fn (a j INTER b x) t) s) x'`
          by (RW_TAC std_ss [] \\
             `!j. (\j. Normal (y x') * indicator_fn (a j INTER b x') t) j <> NegInf`
                  by (RW_TAC std_ss [indicator_fn_def, mul_rzero, mul_rone] \\
                      METIS_TAC [extreal_of_num_def, extreal_not_infty]) \\
              FULL_SIMP_TAC std_ss [EXTREAL_SUM_IMAGE_NOT_INFTY]) \\
-     (MP_TAC o Q.SPEC `(\x:num. SIGMA (\j:num. Normal (y x) * indicator_fn (a j INTER b x) t) s)`
-             o UNDISCH o Q.ISPEC `(s' :num -> bool)`) (GSYM EXTREAL_SUM_IMAGE_IN_IF) \\
+    (MP_TAC o Q.SPEC `(\x:num. SIGMA (\j:num. Normal (y x) *
+                                              indicator_fn (a j INTER b x) t) s)`
+            o UNDISCH o Q.ISPEC `(s' :num -> bool)`) (GSYM EXTREAL_SUM_IMAGE_IN_IF) \\
      RW_TAC std_ss [] \\
-     (MP_TAC o Q.ISPECL [`s':num->bool`,`s:num->bool`]) EXTREAL_SUM_IMAGE_SUM_IMAGE \\
+    (MP_TAC o Q.ISPECL [`s':num->bool`,`s:num->bool`]) EXTREAL_SUM_IMAGE_SUM_IMAGE \\
      RW_TAC std_ss [] \\
-     POP_ASSUM (MP_TAC o Q.SPEC `(\x j. Normal (y x) * indicator_fn (a j INTER b x) t)`) \\
+     POP_ASSUM (MP_TAC o Q.SPEC `(\x j. Normal (y x) *
+                                        indicator_fn (a j INTER b x) t)`) \\
     `!x. Normal (y x) * indicator_fn (a j INTER b x) t <> NegInf`
          by (RW_TAC std_ss [indicator_fn_def, mul_rzero, mul_rone] \\
              METIS_TAC [extreal_of_num_def, extreal_not_infty]) \\
@@ -427,7 +437,8 @@ Proof
          by (RW_TAC std_ss [Once EXTENSION, IN_CROSS, IN_IMAGE] \\
              (MP_TAC o Q.ISPEC `x':num#num`) pair_CASES \\
              RW_TAC std_ss [] >> RW_TAC std_ss [FST,SND] \\
-             EQ_TAC >- (STRIP_TAC >> Q.EXISTS_TAC `(r,q)` >> RW_TAC std_ss [FST, SND]) \\
+             EQ_TAC
+             >- (STRIP_TAC >> Q.EXISTS_TAC `(r,q)` >> RW_TAC std_ss [FST, SND]) \\
              RW_TAC std_ss [] >> RW_TAC std_ss []) >> POP_ORW \\
     `INJ (\x. (SND x,FST x)) (s CROSS s')
          (IMAGE (\x. (SND x,FST x)) (s CROSS s'))`
@@ -436,11 +447,13 @@ Proof
              (MP_TAC o Q.ISPEC `x'':num#num`) pair_CASES \\
              RW_TAC std_ss [] \\
              FULL_SIMP_TAC std_ss [FST,SND]) \\
-     (MP_TAC o Q.SPEC `(\x. Normal (y (FST x)) * indicator_fn (a (SND x) INTER b (FST x)) t)`
-             o UNDISCH o Q.SPEC `(\x. (SND x, FST x))` o UNDISCH
-             o Q.ISPEC `((s:num->bool) CROSS (s':num->bool))`
-             o INST_TYPE [``:'b``|->``:num#num``]) EXTREAL_SUM_IMAGE_IMAGE \\
-    `!x. (\x. Normal (y (FST x)) * indicator_fn (a (SND x) INTER b (FST x)) t) x <> NegInf`
+    (MP_TAC o Q.SPEC `(\x. Normal (y (FST x)) *
+                           indicator_fn (a (SND x) INTER b (FST x)) t)`
+            o UNDISCH o Q.SPEC `(\x. (SND x, FST x))` o UNDISCH
+            o Q.ISPEC `((s:num->bool) CROSS (s':num->bool))`
+            o INST_TYPE [``:'b``|->``:num#num``]) EXTREAL_SUM_IMAGE_IMAGE \\
+    `!x. (\x. Normal (y (FST x)) *
+              indicator_fn (a (SND x) INTER b (FST x)) t) x <> NegInf`
          by (RW_TAC std_ss [indicator_fn_def, mul_rzero, mul_rone] \\
              METIS_TAC [extreal_of_num_def, extreal_not_infty]) \\
      RW_TAC std_ss [o_DEF] \\
@@ -475,7 +488,8 @@ Proof
                      SIGMA (\j. Normal (x i) * measure m (a i INTER b j)) s')`
          by (RW_TAC std_ss [] \\
             `!j. j IN s' ==> (\j. measure m (a i INTER b j)) j <> NegInf`
-                by METIS_TAC [positive_not_infty, measure_space_def, MEASURE_SPACE_INTER] \\
+                by METIS_TAC [positive_not_infty, measure_space_def,
+                              MEASURE_SPACE_INTER] \\
              FULL_SIMP_TAC std_ss [GSYM EXTREAL_SUM_IMAGE_CMUL]) \\
      FULL_SIMP_TAC std_ss [] \\
     `FINITE (s CROSS s')` by RW_TAC std_ss [FINITE_CROSS] \\
@@ -2554,28 +2568,8 @@ Proof
 QED
 
 (**********************************************************)
-(*  Existence of convergent sequence (fn_seq)             *)
+(*  Integration of convergent sequence (fn_seq_integral)  *)
 (**********************************************************)
-
-(**** Define the sequence ****)
-val fn_seq_def = Define
-   `fn_seq m f =
-       (\n x. SIGMA
-                (\k. &k / 2 pow n *
-                     indicator_fn
-                       {x | x IN m_space m /\ &k / 2 pow n <= f x /\
-                            f x < (&k + 1) / 2 pow n} x) (count (4 ** n)) +
-              2 pow n * indicator_fn {x | x IN m_space m /\ 2 pow n <= f x} x)`;
-
-(**** Define their integrals ****)
-val fn_seq_integral_def = Define
-   `fn_seq_integral m f =
-         (\n. SIGMA
-                (\k. &k / 2 pow n *
-                     measure m
-                       {x | x IN m_space m /\ &k / 2 pow n <= f x /\
-                            f x < (&k + 1) / 2 pow n}) (count (4 ** n)) +
-              2 pow n * measure m {x | x IN m_space m /\ 2 pow n <= f x})`;
 
 (* NOTE: Given the following (s,a,x) for a sequence of positive simple function:
 
@@ -2590,389 +2584,17 @@ val fn_seq_integral_def = Define
    |- fn_seq m f = \n t. SIGMA (\i. Normal (x i) * indicator_fn (a i) t) s)
    |- fn_seq_integral m f n = pos_simple_fn_integral m s a x
  *)
+Definition fn_seq_integral_def :
+    fn_seq_integral m f =
+         (\n. SIGMA
+                (\k. &k / 2 pow n *
+                     measure m
+                       {x | x IN m_space m /\ &k / 2 pow n <= f x /\
+                            f x < (&k + 1) / 2 pow n}) (count (4 ** n)) +
+              2 pow n * measure m {x | x IN m_space m /\ 2 pow n <= f x})
+End
 
-(******************************************************)
-(****   f_n(x) = &k / 2 pow n in the k^th interval ****)
-(******************************************************)
-
-val lemma_fn_1 = prove (
-  ``!m f n x k. x IN m_space m /\ k IN count (4 ** n) /\ &k / 2 pow n <= f x /\
-                f x < (&k + 1) / 2 pow n
-            ==> (fn_seq m f n x = &k / 2 pow n)``,
- (* proof *)
-  RW_TAC std_ss []
-  >> `0:real < 2 pow n` by RW_TAC real_ss [REAL_POW_LT]
-  >> `0:real <> 2 pow n` by RW_TAC real_ss [REAL_LT_IMP_NE]
-  >> FULL_SIMP_TAC real_ss [fn_seq_def, indicator_fn_def, GSPECIFICATION, IN_COUNT,
-                            mul_rone, mul_rzero, extreal_of_num_def, extreal_pow_def,
-                            extreal_div_eq, extreal_add_def]
-  >> `f x <> PosInf` by METIS_TAC [lt_infty,lt_trans]
-  >> `f x <> NegInf` by METIS_TAC [lt_infty,lte_trans]
-  >> `?r. f x = Normal r` by METIS_TAC [extreal_cases]
-  >> FULL_SIMP_TAC std_ss [extreal_lt_eq,extreal_le_def]
-  >> `(\k'. Normal (&k' / 2 pow n) * if &k' / 2 pow n <= r /\ r < &(k' + 1) / 2 pow n then Normal 1 else Normal 0) =
-      (\k'. Normal((&k' / 2 pow n) * if &k' / 2 pow n <= r /\ r < &(k' + 1) / 2 pow n then 1 else 0))`
-         by (RW_TAC std_ss [FUN_EQ_THM] >> METIS_TAC [extreal_add_def,extreal_mul_def])
-  >> POP_ORW
-  >> `FINITE (count (4 ** n))` by RW_TAC std_ss [FINITE_COUNT]
-  >> RW_TAC real_ss [EXTREAL_SUM_IMAGE_NORMAL,extreal_11,extreal_mul_def,extreal_add_def]
-  >- (`k + 1 <= 4 ** n` by RW_TAC real_ss [LESS_EQ]
-      >> `&(k + 1) <= (4:real) pow n` by RW_TAC real_ss [REAL_OF_NUM_POW]
-      >> FULL_SIMP_TAC real_ss [REAL_LT_RDIV_EQ]
-      >> `r * 2 pow n < 4 pow n` by METIS_TAC [REAL_LTE_TRANS]
-      >> METIS_TAC [REAL_LT_RDIV_EQ,REAL_POW_DIV,EVAL ``4/2:real``,real_lte])
-  >> FULL_SIMP_TAC real_ss [GSYM real_lt]
-  >> (MP_TAC o UNDISCH o Q.SPECL [`k`,`count (4 ** n)`] o CONJUNCT2 o Q.SPEC `(\k'. &k' / 2 pow n *
-           if &k' / 2 pow n <= r:real /\ r < &(k' + 1) / 2 pow n then 1 else 0)`) (INST_TYPE [alpha |-> ``:num``] REAL_SUM_IMAGE_THM)
-  >> RW_TAC real_ss []
-  >> `count (4 ** n) = k INSERT (count (4 ** n))` by RW_TAC std_ss [GSYM ABSORPTION,IN_COUNT]
-  >> POP_ORW
-  >> RW_TAC std_ss [REAL_SUM_IMAGE_THM]
-  >> Suff `SIGMA (\k'. &k' / 2 pow n * if &k' / 2 pow n <= r /\ r < &(k' + 1) / 2 pow n then 1 else 0)
-                 (count (4 ** n) DELETE k) = 0:real`
-  >- RW_TAC real_ss []
-  >> `FINITE (count (4 ** n) DELETE k)` by RW_TAC std_ss [FINITE_COUNT,FINITE_DELETE]
-  >> ONCE_REWRITE_TAC [(UNDISCH o Q.SPEC `count (4 ** n) DELETE k` o INST_TYPE [alpha |-> ``:num``]) REAL_SUM_IMAGE_IN_IF]
-  >> Suff `(\x. if x IN count (4 ** n) DELETE k then (\k'. &k' / 2 pow n *
-              if &k' / 2 pow n <= r:real /\ r < &(k' + 1) / 2 pow n then
-                1 else 0) x else 0) = (\x:num. 0:real)`
-  >- FULL_SIMP_TAC real_ss [REAL_SUM_IMAGE_0]
-  >> RW_TAC real_ss [FUN_EQ_THM,IN_COUNT,IN_DELETE]
-  >> RW_TAC real_ss [COND_EXPAND]
-  >> Cases_on `&x'<=((&k):real)`
-  >- (`&(x'+1)<=(&k):real` by FULL_SIMP_TAC real_ss [LESS_EQ,REAL_LE_LT]
-      >> `r * 2 pow n < &(x' + 1)` by METIS_TAC [REAL_LT_RDIV_EQ]
-      >> `r:real * 2 pow n < &k` by METIS_TAC [REAL_LTE_TRANS]
-      >> METIS_TAC [REAL_LT_RDIV_EQ,real_lte])
-  >> FULL_SIMP_TAC std_ss [GSYM real_lt]
-  >> `&(k+1)<=(&x'):real` by FULL_SIMP_TAC real_ss [LESS_EQ,REAL_LE_LT]
-  >> `&x' <= r * 2 pow n` by METIS_TAC [REAL_LE_LDIV_EQ]
-  >> `&(k+1) <= r * 2 pow n` by METIS_TAC [REAL_LE_TRANS]
-  >> METIS_TAC [REAL_LE_LDIV_EQ,real_lte]);
-
-(**********************************************)
-(****   f_n(x) = 2 pow n if 2 pow n <= f x ****)
-(**********************************************)
-
-val lemma_fn_2 = prove (
-  ``!m f n x. x IN m_space m /\ 2 pow n <= f x ==> (fn_seq m f n x = 2 pow n)``,
- (* proof *)
-  RW_TAC real_ss [fn_seq_def,indicator_fn_def,GSPECIFICATION,mul_rone]
-  >> `FINITE (count (4 ** n))` by RW_TAC std_ss [FINITE_COUNT]
-  >> `0:real < 2 pow n` by RW_TAC real_ss [REAL_POW_LT]
-  >> `0:real <> 2 pow n` by RW_TAC real_ss [REAL_LT_IMP_NE]
-  >> Suff `SIGMA (\k. &k / 2 pow n *  if &k / 2 pow n <= f x /\ f x < (&k + 1) / 2 pow n then 1 else 0) (count (4 ** n)) = 0`
-  >- RW_TAC real_ss [add_lzero]
-  >> (MP_TAC o Q.SPEC `(\k. &k / 2 pow n * if &k / 2 pow n <= f x /\ f x < (&k + 1) / 2 pow n then 1 else 0)` o UNDISCH o Q.SPEC `count (4 ** n)` o INST_TYPE [alpha |-> ``:num``]) EXTREAL_SUM_IMAGE_IN_IF
-  >> `!x'. (\k. &k / 2 pow n * if &k / 2 pow n <= f x /\ f x < (&k + 1) / 2 pow n then 1 else 0) x' <> NegInf`
-      by (RW_TAC std_ss [mul_rone,mul_rzero]
-          >> RW_TAC std_ss [extreal_of_num_def,extreal_pow_def,extreal_mul_def,extreal_div_eq,extreal_not_infty])
-  >> Suff `(\x'. if x' IN count (4 ** n) then &x' / 2 pow n * if &x' / 2 pow n <= f x /\ f x < (&x' + 1) / 2 pow n then 1 else 0 else 0) = (\x. 0)`
-  >- RW_TAC std_ss [EXTREAL_SUM_IMAGE_ZERO]
-  >> RW_TAC real_ss [FUN_EQ_THM,IN_COUNT]
-  >> RW_TAC real_ss [COND_EXPAND,mul_rzero,mul_rone]
-  >> `&(x' + 1):real <= 4 pow n` by RW_TAC real_ss [LESS_EQ,REAL_OF_NUM_POW]
-  >> `&(x' + 1):real / 2 pow n <= 4 pow n / 2 pow n` by RW_TAC real_ss [REAL_LE_LDIV_EQ,REAL_POS_NZ,REAL_DIV_RMUL]
-  >> `(&x' + 1) / 2 pow n <= 4 pow n / 2 pow n` by RW_TAC real_ss [extreal_div_eq,extreal_pow_def,extreal_add_def,extreal_of_num_def,extreal_le_def]
-  >> `f x < 4 pow n / 2 pow n` by METIS_TAC [lte_trans]
-  >> `4 pow n / 2 pow n = 2 pow n` by RW_TAC std_ss [extreal_pow_def,extreal_div_eq,extreal_of_num_def,GSYM REAL_POW_DIV,EVAL ``4/2:real``]
-  >> METIS_TAC [extreal_lt_def]);
-
-(************************************************************************)
-(*** f(x) is either larger than 2 pow n or is inside some k interval ****)
-(************************************************************************)
-
-val lemma_fn_3 = prove (
-  ``!m f n x. x IN m_space m /\ 0 <= f x ==>
-             (2 pow n <= f x) \/
-             (?k. k IN count (4 ** n) /\ &k / 2 pow n <= f x /\ f x < (&k + 1) / 2 pow n)``,
- (* proof *)
-  RW_TAC real_ss [IN_COUNT]
-  >> Cases_on `2 pow n <= f x`
-  >- RW_TAC std_ss []
-  >> `f x < 2 pow n` by FULL_SIMP_TAC std_ss [extreal_lt_def]
-  >> `f x <> PosInf` by METIS_TAC [extreal_of_num_def,extreal_pow_def,extreal_not_infty,lt_infty,lt_trans]
-  >> `f x <> NegInf` by METIS_TAC [lt_infty,lte_trans,extreal_of_num_def,extreal_not_infty]
-  >> `?r. f x = Normal r` by METIS_TAC [extreal_cases]
-  >> `0:real < 2 pow n` by RW_TAC real_ss [REAL_POW_LT]
-  >> `0:real <> 2 pow n` by RW_TAC real_ss [REAL_LT_IMP_NE]
-  >> FULL_SIMP_TAC real_ss [extreal_of_num_def,extreal_pow_def,extreal_le_def,extreal_lt_eq,extreal_div_eq,extreal_add_def]
-  >> Q.EXISTS_TAC `flr (2 pow n * r)`
-  >> CONJ_TAC
-  >- (`2 pow n * r < 2 pow n * 2 pow n` by RW_TAC real_ss [REAL_LT_LMUL]
-    >> `2 pow n * 2 pow n = 4:real pow n` by RW_TAC real_ss [GSYM POW_MUL]
-    >> `0 <= 2 pow n * r` by RW_TAC real_ss [REAL_LT_LE_MUL]
-    >> `&(4 ** n) = 4:real pow n` by RW_TAC real_ss [GSYM REAL_OF_NUM_POW]
-    >> FULL_SIMP_TAC real_ss []
-    >> `&flr (2 pow n * r) <= 2 pow n * r` by RW_TAC real_ss [NUM_FLOOR_LE]
-    >> `&flr (2 pow n * r) < 4:real pow n` by METIS_TAC [REAL_LET_TRANS]
-    >> METIS_TAC [REAL_LT])
-  >> CONJ_TAC
-  >- (`0 <= 2 pow n * r` by RW_TAC real_ss [REAL_LT_LE_MUL]
-     >> `&flr (2 pow n * r) <= 2 pow n * r` by RW_TAC real_ss [NUM_FLOOR_LE]
-     >> `&flr (2 pow n * r) / 2 pow n <= 2 pow n * r / 2 pow n`
-        by RW_TAC real_ss [REAL_LE_LDIV_EQ,REAL_POS_NZ,REAL_DIV_RMUL]
-     >> METIS_TAC [REAL_EQ_LDIV_EQ,REAL_MUL_COMM])
-  >> `0 <= 2 pow n * r` by RW_TAC real_ss [REAL_LT_LE_MUL]
-  >> `2 pow n * r < &(flr (2 pow n * r) + 1)` by METIS_TAC [NUM_FLOOR_DIV_LOWERBOUND,REAL_LT_01,REAL_OVER1,REAL_MUL_RID]
-  >> `2 pow n * r / 2 pow n < &(flr (2 pow n * r) + 1) / 2 pow n`
-      by RW_TAC real_ss [REAL_LT_LDIV_EQ,REAL_POS_NZ,REAL_DIV_RMUL]
-  >> METIS_TAC [REAL_EQ_LDIV_EQ,REAL_MUL_COMM]);
-
-(*********************************)
-(*   fn_(x) = 0 outside m_space  *)
-(*********************************)
-
-val lemma_fn_4 = prove (
-  ``!m f n x. ~(x IN m_space m) ==> (fn_seq m f n x = 0)``,
-    RW_TAC real_ss [fn_seq_def,indicator_fn_def,GSPECIFICATION,mul_rzero,add_rzero]
- >> METIS_TAC [FINITE_COUNT,EXTREAL_SUM_IMAGE_ZERO]);
-
-(*********************************)
-(*       fn_(x) positive         *)
-(*********************************)
-
-Theorem lemma_fn_seq_positive :
-    !m f n x. 0 <= f x ==> (0 <= fn_seq m f n x)
-Proof
-    RW_TAC real_ss []
- >> `0:real < 2 pow n` by RW_TAC real_ss [REAL_POW_LT]
- >> `0:real <> 2 pow n` by RW_TAC real_ss [REAL_LT_IMP_NE]
- >> `0 < 2 pow n` by METIS_TAC [extreal_of_num_def,extreal_pow_def,extreal_lt_eq]
- >> Cases_on `~(x IN m_space m)`
- >- RW_TAC std_ss [lemma_fn_4,le_refl]
- >> FULL_SIMP_TAC std_ss []
- >> (MP_TAC o Q.SPECL [`m`,`f`,`n`,`x`]) lemma_fn_3
- >> RW_TAC real_ss []
- >- RW_TAC real_ss [lt_imp_le,lemma_fn_2]
- >> `fn_seq m f n x = &k / 2 pow n` by RW_TAC real_ss [lemma_fn_1]
- >> ASM_SIMP_TAC std_ss []
- >> RW_TAC std_ss [extreal_of_num_def,extreal_pow_def,extreal_div_eq,extreal_le_def]
- >> MATCH_MP_TAC REAL_LE_DIV
- >> RW_TAC real_ss [REAL_POW_LT,REAL_LT_IMP_LE]
-QED
-
-(*******************************************************************************)
-(*                        MONOTONICALLY INCREASING                             *)
-(*******************************************************************************)
-
-Theorem lemma_fn_seq_mono_increasing :
-    !m f x. 0 <= f x ==> mono_increasing (\n. fn_seq m f n x)
-Proof
-    RW_TAC std_ss [ext_mono_increasing_suc,ADD1]
- >> Cases_on `~(x IN m_space m)`
- >- RW_TAC real_ss [lemma_fn_4, le_refl]
- >> FULL_SIMP_TAC std_ss []
- >> `!n x k. x IN m_space m /\ (k IN count (4 ** n)) /\
-            (&k / 2 pow n <= f x /\ f x < (&k + 1) / 2 pow n) ==> (fn_seq m f n x = &k / 2 pow n)`
-      by RW_TAC std_ss [lemma_fn_1]
- >> `!n x. x IN m_space m /\ 2 pow n <= f x ==> (fn_seq m f n x = 2 pow n)`
-      by RW_TAC std_ss [lemma_fn_2]
- >> `!n. 0:real < 2 pow n` by RW_TAC real_ss [REAL_POW_LT]
- >> `!n. 0:real <> 2 pow n` by RW_TAC real_ss [REAL_LT_IMP_NE]
- >> `!n k. k IN count (4 ** (n + 1)) /\
-          (&k / 2 pow (n + 1) <= f x /\ f x < (&k + 1) / 2 pow (n + 1)) ==>
-          (fn_seq m f n x <= fn_seq m f (n + 1) x)`
-      by (RW_TAC real_ss [] \\
-         `fn_seq m f (n + 1) x = &k / (2 pow (n + 1))` by RW_TAC real_ss [] \\
-         `f x <> NegInf` by METIS_TAC [lt_infty, lte_trans, extreal_of_num_def, extreal_not_infty] \\
-         `f x <> PosInf` by METIS_TAC [extreal_of_num_def, extreal_pow_def, extreal_not_infty,
-                                       lt_infty, lt_trans] \\
-         `?r. f x = Normal r` by METIS_TAC [extreal_cases] \\
-         `0:real <> 2 pow (n + 1)` by RW_TAC real_ss [] \\
-          FULL_SIMP_TAC std_ss [extreal_of_num_def, extreal_pow_def, extreal_div_eq, extreal_add_def,
-                                extreal_mul_def, extreal_le_def, extreal_lt_eq] \\
-         `&(k + 1) / (2 pow (n + 1)):real = (&(k + 1) / 2) / (2 pow (n + 1) / 2)`
-             by RW_TAC real_ss [REAL_DIV_DENOM_CANCEL] \\
-         `2 pow (n + 1) / 2 = (2 pow n):real`
-             by (RW_TAC std_ss [GSYM ADD1, pow] \\
-                 RW_TAC real_ss [REAL_EQ_LDIV_EQ, REAL_MUL_COMM]) \\
-         `&k / 2 pow (n + 1) = (&k / 2) / (2 pow (n + 1) / 2):real`
-             by RW_TAC real_ss [REAL_DIV_DENOM_CANCEL] \\
-          FULL_SIMP_TAC std_ss [] \\
-          STRUCT_CASES_TAC (Q.SPEC `k` EVEN_OR_ODD)
-          >- (FULL_SIMP_TAC std_ss [EVEN_EXISTS] \\
-              FULL_SIMP_TAC real_ss [] \\
-             `&k / 2:real = &m'` by RW_TAC real_ss [REAL_EQ_LDIV_EQ] \\
-             `&(2 * m' + 1):real < &(2 * m' + 2)` by RW_TAC real_ss [] \\
-             `&(2 * m' + 1) / 2:real < &(2 * m' + 2) / 2` by RW_TAC real_ss [REAL_LT_RDIV] \\
-             `&(2 * m' + 1) / 2 / (2 pow n):real < &(2 * m' + 2) / 2 / 2 pow n`
-                 by RW_TAC real_ss [REAL_LT_RDIV] \\
-             `&(2 * m' + 2) / 2 = &(m'+1):real`
-                 by RW_TAC real_ss [REAL_EQ_LDIV_EQ, REAL_ADD_LDISTRIB] \\
-             `r < &(m' + 1) / 2 pow n` by METIS_TAC [REAL_LT_TRANS] \\
-             `&(2 * m') / 2 / 2 pow n = &m' / (2 pow n):real` by METIS_TAC [] \\
-              FULL_SIMP_TAC real_ss [] \\
-              Cases_on `m' IN count (4 ** n)`
-              >- (`fn_seq m f n x = Normal (&m' / 2 pow n)`
-                     by METIS_TAC [extreal_le_def, extreal_lt_eq] \\
-                  RW_TAC std_ss [le_refl]) \\
-              FULL_SIMP_TAC real_ss [IN_COUNT, NOT_LESS] \\
-             `4:real pow n <= &m'` by RW_TAC real_ss [REAL_OF_NUM_POW] \\
-             `4:real pow n / 2 pow n <= &m' / 2 pow n`
-                 by RW_TAC real_ss [REAL_LE_LDIV_EQ, REAL_POS_NZ, REAL_DIV_RMUL] \\
-             `2 pow n <= r` by METIS_TAC [REAL_LE_TRANS, REAL_POW_DIV, EVAL ``4/2:real``] \\
-             `fn_seq m f n x = Normal (2 pow n)` by METIS_TAC [extreal_le_def, extreal_lt_eq] \\
-             `(2 pow n):real <= &m' / 2 pow n` by METIS_TAC [REAL_POW_DIV,EVAL ``4/2:real``] \\
-             `&(2*m')/2 = &m':real` by RW_TAC real_ss [] \\
-              RW_TAC std_ss [extreal_le_def]) \\
-          FULL_SIMP_TAC std_ss [ODD_EXISTS] \\
-         `(k - 1) < k` by RW_TAC real_ss [] \\
-         `&(k - 1) / 2 < (&k) / 2:real` by RW_TAC real_ss [REAL_LT_LDIV_EQ, REAL_DIV_RMUL] \\
-         `&(k - 1) / 2 / 2 pow n < (&k) / 2 / (2 pow n):real`
-             by RW_TAC real_ss [REAL_LT_LDIV_EQ, REAL_DIV_RMUL, REAL_POS_NZ] \\
-         `&(k - 1) / 2 / 2 pow n <= r` by METIS_TAC [REAL_LTE_TRANS, REAL_LT_IMP_LE] \\
-         `&(k - 1):real = 2 * &m'` by RW_TAC real_ss [] \\
-         `!x. 2 * x / 2 = x:real` by RW_TAC real_ss [REAL_EQ_LDIV_EQ, REAL_MUL_COMM] \\
-         `&m' / (2 pow n) <= r` by METIS_TAC [REAL_MUL] \\
-         `&(k + 1):real = 2 * (&m' + 1)` by RW_TAC real_ss [] \\
-          FULL_SIMP_TAC real_ss [] \\
-         `r < &(m' + 1) / (2 pow n)` by METIS_TAC [REAL_MUL, REAL_ADD] \\
-          Cases_on `m' IN count (4 ** n)`
-          >- (Q.PAT_X_ASSUM `!n x k. Q` (MP_TAC o Q.SPECL [`n`,`x`, `m'`]) \\
-              RW_TAC std_ss [extreal_le_def, extreal_lt_eq] \\
-             `&(2 * m'):real <= &SUC (2*m')` by RW_TAC real_ss [] \\
-             `&(2 * m') / 2:real <= &SUC (2 * m') / 2`
-                 by RW_TAC real_ss [REAL_LE_LDIV_EQ, REAL_DIV_RMUL] \\
-             `&(2 * m') / 2 / 2 pow n <= &SUC (2 * m') / 2 / (2 pow n):real`
-                 by RW_TAC real_ss [REAL_LE_LDIV_EQ, REAL_DIV_RMUL, REAL_POS_NZ] \\
-             `&(2 * m') / 2:real = &m'` by RW_TAC real_ss [REAL_EQ_LDIV_EQ] \\
-              FULL_SIMP_TAC real_ss [REAL_LE_TRANS]) \\
-          FULL_SIMP_TAC real_ss [IN_COUNT, NOT_LESS] \\
-         `4 pow n <= &m':real` by RW_TAC real_ss [REAL_OF_NUM_POW] \\
-         `4:real pow n / 2 pow n <= &m' / 2 pow n`
-             by RW_TAC real_ss [REAL_LE_LDIV_EQ, REAL_POS_NZ, REAL_DIV_RMUL] \\
-         `&(k - 1):real = 2 * &m'` by RW_TAC real_ss [] \\
-         `&m' < &k / 2:real` by METIS_TAC [] \\
-         `&m' / (2 pow n):real  < &k / 2 / 2 pow n`
-             by RW_TAC real_ss [REAL_LT_LDIV_EQ, REAL_POS_NZ, REAL_DIV_RMUL] \\
-         `2 pow n <= r`
-             by METIS_TAC [REAL_POW_DIV, EVAL ``4/2:real``, REAL_LET_TRANS,
-                           REAL_LTE_TRANS, REAL_LT_IMP_LE] \\
-         `fn_seq m f n x = Normal (2 pow n)` by METIS_TAC [extreal_le_def, extreal_lt_eq] \\
-         `2 pow n <= &m' / (2 pow n):real` by METIS_TAC [REAL_POW_DIV, EVAL ``4/2:real``] \\
-         `&(2 * m'):real <= &SUC (2 * m')` by RW_TAC real_ss [] \\
-         `&(2 * m') / 2:real <= &SUC (2 * m') / 2`
-             by RW_TAC real_ss [REAL_LE_LDIV_EQ, REAL_DIV_RMUL] \\
-         `&(2 * m') / 2 / 2 pow n <= &SUC (2 * m') / 2 / (2 pow n):real`
-             by RW_TAC real_ss [REAL_LE_LDIV_EQ, REAL_DIV_RMUL, REAL_POS_NZ] \\
-         `&(2 * m') / 2:real = &m'` by RW_TAC real_ss [REAL_EQ_LDIV_EQ] \\
-          METIS_TAC [REAL_LE_TRANS, extreal_le_def])
- >> `!n. 2 pow (n + 1) <= f x ==> (fn_seq m f n x <= fn_seq m f (n + 1) x)`
-       by (RW_TAC real_ss [] \\
-          `2:real pow n < 2 pow (n + 1)` by RW_TAC real_ss [REAL_POW_MONO_LT] \\
-          `2 pow n < 2 pow (n + 1)`
-             by METIS_TAC [extreal_pow_def, extreal_of_num_def, extreal_lt_eq] \\
-           METIS_TAC [extreal_le_def, extreal_lt_eq, lte_trans, lt_imp_le])
- >> (MP_TAC o Q.SPECL [`m`,`f`,`n + 1`,`x`]) lemma_fn_3
- >> RW_TAC std_ss []
- >- RW_TAC std_ss []
- >> METIS_TAC []
-QED
-
-(*******************************************************************************)
-(*                            UPPER BOUNDED BY f                               *)
-(*******************************************************************************)
-
-Theorem lemma_fn_seq_upper_bounded[local] :
-    !m f n x. 0 <= f x ==> (fn_seq m f n x <= f x)
-Proof
-    RW_TAC std_ss []
- >> Cases_on `~(x IN m_space m)` >- RW_TAC real_ss [lemma_fn_4]
- >> FULL_SIMP_TAC std_ss []
- >> (MP_TAC o Q.SPECL [`m`,`f`,`n`,`x`]) lemma_fn_3
- >> RW_TAC real_ss []
- >- METIS_TAC [lemma_fn_2,le_refl]
- >> `fn_seq m f n x =  &k / 2 pow n` by RW_TAC real_ss [lemma_fn_1]
- >> RW_TAC std_ss []
-QED
-
-(*******************************************************************************)
-(*                            f Supremum of fn_seq                             *)
-(*******************************************************************************)
-
-Theorem lemma_fn_seq_sup :
-    !m f x. x IN m_space m /\ 0 <= f x ==>
-            (sup (IMAGE (\n. fn_seq m f n x) UNIV) = f x)
-Proof
-     RW_TAC std_ss []
-  >> Cases_on `f x = PosInf`
-  >- (`!n:num. fn_seq m f n x = 2 pow n` by METIS_TAC [le_infty,lemma_fn_2]
-      >> RW_TAC std_ss [sup_eq,le_infty]
-      >> `!n. 2 pow n <= y`
-            by (RW_TAC std_ss []
-                >> POP_ASSUM MATCH_MP_TAC
-                >> ONCE_REWRITE_TAC [GSYM SPECIFICATION]
-                >> RW_TAC std_ss [IN_IMAGE,IN_UNIV]
-                >> METIS_TAC [])
-      >> SPOSE_NOT_THEN ASSUME_TAC
-      >> METIS_TAC [EXTREAL_ARCH_POW2, extreal_lt_def])
-  >> `!n.  fn_seq m f n x <= f x` by METIS_TAC [lemma_fn_seq_upper_bounded]
-  >> `?r. f x = Normal r` by METIS_TAC [extreal_cases,lt_infty,lte_trans,extreal_of_num_def]
-  >> `!n. fn_seq m f n x <> PosInf` by METIS_TAC [lt_infty,let_trans]
-  >> `!n. fn_seq m f n x <> NegInf`
-        by METIS_TAC [lt_infty,lte_trans,lemma_fn_seq_positive,extreal_of_num_def]
-  >> `?r. !n. fn_seq m f n x = Normal (r n)`
-         by (Q.EXISTS_TAC `\n. @r. fn_seq m f n x = Normal r`
-             >> GEN_TAC >> RW_TAC std_ss []
-             >> SELECT_ELIM_TAC
-                >> RW_TAC std_ss []
-             >> METIS_TAC [extreal_cases])
-  >> `?N. f x < 2 pow N` by RW_TAC std_ss [EXTREAL_ARCH_POW2]
-  >> `!p n. p <= n ==> 2 pow p <= 2 pow n` by METIS_TAC [pow_le_mono,EVAL ``1<=2``]
-  >> `!n. N <= n ==> f x < 2 pow n` by METIS_TAC [lte_trans]
-  >> `!n. N <= n ==> ?k. k IN count (4 ** n) /\ &k / 2 pow n <= f x /\ f x < (&k + 1) / 2 pow n`
-       by METIS_TAC [lemma_fn_3,extreal_lt_def]
-  >> `!n. 0:real < 2 pow n` by RW_TAC real_ss [REAL_POW_LT]
-  >> `!n. 0:real <> 2 pow n` by RW_TAC real_ss [REAL_LT_IMP_NE]
-  >> `!n k. &k / 2 pow n = Normal (&k / 2 pow n)`
-       by METIS_TAC [extreal_of_num_def,extreal_pow_def,extreal_div_eq]
-  >> `!n z. Normal z / 2 pow n = Normal (z / 2 pow n)`
-       by METIS_TAC [extreal_pow_def,extreal_div_eq,extreal_of_num_def]
-  >> `!n. N <= n ==> (f x - 1 / 2 pow n < fn_seq m f n x)`
-       by (RW_TAC real_ss []
-            >> `?k. k IN count (4 ** n) /\ &k / 2 pow n <= f x /\ f x < (&k + 1) / 2 pow n` by METIS_TAC []
-            >> `fn_seq m f n x = &k / 2 pow n` by METIS_TAC [lemma_fn_1]
-            >> `Normal (&k + 1) / Normal (2 pow n) = Normal ((&k + 1) / (2 pow n))`
-                by METIS_TAC [extreal_div_eq]
-            >> `Normal r < Normal ((&k + 1) /  (2 pow n))`
-                by METIS_TAC [extreal_pow_def,extreal_of_num_def,extreal_add_def]
-            >> FULL_SIMP_TAC std_ss [extreal_lt_eq,GSYM REAL_DIV_ADD,extreal_pow_def,extreal_sub_def,
-                                     extreal_of_num_def,extreal_div_eq,extreal_lt_eq,REAL_LT_SUB_RADD]
-            >> `r' n = &k / 2 pow n` by METIS_TAC [extreal_div_eq,extreal_11]
-            >> FULL_SIMP_TAC std_ss [])
-  >> FULL_SIMP_TAC std_ss []
-  >> `!n. N <= n ==> (r - 1 / 2 pow n < r' n)`
-        by (FULL_SIMP_TAC std_ss [extreal_le_def,extreal_lt_eq,extreal_of_num_def,extreal_pow_def,
-                                  extreal_div_eq,extreal_add_def]
-            >> RW_TAC std_ss []
-            >> METIS_TAC [extreal_sub_def,extreal_lt_eq])
-  >> `mono_increasing (\n. fn_seq m f n x)` by METIS_TAC [lemma_fn_seq_mono_increasing]
-  >> `mono_increasing r'`
-        by (FULL_SIMP_TAC std_ss [ext_mono_increasing_def,mono_increasing_def] \\
-            METIS_TAC [extreal_le_def])
-  >> FULL_SIMP_TAC std_ss [extreal_le_def,extreal_lt_eq,extreal_of_num_def,extreal_pow_def,
-                           extreal_div_eq,extreal_add_def,extreal_sub_def,extreal_not_infty]
-  >> RW_TAC std_ss [GSYM sup_seq,SEQ,GREATER_EQ]
-  >> `!n. 1:real / 2 pow n = (1 / 2) pow n` by RW_TAC real_ss [POW_ONE,REAL_POW_DIV]
-  >> `!n. r' n < r + 1 / 2 pow n`
-       by METIS_TAC [POW_HALF_POS,REAL_LT_ADDR,REAL_LET_TRANS,REAL_LT_IMP_LE]
-  >> `!n. N <= n ==> (abs (r' n - r) < 1 / 2 pow n)` by METIS_TAC [ABS_BETWEEN,POW_HALF_POS]
-  >> `?N1. (1 / 2) pow N1 < e:real` by RW_TAC std_ss [POW_HALF_SMALL]
-  >> `!n. N1 <= n ==> ((1 / 2:real) pow n <= (1 / 2) pow N1)` by RW_TAC std_ss [POW_HALF_MONO]
-  >> `!n. N1 <= n ==> ((1 / 2:real) pow n < e)` by METIS_TAC [REAL_LET_TRANS]
-  >> Q.EXISTS_TAC `N + N1`
-  >> RW_TAC real_ss []
-  >> `N <= N + N1` by RW_TAC std_ss [LESS_EQ_ADD]
-  >> `N1 <= N + N1` by RW_TAC std_ss [LESS_EQ_ADD]
-  >> `N <= n /\ N1 <= n` by METIS_TAC [LESS_EQ_TRANS]
-  >> METIS_TAC [REAL_LT_TRANS]
-QED
-
-(*******************************************************************************)
-(*          SEQ Positive Simple Functions and Define Integral                  *)
-(*******************************************************************************)
-
+(* SEQ Positive Simple Functions and Define Integral *)
 Theorem lemma_fn_seq_measurable:
     !m f n. measure_space m /\ (!x. x IN m_space m ==> 0 <= f x) /\
             f IN measurable (m_space m,measurable_sets m) Borel ==>
@@ -2987,7 +2609,8 @@ Proof
                               f x < (&k + 1) / 2 pow n} x) (count (4 ** n))’,
                   ‘\x. 2 pow n *
                        indicator_fn {x | x IN m_space m /\ 2 pow n <= f x} x’]
- >> ‘sigma_algebra (m_space m,measurable_sets m)’ by FULL_SIMP_TAC std_ss [measure_space_def]
+ >> ‘sigma_algebra (m_space m,measurable_sets m)’
+       by FULL_SIMP_TAC std_ss [measure_space_def]
  >> ASM_SIMP_TAC std_ss []
  >> CONJ_TAC
  >- (MATCH_MP_TAC (INST_TYPE [“:'b” |-> “:num”] IN_MEASURABLE_BOREL_SUM) \\
@@ -3000,7 +2623,8 @@ Proof
      reverse CONJ_TAC
      >- (rpt GEN_TAC >> STRIP_TAC \\
          rename1 ‘&i / 2 pow n * indicator_fn s x’ \\
-        ‘?r. indicator_fn s x = Normal r’ by METIS_TAC [indicator_fn_normal] >> POP_ORW \\
+        ‘?r. indicator_fn s x = Normal r’
+           by METIS_TAC [indicator_fn_normal] >> POP_ORW \\
         ‘!n. 0:real < 2 pow n’ by RW_TAC real_ss [REAL_POW_LT] \\
         ‘!n. 0:real <> 2 pow n’ by RW_TAC real_ss [REAL_LT_IMP_NE] \\
         ‘!n k. &k / 2 pow n = Normal (&k / 2 pow n)’
@@ -4180,31 +3804,6 @@ Proof
  >> METIS_TAC [IN_psfis_eq, psfis_add, pos_fn_integral_pos_simple_fn]
 QED
 
-Theorem pos_fn_integral_add3 :
-    !m f g h. measure_space m /\
-             (!x. x IN m_space m ==> 0 <= f x) /\
-             (!x. x IN m_space m ==> 0 <= g x) /\
-             (!x. x IN m_space m ==> 0 <= h x) /\
-              f IN measurable (m_space m,measurable_sets m) Borel /\
-              g IN measurable (m_space m,measurable_sets m) Borel /\
-              h IN measurable (m_space m,measurable_sets m) Borel
-          ==> pos_fn_integral m (\x. f x + g x + h x) =
-              pos_fn_integral m f + pos_fn_integral m g + pos_fn_integral m h
-Proof
-    rpt STRIP_TAC
- >> Know ‘pos_fn_integral m (\x. f x + g x + h x) =
-          pos_fn_integral m (\x. f x + g x) +
-          pos_fn_integral m h’
- >- (HO_MATCH_MP_TAC pos_fn_integral_add >> rw [le_add] \\
-     MATCH_MP_TAC IN_MEASURABLE_BOREL_ADD' \\
-     qexistsl_tac [‘f’, ‘g’] >> rw [] \\
-     fs [measure_space_def])
- >> Rewr'
- >> Suff ‘pos_fn_integral m (\x. f x + g x) =
-          pos_fn_integral m f + pos_fn_integral m g’ >- rw []
- >> MATCH_MP_TAC pos_fn_integral_add >> art []
-QED
-
 (* added ‘x IN m_space m’. used by martingaleTheory.EXISTENCE_OF_PROD_MEASURE *)
 Theorem pos_fn_integral_sub :
     !m f g. measure_space m /\
@@ -4566,7 +4165,6 @@ Proof
  >> MATCH_MP_TAC pos_fn_integral_mono >> art []
 QED
 
-(* cf. lebesgue_monotone_convergence_subset *)
 Theorem lebesgue_monotone_convergence_decreasing' :
     !m f fi A. measure_space m /\
         (!i. fi i IN measurable (m_space m, measurable_sets m) Borel) /\
@@ -7431,6 +7029,38 @@ Proof
  >> METIS_TAC [countably_additive_alt_eq, space_def, subsets_def]
 QED
 
+Definition distr_of : (* was: distr *)
+    distr_of M N (f :'a -> 'b) =
+     (m_space N, measurable_sets N,
+      \s. if s IN measurable_sets N then measure M (PREIMAGE f s INTER m_space M)
+          else 0)
+End
+
+Theorem distr_of_alt_distr :
+    !M N f. distr_of M N f =
+           (m_space N, measurable_sets N,
+            \s. if s IN measurable_sets N then distr M f s else 0)
+Proof
+    rw [distr_of, distr_def]
+QED
+
+(* NOTE: new proof by measure_space_distr *)
+Theorem measure_space_distr_of :
+    !M N f. measure_space M /\ measure_space N /\
+            f IN measurable (measurable_space M) (measurable_space N) ==>
+            measure_space (distr_of M N f)
+Proof
+    rw [distr_of_alt_distr]
+ >> MATCH_MP_TAC measure_space_eq
+ >> Q.EXISTS_TAC ‘(m_space N,measurable_sets N,distr M f)’
+ >> simp [m_space_def, measurable_sets_def, measure_def]
+ >> qabbrev_tac ‘B = measurable_space N’
+ >> ‘m_space N = space B’ by rw [Abbr ‘B’] >> POP_ORW
+ >> ‘measurable_sets N = subsets B’ by rw [Abbr ‘B’] >> POP_ORW
+ >> MATCH_MP_TAC measure_space_distr
+ >> rw [Abbr ‘B’, MEASURE_SPACE_SIGMA_ALGEBRA]
+QED
+
 (* Proposition 11.5 [1, p.91]
 
    NOTE: "markov_ineq" in real_lebesgueTheory is a variant [1, p.93] that we shall
@@ -7457,7 +7087,8 @@ Proof
          Q.EXISTS_TAC `f` >> RW_TAC std_ss [o_DEF, space_def] \\
          fs [measure_space_def]) \\
      DISCH_THEN (STRIP_ASSUME_TAC o
-                 (SIMP_RULE std_ss [measurable_def, GSPECIFICATION, space_def, subsets_def])) \\
+                 (SIMP_RULE std_ss [measurable_def, GSPECIFICATION, space_def,
+                                    subsets_def])) \\
      FIRST_X_ASSUM MATCH_MP_TAC \\
      REWRITE_TAC [BOREL_MEASURABLE_SETS_CR])
  >> DISCH_TAC
@@ -7475,23 +7106,29 @@ Proof
  >- (MATCH_MP_TAC EQ_SYM \\
      MATCH_MP_TAC integral_indicator >> art []) >> Rewr'
  >> REWRITE_TAC [INDICATOR_FN_INTER]
- >> Know `integral m (\t. indicator_fn {x | c <= abs (f x)} t * indicator_fn a t) =
-          integral m (\t. inv c * (c * indicator_fn {x | c <= abs (f x)} t * indicator_fn a t))`
+ >> Know ‘integral m (\t. indicator_fn {x | c <= abs (f x)} t * indicator_fn a t) =
+          integral m
+            (\t. inv c *
+                 (c * indicator_fn {x | c <= abs (f x)} t * indicator_fn a t))’
  >- (REWRITE_TAC [mul_assoc] \\
      `inv c * c = 1` by PROVE_TAC [mul_linv_pos] >> POP_ORW \\
      REWRITE_TAC [mul_lone]) >> Rewr'
  >> `c <> NegInf` by PROVE_TAC [pos_not_neginf, lt_imp_le]
  >> Cases_on `c` >> fs [extreal_of_num_def, extreal_lt_eq]
  >> `r <> 0` by PROVE_TAC [REAL_LT_LE]
- >> `inv (Normal r) = Normal (inv r)` by ASM_SIMP_TAC std_ss [extreal_inv_def] >> POP_ORW
+ >> `inv (Normal r) = Normal (inv r)`
+       by ASM_SIMP_TAC std_ss [extreal_inv_def] >> POP_ORW
  (* before further moves, we must convert all `integral`s into `pos_fn_intergral`s *)
  >> `0 <= inv r` by PROVE_TAC [REAL_LT_IMP_LE, REAL_LE_INV]
- >> Know `integral m (\t. Normal (inv r) *
-                         (Normal r * indicator_fn {x | Normal r <= abs (f x)} t * indicator_fn a t)) =
-   pos_fn_integral m (\t. Normal (inv r) *
-                         (Normal r * indicator_fn {x | Normal r <= abs (f x)} t * indicator_fn a t))`
- >- (MATCH_MP_TAC integral_pos_fn >> art [] \\
-     RW_TAC std_ss [] \\
+ >> Know ‘integral m
+            (\t. Normal (inv r) *
+                (Normal r * indicator_fn {x | Normal r <= abs (f x)} t *
+                 indicator_fn a t)) =
+          pos_fn_integral m
+            (\t. Normal (inv r) *
+                (Normal r * indicator_fn {x | Normal r <= abs (f x)} t *
+                 indicator_fn a t))’
+ >- (MATCH_MP_TAC integral_pos_fn >> RW_TAC std_ss [] \\
      MATCH_MP_TAC le_mul >> CONJ_TAC >- art [extreal_of_num_def, extreal_le_eq] \\
      MATCH_MP_TAC le_mul >> reverse CONJ_TAC >- REWRITE_TAC [INDICATOR_FN_POS] \\
      MATCH_MP_TAC le_mul >> reverse CONJ_TAC >- REWRITE_TAC [INDICATOR_FN_POS] \\
@@ -7503,11 +7140,14 @@ Proof
      RW_TAC std_ss [] \\
      MATCH_MP_TAC le_mul >> reverse CONJ_TAC >- REWRITE_TAC [INDICATOR_FN_POS] \\
      REWRITE_TAC [abs_pos]) >> Rewr'
- >> Know `pos_fn_integral m (\x. Normal (inv r) *
-                                (\t. Normal r * indicator_fn {x | Normal r <= abs (f x)} t
-                                     * indicator_fn a t) x) =
-          Normal (inv r) * pos_fn_integral m (\t. Normal r * indicator_fn {x | Normal r <= abs (f x)} t
-                                                  * indicator_fn a t)`
+ >> Know ‘pos_fn_integral m
+            (\x. Normal (inv r) *
+                (\t. Normal r * indicator_fn {x | Normal r <= abs (f x)} t *
+                 indicator_fn a t) x) =
+          Normal (inv r) *
+          pos_fn_integral m
+            (\t. Normal r * indicator_fn {x | Normal r <= abs (f x)} t *
+                 indicator_fn a t)’
  >- (MATCH_MP_TAC pos_fn_integral_cmul >> art [] \\
      RW_TAC std_ss [] \\
      MATCH_MP_TAC le_mul >> reverse CONJ_TAC >- REWRITE_TAC [INDICATOR_FN_POS] \\
@@ -7518,8 +7158,10 @@ Proof
  >> CONJ_TAC >- art [extreal_of_num_def, extreal_le_eq]
  (* now the core of proof: a smart application of `le_trans` *)
  >> MATCH_MP_TAC le_trans
- >> Q.EXISTS_TAC `pos_fn_integral m
-                    (\t. abs (f t) * indicator_fn {x | Normal r <= abs (f x)} t * indicator_fn a t)`
+ >> Q.EXISTS_TAC
+     ‘pos_fn_integral m
+        (\t. abs (f t) * indicator_fn {x | Normal r <= abs (f x)} t *
+             indicator_fn a t)’
  >> CONJ_TAC
  >- (MATCH_MP_TAC pos_fn_integral_mono \\
      RW_TAC std_ss []
@@ -7531,7 +7173,8 @@ Proof
      >- (REWRITE_TAC [GSYM mul_assoc] \\
          MATCH_MP_TAC le_rmul_imp >> art [] \\
          MATCH_MP_TAC le_mul >> REWRITE_TAC [INDICATOR_FN_POS]) \\
-     ASM_SIMP_TAC std_ss [indicator_fn_def, GSPECIFICATION, mul_lzero, mul_rzero, le_refl])
+     ASM_SIMP_TAC std_ss [indicator_fn_def, GSPECIFICATION, mul_lzero, mul_rzero,
+                          le_refl])
  >> MATCH_MP_TAC pos_fn_integral_mono
  >> RW_TAC std_ss []
  >- (MATCH_MP_TAC le_mul >> reverse CONJ_TAC >- REWRITE_TAC [INDICATOR_FN_POS] \\
@@ -7545,21 +7188,24 @@ Proof
  >> REWRITE_TAC [abs_pos, INDICATOR_FN_LE_1]
 QED
 
-(* The special version with `a = m_space m`, the part `INTER m_space m` cannot be removed,
-   because in general the PREIMAGE of f may go outside of `m_space m`, even it's integrable.
+(* The special version with `a = m_space m`, the part `INTER m_space m` cannot be
+   removed, because in general the PREIMAGE of f may go outside of `m_space m`,
+   even it's integrable.
  *)
-Theorem markov_ineq : (* cf. real_lebesgueTheory.markov_ineq *)
+Theorem markov_ineq :
     !m f c. measure_space m /\ integrable m f /\ 0 < c ==>
-            measure m ({x | c <= abs (f x)} INTER m_space m) <= inv c * integral m (abs o f)
+            measure m ({x | c <= abs (f x)} INTER m_space m) <=
+            inv c * integral m (abs o f)
 Proof
     RW_TAC std_ss [o_DEF]
  >> MP_TAC (Q.SPECL [`m`, `f`, `m_space m`, `c`] markov_inequality)
  >> Know `m_space m IN measurable_sets m`
  >- (MATCH_MP_TAC (REWRITE_RULE [space_def, subsets_def]
-                                (Q.SPEC `(m_space m,measurable_sets m)` ALGEBRA_SPACE)) \\
+                    (Q.SPEC ‘(m_space m,measurable_sets m)’ ALGEBRA_SPACE)) \\
      fs [measure_space_def, sigma_algebra_def])
  >> RW_TAC std_ss []
- >> Know `integral m (\x. abs (f x)) = integral m (\t. (\x. abs (f x)) t * indicator_fn (m_space m) t)`
+ >> Know ‘integral m (\x. abs (f x)) =
+          integral m (\t. (\x. abs (f x)) t * indicator_fn (m_space m) t)’
  >- (MATCH_MP_TAC integral_mspace >> art [])
  >> BETA_TAC >> Rewr' >> art []
 QED
@@ -7891,7 +7537,8 @@ QED
 Theorem pos_fn_integral_eq_0 : (* was: positive_integral_0_iff *)
     !m f. measure_space m /\ (!x. x IN m_space m ==> 0 <= f x) /\
           f IN measurable (m_space m, measurable_sets m) Borel ==>
-        ((pos_fn_integral m f = 0) <=> (measure m {x | x IN m_space m /\ f x <> 0} = 0))
+        ((pos_fn_integral m f = 0) <=>
+         (measure m {x | x IN m_space m /\ f x <> 0} = 0))
 Proof
     rpt STRIP_TAC
  >> MP_TAC (Q.SPECL [`m`, `f`] integral_abs_eq_0)
@@ -8411,218 +8058,6 @@ Proof
   METIS_TAC [le_mul]
 QED
 
-Theorem pos_fn_integral_density :
-    !m f g. measure_space m /\
-            f IN measurable (m_space m, measurable_sets m) Borel /\
-            g IN measurable (m_space m, measurable_sets m) Borel /\
-           (AE x::m. 0 <= f x) /\ (!x. 0 <= g x)
-       ==> (pos_fn_integral (density m (fn_plus f)) g =
-            pos_fn_integral m (\x. (fn_plus f) x * g x))
-Proof
-    rpt STRIP_TAC
- >> MP_TAC (Q.SPECL [`f`, `g`, `m`] pos_fn_integral_density')
- >> RW_TAC std_ss [GSYM density_fn_plus]
- >> Know `(\x. max 0 (g x)) = g`
- >- (RW_TAC std_ss [FUN_EQ_THM, GSYM fn_plus] \\
-     Suff `fn_plus g = g` >- rw [] \\
-     MATCH_MP_TAC nonneg_fn_plus >> rw [nonneg_def])
- >> DISCH_THEN (fs o wrap)
- >> POP_ASSUM K_TAC
- >> Suff `!x. max 0 ((\x. f x * g x) x) = (fn_plus f) x * g x` >- rw []
- >> GEN_TAC >> REWRITE_TAC [GSYM fn_plus]
- >> ONCE_REWRITE_TAC [mul_comm]
- >> ASM_SIMP_TAC std_ss [FN_PLUS_FMUL]
-QED
-
-(* ------------------------------------------------------------------------- *)
-(*  Preliminary for Radon-Nikodym Theorem                                    *)
-(* ------------------------------------------------------------------------- *)
-
-Definition seq_sup_def :
-   (seq_sup P 0       = @r. r IN P /\ sup P < r + 1) /\
-   (seq_sup P (SUC n) = @r. r IN P /\ sup P < r + Normal ((1 / 2) pow (SUC n)) /\
-                           (seq_sup P n) < r /\ r < sup P)
-End
-
-Theorem EXTREAL_SUP_SEQ :
-   !P. (?x. P x) /\ (?z. z <> PosInf /\ !x. P x ==> x <= z) ==>
-        ?x. (!n. x n IN P) /\ (!n. x n <= x (SUC n)) /\ (sup (IMAGE x UNIV) = sup P)
-Proof
-  RW_TAC std_ss []
-  >> Cases_on `?z. P z /\ (z = sup P)`
-  >- (Q.EXISTS_TAC `(\i. sup P)`
-      >> RW_TAC std_ss [le_refl,SPECIFICATION]
-      >> `IMAGE (\i:num. sup P) UNIV = (\i. i = sup P)`
-           by RW_TAC std_ss [EXTENSION,IN_IMAGE,IN_UNIV,IN_ABS]
-      >> RW_TAC std_ss [sup_const])
-  >> Cases_on `!x. P x ==> (x = NegInf)`
-  >- (`sup P = NegInf` by METIS_TAC [sup_const_alt]
-      >> Q.EXISTS_TAC `(\n. NegInf)`
-      >> FULL_SIMP_TAC std_ss [le_refl]
-      >> RW_TAC std_ss []
-      >- METIS_TAC []
-      >> METIS_TAC [UNIV_NOT_EMPTY,sup_const_over_set])
-  >> FULL_SIMP_TAC std_ss []
-  >> Q.EXISTS_TAC `seq_sup P`
-  >> FULL_SIMP_TAC std_ss []
-  >> `sup P <> PosInf` by METIS_TAC [sup_le,lt_infty,let_trans]
-  >> `!x. P x ==> x < sup P` by METIS_TAC [lt_le,le_sup_imp]
-  >> `!e. 0 < e ==> ?x. P x /\ sup P < x + e`
-       by (RW_TAC std_ss [] >> MATCH_MP_TAC sup_lt_epsilon >> METIS_TAC [])
-  >> `!n. 0:real < (1 / 2) pow n` by METIS_TAC [HALF_POS,REAL_POW_LT]
-  >> `!n. 0 < Normal ((1 / 2) pow n)` by METIS_TAC [extreal_lt_eq,extreal_of_num_def]
-  >> `!n. seq_sup P n IN P`
-      by (Induct
-          >- (RW_TAC std_ss [seq_sup_def]
-              >> SELECT_ELIM_TAC
-              >> RW_TAC std_ss []
-              >> METIS_TAC [lt_01,SPECIFICATION])
-          >> RW_TAC std_ss [seq_sup_def]
-          >> SELECT_ELIM_TAC
-          >> RW_TAC std_ss []
-          >> `?x. P x /\ seq_sup P n < x` by METIS_TAC [sup_lt,SPECIFICATION]
-          >> rename1 `seq_sup P n < x2`
-          >> `?x. P x /\ sup P < x + Normal ((1 / 2) pow (SUC n))` by METIS_TAC []
-          >> rename1 `sup P < x3 + _`
-          >> Q.EXISTS_TAC `max x2 x3`
-          >> RW_TAC std_ss [extreal_max_def,SPECIFICATION]
-          >- (`x3 < x2` by FULL_SIMP_TAC std_ss [GSYM extreal_lt_def]
-              >> `x3 +  Normal ((1 / 2) pow (SUC n)) <= x2 +  Normal ((1 / 2) pow (SUC n))`
-                  by METIS_TAC [lt_radd,lt_le,extreal_not_infty]
-              >> METIS_TAC [lte_trans])
-          >> METIS_TAC [lte_trans])
-  >> `!n. seq_sup P n <= seq_sup P (SUC n)`
-      by (RW_TAC std_ss [seq_sup_def]
-          >> SELECT_ELIM_TAC
-          >> RW_TAC std_ss []
-          >- (`?x. P x /\ seq_sup P n < x` by METIS_TAC [sup_lt,SPECIFICATION]
-              >> rename1 `sup_sup P n < x2`
-              >> `?x. P x /\ sup P < x + Normal ((1 / 2) pow (SUC n))` by METIS_TAC []
-              >> rename1 `sup P < x3 + _`
-              >> Q.EXISTS_TAC `max x2 x3`
-              >> RW_TAC std_ss [extreal_max_def,SPECIFICATION]
-              >- (`x3 < x2` by FULL_SIMP_TAC std_ss [GSYM extreal_lt_def]
-                  >> `x3 + Normal ((1 / 2) pow (SUC n)) <= x2 + Normal ((1 / 2) pow (SUC n))`
-                      by METIS_TAC [lt_radd,lt_le,extreal_not_infty]
-                  >> METIS_TAC [lte_trans])
-              >> METIS_TAC [lte_trans])
-          >> METIS_TAC [lt_le])
-  >> RW_TAC std_ss []
-  >> `!n. sup P <= seq_sup P n + Normal ((1 / 2) pow n)`
-      by (Induct
-          >- (RW_TAC std_ss [seq_sup_def,pow,GSYM extreal_of_num_def]
-              >> SELECT_ELIM_TAC
-              >> RW_TAC std_ss []
-              >- METIS_TAC [lt_01,SPECIFICATION]
-              >> METIS_TAC [lt_le])
-          >> RW_TAC std_ss [seq_sup_def]
-          >> SELECT_ELIM_TAC
-          >> RW_TAC std_ss []
-          >- (`?x. P x /\ seq_sup P n < x` by METIS_TAC [sup_lt,SPECIFICATION]
-              >> rename1 `sup_sup P n < x2`
-              >> `?x. P x /\ sup P < x + Normal ((1 / 2) pow (SUC n))` by METIS_TAC []
-              >> rename1 `sup P < x3 + _`
-              >> Q.EXISTS_TAC `max x2 x3`
-              >> RW_TAC std_ss [extreal_max_def,SPECIFICATION]
-              >- (`x3 < x2` by FULL_SIMP_TAC std_ss [GSYM extreal_lt_def]
-                  >> `x3 + Normal ((1 / 2) pow (SUC n)) <= x2 + Normal ((1 / 2) pow (SUC n))`
-                      by METIS_TAC [lt_radd,lt_le,extreal_not_infty]
-                  >> METIS_TAC [lte_trans])
-              >> METIS_TAC [lte_trans])
-          >> METIS_TAC [lt_le])
-  >> RW_TAC std_ss [sup_eq]
-  >- (POP_ASSUM (MP_TAC o ONCE_REWRITE_RULE [GSYM SPECIFICATION])
-      >> RW_TAC std_ss [IN_IMAGE,IN_UNIV]
-      >> METIS_TAC [SPECIFICATION,lt_le])
-  >> MATCH_MP_TAC le_epsilon
-  >> RW_TAC std_ss []
-  >> `e <> NegInf` by METIS_TAC [lt_infty,extreal_of_num_def,lt_trans]
-  >> `?r. e = Normal r` by METIS_TAC [extreal_cases]
-  >> FULL_SIMP_TAC std_ss []
-  >> `?n. Normal ((1 / 2) pow n) < Normal r` by METIS_TAC [EXTREAL_ARCH_POW2_INV]
-  >> MATCH_MP_TAC le_trans
-  >> Q.EXISTS_TAC `seq_sup P n + Normal ((1 / 2) pow n)`
-  >> RW_TAC std_ss []
-  >> MATCH_MP_TAC le_add2
-  >> FULL_SIMP_TAC std_ss [lt_le]
-  >> Q.PAT_X_ASSUM `!z. IMAGE (seq_sup P) UNIV z ==> z <= y` MATCH_MP_TAC
-  >> ONCE_REWRITE_TAC [GSYM SPECIFICATION]
-  >> RW_TAC std_ss [IN_UNIV,IN_IMAGE]
-  >> METIS_TAC []
-QED
-
-Theorem EXTREAL_SUP_FUN_SEQ_IMAGE :
-    !(P:extreal->bool) (P':('a->extreal)->bool) f.
-       (?x. P x) /\ (?z. z <> PosInf /\ !x. P x ==> x <= z) /\ (P = IMAGE f P')
-           ==> ?g. (!n:num. g n IN P') /\
-                   (sup (IMAGE (\n. f (g n)) UNIV) = sup P)
-Proof
-  rpt STRIP_TAC
-  >> `?y. (!n. y n IN P) /\ (!n. y n <= y (SUC n)) /\ (sup (IMAGE y UNIV) = sup P)`
-     by METIS_TAC [EXTREAL_SUP_SEQ]
-  >> Q.EXISTS_TAC `(\n. @r. (r IN P') /\ (f r  = y n))`
-  >> `(\n. f (@(r :'a -> extreal). r IN (P' :('a -> extreal) -> bool) /\
-                                  ((f :('a -> extreal) -> extreal) r = (y :num -> extreal) n))) = y`
-  by (rw [FUN_EQ_THM] >> SELECT_ELIM_TAC
-      >> RW_TAC std_ss []
-      >> METIS_TAC [IN_IMAGE])
-  >> ASM_SIMP_TAC std_ss []
-  >> RW_TAC std_ss []
-  >> SELECT_ELIM_TAC
-  >> RW_TAC std_ss []
-  >> METIS_TAC [IN_IMAGE]
-QED
-
-Theorem EXTREAL_SUP_FUN_SEQ_MONO_IMAGE :
-    !f (P :extreal->bool) (P' :('a->extreal)->bool).
-       (?x. P x) /\ (?z. z <> PosInf /\ !x. P x ==> x <= z) /\ (P = IMAGE f P') /\
-       (!g1 g2. (g1 IN P' /\ g2 IN P' /\ (!x. g1 x <= g2 x))  ==> f g1 <= f g2) /\
-       (!g1 g2. g1 IN P' /\ g2 IN P' ==> (\x. max (g1 x) (g2 x)) IN P')
-      ==>
-       ?g. (!n. g n IN P') /\ (!x n. g n x <= g (SUC n) x) /\
-           (sup (IMAGE (\n. f (g n)) UNIV) = sup P)
-Proof
-    rpt STRIP_TAC
-  >> `?g. (!n:num. g n IN P') /\ (sup (IMAGE (\n. f (g n)) UNIV) = sup P)`
-      by METIS_TAC [EXTREAL_SUP_FUN_SEQ_IMAGE]
-  >> Q.EXISTS_TAC `max_fn_seq g`
-  >> `!n. max_fn_seq g n IN P'`
-      by (Induct
-          >- (`max_fn_seq g 0 = g 0` by RW_TAC std_ss [FUN_EQ_THM,max_fn_seq_def]
-              >> METIS_TAC [])
-              >> `max_fn_seq g (SUC n) = (\x. max (max_fn_seq g n x) (g (SUC n) x))`
-                  by RW_TAC std_ss [FUN_EQ_THM,max_fn_seq_def]
-              >> RW_TAC std_ss []
-              >> METIS_TAC [])
-  >> `!g n x. max_fn_seq g n x <= max_fn_seq g (SUC n) x`
-      by RW_TAC real_ss [max_fn_seq_def,extreal_max_def,le_refl]
-  >> CONJ_TAC >- RW_TAC std_ss []
-  >> CONJ_TAC >- RW_TAC std_ss []
-  >> `!n. (!x. g n x <= max_fn_seq g n x)`
-      by (Induct >- RW_TAC std_ss [max_fn_seq_def,le_refl]
-          >> METIS_TAC [le_max2,max_fn_seq_def])
-  >> `!n. f (g n) <= f (max_fn_seq g n)` by METIS_TAC []
-  >> `sup (IMAGE (\n. f (g n)) UNIV) <= sup (IMAGE (\n. f (max_fn_seq g n)) UNIV)`
-      by (MATCH_MP_TAC sup_le_sup_imp
-          >> RW_TAC std_ss []
-          >> POP_ASSUM (MP_TAC o ONCE_REWRITE_RULE [GSYM SPECIFICATION])
-          >> RW_TAC std_ss [IN_IMAGE,IN_UNIV]
-          >> Q.EXISTS_TAC `f (max_fn_seq g n)`
-          >> RW_TAC std_ss []
-          >> ONCE_REWRITE_TAC [GSYM SPECIFICATION]
-          >> RW_TAC std_ss [IN_IMAGE,IN_UNIV]
-          >> METIS_TAC [])
-  >> `sup (IMAGE (\n. f (max_fn_seq g n)) UNIV) <= sup P`
-      by (RW_TAC std_ss [sup_le]
-          >> POP_ASSUM (MP_TAC o ONCE_REWRITE_RULE [GSYM SPECIFICATION])
-          >> RW_TAC std_ss [IN_IMAGE,IN_UNIV]
-          >> MATCH_MP_TAC le_sup_imp
-          >> ONCE_REWRITE_TAC [GSYM SPECIFICATION]
-          >> RW_TAC std_ss [IN_IMAGE]
-          >> METIS_TAC [])
-  >> METIS_TAC [le_antisym]
-QED
-
 (**********************************************************)
 (*  Radon-Nikodym Theorem                                 *)
 (**********************************************************)
@@ -9081,34 +8516,32 @@ val RN_lemma2 = Q.prove (
            >> METIS_TAC [])
  >> METIS_TAC [le_neg]);
 
-(* NOTE: the resulting function ‘f’ is total, i.e. ‘!x. 0 <= f x’, usually more than
-         what's needed (!x. x IN m_space m ==> 0 <= f x) in RN_deriv_def
- *)
 Theorem Radon_Nikodym_finite : (* was: Radon_Nikodym *)
     !M N. measure_space M /\ measure_space N /\
-         (m_space M = m_space N) /\ (measurable_sets M = measurable_sets N) /\
+          measurable_sets M = measurable_sets N /\
           measure M (m_space M) <> PosInf /\
           measure N (m_space N) <> PosInf /\
           measure_absolutely_continuous (measure N) M ==>
-      ?f. f IN measurable (m_space M,measurable_sets M) Borel /\
-          (!x. 0 <= f x) /\
-          !A. A IN measurable_sets M ==>
-             (pos_fn_integral M (\x. f x * indicator_fn A x) = measure N A)
+         ?f. f IN measurable (m_space M,measurable_sets M) Borel /\
+            (!x. 0 <= f x) /\
+             !A. A IN measurable_sets M ==>
+                 pos_fn_integral M (\x. f x * indicator_fn A x) = measure N A
 Proof
     qx_genl_tac [`m`, `v`] >> rpt STRIP_TAC
- >> Q.PAT_X_ASSUM `m_space m = m_space v` (ASSUME_TAC o SYM)
+ >> ‘m_space v = m_space m’ by PROVE_TAC [sets_eq_imp_space_eq]
  >> Q.PAT_X_ASSUM `measurable_sets m = measurable_sets v` (ASSUME_TAC o SYM)
  >> `?f_n. (!n. f_n n IN RADON_F m v) /\ (!x n. f_n n x <= f_n (SUC n) x) /\
-           (sup (IMAGE (\n. pos_fn_integral m (f_n n)) univ(:num)) = sup (RADON_F_integrals m v))`
+           (sup (IMAGE (\n. pos_fn_integral m (f_n n)) univ(:num)) =
+            sup (RADON_F_integrals m v))`
        by RW_TAC std_ss [lemma_radon_seq_conv_sup]
  >> Q.ABBREV_TAC `g = (\x. sup (IMAGE (\n. f_n n x) UNIV))`
  >> Q.EXISTS_TAC `g`
  >> `g IN measurable (m_space m,measurable_sets m) Borel`
        by (MATCH_MP_TAC IN_MEASURABLE_BOREL_MONO_SUP
            >> Q.EXISTS_TAC `f_n`
-           >> FULL_SIMP_TAC std_ss [RADON_F_def, GSPECIFICATION, measure_space_def, space_def]
-           >> Q.UNABBREV_TAC `g`
-           >> RW_TAC std_ss [])
+           >> FULL_SIMP_TAC std_ss [RADON_F_def, GSPECIFICATION, measure_space_def,
+                                    space_def]
+           >> RW_TAC std_ss [Abbr ‘g’])
  >> Know `!x. 0 <= g x`
  >- (RW_TAC std_ss [Abbr ‘g’, le_sup'] \\
      MATCH_MP_TAC le_trans >> Q.EXISTS_TAC `f_n 0 x` \\
@@ -9122,9 +8555,9 @@ Proof
           sup (IMAGE (\n. pos_fn_integral m (\x. f_n n x * indicator_fn A x)) UNIV))`
        by (RW_TAC std_ss []
            >> MATCH_MP_TAC lebesgue_monotone_convergence_subset
-           >> FULL_SIMP_TAC std_ss [RADON_F_def, GSPECIFICATION, ext_mono_increasing_suc]
-           >> RW_TAC std_ss []
-           >> Q.UNABBREV_TAC `g`
+           >> FULL_SIMP_TAC std_ss [RADON_F_def, GSPECIFICATION,
+                                    ext_mono_increasing_suc]
+           >> RW_TAC std_ss [Abbr ‘g’]
            >> METIS_TAC [])
  >> `g IN RADON_F m v`
        by (FULL_SIMP_TAC std_ss [RADON_F_def,GSPECIFICATION,sup_le]
@@ -9138,7 +8571,8 @@ Proof
            >> Q.UNABBREV_TAC `g`
            >> METIS_TAC [])
  >> `pos_fn_integral m g = sup (RADON_F_integrals m v)` by FULL_SIMP_TAC std_ss []
- >> Q.ABBREV_TAC `nu = (\A. measure v A - pos_fn_integral m (\x. g x * indicator_fn A x))`
+ >> Q.ABBREV_TAC
+     `nu = (\A. measure v A - pos_fn_integral m (\x. g x * indicator_fn A x))`
  >> `!A. A IN measurable_sets m ==>
          pos_fn_integral m (\x. g x * indicator_fn A x) <= measure v A`
        by FULL_SIMP_TAC std_ss [RADON_F_def, GSPECIFICATION]
@@ -9150,7 +8584,8 @@ Proof
                      MEASURE_SPACE_SUBSET_MSPACE, MEASURE_SPACE_MSPACE_MEASURABLE]
  >> `!A x. 0 <= (\x. g x * indicator_fn A x) x`
        by RW_TAC std_ss [indicator_fn_def, mul_rzero, mul_rone, le_01, le_refl]
- >> `!A. A IN measurable_sets m ==> 0 <= pos_fn_integral m (\x. g x * indicator_fn A x)`
+ >> `!A. A IN measurable_sets m ==>
+         0 <= pos_fn_integral m (\x. g x * indicator_fn A x)`
        by (REPEAT STRIP_TAC >> MATCH_MP_TAC pos_fn_integral_pos >> METIS_TAC [])
  >> `!A. A IN measurable_sets m ==>
          pos_fn_integral m (\x. g x * indicator_fn A x) <> NegInf`
@@ -9208,7 +8643,8 @@ Proof
                 by (RW_TAC std_ss [] \\
                     METIS_TAC [IN_MEASURABLE_BOREL_MUL_INDICATOR, IN_FUNSET,
                                IN_UNIV, measurable_sets_def, subsets_def])
-           >> (MP_TAC o Q.SPECL [`m`,`(\i:num. (\x. g x * indicator_fn (f i) x))`]) pos_fn_integral_suminf
+           >> (MP_TAC o Q.SPECL [`m`,`(\i:num. (\x. g x * indicator_fn (f i) x))`])
+                                pos_fn_integral_suminf
            >> RW_TAC std_ss []
            >> POP_ASSUM (MP_TAC o GSYM)
            >> RW_TAC std_ss []
@@ -9216,15 +8652,18 @@ Proof
                     (\x'. suminf (\x. g x' * indicator_fn (f x) x'))`
            >- RW_TAC std_ss []
            >> RW_TAC std_ss [FUN_EQ_THM]
-           >> `suminf (\x. g x' * (\x. indicator_fn (f x) x') x) = g x' * suminf (\x. indicator_fn (f x) x')`
+           >> `suminf (\x. g x' * (\x. indicator_fn (f x) x') x) =
+               g x' * suminf (\x. indicator_fn (f x) x')`
                 by (MATCH_MP_TAC ext_suminf_cmul \\
                     RW_TAC std_ss [mul_rone,mul_rzero,le_refl,indicator_fn_def,le_01])
            >> FULL_SIMP_TAC std_ss []
-           >> Suff `suminf (\i. indicator_fn (f i) x') = indicator_fn (BIGUNION (IMAGE f univ(:num))) x'`
+           >> Suff `suminf (\i. indicator_fn (f i) x') =
+                    indicator_fn (BIGUNION (IMAGE f univ(:num))) x'`
            >- RW_TAC std_ss []
            >> FULL_SIMP_TAC std_ss [indicator_fn_suminf])
  >> `!A. A IN measurable_sets m ==> nu A <= nu (m_space m)`
-       by METIS_TAC [MEASURE_SPACE_INCREASING, INCREASING, MEASURE_SPACE_SUBSET_MSPACE,
+       by METIS_TAC [MEASURE_SPACE_INCREASING, INCREASING,
+                     MEASURE_SPACE_SUBSET_MSPACE,
                      measure_def, measurable_sets_def, m_space_def,
                      MEASURE_SPACE_MSPACE_MEASURABLE]
  >> Cases_on `nu A = 0` >- METIS_TAC [sub_0]
@@ -9233,7 +8672,8 @@ Proof
  >> `0 <> measure m (m_space m)`
        by (SPOSE_NOT_THEN ASSUME_TAC
            >> `measure v (m_space m) = 0`
-                 by METIS_TAC [MEASURE_SPACE_MSPACE_MEASURABLE, measure_absolutely_continuous_def]
+                 by METIS_TAC [MEASURE_SPACE_MSPACE_MEASURABLE,
+                               measure_absolutely_continuous_def]
            >> `pos_fn_integral m (\x. g x * indicator_fn (m_space m) x) <= 0`
                  by METIS_TAC [MEASURE_SPACE_MSPACE_MEASURABLE]
            >> `pos_fn_integral m (\x. g x * indicator_fn (m_space m) x) =  0`
@@ -9241,7 +8681,8 @@ Proof
            >> `nu (m_space m) = 0` by (Q.UNABBREV_TAC `nu` >> METIS_TAC [sub_rzero])
            >> METIS_TAC [lt_imp_ne])
  >> `0 < measure m (m_space m)`
-       by METIS_TAC [lt_le, MEASURE_SPACE_POSITIVE, positive_def, MEASURE_SPACE_MSPACE_MEASURABLE]
+       by METIS_TAC [lt_le, MEASURE_SPACE_POSITIVE, positive_def,
+                     MEASURE_SPACE_MSPACE_MEASURABLE]
  >> Q.ABBREV_TAC `z = nu (m_space m) / (2 * measure m (m_space m)) `
  >> `nu (m_space m) <> NegInf` by METIS_TAC [lt_trans, lt_infty, num_not_infty]
  >> `measure m (m_space m) <> NegInf` by METIS_TAC [lt_trans, lt_infty, num_not_infty]
@@ -9269,7 +8710,8 @@ Proof
                        `(m_space m, measurable_sets m, (\A. Normal e * measure m A))`]
                       RN_lemma2) \\
            RW_TAC std_ss [m_space_def, measurable_sets_def, measure_def] \\
-           METIS_TAC [MEASURE_SPACE_CMUL, REAL_LT_IMP_LE, mul_not_infty, extreal_not_infty])
+           METIS_TAC [MEASURE_SPACE_CMUL, REAL_LT_IMP_LE, mul_not_infty,
+                      extreal_not_infty])
  >> Q.ABBREV_TAC `g' = (\x. g x + Normal e * indicator_fn (A') x)`
  >> `!A. A IN measurable_sets m ==>
          pos_fn_integral m (\x. g' x * indicator_fn A x) =
@@ -9384,14 +8826,15 @@ Proof
           `0 < r1` by METIS_TAC [extreal_of_num_def,extreal_lt_eq] \\
           `0 < r2` by METIS_TAC [extreal_of_num_def,extreal_lt_eq] \\
           `0 < 2 * r2` by RW_TAC real_ss [REAL_LT_MUL] \\
-          `Normal e = nu (m_space m) / (2 * measure m (m_space m))` by RW_TAC std_ss [] \\
-           POP_ORW \\
+          `Normal e = nu (m_space m) / (2 * measure m (m_space m))`
+             by RW_TAC std_ss [] >> POP_ORW \\
            REWRITE_TAC [extreal_of_num_def] \\
            FULL_SIMP_TAC std_ss [extreal_mul_def, extreal_div_eq, REAL_LT_IMP_NE,
                                  extreal_sub_def, extreal_lt_eq] \\
            RW_TAC real_ss [real_div, REAL_INV_MUL, REAL_LT_IMP_NE, REAL_MUL_ASSOC] \\
           `inv 2 * inv r2 * r2 = inv 2`
-             by METIS_TAC [REAL_LT_IMP_NE, REAL_MUL_LINV, REAL_MUL_ASSOC, REAL_MUL_RID] \\
+             by METIS_TAC [REAL_LT_IMP_NE, REAL_MUL_LINV, REAL_MUL_ASSOC,
+                           REAL_MUL_RID] \\
           `r1 - r1 * inv 2 * inv r2 * r2 = r1 / 2`
              by METIS_TAC [REAL_NEG_HALF, real_div, REAL_MUL_ASSOC] \\
            FULL_SIMP_TAC real_ss [REAL_LT_DIV])
@@ -9411,7 +8854,8 @@ Proof
              by METIS_TAC [MEASURE_SPACE_MSPACE_MEASURABLE,
                            measure_absolutely_continuous_def] \\
           `pos_fn_integral m (\x. g x * indicator_fn A' x) <= 0` by METIS_TAC [] \\
-          `pos_fn_integral m (\x. g x * indicator_fn A' x) =  0` by METIS_TAC [le_antisym] \\
+          `pos_fn_integral m (\x. g x * indicator_fn A' x) =  0`
+             by METIS_TAC [le_antisym] \\
           `nu A' = 0` by (Q.UNABBREV_TAC `nu` >> METIS_TAC [sub_rzero]) \\
            METIS_TAC [lt_imp_ne])
  >> `0 < measure m A'`
@@ -9492,7 +8936,9 @@ Proof
     ALL_TAC] THEN
    GEN_TAC THEN
    SIMP_TAC std_ss [indicator_fn_def] THEN COND_CASES_TAC THEN
-   SIMP_TAC real_ss [le_refl, extreal_of_num_def, extreal_le_def] ) THEN
+   SIMP_TAC real_ss [le_refl, extreal_of_num_def, extreal_le_def]
+ (* end of Suff *)
+  ) THEN
   Q.UNABBREV_TAC `m` THEN
   FULL_SIMP_TAC std_ss [measure_space_def, m_space_def, measurable_sets_def] THEN
   CONJ_TAC THENL
@@ -9502,24 +8948,28 @@ Proof
    GEN_TAC THEN STRIP_TAC THEN MATCH_MP_TAC pos_fn_integral_pos THEN
    FULL_SIMP_TAC std_ss [measure_space_def] THEN GEN_TAC THEN
    REPEAT COND_CASES_TAC THEN
-   SIMP_TAC real_ss [le_refl, extreal_of_num_def, extreal_le_def, mul_rone, mul_rzero],
+   SIMP_TAC real_ss [le_refl, extreal_of_num_def, extreal_le_def, mul_rone,
+                     mul_rzero],
    ALL_TAC] THEN
   SIMP_TAC std_ss [countably_additive_alt_eq, INDICATOR_FN_MUL_INTER] THEN
   REPEAT STRIP_TAC THEN SIMP_TAC std_ss [o_DEF] THEN
   `!x. A x IN measurable_sets M` by ASM_SET_TAC [] THEN
   ASM_SIMP_TAC std_ss [INTER_BIGUNION, GSPECIFICATION, IN_UNIV] THEN
-  REWRITE_TAC [SET_RULE ``{s INTER x | ?i'. x = A i'} = {s INTER A i' | i' IN UNIV}``] THEN
+  REWRITE_TAC
+    [SET_RULE ``{s INTER x | ?i'. x = A i'} = {s INTER A i' | i' IN UNIV}``] THEN
   SIMP_TAC std_ss [GSYM IMAGE_DEF] THEN
   Suff `!x. indicator_fn (BIGUNION (IMAGE (\i'. s INTER A i') univ(:num))) x =
    suminf (\j. indicator_fn ((\i'. s INTER A i') j) x)` THENL
   [DISCH_TAC THEN ASM_SIMP_TAC std_ss [],
-   GEN_TAC THEN ONCE_REWRITE_TAC [EQ_SYM_EQ] THEN MATCH_MP_TAC indicator_fn_suminf THEN
+   GEN_TAC THEN ONCE_REWRITE_TAC [EQ_SYM_EQ] THEN
+   MATCH_MP_TAC indicator_fn_suminf THEN
   FULL_SIMP_TAC std_ss [disjoint_family_on, DISJOINT_DEF] THEN
   ASM_SET_TAC []] THEN ONCE_REWRITE_TAC [METIS [ETA_AX]
-   ``(\x'. indicator_fn (s INTER A x) x') = (\x. indicator_fn (s INTER A x)) x``] THEN
+    “(\x'. indicator_fn (s INTER A x) x') = (\x. indicator_fn (s INTER A x)) x”] THEN
   ONCE_REWRITE_TAC [METIS [] ``suminf (\j. indicator_fn (s INTER A j) x) =
                        suminf (\j. (\k. indicator_fn (s INTER A k)) j x)``] THEN
-  MATCH_MP_TAC pos_fn_integral_suminf THEN ASM_SIMP_TAC std_ss [measure_space_def] THEN
+  MATCH_MP_TAC pos_fn_integral_suminf THEN
+  ASM_SIMP_TAC std_ss [measure_space_def] THEN
   CONJ_TAC THENL
   [SIMP_TAC std_ss [indicator_fn_def] THEN REPEAT GEN_TAC THEN COND_CASES_TAC THEN
    SIMP_TAC real_ss [le_refl, extreal_of_num_def, extreal_le_def], ALL_TAC] THEN
@@ -9538,568 +8988,8 @@ val measure_density_indicator = save_thm
   ("measure_density_indicator",
     REWRITE_RULE [GSYM density_def, GSYM density_measure_def] measure_restricted);
 
-(* NOTE: changed the universal quantifier ‘I’ to ‘J’ *)
-Theorem measure_subadditive_finite :
-   !J A M. measure_space M /\ FINITE J /\
-           IMAGE A J SUBSET measurable_sets M ==>
-           measure M (BIGUNION {A i | (i:num) IN J}) <=
-           SIGMA (\i. measure M (A i)) J
-Proof
-  RW_TAC std_ss [] THEN NTAC 2 (POP_ASSUM MP_TAC) THEN
-  qid_spec_tac ‘J’ THEN SET_INDUCT_TAC THEN1
-  (SIMP_TAC std_ss [EXTREAL_SUM_IMAGE_EMPTY, NOT_IN_EMPTY] THEN
-   REWRITE_TAC [SET_RULE ``{A i | i | F} = {}``] THEN
-   FULL_SIMP_TAC std_ss [BIGUNION_EMPTY, measure_space_def, positive_def] THEN
-   SIMP_TAC std_ss [le_refl]) THEN
-  REWRITE_TAC [SET_RULE ``BIGUNION {A i | i IN e INSERT s} =
-                          BIGUNION {A i | i IN s} UNION A e``] THEN
-  DISCH_TAC THEN MATCH_MP_TAC le_trans THEN
-  Q.EXISTS_TAC `measure M (BIGUNION {A i | i IN s}) + measure M (A e)` THEN
-  CONJ_TAC THEN1
-  (Know `measure M (BIGUNION {A i | i IN s} UNION A e) =
-         measure M (BIGUNION {A i | i IN s}) +
-         measure M (A e DIFF BIGUNION {A i | i IN s})` THEN1
-   (MATCH_MP_TAC ADDITIVE THEN
-    ASM_SIMP_TAC std_ss [MEASURE_SPACE_ADDITIVE] THEN
-    REPEAT CONJ_TAC THENL (* 5 subgoals *)
-    [(* goal 1 (of 5) *)
-     ONCE_REWRITE_TAC [METIS [subsets_def]
-     ``measurable_sets m = subsets (m_space m, measurable_sets m)``] THEN
-     MATCH_MP_TAC SIGMA_ALGEBRA_COUNTABLE_UNION THEN
-     FULL_SIMP_TAC std_ss [measure_space_def] THEN
-     CONJ_TAC >- (SIMP_TAC std_ss [GSYM IMAGE_DEF] THEN
-      MATCH_MP_TAC image_countable THEN
-      SIMP_TAC std_ss [pred_setTheory.COUNTABLE_NUM]) THEN
-     SIMP_TAC std_ss [GSYM IMAGE_DEF, SUBSET_DEF, IN_IMAGE, subsets_def, GSPECIFICATION] THEN
-     GEN_TAC THEN STRIP_TAC THEN ASM_REWRITE_TAC [] THEN ASM_SET_TAC [],
-     (* goal 2 (of 5) *)
-     ONCE_REWRITE_TAC [METIS [subsets_def]
-       ``measurable_sets m = subsets (m_space m, measurable_sets m)``] THEN
-     MATCH_MP_TAC ALGEBRA_DIFF THEN
-     FULL_SIMP_TAC std_ss [measure_space_def, sigma_algebra_def] THEN
-     SIMP_TAC std_ss [subsets_def] THEN CONJ_TAC THENL [ASM_SET_TAC [], ALL_TAC] THEN
-     ONCE_REWRITE_TAC [METIS [subsets_def]
-       ``measurable_sets m = subsets (m_space m, measurable_sets m)``] THEN
-     MATCH_MP_TAC SIGMA_ALGEBRA_COUNTABLE_UNION THEN
-     FULL_SIMP_TAC std_ss [sigma_algebra_def] THEN
-     CONJ_TAC THENL [SIMP_TAC std_ss [GSYM IMAGE_DEF] THEN
-       MATCH_MP_TAC image_countable THEN
-       SIMP_TAC std_ss [pred_setTheory.COUNTABLE_NUM], ALL_TAC] THEN
-     SIMP_TAC std_ss [GSYM IMAGE_DEF, SUBSET_DEF, IN_IMAGE, subsets_def, GSPECIFICATION] THEN
-     GEN_TAC THEN STRIP_TAC THEN ASM_REWRITE_TAC [] THEN ASM_SET_TAC [],
-     (* goal 3 of 5) *)
-     ASM_SIMP_TAC std_ss [DISJOINT_DEF] THEN SET_TAC [],
-     (* goal 4 of 5) *)
-     FULL_SIMP_TAC std_ss [IMAGE_INSERT] \\
-    `A e IN measurable_sets M` by ASM_SET_TAC [] \\
-    `IMAGE A s SUBSET measurable_sets M` by ASM_SET_TAC [] \\
-     ONCE_REWRITE_TAC [METIS [subsets_def]
-       ``measurable_sets m = subsets (m_space m, measurable_sets m)``] \\
-     MATCH_MP_TAC ALGEBRA_UNION \\
-     FULL_SIMP_TAC std_ss [measure_space_def, sigma_algebra_def] \\
-    `{A i | i IN s} = IMAGE A s` by SET_TAC [] >> POP_ORW \\
-     reverse CONJ_TAC >- FULL_SIMP_TAC std_ss [subsets_def] \\
-     MATCH_MP_TAC ALGEBRA_FINITE_UNION \\
-     FULL_SIMP_TAC std_ss [IMAGE_FINITE, subsets_def],
-     (* goal 5 of 5) *)
-     SET_TAC [] ]) THEN DISC_RW_KILL THEN
-   MATCH_MP_TAC le_ladd_imp THEN MATCH_MP_TAC INCREASING THEN
-   ASM_SIMP_TAC std_ss [MEASURE_SPACE_INCREASING] THEN
-   CONJ_TAC THENL [ASM_SET_TAC [], ALL_TAC] THEN
-   CONJ_TAC THENL [ALL_TAC, ASM_SET_TAC []] THEN
-   ONCE_REWRITE_TAC [METIS [subsets_def]
-    ``measurable_sets m = subsets (m_space m, measurable_sets m)``] THEN
-    MATCH_MP_TAC ALGEBRA_DIFF THEN
-    FULL_SIMP_TAC std_ss [measure_space_def, sigma_algebra_def] THEN
-    CONJ_TAC THENL [ASM_SET_TAC [subsets_def], ALL_TAC] THEN
-    MATCH_MP_TAC SIGMA_ALGEBRA_COUNTABLE_UNION THEN
-    FULL_SIMP_TAC std_ss [sigma_algebra_def] THEN
-    CONJ_TAC THENL [SIMP_TAC std_ss [GSYM IMAGE_DEF] THEN
-     MATCH_MP_TAC image_countable THEN
-     SIMP_TAC std_ss [pred_setTheory.COUNTABLE_NUM], ALL_TAC] THEN
-    SIMP_TAC std_ss [GSYM IMAGE_DEF, SUBSET_DEF, IN_IMAGE, subsets_def, GSPECIFICATION] THEN
-    GEN_TAC THEN STRIP_TAC THEN ASM_REWRITE_TAC [] THEN ASM_SET_TAC [] ) THEN
-   Suff `SIGMA (\i. measure M (A i)) (e INSERT s) =
-    SIGMA (\i. measure M (A i)) (s DELETE e) + (\i. measure M (A i)) e` THENL
-   [DISC_RW_KILL THEN SIMP_TAC std_ss [] THEN MATCH_MP_TAC le_radd_imp THEN
-    ASM_SIMP_TAC std_ss [SET_RULE ``e NOTIN s ==> (s DELETE e = s)``] THEN
-    FIRST_X_ASSUM MATCH_MP_TAC THEN ASM_SET_TAC [],
-    ALL_TAC] THEN
-   ASM_CASES_TAC ``!x:num. x IN e INSERT s ==> ((\i. measure M (A i)) x <> PosInf)`` THENL
-   [`(\i. measure M (A i)) e <> PosInf` by (FIRST_ASSUM MATCH_MP_TAC THEN ASM_SET_TAC []) THEN
-    `SIGMA (\i. measure M (A i)) (s DELETE e) <> PosInf`
-     by (MATCH_MP_TAC EXTREAL_SUM_IMAGE_NOT_POSINF THEN
-         ASM_SIMP_TAC std_ss [SET_RULE ``e NOTIN s ==> (s DELETE e = s)``] THEN
-         ASM_SET_TAC []) THEN
-    `SIGMA (\i. measure M (A i)) (s DELETE e) + (\i. measure M (A i)) e =
-     (\i. measure M (A i)) e + SIGMA (\i. measure M (A i)) (s DELETE e)`
-      by METIS_TAC [add_comm] THEN ONCE_ASM_REWRITE_TAC [] THEN
-    FIRST_ASSUM (ASSUME_TAC o MATCH_MP EXTREAL_SUM_IMAGE_PROPERTY_POS) THEN
-    POP_ASSUM MATCH_MP_TAC THEN FULL_SIMP_TAC std_ss [],
-    ALL_TAC] THEN FULL_SIMP_TAC std_ss [] THEN
-   Suff `!x. x IN s ==> (\i. measure M (A i)) x <= SIGMA (\i. measure M (A i)) s` THENL
-   [DISCH_TAC,
-    MATCH_MP_TAC EXTREAL_SUM_IMAGE_POS_MEM_LE THEN RW_TAC std_ss [] THEN
-    FIRST_ASSUM (ASSUME_TAC o MATCH_MP MEASURE_SPACE_POSITIVE) THEN
-    FULL_SIMP_TAC std_ss [positive_def] THEN FIRST_X_ASSUM MATCH_MP_TAC THEN
-    ASM_SET_TAC []] THEN
-   Suff `!x. x IN (e INSERT s) ==>
-    (\i. measure M (A i)) x <= SIGMA (\i. measure M (A i)) (e INSERT s)` THENL
-   [DISCH_TAC,
-    MATCH_MP_TAC EXTREAL_SUM_IMAGE_POS_MEM_LE THEN RW_TAC std_ss [FINITE_INSERT] THEN
-    FIRST_ASSUM (ASSUME_TAC o MATCH_MP MEASURE_SPACE_POSITIVE) THEN
-    FULL_SIMP_TAC std_ss [positive_def] THEN FIRST_X_ASSUM MATCH_MP_TAC THEN
-    ASM_SET_TAC []] THEN
-   POP_ASSUM (MP_TAC o Q.SPEC `x`) THEN ASM_SIMP_TAC std_ss [le_infty] THEN
-   DISCH_TAC THEN UNDISCH_TAC ``(x:num) IN e INSERT s`` THEN
-   Suff `SIGMA (\i. measure M (A i)) (s DELETE e) <> NegInf` THENL
-   [DISCH_TAC,
-    MATCH_MP_TAC EXTREAL_SUM_IMAGE_NOT_NEGINF THEN
-    ASM_SIMP_TAC std_ss [SET_RULE ``e NOTIN s ==> (s DELETE e = s)``] THEN
-    RW_TAC std_ss [lt_infty] THEN MATCH_MP_TAC lte_trans THEN
-    Q.EXISTS_TAC `0` THEN SIMP_TAC std_ss [GSYM lt_infty, num_not_infty] THEN
-    FIRST_ASSUM (ASSUME_TAC o MATCH_MP MEASURE_SPACE_POSITIVE) THEN
-    FULL_SIMP_TAC std_ss [positive_def] THEN FIRST_X_ASSUM MATCH_MP_TAC THEN
-    ASM_SET_TAC []] THEN
-   RW_TAC std_ss [INSERT_DEF, GSPECIFICATION] THENL
-   [ASM_REWRITE_TAC [] THEN
-    ASM_CASES_TAC ``SIGMA (\i:num. measure M (A i)) (s DELETE e) = PosInf`` THENL
-    [FULL_SIMP_TAC std_ss [extreal_add_def], ALL_TAC] THEN
-    METIS_TAC [normal_real, extreal_add_def],
-    ALL_TAC] THEN
-   FIRST_X_ASSUM (MP_TAC o Q.SPEC `x`) THEN ASM_SIMP_TAC std_ss [le_infty] THEN
-   ASM_SIMP_TAC std_ss [SET_RULE ``e NOTIN s ==> (s DELETE e = s)``] THEN
-   DISCH_TAC THEN Suff `measure M (A e) <> NegInf` THENL
-   [DISCH_TAC,
-    RW_TAC std_ss [lt_infty] THEN MATCH_MP_TAC lte_trans THEN
-    Q.EXISTS_TAC `0` THEN SIMP_TAC std_ss [GSYM lt_infty, num_not_infty] THEN
-    FIRST_ASSUM (ASSUME_TAC o MATCH_MP MEASURE_SPACE_POSITIVE) THEN
-    FULL_SIMP_TAC std_ss [positive_def] THEN FIRST_X_ASSUM MATCH_MP_TAC THEN
-    ASM_SET_TAC []] THEN
-   ASM_CASES_TAC ``measure M (A (e:num)) = PosInf`` THENL
-   [FULL_SIMP_TAC std_ss [extreal_add_def], ALL_TAC] THEN
-   METIS_TAC [normal_real, extreal_add_def]
-QED
-
-(* A0 and B (all djsjoint) are in measurable_sets M, together `m_space M`.
-
-  `measure N (B i) <> PosInf` although `measure N (m_space M) = PosInf`,
-   i.e. `m_space M` is splited with all infinite measures only in A0.
- *)
-Theorem split_space_into_finite_sets_and_rest[local] :
-    !M N. measure_space M /\ measure_space N /\
-         (m_space M = m_space N) /\ (measurable_sets M = measurable_sets N) /\
-          measure M (m_space M) <> PosInf /\
-          measure_absolutely_continuous (measure N) M ==>
-       ?A0 B. A0 IN measurable_sets M /\ disjoint_family B /\
-              IMAGE B univ(:num) SUBSET measurable_sets M /\
-             (A0 = m_space M DIFF BIGUNION {B i | i IN UNIV}) /\
-             (!A. A IN measurable_sets M /\ A SUBSET A0 ==>
-                  (((measure M A = 0) /\ (measure N A = 0)) \/
-                   (0 < measure M A /\ (measure N A = PosInf)))) /\
-             (!i. measure N (B i) <> PosInf)
-Proof
-  RW_TAC std_ss [] THEN
-  Q.ABBREV_TAC `Q = {x | x IN measurable_sets M /\ (measure N x <> PosInf)}` THEN
-  Q.ABBREV_TAC `a = sup {measure M x | x IN Q}` THEN
-  Know `{} IN Q`
-  >- (Q.UNABBREV_TAC `Q` >> RW_TAC std_ss [GSPECIFICATION] \\
-      FULL_SIMP_TAC std_ss [measure_space_def, positive_def, num_not_infty,
-                            sigma_algebra_alt_pow]) >> DISCH_TAC \\
-  `Q <> {}` by ASM_SET_TAC [] THEN
-  Know `a <= measure M (m_space M)`
-  >- (Q.UNABBREV_TAC `a` THEN REWRITE_TAC [sup_le'] THEN GEN_TAC THEN
-      SIMP_TAC std_ss [GSPECIFICATION] THEN RW_TAC std_ss [] THEN
-      MATCH_MP_TAC INCREASING THEN
-      ASM_SIMP_TAC std_ss [MEASURE_SPACE_MSPACE_MEASURABLE, MEASURE_SPACE_INCREASING] THEN
-      Q.UNABBREV_TAC `Q` THEN
-      REV_FULL_SIMP_TAC std_ss [GSPECIFICATION, MEASURE_SPACE_SUBSET_MSPACE])
-  THEN DISCH_TAC THEN
-  Know `a <> PosInf`
-  >- (Q.UNABBREV_TAC `a` THEN FULL_SIMP_TAC std_ss [lt_infty] THEN
-      MATCH_MP_TAC let_trans THEN Q.EXISTS_TAC `measure M (m_space M)` THEN
-      ASM_SIMP_TAC std_ss []) THEN DISCH_TAC THEN
-  Know `?Q''. IMAGE Q'' UNIV SUBSET IMAGE (measure M) Q /\
-             (a = sup {Q'' i | i IN univ(:num)})`
-  >- (FIRST_ASSUM (ASSUME_TAC o MATCH_MP sup_seq_countable_seq) THEN
-      POP_ASSUM (MP_TAC o Q.SPEC `(\x. measure M x)`) THEN STRIP_TAC THEN
-      Q.EXISTS_TAC `f` THEN METIS_TAC []) THEN STRIP_TAC THEN
-  Know `!i. ?Q'. (Q'' i = measure M Q') /\ Q' IN Q`
-  >- (ASM_SET_TAC []) THEN STRIP_TAC THEN
-  Know `?Q'. !i. (Q'' i = measure M (Q' i)) /\ Q' i IN Q`
-  >- (METIS_TAC []) THEN STRIP_TAC THEN
-  Know `a = sup {measure M (Q' i) | i IN univ(:num)}`
-  >- (FULL_SIMP_TAC std_ss []) THEN DISCH_TAC THEN
-  Q.ABBREV_TAC `D = (\n. BIGUNION {Q' i | i <= n:num})` THEN
-  Know `sup {measure M (D i) | i IN univ(:num)} =
-        measure M (BIGUNION {D i | i IN univ(:num)})` >-
-  (SIMP_TAC std_ss [GSYM IMAGE_DEF] THEN
-   MATCH_MP_TAC (REWRITE_RULE [o_DEF] MONOTONE_CONVERGENCE2) THEN
-   ASM_REWRITE_TAC [] THEN CONJ_TAC >-
-   (Q.UNABBREV_TAC `D` THEN SRW_TAC[] [IN_DEF, IN_FUNSET] THEN
-    ONCE_REWRITE_TAC [GSYM SPECIFICATION] THEN RW_TAC std_ss [] THEN
-    ONCE_REWRITE_TAC [SET_RULE ``{Q' i' | i' <= i} =
-             IMAGE (\i':num. Q' i') {i' | i' <= i}``] THEN
-    ONCE_REWRITE_TAC [METIS [subsets_def]
-     ``measurable_sets m = subsets (m_space m, measurable_sets m)``] THEN
-    MATCH_MP_TAC SIGMA_ALGEBRA_COUNTABLE_UNION THEN
-    FULL_SIMP_TAC std_ss [measure_space_def] THEN
-    CONJ_TAC >- (MATCH_MP_TAC image_countable THEN
-                 SIMP_TAC std_ss [pred_setTheory.COUNTABLE_NUM]) THEN
-    SIMP_TAC std_ss [SUBSET_DEF, IN_IMAGE, subsets_def, GSPECIFICATION] THEN
-    GEN_TAC THEN STRIP_TAC THEN ASM_REWRITE_TAC [] THEN
-    FIRST_X_ASSUM (MP_TAC o Q.SPEC `i'`) THEN
-    Q.UNABBREV_TAC `Q` THEN SIMP_TAC std_ss [GSPECIFICATION] THEN METIS_TAC []) THEN
-   Q.UNABBREV_TAC `D` THEN
-   RW_TAC std_ss [SUBSET_DEF, IN_BIGUNION, GSPECIFICATION] THEN
-   Q.EXISTS_TAC `Q' i` THEN ASM_REWRITE_TAC [] THEN
-   Q.EXISTS_TAC `i` THEN ASM_SIMP_TAC arith_ss [] ) THEN DISCH_TAC THEN
-  Know `!i. Q' i IN measurable_sets M`
-  >- (GEN_TAC THEN FIRST_X_ASSUM (MP_TAC o Q.SPEC `i`) THEN
-      Q.UNABBREV_TAC `Q` THEN
-      RW_TAC std_ss [GSPECIFICATION] THEN METIS_TAC []) THEN DISCH_TAC THEN
-  Know `!i. D i IN measurable_sets M`
-  >- (Q.UNABBREV_TAC `D` THEN RW_TAC std_ss [] THEN
-      ONCE_REWRITE_TAC [SET_RULE ``{Q' i' | i' <= i} =
-                        IMAGE (\i':num. Q' i') {i' | i' <= i}``] THEN
-      ONCE_REWRITE_TAC [METIS [subsets_def]
-       ``measurable_sets m = subsets (m_space m, measurable_sets m)``] THEN
-      MATCH_MP_TAC SIGMA_ALGEBRA_COUNTABLE_UNION THEN
-      FULL_SIMP_TAC std_ss [measure_space_def] THEN
-      CONJ_TAC >- (MATCH_MP_TAC image_countable THEN
-                   SIMP_TAC std_ss [pred_setTheory.COUNTABLE_NUM]) THEN
-      SIMP_TAC std_ss [SUBSET_DEF, IN_IMAGE, subsets_def, GSPECIFICATION] THEN
-      GEN_TAC THEN STRIP_TAC THEN ASM_REWRITE_TAC [] THEN METIS_TAC []) THEN
-  DISCH_TAC THEN
-  Know `!i. D i IN Q`
-  >- (Know `!i. IMAGE Q' {x | x <= i} SUBSET measurable_sets M`
-      >- (RW_TAC std_ss [SUBSET_DEF, IN_IMAGE] THEN METIS_TAC []) THEN
-      DISCH_TAC THEN
-      Suff `!i. measure N (D i) <= SIGMA (\i. measure N (Q' i)) {x | x <= i}`
-      >- (DISCH_TAC THEN GEN_TAC THEN qunabbrevl_tac [`D`, `Q`] THEN
-          FULL_SIMP_TAC std_ss [GSPECIFICATION] THEN CONJ_TAC THENL
-          [METIS_TAC [], ALL_TAC] THEN
-          REWRITE_TAC [lt_infty] THEN MATCH_MP_TAC let_trans THEN
-          Q.EXISTS_TAC `SIGMA (\i. measure N (Q' i)) {x | x <= i}` THEN
-          ASM_REWRITE_TAC [GSYM lt_infty] THEN
-          MATCH_MP_TAC EXTREAL_SUM_IMAGE_NOT_POSINF THEN
-          SIMP_TAC std_ss [FINITE_NUMSEG_LE, GSPECIFICATION] THEN
-          GEN_TAC THEN DISCH_TAC THEN
-          Q.PAT_X_ASSUM `!i. (Q'' i = measure M (Q' i)) /\ _` MP_TAC THEN
-          DISCH_THEN (MP_TAC o Q.SPEC `x`) THEN SIMP_TAC std_ss []) THEN
-      GEN_TAC THEN Q.UNABBREV_TAC `D` THEN BETA_TAC THEN
-      ONCE_REWRITE_TAC [SET_RULE ``(BIGUNION {Q' i' | i' <= i:num}) =
-                      (BIGUNION {Q' i' | i' IN {x | x <= i}})``] THEN
-      MATCH_MP_TAC measure_subadditive_finite THEN
-      ASM_SIMP_TAC std_ss [FINITE_NUMSEG_LE] THEN METIS_TAC []) THEN DISCH_TAC THEN
-  Know `!n. D n SUBSET D (SUC n)`
-  >- (Q.UNABBREV_TAC `D` THEN
-      GEN_TAC THEN SIMP_TAC std_ss [SUBSET_DEF, IN_BIGUNION] THEN
-      GEN_TAC THEN SIMP_TAC std_ss [GSPECIFICATION] THEN STRIP_TAC THEN
-      Q.EXISTS_TAC `Q' i` THEN FULL_SIMP_TAC std_ss [] THEN
-      Q.EXISTS_TAC `i` THEN FULL_SIMP_TAC arith_ss []) THEN DISCH_TAC THEN
-  Know `a = measure M (BIGUNION {D i | i IN univ(:num)})`
-  >- (REWRITE_TAC [GSYM le_antisym] THEN CONJ_TAC >-
-      (ASM_REWRITE_TAC [sup_le'] THEN GEN_TAC THEN
-       SIMP_TAC std_ss [GSPECIFICATION] THEN STRIP_TAC THEN ASM_REWRITE_TAC [] THEN
-       MATCH_MP_TAC INCREASING THEN ASM_SIMP_TAC std_ss [MEASURE_SPACE_INCREASING] THEN
-       reverse CONJ_TAC
-       >- (ONCE_REWRITE_TAC [METIS [subsets_def]
-            ``measurable_sets m = subsets (m_space m, measurable_sets m)``] THEN
-           MATCH_MP_TAC SIGMA_ALGEBRA_COUNTABLE_UNION THEN
-           FULL_SIMP_TAC std_ss [measure_space_def, GSYM IMAGE_DEF] THEN
-           CONJ_TAC THENL [MATCH_MP_TAC image_countable THEN
-              SIMP_TAC std_ss [pred_setTheory.COUNTABLE_NUM], ALL_TAC] THEN
-           SIMP_TAC std_ss [SUBSET_DEF, IN_IMAGE, subsets_def, GSPECIFICATION] THEN
-           GEN_TAC THEN STRIP_TAC THEN ASM_REWRITE_TAC [] THEN METIS_TAC []) \\
-       Q.UNABBREV_TAC `D` THEN
-       SIMP_TAC std_ss [SUBSET_DEF, IN_BIGUNION, GSPECIFICATION] THEN
-       GEN_TAC THEN STRIP_TAC THEN
-       Q.EXISTS_TAC `BIGUNION {Q' x | x <= i}` THEN
-       CONJ_TAC THENL [ALL_TAC, METIS_TAC [IN_UNIV]] THEN
-       ASM_SIMP_TAC arith_ss [IN_BIGUNION, GSPECIFICATION] THEN
-       Q.EXISTS_TAC `Q' i` THEN METIS_TAC [LESS_OR_EQ]) THEN
-      UNDISCH_TAC ``sup {measure M (D i) | i IN univ(:num)} =
-          measure M (BIGUNION {D i | i IN univ(:num)})`` THEN
-      GEN_REWR_TAC LAND_CONV [EQ_SYM_EQ] THEN SIMP_TAC std_ss [] THEN DISCH_TAC THEN
-      Suff `!n. BIGUNION {Q' i | i <= n} = D n` THENL
-      [DISCH_TAC, METIS_TAC []] THEN
-      Suff `!n. ?x. x IN Q /\ measure M (BIGUNION {Q' i | i <= n}) <= measure M x` THENL
-      [DISCH_TAC,
-       GEN_TAC THEN Q.EXISTS_TAC `D n` THEN ASM_SIMP_TAC std_ss [le_refl]] THEN
-      Q.UNABBREV_TAC `a` THEN SIMP_TAC std_ss [GSYM IMAGE_DEF] THEN
-      MATCH_MP_TAC sup_le_sup_imp THEN GEN_TAC THEN
-      GEN_REWR_TAC LAND_CONV [GSYM SPECIFICATION] THEN
-      SIMP_TAC std_ss [IN_IMAGE] THEN STRIP_TAC THEN ASM_REWRITE_TAC [] THEN
-      FIRST_X_ASSUM (MP_TAC o Q.SPEC `i`) THEN STRIP_TAC THEN
-      Q.EXISTS_TAC `measure M x'` THEN
-      Q.UNABBREV_TAC `D` THEN BETA_TAC THEN ASM_REWRITE_TAC [] THEN
-      ONCE_REWRITE_TAC [GSYM SPECIFICATION] THEN SIMP_TAC std_ss [IN_IMAGE] THEN
-      METIS_TAC [] ) THEN DISCH_TAC THEN
-  Q.ABBREV_TAC `O_o = BIGUNION {(D:num->'a->bool) i | i IN UNIV}` THEN
-  Know `O_o IN measurable_sets M`
-  >- (Q.UNABBREV_TAC `O_o` THEN
-      ONCE_REWRITE_TAC [METIS [subsets_def]
-       ``measurable_sets m = subsets (m_space m, measurable_sets m)``] THEN
-      MATCH_MP_TAC SIGMA_ALGEBRA_COUNTABLE_UNION THEN
-      FULL_SIMP_TAC std_ss [measure_space_def, GSYM IMAGE_DEF] THEN
-      CONJ_TAC THENL [MATCH_MP_TAC image_countable THEN
-        SIMP_TAC std_ss [pred_setTheory.COUNTABLE_NUM], ALL_TAC] THEN
-      SIMP_TAC std_ss [SUBSET_DEF, IN_IMAGE, subsets_def, GSPECIFICATION] THEN
-      GEN_TAC THEN STRIP_TAC THEN ASM_REWRITE_TAC [] THEN METIS_TAC []) THEN
-  DISCH_TAC THEN
-  Q.ABBREV_TAC `(QQ) = (\i. if i = 0 then (Q':num->'a->bool) 0
-                         else D i DIFF (D:num->'a->bool) (i - 1))` THEN
-  Know `!i. QQ i IN measurable_sets M`
-  >- (GEN_TAC THEN ASM_CASES_TAC ``i = 0:num``
-      >- (Q.UNABBREV_TAC `QQ` THEN ASM_SIMP_TAC std_ss [] THEN
-          METIS_TAC []) THEN
-      Know `?n. i = SUC n`
-      >- (Q.EXISTS_TAC `PRE i` THEN ONCE_REWRITE_TAC [EQ_SYM_EQ] THEN
-          REWRITE_TAC [GSYM SUC_PRE] THEN ASM_SIMP_TAC arith_ss []) THEN
-      STRIP_TAC THEN ASM_REWRITE_TAC [] THEN
-      Q.UNABBREV_TAC `QQ` THEN ASM_SIMP_TAC arith_ss [] THEN
-      ONCE_REWRITE_TAC [METIS [subsets_def]
-        ``measurable_sets m = subsets (m_space m, measurable_sets m)``] THEN
-      MATCH_MP_TAC ALGEBRA_DIFF THEN SIMP_TAC std_ss [subsets_def] THEN
-      CONJ_TAC THENL [ALL_TAC, METIS_TAC []] THEN
-      FULL_SIMP_TAC std_ss [measure_space_def, sigma_algebra_def]) THEN
-  DISCH_TAC THEN
-  Q.EXISTS_TAC `QQ` THEN CONJ_TAC THENL
-  [ONCE_REWRITE_TAC [METIS [subsets_def]
-    ``measurable_sets m = subsets (m_space m, measurable_sets m)``] THEN
-   MATCH_MP_TAC ALGEBRA_DIFF THEN CONJ_TAC THENL
-   [FULL_SIMP_TAC std_ss [measure_space_def, sigma_algebra_def],
-    ALL_TAC] THEN CONJ_TAC THENL
-   [METIS_TAC [MEASURE_SPACE_MSPACE_MEASURABLE, subsets_def],
-    ALL_TAC] THEN
-   MATCH_MP_TAC SIGMA_ALGEBRA_COUNTABLE_UNION THEN
-   FULL_SIMP_TAC std_ss [measure_space_def, GSYM IMAGE_DEF] THEN
-   CONJ_TAC THENL [MATCH_MP_TAC image_countable THEN
-    SIMP_TAC std_ss [pred_setTheory.COUNTABLE_NUM], ALL_TAC] THEN
-   SIMP_TAC std_ss [SUBSET_DEF, IN_IMAGE, subsets_def, GSPECIFICATION] THEN
-   GEN_TAC THEN STRIP_TAC THEN ASM_REWRITE_TAC [] THEN METIS_TAC [], ALL_TAC] THEN
-  CONJ_TAC THENL
-  [SIMP_TAC std_ss [disjoint_family_on, IN_UNIV] THEN
-   REPEAT STRIP_TAC THEN Q.UNABBREV_TAC `QQ` THEN BETA_TAC THEN
-   SIMP_TAC std_ss [INTER_DEF, EXTENSION, NOT_IN_EMPTY, GSPECIFICATION] THEN
-   GEN_TAC THEN REPEAT COND_CASES_TAC THENL (* 4 subgoals *)
-   [(* goal 1 (of 4) *)
-    FULL_SIMP_TAC arith_ss [],
-    (* goal 2 (of 4) *)
-    ASM_CASES_TAC ``(x:'a) NOTIN Q' (0:num)`` THEN FULL_SIMP_TAC std_ss [] THEN
-    `1 <= n` by ASM_SIMP_TAC arith_ss [] THEN
-    SIMP_TAC std_ss [Abbr ‘D’, IN_DIFF, IN_BIGUNION, GSPECIFICATION] \\
-    Cases_on `!s. x NOTIN s \/ !i. s = Q' i ==> ~(i <= n)` >- art [] \\
-    DISJ2_TAC \\
-    Q.EXISTS_TAC `Q' 0` >> ASM_SIMP_TAC std_ss [] \\
-    Q.EXISTS_TAC `0` >> SIMP_TAC arith_ss [],
-    (* goal 3 (of 4) *)
-    ASM_CASES_TAC ``(x:'a) NOTIN Q' (0:num)`` THEN FULL_SIMP_TAC std_ss [] THEN
-    `1 <= m` by ASM_SIMP_TAC arith_ss [] THEN
-    SIMP_TAC std_ss [Abbr ‘D’, IN_DIFF, IN_BIGUNION, GSPECIFICATION] \\
-    Cases_on `!s. x NOTIN s \/ !i. s = Q' i ==> ~(i <= m)` >- art [] \\
-    DISJ2_TAC \\
-    Q.EXISTS_TAC `Q' 0` >> ASM_SIMP_TAC std_ss [] \\
-    Q.EXISTS_TAC `0` >> SIMP_TAC arith_ss [],
-    (* goal 4 (of 4) *)
-    ALL_TAC] THEN
-   ASM_CASES_TAC ``x NOTIN (D:num->'a->bool) m DIFF D (m - 1)`` THEN
-   FULL_SIMP_TAC std_ss [IN_DIFF] THEN
-   ASM_CASES_TAC ``m < n:num`` THENL
-   [ASM_CASES_TAC ``x NOTIN (D:num->'a->bool) n`` THEN ASM_SIMP_TAC std_ss [] THEN
-    POP_ASSUM MP_TAC THEN POP_ASSUM MP_TAC THEN
-    POP_ASSUM MP_TAC THEN POP_ASSUM MP_TAC THEN
-    Q.UNABBREV_TAC `D` THEN BETA_TAC THEN
-    SIMP_TAC std_ss [IN_BIGUNION, GSPECIFICATION] THEN REPEAT STRIP_TAC THEN
-    Q.EXISTS_TAC `s` THEN ASM_REWRITE_TAC [] THEN Q.EXISTS_TAC `i` THEN
-    ASM_SIMP_TAC arith_ss [], ALL_TAC] THEN
-   ASM_CASES_TAC ``x IN (D:num->'a->bool) (n - 1)`` THEN ASM_SIMP_TAC std_ss [] THEN
-   POP_ASSUM MP_TAC THEN POP_ASSUM MP_TAC THEN
-   POP_ASSUM MP_TAC THEN POP_ASSUM MP_TAC THEN
-   SIMP_TAC std_ss [Abbr ‘D’, IN_BIGUNION, GSPECIFICATION] \\
-   rpt STRIP_TAC \\
-   `n < m` by FULL_SIMP_TAC arith_ss [] \\
-   NTAC 2 (POP_ASSUM MP_TAC) \\
-   FIRST_X_ASSUM (MP_TAC o Q.SPEC `s'`) THEN REPEAT STRIP_TAC THEN
-   ASM_REWRITE_TAC [] THEN DISJ2_TAC THEN GEN_TAC THEN
-   FIRST_X_ASSUM (MP_TAC o Q.SPEC `i':num`) THEN STRIP_TAC THEN
-   ASM_REWRITE_TAC [] THEN STRIP_TAC \\
-   FULL_SIMP_TAC arith_ss [NOT_LESS_EQUAL], ALL_TAC] THEN
-  CONJ_TAC >- ASM_SET_TAC [] THEN
-  reverse CONJ_TAC >-
-  (GEN_TAC THEN Q.UNABBREV_TAC `QQ` THEN BETA_TAC THEN
-   ASM_CASES_TAC ``i = 0:num`` THEN ASM_SIMP_TAC std_ss [] THENL
-   [ASM_SET_TAC [], ALL_TAC] THEN
-   SIMP_TAC std_ss [lt_infty] THEN MATCH_MP_TAC let_trans THEN
-   Q.EXISTS_TAC `measure N (D i) - measure N (D (i - 1))` THEN
-   CONJ_TAC THENL
-   [SIMP_TAC std_ss [le_lt] THEN DISJ2_TAC THEN
-    MATCH_MP_TAC MEASURE_SPACE_FINITE_DIFF_SUBSET THEN
-    ASM_SIMP_TAC std_ss [] THEN REPEAT (CONJ_TAC THENL [ASM_SET_TAC [], ALL_TAC]) THEN
-    CONJ_TAC THENL [METIS_TAC [ARITH_PROVE ``i <> 0 ==> (i = SUC (i - 1))``], ALL_TAC] THEN
-    ASM_SET_TAC [], ALL_TAC] THEN
-   REWRITE_TAC [GSYM lt_infty] THEN MATCH_MP_TAC (METIS [sub_not_infty]
-    ``x <> PosInf /\ y <> NegInf ==> x - y <> PosInf``) THEN
-   CONJ_TAC THENL [ASM_SET_TAC [], ALL_TAC] THEN
-   `positive N` by METIS_TAC [MEASURE_SPACE_POSITIVE] THEN
-   FULL_SIMP_TAC std_ss [positive_def, lt_infty] THEN
-   MATCH_MP_TAC lte_trans THEN Q.EXISTS_TAC `0` THEN
-   SIMP_TAC std_ss [GSYM lt_infty, num_not_infty] THEN
-   FIRST_ASSUM MATCH_MP_TAC THEN METIS_TAC [] ) THEN
-  GEN_TAC THEN STRIP_TAC THEN
-  ASM_CASES_TAC ``0 < measure M A ==> (measure N (A:'a->bool) <> PosInf)`` THENL
-  [ALL_TAC, FULL_SIMP_TAC std_ss []] THEN
-  ASM_CASES_TAC ``measure M (A:'a->bool) = 0`` THENL
-  [FULL_SIMP_TAC std_ss [measure_absolutely_continuous_def], ALL_TAC] THEN
-  `positive M` by METIS_TAC [MEASURE_SPACE_POSITIVE] THEN
-  POP_ASSUM (STRIP_ASSUME_TAC o (REWRITE_RULE [positive_def])) THEN
-  POP_ASSUM (MP_TAC o Q.SPEC `A`) THEN
-  ASM_REWRITE_TAC [le_lt] THEN STRIP_TAC THENL [ALL_TAC, METIS_TAC []] THEN
-  ASM_REWRITE_TAC [] THEN UNDISCH_TAC ``0 < measure M A ==> measure N A <> PosInf`` THEN
-  ASM_REWRITE_TAC [] THEN DISCH_TAC THEN
-  Know `measure M O_o + measure M A = measure M (O_o UNION A)` >-
-  (ONCE_REWRITE_TAC [EQ_SYM_EQ] THEN MATCH_MP_TAC ADDITIVE THEN
-   ASM_SIMP_TAC std_ss [MEASURE_SPACE_ADDITIVE, DISJOINT_DEF] THEN
-   reverse CONJ_TAC
-   >- (MATCH_MP_TAC MEASURE_SPACE_UNION >> rfs []) THEN
-   Q.PAT_X_ASSUM  `A SUBSET m_space N DIFF BIGUNION {QQ i | i IN univ(:num)}` MP_TAC THEN
-   qunabbrevl_tac [`QQ`, `O_o`] THEN BETA_TAC THEN
-   Suff `BIGUNION {D i | i IN univ(:num)} =
-         BIGUNION {if i = 0 then Q' 0 else D i DIFF D (i - 1) | i IN univ(:num)}`
-   >- (Rewr' >> SET_TAC []) THEN
-   SIMP_TAC std_ss [EXTENSION, IN_BIGUNION, GSPECIFICATION, IN_UNIV] THEN
-   GEN_TAC THEN EQ_TAC THEN STRIP_TAC
-   >- (FULL_SIMP_TAC std_ss [] THEN POP_ASSUM K_TAC THEN
-       ASM_CASES_TAC ``x IN (D:num->'a->bool) 0``
-       >- (Q.EXISTS_TAC `D 0` THEN FULL_SIMP_TAC std_ss [] THEN
-           Q.EXISTS_TAC `0` THEN
-           Q.UNABBREV_TAC `D` THEN SIMP_TAC std_ss [] THEN
-           SET_TAC []) THEN
-       Suff `?i. i <> 0 /\ x IN D i DIFF D (i - 1)` THENL
-       [STRIP_TAC THEN Q.EXISTS_TAC `D i' DIFF D (i' - 1)` THEN
-        ASM_REWRITE_TAC [] THEN METIS_TAC [], ALL_TAC] THEN
-       Induct_on `i` THENL [METIS_TAC [], ALL_TAC] THEN
-       DISCH_TAC THEN ASM_CASES_TAC ``x IN D (SUC i) DIFF ((D:num->'a->bool) i)`` THENL
-       [Q.EXISTS_TAC `SUC i` THEN ASM_SIMP_TAC arith_ss [], ALL_TAC] THEN
-       ASM_SET_TAC []) THEN
-   FULL_SIMP_TAC std_ss [] THEN POP_ASSUM K_TAC THEN
-   ASM_CASES_TAC ``i = 0:num``
-   >- (Q.EXISTS_TAC `Q' 0` THEN FULL_SIMP_TAC std_ss [] THEN
-       Q.UNABBREV_TAC `D` THEN Q.EXISTS_TAC `0` THEN
-       BETA_TAC THEN SET_TAC []) THEN
-   FULL_SIMP_TAC std_ss [] THEN Q.EXISTS_TAC `D i` THEN CONJ_TAC THENL
-   [ALL_TAC, METIS_TAC []] THEN
-   ASM_SET_TAC [] ) THEN DISCH_TAC THEN
-  Know `measure M (BIGUNION {D i | i IN univ(:num)} UNION A) =
-             sup {measure M ((D i) UNION A) | i IN univ(:num)}` >-
-  (SIMP_TAC std_ss [GSYM IMAGE_DEF] THEN
-   `(\i. measure M (D i UNION A)) = measure M o (\i. (D:num->'a->bool) i UNION A)`
-     by SIMP_TAC std_ss [o_DEF] THEN
-   FIRST_X_ASSUM (fn th => ONCE_REWRITE_TAC [th]) THEN
-   ONCE_REWRITE_TAC [EQ_SYM_EQ] THEN MATCH_MP_TAC MONOTONE_CONVERGENCE THEN
-   ASM_SIMP_TAC std_ss [] THEN CONJ_TAC THENL
-   [EVAL_TAC THEN SRW_TAC[][IN_DEF,IN_FUNSET]  THEN
-    ONCE_REWRITE_TAC [GSYM SPECIFICATION] THEN
-    ONCE_REWRITE_TAC [METIS [subsets_def]
-     ``measurable_sets m = subsets (m_space m, measurable_sets m)``] THEN
-    MATCH_MP_TAC ALGEBRA_UNION THEN
-    FULL_SIMP_TAC std_ss [measure_space_def, sigma_algebra_def] THEN
-    METIS_TAC [subsets_def], ALL_TAC] THEN
-   CONJ_TAC THENL
-   [GEN_TAC THEN MATCH_MP_TAC (SET_RULE ``a SUBSET c /\ b SUBSET d ==>
-                  a UNION b SUBSET c UNION d``) THEN
-    ASM_SIMP_TAC std_ss [SUBSET_REFL], ALL_TAC] THEN
-   GEN_REWR_TAC (LAND_CONV o RAND_CONV) [SET_RULE ``A = BIGUNION {A}``] THEN
-   REWRITE_TAC [GSYM BIGUNION_UNION] THEN
-   SIMP_TAC std_ss [EXTENSION, IN_BIGUNION, IN_IMAGE, IN_UNIV, GSPECIFICATION, IN_UNION] THEN
-   GEN_TAC THEN EQ_TAC THEN STRIP_TAC THENL
-   [Q.EXISTS_TAC `D x' UNION A` THEN ASM_SET_TAC [],
-    Q.EXISTS_TAC `D x' UNION A` THEN ASM_SET_TAC [],
-    ASM_SET_TAC []] ) THEN DISCH_TAC THEN
-  Know `sup {measure M ((D i) UNION A) | i IN univ(:num)} <= a` THEN1
-  (REWRITE_TAC [sup_le'] THEN GEN_TAC THEN
-   SIMP_TAC std_ss [GSPECIFICATION] THEN STRIP_TAC THEN
-   Q.PAT_X_ASSUM `y = _` (ONCE_REWRITE_TAC o wrap) THEN
-   Know `a = sup {measure M x | x IN Q}` >- METIS_TAC [] THEN Rewr' THEN
-   Know `!i. D i UNION A IN Q` >-
-   (Know `!i. D i UNION A IN measurable_sets M`
-    >- (GEN_TAC THEN ONCE_REWRITE_TAC [METIS [subsets_def]
-         ``measurable_sets m = subsets (m_space m, measurable_sets m)``] THEN
-        MATCH_MP_TAC ALGEBRA_UNION THEN
-        FULL_SIMP_TAC std_ss [measure_space_def, sigma_algebra_def] THEN
-        METIS_TAC [subsets_def]) THEN DISCH_TAC THEN
-    GEN_TAC THEN
-    Know `Q = {x | x IN measurable_sets M /\ measure N x <> PosInf}`
-    >- (Q.UNABBREV_TAC `Q` >> REWRITE_TAC []) >> Rewr' THEN
-    ASM_SIMP_TAC std_ss [GSPECIFICATION] THEN
-    CONJ_TAC THENL [METIS_TAC [], ALL_TAC] THEN
-    SIMP_TAC std_ss [lt_infty] THEN MATCH_MP_TAC let_trans THEN
-    Q.EXISTS_TAC `measure N (D i') + measure N A` THEN
-    reverse CONJ_TAC
-    >- (SIMP_TAC std_ss [GSYM lt_infty] THEN
-        MATCH_MP_TAC (METIS [add_not_infty]
-          ``x <> PosInf /\ y <> PosInf ==> x + y <> PosInf``) THEN
-        ASM_SIMP_TAC std_ss [] THEN
-        `D i' IN Q` by METIS_TAC [] THEN POP_ASSUM MP_TAC THEN
-        Q.UNABBREV_TAC `Q` THEN SIMP_TAC std_ss [GSPECIFICATION]) THEN
-    REWRITE_TAC [le_lt] THEN DISJ2_TAC THEN MATCH_MP_TAC ADDITIVE THEN
-    REV_FULL_SIMP_TAC std_ss [MEASURE_SPACE_ADDITIVE] THEN
-    SIMP_TAC std_ss [DISJOINT_DEF] THEN
-    ASM_SIMP_TAC std_ss [EXTENSION, IN_INTER, NOT_IN_EMPTY] THEN
-    GEN_TAC THEN ASM_CASES_TAC ``(x:'a) NOTIN A`` THEN
-    FULL_SIMP_TAC std_ss [] THEN
-    UNDISCH_TAC ``(A:'a->bool) SUBSET m_space N DIFF BIGUNION {QQ i | i IN univ(:num)}`` THEN
-    Q.UNABBREV_TAC `QQ` THEN FULL_SIMP_TAC bool_ss [] THEN
-    Suff `BIGUNION {D i | i IN univ(:num)} =
-          BIGUNION {if i = 0 then Q' 0 else D i DIFF D (i - 1) | i IN univ(:num)}`
-    >- (GEN_REWR_TAC LAND_CONV [EQ_SYM_EQ] THEN DISC_RW_KILL THEN
-        SIMP_TAC std_ss [SUBSET_DEF] THEN DISCH_THEN (MP_TAC o Q.SPEC `x`) THEN
-        ASM_REWRITE_TAC [] THEN ASM_SET_TAC []) THEN
-    SIMP_TAC std_ss [EXTENSION, IN_BIGUNION, GSPECIFICATION, IN_UNIV] THEN
-    GEN_TAC THEN EQ_TAC THEN STRIP_TAC
-    >- (FULL_SIMP_TAC std_ss [] THEN POP_ASSUM K_TAC THEN
-        ASM_CASES_TAC ``x' IN (D:num->'a->bool) 0``
-        >- (Q.EXISTS_TAC `D 0` THEN FULL_SIMP_TAC std_ss [] THEN
-            Q.EXISTS_TAC `0` THEN
-            Q.UNABBREV_TAC `D` THEN SIMP_TAC std_ss [] THEN
-            SET_TAC []) THEN
-        Suff `?i. i <> 0 /\ x' IN D i DIFF D (i - 1)` THENL
-        [STRIP_TAC THEN Q.EXISTS_TAC `D i'' DIFF D (i'' - 1)` THEN
-         ASM_REWRITE_TAC [] THEN METIS_TAC [], ALL_TAC] THEN
-         Induct_on `i'` THENL [METIS_TAC [], ALL_TAC] THEN
-        DISCH_TAC THEN ASM_CASES_TAC ``x' IN D (SUC i') DIFF ((D:num->'a->bool) i')`` THENL
-        [Q.EXISTS_TAC `SUC i'` THEN ASM_SIMP_TAC arith_ss [], ALL_TAC] THEN
-        ASM_SET_TAC []) THEN
-    FULL_SIMP_TAC std_ss [] THEN POP_ASSUM K_TAC THEN
-    ASM_CASES_TAC ``i' = 0:num``
-    >- (Q.EXISTS_TAC `Q' 0` THEN FULL_SIMP_TAC std_ss [] THEN
-        Q.UNABBREV_TAC `D` THEN BETA_TAC THEN
-        Q.EXISTS_TAC `0` THEN SET_TAC []) THEN
-    FULL_SIMP_TAC std_ss [] THEN Q.EXISTS_TAC `D i'` THEN CONJ_TAC THENL
-    [ALL_TAC, METIS_TAC []] THEN
-    ASM_SET_TAC [] ) THEN DISCH_TAC THEN
-   MATCH_MP_TAC le_sup_imp' THEN SIMP_TAC std_ss [GSPECIFICATION] THEN
-   METIS_TAC [] ) THEN DISCH_TAC THEN
-  POP_ASSUM MP_TAC THEN
-  SIMP_TAC std_ss [GSYM extreal_lt_def] THEN
-  POP_ASSUM (ONCE_REWRITE_TAC o wrap o SYM) THEN
- `BIGUNION {D i | i IN univ(:num)} = O_o` by METIS_TAC [] THEN POP_ORW THEN
-  POP_ASSUM (ONCE_REWRITE_TAC o wrap o SYM) THEN
-  Know `a = measure M O_o` >- METIS_TAC [] THEN Rewr' THEN DISCH_TAC THEN
-  Know `measure M O_o <> NegInf`
-  >- (MATCH_MP_TAC pos_not_neginf THEN
-     `positive M` by PROVE_TAC [MEASURE_SPACE_POSITIVE] THEN
-      fs [positive_def, measurable_sets_def, measure_def]) THEN DISCH_TAC THEN
- `measure M O_o <> PosInf` by PROVE_TAC [] THEN
- `measure M A <= 0`
-    by PROVE_TAC [REWRITE_RULE [add_rzero]
-                   (Q.SPECL [`measure M O_o`, `measure M A`, `0`] le_ladd)] THEN
-  PROVE_TAC [let_antisym]
-QED
-
 (* M is finite, while N can be infinite *)
-Theorem Radon_Nikodym_finite_arbitrary : (* was: Radon_Nikodym_finite_measure_infinite *)
+Theorem Radon_Nikodym_finite_arbitrary :
     !M N. measure_space M /\ measure_space N /\
          (m_space M = m_space N) /\ (measurable_sets M = measurable_sets N) /\
          (measure M (m_space M) <> PosInf) /\
@@ -10649,49 +9539,6 @@ Proof
   CONJ_TAC THENL [METIS_TAC [], ALL_TAC] THEN ASM_SET_TAC [DISJOINT_DEF]
 QED
 
-Theorem ext_suminf_cmult_indicator :
-    !A f x i. disjoint_family A /\ x IN A i /\ (!i. 0 <= f i) ==>
-              (suminf (\n. f n * indicator_fn (A n) x) = f i)
-Proof
-  RW_TAC std_ss [disjoint_family_on, IN_UNIV] THEN
-  Suff `!n. f n * indicator_fn (A n) x = if n = i then f n else 0` THENL
-  [DISCH_TAC,
-   RW_TAC std_ss [indicator_fn_def, mul_rone, mul_rzero] THEN
-   ASM_SET_TAC []] THEN
-  Suff `f i = SIGMA (\i. f i * indicator_fn (A i) x) (count (SUC i))` THENL
-  [DISCH_THEN (fn th => ONCE_REWRITE_TAC [th]) THEN MATCH_MP_TAC ext_suminf_sum THEN
-   RW_TAC std_ss [le_refl] THEN POP_ASSUM MP_TAC THEN ASM_SIMP_TAC arith_ss [ADD1],
-   ASM_SIMP_TAC std_ss []] THEN
-  `count (SUC i) <> {}` by (SIMP_TAC std_ss [GSYM MEMBER_NOT_EMPTY] THEN
-     Q.EXISTS_TAC `i` THEN SIMP_TAC arith_ss [GSPECIFICATION, count_def]) THEN
-  Suff `count (SUC i) = count i UNION {i}` THENL
-  [RW_TAC std_ss [],
-   SIMP_TAC arith_ss [count_def, EXTENSION, IN_UNION, GSPECIFICATION, IN_SING]] THEN
-  Suff `SIGMA (\i'. if i' = i then f i else 0) (count i UNION {i}) =
-                  SIGMA (\i'. if i' = i then f i else 0) (count i) +
-                  SIGMA (\i'. if i' = i then f i else 0) ({i})` THENL
-  [RW_TAC std_ss [],
-   ABBREV_TAC ``g = (\i'. if i' = i then (f:num->extreal) i else 0)`` THEN
-   Suff `(!x. x IN (count i UNION {i}) ==> g x <> NegInf) \/
-                   (!x. x IN (count i UNION {i}) ==> g x <> PosInf)` THENL
-   [Q.SPEC_TAC (`g`,`g`) THEN MATCH_MP_TAC EXTREAL_SUM_IMAGE_DISJOINT_UNION THEN
-    SIMP_TAC std_ss [FINITE_COUNT, FINITE_SING, DISJOINT_DEF] THEN
-    SIMP_TAC std_ss [EXTENSION, IN_INTER, IN_SING, NOT_IN_EMPTY, count_def] THEN
-    SIMP_TAC arith_ss [GSPECIFICATION],
-    DISJ1_TAC] THEN
-   EXPAND_TAC "g" THEN POP_ASSUM K_TAC THEN RW_TAC std_ss [lt_infty] THENL
-   [ALL_TAC, METIS_TAC [lt_infty, num_not_infty]] THEN
-   MATCH_MP_TAC lte_trans THEN Q.EXISTS_TAC `0` THEN ASM_REWRITE_TAC [] THEN
-   METIS_TAC [lt_infty, num_not_infty]] THEN
-  SIMP_TAC std_ss [EXTREAL_SUM_IMAGE_SING] THEN
-  Suff `SIGMA (\i'. if i' = i then f i else 0) (count i) = 0` THENL
-  [SIMP_TAC std_ss [add_lzero],
-   MATCH_MP_TAC EXTREAL_SUM_IMAGE_0] THEN
-  RW_TAC std_ss [FINITE_COUNT] THEN POP_ASSUM MP_TAC THEN
-  ONCE_REWRITE_TAC [MONO_NOT_EQ] THEN RW_TAC std_ss [] THEN
-  SIMP_TAC arith_ss [count_def, GSPECIFICATION]
-QED
-
 Theorem finite_integrable_function_exists : (* was: Ex_finite_integrable_function *)
     !m. measure_space m /\ sigma_finite m ==>
         ?h. h IN measurable (m_space m, measurable_sets m) Borel /\
@@ -10849,10 +9696,11 @@ Proof
    MATCH_MP_TAC le_trans THEN Q.EXISTS_TAC `(1 / 2 * 2) pow 0` THEN
    CONJ_TAC >- (SIMP_TAC std_ss [pow_0, le_lt]) THEN
    MATCH_MP_TAC pow_le_mono THEN SIMP_TAC arith_ss [] THEN
-   SIMP_TAC real_ss [extreal_le_def, extreal_of_num_def, extreal_div_eq, extreal_mul_def,
-                     GSYM REAL_LE_LDIV_EQ] ) THEN
+   SIMP_TAC real_ss [extreal_le_def, extreal_of_num_def, extreal_div_eq,
+                     extreal_mul_def, GSYM REAL_LE_LDIV_EQ] ) THEN
   RW_TAC std_ss [pow_half_ser'] THEN
-  `pos_fn_integral m h <> PosInf` by METIS_TAC [lt_infty, num_not_infty, let_trans] THEN
+ `pos_fn_integral m h <> PosInf`
+    by METIS_TAC [lt_infty, num_not_infty, let_trans] THEN
   Know `!x. x IN m_space m ==> ?i. x IN A i`
   >- (RULE_ASSUM_TAC (ONCE_REWRITE_RULE [EQ_SYM_EQ]) THEN
       FULL_SIMP_TAC std_ss [IN_BIGUNION, IN_UNIV, GSPECIFICATION] THEN
@@ -10901,20 +9749,17 @@ Proof
     MATCH_MP_TAC le_mul >> art [INDICATOR_FN_POS] ]
 QED
 
-(* The most general version (M: sigma-finite, N: arbitrary).
-
-   cf. Radon_Nikodym_finite, Radon_Nikodym_finite_arbitrary
- *)
-Theorem Radon_Nikodym_sigma_finite : (* was: RADON_NIKODYM *)
+(* The most general version (M: sigma-finite, N: arbitrary). *)
+Theorem Radon_Nikodym_sigma_finite :
     !M N. measure_space M /\ measure_space N /\
-         (m_space M = m_space N) /\ (measurable_sets M = measurable_sets N) /\
-          sigma_finite M /\
-          measure_absolutely_continuous (measure N) M ==>
+          measurable_sets M = measurable_sets N /\
+          sigma_finite M /\ measure_absolutely_continuous (measure N) M ==>
       ?f. f IN measurable (m_space M,measurable_sets M) Borel /\ (!x. 0 <= f x) /\
           !A. A IN measurable_sets M ==>
              (pos_fn_integral M (\x. f x * indicator_fn A x) = measure N A)
 Proof
     rpt STRIP_TAC
+ >> `m_space M = m_space N` by METIS_TAC [sets_eq_imp_space_eq]
  >> ‘sigma_algebra (measurable_space M) /\ sigma_algebra (measurable_space N)’
       by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA]
  >> Q.PAT_X_ASSUM `m_space M = m_space N` (ASSUME_TAC o SYM)
@@ -10967,8 +9812,9 @@ Proof
      SIMP_TAC std_ss [] \\
      ONCE_REWRITE_TAC [METIS [] ``(\x'. h x' * indicator_fn (A x) x') =
                              (\x. (\x'. h x' * indicator_fn (A x) x')) x``] \\
-     ONCE_REWRITE_TAC [METIS [] ``suminf (\j. h x * indicator_fn (A j) x) =
-                                  suminf (\j. (\x x'. h x' * indicator_fn (A x) x') j x)``] \\
+     ONCE_REWRITE_TAC
+       [METIS [] ``suminf (\j. h x * indicator_fn (A j) x) =
+                   suminf (\j. (\x x'. h x' * indicator_fn (A x) x') j x)``] \\
      MATCH_MP_TAC pos_fn_integral_suminf \\
      ASM_SIMP_TAC std_ss [measure_space_def] \\
      CONJ_TAC >- (RW_TAC std_ss [] \\
@@ -11007,8 +9853,9 @@ Proof
                pos_fn_integral M (\x. h x * (\x. f x * indicator_fn A x) x))`
      >- (GEN_TAC THEN DISCH_TAC THEN
          Q.UNABBREV_TAC `mt` THEN
-         ONCE_REWRITE_TAC [METIS [] ``pos_fn_integral M (\x. h x * (f x * indicator_fn A x)) =
-                             pos_fn_integral M (\x. h x * (\x. f x * indicator_fn A x) x)``] \\
+         ONCE_REWRITE_TAC [METIS []
+           “pos_fn_integral M (\x. h x * (f x * indicator_fn A x)) =
+            pos_fn_integral M (\x. h x * (\x. f x * indicator_fn A x) x)”] \\
          Suff `pos_fn_integral
                 (m_space M,measurable_sets M,
                  (\A. pos_fn_integral M (\x. max 0 (h x * indicator_fn A x))))
@@ -11019,7 +9866,8 @@ Proof
          MATCH_MP_TAC pos_fn_integral_density' THEN ASM_SIMP_TAC std_ss [] \\
          CONJ_TAC
          >- (MATCH_MP_TAC IN_MEASURABLE_BOREL_MUL_INDICATOR \\
-             METIS_TAC [subsets_def, measure_space_def, measurable_sets_def, m_space_def]) \\
+             METIS_TAC [subsets_def, measure_space_def, measurable_sets_def,
+                        m_space_def]) \\
          CONJ_TAC
          >- (SIMP_TAC std_ss [AE_ALT, GSPECIFICATION, null_set_def, GSPEC_T] \\
              Q.EXISTS_TAC `{}` >> SIMP_TAC std_ss [IN_UNIV, GSPEC_F, SUBSET_REFL] \\
@@ -11048,7 +9896,7 @@ Proof
  >> ASM_SIMP_TAC std_ss []
  >> Know ‘!x. x IN m_space M ==> 0 <= h x * indicator_fn A x’
  >- rw [le_mul, INDICATOR_FN_POS]
- >> Know `(\x. h x * indicator_fn A x) IN Borel_measurable (m_space M,measurable_sets M)`
+ >> Know `(\x. h x * indicator_fn A x) IN Borel_measurable (measurable_space M)`
  >- (MATCH_MP_TAC IN_MEASURABLE_BOREL_MUL_INDICATOR \\
      fs [measure_space_def, subsets_def])
  >> RW_TAC std_ss []
@@ -11060,10 +9908,22 @@ Proof
  >> METIS_TAC [lt_le]
 QED
 
-(* Final version: more compact using of "<<" and "*" (density_measure_def).
+(* This version has “!x. x IN m_space M ==> 0 <= f x” instead of “!x. 0 <= f x” *)
+Theorem RADON_NIKODYM :
+    !M N. measure_space M /\ measure_space N /\
+          measurable_sets M = measurable_sets N /\
+          sigma_finite M /\ measure_absolutely_continuous (measure N) M ==>
+      ?f. f IN measurable (m_space M,measurable_sets M) Borel /\
+          (!x. x IN m_space M ==> 0 <= f x) /\
+          !A. A IN measurable_sets M ==>
+             (pos_fn_integral M (\x. f x * indicator_fn A x) = measure N A)
+Proof
+    rpt STRIP_TAC
+ >> MP_TAC (Q.SPECL [‘M’, ‘N’] Radon_Nikodym_sigma_finite) >> rw []
+ >> Q.EXISTS_TAC ‘f’ >> rw []
+QED
 
-   Previous versions are not needed any more, cf. FINITE_IMP_SIGMA_FINITE.
- *)
+(* Final version: more compact using of "<<" and "*" (density_measure_def) *)
 Theorem Radon_Nikodym :
     !m v. measure_space m /\ sigma_finite m /\
           measure_space (m_space m,measurable_sets m,v) /\
@@ -11092,293 +9952,6 @@ Proof
          !s. s IN (measurable_sets m) ==> ((f * m) s = v s)’
       by METIS_TAC [Radon_Nikodym]
  >> Q.EXISTS_TAC ‘f’ >> rw []
-QED
-
-(* ------------------------------------------------------------------------- *)
-(*   Applications of Radon_Nikodym (ported from HVG's normal_rvScript.sml)   *)
-(* ------------------------------------------------------------------------- *)
-
-(* Radon-Nikodym derivative (RN_deriv)
-
-  `RN_deriv v m` (HOL) = `RN_deriv m (m_space m,measurable_sets m,v)` (Isabelle/HOL)
-
-   The existence of `RN_deriv v m` is then asserted by Radon-Nikodym theorem, and
-   its uniqueness is asserted by the following (unproved) theorem:
-
-     !m f f'. measure_space m /\ sigma_finite m /\
-              f IN borel_measurable (m_space m,measurable_sets m) /\
-              f' IN borel_measurable (m_space m,measurable_sets m) /\
-              nonneg f /\ nonneg f' /\
-              (!s. s IN measurable_sets m ==> ((f * m) s = (f' * m) s))
-          ==> AE x::m. (f x = f' x)
-
-   see also density_measure_def for the overload of ‘*’ in `f * m`.
- *)
-Definition RN_deriv_def : (* or `v / m` (dv/dm) *)
-    RN_deriv v m =
-      @f. f IN measurable (m_space m,measurable_sets m) Borel /\
-          (!x. x IN m_space m ==> 0 <= f x) /\
-          !s. s IN measurable_sets m ==> ((f * m) s = v s)
-End
-
-(* `f = RN_deriv v m` is denoted by `f = v / m`
-   NOTE: cannot use the Overload syntax sugar here (on "/").
- *)
-val _ = overload_on ("/", “RN_deriv”);
-
-Theorem RN_deriv_thm :
-    !m v. measure_space m /\
-          (?f. f IN measurable (m_space m,measurable_sets m) Borel /\
-              (!x. x IN m_space m ==> 0 <= f x) /\
-              (!s. s IN measurable_sets m ==> (f * m) s = v s)) ==>
-          !s. s IN measurable_sets m ==> (v / m * m) s = v s
-Proof
-    RW_TAC std_ss [RN_deriv_def]
- >> SELECT_ELIM_TAC
- >> CONJ_TAC >- (Q.EXISTS_TAC ‘f’ >> rw [])
- >> Q.X_GEN_TAC ‘g’
- >> rpt STRIP_TAC
- >> POP_ASSUM MATCH_MP_TAC >> art []
-QED
-
-(* This is ported from the following theorem (RN_derivI)
-
-    !f M N. f IN measurable (m_space M, measurable_sets M) Borel /\
-            (!x. 0 <= f x) /\ (density M f = measure_of N) /\
-             measure_space M /\ measure_space N /\
-            (measurable_sets M = measurable_sets N) ==>
-            (density M (RN_deriv M N) = measure_of N)
- *)
-Theorem RN_deriv_thm' : (* was: RN_derivI *)
-    !f m v. measure_space m /\
-            f IN measurable (m_space m,measurable_sets m) Borel /\
-           (!x. x IN m_space m ==> 0 <= f x) /\
-           (!s. s IN measurable_sets m ==> (f * m) s = v s) ==>
-            measure_space_eq (density m (v / m))
-                             (m_space m,measurable_sets m,v)
-Proof
-    rw [measure_space_eq_def, density_def]
- >> irule RN_deriv_thm >> art []
- >> Q.EXISTS_TAC ‘f’ >> rw []
-QED
-
-(***********************)
-(*   Further Results   *)
-(***********************)
-
-(*  I add these results at the end
-      in order to manipulate the simplifier without breaking anything
-      - Jared Yeager                                                    *)
-
-(*** integral and integrable Theorems with fewer preconditions ***)
-
-Theorem integrable_measurable:
-    !m f. integrable m f ==> f IN Borel_measurable (measurable_space m)
-Proof
-    simp[integrable_def]
-QED
-
-Theorem pos_fn_integrable_AE_finite:
-    !m f. measure_space m /\ (!x. x IN m_space m ==> 0 <= f x) /\
-        f IN Borel_measurable (measurable_space m) /\ pos_fn_integral m f <> PosInf ==>
-        AE x::m. f x = (Normal o real o f) x
-Proof
-    rw[] >> rw[AE_ALT] >> qexists_tac ‘{x | x IN m_space m /\ f x = PosInf}’ >>
-    simp[pos_fn_integral_infty_null] >> rw[SUBSET_DEF] >>
-    Cases_on ‘f x’ >> fs[normal_real] >> rw[] >>
-    last_x_assum (dxrule_then assume_tac) >> rfs[]
-QED
-
-Theorem integrable_AE_finite:
-    !m f. measure_space m /\ integrable m f ==> AE x::m. f x = (Normal o real o f) x
-Proof
-    rw[] >> fs[integrable_def] >>
-    map_every (fn tm => (qspecl_then [‘m’,tm] assume_tac) pos_fn_integrable_AE_finite) [‘f^+’,‘f^-’] >>
-    rfs[FN_PLUS_POS,FN_MINUS_POS,IN_MEASURABLE_BOREL_FN_PLUS,IN_MEASURABLE_BOREL_FN_MINUS] >>
-    fs[AE_ALT] >> qexists_tac ‘N UNION N'’ >> (drule_then assume_tac) NULL_SET_UNION >>
-    rfs[IN_APP] >> pop_assum kall_tac >> fs[SUBSET_DEF] >> rw[] >>
-    NTAC 2 (last_x_assum (drule_then assume_tac)) >> Cases_on ‘f x’ >> rw[] >>
-    DISJ2_TAC >> first_x_assum irule >> simp[fn_minus_def,extreal_ainv_def]
-QED
-
-Theorem integrable_eq_AE_alt:
-    !m f g. measure_space m /\ integrable m f /\ (AE x::m. f x = g x) /\
-        g IN Borel_measurable (measurable_space m) ==> integrable m g
-Proof
-    simp[integrable_def] >> NTAC 4 strip_tac >>
-    ‘pos_fn_integral m f^+ = pos_fn_integral m g^+ /\
-        pos_fn_integral m f^- = pos_fn_integral m g^-’ suffices_by (rw[] >> fs[]) >>
-    rw[] >> irule pos_fn_integral_cong_AE >> simp[FN_PLUS_POS,FN_MINUS_POS] >>
-    fs[AE_ALT,SUBSET_DEF] >> qexists_tac ‘N’ >> rw[] >>
-    last_x_assum (dxrule_then assume_tac) >> pop_assum irule >>
-    pop_assum mp_tac >> CONV_TAC CONTRAPOS_CONV >>
-    simp[fn_plus_def,fn_minus_def]
-QED
-
-Theorem integrable_cong_AE:
-    !m f g. complete_measure_space m /\ (AE x::m. f x = g x) ==>
-        (integrable m f <=> integrable m g)
-Proof
-    rw[] >> eq_tac >> rw[] >>
-    dxrule_at_then (Pos $ el 1) (dxrule_at_then (Pos $ el 1) irule) integrable_eq_AE >> simp[] >>
-    qspecl_then [‘m’,‘λx. g x = f x’,‘λx. f x = g x’] (irule_at Any o SIMP_RULE (srw_ss ()) []) AE_subset >>
-    simp[]
-QED
-
-Theorem integrable_cong_AE_alt:
-    !m f g. measure_space m /\ (AE x::m. f x = g x) /\
-        f IN Borel_measurable (measurable_space m) /\ g IN Borel_measurable (measurable_space m)==>
-        (integrable m f <=> integrable m g)
-Proof
-    rw[] >> eq_tac >> rw[] >>
-    dxrule_at_then (Pos $ el 1) (dxrule_at_then (Pos $ el 1) irule) integrable_eq_AE_alt >> simp[] >>
-    qspecl_then [‘m’,‘λx. g x = f x’,‘λx. f x = g x’] (irule_at Any o SIMP_RULE (srw_ss ()) []) AE_subset >>
-    simp[]
-QED
-
-Theorem integral_mono_AE:
-    !m f g. measure_space m /\ (AE x::m. f x <= g x) ==> integral m f <= integral m g
-Proof
-    rw[integral_def] >> irule sub_le_sub_imp >> NTAC 2 $ irule_at Any pos_fn_integral_mono_AE >>
-    simp[FN_PLUS_POS,FN_MINUS_POS] >>
-    map_every (fn tms => qspecl_then tms (irule_at Any o SIMP_RULE (srw_ss ()) []) AE_subset)
-        [[‘m’,‘λx. f x <= g x’,‘λx. f^+ x <= g^+ x’],[‘m’,‘λx. f x <= g x’,‘λx. g^- x <= f^- x’]] >>
-    simp[GSYM FORALL_AND_THM,GSYM IMP_CONJ_THM] >> NTAC 2 strip_tac >>
-    rw[fn_plus_def,fn_minus_def]
-    >| [simp[le_neg],simp[Once le_negl],simp[Once le_negr,le_lt],simp[],simp[le_lt]] >>
-    ‘F’ suffices_by simp[] >> qpat_x_assum ‘~b’ mp_tac >> simp[]
-    >- (irule let_trans >> qexists_tac ‘g x’ >> simp[])
-    >- (irule lte_trans >> qexists_tac ‘f x’ >> simp[])
-QED
-
-Theorem integral_add':
-    !m f g. measure_space m /\ integrable m f /\ integrable m g ==>
-        integral m (λx. f x + g x) = integral m f + integral m g
-Proof
-    rw[] >> imp_res_tac integrable_AE_finite >>
-    (qspecl_then [‘m’,‘f’,‘Normal o real o f’,‘g’,‘Normal o real o g’] assume_tac)
-        AE_eq_add >> rfs[] >>
-    map_every (fn tms => (qspecl_then tms assume_tac) integral_cong_AE)
-        [[‘m’,‘f’,‘Normal o real o f’],[‘m’,‘g’,‘Normal o real o g’],
-        [‘m’,‘λx. f x + g x’,‘λx. Normal (real (f x)) + Normal (real (g x))’]] >>
-    rfs[] >> NTAC 3 (pop_assum kall_tac) >>
-    qspecl_then [‘m’,‘Normal o real o f’,‘Normal o real o g’] assume_tac integral_add >>
-    rfs[] >> pop_assum irule >> rw[] >> irule integrable_eq_AE_alt >> fs[integrable_def] >>
-    simp[IN_MEASURABLE_BOREL_NORMAL_REAL]
-    >| [qexists_tac ‘f’,qexists_tac ‘g’] >> simp[]
-QED
-
-Theorem integrable_add':
-    !m f g. measure_space m /\ integrable m f /\ integrable m g ==> integrable m (λx. f x + g x)
-Proof
-    rw[] >> imp_res_tac integrable_AE_finite >>
-    (qspecl_then [‘m’,‘f’,‘Normal o real o f’,‘g’,‘Normal o real o g’] assume_tac) AE_eq_add >> rfs[] >>
-    map_every (fn tms => (qspecl_then tms assume_tac) integrable_eq_AE_alt)
-        [[‘m’,‘f’,‘Normal o real o f’],[‘m’,‘g’,‘Normal o real o g’],
-        [‘m’,‘λx. Normal (real (f x)) + Normal (real (g x))’,‘λx. f x + g x’]] >>
-    rfs[integrable_measurable,IN_MEASURABLE_BOREL_NORMAL_REAL] >> pop_assum irule >>
-    simp[Once EQ_SYM_EQ] >> irule_at Any IN_MEASURABLE_BOREL_ADD' >>
-    qexistsl_tac [‘g’,‘f’] >> simp[integrable_measurable] >>
-    qspecl_then [‘m’,‘Normal o real o f’,‘Normal o real o g’] (irule o SIMP_RULE (srw_ss ()) []) integrable_add >>
-    simp[]
-QED
-
-(* NOTE: reworked proof for "HOL warning: Type.mk_vartype: non-standard syntax" *)
-Theorem integral_sum' :
-    !m f s. FINITE s /\ measure_space m /\ (!i. i IN s ==> integrable m (f i)) ==>
-            integral m (λx. SIGMA (λi. f i x) s) = SIGMA (λi. integral m (f i)) s
-Proof
-    rpt STRIP_TAC
- (* applying integral_sum *)
- >> MP_TAC (Q.SPECL [‘m’, ‘\i. Normal o real o f i’, ‘s’] integral_sum)
- >> simp []
- >> qabbrev_tac ‘g = \i. Normal o real o f i’ >> simp []
- >> Know ‘!i. i IN s ==> integrable m (g i)’
- >- (rw [Abbr ‘g’] \\
-     MATCH_MP_TAC integrable_eq_AE_alt \\
-     Q.EXISTS_TAC ‘f i’ >> ASM_SIMP_TAC bool_ss [] \\
-     CONJ_TAC >- (MATCH_MP_TAC integrable_AE_finite >> rw []) \\
-     MATCH_MP_TAC IN_MEASURABLE_BOREL_NORMAL_REAL \\
-     fs [measure_space_def, integrable_def])
- >> RW_TAC std_ss []
- (* rewrite RHS from f to g *)
- >> MATCH_MP_TAC EQ_TRANS
- >> Q.EXISTS_TAC ‘SIGMA (\i. integral m (g i)) s’
- >> reverse CONJ_TAC
- >- (irule EXTREAL_SUM_IMAGE_EQ' >> rw [] \\
-     ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
-     MATCH_MP_TAC integral_cong_AE >> RW_TAC bool_ss [Abbr ‘g’] \\
-     MATCH_MP_TAC integrable_AE_finite >> rw [])
- (* rewrite LHS from f to g *)
- >> MATCH_MP_TAC EQ_TRANS
- >> Q.EXISTS_TAC ‘integral m (\x. SIGMA (\i. g i x) s)’
- >> CONJ_TAC
- >- (MATCH_MP_TAC integral_cong_AE >> rw [] \\
-     HO_MATCH_MP_TAC AE_subset \\
-     Q.EXISTS_TAC ‘\x. !i. i IN s ==> f i x = g i x’ >> simp [] \\
-     reverse CONJ_TAC >- (rpt STRIP_TAC \\
-                          irule EXTREAL_SUM_IMAGE_EQ' >> rw []) \\
-     HO_MATCH_MP_TAC AE_BIGINTER \\
-     RW_TAC bool_ss [finite_countable, Abbr ‘g’] \\
-     MATCH_MP_TAC integrable_AE_finite >> rw [])
- >> simp [Abbr ‘g’]
-QED
-
-Theorem integrable_sum':
-    !m f s. FINITE s /\ measure_space m /\ (!i. i IN s ==> integrable m (f i)) ==>
-        integrable m (λx. SIGMA (λi. f i x) s)
-Proof
-    rw[] >> irule integrable_eq_AE_alt >> simp[] >> drule_then (irule_at Any) IN_MEASURABLE_BOREL_SUM' >>
-    qexistsl_tac [‘f’,‘λx. SIGMA (λi. Normal (real (f i x))) s’] >> simp[integrable_measurable] >>
-    qspecl_then [‘m’,‘λi. Normal o real o f i’,‘s’] (irule_at Any o SIMP_RULE (srw_ss ()) []) integrable_sum >>
-    simp[] >> first_assum $ C (resolve_then Any assume_tac) integrable_AE_finite >> rfs[] >>
-    qspecl_then [‘m’,‘λi x. f i x = Normal (real (f i x))’,‘s’] assume_tac AE_BIGINTER >>
-    rfs[finite_countable] >> rw[]
-    >- (irule integrable_eq_AE_alt >> simp[integrable_measurable,IN_MEASURABLE_BOREL_NORMAL_REAL] >>
-        qexists_tac ‘f i’ >> simp[])
-    >- (qspecl_then [‘m’,‘λx. !n. n IN s ==> f n x = Normal (real (f n x))’,
-            ‘λx. SIGMA (λi. Normal (real (f i x))) s = SIGMA (λi. f i x) s’]
-            (irule o SIMP_RULE (srw_ss ()) []) AE_subset >>
-        rw[] >> irule EXTREAL_SUM_IMAGE_EQ' >> simp[])
-QED
-
-Theorem integral_sub':
-    !m f g. measure_space m /\ integrable m f /\ integrable m g ==>
-        integral m (λx. f x - g x) = integral m f - integral m g
-Proof
-    rw [extreal_sub]
- >> ‘integrable m (\x. -g x)’ by METIS_TAC [integrable_ainv]
- >> Know ‘Normal (-1) * integral m g = integral m (\x. Normal (-1) * g x)’
- >- (ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
-     MATCH_MP_TAC integral_cmul >> art [])
- >> rw [GSYM neg_minus1, GSYM extreal_ainv_def, normal_1]
- >> HO_MATCH_MP_TAC integral_add' >> rw []
-QED
-
-Theorem integrable_sub':
-    !m f g. measure_space m /\ integrable m f /\ integrable m g ==>
-        integrable m (λx. f x - g x)
-Proof
-    rw [extreal_sub]
- >> ‘integrable m (\x. -g x)’ by METIS_TAC [integrable_ainv]
- >> HO_MATCH_MP_TAC integrable_add' >> rw []
-QED
-
-(* An easy corollary of the new integral_add' and integrable_add' *)
-Theorem integral_add3 :
-    !m f g h. measure_space m /\
-              integrable m f /\ integrable m g /\ integrable m h
-          ==> integral m (\x. f x + g x + h x) =
-              integral m f + integral m g + integral m h
-Proof
-    rpt STRIP_TAC
- >> Know ‘integral m (\x. f x + g x + h x) =
-          integral m (\x. f x + g x) + integral m h’
- >- (HO_MATCH_MP_TAC integral_add' >> simp [] \\
-     MATCH_MP_TAC integrable_add' >> rw [])
- >> Rewr'
- >> Suff ‘integral m (\x. f x + g x) = integral m f + integral m g’ >- rw []
- >> MATCH_MP_TAC integral_add' >> rw []
 QED
 
 val _ = export_theory ();

--- a/src/probability/martingaleScript.sml
+++ b/src/probability/martingaleScript.sml
@@ -95,6 +95,266 @@ Definition sub_martingale_def :
             integral m (\x. u (SUC n) x * indicator_fn s x)))
 End
 
+(*** integral and integrable Theorems with fewer preconditions ***)
+
+Theorem integrable_measurable:
+    !m f. integrable m f ==> f IN Borel_measurable (measurable_space m)
+Proof
+    simp[integrable_def]
+QED
+
+Theorem pos_fn_integrable_AE_finite:
+    !m f. measure_space m /\ (!x. x IN m_space m ==> 0 <= f x) /\
+          f IN Borel_measurable (measurable_space m) /\
+          pos_fn_integral m f <> PosInf ==>
+          AE x::m. f x = (Normal o real o f) x
+Proof
+    rw[] >> rw[AE_ALT] >> qexists_tac ‘{x | x IN m_space m /\ f x = PosInf}’ >>
+    simp[pos_fn_integral_infty_null] >> rw[SUBSET_DEF] >>
+    Cases_on ‘f x’ >> fs[normal_real] >> rw[] >>
+    last_x_assum (dxrule_then assume_tac) >> rfs[]
+QED
+
+Theorem integrable_AE_finite:
+    !m f. measure_space m /\ integrable m f ==>
+          AE x::m. f x = (Normal o real o f) x
+Proof
+    rw[] >> fs[integrable_def]
+ >> map_every (fn tm => qspecl_then [‘m’,tm] assume_tac
+                                    pos_fn_integrable_AE_finite) [‘f^+’,‘f^-’]
+ >> rfs[FN_PLUS_POS,FN_MINUS_POS,IN_MEASURABLE_BOREL_FN_PLUS,
+        IN_MEASURABLE_BOREL_FN_MINUS]
+ >> fs[AE_ALT] >> qexists_tac ‘N UNION N'’
+ >> drule_then assume_tac NULL_SET_UNION
+ >> rfs[IN_APP] >> pop_assum kall_tac
+ >> fs[SUBSET_DEF] >> rw[]
+ >> NTAC 2 (last_x_assum (drule_then assume_tac)) >> Cases_on ‘f x’ >> rw[]
+ >> DISJ2_TAC >> first_x_assum irule >> simp[fn_minus_def,extreal_ainv_def]
+QED
+
+Theorem integrable_eq_AE_alt:
+    !m f g. measure_space m /\ integrable m f /\ (AE x::m. f x = g x) /\
+        g IN Borel_measurable (measurable_space m) ==> integrable m g
+Proof
+    simp[integrable_def] >> NTAC 4 strip_tac >>
+    ‘pos_fn_integral m f^+ = pos_fn_integral m g^+ /\
+        pos_fn_integral m f^- = pos_fn_integral m g^-’ suffices_by (rw[] >> fs[]) >>
+    rw[] >> irule pos_fn_integral_cong_AE >> simp[FN_PLUS_POS,FN_MINUS_POS] >>
+    fs[AE_ALT,SUBSET_DEF] >> qexists_tac ‘N’ >> rw[] >>
+    last_x_assum (dxrule_then assume_tac) >> pop_assum irule >>
+    pop_assum mp_tac >> CONV_TAC CONTRAPOS_CONV >>
+    simp[fn_plus_def,fn_minus_def]
+QED
+
+Theorem integrable_cong_AE:
+    !m f g. complete_measure_space m /\ (AE x::m. f x = g x) ==>
+        (integrable m f <=> integrable m g)
+Proof
+    rw[] >> eq_tac >> rw[] >>
+    dxrule_at_then (Pos $ el 1) (dxrule_at_then (Pos $ el 1) irule) integrable_eq_AE >> simp[] >>
+    qspecl_then [‘m’,‘λx. g x = f x’,‘λx. f x = g x’] (irule_at Any o SIMP_RULE (srw_ss ()) []) AE_subset >>
+    simp[]
+QED
+
+Theorem integrable_cong_AE_alt:
+    !m f g. measure_space m /\ (AE x::m. f x = g x) /\
+            f IN Borel_measurable (measurable_space m) /\
+            g IN Borel_measurable (measurable_space m) ==>
+           (integrable m f <=> integrable m g)
+Proof
+    rw[] >> eq_tac >> rw[]
+ >> dxrule_at_then (Pos $ el 1)
+       (dxrule_at_then (Pos $ el 1) irule) integrable_eq_AE_alt >> simp[]
+ >> qspecl_then [‘m’,‘λx. g x = f x’,‘λx. f x = g x’]
+                (irule_at Any o SIMP_RULE (srw_ss ()) []) AE_subset
+ >> simp[]
+QED
+
+Theorem integral_mono_AE:
+    !m f g. measure_space m /\ (AE x::m. f x <= g x) ==>
+            integral m f <= integral m g
+Proof
+    rw [integral_def]
+ >> irule sub_le_sub_imp >> NTAC 2 $ irule_at Any pos_fn_integral_mono_AE
+ >> simp[FN_PLUS_POS,FN_MINUS_POS]
+ >> map_every (fn tms => qspecl_then tms
+                          (irule_at Any o SIMP_RULE (srw_ss ()) []) AE_subset)
+     [[‘m’,‘λx. f x <= g x’,‘λx. f^+ x <= g^+ x’],
+      [‘m’,‘λx. f x <= g x’,‘λx. g^- x <= f^- x’]]
+ >> simp[GSYM FORALL_AND_THM,GSYM IMP_CONJ_THM]
+ >> NTAC 2 strip_tac >> rw [fn_plus_def,fn_minus_def]
+ >| [ simp[le_neg],
+      simp[Once le_negl],
+      simp[Once le_negr,le_lt],
+      simp[],
+      simp[le_lt] ]
+ >> ‘F’ suffices_by simp[] >> qpat_x_assum ‘~b’ mp_tac >> simp[]
+ >- (irule let_trans >> qexists_tac ‘g x’ >> simp[])
+ >> (irule lte_trans >> qexists_tac ‘f x’ >> simp[])
+QED
+
+Theorem integral_add':
+    !m f g. measure_space m /\ integrable m f /\ integrable m g ==>
+        integral m (λx. f x + g x) = integral m f + integral m g
+Proof
+    rw[] >> imp_res_tac integrable_AE_finite >>
+    (qspecl_then [‘m’,‘f’,‘Normal o real o f’,‘g’,‘Normal o real o g’] assume_tac)
+        AE_eq_add >> rfs[] >>
+    map_every (fn tms => (qspecl_then tms assume_tac) integral_cong_AE)
+        [[‘m’,‘f’,‘Normal o real o f’],[‘m’,‘g’,‘Normal o real o g’],
+        [‘m’,‘λx. f x + g x’,‘λx. Normal (real (f x)) + Normal (real (g x))’]] >>
+    rfs[] >> NTAC 3 (pop_assum kall_tac) >>
+    qspecl_then [‘m’,‘Normal o real o f’,‘Normal o real o g’] assume_tac integral_add >>
+    rfs[] >> pop_assum irule >> rw[] >> irule integrable_eq_AE_alt >> fs[integrable_def] >>
+    simp[IN_MEASURABLE_BOREL_NORMAL_REAL]
+    >| [qexists_tac ‘f’,qexists_tac ‘g’] >> simp[]
+QED
+
+Theorem integrable_add':
+    !m f g. measure_space m /\ integrable m f /\ integrable m g ==> integrable m (λx. f x + g x)
+Proof
+    rw[] >> imp_res_tac integrable_AE_finite >>
+    (qspecl_then [‘m’,‘f’,‘Normal o real o f’,‘g’,‘Normal o real o g’] assume_tac) AE_eq_add >> rfs[] >>
+    map_every (fn tms => (qspecl_then tms assume_tac) integrable_eq_AE_alt)
+        [[‘m’,‘f’,‘Normal o real o f’],[‘m’,‘g’,‘Normal o real o g’],
+        [‘m’,‘λx. Normal (real (f x)) + Normal (real (g x))’,‘λx. f x + g x’]] >>
+    rfs[integrable_measurable,IN_MEASURABLE_BOREL_NORMAL_REAL] >> pop_assum irule >>
+    simp[Once EQ_SYM_EQ] >> irule_at Any IN_MEASURABLE_BOREL_ADD' >>
+    qexistsl_tac [‘g’,‘f’] >> simp[integrable_measurable] >>
+    qspecl_then [‘m’,‘Normal o real o f’,‘Normal o real o g’] (irule o SIMP_RULE (srw_ss ()) []) integrable_add >>
+    simp[]
+QED
+
+(* NOTE: reworked proof for "HOL warning: Type.mk_vartype: non-standard syntax" *)
+Theorem integral_sum' :
+    !m f s. FINITE s /\ measure_space m /\ (!i. i IN s ==> integrable m (f i)) ==>
+            integral m (λx. SIGMA (λi. f i x) s) = SIGMA (λi. integral m (f i)) s
+Proof
+    rpt STRIP_TAC
+ (* applying integral_sum *)
+ >> MP_TAC (Q.SPECL [‘m’, ‘\i. Normal o real o f i’, ‘s’] integral_sum)
+ >> simp []
+ >> qabbrev_tac ‘g = \i. Normal o real o f i’ >> simp []
+ >> Know ‘!i. i IN s ==> integrable m (g i)’
+ >- (rw [Abbr ‘g’] \\
+     MATCH_MP_TAC integrable_eq_AE_alt \\
+     Q.EXISTS_TAC ‘f i’ >> ASM_SIMP_TAC bool_ss [] \\
+     CONJ_TAC >- (MATCH_MP_TAC integrable_AE_finite >> rw []) \\
+     MATCH_MP_TAC IN_MEASURABLE_BOREL_NORMAL_REAL \\
+     fs [measure_space_def, integrable_def])
+ >> RW_TAC std_ss []
+ (* rewrite RHS from f to g *)
+ >> MATCH_MP_TAC EQ_TRANS
+ >> Q.EXISTS_TAC ‘SIGMA (\i. integral m (g i)) s’
+ >> reverse CONJ_TAC
+ >- (irule EXTREAL_SUM_IMAGE_EQ' >> rw [] \\
+     ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
+     MATCH_MP_TAC integral_cong_AE >> RW_TAC bool_ss [Abbr ‘g’] \\
+     MATCH_MP_TAC integrable_AE_finite >> rw [])
+ (* rewrite LHS from f to g *)
+ >> MATCH_MP_TAC EQ_TRANS
+ >> Q.EXISTS_TAC ‘integral m (\x. SIGMA (\i. g i x) s)’
+ >> CONJ_TAC
+ >- (MATCH_MP_TAC integral_cong_AE >> rw [] \\
+     HO_MATCH_MP_TAC AE_subset \\
+     Q.EXISTS_TAC ‘\x. !i. i IN s ==> f i x = g i x’ >> simp [] \\
+     reverse CONJ_TAC >- (rpt STRIP_TAC \\
+                          irule EXTREAL_SUM_IMAGE_EQ' >> rw []) \\
+     HO_MATCH_MP_TAC AE_BIGINTER \\
+     RW_TAC bool_ss [finite_countable, Abbr ‘g’] \\
+     MATCH_MP_TAC integrable_AE_finite >> rw [])
+ >> simp [Abbr ‘g’]
+QED
+
+Theorem integrable_sum':
+    !m f s. FINITE s /\ measure_space m /\ (!i. i IN s ==> integrable m (f i)) ==>
+            integrable m (λx. SIGMA (λi. f i x) s)
+Proof
+    rw[] >> irule integrable_eq_AE_alt
+ >> simp[] >> drule_then (irule_at Any) IN_MEASURABLE_BOREL_SUM'
+ >> qexistsl_tac [‘f’,‘λx. SIGMA (λi. Normal (real (f i x))) s’]
+ >> simp[integrable_measurable]
+ >> qspecl_then [‘m’,‘λi. Normal o real o f i’,‘s’]
+                (irule_at Any o SIMP_RULE (srw_ss ()) []) integrable_sum
+ >> simp[]
+ >> first_assum $ C (resolve_then Any assume_tac) integrable_AE_finite >> rfs[]
+ >> qspecl_then [‘m’,‘λi x. f i x = Normal (real (f i x))’,‘s’]
+                assume_tac AE_BIGINTER
+ >> rfs[finite_countable] >> rw[]
+ >- (irule integrable_eq_AE_alt \\
+     simp[integrable_measurable,IN_MEASURABLE_BOREL_NORMAL_REAL] \\
+     qexists_tac ‘f i’ >> simp[])
+ >> qspecl_then [‘m’,‘λx. !n. n IN s ==> f n x = Normal (real (f n x))’,
+                 ‘λx. SIGMA (λi. Normal (real (f i x))) s = SIGMA (λi. f i x) s’]
+                (irule o SIMP_RULE (srw_ss ()) []) AE_subset
+ >> rw[]
+ >> irule EXTREAL_SUM_IMAGE_EQ' >> simp[]
+QED
+
+Theorem integral_sub':
+    !m f g. measure_space m /\ integrable m f /\ integrable m g ==>
+            integral m (λx. f x - g x) = integral m f - integral m g
+Proof
+    rw [extreal_sub]
+ >> ‘integrable m (\x. -g x)’ by METIS_TAC [integrable_ainv]
+ >> Know ‘Normal (-1) * integral m g = integral m (\x. Normal (-1) * g x)’
+ >- (ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
+     MATCH_MP_TAC integral_cmul >> art [])
+ >> rw [GSYM neg_minus1, GSYM extreal_ainv_def, normal_1]
+ >> HO_MATCH_MP_TAC integral_add' >> rw []
+QED
+
+Theorem integrable_sub':
+    !m f g. measure_space m /\ integrable m f /\ integrable m g ==>
+            integrable m (λx. f x - g x)
+Proof
+    rw [extreal_sub]
+ >> ‘integrable m (\x. -g x)’ by METIS_TAC [integrable_ainv]
+ >> HO_MATCH_MP_TAC integrable_add' >> rw []
+QED
+
+Theorem pos_fn_integral_add3 :
+    !m f g h. measure_space m /\
+             (!x. x IN m_space m ==> 0 <= f x) /\
+             (!x. x IN m_space m ==> 0 <= g x) /\
+             (!x. x IN m_space m ==> 0 <= h x) /\
+              f IN measurable (m_space m,measurable_sets m) Borel /\
+              g IN measurable (m_space m,measurable_sets m) Borel /\
+              h IN measurable (m_space m,measurable_sets m) Borel
+          ==> pos_fn_integral m (\x. f x + g x + h x) =
+              pos_fn_integral m f + pos_fn_integral m g + pos_fn_integral m h
+Proof
+    rpt STRIP_TAC
+ >> Know ‘pos_fn_integral m (\x. f x + g x + h x) =
+          pos_fn_integral m (\x. f x + g x) +
+          pos_fn_integral m h’
+ >- (HO_MATCH_MP_TAC pos_fn_integral_add >> rw [le_add] \\
+     MATCH_MP_TAC IN_MEASURABLE_BOREL_ADD' \\
+     qexistsl_tac [‘f’, ‘g’] >> rw [] \\
+     fs [measure_space_def])
+ >> Rewr'
+ >> Suff ‘pos_fn_integral m (\x. f x + g x) =
+          pos_fn_integral m f + pos_fn_integral m g’ >- rw []
+ >> MATCH_MP_TAC pos_fn_integral_add >> art []
+QED
+
+(* An easy corollary of the new integral_add' and integrable_add' *)
+Theorem integral_add3 :
+    !m f g h. measure_space m /\
+              integrable m f /\ integrable m g /\ integrable m h
+          ==> integral m (\x. f x + g x + h x) =
+              integral m f + integral m g + integral m h
+Proof
+    rpt STRIP_TAC
+ >> Know ‘integral m (\x. f x + g x + h x) =
+          integral m (\x. f x + g x) + integral m h’
+ >- (HO_MATCH_MP_TAC integral_add' >> simp [] \\
+     MATCH_MP_TAC integrable_add' >> rw [])
+ >> Rewr'
+ >> Suff ‘integral m (\x. f x + g x) = integral m f + integral m g’ >- rw []
+ >> MATCH_MP_TAC integral_add' >> rw []
+QED
+
 (* ------------------------------------------------------------------------- *)
 (*   Convergence theorems and their applications [1, Chapter 9 & 12]         *)
 (* ------------------------------------------------------------------------- *)
@@ -1669,9 +1929,40 @@ Theorem pos_fn_integral_cong_measure' :
              (pos_fn_integral m1 f = pos_fn_integral m2 f)
 Proof
     RW_TAC std_ss [measure_space_eq_def]
- >> MP_TAC (Q.SPECL [‘m_space m1’, ‘measurable_sets m1’, ‘measure m1’, ‘measure m2’, ‘f’]
-                    pos_fn_integral_cong_measure)
+ >> MP_TAC (Q.SPECL [‘m_space m1’, ‘measurable_sets m1’, ‘measure m1’,
+                     ‘measure m2’, ‘f’] pos_fn_integral_cong_measure)
  >> rw []
+QED
+
+Theorem pos_fn_integral_distr_of :
+    !M N f u.
+        measure_space M /\ measure_space N /\
+        f IN measurable (measurable_space M) (measurable_space N) /\
+        u IN Borel_measurable (measurable_space N) /\
+       (!x. x IN m_space N ==> 0 <= u x) ==>
+        pos_fn_integral (distr_of M N f) u = pos_fn_integral M (u o f)
+Proof
+    rpt STRIP_TAC
+ >> Know ‘measure_space (distr_of M N f)’
+ >- (MATCH_MP_TAC measure_space_distr_of >> art [])
+ >> DISCH_TAC
+ >> Know ‘measure_space (m_space N,measurable_sets N,distr M f)’
+ >- (qabbrev_tac ‘B = measurable_space N’ \\
+    ‘m_space N = space B’ by rw [Abbr ‘B’] >> POP_ORW \\
+    ‘measurable_sets N = subsets B’ by rw [Abbr ‘B’] >> POP_ORW \\
+     MATCH_MP_TAC measure_space_distr \\
+     rw [MEASURE_SPACE_SIGMA_ALGEBRA, Abbr ‘B’])
+ >> DISCH_TAC
+ >> Know ‘pos_fn_integral (distr_of M N f) u =
+          pos_fn_integral (m_space N,measurable_sets N,distr M f) u’
+ >- (MATCH_MP_TAC pos_fn_integral_cong_measure' >> art [] \\
+     rw [measure_space_eq_def, distr_of, distr_def])
+ >> Rewr'
+ >> qabbrev_tac ‘B = measurable_space N’
+ >> ‘m_space N = space B’ by rw [Abbr ‘B’] >> POP_ORW
+ >> ‘measurable_sets N = subsets B’ by rw [Abbr ‘B’] >> POP_ORW
+ >> MATCH_MP_TAC pos_fn_integral_distr
+ >> rw [MEASURE_SPACE_SIGMA_ALGEBRA, Abbr ‘B’]
 QED
 
 Theorem integral_cong_measure_base[local] :
@@ -1683,9 +1974,10 @@ Theorem integral_cong_measure_base[local] :
 Proof
     rpt GEN_TAC >> STRIP_TAC
  >> simp [integral_def, integrable_def]
- >> Suff ‘(pos_fn_integral (sp,sts,u) (fn_plus f) = pos_fn_integral (sp,sts,v) (fn_plus f)) /\
-          (pos_fn_integral (sp,sts,u) (fn_minus f) = pos_fn_integral (sp,sts,v) (fn_minus f))’
- >- rw []
+ >> Suff ‘pos_fn_integral (sp,sts,u) (fn_plus f) =
+          pos_fn_integral (sp,sts,v) (fn_plus f) /\
+          pos_fn_integral (sp,sts,u) (fn_minus f) =
+          pos_fn_integral (sp,sts,v) (fn_minus f)’ >- rw []
  >> CONJ_TAC (* 2 subgoals, same tactics *)
  >> MATCH_MP_TAC pos_fn_integral_cong_measure
  >> rw [FN_PLUS_POS, FN_MINUS_POS]
@@ -1705,8 +1997,8 @@ Theorem integral_cong_measure' :
              (integral m1 f = integral m2 f)
 Proof
     RW_TAC std_ss [measure_space_eq_def]
- >> MP_TAC (Q.SPECL [‘m_space m1’, ‘measurable_sets m1’, ‘measure m1’, ‘measure m2’, ‘f’]
-                    integral_cong_measure)
+ >> MP_TAC (Q.SPECL [‘m_space m1’, ‘measurable_sets m1’, ‘measure m1’,
+                     ‘measure m2’, ‘f’] integral_cong_measure)
  >> rw []
 QED
 
@@ -1725,8 +2017,8 @@ Theorem integrable_cong_measure' :
              (integrable m1 f <=> integrable m2 f)
 Proof
     RW_TAC std_ss [measure_space_eq_def]
- >> MP_TAC (Q.SPECL [‘m_space m1’, ‘measurable_sets m1’, ‘measure m1’, ‘measure m2’, ‘f’]
-                    integrable_cong_measure)
+ >> MP_TAC (Q.SPECL [‘m_space m1’, ‘measurable_sets m1’, ‘measure m1’,
+                     ‘measure m2’, ‘f’] integrable_cong_measure)
  >> rw []
 QED
 
@@ -1734,9 +2026,9 @@ QED
 (*  Product measures and Fubini's theorem (Chapter 14 of [1])                *)
 (* ------------------------------------------------------------------------- *)
 
-(* ‘FCP_CONCAT s t’ is in place of ‘(a,b)’ (pair), thus ’fcp_pair a b’ is ‘a CROSS b’ *)
-val fcp_cross_def = Define (* cf. CROSS_DEF *)
-   ‘fcp_cross A B = {FCP_CONCAT a b | a IN A /\ b IN B}’;
+Definition fcp_cross_def : (* cf. CROSS_DEF *)
+    fcp_cross A B = {FCP_CONCAT a b | a IN A /\ b IN B}
+End
 
 Theorem IN_FCP_CROSS : (* cf. IN_CROSS *)
     !s a b. s IN fcp_cross a b <=> ?t u. (s = FCP_CONCAT t u) /\ t IN a /\ u IN b
@@ -1773,7 +2065,8 @@ Proof
 QED
 
 Theorem FCP_BIGUNION_CROSS :
-    !f s t. fcp_cross (BIGUNION (IMAGE f s)) t = BIGUNION (IMAGE (\n. fcp_cross (f n) t) s)
+    !f s t. fcp_cross (BIGUNION (IMAGE f s)) t =
+            BIGUNION (IMAGE (\n. fcp_cross (f n) t) s)
 Proof
     rw [Once EXTENSION, IN_BIGUNION_IMAGE, IN_FCP_CROSS]
  >> EQ_TAC >> rpt STRIP_TAC
@@ -1786,7 +2079,8 @@ Proof
 QED
 
 Theorem FCP_CROSS_BIGUNION :
-    !f s t. fcp_cross t (BIGUNION (IMAGE f s)) = BIGUNION (IMAGE (\n. fcp_cross t (f n)) s)
+    !f s t. fcp_cross t (BIGUNION (IMAGE f s)) =
+            BIGUNION (IMAGE (\n. fcp_cross t (f n)) s)
 Proof
     rw [Once EXTENSION, IN_BIGUNION_IMAGE, IN_FCP_CROSS]
  >> EQ_TAC >> rpt STRIP_TAC
@@ -1936,7 +2230,8 @@ val general_prod_def = Define
 
 Theorem IN_general_prod :
     !(cons :'a -> 'b -> 'c) s A B.
-        s IN general_prod cons A B <=> ?a b. (s = general_cross cons a b) /\ a IN A /\ b IN B
+        s IN general_prod cons A B <=>
+       ?a b. s = general_cross cons a b /\ a IN A /\ b IN B
 Proof
     RW_TAC std_ss [general_prod_def, GSPECIFICATION, UNCURRY]
  >> EQ_TAC >> rpt STRIP_TAC
@@ -1945,14 +2240,12 @@ Proof
  >> RW_TAC std_ss []
 QED
 
-(* alternative definition of prod_sets *)
 Theorem prod_sets_alt :
     !A B. prod_sets A B = general_prod pair$, A B
 Proof
     RW_TAC std_ss [Once EXTENSION, IN_PROD_SETS, IN_general_prod, GSYM CROSS_ALT]
 QED
 
-(* alternative definition of fcp_prod *)
 Theorem fcp_prod_alt :
     !A B. fcp_prod A B = general_prod FCP_CONCAT A B
 Proof
@@ -6911,7 +7204,8 @@ Proof
        >- (rpt STRIP_TAC \\
            fs [null_set_def] \\
            Q.ABBREV_TAC ‘s = {x | x IN m_space m /\ c <= abs (f x)}’ \\
-          ‘s IN measurable_sets m’ by rw [Abbr ‘s’, IN_MEASURABLE_BOREL_ALL_MEASURE_ABS'] \\
+          ‘s IN measurable_sets m’
+             by rw [Abbr ‘s’, IN_MEASURABLE_BOREL_ALL_MEASURE_ABS'] \\
           ‘s = (s DIFF N) UNION (s INTER N)’ by SET_TAC [] >> POP_ORW \\
           ‘DISJOINT (s DIFF N) (s INTER N)’ by SET_TAC [DISJOINT_ALT] \\
            Know ‘measure m (s DIFF N UNION s INTER N) =
@@ -6971,7 +7265,8 @@ Proof
       ‘measure m s = 0 \/ 0 < measure m s’ by PROVE_TAC [MEASURE_POSITIVE, le_lt] \\
        Q.PAT_X_ASSUM ‘measure m s <> 0’ K_TAC \\
        POP_ASSUM MP_TAC (* 0 < measure m s *) \\
-       Know ‘s = BIGUNION (IMAGE (\n. {x | x IN m_space m /\ (inv &SUC n) <= abs (f x)}) UNIV)’
+       Know ‘s = BIGUNION (IMAGE (\n. {x | x IN m_space m /\
+                                      (inv &SUC n) <= abs (f x)}) UNIV)’
        >- (rw [Abbr ‘s’, Once EXTENSION, IN_BIGUNION_IMAGE, Excl "abs_gt_0"] \\
            reverse EQ_TAC >> RW_TAC std_ss [] >> art []
            >- (MATCH_MP_TAC lte_trans \\
@@ -7094,7 +7389,8 @@ Proof
            pos_fn_integral m (\x. seminorm PosInf m u * (abs o v) x)’
      >- (ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
         ‘?r. 0 <= r /\ seminorm PosInf m u = Normal r’
-           by METIS_TAC [extreal_cases, extreal_of_num_def, extreal_le_eq] >> POP_ORW \\
+           by METIS_TAC [extreal_cases, extreal_of_num_def, extreal_le_eq] \\
+         POP_ORW \\
          MATCH_MP_TAC pos_fn_integral_cmul >> rw [o_DEF, abs_pos]) >> Rewr' \\
      MATCH_MP_TAC pos_fn_integral_mono_AE >> rw [abs_pos]
      >- (MATCH_MP_TAC le_mul >> rw [abs_pos]) \\
@@ -7108,7 +7404,8 @@ Proof
  >- (MATCH_MP_TAC IN_MEASURABLE_BOREL_TIMES \\
      qexistsl_tac [‘u’, ‘v’] >> rw [])
  >> rw [integrable_abs_alt, lt_infty]
- >> Know ‘pos_fn_integral m (abs o (\x. u x * v x)) = integral m (\x. abs (u x * v x))’
+ >> Know ‘pos_fn_integral m (abs o (\x. u x * v x)) =
+          integral m (\x. abs (u x * v x))’
  >- (rw [o_DEF, Once EQ_SYM_EQ] \\
      MATCH_MP_TAC integral_pos_fn >> rw [abs_pos])
  >> Rewr'
@@ -7226,7 +7523,8 @@ Proof
      CONJ_TAC >- (MATCH_MP_TAC INCREASING \\
                   rw [MEASURE_SPACE_INCREASING, SUBSET_DEF]) \\
     ‘0 = measure m N’ by PROVE_TAC [null_set_def] \\
-     POP_ASSUM (GEN_REWRITE_TAC (RAND_CONV o ONCE_DEPTH_CONV) empty_rewrites o wrap) \\
+     POP_ASSUM
+       (GEN_REWRITE_TAC (RAND_CONV o ONCE_DEPTH_CONV) empty_rewrites o wrap) \\
      MATCH_MP_TAC INCREASING >> rw [MEASURE_SPACE_INCREASING] \\
      fs [null_set_def])
  >> Cases_on ‘seminorm q m v = 0’ (* symmetric with above *)
@@ -7281,7 +7579,8 @@ Proof
      CONJ_TAC >- (MATCH_MP_TAC INCREASING \\
                   rw [MEASURE_SPACE_INCREASING, SUBSET_DEF]) \\
     ‘0 = measure m N’ by PROVE_TAC [null_set_def] \\
-     POP_ASSUM (GEN_REWRITE_TAC (RAND_CONV o ONCE_DEPTH_CONV) empty_rewrites o wrap) \\
+     POP_ASSUM
+       (GEN_REWRITE_TAC (RAND_CONV o ONCE_DEPTH_CONV) empty_rewrites o wrap) \\
      MATCH_MP_TAC INCREASING >> rw [MEASURE_SPACE_INCREASING] \\
      fs [null_set_def])
  >> ‘0 <= seminorm p m u /\ 0 <= seminorm q m v’ by PROVE_TAC [seminorm_pos]
@@ -7328,9 +7627,11 @@ Proof
      Know ‘!x. abs (u x) / seminorm p m u * (abs (v x) / seminorm q m v) =
                abs (u x * v x) / (seminorm p m u * seminorm q m v)’
      >- (Q.X_GEN_TAC ‘x’ \\
-        ‘?a. a <> 0 /\ seminorm p m u = Normal a’ by METIS_TAC [extreal_cases, extreal_of_num_def] \\
+        ‘?a. a <> 0 /\ seminorm p m u = Normal a’
+           by METIS_TAC [extreal_cases, extreal_of_num_def] \\
          POP_ORW \\
-        ‘?b. b <> 0 /\ seminorm q m v = Normal b’ by METIS_TAC [extreal_cases, extreal_of_num_def] \\
+        ‘?b. b <> 0 /\ seminorm q m v = Normal b’
+           by METIS_TAC [extreal_cases, extreal_of_num_def] \\
          POP_ORW \\
         ‘a * b <> 0’ by PROVE_TAC [REAL_ENTIRE] \\
          rw [extreal_div_def, extreal_mul_def, abs_mul] \\
@@ -7400,7 +7701,8 @@ Proof
          by METIS_TAC [extreal_cases, extreal_of_num_def, extreal_lt_eq] >> POP_ORW \\
       ‘Q <> 0’ by rw [REAL_LT_IMP_NE] \\
       ‘0 < inv r’ by rw [REAL_INV_POS] \\
-       rw [extreal_div_def, extreal_inv_def, extreal_mul_def, normal_powr, GSYM mul_assoc] \\
+       rw [extreal_div_def, extreal_inv_def, extreal_mul_def, normal_powr,
+           GSYM mul_assoc] \\
        MATCH_MP_TAC IN_MEASURABLE_BOREL_CMUL \\
        qexistsl_tac [‘\x. abs (v x) powr Normal Q’, ‘inv Q * inv r powr Q’] \\
        RW_TAC std_ss [] >| (* 3 subgoals *)
@@ -7449,8 +7751,8 @@ Proof
  >| [ (* goal 1 (of 2) *)
       Know ‘!x. abs (u x) / seminorm p m u = abs (u x) * inv (seminorm p m u)’
       >- (‘?r. 0 < r /\ seminorm p m u = Normal r’
-            by METIS_TAC [extreal_cases, extreal_of_num_def, extreal_lt_eq] >> POP_ORW \\
-          ‘r <> 0’ by rw [REAL_LT_IMP_NE] \\
+            by METIS_TAC [extreal_cases, extreal_of_num_def, extreal_lt_eq] \\
+          POP_ORW >> ‘r <> 0’ by rw [REAL_LT_IMP_NE] \\
           rw [extreal_div_def]) >> Rewr' \\
       Know ‘!x. (abs (u x) * inv (seminorm p m u)) powr p =
                 (abs (u x)) powr p * (inv (seminorm p m u)) powr p’
@@ -7478,7 +7780,8 @@ Proof
       Know ‘pos_fn_integral m (\x. inv c * abs (u x) powr p) =
             inv c * pos_fn_integral m (\x. abs (u x) powr p)’
       >- (‘?r. 0 <= r /\ inv c = Normal r’
-            by METIS_TAC [extreal_cases, extreal_of_num_def, extreal_le_eq] >> POP_ORW \\
+            by METIS_TAC [extreal_cases, extreal_of_num_def, extreal_le_eq] \\
+          POP_ORW \\
           HO_MATCH_MP_TAC pos_fn_integral_cmul >> rw [powr_pos]) >> Rewr' \\
       simp [] (* inv c * c = 1 *) \\
       MATCH_MP_TAC mul_linv_pos >> art [] \\
@@ -7487,8 +7790,8 @@ Proof
       (* goal 2 (of 2), symmetric with above *)
       Know ‘!x. abs (v x) / seminorm q m v = abs (v x) * inv (seminorm q m v)’
       >- (‘?r. 0 < r /\ seminorm q m v = Normal r’
-            by METIS_TAC [extreal_cases, extreal_of_num_def, extreal_lt_eq] >> POP_ORW \\
-          ‘r <> 0’ by rw [REAL_LT_IMP_NE] \\
+            by METIS_TAC [extreal_cases, extreal_of_num_def, extreal_lt_eq] \\
+          POP_ORW >> ‘r <> 0’ by rw [REAL_LT_IMP_NE] \\
           rw [extreal_div_def]) >> Rewr' \\
       Know ‘!x. (abs (v x) * inv (seminorm q m v)) powr q =
                 (abs (v x)) powr q * (inv (seminorm q m v)) powr q’
@@ -7516,7 +7819,8 @@ Proof
       Know ‘pos_fn_integral m (\x. inv c * abs (v x) powr q) =
             inv c * pos_fn_integral m (\x. abs (v x) powr q)’
       >- (‘?r. 0 <= r /\ inv c = Normal r’
-            by METIS_TAC [extreal_cases, extreal_of_num_def, extreal_le_eq] >> POP_ORW \\
+            by METIS_TAC [extreal_cases, extreal_of_num_def, extreal_le_eq] \\
+          POP_ORW \\
           HO_MATCH_MP_TAC pos_fn_integral_cmul >> rw [powr_pos]) >> Rewr' \\
       simp [] (* inv c * c = 1 *) \\
       MATCH_MP_TAC mul_linv_pos >> art [] \\
@@ -7528,7 +7832,8 @@ QED
 Theorem Hoelder_inequality' :
     !m u v p q. measure_space m /\ 0 < p /\ 0 < q /\ inv(p) + inv(q) = 1 /\
                 u IN lp_space p m /\ v IN lp_space q m
-            ==> pos_fn_integral m (\x. abs (u x * v x)) <= seminorm p m u * seminorm q m v
+            ==> pos_fn_integral m (\x. abs (u x * v x)) <=
+                seminorm p m u * seminorm q m v
 Proof
     rpt STRIP_TAC
  >> Suff ‘pos_fn_integral m (\x. abs (u x * v x)) = integral m (\x. abs (u x * v x))’
@@ -7698,7 +8003,8 @@ Proof
  >> POP_ORW
  >> rw [extreal_abs_def]
  >> ‘0 < abs (a + b) /\ 0 < abs a /\ 0 < abs b’ by rw []
- >> rw [normal_powr, extreal_of_num_def, extreal_add_def, extreal_mul_def, extreal_le_eq]
+ >> rw [normal_powr, extreal_of_num_def, extreal_add_def, extreal_mul_def,
+        extreal_le_eq]
  >> ONCE_REWRITE_TAC [REAL_MUL_COMM]
  (* below is real-only *)
  >> MATCH_MP_TAC REAL_LE_TRANS
@@ -7733,7 +8039,7 @@ QED
 
    see, e.g., Corollary 13.4 (Minkowski's inequality) [1, p.118]
 
-   NOTE: This inequality does NOT hold when ‘0 < p < 1’, in which case the inequality
+   NOTE: This inequality does NOT hold when ‘0 < p < 1’, where the inequality
          became ‘seminorm p m u + seminorm p m v <= seminorm p m (\x. u x + v x)’,
          namely "Reversed Minkowski's Inequality" (less useful), which can be proven
          from the present Minkowski_inequality by considering u and (\x. 1 / v x).
@@ -7767,13 +8073,15 @@ Proof
                  ‘0 < PosInf’ by rw [] \\
                   rw [seminorm_pos, Abbr ‘cu’, Abbr ‘cv’]) \\
      Q.ABBREV_TAC ‘P = \x. abs (u x + v x) < cu + cv + e’ \\
-    ‘{x | x IN m_space m /\ cu + cv + e <= abs (u x + v x)} = {x | x IN m_space m /\ ~P x}’
+    ‘{x | x IN m_space m /\ cu + cv + e <= abs (u x + v x)} =
+     {x | x IN m_space m /\ ~P x}’
         by rw [Abbr ‘P’, extreal_lt_def] >> POP_ORW \\
      Know ‘measure m {x | x IN m_space m /\ ~P x} = 0 <=> (AE x::m. P x)’
      >- (ONCE_REWRITE_TAC [EQ_SYM_EQ] \\
          MATCH_MP_TAC AE_iff_measurable >> rw [Abbr ‘P’, extreal_lt_def] \\
          Q.ABBREV_TAC ‘f = (\x. u x + v x)’ \\
-        ‘sigma_algebra (measurable_space m)’ by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA] \\
+        ‘sigma_algebra (measurable_space m)’
+           by PROVE_TAC [MEASURE_SPACE_SIGMA_ALGEBRA] \\
         ‘f IN Borel_measurable (measurable_space m)’ by fs [lp_space_def] \\
          rw [le_abs_bounds] \\
         ‘{x | x IN m_space m /\ (f x <= -(cu + cv + e) \/ cu + cv + e <= f x)} =
@@ -7806,7 +8114,8 @@ Proof
  >> ‘p <> NegInf’ by rw [pos_not_neginf]
  >> ‘0 <= p - 1’ by rw [GSYM sub_zero_le]
  >> Know ‘pos_fn_integral m (\x. abs (u x + v x) powr (1 + (p - 1))) =
-          pos_fn_integral m (\x. abs (u x + v x) powr 1 * abs (u x + v x) powr (p - 1))’
+          pos_fn_integral m (\x. abs (u x + v x) powr 1 *
+                                 abs (u x + v x) powr (p - 1))’
  >- (MATCH_MP_TAC pos_fn_integral_cong >> rw [powr_pos]
      >- (MATCH_MP_TAC le_mul >> rw [powr_pos]) \\
      MATCH_MP_TAC powr_add >> rw [abs_pos, sub_not_infty])
@@ -7814,7 +8123,8 @@ Proof
  >> DISCH_TAC
  (* applying abs_triangle *)
  >> Know ‘pos_fn_integral m (\x. abs (u x + v x) powr p) <=
-          pos_fn_integral m (\x. (abs (u x) + abs (v x)) * abs (u x + v x) powr (p - 1))’
+          pos_fn_integral m (\x. (abs (u x) + abs (v x)) *
+                                  abs (u x + v x) powr (p - 1))’
  >- (POP_ORW \\
      MATCH_MP_TAC pos_fn_integral_mono_AE \\
      rw [le_mul, le_add, abs_pos, powr_pos] \\
@@ -7895,7 +8205,8 @@ Proof
  >- (Q.UNABBREV_TAC ‘q’ \\
      Know ‘1 <= p / (p - 1) <=> 1 * (p - 1) <= p’
      >- (‘?r. 0 < r /\ p - 1 = Normal r’
-            by METIS_TAC [extreal_cases, extreal_of_num_def, extreal_lt_eq] >> POP_ORW \\
+            by METIS_TAC [extreal_cases, extreal_of_num_def, extreal_lt_eq] \\
+         POP_ORW \\
          MATCH_MP_TAC (GSYM le_rdiv) >> art []) >> Rewr' \\
      rw [sub_le_eq, le_addr])
  >> DISCH_TAC
@@ -8134,8 +8445,10 @@ Proof
  >- (MATCH_MP_TAC IN_MEASURABLE_BOREL_ABS_POWR \\
      rw [REAL_LT_IMP_LE])
  >> DISCH_TAC
- >> Know ‘pos_fn_integral m (\x. Normal (abs r) powr Normal z * abs (u x) powr Normal z) =
-          Normal (abs r) powr Normal z * pos_fn_integral m (\x. abs (u x) powr Normal z)’
+ >> Know ‘pos_fn_integral m (\x. Normal (abs r) powr Normal z *
+                                 abs (u x) powr Normal z) =
+          Normal (abs r) powr Normal z *
+          pos_fn_integral m (\x. abs (u x) powr Normal z)’
  >- (Know ‘Normal (abs r) powr (Normal z) = Normal (abs r powr z)’
      >- (MATCH_MP_TAC normal_powr >> rw []) >> Rewr' \\
      HO_MATCH_MP_TAC pos_fn_integral_cmul >> rw [powr_pos] \\
@@ -8149,20 +8462,21 @@ Proof
      MATCH_MP_TAC pos_fn_integral_pos >> rw [powr_pos])
  >> DISCH_TAC
  >> Know ‘(Normal (abs r) powr (Normal z) * y) powr inv (Normal z) =
-          (Normal (abs r) powr (Normal z)) powr inv (Normal z) * y powr inv (Normal z)’
+          (Normal (abs r) powr (Normal z)) powr inv (Normal z) *
+           y powr inv (Normal z)’
  >- (MATCH_MP_TAC mul_powr \\
     ‘Normal z <> 0’ by rw [REAL_LT_IMP_NE] \\
      rw [inv_pos', inv_not_infty, powr_pos])
  >> Rewr'
- >> Suff ‘(Normal (abs r) powr Normal z) powr inv (Normal z) = Normal (abs r)’ >- rw []
+ >> Suff ‘(Normal (abs r) powr Normal z) powr inv (Normal z) = Normal (abs r)’
+ >- rw []
  >> Know ‘(Normal (abs r) powr Normal z) powr inv (Normal z) =
            Normal (abs r) powr (Normal z * inv (Normal z))’
  >- (MATCH_MP_TAC powr_powr \\
     ‘Normal z <> 0’ by rw [REAL_LT_IMP_NE] \\
      rw [inv_pos', inv_not_infty, powr_pos])
  >> Rewr'
- >> Suff ‘Normal z * inv (Normal z) = 1’
- >- (Rewr' >> rw [powr_1])
+ >> Suff ‘Normal z * inv (Normal z) = 1’ >- (Rewr' >> rw [powr_1])
  >> ONCE_REWRITE_TAC [mul_comm]
  >> MATCH_MP_TAC mul_linv_pos >> rw []
 QED
@@ -8185,12 +8499,12 @@ Proof
 QED
 
 Theorem lp_space_add_cmul :
-    !p m u v a b. measure_space m /\ 0 < p /\ u IN lp_space p m /\ v IN lp_space p m
-              ==> (\x. Normal a * u x + Normal b * v x) IN lp_space p m
+    !p m u v a b.
+       measure_space m /\ 0 < p /\ u IN lp_space p m /\ v IN lp_space p m ==>
+      (\x. Normal a * u x + Normal b * v x) IN lp_space p m
 Proof
     rpt STRIP_TAC
- >> HO_MATCH_MP_TAC lp_space_add
- >> rw [lp_space_cmul]
+ >> HO_MATCH_MP_TAC lp_space_add >> rw [lp_space_cmul]
 QED
 
 (* cf. lp_space_alt_finite, lp_space_alt_infinite *)
@@ -8203,13 +8517,11 @@ Proof
  >- (‘?c. 0 < c /\ c <> PosInf /\ AE x::m. abs (f x) < c’
         by METIS_TAC [lp_space_alt_infinite] \\
      POP_ASSUM MP_TAC >> rw [AE_DEF, abs_bounds_lt, lt_infty] \\
-     Q.EXISTS_TAC ‘N’ >> rw [] >| (* 2 subgoals *)
-     [ (* goal 1 (of 2) *)
-       MATCH_MP_TAC lt_trans >> Q.EXISTS_TAC ‘c’ >> rw [GSYM lt_infty],
-       (* goal 2 (of 2) *)
-       MATCH_MP_TAC lt_trans >> Q.EXISTS_TAC ‘-c’ >> rw [GSYM lt_infty] \\
-      ‘NegInf = -PosInf’ by rw [extreal_ainv_def] >> POP_ORW \\
-       rw [eq_neg] ])
+     Q.EXISTS_TAC ‘N’ >> rw []
+     >- (Q_TAC (TRANS_TAC lt_trans) ‘c’ >> rw [GSYM lt_infty]) \\
+     Q_TAC (TRANS_TAC lt_trans) ‘-c’ >> rw [GSYM lt_infty] \\
+    ‘NegInf = -PosInf’ by rw [extreal_ainv_def] >> POP_ORW \\
+     rw [eq_neg])
  >> ‘f IN Borel_measurable (measurable_space m) /\
      pos_fn_integral m (\x. abs (f x) powr p) <> PosInf’
        by METIS_TAC [lp_space_alt_finite]
@@ -8228,15 +8540,296 @@ Proof
 QED
 
 Theorem lp_space_sub :
-    !p m u v. measure_space m /\ 0 < p /\ u IN lp_space p m /\ v IN lp_space p m
-          ==> (\x. u x - v x) IN lp_space p m
+    !p m u v. measure_space m /\ 0 < p /\
+              u IN lp_space p m /\ v IN lp_space p m ==>
+             (\x. u x - v x) IN lp_space p m
 Proof
     rw [extreal_sub]
  >> HO_MATCH_MP_TAC lp_space_add >> art []
  >> ‘(\x. -v x) = (\x. Normal (-1) * v x)’
-       by (rw [FUN_EQ_THM, GSYM extreal_ainv_def, GSYM neg_minus1, normal_1])
+       by rw [FUN_EQ_THM, GSYM extreal_ainv_def, GSYM neg_minus1, normal_1]
  >> POP_ORW
  >> MATCH_MP_TAC lp_space_cmul >> art []
+QED
+
+(* ------------------------------------------------------------------------- *)
+(*   Applications of Radon_Nikodym (ported from HVG's normal_rvScript.sml)   *)
+(* ------------------------------------------------------------------------- *)
+
+(* Radon-Nikodym derivative (RN_deriv)
+
+  `RN_deriv v m` (HOL) = `RN_deriv m (m_space m,measurable_sets m,v)` (Isabelle/HOL)
+
+   The existence of `RN_deriv v m` is then asserted by Radon-Nikodym theorem, and
+   its uniqueness is asserted by the following (unproved) theorem:
+
+     !m f f'. measure_space m /\ sigma_finite m /\
+              f IN borel_measurable (m_space m,measurable_sets m) /\
+              f' IN borel_measurable (m_space m,measurable_sets m) /\
+              nonneg f /\ nonneg f' /\
+              (!s. s IN measurable_sets m ==> ((f * m) s = (f' * m) s))
+          ==> AE x::m. (f x = f' x)
+
+   see also density_measure_def for the overload of ‘*’ in `f * m`.
+ *)
+Definition RN_deriv_def : (* or `v / m` (dv/dm) *)
+    RN_deriv v m =
+      @f. f IN measurable (m_space m,measurable_sets m) Borel /\
+          (!x. x IN m_space m ==> 0 <= f x) /\
+          !s. s IN measurable_sets m ==> ((f * m) s = v s)
+End
+
+(* `f = RN_deriv v m` is denoted by `f = v / m`
+   NOTE: cannot use the Overload syntax sugar here (on "/").
+ *)
+val _ = overload_on ("/", “RN_deriv”);
+
+Theorem RN_deriv_thm :
+    !m v. measure_space m /\
+          (?f. f IN measurable (m_space m,measurable_sets m) Borel /\
+              (!x. x IN m_space m ==> 0 <= f x) /\
+              (!s. s IN measurable_sets m ==> (f * m) s = v s)) ==>
+          !s. s IN measurable_sets m ==> (v / m * m) s = v s
+Proof
+    RW_TAC std_ss [RN_deriv_def]
+ >> SELECT_ELIM_TAC
+ >> CONJ_TAC >- (Q.EXISTS_TAC ‘f’ >> rw [])
+ >> Q.X_GEN_TAC ‘g’
+ >> rpt STRIP_TAC
+ >> POP_ASSUM MATCH_MP_TAC >> art []
+QED
+
+(* This is ported from the following theorem (RN_derivI)
+
+    !f M N. f IN measurable (m_space M, measurable_sets M) Borel /\
+            (!x. 0 <= f x) /\ (density M f = measure_of N) /\
+             measure_space M /\ measure_space N /\
+            (measurable_sets M = measurable_sets N) ==>
+            (density M (RN_deriv M N) = measure_of N)
+ *)
+Theorem RN_deriv_thm' :
+    !f m v. measure_space m /\
+            f IN measurable (m_space m,measurable_sets m) Borel /\
+           (!x. x IN m_space m ==> 0 <= f x) /\
+           (!s. s IN measurable_sets m ==> (f * m) s = v s) ==>
+            measure_space_eq (density m (v / m))
+                             (m_space m,measurable_sets m,v)
+Proof
+    rw [measure_space_eq_def, density_def]
+ >> irule RN_deriv_thm >> art []
+ >> Q.EXISTS_TAC ‘f’ >> rw []
+QED
+
+(* NOTE: This is compatible with the original "RN_deriv" of HVG Concordia *)
+Overload RN_deriv' = “\M N. RN_deriv (measure N) M”
+
+Theorem RN_derivI :
+    !f M N. measure_space M /\ measure_space N /\
+            f IN measurable (m_space M, measurable_sets M) Borel /\
+            (!x. x IN m_space M ==> 0 <= f x) /\
+             density_of M f = measure_of N /\
+             measure_space M /\ measure_space N /\
+             measurable_sets M = measurable_sets N ==>
+             density_of M (RN_deriv' M N) = measure_of N
+Proof
+    RW_TAC std_ss [RN_deriv_def] >> SELECT_ELIM_TAC
+ >> `m_space M = m_space N` by METIS_TAC [sets_eq_imp_space_eq]
+ >> Know `measurable_sets N SUBSET POW (m_space N)`
+ >- FULL_SIMP_TAC std_ss [measure_space_def, sigma_algebra_iff2]
+ >> DISCH_TAC
+ >> `sigma_sets (m_space N) (measurable_sets N) = measurable_sets N`
+      by METIS_TAC [sigma_sets_eq, measure_space_def]
+ >> RW_TAC std_ss []
+ >- (Q.EXISTS_TAC `f` >> FULL_SIMP_TAC std_ss [] \\
+     RW_TAC std_ss [] \\
+     UNDISCH_TAC ``density_of M f = measure_of N`` \\
+     GEN_REWR_TAC (LAND_CONV o RAND_CONV o RAND_CONV) [GSYM MEASURE_SPACE_REDUCE] \\
+     simp [density_measure_def, measure_of, FUN_EQ_THM, density_of] THEN
+     DISCH_THEN (MP_TAC o Q.SPEC `s`) >> simp [] \\
+     DISCH_THEN (REWRITE_TAC o wrap o SYM) \\
+     MATCH_MP_TAC pos_fn_integral_cong >> simp [] \\
+     CONJ_ASM1_TAC
+     >- (Q.X_GEN_TAC ‘y’ >> STRIP_TAC \\
+         MATCH_MP_TAC le_mul >> rw [INDICATOR_FN_POS]) \\
+     CONJ_TAC >- rw [le_max] \\
+     rw [Once EQ_SYM_EQ] \\
+     MATCH_MP_TAC max_0_reduce >> rw [])
+ >> GEN_REWR_TAC (RAND_CONV o RAND_CONV) [GSYM MEASURE_SPACE_REDUCE]
+ >> FULL_SIMP_TAC std_ss [density_of, measure_def, measure_of]
+ >> RW_TAC std_ss [MEASURE_SPACE_REDUCE, FUN_EQ_THM]
+ >> Cases_on ‘a IN measurable_sets N’ >> rw []
+ >> Know ‘pos_fn_integral M (\x'. max 0 (x x' * indicator_fn a x')) =
+          pos_fn_integral M (\x'. x x' * indicator_fn a x')’
+ >- (MATCH_MP_TAC pos_fn_integral_cong \\
+     simp [] \\
+     CONJ_TAC >- rw [le_max] \\
+     CONJ_ASM1_TAC
+     >- (Q.X_GEN_TAC ‘y’ >> STRIP_TAC \\
+         MATCH_MP_TAC le_mul >> rw [INDICATOR_FN_POS]) \\
+     Q.X_GEN_TAC ‘z’ >> STRIP_TAC \\
+     MATCH_MP_TAC max_0_reduce \\
+     MATCH_MP_TAC le_mul >> rw [INDICATOR_FN_POS])
+ >> Rewr'
+ >> SIMP_TAC std_ss [GSYM density_measure]
+ >> FIRST_X_ASSUM MATCH_MP_TAC >> art []
+QED
+
+Theorem density_RN_deriv :
+    !M N. sigma_finite_measure_space M /\ measure_space N /\
+          measure_absolutely_continuous' N M /\
+          measurable_sets M = measurable_sets N ==>
+          density_of M (RN_deriv' M N) = measure_of N
+Proof
+    RW_TAC std_ss [sigma_finite_measure_space_def]
+ >> MATCH_MP_TAC RN_derivI
+ >> MP_TAC (Q.SPECL [‘M’, ‘N’] RADON_NIKODYM) >> rw []
+ >> Q.EXISTS_TAC ‘f’ >> rw []
+ >> ASM_SIMP_TAC std_ss [density_of]
+ >> ‘m_space M = m_space N’ by METIS_TAC [sets_eq_imp_space_eq]
+ >> Know ‘measurable_sets N SUBSET POW (m_space N)’
+ >- FULL_SIMP_TAC std_ss [measure_space_def, sigma_algebra_iff2]
+ >> DISCH_TAC
+ >> ‘sigma_sets (m_space N) (measurable_sets N) = measurable_sets N’
+      by METIS_TAC [sigma_sets_eq, measure_space_def]
+ >> GEN_REWR_TAC (RAND_CONV o RAND_CONV) [GSYM MEASURE_SPACE_REDUCE]
+ >> ASM_SIMP_TAC std_ss [FUN_EQ_THM, measure_of]
+ >> rw [MEASURE_SPACE_REDUCE, density_measure_def]
+ >> Suff ‘pos_fn_integral M (\x. max 0 (f x * indicator_fn a x)) =
+          pos_fn_integral M (\x. f x * indicator_fn a x)’ >- rw []
+ >> MATCH_MP_TAC pos_fn_integral_cong >> simp []
+ >> CONJ_TAC >- rw [le_max]
+ >> CONJ_ASM1_TAC
+ >- (Q.X_GEN_TAC ‘y’ >> STRIP_TAC \\
+     MATCH_MP_TAC le_mul >> rw [INDICATOR_FN_POS])
+ >> Q.X_GEN_TAC ‘z’ >> STRIP_TAC
+ >> MATCH_MP_TAC max_0_reduce
+ >> MATCH_MP_TAC le_mul >> rw [INDICATOR_FN_POS]
+QED
+
+(* NOTE: The new, shorter proof is based on pos_fn_integral_cong_measure' *)
+Theorem RN_deriv_positive_integral :
+    !M N f. sigma_finite_measure_space M /\ measure_space N /\
+            measure_absolutely_continuous' N M /\
+            measurable_sets M = measurable_sets N /\
+            f IN measurable (m_space M, measurable_sets M) Borel /\
+           (!x. x IN m_space M ==> 0 <= f x) ==>
+            pos_fn_integral N f =
+            pos_fn_integral (density_of M (RN_deriv' M N)) f
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC pos_fn_integral_cong_measure'
+ >> Know ‘density_of M (RN_deriv' M N) = measure_of N’
+ >- (MATCH_MP_TAC density_RN_deriv >> art [])
+ >> Rewr'
+ >> fs [sigma_finite_measure_space_def]
+ >> ‘m_space N = m_space M’ by METIS_TAC [sets_eq_imp_space_eq]
+ >> simp [measure_of_measure_space, measure_space_eq_measure_of]
+QED
+
+Theorem pos_fn_integral_max_0 :
+    !m f. measure_space m /\
+         (!x. x IN m_space m ==> 0 <= f x) ==>
+          pos_fn_integral m (\x. max 0 (f x)) = pos_fn_integral m f
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC pos_fn_integral_cong >> rw [le_max]
+ >> MATCH_MP_TAC max_0_reduce >> rw []
+QED
+
+Theorem pos_fn_integral_density_of :
+    !m f g. measure_space m /\
+           (!x. x IN m_space m ==> 0 <= f x) /\
+           (!x. x IN m_space m ==> 0 <= g x) /\
+            f IN Borel_measurable (measurable_space m) ==>
+            pos_fn_integral (density_of m f) g = pos_fn_integral (density m f) g
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC pos_fn_integral_cong_measure'
+ >> simp [measure_space_density, measure_space_density_of]
+ >> reverse CONJ_TAC >- rw [density_of]
+ >> rw [measure_space_eq_def, density_def, density_of]
+ >> qabbrev_tac ‘h = \x. f x * indicator_fn s x’ >> simp []
+ >> Know ‘pos_fn_integral m (\x. max 0 (h x)) = pos_fn_integral m h’
+ >- (MATCH_MP_TAC pos_fn_integral_max_0 >> rw [Abbr ‘h’] \\
+     MATCH_MP_TAC le_mul >> rw [INDICATOR_FN_POS])
+ >> Rewr'
+ >> rw [Abbr ‘h’, density_measure_def]
+QED
+
+Theorem pos_fn_integral_density :
+    !m f g. measure_space m /\
+            f IN measurable (m_space m, measurable_sets m) Borel /\
+            g IN measurable (m_space m, measurable_sets m) Borel /\
+           (AE x::m. 0 <= f x) /\ (!x. 0 <= g x)
+       ==> (pos_fn_integral (density m (fn_plus f)) g =
+            pos_fn_integral m (\x. (fn_plus f) x * g x))
+Proof
+    rpt STRIP_TAC
+ >> MP_TAC (Q.SPECL [`f`, `g`, `m`] pos_fn_integral_density')
+ >> RW_TAC std_ss [GSYM density_fn_plus]
+ >> Know `(\x. max 0 (g x)) = g`
+ >- (RW_TAC std_ss [FUN_EQ_THM, GSYM fn_plus] \\
+     Suff `fn_plus g = g` >- rw [] \\
+     MATCH_MP_TAC nonneg_fn_plus >> rw [nonneg_def])
+ >> DISCH_THEN (fs o wrap)
+ >> POP_ASSUM K_TAC
+ >> Suff `!x. max 0 ((\x. f x * g x) x) = (fn_plus f) x * g x` >- rw []
+ >> GEN_TAC >> REWRITE_TAC [GSYM fn_plus]
+ >> ONCE_REWRITE_TAC [mul_comm]
+ >> ASM_SIMP_TAC std_ss [FN_PLUS_FMUL]
+QED
+
+Theorem density_eq :
+    !m f g. measure_space m /\
+           (!x. x IN m_space m ==> 0 <= g x) /\
+           (!x. x IN m_space m ==> f x = g x) ==>
+            density m f = density m g
+Proof
+    rw [density_def, density_measure_def, FUN_EQ_THM]
+ >> MATCH_MP_TAC pos_fn_integral_cong
+ >> simp []
+ >> rpt STRIP_TAC
+ >> MATCH_MP_TAC le_mul >> rw [INDICATOR_FN_POS]
+QED
+
+Theorem pos_fn_integral_density_reduce :
+    !m f g. measure_space m /\
+            f IN measurable (m_space m, measurable_sets m) Borel /\
+            g IN measurable (m_space m, measurable_sets m) Borel /\
+           (!x. x IN m_space m ==> 0 <= f x) /\
+           (!x. x IN m_space m ==> 0 <= g x)
+       ==> pos_fn_integral (density m f) g = pos_fn_integral m (\x. f x * g x)
+Proof
+    rpt STRIP_TAC
+ >> qabbrev_tac ‘g' = \x. if x IN m_space m then g x else 0’
+ >> ‘!x. 0 <= g' x’ by rw [Abbr ‘g'’]
+ >> Know ‘g' IN Borel_measurable (measurable_space m)’
+ >- (MATCH_MP_TAC IN_MEASURABLE_BOREL_EQ \\
+     Q.EXISTS_TAC ‘g’ >> rw [Abbr ‘g'’])
+ >> DISCH_TAC
+ >> Know ‘AE x::m. 0 <= f x’
+ >- (HO_MATCH_MP_TAC FORALL_IMP_AE >> rw [])
+ >> DISCH_TAC
+ >> Know ‘measure_space (density m f)’
+ >- (MATCH_MP_TAC measure_space_density >> rw [])
+ >> DISCH_TAC
+ >> Know ‘pos_fn_integral (density m f) g = pos_fn_integral (density m f) g'’
+ >- (MATCH_MP_TAC pos_fn_integral_cong >> rw [density_def] \\
+     rw [Abbr ‘g'’])
+ >> Rewr'
+ >> Know ‘pos_fn_integral m (\x. f x * g x) = pos_fn_integral m (\x. f x * g' x)’
+ >- (MATCH_MP_TAC pos_fn_integral_cong >> simp [Abbr ‘g'’] \\
+     rpt STRIP_TAC \\
+     MATCH_MP_TAC le_mul >> rw [])
+ >> Rewr'
+ >> MP_TAC (Q.SPECL [‘m’, ‘f’, ‘g'’] pos_fn_integral_density) >> simp []
+ >> Know ‘density m f^+ = density m f’
+ >- (MATCH_MP_TAC density_eq >> rw [FN_PLUS_REDUCE])
+ >> Rewr'
+ >> Rewr'
+ >> MATCH_MP_TAC pos_fn_integral_cong >> simp []
+ >> rpt STRIP_TAC
+ >> MATCH_MP_TAC le_mul >> rw []
 QED
 
 (* END *)

--- a/src/probability/real_borelScript.sml
+++ b/src/probability/real_borelScript.sml
@@ -752,6 +752,15 @@ val in_borel_measurable = store_thm
             >> RW_TAC std_ss [subset_class_def, SUBSET_DEF, IN_UNIV])
    >> ASM_REWRITE_TAC []);
 
+Theorem in_borel_measurable_I :
+    (\x. x) IN measurable borel borel
+Proof
+    ‘(\x :real. x) = I’ by METIS_TAC [I_THM]
+ >> POP_ORW
+ >> MATCH_MP_TAC MEASURABLE_I
+ >> REWRITE_TAC [sigma_algebra_borel]
+QED
+
 val borel_measurable_indicator = store_thm
   ("borel_measurable_indicator",
    ``!s a. sigma_algebra s /\ a IN subsets s ==>

--- a/src/real/realScript.sml
+++ b/src/real/realScript.sml
@@ -1286,6 +1286,12 @@ Proof
   REWRITE_TAC[REAL_LE_REFL]
 QED
 
+Theorem ABS_EQ_NEG :
+    !(x :real). x < 0 ==> abs x = -x
+Proof
+    RW_TAC std_ss [real_lt, real_abs]
+QED
+
 (* |- !n. abs (&n) = &n *)
 Theorem ABS_N[simp] = REAL_ABS_NUM
 

--- a/src/real/real_sigmaScript.sml
+++ b/src/real/real_sigmaScript.sml
@@ -2534,20 +2534,41 @@ val REAL_LT_RDIV_EQ_NEG = store_thm
   >> `-y * inv(-z) < x` by METIS_TAC [GSYM REAL_LT_LDIV_EQ, real_div]
   >> METIS_TAC [REAL_NEG_INV, REAL_NEG_MUL2, GSYM real_div]);
 
-val REAL_LE_RDIV_EQ_NEG = store_thm
-  ("REAL_LE_RDIV_EQ_NEG", ``!x y z. z < 0:real ==> (y / z <= x <=> x * z <= y)``,
-  RW_TAC real_ss []
-  >> `0 < -z` by RW_TAC real_ss [REAL_NEG_GT0]
-  >> `z <> 0` by (METIS_TAC [REAL_LT_IMP_NE])
-  >>EQ_TAC
-  >- (RW_TAC real_ss []
-      >> `y / z * (-z) <= x * (-z)` by METIS_TAC [GSYM REAL_LE_RMUL]
-      >> FULL_SIMP_TAC real_ss []
-      >> METIS_TAC [REAL_DIV_RMUL,REAL_LE_NEG])
-  >> RW_TAC real_ss []
-  >> `-y <= x * (-z)` by FULL_SIMP_TAC real_ss [REAL_LE_NEG]
-  >> `-y * inv (-z) <= x` by METIS_TAC [GSYM REAL_LE_LDIV_EQ, real_div]
-  >> METIS_TAC [REAL_NEG_INV, REAL_NEG_MUL2, GSYM real_div]);
+(* REAL_LE_RDIV_EQ: |- !x y z. 0 < z ==> (x <= y / z <=> x * z <= y) *)
+Theorem REAL_LE_RDIV_EQ_NEG :
+    !x y z. z < (0 :real) ==> (y / z <= x <=> x * z <= y)
+Proof
+    RW_TAC real_ss []
+ >> `0 < -z` by RW_TAC real_ss [REAL_NEG_GT0]
+ >> `z <> 0` by (METIS_TAC [REAL_LT_IMP_NE])
+ >> EQ_TAC
+ >- (RW_TAC real_ss [] \\
+    `y / z * (-z) <= x * (-z)` by METIS_TAC [GSYM REAL_LE_RMUL] \\
+     FULL_SIMP_TAC real_ss [] \\
+     METIS_TAC [REAL_DIV_RMUL, REAL_LE_NEG])
+ >> RW_TAC real_ss []
+ >> `-y <= x * (-z)` by FULL_SIMP_TAC real_ss [REAL_LE_NEG]
+ >> `-y * inv (-z) <= x` by METIS_TAC [GSYM REAL_LE_LDIV_EQ, real_div]
+ >> METIS_TAC [REAL_NEG_INV, REAL_NEG_MUL2, GSYM real_div]
+QED
+
+(* REAL_LE_LDIV_EQ: |- !x y z. 0 < z ==> (x / z <= y <=> x <= y * z) *)
+Theorem REAL_LE_LDIV_EQ_NEG :
+    !x y z. z < (0 :real) ==> (x <= y / z <=> y <= x * z)
+Proof
+    RW_TAC real_ss []
+ >> `0 < -z` by RW_TAC real_ss [REAL_NEG_GT0]
+ >> `z <> 0` by (METIS_TAC [REAL_LT_IMP_NE])
+ >> EQ_TAC
+ >- (RW_TAC real_ss [] \\
+    `x * (-z) <= y / z * (-z)` by METIS_TAC [GSYM REAL_LE_RMUL] \\
+     FULL_SIMP_TAC real_ss [] \\
+     METIS_TAC [REAL_DIV_RMUL, REAL_LE_NEG])
+ >> RW_TAC real_ss []
+ >> `x * (-z) <= -y` by FULL_SIMP_TAC real_ss [REAL_LE_NEG]
+ >> `x <= -y * inv (-z)` by METIS_TAC [GSYM REAL_LE_RDIV_EQ, real_div]
+ >> METIS_TAC [REAL_NEG_INV, REAL_NEG_MUL2, GSYM real_div]
+QED
 
 val POW_POS_EVEN = store_thm
   ("POW_POS_EVEN",``!x:real. x < 0 ==> ((0 < x pow n) <=> (EVEN n))``,


### PR DESCRIPTION
Hi,

The property of normal random variables (and normal distributions/density) is an important part in probability formalisation, and is needed in stating/proving Central Limit Theorem, etc. But current HOL4 doesn't have them in official library and examples.

This PR contains the 1st part (of 2 parts) of porting HVG Concordia people's probability work on normal random variable (Master Thesis of Muhammad Qasim [1]).  Previously the concept `normal_density` was added into the new `distributionTheory` (#1340) but no much supporting properties were added. This PR further enrich `distributionTheory` by porting the old proof scripts (ever downloaded from HVG's file server) to latest HOL4. The ported theorems cover everything before "convolution" (distribution of sum of r.v.'s).

Some notable results are listed below:
```
[integral_normal_pdf_eq_density]
⊢ ∀X p mu sig A.
    normal_rv X p mu sig ∧ A ∈ measurable_sets lborel ⇒
    ∫⁺ lborel (λx. PDF p X x * 𝟙 A x) =
    ∫⁺ lborel (λx. Normal_density mu sig x * 𝟙 A x)

[integral_normal_pdf_eq_density']
⊢ ∀X p mu sig f.
    prob_space p ∧ normal_rv X p mu sig ∧ (∀x. 0 ≤ f x) ∧
    f ∈ Borel_measurable (measurable_space lborel) ⇒
    ∫⁺ lborel (λx. f x * PDF p X x) =
    ∫⁺ lborel (λx. f x * Normal_density mu sig x)

[integral_normal_pdf_half1]
⊢ ∀X p mu sig A.
    prob_space p ∧ normal_rv X p mu sig ∧ A = {x | x ≤ mu} ⇒
    ∫⁺ lborel (λx. PDF p X x * 𝟙 A x) = 1 / 2

[integral_normal_pdf_half2]
⊢ ∀X p mu sig A.
    prob_space p ∧ normal_rv X p mu sig ∧ A = {x | mu ≤ x} ⇒
    ∫⁺ lborel (λx. PDF p X x * 𝟙 A x) = 1 / 2

[integral_normal_pdf_split]
⊢ ∀X p mu sig.
    prob_space p ∧ normal_rv X p mu sig ⇒
    ∫⁺ lborel (PDF p X) =
    ∫⁺ lborel (λx. PDF p X x * 𝟙 {x | x ≤ mu} x) +
    ∫⁺ lborel (λx. PDF p X x * 𝟙 {x | mu ≤ x} x)

[integral_normal_pdf_symmetry]
⊢ ∀X p mu sig.
    prob_space p ∧ normal_rv X p mu sig ⇒
    ∫⁺ lborel (λx. PDF p X x * 𝟙 {x | x ≤ mu} x) =
    ∫⁺ lborel (λx. PDF p X x * 𝟙 {x | mu ≤ x} x)

[integral_normal_pdf_symmetry']
⊢ ∀X p mu sig a.
    prob_space p ∧ normal_rv X p mu sig ⇒
    ∫⁺ lborel (λx. PDF p X x * 𝟙 {x | mu − a ≤ x ∧ x ≤ mu} x) =
    ∫⁺ lborel (λx. PDF p X x * 𝟙 {x | mu ≤ x ∧ x ≤ mu + a} x)

[lebesgue_pos_integral_real_affine]
⊢ ∀f c t.
    c ≠ 0 ∧ f ∈ Borel_measurable borel ⇒
    ∫⁺ lborel (λx. max 0 (f x)) =
    Normal (abs c) * ∫⁺ lborel (λx. max 0 (f (t + c * x)))

[lebesgue_pos_integral_real_affine']
⊢ ∀f c t.
    c ≠ 0 ∧ f ∈ Borel_measurable borel ∧ (∀x. 0 ≤ f x) ⇒
    ∫⁺ lborel f = Normal (abs c) * ∫⁺ lborel (λx. f (t + c * x))

[normal_rv_affine]
⊢ ∀X p mu sig Y b.
    prob_space p ∧ normal_rv X p mu sig ∧ (∀x. Y x = X x + b) ⇒
    normal_rv Y p (mu + b) sig

[normal_rv_affine']
⊢ ∀X p mu sig Y a b.
    prob_space p ∧ a ≠ 0 ∧ 0 < sig ∧ normal_rv X p mu sig ∧
    (∀x. Y x = b + a * X x) ⇒
    normal_rv Y p (b + a * mu) (abs a * sig)
```

HVG people prefer total measure functions (i.e. the measure of sets outside of the given measure space is forcely defined to be 0), which sometimes simplify the theorem statements. This brings some alternative definitions and bridging theorems on distributions and densities, which really belongs to `lebesgueTheory`. But the size of `lebesgueTheory` is already too big (more than 10K lines), so in this PR I also moved some theorems of `lebesgueTheory`, either to upstream theories or later theory (`martingale`), to make a balance on code size of scripts under `src/probability`. As the result, all files there are now below 10K lines (no example theory is broken by this change.)

Note that many old proofs (for normal r.v.'s) are reworked (resulting in shorter proofs), but the main definitions, chain of theorem statements are still theirs, thus the credits still go to HVG people.

Some other useful results were added too. One is that mono-increasing functions (e.g. distribution functions) are always Borel-measurable:
```
   [IN_MEASURABLE_BOREL_MONO_INCREASING]  Theorem (borelTheory)
      ⊢ ∀f sp.
          (∀x y. x ≤ y ⇒ f x ≤ f y) ∧ sp ∈ subsets Borel ⇒
          f ∈ Borel_measurable (restrict_algebra Borel sp)
```
This generalises a previous existing theorem by putting the target function into a restricted domain, based on the new concept `restrict_algebra`:
```
   [restrict_algebra_def]  Definition (sigma_algebraTheory)      
      ⊢ ∀A sp.
          restrict_algebra A sp =
          (sp ∩ space A,IMAGE (λa. a ∩ sp) (subsets A))
```

--Chun

[1] Qasim, M.: Formalization of Normal Random Variables, Concordia University (2016).