### PR TITLE
support FIRST_LT in goalFrag

### DIFF
--- a/src/parse/TacticParse.sig
+++ b/src/parse/TacticParse.sig
@@ -34,6 +34,7 @@ datatype 'a tac_expr
   | LTacsToLT of 'a tac_expr
   | LNullOk of 'a tac_expr
   | LFirst of 'a tac_expr list
+  | LFirstLT of 'a tac_expr
   | LSelectGoal of 'a
   | LSelectGoals of 'a
   | LAllGoals of 'a tac_expr
@@ -77,6 +78,7 @@ datatype tac_frag_open
   | FOpenHeadGoal
   | FOpenSplit of int * int
   | FOpenSelect
+  | FOpenFirstLT
 
 datatype tac_frag_mid
   = FNextFirst
@@ -88,6 +90,7 @@ datatype tac_frag_close
   = FClose
   | FCloseFirst
   | FCloseRepeat
+  | FCloseFirstLT
 
 datatype tac_frag
   = FFOpen of tac_frag_open

--- a/src/proofman/goalFrag.sig
+++ b/src/proofman/goalFrag.sig
@@ -27,6 +27,7 @@ val open_select_lt  : frag_tactic
 val open_split_lt   : int -> frag_tactic
 val open_tacs_to_lt : frag_tactic
 val open_then1      : frag_tactic
+val open_first_lt   : frag_tactic
 val next_select_lt  : frag_tactic
 val next_first      : frag_tactic
 val next_split_lt   : frag_tactic
@@ -34,6 +35,7 @@ val next_tacs_to_lt : frag_tactic
 val close_first     : frag_tactic
 val close_paren     : frag_tactic
 val close_repeat    : frag_tactic
+val close_first_lt  : frag_tactic
 
 val pp_goalstate    : goalstate Parse.pprinter
 


### PR DESCRIPTION
Turns out `FIRST_LT` is not just n-ary `ORELSE_LT`, it has different semantics and we need a new primitive for it in `goalFrag`.