### PR TITLE
More list simps

### DIFF
--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -1975,35 +1975,37 @@ End
 
 Theorem TAKE_nil[simp] = cj 1 TAKE_def
 
-val TAKE_cons = store_thm(
-  "TAKE_cons", “0 < n ==> (TAKE n (x::xs) = x::(TAKE (n-1) xs))”,
-  SRW_TAC[][TAKE_def]);
-val _ = export_rewrites ["TAKE_cons"];
+Theorem TAKE_cons[simp]:
+  0 < n ==> (TAKE n (x::xs) = x::(TAKE (n-1) xs))
+Proof
+  SRW_TAC[][TAKE_def]
+QED
 
 Theorem DROP_nil[simp] = CONJUNCT1 DROP_def
 
-val DROP_cons = store_thm(
-  "DROP_cons",“0 < n ==> (DROP n (x::xs) = DROP (n-1) xs)”,
-  SRW_TAC[][DROP_def]);
-val _ = export_rewrites ["DROP_cons"];
+Theorem DROP_cons[simp]:
+  0 < n ==> (DROP n (x::xs) = DROP (n-1) xs)
+Proof
+  SRW_TAC[][DROP_def]
+QED
 
-val TAKE_0 = store_thm(
-  "TAKE_0",
-  “TAKE 0 l = []”,
-  Cases_on ‘l’ THEN SRW_TAC [] [TAKE_def]);
-val _  = export_rewrites ["TAKE_0"]
+Theorem TAKE_0[simp]:
+  TAKE 0 l = []
+Proof
+  Cases_on ‘l’ THEN SRW_TAC[][TAKE_def]
+QED
 
-val TAKE_LENGTH_ID = store_thm(
-  "TAKE_LENGTH_ID",
-  “!l. TAKE (LENGTH l) l = l”,
-  Induct_on ‘l’ THEN SRW_TAC [] []);
-val _ = export_rewrites ["TAKE_LENGTH_ID"]
+Theorem TAKE_LENGTH_ID[simp]:
+  !l. TAKE (LENGTH l) l = l
+Proof
+  Induct_on ‘l’ THEN SRW_TAC [] []
+QED
 
-val LENGTH_TAKE = store_thm(
-  "LENGTH_TAKE",
-  “!n l. n <= LENGTH l ==> (LENGTH (TAKE n l) = n)”,
-  Induct_on ‘l’ THEN SRW_TAC [numSimps.ARITH_ss] [TAKE_def]);
-val _ = export_rewrites ["LENGTH_TAKE"]
+Theorem LENGTH_TAKE[simp]:
+  !n l. n <= LENGTH l ==> (LENGTH (TAKE n l) = n)
+Proof
+  Induct_on ‘l’ THEN SRW_TAC [numSimps.ARITH_ss] [TAKE_def]
+QED
 
 Theorem TAKE_LENGTH_TOO_LONG:
   !l n. LENGTH l <= n ==> (TAKE n l = l)

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -2013,11 +2013,17 @@ Proof
   Induct THEN SRW_TAC [numSimps.ARITH_ss] []
 QED
 
+Theorem LENGTH_TAKE_EQ_MIN[simp]:
+  LENGTH (TAKE n xs) = MIN n (LENGTH xs)
+Proof
+  SRW_TAC [] [MIN_ALT] THEN fs[GSYM NOT_LESS] THEN AP_TERM_TAC
+  THEN MATCH_MP_TAC TAKE_LENGTH_TOO_LONG THEN numLib.DECIDE_TAC
+QED
+
 Theorem LENGTH_TAKE_EQ:
   LENGTH (TAKE n xs) = if n <= LENGTH xs then n else LENGTH xs
 Proof
-  SRW_TAC [] [] THEN fs [GSYM NOT_LESS] THEN AP_TERM_TAC
-  THEN MATCH_MP_TAC TAKE_LENGTH_TOO_LONG THEN numLib.DECIDE_TAC
+  rw[MIN_DEF] THEN numLib.DECIDE_TAC
 QED
 
 Theorem EL_TAKE:
@@ -2103,9 +2109,8 @@ QED
 Theorem TAKE_EQ_REWRITE :
     !l m n. m <= LENGTH l /\ n <= LENGTH l ==> (TAKE m l = TAKE n l <=> m = n)
 Proof
-    rpt STRIP_TAC
- >> rw [LIST_EQ_REWRITE]
- >> EQ_TAC >> rw []
+    rpt STRIP_TAC >> fs [LIST_EQ_REWRITE,MIN_ALT]
+    >> EQ_TAC >> rw []
 QED
 
 Theorem TAKE_TAKE_MIN:
@@ -3989,11 +3994,11 @@ Proof
  >> PROVE_TAC []
 QED
 
-val WF_SHORTLEX_same_lengths = Q.store_thm(
-  "WF_SHORTLEX_same_lengths",
-  ‘WF R ==>
+Theorem WF_SHORTLEX_same_lengths:
+  WF R ==>
    !l s. (!d. d IN s ==> (LENGTH d = l)) /\ (?a. a IN s) ==>
-         ?b. b IN s /\ !c. SHORTLEX R c b ==> c NOTIN s’,
+         ?b. b IN s /\ !c. SHORTLEX R c b ==> c NOTIN s
+Proof
   strip_tac >> ho_match_mp_tac (TypeBase.induction_of “:num”) >>
   simp[] >> rw[] >- (Q.EXISTS_TAC ‘[]’ >> simp[] >> metis_tac[]) >>
   Q.RENAME_TAC [‘LENGTH _ = SUC N’] >>
@@ -4036,7 +4041,8 @@ val WF_SHORTLEX_same_lengths = Q.store_thm(
   >- fs[Abbr‘mts’, Abbr‘ms’]
   >- fs[Abbr‘mts’, Abbr‘ms’]
   >- (fs[Abbr‘mts’, Abbr‘ms’] >> rw[]) >>
-  fs[Abbr‘mts’, Abbr‘ms’] >> rw[] >> metis_tac[IN_DEF]);
+  fs[Abbr‘mts’, Abbr‘ms’] >> rw[] >> metis_tac[IN_DEF]
+QED
 
 val WF_SHORTLEX = Q.store_thm(
   "WF_SHORTLEX[simp]",

--- a/src/list/src/rich_listScript.sml
+++ b/src/list/src/rich_listScript.sml
@@ -4893,10 +4893,11 @@ val DROP_HEAD_ELEMENT = store_thm(
       Then LENGTH (TAKE n ls) = LENGTH ls   by LENGTH_TAKE_EQ
       Thus DROP n (TAKE n ls) = []          by DROP_LENGTH_TOO_LONG
 *)
-val DROP_TAKE_EQ_NIL = store_thm(
-  "DROP_TAKE_EQ_NIL",
-  ``!ls n. DROP n (TAKE n ls) = []``,
-  rw[LENGTH_TAKE_EQ, DROP_LENGTH_TOO_LONG]);
+Theorem DROP_TAKE_EQ_NIL[simp]:
+  !ls n. DROP n (TAKE n ls) = []
+Proof
+  rw[]
+QED
 
 (* Theorem: TAKE m (DROP n ls) = DROP n (TAKE (n + m) ls) *)
 (* Proof:


### PR DESCRIPTION
Add more simps about lists
This adds LENGTH_TAKE_EQ_MIN
and makes DROP_TAKE_EQ_NIL simps.
Rational for making LENGTH_TAKE_EQ_MIN simp is that
before that rewriting
DROP n (TAKE n ls) = []
would rewrite with DROP_EQ_NIL
!ls n. DROP n ls = [] <=> LENGTH ls <= n
to
LENGTH (TAKE n ls) <= n
With this simp rule it will rewrite to
MIN n (LENGTH ls) <= n