### PR TITLE
[CI] Docker image returns to Debian stable (bookworm)

### DIFF
--- a/developers/docker-ci/Dockerfile
+++ b/developers/docker-ci/Dockerfile
@@ -26,13 +26,13 @@ ARG CVC_VERSION
 ARG YICES_VERSION
 
 # if --build-arg Z3_VERSION=anything, set HOL4_Z3_EXECUTABLE to system-installed z3
-ENV HOL4_Z3_EXECUTABLE=${Z3_VERSION:+/usr/bin/z3}
+ENV HOL4_Z3_EXECUTABLE=${Z3_VERSION:+/ML/z3-${Z3_VERSION}/bin/z3}
 RUN if [ "" != "${Z3_VERSION}" ]; then \
     echo "Using Z3 solver: `${HOL4_Z3_EXECUTABLE} -version`"; \
 fi
 
 # if --build-arg CVC_VERSION=5, set HOL4_CVC_EXECUTABLE to system-installed cvc5
-ENV HOL4_CVC_EXECUTABLE=${CVC_VERSION:+/usr/bin/cvc5}
+ENV HOL4_CVC_EXECUTABLE=${CVC_VERSION:+/ML/cvc5-Linux}
 RUN if [ "" != "${CVC_VERSION}" ]; then \
     echo "Using CVC solver: `${HOL4_CVC_EXECUTABLE} --version | head -1`"; \
 fi

--- a/developers/docker-ci/base/Dockerfile
+++ b/developers/docker-ci/base/Dockerfile
@@ -5,7 +5,7 @@
 # e.g. docker buildx build --platform linux/amd64,linux/arm64v8 .
 
 # GitHub Actions recommends Debian-based systems as base images
-FROM debian:trixie
+FROM debian:bookworm
 
 LABEL org.opencontainers.image.authors="Chun Tian (binghe) <binghe.lisp@gmail.com>"
 
@@ -27,7 +27,7 @@ ENV PATH=/ML/HOL/bin:$PATH
 # Some necessary Debian packages
 # NOTE: GCC 13 is necessary for building Moscow ML (default compiler is now GCC 14).
 RUN apt-get update -qy
-RUN apt-get install -qy build-essential git libgmp-dev wget curl procps file unzip vim gcc-13
+RUN apt-get install -qy build-essential git libgmp-dev wget curl procps file unzip vim
 RUN apt-get clean
 
 # for Unicode display, learnt from Magnus Myreen
@@ -40,9 +40,9 @@ RUN apt-get install -qy graphviz emacs-nox
 RUN apt-get clean
 
 # 1. install Moscow ML (https://github.com/kfl/mosml.git) with GCC 13
-COPY mosml-gcc-13.patch /ML
+# COPY mosml-gcc-13.patch /ML
 RUN wget -q -O - https://github.com/kfl/mosml/archive/refs/tags/ver-2.10.1.tar.gz | tar xzf -
-RUN cd mosml-ver-2.10.1/src; patch -p0 < /ML/mosml-gcc-13.patch;
+# RUN cd mosml-ver-2.10.1/src; patch -p0 < /ML/mosml-gcc-13.patch;
 RUN cd mosml-ver-2.10.1; make -C src world install
 RUN rm -rf mosml-ver-2.10.1 *.patch
 

--- a/developers/docker-ci/base/Makefile
+++ b/developers/docker-ci/base/Makefile
@@ -1,7 +1,7 @@
 DOCKER_IMAGE=binghelisp/hol-dev:base
 
 build:
-	docker buildx build --platform linux/386,linux/amd64,linux/arm64,linux/riscv64 \
+	docker buildx build --platform linux/386,linux/amd64,linux/arm64 \
 		-t $(DOCKER_IMAGE) .
 
 push:

--- a/developers/docker-ci/latest/Dockerfile
+++ b/developers/docker-ci/latest/Dockerfile
@@ -113,6 +113,4 @@ RUN apt-get install -qy pandoc latexmk texlive-latex-extra
 RUN apt-get install -qy texlive-fonts-extra texlive-science
 RUN apt-get clean
 
-# z3 and cvc5 as system packages
-RUN apt-get install -qy z3 cvc5
 RUN apt-get clean

--- a/developers/docker-ci/latest/Makefile
+++ b/developers/docker-ci/latest/Makefile
@@ -1,7 +1,7 @@
 DOCKER_IMAGE=binghelisp/hol-dev:latest
 
 build:
-	docker buildx build --platform linux/386,linux/amd64,linux/arm64,linux/riscv64 \
+	docker buildx build --platform linux/386,linux/amd64,linux/arm64 \
 		-t $(DOCKER_IMAGE) .
 
 push:


### PR DESCRIPTION
Hi,

Today I try to update the Docker image for CI builds (`binghelisp/hol-dev:latest`) and found that PolyML 5.9.1 and master are no longer buildable with the default C++ compiler in Debian testing, and therefore I have returned to Debian stable (`bookworm`). But then I found that in Debian stable at least one of `z3` and `cvc5` packages doesn't exist, therefore we need to fallback to user-installed versions of these solvers.

By merging this PR, new CI builds should return to normal, otherwise there will be errors saying `/usr/bin/z3` doesn't exist.

--Chun