### PR TITLE
Enriched set_relationTheory

### DIFF
--- a/examples/formal-languages/pi-calculus/README.md
+++ b/examples/formal-languages/pi-calculus/README.md
@@ -1,0 +1,2 @@
+# Pi-calculus in HOL4 (in progress)
+

--- a/examples/formal-languages/pi-calculus/open_bisimulationScript.sml
+++ b/examples/formal-languages/pi-calculus/open_bisimulationScript.sml
@@ -1,0 +1,574 @@
+(* ========================================================================== *)
+(* FILE          : open_bisimulationScript.sml                                *)
+(* DESCRIPTION   : Open bisimulation for the pi-calculus with mismatch        *)
+(*                                                                            *)
+(* Copyright 2025  The Australian National University (Author: Chun Tian)     *)
+(* ========================================================================== *)
+
+open HolKernel Parse boolLib bossLib;
+
+open pairTheory pred_setTheory set_relationTheory hurdUtils;
+
+open nomsetTheory NEWLib pi_agentTheory;
+
+val _ = new_theory "open_bisimulation";
+
+(* some proofs here are large with too many assumptions *)
+val _ = set_trace "Goalstack.print_goal_at_top" 0;
+
+(* ----------------------------------------------------------------------
+   Pi-calculus as a nominal datatype in HOL4
+
+   HOL4 syntax ('free and 'bound are special type variables (alias of string)
+
+   Nominal_datatype :
+
+           name = Name 'free
+
+           pi   = Nil                      (* 0 *)
+                | Tau pi                   (* tau.P *)
+                | Input name 'bound pi     (* a(x).P *)
+                | Output name name pi      (* {a}b.P *)
+                | Match name name pi       (* [a == b] P *)
+                | Mismatch name name pi    (* [a <> b] P *)
+                | Sum pi pi                (* P + Q *)
+                | Par pi pi                (* P | Q *)
+                | Res 'bound pi            (* nu x. P *)
+
+       residual = TauR pi
+                | InputS name 'bound pi
+                | FreeOutput name name pi
+                | BoundOutput name 'bound pi
+   End
+
+   NOTE: Replication ("!") is not supported.
+   ---------------------------------------------------------------------- *)
+
+(* NOTE: We fallback to “:(string # string) -> bool” for the need of permutation
+   on pairs in the dist set.
+ *)
+Type dist[pp] = “:(string # string) -> bool”
+
+(* NOTE: We use uncurried relation (HOL preferred) given in relationTheory *)
+Definition distinction_def :
+    distinction (D :dist) <=> FINITE D /\ symmetric D UNIV /\ irreflexive D UNIV
+End
+
+Overload FV = “domain :dist -> string set”
+Overload "#" = “\v (D :dist). v NOTIN FV D”
+
+Theorem domain_alt :
+    !r. domain r = IMAGE FST r
+Proof
+    rw [Once EXTENSION, in_domain]
+ >> EQ_TAC >> rw []
+ >- (Q.EXISTS_TAC ‘(x,y)’ >> rw [])
+ >> rename1 ‘z IN r’
+ >> PairCases_on ‘z’
+ >> Q.EXISTS_TAC ‘z1’ >> rw []
+QED
+
+(* |- !D. FV D = IMAGE FST D *)
+Theorem FV_distinction =
+        domain_alt |> INST_TYPE [alpha |-> “:string”, beta |-> “:string”]
+                   |> Q.SPEC ‘D’ |> GEN_ALL
+
+Theorem FV_distinction_alt :
+    !D. distinction D ==> FV D = IMAGE SND D
+Proof
+    rw [distinction_def, domain_alt, symmetric_def]
+ >> simp [Once EXTENSION, EXISTS_PROD]
+QED
+
+Theorem finite_domain[simp] :
+    distinction D ==> FINITE (FV D)
+Proof
+    rw [distinction_def, domain_alt]
+QED
+
+Theorem distinction_empty[simp] :
+    distinction {}
+Proof
+    rw [distinction_def, symmetric_def, irreflexive_def]
+QED
+
+Theorem distinction_union :
+    !D1 D2. distinction D1 /\ distinction D2 ==> distinction (D1 UNION D2)
+Proof
+    rw [distinction_def]
+ >- (MATCH_MP_TAC symmetric_union >> art [])
+ >> MATCH_MP_TAC irreflexive_union >> art []
+QED
+
+(* NOTE: This is permutation operation on distinction *)
+Overload dpm[local] = “setpm (pair_pmact string_pmact string_pmact)”
+
+Theorem distinction_dpm_lemma[local] :
+    !pi d. distinction d ==> distinction (dpm pi d)
+Proof
+    rw [distinction_def]
+ >- fs [symmetric_def]
+ >> fs [irreflexive_def]
+QED
+
+Theorem distinction_dpm[simp] :
+    distinction (dpm pi d) <=> distinction d
+Proof
+    reverse EQ_TAC
+ >- rw [distinction_dpm_lemma]
+ >> STRIP_TAC
+ >> MP_TAC (Q.SPECL [‘REVERSE pi’, ‘dpm pi d’] distinction_dpm_lemma)
+ >> simp []
+QED
+
+Theorem dpm_unchanged_lemma[local] :
+    !D. FINITE D ==> !pi. DISJOINT (set (MAP FST pi)) (IMAGE FST D) /\
+                          DISJOINT (set (MAP FST pi)) (IMAGE SND D) /\
+                          DISJOINT (set (MAP SND pi)) (IMAGE FST D) /\
+                          DISJOINT (set (MAP SND pi)) (IMAGE SND D) ==>
+                          dpm pi D = D
+Proof
+    HO_MATCH_MP_TAC FINITE_INDUCT
+ >> rw [pmact_INSERT]
+ >> PairCases_on ‘e’ >> fs []
+ >> Know ‘lswapstr pi e0 = e0’
+ >- (MATCH_MP_TAC lswapstr_unchanged' >> art [])
+ >> Rewr'
+ >> Know ‘lswapstr pi e1 = e1’
+ >- (MATCH_MP_TAC lswapstr_unchanged' >> art [])
+ >> Rewr
+QED
+
+Theorem dpm_unchanged :
+    !D pi. distinction D /\
+           DISJOINT (set (MAP FST pi)) (FV D) /\
+           DISJOINT (set (MAP SND pi)) (FV D) ==> dpm pi D = D
+Proof
+    rpt STRIP_TAC
+ >> irule dpm_unchanged_lemma
+ >> simp [GSYM FV_distinction, GSYM FV_distinction_alt]
+ >> fs [distinction_def]
+QED
+
+(* The original open transition relation *)
+Inductive TRANS :
+[TAU]
+    !P.       TRANS (Tau P) (TauR P)
+[INPUT]
+    !a x P.   x <> a ==> TRANS (Input (Name a) x P) (InputS (Name a) x P)
+[OUTPUT]
+    !a b P.   TRANS (Output (Name a) (Name b) P) (FreeOutput (Name a) (Name b) P)
+[MATCH]
+    !P Rs b.   TRANS P Rs ==> TRANS (Match (Name b) (Name b) P) Rs
+[MISMACH]
+    !P Rs a b. TRANS P Rs /\ a <> b ==> TRANS (Mismatch (Name a) (Name b) P) Rs
+
+[OPEN]
+    !P P' a b. TRANS P (FreeOutput (Name a) (Name b) P') /\ a <> b ==>
+               TRANS (Res b P) (BoundOutput (Name a) b P')
+[SUM1]
+    !P Q Rs. TRANS P Rs ==> TRANS (Sum P Q) Rs
+[SUM2]
+    !P Q Rs. TRANS Q Rs ==> TRANS (Sum P Q) Rs
+
+[PAR1_I]
+    !P P' Q a x.
+       TRANS P (InputS (Name a) x P') /\ x # P /\ x # Q /\ x <> a ==>
+       TRANS (Par P Q) (InputS (Name a) x (Par P' Q))
+[PAR1_BO]
+    !P P' Q a x.
+       TRANS P (BoundOutput (Name a) x P') /\ x # P /\ x # Q /\ x <> a ==>
+       TRANS (Par P Q) (BoundOutput (Name a) x (Par P' Q))
+[PAR1_FO]
+    !P P' Q a b.
+       TRANS P (FreeOutput (Name a) (Name b) P') ==>
+       TRANS (Par P Q) (FreeOutput (Name a) (Name b) (Par P' Q))
+[PAR1_T]
+    !P P' Q. TRANS P (TauR P') ==> TRANS (Par P Q) (TauR (Par P' Q))
+
+[PAR2_I]
+    !P Q Q' a x.
+       TRANS Q (InputS (Name a) x Q') /\ x # Q /\ x # P /\ x <> a ==>
+       TRANS (Par P Q) (InputS (Name a) x (Par P Q'))
+[PAR2_BO]
+    !P Q Q' a x.
+       TRANS Q (BoundOutput (Name a) x Q') /\ x # Q /\ x # P /\ x <> a ==>
+       TRANS (Par P Q) (BoundOutput (Name a) x (Par P Q'))
+[PAR2_FO]
+    !P Q Q' a b.
+       TRANS Q (FreeOutput (Name a) (Name b) Q') ==>
+       TRANS (Par P Q) (FreeOutput (Name a) (Name b) (Par P Q'))
+[PAR2_T]
+    !P Q Q'. TRANS Q (TauR Q') ==> TRANS (Par P Q) (TauR (Par P Q'))
+
+[COMM1] (* TODO: tpm should change to SUB *)
+    !P P' Q Q' a b x.
+       TRANS P (InputS (Name a) x P') /\ TRANS Q (FreeOutput (Name a) (Name b) Q') /\
+       x # P /\ x # Q /\ x <> a /\ x <> b /\ x # Q' ==>
+       TRANS (Par P Q) (TauR (Par (tpm [(x,b)] P') Q'))
+[COMM2] (* TODO: tpm should change to SUB *)
+    !P P' Q Q' a b x.
+       TRANS P (FreeOutput (Name a) (Name b) P') /\ TRANS Q (InputS (Name a) x Q') /\
+       x # Q /\ x # P /\ x <> a /\ x <> b /\ x # P' ==>
+       TRANS (Par P Q) (TauR (Par P' (tpm [(x,b)] Q')))
+[CLOSE1] (* TODO: tpm should change to SUB *)
+    !P P' Q Q' a x y.
+       TRANS P (InputS (Name a) x P') /\
+       TRANS Q (BoundOutput (Name a) y Q') /\
+       x # P /\ x # Q /\ y # P /\ y # Q /\
+       x <> a /\ x # Q' /\ y <> a /\ y # P' /\ x <> y ==>
+       TRANS (Par P Q) (TauR (Res y (Par (tpm [(x,y)] P') Q')))
+[CLOSE2] (* TODO: tpm should change to SUB *)
+    !P P' Q Q' a x y.
+       TRANS P (BoundOutput (Name a) y P') /\
+       TRANS Q (InputS (Name a) x Q') /\
+       x # P /\ x # Q /\ y # P /\ y # Q /\
+       x <> a /\ x # P' /\ y <> a /\ y # Q' /\ x <> y ==>
+       TRANS (Par P Q) (TauR (Res y (Par P' (tpm [(x,y)] Q'))))
+[RES_I]
+    !P P' a x y.
+       TRANS P (InputS (Name a) x P') /\
+       y <> a /\ y <> x /\ x # P /\ x <> a ==>
+       TRANS (Res y P) (InputS (Name a) x (Res y P'))
+[RES_BO]
+    !P P' a x y.
+       TRANS P (BoundOutput (Name a) x P') /\
+       y <> a /\ y <> x /\ x # P /\ x <> a ==>
+       TRANS (Res y P) (BoundOutput (Name a) x (Res y P'))
+[RES_FO]
+    !P P' a b y.
+       TRANS P (FreeOutput (Name a) (Name b) P') /\
+       y <> a /\ y <> b ==>
+       TRANS (Res y P) (FreeOutput (Name a) (Name b) (Res y P'))
+[RES_T]
+    !P P' y.
+       TRANS P (TauR P') ==> TRANS (Res y P) (TauR (Res y P'))
+End
+
+(* Open transition relation w.r.t. distinction *)
+Inductive DTRANS :
+[DTAU]
+    !D P. DTRANS (D :dist) (Tau P) (TauR P)
+[DINPUT]
+    !D a x P. x <> a ==> DTRANS D (Input (Name a) x P) (InputS (Name a) x P)
+[DOUTPUT]
+    !D a b P. DTRANS D (Output (Name a) (Name b) P)
+                       (FreeOutput (Name a) (Name b) P)
+[DMATCH]
+    !D P Rs b. DTRANS D P Rs ==> DTRANS D (Match (Name b) (Name b) P) Rs
+[DMISMACH]
+    !D P Rs a b.
+       distinction D /\ (a,b) IN D /\ DTRANS D P Rs ==>
+       DTRANS D (Mismatch (Name a) (Name b) P) Rs
+
+[DOPEN]
+    !D D' P P' a b.
+    (* begin extra antecedents *)
+       distinction D /\ b # D /\
+       D' = D UNION sc {(a,s) | s IN FV (Res b P)} /\
+    (* end extra antecedents *)
+       DTRANS D' P (FreeOutput (Name a) (Name b) P') /\ a <> b ==>
+       DTRANS D (Res b P) (BoundOutput (Name a) b P')
+[DSUM1]
+    !D P Q Rs. DTRANS D P Rs ==> DTRANS D (Sum P Q) Rs
+[DSUM2]
+    !D P Q Rs. DTRANS D Q Rs ==> DTRANS D (Sum P Q) Rs
+
+[DPAR1_I]
+    !D P P' Q a x.
+       DTRANS D P (InputS (Name a) x P') /\ x # P /\ x # Q /\ x <> a ==>
+       DTRANS D (Par P Q) (InputS (Name a) x (Par P' Q))
+[DPAR1_BO]
+    !D P P' Q a x.
+       DTRANS D P (BoundOutput (Name a) x P') /\ x # P /\ x # Q /\ x <> a ==>
+       DTRANS D (Par P Q) (BoundOutput (Name a) x (Par P' Q))
+[DPAR1_FO]
+    !D P P' Q a b.
+       DTRANS D P (FreeOutput (Name a) (Name b) P') ==>
+       DTRANS D (Par P Q) (FreeOutput (Name a) (Name b) (Par P' Q))
+[DPAR1_T]
+    !D P P' Q. DTRANS D P (TauR P') ==> DTRANS D (Par P Q) (TauR (Par P' Q))
+
+[DPAR2_I]
+    !D P Q Q' a x.
+       DTRANS D Q (InputS (Name a) x Q') /\ x # Q /\ x # P /\ x <> a ==>
+       DTRANS D (Par P Q) (InputS (Name a) x (Par P Q'))
+[DPAR2_BO]
+    !D P Q Q' a x.
+       DTRANS D Q (BoundOutput (Name a) x Q') /\ x # Q /\ x # P /\ x <> a ==>
+       DTRANS D (Par P Q) (BoundOutput (Name a) x (Par P Q'))
+[DPAR2_FO]
+    !D P Q Q' a b.
+       DTRANS D Q (FreeOutput (Name a) (Name b) Q') ==>
+       DTRANS D (Par P Q) (FreeOutput (Name a) (Name b) (Par P Q'))
+[DPAR2_T]
+    !D P Q Q'. DTRANS D Q (TauR Q') ==> DTRANS D (Par P Q) (TauR (Par P Q'))
+
+[DCOMM1] (* TODO: tpm should change to SUB *)
+    !D P P' Q Q' a b x.
+       DTRANS D P (InputS (Name a) x P') /\
+       DTRANS D Q (FreeOutput (Name a) (Name b) Q') /\
+       x # P /\ x # Q /\ x <> a /\ x <> b /\ x # Q' ==>
+       DTRANS D (Par P Q) (TauR (Par (tpm [(x,b)] P') Q'))
+[DCOMM2] (* TODO: tpm should change to SUB *)
+    !D P P' Q Q' a b x.
+       DTRANS D P (FreeOutput (Name a) (Name b) P') /\
+       DTRANS D Q (InputS (Name a) x Q') /\
+       x # Q /\ x # P /\ x <> a /\ x <> b /\ x # P' ==>
+       DTRANS D (Par P Q) (TauR (Par P' (tpm [(x,b)] Q')))
+[DCLOSE1] (* TODO: tpm should change to SUB *)
+    !D P P' Q Q' a x y.
+       DTRANS D P (InputS (Name a) x P') /\
+       DTRANS D Q (BoundOutput (Name a) y Q') /\
+       x # P /\ x # Q /\ y # P /\ y # Q /\
+       x <> a /\ x # Q' /\ y <> a /\ y # P' /\ x <> y ==>
+       DTRANS D (Par P Q) (TauR (Res y (Par (tpm [(x,y)] P') Q')))
+[DCLOSE2] (* TODO: tpm should change to SUB *)
+    !D P P' Q Q' a x y.
+       DTRANS D P (BoundOutput (Name a) y P') /\
+       DTRANS D Q (InputS (Name a) x Q') /\
+       x # P /\ x # Q /\ y # P /\ y # Q /\
+       x <> a /\ x # P' /\ y <> a /\ y # Q' /\ x <> y ==>
+       DTRANS D (Par P Q) (TauR (Res y (Par P' (tpm [(x,y)] Q'))))
+
+[DRES_I]
+    !D D' P P' a x y.
+    (* begin extra antecedents *)
+       distinction D /\
+       D' = D UNION sc {(y,s) | s IN FV (Res y P)} /\
+    (* end extra antecedents *)
+       DTRANS D' P (InputS (Name a) x P') /\
+       y <> a /\ y <> x /\ x # P /\ x <> a ==>
+       DTRANS D (Res y P) (InputS (Name a) x (Res y P'))
+[DRES_BO]
+    !D D' P P' a x y.
+    (* begin extra antecedents *)
+       distinction D /\
+       D' = D UNION sc {(y,s) | s IN FV (Res y P)} /\
+    (* end extra antecedents *)
+       DTRANS D' P (BoundOutput (Name a) x P') /\
+       y <> a /\ y <> x /\ x # P /\ x <> a ==>
+       DTRANS D (Res y P) (BoundOutput (Name a) x (Res y P'))
+[DRES_FO]
+    !D D' P P' a b y.
+    (* begin extra antecedents *)
+       distinction D /\
+       D' = D UNION sc {(y,s) | s IN FV (Res y P)} /\
+    (* end extra antecedents *)
+       DTRANS D' P (FreeOutput (Name a) (Name b) P') /\
+       y <> a /\ y <> b ==>
+       DTRANS D (Res y P) (FreeOutput (Name a) (Name b) (Res y P'))
+[DRES_T]
+    !D D' P P' y.
+    (* begin extra antecedents *)
+       distinction D /\
+       D' = D UNION sc {(y,s) | s | s IN FV (Res y P)} /\
+    (* end extra antecedents *)
+       DTRANS D' P (TauR P') ==> DTRANS D (Res y P) (TauR (Res y P'))
+End
+
+(* NOTE: "simulation" is a property of 3-way relation R as tuples (P, Q, D), where
+   P and Q are pi-agents, D is a distinction.
+ *)
+Definition dist_simulation_def :
+    dist_simulation (R :(pi # pi # dist) set) <=>
+    !P Q D. (P,Q,D) IN R ==>
+    (* 0 *)
+       distinction D /\
+    (* 1 *)
+      (!pi. (tpm pi P, tpm pi Q, dpm pi D) IN R) /\
+    (* 2 *)
+      (!D'. D SUBSET D' /\ distinction D' ==> (P,Q,D') IN R) /\
+    (* 3a *)
+      (!P'. DTRANS D P (TauR P') ==>
+            ?Q'. DTRANS D Q (TauR Q') /\ (P',Q',D) IN R) /\
+    (* 3b: enriched with ‘x # D /\ x # P’ *)
+      (!a x P'. DTRANS D P (InputS (Name a) x P') /\ x # D /\ x # P /\ x # Q ==>
+                ?Q'. DTRANS D Q (InputS (Name a) x Q') /\ (P',Q',D) IN R) /\
+    (* 3c *)
+      (!a b P'. DTRANS D P (FreeOutput (Name a) (Name b) P') ==>
+                ?Q'. DTRANS D Q (FreeOutput (Name a) (Name b) Q') /\
+                    (P',Q',D) IN R) /\
+    (* 4 *)
+      (!b x P'. DTRANS D P (BoundOutput (Name b) x P') ==>
+                ?Q' D'. DTRANS D Q (BoundOutput (Name b) x Q') /\
+                        D' = D UNION sc {(b, x) | x | x IN FV (Res b Q)} /\
+                       (P',Q',D') IN R)
+End
+
+Theorem dist_simulation_id :
+    dist_simulation {x | ?P D. x = (P,P,D) /\ distinction D}
+Proof
+    rw [dist_simulation_def]
+ >> MATCH_MP_TAC distinction_union >> art []
+ >> rw [distinction_def]
+ >- (MATCH_MP_TAC finite_sc \\
+     qmatch_abbrev_tac ‘FINITE s’ \\
+     irule SUBSET_FINITE \\
+     Q.EXISTS_TAC ‘{(b,y) | y | y IN FV P}’ \\
+     qunabbrev_tac ‘s’ \\
+     reverse CONJ_TAC >- rw [SUBSET_DEF] \\
+     qmatch_abbrev_tac ‘FINITE s’ \\
+     Know ‘s = IMAGE (\y. (b,y)) (FV P)’
+     >- rw [Abbr ‘s’, Once EXTENSION] >> Rewr' \\
+     MATCH_MP_TAC IMAGE_FINITE >> rw [])
+ >> MATCH_MP_TAC sc_irreflexive
+ >> rw [irreflexive_def]
+QED
+
+Theorem dist_simulation_union :
+    !R1 R2. dist_simulation R1 /\ dist_simulation R2 ==>
+            dist_simulation (R1 UNION R2)
+Proof
+    rw [dist_simulation_def] (* 7+7 subgoals *)
+ (* goal 1 (of 14) *)
+ >- (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R1 ==> _’
+      (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [])
+ (* goal 2 (of 14) *)
+ >- (DISJ1_TAC \\
+     Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R1 ==> _’
+       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [])
+ (* goal 3 (of 14) *)
+ >- (DISJ1_TAC \\
+     Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R1 ==> _’
+       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [])
+ (* goal 4 (of 14) *)
+ >- (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R1 ==> _’
+       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [] \\
+     Q.PAT_X_ASSUM ‘!P'. DTRANS D P (TauR P') ==> _’
+       (MP_TAC o Q.SPEC ‘P'’) >> rw [] \\
+     Q.EXISTS_TAC ‘Q'’ >> rw [])
+ (* goal 5 (of 14) *)
+ >- (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R1 ==> _’
+       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [] \\
+     Q.PAT_X_ASSUM ‘!a x P'.
+                       DTRANS D P (InputS (Name a) x P') /\ _ ==> _’
+       (MP_TAC o Q.SPECL [‘a’, ‘x’, ‘P'’]) >> rw [] \\
+     Q.EXISTS_TAC ‘Q'’ >> rw [])
+ (* goal 6 (of 14) *)
+ >- (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R1 ==> _’
+       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [] \\
+     Q.PAT_X_ASSUM ‘!a b P'.
+                       DTRANS D P (FreeOutput (Name a) (Name b) P') ==> _’
+       (MP_TAC o Q.SPECL [‘a’, ‘b’, ‘P'’]) >> rw [] \\
+     Q.EXISTS_TAC ‘Q'’ >> rw [])
+ (* goal 7 (of 14) *)
+ >- (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R1 ==> _’
+       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [] \\
+     Q.PAT_X_ASSUM ‘!b x P'. DTRANS D P (BoundOutput (Name b) x P') ==> _’
+       (MP_TAC o Q.SPECL [‘b’, ‘x’, ‘P'’]) >> rw [] \\
+     Q.EXISTS_TAC ‘Q'’ >> rw [])
+ (* goal 8 (of 14) *)
+ >- (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R2 ==> _’
+       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [])
+ (* goal 9 (of 14) *)
+ >- (DISJ2_TAC \\
+     Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R2 ==> _’
+       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [])
+ (* goal 10 (of 14) *)
+ >- (DISJ2_TAC \\
+     Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R2 ==> _’
+       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [])
+ (* goal 11 (of 14) *)
+ >- (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R2 ==> _’
+       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [] \\
+     Q.PAT_X_ASSUM ‘!P'. DTRANS D P (TauR P') ==> _’
+       (MP_TAC o Q.SPEC ‘P'’) >> rw [] \\
+     Q.EXISTS_TAC ‘Q'’ >> rw [])
+ (* goal 12 (of 14) *)
+ >- (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R2 ==> _’
+       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [] \\
+     Q.PAT_X_ASSUM ‘!a x P'.
+                       DTRANS D P (InputS (Name a) x P') /\ _ ==> _’
+       (MP_TAC o Q.SPECL [‘a’, ‘x’, ‘P'’]) >> rw [] \\
+     Q.EXISTS_TAC ‘Q'’ >> rw [])
+ (* goal 13 (of 14) *)
+ >- (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R2 ==> _’
+       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [] \\
+     Q.PAT_X_ASSUM ‘!a b P'.
+                       DTRANS D P (FreeOutput (Name a) (Name b) P') ==> _’
+       (MP_TAC o Q.SPECL [‘a’, ‘b’, ‘P'’]) >> rw [] \\
+     Q.EXISTS_TAC ‘Q'’ >> rw [])
+ (* goal 14 (of 14) *)
+ >> (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R2 ==> _’
+       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [] \\
+     Q.PAT_X_ASSUM ‘!b x P'. DTRANS D P (BoundOutput (Name b) x P') ==> _’
+       (MP_TAC o Q.SPECL [‘b’, ‘x’, ‘P'’]) >> rw [] \\
+     Q.EXISTS_TAC ‘Q'’ >> rw [])
+QED
+
+Theorem dist_simulation_imp_distinction :
+    !R P Q D. dist_simulation R /\ (P,Q,D) IN R ==> distinction D
+Proof
+    rw [dist_simulation_def]
+ >> FIRST_X_ASSUM drule >> rw []
+QED
+
+Theorem dist_simulation_open_distinction :
+    !R P Q D D'. dist_simulation R /\ (P,Q,D) IN R /\ D SUBSET D' /\
+                 distinction D' ==> (P,Q,D') IN R
+Proof
+    rw [dist_simulation_def]
+ >> Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R ==> _’ drule >> rw []
+QED
+
+Definition dist_bisimulation_def :
+    dist_bisimulation (R :(pi # pi # dist) set) <=>
+    dist_simulation R /\ dist_simulation {(Q,P,D) | (P,Q,D) IN R}
+End
+
+Definition dist_bisimilar :
+    dist_bisimilar P Q D <=> ?R. dist_bisimulation R /\ (P,Q,D) IN R
+End
+
+(* |- !P Q D.
+        dist_bisimilar P Q D <=>
+        ?R. (dist_simulation R /\ dist_simulation {(Q,P,D) | (P,Q,D) IN R}) /\
+            (P,Q,D) IN R
+ *)
+Theorem dist_bisimilar_def =
+        dist_bisimilar |> REWRITE_RULE [dist_bisimulation_def]
+
+Theorem dist_bisimilar_imp_distinction :
+    !P Q D. dist_bisimilar P Q D ==> distinction D
+Proof
+    rw [dist_bisimilar_def, dist_simulation_def]
+ >> FIRST_X_ASSUM drule >> rw []
+QED
+
+Theorem dist_bisimilar_reflexive :
+    !P D. distinction D ==> dist_bisimilar P P D
+Proof
+    rw [dist_bisimilar_def]
+ >> Q.EXISTS_TAC ‘{x | ?P D. x = (P,P,D) /\ distinction D}’
+ >> simp [dist_simulation_id]
+ >> qmatch_abbrev_tac ‘dist_simulation R’
+ >> Suff ‘R = {x | (?P D. x = (P,P,D) /\ distinction D)}’
+ >- rw [dist_simulation_id]
+ >> rw [Abbr ‘R’, Once EXTENSION]
+QED
+
+Theorem dist_bisimilar_symmetric :
+    !P Q D. dist_bisimilar P Q D ==> dist_bisimilar Q P D
+Proof
+    rw [dist_bisimilar_def]
+ >> qabbrev_tac ‘R' = {(Q,P,D) | (P,Q,D) IN R}’
+ >> Q.EXISTS_TAC ‘R UNION R'’
+ >> reverse CONJ_TAC
+ >- (simp [] \\
+     DISJ2_TAC >> rw [Abbr ‘R'’])
+ >> CONJ_TAC
+ >- (MATCH_MP_TAC dist_simulation_union >> art [])
+ >> qmatch_abbrev_tac ‘dist_simulation R2’
+ >> Suff ‘R2 = R UNION R'’
+ >- (Rewr' \\
+     MATCH_MP_TAC dist_simulation_union >> art [])
+ >> rw [Once EXTENSION, Abbr ‘R2’, Abbr ‘R'’]
+ >> EQ_TAC >> rw []
+ >> PairCases_on ‘x’ (* this asserts (x0,x1,x2) *)
+ >> rename1 ‘(P',Q',D') IN R’
+ >> qexistsl_tac [‘P'’, ‘Q'’, ‘D'’] >> simp []
+QED
+
+val _ = export_theory ();
+val _ = html_theory "open_bisimulation";

--- a/examples/formal-languages/pi-calculus/pi_agentScript.sml
+++ b/examples/formal-languages/pi-calculus/pi_agentScript.sml
@@ -7,7 +7,9 @@
 
 open HolKernel Parse boolLib bossLib;
 
-open pred_setTheory generic_termsTheory binderLib nomsetTheory nomdatatype;
+open pred_setTheory listTheory;
+
+open generic_termsTheory binderLib nomsetTheory nomdatatype;
 
 val _ = new_theory "pi_agent";
 
@@ -31,7 +33,7 @@ val _ = new_theory "pi_agent";
                 | Res ''name pi            (* nu x. P *)
 
        residual = TauR pi
-                | InputR name ''name pi      (* (Bound) input *)
+                | InputS name ''name pi      (* Input *)
                 | BoundOutput name ''name pi (* Bound output *)
                 | FreeOutput name name pi    (* Free output *)
    End
@@ -44,13 +46,14 @@ val tyname1 = "pi";
 val tyname2 = "residual";
 
 (* "Name" is under GVAR (of type 0); There's an extra "Var" under type 1 *)
-val gvar_rep_t = “:unit”;
-val u_tm = mk_var("u", gvar_rep_t);
+val unit_t = “:unit”;
+val u_tm = mk_var("u", unit_t);
 val vp = “(\n ^u_tm. n = 0)”;
 
-(* other operators (type 1) are under GLAM (of type 1) *)
-val glam_rep_t = “:unit + unit + unit + unit + unit + unit + unit + unit + unit”;
-val d_tm = mk_var("d", glam_rep_t);
+(* other operators (type 1) are under GLAM (of type 1), 9 + 4 units *)
+val rep_t = “:unit + unit + unit + unit + unit + unit + unit + unit + unit +
+              unit + unit + unit + unit”;
+val d_tm = mk_var("d", rep_t);
 val lp =
   “(\n ^d_tm tns uns.
      n = 1 /\ ISL d /\                                        (* 1. nil *)
@@ -90,17 +93,58 @@ val lp =
               ISR (OUTR (OUTR (OUTR (OUTR (OUTR d))))) /\
               ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d)))))) /\
               ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d))))))) /\
+              ISL (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d)))))))) /\
               tns = [1] /\ uns = [] \/
-     n = 2 /\ ISL d /\                                        (* tau residual *)
+     n = 2 /\ ISR d /\ ISR (OUTR d) /\ ISR (OUTR (OUTR d)) /\ (* 1. tau residual *)
+              ISR (OUTR (OUTR (OUTR d))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR d)))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR d))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d)))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d))))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d)))))))) /\
+              ISL (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d))))))))) /\
               tns = [] ∧ uns = [1] \/
-     n = 2 /\ ISR d /\ ISL (OUTR d) /\                        (* bound output *)
+     n = 2 /\ ISR d /\ ISR (OUTR d) /\ ISR (OUTR (OUTR d)) /\ (* 2. bound output *)
+              ISR (OUTR (OUTR (OUTR d))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR d)))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR d))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d)))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d))))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d)))))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d))))))))) /\
+              ISL (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR
+                  (OUTR d)))))))))) /\
               tns = [1] /\ uns = [0] \/
-     n = 2 /\ ISR d /\ ISR (OUTR d) /\ ISL (OUTR (OUTR d)) /\ (* input residual *)
+     n = 2 /\ ISR d /\ ISR (OUTR d) /\ ISR (OUTR (OUTR d)) /\ (* 3. input residual *)
+              ISR (OUTR (OUTR (OUTR d))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR d)))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR d))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d)))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d))))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d)))))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d))))))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR
+                  (OUTR d)))))))))) /\
+              ISL (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR
+                  (OUTR (OUTR d))))))))))) /\
               tns = [1] /\ uns = [0] \/
-     n = 2 /\ ISR d /\ ISR (OUTR d) /\ ISR (OUTR (OUTR d)) /\ (* free output *)
-              ISL (OUTR (OUTR (OUTR d))) /\
+     n = 2 /\ ISR d /\ ISR (OUTR d) /\ ISR (OUTR (OUTR d)) /\ (* 4. free output *)
+              ISR (OUTR (OUTR (OUTR d))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR d)))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR d))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d)))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d))))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d)))))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR d))))))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR
+                  (OUTR d)))))))))) /\
+              ISR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR
+                  (OUTR (OUTR d))))))))))) /\
               tns = [] /\ uns = [0; 0; 1]
     )”;
+
+(* This is often useful for debugging purposes *)
+Overload LP = lp;
 
 (* type 0 (:name) *)
 val {term_ABS_pseudo11 = term_ABS_pseudo11_0,
@@ -304,7 +348,7 @@ val Res_t = mk_var("Res", “:string -> ^newty1 -> ^newty1”);
 val Res_def = new_definition(
    "Res_def",
   “^Res_t v P =
-   ^term_ABS_t1 (GLAM v (INR (INR (INR (INR (INR (INR (INR (INR ()))))))))
+   ^term_ABS_t1 (GLAM v (INR (INR (INR (INR (INR (INR (INR (INR (INL ())))))))))
                         [^term_REP_t1 P] [])”);
 val Res_tm = Res_def |> concl |> strip_forall |> snd |> rhs |> rand;
 val Res_termP = prove(
@@ -316,14 +360,21 @@ val Res_t = defined_const Res_def;
 val TauR_t = mk_var("TauR", “:^newty1 -> ^newty2”);
 val TauR_def = new_definition(
    "TauR_def",
-  “^TauR_t P = ^term_ABS_t2 (GLAM ARB (INL ()) [] [^term_REP_t1 P])”);
+  “^TauR_t P =
+   ^term_ABS_t2 (GLAM ARB (INR (INR (INR (INR (INR (INR (INR (INR (INR
+                               (INL ()))))))))))
+                          [] [^term_REP_t1 P])”);
 val TauR_tm = TauR_def |> concl |> strip_forall |> snd |> rhs |> rand;
 val TauR_termP = prove(
-   “^termP2 (GLAM x (INL ()) [] [^term_REP_t1 P])”,
+   “^termP2 (GLAM x (INR (INR (INR (INR (INR (INR (INR (INR (INR
+                              (INL ()))))))))))
+                    [] [^term_REP_t1 P])”,
     match_mp_tac glam >> srw_tac [][genind_term_REP1]);
 val TauR_t = defined_const TauR_def;
 val TauR_def' = prove(
-  “^term_ABS_t2 (GLAM v (INL ()) [] [^term_REP_t1 P]) = ^TauR_t P”,
+  “^term_ABS_t2 (GLAM v (INR (INR (INR (INR (INR (INR (INR (INR (INR
+                             (INL ()))))))))))
+                        [] [^term_REP_t1 P]) = ^TauR_t P”,
     srw_tac [][TauR_def, GLAM_NIL_EQ, term_ABS_pseudo11_2, TauR_termP]);
 
 (* Bound output (residual) *)
@@ -331,48 +382,53 @@ val BoundOutput_t =
     mk_var("BoundOutput", “:^newty0 -> string -> ^newty1 -> ^newty2”);
 val BoundOutput_def = new_definition(
    "BoundOutput_def",
-  “^BoundOutput_t a x P = ^term_ABS_t2 (GLAM x (INR (INL ()))
-                                               [^term_REP_t1 P]
-                                               [^term_REP_t0 a])”);
+  “^BoundOutput_t a x P =
+   ^term_ABS_t2 (GLAM x (INR (INR (INR (INR (INR (INR (INR (INR (INR (INR
+                             (INL ())))))))))))
+                        [^term_REP_t1 P] [^term_REP_t0 a])”);
 val BoundOutput_termP = prove(
     mk_comb(termP2, BoundOutput_def |> SPEC_ALL |> concl |> rhs |> rand),
     match_mp_tac glam >> srw_tac [][genind_term_REP0, genind_term_REP1]);
 val BoundOutput_t = defined_const BoundOutput_def;
 
 (* Input residual *)
-val InputR_t = mk_var("InputR",
-                             “:^newty0 -> string -> ^newty1 -> ^newty2”);
-val InputR_def = new_definition(
-   "InputR_def",
-  “^InputR_t a x P = ^term_ABS_t2 (GLAM x (INR (INR (INL ())))
-                                                 [^term_REP_t1 P]
-                                                 [^term_REP_t0 a])”);
-val InputR_termP = prove(
-    mk_comb(termP2, InputR_def |> SPEC_ALL |> concl |> rhs |> rand),
+val InputS_t = mk_var("InputS", “:^newty0 -> string -> ^newty1 -> ^newty2”);
+val InputS_def = new_definition(
+   "InputS_def",
+  “^InputS_t a x P =
+   ^term_ABS_t2 (GLAM x (INR (INR (INR (INR (INR (INR (INR (INR (INR (INR (INR
+                             (INL ()))))))))))))
+                        [^term_REP_t1 P] [^term_REP_t0 a])”);
+val InputS_termP = prove(
+    mk_comb(termP2, InputS_def |> SPEC_ALL |> concl |> rhs |> rand),
     match_mp_tac glam >> srw_tac [][genind_term_REP0, genind_term_REP1]);
-val InputR_t = defined_const InputR_def;
+val InputS_t = defined_const InputS_def;
 
 (* Free output (residual) *)
 val FreeOutput_t =
     mk_var("FreeOutput", “:^newty0 -> ^newty0 -> ^newty1 -> ^newty2”);
 val FreeOutput_def = new_definition(
    "FreeOutput_def",
-  “^FreeOutput_t a b P = ^term_ABS_t2 (GLAM ARB (INR (INR (INR (INL ())))) []
-                                            [^term_REP_t0 a;
-                                             ^term_REP_t0 b;
-                                             ^term_REP_t1 P])”);
+  “^FreeOutput_t a b P =
+   ^term_ABS_t2 (GLAM ARB (INR (INR (INR (INR (INR (INR (INR (INR (INR (INR (INR
+                               (INR ()))))))))))))
+                          [] [^term_REP_t0 a;
+                              ^term_REP_t0 b;
+                              ^term_REP_t1 P])”);
 val FreeOutput_termP = prove(
-   “^termP2 (GLAM x (INR (INR (INR (INL ())))) []
-                                            [^term_REP_t0 a;
-                                             ^term_REP_t0 b;
-                                             ^term_REP_t1 P])”,
+   “^termP2 (GLAM x (INR (INR (INR (INR (INR (INR (INR (INR (INR (INR (INR
+                              (INR ()))))))))))))
+                    [] [^term_REP_t0 a;
+                        ^term_REP_t0 b;
+                        ^term_REP_t1 P])”,
     match_mp_tac glam >> srw_tac [][genind_term_REP0, genind_term_REP1]);
 val FreeOutput_t = defined_const FreeOutput_def;
 val FreeOutput_def' = prove(
-  “^term_ABS_t2 (GLAM v (INR (INR (INR (INL ())))) []
-                                            [^term_REP_t0 a;
-                                             ^term_REP_t0 b;
-                                             ^term_REP_t1 P]) = ^FreeOutput_t a b P”,
+  “^term_ABS_t2 (GLAM v (INR (INR (INR (INR (INR (INR (INR (INR (INR (INR (INR
+                             (INR ()))))))))))))
+                        [] [^term_REP_t0 a;
+                            ^term_REP_t0 b;
+                            ^term_REP_t1 P]) = ^FreeOutput_t a b P”,
     srw_tac [][FreeOutput_def, GLAM_NIL_EQ, term_ABS_pseudo11_2,
                FreeOutput_termP]);
 
@@ -411,7 +467,7 @@ QED
 Theorem npm_CONS :
     npm ((x,y)::pi) (t :name) = npm [(x,y)] (npm pi t)
 Proof
-  SRW_TAC [][GSYM pmact_decompose]
+    SRW_TAC [][GSYM pmact_decompose]
 QED
 
 (* ----------------------------------------------------------------------
@@ -459,7 +515,7 @@ QED
 Theorem tpm_CONS :
     tpm ((x,y)::pi) (t :pi) = tpm [(x,y)] (tpm pi t)
 Proof
-  SRW_TAC [][GSYM pmact_decompose]
+    SRW_TAC [][GSYM pmact_decompose]
 QED
 
 (* ----------------------------------------------------------------------
@@ -469,7 +525,7 @@ QED
 val rcons_info =
     [{con_termP = TauR_termP,        con_def = SYM TauR_def'},
      {con_termP = BoundOutput_termP, con_def = BoundOutput_def},
-     {con_termP = InputR_termP,      con_def = InputR_def},
+     {con_termP = InputS_termP,      con_def = InputS_def},
      {con_termP = FreeOutput_termP,  con_def = SYM FreeOutput_def'}];
 
 val rpm_name_pfx = "r";
@@ -488,8 +544,9 @@ val {tpm_thm = rpm_thm,
                         genind_term_REP = genind_term_REP2};
 
 Theorem rpm_thm[allow_rebind] =
-        rpm_thm |> REWRITE_RULE [GSYM term_REP_npm, GSYM term_REP_tpm, TauR_def',
-                                 GSYM BoundOutput_def, GSYM InputR_def, FreeOutput_def']
+        rpm_thm
+     |> REWRITE_RULE [GSYM term_REP_npm, GSYM term_REP_tpm, TauR_def',
+                      GSYM BoundOutput_def, GSYM InputS_def, FreeOutput_def']
 
 Theorem rpm_eqr :
     t = rpm pi u <=> rpm (REVERSE pi) t = (u :residual)
@@ -506,7 +563,7 @@ QED
 Theorem rpm_CONS :
     rpm ((x,y)::pi) (t :residual) = rpm [(x,y)] (rpm pi t)
 Proof
-  SRW_TAC [][GSYM pmact_decompose]
+    SRW_TAC [][GSYM pmact_decompose]
 QED
 
 (* ----------------------------------------------------------------------
@@ -545,6 +602,8 @@ val supp_npm = prove(
  >> srw_tac [][supp_npm_support, supp_npm_apart, FINITE_GFV]);
 
 val _ = overload_on ("FV", “supp ^n_pmact_t”);
+
+val _ = set_fixity "#" (Infix(NONASSOC, 450));
 val _ = overload_on ("#", “\v (P :name). v NOTIN FV P”);
 
 Theorem FINITE_FV_name[simp] :
@@ -611,8 +670,6 @@ val supp_tpm = prove(
  >> srw_tac [][supp_tpm_support, supp_tpm_apart, FINITE_GFV]);
 
 val _ = overload_on ("FV", “supp ^t_pmact_t”);
-
-val _ = set_fixity "#" (Infix(NONASSOC, 450));
 val _ = overload_on ("#", “\v (P :pi). v NOTIN FV P”);
 
 Theorem FINITE_FV[simp] :
@@ -727,7 +784,7 @@ val LIST_REL_NIL = listTheory.LIST_REL_NIL;
 
 val term_ind =
     bvc_genind
-        |> INST_TYPE [alpha |-> glam_rep_t, beta |-> gvar_rep_t]
+        |> INST_TYPE [alpha |-> rep_t, beta |-> unit_t]
         |> Q.INST [‘vp’ |-> ‘^vp’, ‘lp’ |-> ‘^lp’]
         |> SIMP_RULE std_ss [LIST_REL_CONS1, RIGHT_AND_OVER_OR,
                              LEFT_AND_OVER_OR, DISJ_IMP_THM, LIST_REL_NIL]
@@ -826,5 +883,254 @@ Proof
     SRW_TAC [boolSimps.CONJ_ss][Input_eq_thm, pmact_flip_args]
 QED
 
+(* |- !a b x y t1 t2.
+        InputS a x t1 = InputS b y t2 <=>
+        x = y /\ t1 = t2 /\ a = b \/
+        x <> y /\ x # t2 /\ t1 = tpm [(x,y)] t2 /\ a = b
+ *)
+Theorem InputS_eq_thm =
+  “InputS a x t1 = InputS b y (t2 :pi)”
+     |> SIMP_CONV (srw_ss()) [InputS_def, InputS_termP, term_ABS_pseudo11_2,
+                              GLAM_eq_thm,
+                              term_REP_11_0, term_REP_11_1, term_REP_11_2,
+                              GSYM term_REP_tpm, GSYM term_REP_rpm,
+                              GSYM supp_tpm, GSYM supp_rpm]
+     |> Q.GENL [‘a’, ‘b’, ‘x’, ‘y’, ‘t1’, ‘t2’]
+
+Theorem InputS_tpm_ALPHA :
+    v # (u :pi) ==> InputS a x u = InputS a v (tpm [(v,x)] u)
+Proof
+    SRW_TAC [boolSimps.CONJ_ss][InputS_eq_thm, pmact_flip_args]
+QED
+
+(* ----------------------------------------------------------------------
+    term recursion
+   ---------------------------------------------------------------------- *)
+
+(* NOTE: all 3 types have the same repty *)
+val (_, repty) = dom_rng (type_of term_REP_t0);
+val repty' = ty_antiq repty;
+
+val termP_elim0 = prove(
+   “(!g. ^termP0 g ==> P g) <=> (!t. P (^term_REP_t0 t))”,
+    srw_tac [][EQ_IMP_THM] >- srw_tac [][genind_term_REP0]
+ >> first_x_assum (qspec_then ‘^term_ABS_t0 g’ mp_tac)
+ >> srw_tac [][repabs_pseudo_id0]);
+
+val termP_removal0 =
+    nomdatatype.termP_removal {
+      elimth = termP_elim0, absrep_id = absrep_id0,
+      tpm_def = AP_TERM term_ABS_t0 term_REP_npm |> REWRITE_RULE [absrep_id0],
+      termP = termP0, repty = repty};
+
+val termP_elim1 = prove(
+   “(!g. ^termP1 g ==> P g) <=> (!t. P (^term_REP_t1 t))”,
+    srw_tac [][EQ_IMP_THM] >- srw_tac [][genind_term_REP1]
+ >> first_x_assum (qspec_then ‘^term_ABS_t1 g’ mp_tac)
+ >> srw_tac [][repabs_pseudo_id1]);
+
+val termP_removal1 =
+    nomdatatype.termP_removal {
+      elimth = termP_elim1, absrep_id = absrep_id1,
+      tpm_def = AP_TERM term_ABS_t1 term_REP_tpm |> REWRITE_RULE [absrep_id1],
+      termP = termP1, repty = repty};
+
+val termP_elim2 = prove(
+   “(!g. ^termP2 g ==> P g) <=> (!t. P (^term_REP_t2 t))”,
+    srw_tac [][EQ_IMP_THM] >- srw_tac [][genind_term_REP2]
+ >> first_x_assum (qspec_then ‘^term_ABS_t2 g’ mp_tac)
+ >> srw_tac [][repabs_pseudo_id2]);
+
+val termP_removal2 =
+    nomdatatype.termP_removal {
+      elimth = termP_elim2, absrep_id = absrep_id2,
+      tpm_def = AP_TERM term_ABS_t2 term_REP_rpm |> REWRITE_RULE [absrep_id2],
+      termP = termP2, repty = repty};
+
+val termP' = prove(
+   “genind ^vp ^lp n t <=>
+      ^termP0 t /\ n = 0 \/
+      ^termP1 t /\ n = 1 \/
+      ^termP2 t /\ n = 2”,
+    EQ_TAC >> simp_tac (srw_ss()) [] >> strip_tac >> rw []
+ >> qsuff_tac ‘n = 0 \/ n = 1 \/ n = 2’ >- (strip_tac >> srw_tac [][])
+ >> pop_assum mp_tac
+ >> Q.ISPEC_THEN ‘t’ STRUCT_CASES_TAC gterm_cases
+ >> srw_tac [][genind_GVAR, genind_GLAM_eqn]);
+
+(* “tvf :string -> 'q -> 'r” *)
+val tvf = “λ(s :string) (u :unit) (p :'q). tvf s p :'r”; (* Name *)
+
+(* Type of constants (all constructors are included) occurring in tlf:
+
+   Nil:    “tnf :('q -> 'r)”
+   Tau:    “ttf :('q -> 'r) -> pi -> ('q -> 'r)”
+   Input:  “tif :('q -> 'r) -> string -> ('q -> 'r) ->
+                 name -> pi -> ('q -> 'r)”
+   Output: “tof :('q -> 'r) -> ('q -> 'r) -> ('q -> 'r) ->
+                 name -> name -> pi -> ('q -> 'r)”
+   Match:  “tmf :('q -> 'r) -> ('q -> 'r) -> ('q -> 'r) ->
+                 name -> name -> pi -> ('q -> 'r)”
+   Mismatch: “tuf :('q -> 'r) -> ('q -> 'r) -> ('q -> 'r) ->
+                   name -> name -> pi -> ('q -> 'r)”
+   Sum:    “tsf :('q -> 'r) -> ('q -> 'r) -> pi -> pi -> ('q -> 'r)”
+   Par:    “tpf :('q -> 'r) -> ('q -> 'r) -> pi -> pi -> ('q -> 'r)”
+   Res:    “tcf :string -> ('q -> 'r) -> pi -> ('q -> 'r)”
+
+   TauR:        “taf :('q -> 'r) -> pi -> ('q -> 'r)”
+   InputS:      “trf :('q -> 'r) -> string -> ('q -> 'r) ->
+                      name -> pi -> ('q -> 'r)”
+   BoundOutput: “tbf :('q -> 'r) -> string -> ('q -> 'r) ->
+                      name -> pi -> ('q -> 'r)”
+   FreeOutput:  “tff :('q -> 'r) -> ('q -> 'r) -> ('q -> 'r) ->
+                      name -> name -> pi -> ('q -> 'r)”
+
+   NOTE: ds1 is the list of (bounded) recursive parameters as functions ('q -> 'r).
+         ts1 is the list of (bounded) actual arguments in the same position.
+         ds2 is the list of (unbounded) recursive parameters as functions ('q -> 'r).
+         ts2 is the list of (unbounded) actual arguments in the same position.
+         non-recursive parameters are taken from the corresponding position of u.
+        "if conditions" identify the constructor.
+         v is the only binding variable.
+ *)
+val u_tm = mk_var("u", rep_t);
+
+(* tlf's ty :string ->
+             'a ->
+             ('q -> 'c) list ->
+             ('q -> 'c) list ->
+             ('a, 'b) gterm list -> ('a, 'b) gterm list -> 'q -> 'c)
+ *)
+val tlf =
+   “λ(v :string) ^u_tm (ds1 :('q -> 'r) list) (ds2 :('q -> 'r) list)
+                       (ts1 :^repty' list) (ts2 :^repty' list) (p :'q).
+       if ISL u then                                   (* Nil *)
+         tnf p :'r
+       else if ISL (OUTR u) then                       (* Tau *)
+         ttf (HD ds2) (^term_ABS_t1 (HD ts2)) p :'r
+       else if ISL (OUTR (OUTR u)) then                (* Input *)
+         tif (HD ds2) v (HD ds1)
+             (^term_ABS_t0 (HD ts2)) (^term_ABS_t1 (HD ts1)) p :'r
+       else if ISL (OUTR (OUTR (OUTR u))) then         (* Output *)
+         tof (HD ds2) (HD (TL ds2)) (HD (TL (TL ds2)))
+             (^term_ABS_t0 (HD ts2))
+             (^term_ABS_t0 (HD (TL ts2)))
+             (^term_ABS_t1 (HD (TL (TL ts2)))) p :'r
+       else if ISL (OUTR (OUTR (OUTR (OUTR u)))) then  (* Match *)
+         tmf (HD ds2) (HD (TL ds2)) (HD (TL (TL ds2)))
+             (^term_ABS_t0 (HD ts2))
+             (^term_ABS_t0 (HD (TL ts2)))
+             (^term_ABS_t1 (HD (TL (TL ts2)))) p :'r
+       else if ISL (OUTR (OUTR (OUTR (OUTR (OUTR u))))) then (* Mismatch *)
+         tuf (HD ds2) (HD (TL ds2)) (HD (TL (TL ds2)))
+             (^term_ABS_t0 (HD ts2))
+             (^term_ABS_t0 (HD (TL ts2)))
+             (^term_ABS_t1 (HD (TL (TL ts2)))) p :'r
+       else if ISL (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR u)))))) then (* Sum *)
+         tsf (HD ds2) (HD (TL ds2))
+             (^term_ABS_t1 (HD ts2))
+             (^term_ABS_t1 (HD (TL ts2))) p :'r
+       else if ISL (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR u))))))) then (* Par *)
+         tpf (HD ds2) (HD (TL ds2))
+             (^term_ABS_t1 (HD ts2))
+             (^term_ABS_t1 (HD (TL ts2))) p :'r
+       else if ISL (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (* Res *)
+                   (OUTR u)))))))) then
+         tcf v (HD ds1) (^term_ABS_t1 (HD ts1)) p :'r
+       else if ISL (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (* TauR *)
+                   (OUTR (OUTR u))))))))) then
+         taf (HD ds2) (^term_ABS_t1 (HD ts2)) p :'r
+       else if ISL (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (* InputS *)
+                   (OUTR (OUTR (OUTR u)))))))))) then
+         trf (HD ds2) v (HD ds1)
+             (^term_ABS_t0 (HD ts2)) (^term_ABS_t1 (HD ts1)) p :'r
+       else if ISL (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (OUTR (* BoundOutput *)
+                   (OUTR (OUTR (OUTR (OUTR u))))))))))) then
+         tbf (HD ds2) v (HD ds1)
+             (^term_ABS_t0 (HD ts2)) (^term_ABS_t1 (HD ts1)) p :'r
+       else
+         tof (HD ds2) (HD (TL ds2)) (HD (TL (TL ds2)))
+             (^term_ABS_t0 (HD ts2))
+             (^term_ABS_t0 (HD (TL ts2)))
+             (^term_ABS_t1 (HD (TL (TL ts2)))) p :'r”;
+
+Overload TLF = tlf
+
+Theorem parameter_tm_recursion0 =
+  parameter_gtm_recursion
+      |> INST_TYPE [alpha |-> rep_t, beta |-> unit_t, gamma |-> “:'r”]
+      |> Q.INST [‘lf’ |-> ‘^tlf’, ‘vf’ |-> ‘^tvf’, ‘vp’ |-> ‘^vp’,
+                 ‘lp’ |-> ‘^lp’]
+      |> SIMP_RULE (srw_ss()) [sumTheory.FORALL_SUM, FORALL_AND_THM,
+                               GSYM RIGHT_FORALL_IMP_THM, IMP_CONJ_THM,
+                               GSYM RIGHT_EXISTS_AND_THM,
+                               GSYM LEFT_EXISTS_AND_THM,
+                               GSYM LEFT_FORALL_IMP_THM,
+                               LIST_REL_CONS1, genind_GVAR,
+                               genind_GLAM_eqn, sidecond_def,
+                               NEWFCB_def, relsupp_def,
+                               LENGTH_NIL_SYM, LENGTH1, LENGTH2]
+      |> ONCE_REWRITE_RULE [termP']
+      |> SIMP_RULE (srw_ss() ++ DNF_ss) [LENGTH1, LENGTH2, LENGTH_NIL]
+      |> CONV_RULE (DEPTH_CONV termP_removal0)
+      |> CONV_RULE (DEPTH_CONV termP_removal1)
+      |> CONV_RULE (DEPTH_CONV termP_removal2)
+      |> SIMP_RULE (srw_ss()) [GSYM supp_npm, SYM term_REP_npm,
+                               GSYM supp_tpm, SYM term_REP_tpm,
+                               GSYM supp_rpm, SYM term_REP_rpm]
+      |> UNDISCH
+      |> rpt_hyp_dest_conj
+(*
+      |> lift_exfunction {repabs_pseudo_id = repabs_pseudo_id2,
+                          term_REP_t = term_REP_t2,
+                          cons_info = rcons_info}
+      |> lift_exfunction {repabs_pseudo_id = repabs_pseudo_id1,
+                          term_REP_t = term_REP_t1,
+                          cons_info = cons_info}
+      |> lift_exfunction {repabs_pseudo_id = repabs_pseudo_id0,
+                          term_REP_t = term_REP_t0,
+                          cons_info = ncons_info}
+      |> DISCH_ALL
+      |> elim_unnecessary_atoms {finite_fv = FINITE_FV}
+                                [ASSUME ``FINITE (A:string set)``,
+                                 ASSUME ``!p :'q. FINITE (supp ppm p)``]
+      |> UNDISCH_ALL |> DISCH_ALL
+      |> REWRITE_RULE [AND_IMP_INTRO]
+      |> CONV_RULE (LAND_CONV (REWRITE_CONV [GSYM CONJ_ASSOC]))
+      |> Q.INST [‘tvf’ |-> ‘vr’, (* Name? *)
+                 ‘tnf’ |-> ‘f0’, (* Nil *)
+                 ‘ttf’ |-> ‘f1’, (* Tau *)
+                 ‘tif’ |-> ‘f2’, (* Input *)
+                 ‘tof’ |-> ‘f3’, (* Output *)
+                 ‘tmf’ |-> ‘f4’, (* Match *)
+                 ‘tuf’ |-> ‘f5’, (* Mismatch *)
+                 ‘tsf’ |-> ‘f6’, (* Sum *)
+                 ‘tpf’ |-> ‘f7’, (* Par *)
+                 ‘trf’ |-> ‘f8’, (* Res *)
+                 ‘dpm’ |-> ‘apm’]
+      |> CONV_RULE (REDEPTH_CONV sort_uvars)
+
+Theorem tm_recursion =
+  parameter_tm_recursion
+      |> Q.INST_TYPE [‘:'q’ |-> ‘:unit’]
+      |> Q.INST [‘ppm’ |-> ‘discrete_pmact’,
+                  ‘vr’ |-> ‘\s u. vru s’,
+                  ‘pf’ |-> ‘\r a t u. pfu (r()) a t’,
+                  ‘sm’ |-> ‘\r1 r2 t1 t2 u. smu (r1()) (r2()) t1 t2’,
+                  ‘pr’ |-> ‘\r1 r2 t1 t2 u. pru (r1()) (r2()) t1 t2’,
+                  ‘rs’ |-> ‘\r L t u. rsu (r()) L t’,
+                  ‘rl’ |-> ‘\r t rf u. rlu (r()) t rf’,
+                  ‘re’ |-> ‘\r v t u. reu (r()) v t’]
+      |> SIMP_RULE (srw_ss()) [oneTheory.FORALL_ONE, oneTheory.FORALL_ONE_FN,
+                               oneTheory.EXISTS_ONE_FN, fnpm_def]
+      |> SIMP_RULE (srw_ss() ++ CONJ_ss) [supp_unitfn]
+      |> Q.INST [‘vru’ |-> ‘vr’,
+                 ‘pfu’ |-> ‘pf’,
+                 ‘smu’ |-> ‘sm’,
+                 ‘pru’ |-> ‘pr’,
+                 ‘rsu’ |-> ‘rs’,
+                 ‘rlu’ |-> ‘rl’,
+                 ‘reu’ |-> ‘re’]
+*)
 val _ = export_theory ();
 val _ = html_theory "pi_agent";

--- a/src/boss/prove_base_assumsScript.sml
+++ b/src/boss/prove_base_assumsScript.sml
@@ -338,36 +338,38 @@ val goals =
  73 |- Data_Pair_comma x y = Data_Pair_comma a b <=> x = a /\ y = b,
  74 |- Data_Sum_left x = Data_Sum_left y <=> x = y,
  75 |- Data_Sum_right x = Data_Sum_right y <=> x = y,
- 76 |- Function_id = Function_Combinator_s Function_const Function_const,
- 77 |- Relation_empty = (\x y. F),
- 78 |- Relation_universe = (\x y. T),
- 79 |- Number_Natural_bit1 =
+ 76 |- y ==> x <=> ~x ==> ~y
+ 77 |- Function_id = Function_Combinator_s Function_const Function_const,
+ 78 |- Relation_empty = (\x y. F),
+ 79 |- Relation_universe = (\x y. T),
+ 80 |- Number_Natural_bit1 =
        (\n.
             Number_Natural_plus n
               (Number_Natural_plus n (Number_Natural_suc Number_Natural_zero))),
- 80 |- Number_Natural_max = (\m n. if Number_Natural_less m n then n else m),
- 81 |- Number_Natural_min = (\m n. if Number_Natural_less m n then m else n),
- 82 |- Number_Natural_greater = (\m n. Number_Natural_less n m),
- 83 |- Number_Natural_greatereq = (\m n. Number_Natural_greater m n \/ m = n),
- 84 |- Number_Natural_less =
+ 81 |- Number_Natural_max = (\m n. if Number_Natural_less m n then n else m),
+ 82 |- Number_Natural_min = (\m n. if Number_Natural_less m n then m else n),
+ 83 |- Number_Natural_greater = (\m n. Number_Natural_less n m),
+ 84 |- Number_Natural_greatereq = (\m n. Number_Natural_greater m n \/ m = n),
+ 85 |- Number_Natural_less =
        (\m n. ?P. (!n. P (Number_Natural_suc n) ==> P n) /\ P m /\ ~P n),
- 85 |- Number_Natural_lesseq = (\m n. Number_Natural_less m n \/ m = n),
- 86 |- Relation_irreflexive = (\R. !x. ~R x x),
- 87 |- Relation_reflexive = (\R. !x. R x x),
- 88 |- Relation_transitive = (\R. !x y z. R x y /\ R y z ==> R x z),
- 89 |- Relation_wellFounded =
+ 86 |- Number_Natural_lesseq = (\m n. Number_Natural_less m n \/ m = n),
+ 87 |- Relation_irreflexive = (\R. !x. ~R x x),
+ 88 |- Relation_reflexive = (\R. !x. R x x),
+ 89 |- Relation_transitive = (\R. !x y z. R x y /\ R y z ==> R x z),
+ 90 |- Relation_wellFounded =
        (\R. !B. (?w. B w) ==> ?min. B min /\ !b. R b min ==> ~B b),
- 90 |- Relation_transitiveClosure =
+ 91 |- Relation_transitiveClosure =
        (\R a b.
             !P. (!x y. R x y ==> P x y) /\ (!x y z. P x y /\ P y z ==> P x z) ==>
                 P a b),
- 91 |- Relation_subrelation = (\R1 R2. !x y. R1 x y ==> R2 x y),
- 92 |- Relation_intersect = (\R1 R2 x y. R1 x y /\ R2 x y),
- 93 |- Relation_union = (\R1 R2 x y. R1 x y \/ R2 x y),
- 94 |- Function_o = (\f g x. f (g x)),
- 95 |- (!x. P x ==> Q x) ==> (?x. P x) ==> ?x. Q x,
- 96 |- (x ==> y) /\ (z ==> w) ==> x /\ z ==> y /\ w,
- 97 |- (x ==> y) /\ (z ==> w) ==> x \/ z ==> y \/ w]: thm list
+ 92 |- Relation_subrelation = (\R1 R2. !x y. R1 x y ==> R2 x y),
+ 93 |- Relation_intersect = (\R1 R2 x y. R1 x y /\ R2 x y),
+ 94 |- Relation_union = (\R1 R2 x y. R1 x y \/ R2 x y),
+ 95 |- Function_o = (\f g x. f (g x)),
+ 96 |- (!x. P x ==> Q x) ==> (?x. P x) ==> ?x. Q x,
+ 97 |- (x ==> y) /\ (z ==> w) ==> x /\ z ==> y /\ w,
+ 98 |- (x ==> y) /\ (z ==> w) ==> x \/ z ==> y \/ w
+ ]: thm list
  *)
 
 val bool_cases = hd(amatch``(x = T) \/ _``);
@@ -1091,6 +1093,8 @@ val th61 = store_thm
   ("th61",  el 61 goals |> concl,
   PURE_REWRITE_TAC[iff_F,not_not,iff_T,not_F,and_T]);
 
+val BOOL_EQ_DISTINCT = th61;
+
 (* |- Data_List_concat Data_List_nil = Data_List_nil /\
       !h t.
           Data_List_concat (Data_List_cons h t) =
@@ -1236,18 +1240,29 @@ val th75 = store_thm
   ("th75", el 75 goals |> concl,
   MATCH_ACCEPT_TAC right_11);
 
+val mono_not_eq = hd (amatch “~t1 ==> ~t2 <=> t2 ==> t1”);
+val eq_sym_eq = hd (amatch “x = y <=> y = x”);
+
+(* |- y ==> x <=> ~x ==> ~y *)
+val th76 = store_thm
+  ("th76", el 76 goals |> concl,
+    PURE_ONCE_REWRITE_TAC [eq_sym_eq]
+ >> MATCH_ACCEPT_TAC mono_not_eq);
+
+val MONO_NOT_EQ = th76;
+
 val skk = hd(amatch``Function_Combinator_s _ _ = Function_id``);
 
 (* |- Function_id = Function_Combinator_s Function_const Function_const *)
-val th76 = store_thm
-  ("th76", el 76 goals |> concl,
+val th77 = store_thm
+  ("th77", el 77 goals |> concl,
   PURE_REWRITE_TAC[skk] \\ REFL_TAC);
 
 val empty_thm = hd(amatch``Relation_empty _ _``);
 
 (* |- Relation_empty = (\x y. F) *)
-val th77 = store_thm
-  ("th77", el 77 goals |> concl,
+val th78 = store_thm
+  ("th78", el 78 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,EQF_INTRO (SPEC_ALL empty_thm)]
   \\ CONV_TAC (DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
@@ -1255,8 +1270,8 @@ val th77 = store_thm
 val universe_thm = hd(amatch``Relation_universe _ _``);
 
 (* |- Relation_universe = (\x y. T) *)
-val th78 = store_thm
-  ("th78", el 78 goals |> concl,
+val th79 = store_thm
+  ("th79", el 79 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,EQT_INTRO(SPEC_ALL universe_thm)]
   \\ CONV_TAC (DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
@@ -1277,8 +1292,8 @@ val num_less_ind = hd(amatch``(!x. _ ==> _) ==> !n. P (n:Number_Natural_natural)
            Number_Natural_plus n
              (Number_Natural_plus n (Number_Natural_suc Number_Natural_zero)))
  *)
-val th79 = store_thm
-  ("th79", el 79 goals |> concl,
+val th80 = store_thm
+  ("th80", el 80 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,bit1_thm,plus_suc]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ gen_tac
@@ -1297,8 +1312,8 @@ val if_id   = hd(amatch``if _ then x else x``);
 val less_or_eq   = hd(amatch``Number_Natural_lesseq _ _ <=> (Number_Natural_less _ _) \/ _``);
 
 (* |- Number_Natural_max = (\m n. if Number_Natural_less m n then n else m) *)
-val th80 = store_thm
-  ("th80", el 80 goals |> concl,
+val th81 = store_thm
+  ("th81", el 81 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,max_thm,less_or_eq]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac
@@ -1313,8 +1328,8 @@ val th80 = store_thm
 val min_thm = hd(amatch``Number_Natural_min _ _ = COND _ _ _``);
 
 (* |- Number_Natural_min = (\m n. if Number_Natural_less m n then m else n) *)
-val th81 = store_thm
-  ("th81", el 81 goals |> concl,
+val th82 = store_thm
+  ("th82", el 82 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,min_thm,less_or_eq]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac
@@ -1329,8 +1344,8 @@ val th81 = store_thm
 val greater_thm   = hd(amatch``Number_Natural_greater _ _ = _``);
 
 (* |- Number_Natural_greater = (\m n. Number_Natural_less n m) *)
-val th82 = store_thm
-  ("th82", el 82 goals |> concl,
+val th83 = store_thm
+  ("th83", el 83 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,greater_thm]
   \\ CONV_TAC (DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
@@ -1338,8 +1353,8 @@ val th82 = store_thm
 val greatereq_thm = hd(amatch``Number_Natural_greatereq _ _``);
 
 (* |- Number_Natural_greatereq = (\m n. Number_Natural_greater m n \/ m = n) *)
-val th83 = store_thm
-  ("th83", el 83 goals |> concl,
+val th84 = store_thm
+  ("th84", el 84 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,greatereq_thm,less_or_eq,greater_thm]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac
@@ -1367,8 +1382,8 @@ val F_IMP2 = store_thm
 (* |- Number_Natural_less =
       (\m n. ?P. (!n. P (Number_Natural_suc n) ==> P n) /\ P m /\ ~P n)
  *)
-val th84 = store_thm
-  ("th84", el 84 goals |> concl,
+val th85 = store_thm
+  ("th85", el 85 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm]
   \\ qx_genl_tac[`a`,`b`]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
@@ -1427,8 +1442,8 @@ val th84 = store_thm
   \\ PURE_REWRITE_TAC[F_imp]);
 
 (* |- Number_Natural_lesseq = (\m n. Number_Natural_less m n \/ m = n) *)
-val th85 = store_thm
-  ("th85", el 85 goals |> concl,
+val th86 = store_thm
+  ("th86", el 86 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,less_or_eq]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
@@ -1436,8 +1451,8 @@ val th85 = store_thm
 val irreflexive_thm = hd(amatch``Relation_irreflexive _ = _``);
 
 (* |- Relation_irreflexive = (\R. !x. ~R x x) *)
-val th86 = store_thm
-  ("th86", el 86 goals |> concl,
+val th87 = store_thm
+  ("th87", el 87 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm, irreflexive_thm]
   \\ CONV_TAC (DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac
@@ -1446,8 +1461,8 @@ val th86 = store_thm
 val reflexive_thm = hd(amatch``Relation_reflexive _ = _``);
 
 (* |- Relation_reflexive = (\R. !x. R x x) *)
-val th87 = store_thm
-  ("th87", el 87 goals |> concl,
+val th88 = store_thm
+  ("th88", el 88 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm, reflexive_thm]
   \\ CONV_TAC (DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
@@ -1455,8 +1470,8 @@ val th87 = store_thm
 val transitive_thm = hd(amatch``Relation_transitive s <=> _``);
 
 (* |- Relation_transitive = (\R. !x y z. R x y /\ R y z ==> R x z) *)
-val th88 = store_thm
-  ("th88", el 88 goals |> concl,
+val th89 = store_thm
+  ("th89", el 89 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,transitive_thm]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ gen_tac \\ REFL_TAC);
@@ -1466,8 +1481,8 @@ val wellFounded_thm = hd(amatch``Relation_wellFounded r <=> !p. (?x. _) ==> _``)
 (* |- Relation_wellFounded =
       (\R. !B. (?w. B w) ==> ?min. B min /\ !b. R b min ==> ~B b)
  *)
-val th89 = store_thm
-  ("th89", el 89 goals |> concl,
+val th90 = store_thm
+  ("th90", el 90 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm]
   \\ PURE_REWRITE_TAC[wellFounded_thm]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
@@ -1483,8 +1498,8 @@ val subrelation_thm  = hd(amatch``Relation_subrelation x s <=> !x y. _``);
            !P. (!x y. R x y ==> P x y) /\ (!x y z. P x y /\ P y z ==> P x z) ==>
                P a b)
  *)
-val th90 = store_thm
-  ("th90", el 90 goals |> concl,
+val th91 = store_thm
+  ("th91", el 91 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm]
   \\ PURE_REWRITE_TAC[tc_def,bigIntersect_thm,mem_fromPred]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
@@ -1497,8 +1512,8 @@ val th90 = store_thm
   \\ REFL_TAC);
 
 (* |- Relation_subrelation = (\R1 R2. !x y. R1 x y ==> R2 x y) *)
-val th91 = store_thm
-  ("th91", el 91 goals |> concl,
+val th92 = store_thm
+  ("th92", el 92 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,subrelation_thm]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
@@ -1511,15 +1526,15 @@ val mem_union = hd(amatch``Set_member _ (Set_union _ _) <=> _``);
 val mem_toSet = hd(amatch``Set_member _ (Relation_toSet _)``);
 
 (* |- Relation_intersect = (\R1 R2 x y. R1 x y /\ R2 x y) *)
-val th92 = store_thm
-  ("th92", el 92 goals |> concl,
+val th93 = store_thm
+  ("th93", el 93 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,intersect_thm,fromSet_thm,mem_inter,mem_toSet]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
 
 (* |- Relation_union = (\R1 R2 x y. R1 x y \/ R2 x y) *)
-val th93 = store_thm
-  ("th93", el 93 goals |> concl,
+val th94 = store_thm
+  ("th94", el 94 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,union_thm,fromSet_thm,mem_union,mem_toSet]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
@@ -1527,15 +1542,15 @@ val th93 = store_thm
 val o_thm = hd(amatch``(Function_o _ _) _ = _``);
 
 (* |- Function_o = (\f g x. f (g x)) *)
-val th94 = store_thm
-  ("th94", el 94 goals |> concl,
+val th95 = store_thm
+  ("th95", el 95 goals |> concl,
   PURE_REWRITE_TAC[GSYM fun_eq_thm,o_thm]
   \\ CONV_TAC (DEPTH_CONV BETA_CONV)
   \\ rpt gen_tac \\ REFL_TAC);
 
 (* |- (!x. P x ==> Q x) ==> (?x. P x) ==> ?x'. Q x' *)
-val th95 = store_thm
-  ("th95", el 95 goals |> concl,
+val th96 = store_thm
+  ("th96", el 96 goals |> concl,
   rpt strip_tac
   \\ first_x_assum(fn th => first_x_assum (assume_tac o MATCH_MP th))
   \\ qexists_tac`x`
@@ -1550,16 +1565,16 @@ val th94' = store_thm
  *)
 
 (* |- (x ==> y) /\ (z ==> w) ==> x /\ z ==> y /\ w *)
-val th96 = store_thm
-  ("th96", el 96 goals |> concl,
+val th97 = store_thm
+  ("th97", el 97 goals |> concl,
    rpt strip_tac
   \\ first_x_assum(fn th => first_x_assum (assume_tac o MATCH_MP th))
   \\ first_x_assum(fn th => first_x_assum (assume_tac o MATCH_MP th))
   \\ first_assum ACCEPT_TAC);
 
 (* |- (x ==> y) /\ (z ==> w) ==> x \/ z ==> y \/ w *)
-val th97 = store_thm
-  ("th97", el 97 goals |> concl,
+val th98 = store_thm
+  ("th98", el 98 goals |> concl,
   rpt strip_tac
   \\ first_x_assum(fn th => first_x_assum (assume_tac o MATCH_MP th))
   \\ TRY (disj1_tac >> first_assum ACCEPT_TAC)
@@ -1595,8 +1610,8 @@ val th89 = store_thm
   MATCH_ACCEPT_TAC ex_unique_thm);
  *)
 
-(* Now raise an error if the above th96 is not the last one *)
-val _ = if List.length goals <> 97 then
+(* Now raise an error if the above th98 is not the last one *)
+val _ = if List.length goals <> 98 then
             (raise ERR "-" "assumptions changed")
         else ();
 
@@ -1619,23 +1634,11 @@ val MONO_NOT = store_thm
   ("MONO_NOT", concl boolTheory.MONO_NOT,
     MATCH_ACCEPT_TAC mono_not);
 
-val mono_not_eq = hd (amatch “~t1 ==> ~t2 <=> t2 ==> t1”);
-val eq_sym_eq = hd (amatch “x = y <=> y = x”);
-
-(* |- y ==> x <=> ~x ==> ~y *)
-val MONO_NOT_EQ = store_thm
-  ("MONO_NOT_EQ", concl boolTheory.MONO_NOT_EQ,
-    PURE_ONCE_REWRITE_TAC [eq_sym_eq]
- >> MATCH_ACCEPT_TAC mono_not_eq);
-
 (* |- P (let x = M in N x) <=> (let x = M in P (N x)) *)
 val LET_RAND = store_thm("LET_RAND", concl boolTheory.LET_RAND,
   PURE_REWRITE_TAC[LET_DEF]
   \\ CONV_TAC(DEPTH_CONV BETA_CONV)
   \\ REFL_TAC)
-
-(* |- (T <=/=> F) /\ (F <=/=> T) *)
-val BOOL_EQ_DISTINCT = th61;
 
 (* |- (!t1 t2. (if T then t1 else t2) = t1) /\
       !t1 t2. (if F then t1 else t2) = t2


### PR DESCRIPTION
Hi,

The relatively small `set_relationTheory` is sometimes useful for its closeness with textbook definition of (binary) relations. This PR adds `symmetric` and symmetric closure (`sc`), following the existing definition of `tc` (transitive closure).

As an application of these newly added contents (in `set_relation`), I also added a stage work on π-calculus, where the new `open_bisimulationTheory` makes use of `sc`, and `pi_agentTheory` contains a updated version of nominal typing setup with a stage work on the construction of recursive functions on those types (in case you want to help on finishing it).

--Chun