### PR TITLE
Convolution of (Normal) Random Variables

### DIFF
--- a/examples/probability/stochastic_processScript.sml
+++ b/examples/probability/stochastic_processScript.sml
@@ -2061,6 +2061,7 @@ QED
 Theorem existence_of_multidimensional_prob_space :
     !p N. prob_space p /\ 0 < N ==>
          ?pp. prob_space pp /\
+              measurable_space pp = sigma_lists (measurable_space p) N /\
              !E. (?h. E = rectangle h N /\ !i. i < N ==> h i IN events p) ==>
                  E IN events pp /\
                  prob pp E = PI (\i. prob p (IMAGE (EL i) E)) (count N)
@@ -2108,7 +2109,8 @@ Proof
             ‘x NOTIN f n’ by METIS_TAC [DISJOINT_ALT] \\
              gvs []) >> Rewr' \\
          AP_TERM_TAC >> simp [o_DEF, Abbr ‘g’]) \\
-     rw [count_def, prob_def, Abbr ‘f’, unwrap_def, events_def] \\
+     rw [count_def, prob_def, Abbr ‘f’, unwrap_def, events_def]
+     >- (rw [Abbr ‘a'’, Abbr ‘a’, p_space_def, events_def]) \\
      simp [Abbr ‘a'’, sigma_lists_1, Abbr ‘a’, subsets_def] \\
      fs [GSYM events_def] \\
      Q.EXISTS_TAC ‘h 0’ >> art [] \\
@@ -2161,7 +2163,7 @@ Proof
       ‘a = general_sigma CONS (p_space p,events p) (p_space p1,events p1)’
  >> qabbrev_tac ‘p2 = (Z,subsets a,m)’
  >> Q.EXISTS_TAC ‘p2’
- >> CONJ_TAC
+ >> CONJ_TAC (* prob_space p2 *)
  >- (simp [prob_space_def] \\
      fs [sigma_finite_measure_space_def] \\
      simp [GSYM prob_def, GSYM p_space_def] \\
@@ -2177,6 +2179,19 @@ Proof
      >- (FIRST_X_ASSUM MATCH_MP_TAC \\
          simp [EVENTS_SPACE]) >> Rewr' \\
      simp [PROB_UNIV])
+ >> CONJ_TAC
+ >- (simp [Abbr ‘p2’, Abbr ‘Z’] \\
+    ‘0 < N’ by rw [Abbr ‘N’] \\
+     Know ‘sigma_algebra (measurable_space p)’
+     >- (MATCH_MP_TAC MEASURE_SPACE_SIGMA_ALGEBRA \\
+         fs [prob_space_def]) >> DISCH_TAC \\
+     simp [sigma_lists_decomposition] \\
+     Q.PAT_X_ASSUM ‘_ = sigma_lists (measurable_space p) N’
+       (REWRITE_TAC o wrap o SYM) \\
+     Know ‘general_cross CONS (p_space p) (p_space p1) = space a’
+     >- (simp [Abbr ‘a’, general_sigma_def, SPACE_SIGMA]) >> Rewr' \\
+     simp [SPACE, cons_sigma_alt_gen] \\
+     simp [Abbr ‘a’, p_space_def, events_def])
  (* stage work *)
  >> Q.X_GEN_TAC ‘E’ >> simp [list_rectangle_SUC]
  >> STRIP_TAC
@@ -2252,6 +2267,7 @@ QED
 Theorem existence_of_multidimensional_prob_space' :
     !p N. prob_space p /\ 0 < N ==>
          ?pp. prob_space pp /\
+              measurable_space pp = sigma_lists (measurable_space p) N /\
              !E h. E = rectangle h N /\ (!i. i < N ==> h i IN events p) ==>
                    E IN events pp /\ prob pp E = PI (prob p o h) (count N)
 Proof

--- a/src/probability/extrealScript.sml
+++ b/src/probability/extrealScript.sml
@@ -6627,7 +6627,6 @@ Overload lim = “extreal_lim”
 Definition ext_continuous_def :
     ext_continuous f net <=> ext_tendsto f (f (netlimit net)) net
 End
-Overload continuous = “ext_continuous”
 
 (* NOTE: because of the type of ‘at x within s’, here the type of ‘f’ is
   “:real -> extreal”. For a function ‘g :extreal -> extreal’, to say it's
@@ -6643,16 +6642,10 @@ Definition ext_continuous_on_def :
     ext_continuous_on f s <=> !x. x IN s ==> ext_continuous f (at x within s)
 End
 
-(* ‘continuous_on’ is defined in real_topologyTheory *)
-Overload continuous_on = “ext_continuous_on”
-
 (* Use ‘ext_bounded (IMAGE f UNIV)’ to say a function f is bounded (on UNIV) *)
 Definition ext_bounded_def :
     ext_bounded s <=> ?a. a <> PosInf /\ !x. x IN s ==> abs x <= a
 End
-
-(* ‘bounded’ is defined in real_topologyTheory *)
-Overload bounded = “ext_bounded”
 
 Theorem EXTREAL_LIM :
     !(f :'a -> extreal) l net.

--- a/src/probability/probabilityScript.sml
+++ b/src/probability/probabilityScript.sml
@@ -9660,9 +9660,37 @@ Proof
       Q.EXISTS_TAC ‘Normal x’ >> rw [] ]
 QED
 
+Theorem prob_space_ext_lborel_01' :
+    prob_space (restrict_space ext_lborel {x | 0 < x /\ x < 1})
+Proof
+    rw [prob_space_def]
+ >- (MATCH_MP_TAC measure_space_restrict_space \\
+     rw [measure_space_ext_lborel] \\
+     rw [ext_lborel_def, measurable_sets_def] \\
+     rw [BOREL_MEASURABLE_SETS])
+ >> simp [space_restrict_space]
+ >> rw [restrict_space, measure_def, ext_lborel_def, m_space_def, SPACE_BOREL]
+ >> Suff ‘real_set {x | 0 < x /\ x < 1} = interval (0,1)’
+ >- rw [lambda_open_interval]
+ >> rw [Once EXTENSION, real_set_def, OPEN_interval]
+ >> EQ_TAC >> rw []
+ >| [ (* goal 1 (of 3) *)
+      rename1 ‘z < 1’ \\
+     ‘?r. 0 < r /\ r < 1 /\ z = Normal r’
+        by METIS_TAC [extreal_cases, extreal_of_num_def, extreal_lt_eq] \\
+      rw [real_def],
+      (* goal 2 (of 3) *)
+      rename1 ‘0 < z’ \\
+     ‘?r. 0 < r /\ r < 1 /\ z = Normal r’
+        by METIS_TAC [extreal_cases, extreal_of_num_def, extreal_lt_eq] \\
+      rw [real_def],
+      (* goal 3 (of 3) *)
+      Q.EXISTS_TAC ‘Normal x’ >> rw [] ]
+QED
+
 Theorem existence_of_prod_prob_space :
     !p1 p2. prob_space p1 /\ prob_space p2 ==>
-            ?p. prob_space p /\
+            ?p. p = p1 CROSS p2 /\ prob_space p /\
                 !e1 e2. e1 IN events p1 /\ e2 IN events p2 ==>
                         e1 CROSS e2 IN events p /\
                         prob p (e1 CROSS e2) = prob p1 e1 * prob p2 e2
@@ -9672,57 +9700,41 @@ Proof
      sigma_finite_measure_space p2’
        by PROVE_TAC [prob_space_def, PROB_SPACE_SIGMA_FINITE,
                      sigma_finite_measure_space_def]
- >> qabbrev_tac ‘X = p_space p1’
- >> qabbrev_tac ‘A = events p1’
- >> qabbrev_tac ‘u = prob p1’
- >> qabbrev_tac ‘Y = p_space p2’
- >> qabbrev_tac ‘B = events p2’
- >> qabbrev_tac ‘v = prob p2’
- >> qabbrev_tac ‘m0 = \s. prob p1 (IMAGE FST s) * prob p2 (IMAGE SND s)’
- >> MP_TAC (Q.SPECL [‘X’, ‘Y’, ‘A’, ‘B’, ‘u’, ‘v’, ‘m0’] EXISTENCE_OF_PROD_MEASURE)
- >> simp [PROB_SPACE_REDUCE,
-          Abbr ‘X’, Abbr ‘Y’, Abbr ‘A’, Abbr ‘B’, Abbr ‘u’, Abbr ‘v’, Abbr ‘m0’]
- >> impl_tac
- >- (rpt STRIP_TAC \\
-     Cases_on ‘s = {}’ >- simp [PROB_EMPTY] \\
-     Cases_on ‘t = {}’ >- simp [PROB_EMPTY] \\
-     simp [IMAGE_FST_CROSS, IMAGE_SND_CROSS])
- >> STRIP_TAC
- >> Q.PAT_X_ASSUM ‘sigma_finite_measure_space _’ MP_TAC
- >> qmatch_abbrev_tac ‘sigma_finite_measure_space p ==> _’
- >> rw [sigma_finite_measure_space_def]
- >> Q.EXISTS_TAC ‘p’
- >> CONJ_TAC (* prob_space p *)
- >- (POP_ASSUM K_TAC \\
-     rw [prob_space_def, Abbr ‘p’] \\
-     POP_ASSUM K_TAC \\
-    ‘p_space p1 <> {} /\ p_space p2 <> {}’ by PROVE_TAC [PROB_SPACE_NOT_EMPTY] \\
-     qmatch_abbrev_tac ‘m s = 1’ \\
-     Know ‘m s = prob p1 (IMAGE FST s) * prob p2 (IMAGE SND s)’
-     >- (FIRST_X_ASSUM MATCH_MP_TAC \\
-         simp [Abbr ‘s’] \\
-         qexistsl_tac [‘p_space p1’, ‘p_space p2’] >> simp [EVENTS_SPACE]) \\
-     Rewr' \\
-     simp [Abbr ‘s’, IMAGE_FST_CROSS, IMAGE_SND_CROSS, PROB_UNIV])
- >> Know ‘measure p {} = 0’ >- PROVE_TAC [MEASURE_EMPTY]
- >> NTAC 2 (POP_ASSUM K_TAC)
- >> simp [Abbr ‘p’, prob_def, prod_sigma_def, events_def]
- >> simp [GSYM events_def, GSYM prob_def]
- >> STRIP_TAC
- >> rpt GEN_TAC
- >> STRIP_TAC
- >> CONJ_TAC
- >- (MATCH_MP_TAC IN_SIGMA >> rw [IN_PROD_SETS] \\
-     qexistsl_tac [‘e1’, ‘e2’] >> art [])
- >> Cases_on ‘e1 = {}’ >- simp [PROB_EMPTY]
- >> Cases_on ‘e2 = {}’ >- simp [PROB_EMPTY]
- >> qabbrev_tac ‘s = e1 CROSS e2’
- >> Know ‘m s = prob p1 (IMAGE FST s) * prob p2 (IMAGE SND s)’
- >- (FIRST_X_ASSUM MATCH_MP_TAC \\
-     simp [Abbr ‘s’] \\
-     qexistsl_tac [‘e1’, ‘e2’] >> art [])
+ >> Q.EXISTS_TAC ‘p1 CROSS p2’ >> simp []
+ >> reverse CONJ_TAC
+ >- (rw [prod_measure_space_def, prob_def, events_def]
+     >- (rw [prod_sigma_def] \\
+         MATCH_MP_TAC IN_SIGMA \\
+         rw [prod_sets_def] \\
+         qexistsl_tac [‘e1’, ‘e2’] >> art []) \\
+     MATCH_MP_TAC PROD_MEASURE_CROSS \\
+     fs [prob_space_def])
+ >> rw [prob_space_def]
+ >- (MATCH_MP_TAC measure_space_prod_measure >> art [])
+ >> rw [prod_measure_space_def]
+ >> Know ‘prod_measure p1 p2 (m_space p1 CROSS m_space p2) =
+          measure p1 (m_space p1) * measure p2 (m_space p2)’
+ >- (MATCH_MP_TAC PROD_MEASURE_CROSS \\
+     fs [prob_space_def] \\
+     rw [MEASURE_SPACE_MSPACE_MEASURABLE])
  >> Rewr'
- >> simp [Abbr ‘s’, IMAGE_FST_CROSS, IMAGE_SND_CROSS]
+ >> simp [GSYM prob_def, GSYM p_space_def, PROB_UNIV]
+QED
+
+Theorem prob_space_eq :
+    !p1 p2. prob_space p1 /\ p_space p2 = p_space p1 /\ events p2 = events p1 /\
+           (!s. s IN events p2 ==> prob p2 s = prob p1 s) ==> prob_space p2
+Proof
+    rpt GEN_TAC
+ >> simp [prob_space_def, p_space_def, events_def, prob_def]
+ >> STRIP_TAC
+ >> CONJ_ASM1_TAC
+ >- (MATCH_MP_TAC measure_space_eq \\
+     Q.EXISTS_TAC ‘p1’ >> rw [])
+ >> Suff ‘measure p2 (m_space p1) = measure p1 (m_space p1)’ >- rw []
+ >> FIRST_X_ASSUM MATCH_MP_TAC
+ >> Q.PAT_X_ASSUM ‘_ = m_space p1’ (REWRITE_TAC o wrap o SYM)
+ >> MATCH_MP_TAC MEASURE_SPACE_SPACE >> art []
 QED
 
 (* tidy up theory exports, learnt from Magnus Myreen *)

--- a/src/probability/real_borelScript.sml
+++ b/src/probability/real_borelScript.sml
@@ -1264,6 +1264,18 @@ Proof
  >> RW_TAC std_ss []
 QED
 
+Theorem borel_2d_measurable_add :
+    (\(x,y). x + y) IN borel_measurable (borel CROSS borel)
+Proof
+    rpt STRIP_TAC
+ >> ASSUME_TAC sigma_algebra_borel
+ >> ‘sigma_algebra (borel CROSS borel)’ by PROVE_TAC [SIGMA_ALGEBRA_PROD_SIGMA_WEAK]
+ >> MATCH_MP_TAC in_borel_measurable_add
+ >> qexistsl_tac [‘FST’, ‘SND’]
+ >> simp [MEASURABLE_FST, MEASURABLE_SND]
+ >> simp [FORALL_PROD]
+QED
+
 Theorem in_borel_measurable_const :
     !a k f. sigma_algebra a /\ (!x. x IN space a ==> (f x = k)) ==>
             f IN measurable a borel
@@ -1318,6 +1330,18 @@ Proof
       RW_TAC real_ss [],
       (* goal 2 (of 2) *)
       REWRITE_TAC [real_sub] ]
+QED
+
+Theorem borel_2d_measurable_sub :
+    (\(x,y). x - y) IN borel_measurable (borel CROSS borel)
+Proof
+    rpt STRIP_TAC
+ >> ASSUME_TAC sigma_algebra_borel
+ >> ‘sigma_algebra (borel CROSS borel)’ by PROVE_TAC [SIGMA_ALGEBRA_PROD_SIGMA_WEAK]
+ >> MATCH_MP_TAC in_borel_measurable_sub
+ >> qexistsl_tac [‘FST’, ‘SND’]
+ >> simp [MEASURABLE_FST, MEASURABLE_SND]
+ >> simp [FORALL_PROD]
 QED
 
 Theorem in_borel_measurable_pow2 : (* was: in_borel_measurable_sqr *)


### PR DESCRIPTION
Hi,

This PR follows #1447, the 2nd part of HVG's old formalisation of normal random variable. The **convolution** of two measure space is defined by the distribution of the sum function `(\(x,y). x + y)` in their product measure space:
```
[convolution_def] (distributionTheory)
⊢ ∀M N.
    convolution M N =
    (space borel,subsets borel,
     (λs. if s ∈ subsets borel then distr (M × N) (λ(x,y). x + y) s else 0))

[measure_space_convolution]
⊢ ∀M N.
    sigma_finite_measure_space M ∧ sigma_finite_measure_space N ∧
    measurable_space M = borel ∧ measurable_space N = borel ⇒
    measure_space (convolution M N)
```
In probability theory, convolution is used to calculate the distribution of the sum of independent random variables:
```
[sum_indep_random_variable]
⊢ ∀p X Y.
    prob_space p ∧ random_variable X p borel ∧ random_variable Y p borel ∧
    indep_vars p X Y borel borel ⇒
    ∀s. s ∈ subsets borel ⇒
        distribution p (λx. X x + Y x) s =
        measure
          (convolution (distr_of p (space borel,subsets borel,(λx. 0)) X)
             (distr_of p (space borel,subsets borel,(λx. 0)) Y)) s
```
For normal r.v.'s, the following famous result says that the sum of two independent normal r.v.s' is still a normal r.v.:
```
[sum_indep_normal]
⊢ ∀p X Y mu1 mu2 sig1 sig2.
    prob_space p ∧ 0 < sig1 ∧ 0 < sig2 ∧ indep_vars p X Y borel borel ∧
    normal_rv X p mu1 sig1 ∧ normal_rv Y p mu2 sig2 ⇒
    normal_rv (λx. X x + Y x) p (mu1 + mu2) (sqrt (sig1² + sig2²))
```
The above result can easily generalise to a finite number of normal r.v.'s (part of original HVG's work but I decide to abandon their long proof).

Chun