### PR TITLE
[sorting] Add greater_sorted_eq

### DIFF
--- a/src/sort/sortingScript.sml
+++ b/src/sort/sortingScript.sml
@@ -1703,6 +1703,14 @@ val sorted_perm_count_list = Q.store_thm ("sorted_perm_count_list",
           by srw_tac [ARITH_ss] [transitive_def,antisymmetric_def] >>
  metis_tac [sorted_map, SORTED_PERM_EQ, sorted_count_list]);
 
+Theorem greater_sorted_eq:
+  SORTED $> (x::L) ⇔ SORTED $> L ∧ ∀y. MEM y L ⇒ y < x
+Proof
+  qsuff_tac ‘(∀y. MEM y L ⇒ y < x) = (∀y. MEM y L ⇒ x > y)’
+  >- (strip_tac \\ gvs [] \\ irule SORTED_EQ \\ rw [transitive_def])
+  \\ eq_tac \\ rpt strip_tac \\ res_tac \\ decide_tac
+QED
+
 val less_sorted_eq = MATCH_MP SORTED_EQ arithmeticTheory.transitive_LESS
   |> curry save_thm"less_sorted_eq";
 


### PR DESCRIPTION
This theorem was useful for reasoning about a descending list of numbers, which I use to reason about the keys of a map from variable names to unique integers. Since `less_sorted_eq` exists, having a version for `greater` may be a useful addition. If not, feel free to close.