### PR TITLE
Try to handle underscores in `Parse.parse_in_context`

### DIFF
--- a/src/parse/Parse.sml
+++ b/src/parse/Parse.sml
@@ -460,11 +460,14 @@ fun smashErrm m =
     | errormonad.Some (_, result) => result
 val stdprinters = SOME(term_to_string,type_to_string)
 
+fun ctxt_absyn_to_preterm fvs a =
+  TermParse.ctxt_absyn_to_preterm (term_grammar()) fvs a
+
 fun parse_in_context FVs q =
   let
     open errormonad
     val m =
-        (q |> Absyn |> absyn_to_preterm) >-
+        (q |> Absyn |> ctxt_absyn_to_preterm FVs) >-
         TermParse.ctxt_preterm_to_term stdprinters NONE FVs
   in
     smashErrm m

--- a/src/parse/TermParse.sig
+++ b/src/parse/TermParse.sig
@@ -16,6 +16,7 @@ sig
   val preterm : grammar -> tygrammar -> term quotation -> preterm in_env
   val typed_preterm : grammar -> tygrammar -> hol_type -> term quotation ->
                       preterm in_env
+  val ctxt_absyn_to_preterm : grammar -> term list -> absyn -> preterm in_env
   val absyn_to_preterm : grammar -> absyn -> preterm in_env
   val absyn_to_preterm_in_env : grammar -> absyn -> Parse_support.preterm_in_env
   val absyn_to_term : pprinters -> grammar -> absyn -> term


### PR DESCRIPTION
Expose and use the `ctxt_absyn_to_preterm` function created in https://github.com/HOL-Theorem-Prover/HOL/commit/ba1eb9a0ee80cd83cc632d3c2cb1c14668b879c1

Aims to fix https://github.com/HOL-Theorem-Prover/HOL/issues/1489