### PR TITLE
Add selftest for `qpat_abbrev_tac`

### DIFF
--- a/src/q/selftest.sml
+++ b/src/q/selftest.sml
@@ -435,6 +435,11 @@ val _ = require (check_result (fn _ => true))
                  REWRITE_TAC [])
                 ([], ``p /\ T = p``)
 
+val _ = tprint "PAT_ABBREV_TAC handles underscores"
+val _ = require (check_result (fn _ => true))
+                (Q.PAT_ABBREV_TAC `bar = foo _`)
+                ([], ``_ y = foo a``)
+
 val _ = new_definition ("gh425a_def", ``gh425a a = a``);
 val _ = new_definition ("gh425b_def", ``gh425b p = (p ==> T)``);
 val _ = overload_on ("gh425", ``gh425a``);


### PR DESCRIPTION
As per @mn200's comment in https://github.com/HOL-Theorem-Prover/HOL/pull/1496, add a selftest aiming to mimic the original bug report (https://github.com/HOL-Theorem-Prover/HOL/issues/1489)