### PR TITLE
Lipschitz_continuous_map and set_dist (setdist in general metric space)

### DIFF
--- a/src/pred_set/src/more_theories/topologyScript.sml
+++ b/src/pred_set/src/more_theories/topologyScript.sml
@@ -983,6 +983,115 @@ Proof
   SIMP_TAC std_ss [INTERS_GSPEC] THEN SET_TAC[]
 QED
 
+Theorem EXISTS_SUBSET_IMAGE :
+   !P (f :'a->'b) s.
+      (?t. t SUBSET IMAGE f s /\ P t) <=> (?t. t SUBSET s /\ P (IMAGE f t))
+Proof
+  REWRITE_TAC[SUBSET_IMAGE] THEN MESON_TAC[]
+QED
+
+Theorem FORALL_SUBSET_IMAGE :
+   !P (f :'a->'b) s.
+        (!t. t SUBSET IMAGE f s ==> P t) <=>
+        (!t. t SUBSET s ==> P(IMAGE f t))
+Proof
+  REWRITE_TAC[SUBSET_IMAGE] THEN MESON_TAC[]
+QED
+
+Theorem SUBSET_IMAGE_INJ :
+   !(f :'a->'b) s t.
+        s SUBSET (IMAGE f t) <=>
+        ?u. u SUBSET t /\
+            (!x y. x IN u /\ y IN u ==> (f x = f y <=> x = y)) /\
+            s = IMAGE f u
+Proof
+  REPEAT GEN_TAC THEN EQ_TAC THENL [ALL_TAC, MESON_TAC[IMAGE_SUBSET]] THEN
+  DISCH_TAC THEN FIRST_ASSUM(MP_TAC o MATCH_MP (SET_RULE
+   “s SUBSET IMAGE f t ==> !x. x IN s ==> ?y. y IN t /\ f y = x”)) THEN
+  REWRITE_TAC[SURJECTIVE_ON_RIGHT_INVERSE] THEN
+  DISCH_THEN(X_CHOOSE_TAC “g:'b->'a”) THEN
+  EXISTS_TAC “IMAGE (g :'b->'a) s” THEN ASM_SET_TAC[]
+QED
+
+Theorem EXISTS_SUBSET_IMAGE_INJ :
+   !P (f :'a->'b) s.
+    (?t. t SUBSET IMAGE f s /\ P t) <=>
+    (?t. t SUBSET s /\
+         (!x y. x IN t /\ y IN t ==> (f x = f y <=> x = y)) /\
+         P (IMAGE f t))
+Proof
+  REWRITE_TAC[SUBSET_IMAGE_INJ] THEN METIS_TAC []
+QED
+
+Theorem FORALL_SUBSET_IMAGE_INJ :
+   !P (f :'a->'b) s.
+        (!t. t SUBSET IMAGE f s ==> P t) <=>
+        (!t. t SUBSET s /\
+             (!x y. x IN t /\ y IN t ==> (f x = f y <=> x = y))
+             ==> P(IMAGE f t))
+Proof
+  REPEAT GEN_TAC THEN
+  qabbrev_tac ‘Q = \t. t SUBSET IMAGE f s ==> P t’ \\
+  qabbrev_tac ‘R = \t. t SUBSET s /\
+                      (!x y. x IN t /\ y IN t ==> (f x = f y <=> x = y)) ==>
+                       P (IMAGE f t)’ \\
+  ‘$! Q <=> ~(?t. ~Q t)’ by rw [Abbr ‘Q’] >> POP_ORW \\
+  ‘$! R <=> ~(?t. ~R t)’ by rw [Abbr ‘R’] >> POP_ORW \\
+  simp[Abbr ‘Q’, Abbr ‘R’, NOT_IMP, EXISTS_SUBSET_IMAGE_INJ, GSYM CONJ_ASSOC]
+QED
+
+Theorem EXISTS_FINITE_SUBSET_IMAGE_INJ :
+   !P (f :'a->'b) s.
+    (?t. FINITE t /\ t SUBSET IMAGE f s /\ P t) <=>
+    (?t. FINITE t /\ t SUBSET s /\
+         (!x y. x IN t /\ y IN t ==> (f x = f y <=> x = y)) /\
+         P (IMAGE f t))
+Proof
+  ONCE_REWRITE_TAC[TAUT `p /\ q /\ r <=> q /\ p /\ r`] THEN
+  REPEAT GEN_TAC THEN SIMP_TAC std_ss[EXISTS_SUBSET_IMAGE_INJ] THEN
+  AP_TERM_TAC THEN ABS_TAC THEN MESON_TAC[FINITE_IMAGE_INJ_EQ]
+QED
+
+Theorem FORALL_FINITE_SUBSET_IMAGE_INJ :
+   !P (f :'a->'b) s.
+        (!t. FINITE t /\ t SUBSET IMAGE f s ==> P t) <=>
+        (!t. FINITE t /\ t SUBSET s /\
+             (!x y. x IN t /\ y IN t ==> (f x = f y <=> x = y))
+             ==> P(IMAGE f t))
+Proof
+  REPEAT GEN_TAC THEN
+  qabbrev_tac ‘Q = \t. FINITE t /\ t SUBSET IMAGE f s ==> P t’ \\
+  qabbrev_tac ‘R = \t. FINITE t /\ t SUBSET s /\
+                      (!x y. x IN t /\ y IN t ==> (f x = f y <=> x = y)) ==>
+                       P (IMAGE f t)’ \\
+  ‘$! Q <=> ~(?t. ~Q t)’ by rw [Abbr ‘Q’] >> POP_ORW \\
+  ‘$! R <=> ~(?t. ~R t)’ by rw [Abbr ‘R’] >> POP_ORW \\
+  simp[Abbr ‘Q’, Abbr ‘R’, NOT_IMP, EXISTS_FINITE_SUBSET_IMAGE_INJ, GSYM CONJ_ASSOC]
+QED
+
+Theorem EXISTS_FINITE_SUBSET_IMAGE :
+   !P (f :'a->'b) s.
+      (?t. FINITE t /\ t SUBSET IMAGE f s /\ P t) <=>
+      (?t. FINITE t /\ t SUBSET s /\ P (IMAGE f t))
+Proof
+  REPEAT GEN_TAC THEN EQ_TAC THENL
+   [REWRITE_TAC[EXISTS_FINITE_SUBSET_IMAGE_INJ] THEN MESON_TAC[],
+    MESON_TAC[FINITE_IMAGE, IMAGE_SUBSET]]
+QED
+
+Theorem FORALL_FINITE_SUBSET_IMAGE :
+   !P (f :'a->'b) s.
+      (!t. FINITE t /\ t SUBSET IMAGE f s ==> P t) <=>
+      (!t. FINITE t /\ t SUBSET s ==> P(IMAGE f t))
+Proof
+  REPEAT GEN_TAC THEN
+  qabbrev_tac ‘Q = \t. FINITE t /\ t SUBSET IMAGE f s ==> P t’ \\
+  qabbrev_tac ‘R = \t. FINITE t /\ t SUBSET s ==> P (IMAGE f t)’ \\
+  ‘$! Q <=> ~(?t. ~Q t)’ by rw [Abbr ‘Q’] >> POP_ORW \\
+  ‘$! R <=> ~(?t. ~R t)’ by rw [Abbr ‘R’] >> POP_ORW \\
+  simp[Abbr ‘Q’, Abbr ‘R’, NOT_IMP, GSYM CONJ_ASSOC, EXISTS_FINITE_SUBSET_IMAGE]
+QED
+
 (* ------------------------------------------------------------------------- *)
 (* Pairwise property over sets and lists (from real_topologyTheory)          *)
 (* ------------------------------------------------------------------------- *)
@@ -3675,6 +3784,195 @@ Proof
  >> rw []
  >> ‘y IN N’ by METIS_TAC [SUBSET_DEF]
  >> Q.EXISTS_TAC ‘y’ >> fs [IN_APP]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Compact sets and compact topological spaces (from HOL-Light's metric.ml)  *)
+(* ------------------------------------------------------------------------- *)
+
+Definition compact_in :
+   compact_in top s <=>
+     s SUBSET topspace top /\
+     (!U. (!u. u IN U ==> open_in top u) /\ s SUBSET UNIONS U
+          ==> (?V. FINITE V /\ V SUBSET U /\ s SUBSET UNIONS V))
+End
+
+Definition compact_space :
+   compact_space (top :'a topology) <=> compact_in top (topspace top)
+End
+
+Theorem COMPACT_SPACE_ALT :
+   !(top :'a topology).
+        compact_space top <=>
+        !U. (!u. u IN U ==> open_in top u) /\
+            topspace top SUBSET UNIONS U
+            ==> ?V. FINITE V /\ V SUBSET U /\ topspace top SUBSET UNIONS V
+Proof
+  REWRITE_TAC[compact_space, compact_in, SUBSET_REFL]
+QED
+
+Theorem COMPACT_SPACE :
+   !(top :'a topology).
+        compact_space top <=>
+        !U. (!u. u IN U ==> open_in top u) /\
+            UNIONS U = topspace top
+            ==> ?V. FINITE V /\ V SUBSET U /\ UNIONS V = topspace top
+Proof
+  GEN_TAC THEN REWRITE_TAC[COMPACT_SPACE_ALT] THEN
+  SIMP_TAC std_ss[GSYM SUBSET_ANTISYM_EQ, UNIONS_SUBSET] THEN
+  AP_TERM_TAC THEN ABS_TAC THEN
+  MESON_TAC[SUBSET_DEF, OPEN_IN_SUBSET]
+QED
+
+Theorem COMPACT_IN_ABSOLUTE :
+   !top (s :'a set).
+        compact_in (subtopology top s) s <=> compact_in top s
+Proof
+  rw[compact_in] THEN
+  simp[TOPSPACE_SUBTOPOLOGY, SUBSET_INTER, SUBSET_REFL] THEN
+  simp[OPEN_IN_SUBTOPOLOGY, SET_RULE
+   “(!x. x IN s ==> ?y. P y /\ x = f y) <=> s SUBSET IMAGE f {y | P y}”] THEN
+  simp[IMP_CONJ, FORALL_SUBSET_IMAGE] THEN
+  simp[EXISTS_FINITE_SUBSET_IMAGE] THEN
+  simp[GSYM SIMPLE_IMAGE, GSYM INTER_UNIONS] THEN
+  simp[SUBSET_INTER, SUBSET_REFL] THEN SET_TAC[]
+QED
+
+Theorem COMPACT_IN_SUBSPACE :
+   !top (s :'a set).
+        compact_in top s <=>
+        s SUBSET topspace top /\ compact_space (subtopology top s)
+Proof
+  rw[compact_space, COMPACT_IN_ABSOLUTE, TOPSPACE_SUBTOPOLOGY] THEN
+  ONCE_REWRITE_TAC[TAUT `p /\ q <=> ~(p ==> ~q)`] THEN
+  qabbrev_tac ‘t = topspace top’ \\
+  Know ‘(s SUBSET t ==> ~compact_in (subtopology top s) (t INTER s)) <=>
+        (s SUBSET t ==> ~compact_in (subtopology top s) s)’
+  >- METIS_TAC [SET_RULE “s SUBSET t ==> t INTER s = s”] >> Rewr' \\
+  REWRITE_TAC[COMPACT_IN_ABSOLUTE] THEN
+  REWRITE_TAC[TAUT `(p <=> ~(q ==> ~p)) <=> (p ==> q)`] THEN
+  SIMP_TAC std_ss[Abbr ‘t’, compact_in]
+QED
+
+Theorem COMPACT_SPACE_SUBTOPOLOGY :
+   !top (s :'a set). compact_in top s ==> compact_space (subtopology top s)
+Proof
+  SIMP_TAC std_ss[COMPACT_IN_SUBSPACE]
+QED
+
+Theorem COMPACT_IN_SUBTOPOLOGY :
+   !top s (t :'a set).
+        compact_in (subtopology top s) t <=> compact_in top t /\ t SUBSET s
+Proof
+  REPEAT GEN_TAC THEN
+  REWRITE_TAC[COMPACT_IN_SUBSPACE, SUBTOPOLOGY_SUBTOPOLOGY] THEN
+  REWRITE_TAC[TOPSPACE_SUBTOPOLOGY, SUBSET_INTER] THEN
+  ASM_CASES_TAC “(t :'a set) SUBSET s” THEN ASM_REWRITE_TAC[] THEN
+  METIS_TAC [SET_RULE “t SUBSET s ==> s INTER t = t”]
+QED
+
+Theorem COMPACT_IN_SUBSET_TOPSPACE :
+   !top (s :'a set). compact_in top s ==> s SUBSET topspace top
+Proof
+  SIMP_TAC std_ss[compact_in]
+QED
+
+Theorem COMPACT_IN_CONTRACTIVE :
+   !top (top' :'a topology).
+        topspace top' = topspace top /\
+        (!u. open_in top u ==> open_in top' u)
+        ==> !s. compact_in top' s ==> compact_in top s
+Proof
+  REPEAT GEN_TAC THEN STRIP_TAC THEN GEN_TAC THEN
+  REWRITE_TAC[compact_in] THEN MATCH_MP_TAC MONO_AND THEN CONJ_TAC THENL
+   [ASM_SET_TAC[], HO_MATCH_MP_TAC MONO_FORALL THEN ASM_SET_TAC[]]
+QED
+
+Theorem COMPACT_SPACE_CONTRACTIVE :
+   !top (top' :'a topology).
+        topspace top' = topspace top /\
+        (!u. open_in top u ==> open_in top' u)
+        ==> compact_space top' ==> compact_space top
+Proof
+  SIMP_TAC std_ss[compact_space] THEN MESON_TAC[COMPACT_IN_CONTRACTIVE]
+QED
+
+Theorem FINITE_IMP_COMPACT_IN :
+   !top (s :'a set). s SUBSET topspace top /\ FINITE s ==> compact_in top s
+Proof
+  SIMP_TAC std_ss[compact_in] \\
+  rpt STRIP_TAC \\
+  EXISTS_TAC “IMAGE (\(x :'a). @u. u IN U /\ x IN u) s” THEN
+  CONJ_TAC >- (MATCH_MP_TAC FINITE_IMAGE >> art []) \\
+  ASM_SET_TAC []
+QED
+
+Theorem COMPACT_IN_EMPTY :
+   !(top :'a topology). compact_in top {}
+Proof
+  GEN_TAC THEN MATCH_MP_TAC FINITE_IMP_COMPACT_IN THEN
+  REWRITE_TAC[FINITE_EMPTY, EMPTY_SUBSET]
+QED
+
+Theorem COMPACT_SPACE_TOPSPACE_EMPTY :
+   !(top :'a topology). topspace top = {} ==> compact_space top
+Proof
+  MESON_TAC[SUBTOPOLOGY_TOPSPACE, COMPACT_IN_EMPTY, compact_space]
+QED
+
+Theorem FINITE_IMP_COMPACT_IN_EQ :
+   !top (s :'a set).
+        FINITE s ==> (compact_in top s <=> s SUBSET topspace top)
+Proof
+  MESON_TAC[COMPACT_IN_SUBSET_TOPSPACE, FINITE_IMP_COMPACT_IN]
+QED
+
+Theorem COMPACT_IN_SING :
+   !top (a :'a). compact_in top {a} <=> a IN topspace top
+Proof
+  SIMP_TAC std_ss[FINITE_IMP_COMPACT_IN_EQ, FINITE_SING, SING_SUBSET]
+QED
+
+Theorem CLOSED_COMPACT_IN :
+   !top k (c :'a set). compact_in top k /\ c SUBSET k /\ closed_in top c
+                   ==> compact_in top c
+Proof
+    rpt GEN_TAC
+ >> REWRITE_TAC [compact_in] >> STRIP_TAC
+ >> CONJ_TAC >- ASM_SET_TAC []
+ >> rpt STRIP_TAC
+ >> Q.PAT_X_ASSUM ‘!U. _ ==> ?V. FINITE V /\ _’
+      (MP_TAC o Q.SPEC ‘(topspace top DIFF c) INSERT U’)
+ >> ANTS_TAC
+ >- (qabbrev_tac ‘t = topspace top’ \\
+    ‘open_in top t’ by rw [OPEN_IN_TOPSPACE, Abbr ‘t’] \\
+     reverse CONJ_TAC
+     >- (rw [SUBSET_DEF] \\
+         Cases_on ‘x IN c’
+         >- (Q.PAT_X_ASSUM ‘c SUBSET BIGUNION U’ MP_TAC \\
+             rw [SUBSET_DEF] \\
+             POP_ASSUM (MP_TAC o Q.SPEC ‘x’) >> rw [] \\
+             Q.EXISTS_TAC ‘s’ >> rw []) \\
+         Q.EXISTS_TAC ‘t DIFF c’ >> simp [] \\
+         ASM_SET_TAC []) \\
+     rw [] >- (MATCH_MP_TAC OPEN_IN_DIFF >> art []) \\
+     Q.PAT_X_ASSUM ‘c SUBSET BIGUNION U’ MP_TAC \\
+     rw [SUBSET_DEF])
+ >> STRIP_TAC
+ >> Q.EXISTS_TAC ‘V DELETE (topspace top DIFF c)’
+ >> ASM_REWRITE_TAC[FINITE_DELETE]
+ >> CONJ_TAC >- ASM_SET_TAC []
+ >> REWRITE_TAC[SUBSET_DEF, IN_UNIONS, IN_DELETE]
+ >> ASM_SET_TAC []
+QED
+
+Theorem CLOSED_IN_COMPACT_SPACE :
+   !top (s :'a set).
+        compact_space top /\ closed_in top s ==> compact_in top s
+Proof
+  REWRITE_TAC[compact_space] THEN REPEAT STRIP_TAC THEN
+  MATCH_MP_TAC CLOSED_COMPACT_IN THEN EXISTS_TAC “topspace (top :'a topology)” THEN
+  ASM_MESON_TAC[CLOSED_IN_SUBSET]
 QED
 
 val _ = export_theory();

--- a/src/real/analysis/real_topologyScript.sml
+++ b/src/real/analysis/real_topologyScript.sml
@@ -6949,6 +6949,7 @@ QED
 (* Compactness (the definition is the one based on convegent subsequences).  *)
 (* ------------------------------------------------------------------------- *)
 
+(* cf. [compact_def] connecting “compact” with “compact_in” (topologyTheory) *)
 val compact = new_definition ("compact",
  ``compact s <=> !f:num->real. (!n. f(n) IN s)
    ==> ?l r. l IN s /\ (!m n:num. m < n ==> r(m) < r(n)) /\
@@ -7511,6 +7512,13 @@ val COMPACT_EQ_HEINE_BOREL = store_thm ("COMPACT_EQ_HEINE_BOREL",
   DISCH_TAC THEN MATCH_MP_TAC BOUNDED_CLOSED_IMP_COMPACT THEN
   ASM_MESON_TAC[BOLZANO_WEIERSTRASS_IMP_BOUNDED,
    BOLZANO_WEIERSTRASS_IMP_CLOSED]);
+
+Theorem compact_def :
+    !s. compact s <=> compact_in euclidean s
+Proof
+    rw [COMPACT_EQ_HEINE_BOREL, compact_in, TOPSPACE_EUCLIDEAN, euclidean_open_def]
+ >> METIS_TAC []
+QED
 
 val COMPACT_EQ_BOLZANO_WEIERSTRASS = store_thm ("COMPACT_EQ_BOLZANO_WEIERSTRASS",
  ``!s:real->bool. compact s <=>
@@ -18666,13 +18674,6 @@ val CLOSEST_POINT_IN_FRONTIER = store_thm ("CLOSEST_POINT_IN_FRONTIER",
 (* More general infimum of distance between two sets.                        *)
 (* ------------------------------------------------------------------------- *)
 
-(* This is a generalized ‘setdist’ with a metric parameter d *)
-Definition set_dist_def :
-    set_dist (d :'a metric) ((s,t) :'a set # 'a set) =
-      if (s = {}) \/ (t = {}) then (0 :real)
-      else inf {dist d (x,y) | x IN s /\ y IN t}
-End
-
 (* New definition of ‘setdist’ *)
 Overload setdist = “set_dist mr1”
 
@@ -18685,149 +18686,23 @@ Proof
     RW_TAC std_ss [GSYM dist_def, dist, set_dist_def]
 QED
 
-val SETDIST_EMPTY = store_thm ("SETDIST_EMPTY",
- ``(!t. setdist({},t) = &0) /\ (!s. setdist(s,{}) = &0)``,
-  REWRITE_TAC[setdist]);
+(* NOTE: This function translates “set_dist” theorems to “setdist” theorems. *)
+fun mr1_xfer th = th |> INST_TYPE [alpha |-> “:real”]
+                     |> INST [“m :real metric” |-> “mr1”]
+                     |> REWRITE_RULE [GSYM dist_def] (* dist mr1 -> dist *)
 
-val SETDIST_POS_LE = store_thm ("SETDIST_POS_LE",
- ``!s t. &0 <= setdist(s,t)``,
-  REPEAT GEN_TAC THEN REWRITE_TAC[setdist] THEN
-  COND_CASES_TAC THEN REWRITE_TAC[REAL_LE_REFL] THEN
-  MATCH_MP_TAC REAL_LE_INF THEN
-  SIMP_TAC std_ss [FORALL_IN_GSPEC, DIST_POS_LE] THEN
-  SIMP_TAC std_ss [EXTENSION, GSPECIFICATION, EXISTS_PROD] THEN ASM_SET_TAC[]);
-
-val SETDIST_SUBSETS_EQ = store_thm ("SETDIST_SUBSETS_EQ",
- ``!s t s' t':real->bool.
-     s' SUBSET s /\ t' SUBSET t /\
-     (!x y. x IN s /\ y IN t
-            ==> ?x' y'. x' IN s' /\ y' IN t' /\ dist(x',y') <= dist(x,y))
-     ==> (setdist(s',t') = setdist(s,t))``,
-  REPEAT STRIP_TAC THEN
-  ASM_CASES_TAC ``s:real->bool = {}`` THENL
-   [ASM_CASES_TAC ``s':real->bool = {}`` THEN
-    ASM_REWRITE_TAC[SETDIST_EMPTY] THEN ASM_SET_TAC[],
-    ALL_TAC] THEN
-  ASM_CASES_TAC ``t:real->bool = {}`` THENL
-   [ASM_CASES_TAC ``t':real->bool = {}`` THEN
-    ASM_REWRITE_TAC[SETDIST_EMPTY] THEN ASM_SET_TAC[],
-    ALL_TAC] THEN
-  ASM_CASES_TAC ``s':real->bool = {}`` THENL [ASM_SET_TAC[], ALL_TAC] THEN
-  ASM_CASES_TAC ``t':real->bool = {}`` THENL [ASM_SET_TAC[], ALL_TAC] THEN
-  ASM_REWRITE_TAC[setdist] THEN MATCH_MP_TAC INF_EQ THEN
-  SIMP_TAC std_ss [FORALL_IN_GSPEC] THEN
-  CONJ_TAC >- (SIMP_TAC std_ss [EXTENSION, GSPECIFICATION,
-                                EXISTS_PROD, NOT_IN_EMPTY] \\
-               fs [GSYM MEMBER_NOT_EMPTY] \\
-               rename1 `a IN s'` >> Q.EXISTS_TAC `a` \\
-               rename1 `b IN t'` >> Q.EXISTS_TAC `b` \\
-               ASM_REWRITE_TAC []) \\
-  CONJ_TAC >- (Q.EXISTS_TAC `0` >> rw [DIST_POS_LE]) \\
-  CONJ_TAC >- (SIMP_TAC std_ss [EXTENSION, GSPECIFICATION,
-                                EXISTS_PROD, NOT_IN_EMPTY] \\
-               fs [GSYM MEMBER_NOT_EMPTY] \\
-               rename1 `a IN s` >> Q.EXISTS_TAC `a` \\
-               rename1 `b IN t` >> Q.EXISTS_TAC `b` \\
-               ASM_REWRITE_TAC []) \\
-  CONJ_TAC >- (Q.EXISTS_TAC `0` >> rw [DIST_POS_LE]) \\
-  ASM_MESON_TAC[SUBSET_DEF, REAL_LE_TRANS]);
-
-val REAL_LE_SETDIST = store_thm ("REAL_LE_SETDIST",
-  ``!s t:real->bool d.
-        ~(s = {}) /\ ~(t = {}) /\
-        (!x y. x IN s /\ y IN t ==> d <= dist(x,y))
-        ==> d <= setdist(s,t)``,
-  REPEAT STRIP_TAC THEN ASM_REWRITE_TAC[setdist] THEN
-  MP_TAC(ISPEC ``{dist(x:real,y) | x IN s /\ y IN t}`` INF) THEN
-  SIMP_TAC std_ss [FORALL_IN_GSPEC] THEN
-  KNOW_TAC ``{dist (x,y) | x IN s /\ y IN t} <> {} /\
-             (?b. !x y. x IN s /\ y IN t ==> b <= dist (x,y))`` THENL
-   [CONJ_TAC THENL
-    [SIMP_TAC std_ss [EXTENSION, GSPECIFICATION, EXISTS_PROD] THEN
-     ASM_SET_TAC[], MESON_TAC[DIST_POS_LE]],
-     DISCH_TAC THEN ASM_REWRITE_TAC []] THEN
-  ASM_MESON_TAC[]);
-
-val SETDIST_LE_DIST = store_thm ("SETDIST_LE_DIST",
- ``!s t x y:real. x IN s /\ y IN t ==> setdist(s,t) <= dist(x,y)``,
-  REPEAT GEN_TAC THEN REWRITE_TAC[setdist] THEN
-  COND_CASES_TAC THENL [ASM_SET_TAC[], ALL_TAC] THEN
-  MP_TAC(ISPEC ``{dist(x:real,y) | x IN s /\ y IN t}`` INF) THEN
-  SIMP_TAC std_ss [FORALL_IN_GSPEC] THEN
-  KNOW_TAC ``{dist (x,y) | x IN s /\ y IN t} <> {} /\
-             (?b. !x y. x IN s /\ y IN t ==> b <= dist (x,y))`` THENL
-   [CONJ_TAC THENL
-    [SIMP_TAC std_ss [EXTENSION, GSPECIFICATION, EXISTS_PROD] THEN
-     ASM_SET_TAC[], MESON_TAC[DIST_POS_LE]],
-     DISCH_TAC THEN ASM_REWRITE_TAC []] THEN
-  ASM_MESON_TAC[]);
-
-val REAL_LE_SETDIST_EQ = store_thm ("REAL_LE_SETDIST_EQ",
- ``!d s t:real->bool.
-        d <= setdist(s,t) <=>
-        (!x y. x IN s /\ y IN t ==> d <= dist(x,y)) /\
-        ((s = {}) \/ (t = {}) ==> d <= &0)``,
-  REPEAT GEN_TAC THEN MAP_EVERY ASM_CASES_TAC
-   [``s:real->bool = {}``, ``t:real->bool = {}``] THEN
-  ASM_REWRITE_TAC[SETDIST_EMPTY, NOT_IN_EMPTY] THEN
-  ASM_MESON_TAC[REAL_LE_SETDIST, SETDIST_LE_DIST, REAL_LE_TRANS]);
-
-val REAL_SETDIST_LT_EXISTS = store_thm ("REAL_SETDIST_LT_EXISTS",
- ``!s t:real->bool b.
-        ~(s = {}) /\ ~(t = {}) /\ setdist(s,t) < b
-        ==> ?x y. x IN s /\ y IN t /\ dist(x,y) < b``,
-  REWRITE_TAC[GSYM REAL_NOT_LE, REAL_LE_SETDIST_EQ] THEN MESON_TAC[]);
-
-val SETDIST_REFL = store_thm ("SETDIST_REFL",
- ``!s:real->bool. setdist(s,s) = &0``,
-  GEN_TAC THEN REWRITE_TAC[GSYM REAL_LE_ANTISYM, SETDIST_POS_LE] THEN
-  ASM_CASES_TAC ``s:real->bool = {}`` THENL
-   [ASM_REWRITE_TAC[setdist, REAL_LE_REFL], ALL_TAC] THEN
-  ASM_MESON_TAC[SETDIST_LE_DIST, MEMBER_NOT_EMPTY, DIST_REFL]);
-
-val SETDIST_SYM = store_thm ("SETDIST_SYM",
- ``!s t. setdist(s,t) = setdist(t,s)``,
-  REPEAT GEN_TAC THEN REWRITE_TAC[setdist] THEN ONCE_REWRITE_TAC [DISJ_SYM] THEN
-  COND_CASES_TAC THEN ONCE_REWRITE_TAC [DISJ_SYM] THEN ASM_SIMP_TAC std_ss [] THEN
-  AP_TERM_TAC THEN SIMP_TAC std_ss [EXTENSION, GSPECIFICATION, EXISTS_PROD] THEN
-  METIS_TAC[DIST_SYM]);
-
-val SETDIST_TRIANGLE = store_thm ("SETDIST_TRIANGLE",
- ``!s a t:real->bool.
-        setdist(s,t) <= setdist(s,{a}) + setdist({a},t)``,
-  REPEAT STRIP_TAC THEN ASM_CASES_TAC ``s:real->bool = {}`` THEN
-  ASM_REWRITE_TAC[SETDIST_EMPTY, REAL_ADD_LID, SETDIST_POS_LE] THEN
-  ASM_CASES_TAC ``t:real->bool = {}`` THEN
-  ASM_REWRITE_TAC[SETDIST_EMPTY, REAL_ADD_RID, SETDIST_POS_LE] THEN
-  ONCE_REWRITE_TAC[GSYM REAL_LE_SUB_RADD] THEN
-  MATCH_MP_TAC REAL_LE_SETDIST THEN
-  ASM_SIMP_TAC std_ss [NOT_INSERT_EMPTY, IN_SING, CONJ_EQ_IMP,
-                  RIGHT_FORALL_IMP_THM, UNWIND_FORALL_THM2] THEN
-  X_GEN_TAC ``x:real`` THEN DISCH_TAC THEN
-  ONCE_REWRITE_TAC[REAL_ARITH ``x - y <= z <=> x - z <= y:real``] THEN
-  MATCH_MP_TAC REAL_LE_SETDIST THEN
-  ASM_REWRITE_TAC[NOT_INSERT_EMPTY, IN_SING, CONJ_EQ_IMP,
-                  RIGHT_FORALL_IMP_THM, UNWIND_FORALL_THM2] THEN
-  X_GEN_TAC ``y:real`` THEN REPEAT STRIP_TAC THEN
-  REWRITE_TAC[REAL_LE_SUB_RADD] THEN MATCH_MP_TAC REAL_LE_TRANS THEN
-  EXISTS_TAC ``dist(x:real,y')`` THEN
-  ASM_SIMP_TAC std_ss [SETDIST_LE_DIST, dist] THEN REAL_ARITH_TAC);
-
-val SETDIST_SINGS = store_thm ("SETDIST_SINGS",
- ``!x y. setdist({x},{y}) = dist(x,y)``,
-  REWRITE_TAC[setdist, NOT_INSERT_EMPTY] THEN
-  ONCE_REWRITE_TAC [METIS [] ``dist (x,y) = (\x y. dist (x,y)) x y``] THEN
-  KNOW_TAC ``!f:real->real->real x y a b. {f x y | x IN {a} /\ y IN {b}} = {f a b}`` THENL
-  [SIMP_TAC std_ss [EXTENSION, GSPECIFICATION, EXISTS_PROD] THEN SET_TAC [],
-   DISCH_TAC] THEN ASM_REWRITE_TAC [] THEN
-  SIMP_TAC std_ss [INF_INSERT_FINITE, FINITE_EMPTY]);
-
-val SETDIST_LIPSCHITZ = store_thm ("SETDIST_LIPSCHITZ",
- ``!s t x y:real. abs(setdist({x},s) - setdist({y},s)) <= dist(x,y)``,
-  REPEAT STRIP_TAC THEN REWRITE_TAC[GSYM SETDIST_SINGS] THEN
-  REWRITE_TAC[REAL_ARITH
-   ``abs(x - y) <= z <=> x <= z + y /\ y <= z + x:real``] THEN
-  MESON_TAC[SETDIST_TRIANGLE, SETDIST_SYM]);
+Theorem SETDIST_EMPTY          = mr1_xfer SET_DIST_EMPTY
+Theorem SETDIST_POS_LE         = mr1_xfer SET_DIST_POS_LE
+Theorem SETDIST_SUBSETS_EQ     = mr1_xfer SET_DIST_SUBSETS_EQ
+Theorem REAL_LE_SETDIST        = mr1_xfer REAL_LE_SET_DIST
+Theorem SETDIST_LE_DIST        = mr1_xfer SET_DIST_LE_DIST
+Theorem REAL_LE_SETDIST_EQ     = mr1_xfer REAL_LE_SET_DIST_EQ
+Theorem REAL_SETDIST_LT_EXISTS = mr1_xfer REAL_SET_DIST_LT_EXISTS
+Theorem SETDIST_REFL           = mr1_xfer SET_DIST_REFL
+Theorem SETDIST_SYM            = mr1_xfer SET_DIST_SYM
+Theorem SETDIST_TRIANGLE       = mr1_xfer SET_DIST_TRIANGLE
+Theorem SETDIST_SINGS          = mr1_xfer SET_DIST_SINGS
+Theorem SETDIST_LIPSCHITZ      = mr1_xfer SET_DIST_LIPSCHITZ
 
 val CONTINUOUS_AT_SETDIST = store_thm ("CONTINUOUS_AT_SETDIST",
  ``!s x:real. (\y. setdist({y},s)) continuous (at x)``,
@@ -18860,22 +18735,8 @@ val SETDIST_DIFFERENCES = store_thm ("SETDIST_DIFFERENCES",
   SIMP_TAC std_ss [GSYM CONJ_ASSOC, RIGHT_EXISTS_AND_THM, UNWIND_THM2, DIST_0] THEN
   REWRITE_TAC[dist] THEN MESON_TAC[]);
 
-val SETDIST_SUBSET_RIGHT = store_thm ("SETDIST_SUBSET_RIGHT",
- ``!s t u:real->bool.
-    ~(t = {}) /\ t SUBSET u ==> setdist(s,u) <= setdist(s,t)``,
-  REPEAT STRIP_TAC THEN
-  MAP_EVERY ASM_CASES_TAC [``s:real->bool = {}``, ``u:real->bool = {}``] THEN
-  ASM_SIMP_TAC std_ss [SETDIST_EMPTY, SETDIST_POS_LE, REAL_LE_REFL] THEN
-  ASM_REWRITE_TAC[setdist] THEN MATCH_MP_TAC REAL_LE_INF_SUBSET THEN
-  ASM_SIMP_TAC std_ss [FORALL_IN_GSPEC, SUBSET_DEF, EXISTS_PROD, GSPECIFICATION] THEN
-  REPEAT(CONJ_TAC THENL
-  [ASM_SIMP_TAC std_ss [EXTENSION, EXISTS_PROD, GSPECIFICATION] THEN ASM_SET_TAC[],
-   ALL_TAC]) THEN METIS_TAC[DIST_POS_LE]);
-
-val SETDIST_SUBSET_LEFT = store_thm ("SETDIST_SUBSET_LEFT",
- ``!s t u:real->bool.
-    ~(s = {}) /\ s SUBSET t ==> setdist(t,u) <= setdist(s,u)``,
-  MESON_TAC[SETDIST_SUBSET_RIGHT, SETDIST_SYM]);
+Theorem SETDIST_SUBSET_RIGHT = mr1_xfer SET_DIST_SUBSET_RIGHT
+Theorem SETDIST_SUBSET_LEFT  = mr1_xfer SET_DIST_SUBSET_LEFT
 
 val SETDIST_CLOSURE = store_thm ("SETDIST_CLOSURE",
  ``(!s t:real->bool. setdist(closure s,t) = setdist(s,t)) /\
@@ -19039,34 +18900,9 @@ val SETDIST_LINEAR_IMAGE = store_thm ("SETDIST_LINEAR_IMAGE",
   FIRST_X_ASSUM(fn th => REWRITE_TAC[GSYM(MATCH_MP LINEAR_SUB th)]) THEN
   ASM_SIMP_TAC std_ss []);
 
-val SETDIST_UNIQUE = store_thm ("SETDIST_UNIQUE",
- ``!s t a b:real d.
-        a IN s /\ b IN t /\ (dist(a,b) = d) /\
-        (!x y. x IN s /\ y IN t ==> dist(a,b) <= dist(x,y))
-        ==> (setdist(s,t) = d)``,
-  REPEAT STRIP_TAC THEN REWRITE_TAC[GSYM REAL_LE_ANTISYM] THEN CONJ_TAC THENL
-   [ASM_MESON_TAC[SETDIST_LE_DIST],
-    MATCH_MP_TAC REAL_LE_SETDIST THEN ASM_SET_TAC[]]);
-
-val SETDIST_UNIV = store_thm ("SETDIST_UNIV",
- ``(!s. setdist(s,univ(:real)) = &0) /\
-   (!t. setdist(univ(:real),t) = &0)``,
-  GEN_REWR_TAC (RAND_CONV o ONCE_DEPTH_CONV) [SETDIST_SYM] THEN
-  REWRITE_TAC[] THEN X_GEN_TAC ``s:real->bool`` THEN
-  ASM_CASES_TAC ``s:real->bool = {}`` THEN ASM_REWRITE_TAC[SETDIST_EMPTY] THEN
-  MATCH_MP_TAC SETDIST_UNIQUE THEN
-  SIMP_TAC std_ss [IN_UNIV, DIST_EQ_0, RIGHT_EXISTS_AND_THM] THEN
-  ASM_REWRITE_TAC[UNWIND_THM1, DIST_REFL, DIST_POS_LE, MEMBER_NOT_EMPTY]);
-
-val SETDIST_ZERO = store_thm ("SETDIST_ZERO",
- ``!s t:real->bool. ~(DISJOINT s t) ==> (setdist(s,t) = &0)``,
-  REPEAT STRIP_TAC THEN MATCH_MP_TAC SETDIST_UNIQUE THEN
-  KNOW_TAC ``?a. a IN s /\ a IN t /\ (dist (a,a) = 0) /\
-             !x y. x IN s /\ y IN t ==> dist (a,a) <= dist (x,y)`` THENL
-  [ALL_TAC, METIS_TAC []] THEN
-  ONCE_REWRITE_TAC[TAUT `p /\ q /\ r /\ s <=> r /\ p /\ q /\ s`] THEN
-  REWRITE_TAC[DIST_EQ_0, UNWIND_THM2, DIST_REFL, DIST_POS_LE] THEN
-  ASM_SET_TAC[]);
+Theorem SETDIST_UNIQUE = mr1_xfer SET_DIST_UNIQUE
+Theorem SETDIST_UNIV   = mr1_xfer SET_DIST_UNIV
+Theorem SETDIST_ZERO   = mr1_xfer SET_DIST_ZERO
 
 val SETDIST_ZERO_STRONG = store_thm ("SETDIST_ZERO_STRONG",
  ``!s t:real->bool.
@@ -19139,9 +18975,7 @@ val SETDIST_EQ_0_CLOSED_IN = store_thm ("SETDIST_EQ_0_CLOSED_IN",
            ==> ((setdist({x},s) = &0) <=> (s = {}) \/ x IN s)``,
   REWRITE_TAC[SETDIST_EQ_0_SING, CLOSED_IN_INTER_CLOSURE] THEN SET_TAC[]);
 
-val SETDIST_SING_IN_SET = store_thm ("SETDIST_SING_IN_SET",
- ``!x s. x IN s ==> (setdist({x},s) = &0)``,
-  SIMP_TAC std_ss [SETDIST_EQ_0_SING, REWRITE_RULE[SUBSET_DEF] CLOSURE_SUBSET]);
+Theorem SETDIST_SING_IN_SET = mr1_xfer SET_DIST_SING_IN_SET
 
 val SETDIST_SING_FRONTIER_CASES = store_thm ("SETDIST_SING_FRONTIER_CASES",
  ``!s x:real.
@@ -19166,9 +19000,7 @@ val SETDIST_SING_TRIANGLE = store_thm ("SETDIST_SING_TRIANGLE",
   REWRITE_TAC [GSYM dist] THEN
   MATCH_MP_TAC SETDIST_LE_DIST THEN ASM_REWRITE_TAC[IN_SING]);
 
-val SETDIST_LE_SING = store_thm ("SETDIST_LE_SING",
- ``!s t x:real. x IN s ==> setdist(s,t) <= setdist({x},t)``,
-  REPEAT STRIP_TAC THEN MATCH_MP_TAC SETDIST_SUBSET_LEFT THEN ASM_SET_TAC[]);
+Theorem SETDIST_LE_SING = mr1_xfer SET_DIST_LE_SING
 
 val SETDIST_BALLS = store_thm ("SETDIST_BALLS",
  ``(!a b:real r s.

--- a/src/real/metricScript.sml
+++ b/src/real/metricScript.sml
@@ -11,9 +11,10 @@
 open HolKernel Parse bossLib boolLib;
 
 open arithmeticTheory numTheory boolSimps simpLib mesonLib metisLib jrhUtils
-     pairTheory pairLib quotientTheory pred_setTheory pred_setLib RealArith;
+     pairTheory pairLib quotientTheory pred_setTheory pred_setLib RealArith
+     tautLib realSimps;
 
-open realTheory cardinalTheory topologyTheory hurdUtils;
+open realTheory real_sigmaTheory cardinalTheory topologyTheory hurdUtils;
 
 val _ = new_theory "metric";
 
@@ -145,7 +146,7 @@ val METRIC_NZ = store_thm("METRIC_NZ",
   “!m:('a)metric. !x y. ~(x = y) ==> &0 < (dist m)(x,y)”,
   REPEAT GEN_TAC THEN
   SUBST1_TAC(SYM(SPECL [“m:('a)metric”, “x:'a”, “y:'a”] METRIC_ZERO)) THEN
-  ONCE_REWRITE_TAC[TAUT_CONV “~a ==> b <=> b \/ a”] THEN
+  ONCE_REWRITE_TAC[TAUT ‘~a ==> b <=> b \/ a’] THEN
   CONV_TAC(RAND_CONV SYM_CONV) THEN
   REWRITE_TAC[GSYM REAL_LE_LT, METRIC_POS]);
 
@@ -173,7 +174,7 @@ Proof
  >> Know ‘dist m (x,y) = z - 1’
  >- (Q.UNABBREV_TAC ‘z’ >> REAL_ARITH_TAC)
  >> Rewr'
- >> rw [real_div, REAL_SUB_RDISTRIB, REAL_MUL_RINV]
+ >> rw [real_div, REAL_SUB_LDISTRIB, REAL_MUL_RINV]
 QED
 
 Theorem bounded_metric_ismet :
@@ -375,43 +376,23 @@ val BALL_NEIGH = store_thm("BALL_NEIGH",
   POP_ASSUM ACCEPT_TAC);
 
 (*---------------------------------------------------------------------------*)
-(* HOL-Light compatibile theorems                                            *)
+(* HOL-Light compatibile theorems (MDIST_)                                   *)
 (*---------------------------------------------------------------------------*)
 
-Theorem MDIST_REFL :
-   !m (x :'a). x IN mspace m ==> mdist m (x,x) = &0
-Proof
-   rw [mspace, METRIC_SAME]
-QED
-
-Theorem MDIST_SYM :
-   !m (x :'a) y. x IN mspace m /\ y IN mspace m ==> mdist m (x,y) = mdist m (y,x)
-Proof
-   rw [mspace, METRIC_SYM]
-QED
-
-Theorem MDIST_TRIANGLE :
-   !m x y z.
-         x IN mspace m /\ y IN mspace m /\ z IN mspace m
-         ==> mdist m (x,z) <= mdist m (x,y) + mdist m (y,z)
-Proof
-   rw [mspace, METRIC_TRIANGLE]
-QED
+Theorem MDIST_REFL     = METRIC_SAME
+Theorem MDIST_SYM      = METRIC_SYM
+Theorem MDIST_TRIANGLE = METRIC_TRIANGLE
 
 Theorem MDIST_TRIANGLE_SUB :
-    !m x y z. x IN mspace m /\ y IN mspace m /\ z IN mspace m ==>
-              mdist m (x,y) - mdist m (y,z) <= mdist m (x,z)
+    !m x y z. mdist m (x,y) - mdist m (y,z) <= mdist m (x,z)
 Proof
     RW_TAC std_ss [REAL_LE_SUB_RADD]
  >> ‘dist m (y,z) = dist m (z,y)’ by rw [METRIC_SYM] >> POP_ORW
- >> MATCH_MP_TAC MDIST_TRIANGLE >> art []
+ >> rw [MDIST_TRIANGLE]
 QED
 
-Theorem MDIST_POS_LE :
-    !m x y. x IN mspace m /\ y IN mspace m ==> &0 <= mdist m (x,y)
-Proof
-   rw [mspace, METRIC_POS]
-QED
+Theorem MDIST_POS_LE = METRIC_POS
+Theorem MDIST_EQ_0   = METRIC_ZERO
 
 Theorem mtopology :
    !m. mtopology (m:'a metric) =
@@ -1493,8 +1474,479 @@ Proof
           dist m (x,y) - dist m (y,z) <= r’ >- REAL_ARITH_TAC
  >> Rewr'
  >> Q_TAC (TRANS_TAC REAL_LE_TRANS) ‘dist m (x,z)’ >> art []
- >> MATCH_MP_TAC MDIST_TRIANGLE_SUB >> art []
+ >> rw [MDIST_TRIANGLE_SUB]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* More general infimum of distance between two sets.                        *)
+(* ------------------------------------------------------------------------- *)
+
+(* This is a generalized ‘setdist’ with a metric parameter d *)
+Definition set_dist_def :
+    set_dist (d :'a metric) ((s,t) :'a set # 'a set) =
+      if (s = {}) \/ (t = {}) then (0 :real)
+      else inf {dist d (x,y) | x IN s /\ y IN t}
+End
+
+Theorem SET_DIST_EMPTY :
+  (!t. set_dist m({},t) = &0) /\ (!s. set_dist m(s,{}) = &0)
+Proof
+  REWRITE_TAC[set_dist_def]
+QED
+
+Theorem SET_DIST_POS_LE :
+   !s t. &0 <= set_dist m(s,t)
+Proof
+  REPEAT GEN_TAC THEN REWRITE_TAC[set_dist_def] THEN
+  COND_CASES_TAC THEN REWRITE_TAC[REAL_LE_REFL] THEN
+  MATCH_MP_TAC REAL_LE_INF THEN
+  SIMP_TAC std_ss [FORALL_IN_GSPEC, MDIST_POS_LE] THEN
+  SIMP_TAC std_ss [EXTENSION, GSPECIFICATION, EXISTS_PROD] THEN ASM_SET_TAC[]
+QED
+
+Theorem SET_DIST_SUBSETS_EQ :
+   !s t s' t'.
+     s' SUBSET s /\ t' SUBSET t /\
+     (!x y. x IN s /\ y IN t
+            ==> ?x' y'. x' IN s' /\ y' IN t' /\ dist m(x',y') <= dist m(x,y))
+     ==> (set_dist m(s',t') = set_dist m(s,t))
+Proof
+  REPEAT STRIP_TAC THEN
+  ASM_CASES_TAC ``s:'a->bool = {}`` THENL
+   [ASM_CASES_TAC ``s':'a->bool = {}`` THEN
+    ASM_REWRITE_TAC[SET_DIST_EMPTY] THEN ASM_SET_TAC[],
+    ALL_TAC] THEN
+  ASM_CASES_TAC ``t:'a->bool = {}`` THENL
+   [ASM_CASES_TAC ``t':'a->bool = {}`` THEN
+    ASM_REWRITE_TAC[SET_DIST_EMPTY] THEN ASM_SET_TAC[],
+    ALL_TAC] THEN
+  ASM_CASES_TAC ``s':'a->bool = {}`` THENL [ASM_SET_TAC[], ALL_TAC] THEN
+  ASM_CASES_TAC ``t':'a->bool = {}`` THENL [ASM_SET_TAC[], ALL_TAC] THEN
+  ASM_REWRITE_TAC[set_dist_def] THEN MATCH_MP_TAC INF_EQ THEN
+  SIMP_TAC std_ss [FORALL_IN_GSPEC] THEN
+  CONJ_TAC >- (SIMP_TAC std_ss [EXTENSION, GSPECIFICATION,
+                                EXISTS_PROD, NOT_IN_EMPTY] \\
+               fs [GSYM MEMBER_NOT_EMPTY] \\
+               rename1 `a IN s'` >> Q.EXISTS_TAC `a` \\
+               rename1 `b IN t'` >> Q.EXISTS_TAC `b` \\
+               ASM_REWRITE_TAC []) \\
+  CONJ_TAC >- (Q.EXISTS_TAC `0` >> rw [MDIST_POS_LE, mspace]) \\
+  CONJ_TAC >- (SIMP_TAC std_ss [EXTENSION, GSPECIFICATION,
+                                EXISTS_PROD, NOT_IN_EMPTY] \\
+               fs [GSYM MEMBER_NOT_EMPTY] \\
+               rename1 `a IN s` >> Q.EXISTS_TAC `a` \\
+               rename1 `b IN t` >> Q.EXISTS_TAC `b` \\
+               ASM_REWRITE_TAC []) \\
+  CONJ_TAC >- (Q.EXISTS_TAC `0` >> rw [MDIST_POS_LE, mspace]) \\
+  ASM_MESON_TAC[SUBSET_DEF, REAL_LE_TRANS]
+QED
+
+Theorem REAL_LE_SET_DIST :
+    !s t:'a->bool d.
+        ~(s = {}) /\ ~(t = {}) /\
+        (!x y. x IN s /\ y IN t ==> d <= dist m(x,y))
+        ==> d <= set_dist m(s,t)
+Proof
+  REPEAT STRIP_TAC THEN ASM_REWRITE_TAC[set_dist_def] THEN
+  MP_TAC(ISPEC ``{dist m(x:'a,y) | x IN s /\ y IN t}`` INF) THEN
+  SIMP_TAC std_ss [FORALL_IN_GSPEC] THEN
+  KNOW_TAC ``{dist m(x,y) | x IN s /\ y IN t} <> {} /\
+             (?b. !x y. x IN s /\ y IN t ==> b <= dist m(x,y))`` THENL
+   [CONJ_TAC THENL
+    [SIMP_TAC std_ss [EXTENSION, GSPECIFICATION, EXISTS_PROD] THEN
+     ASM_SET_TAC[],
+     Q.EXISTS_TAC ‘d’ >> rw []],
+     DISCH_TAC THEN ASM_REWRITE_TAC []] THEN
+  ASM_MESON_TAC[]
+QED
+
+Theorem SET_DIST_LE_DIST :
+   !s t x y. x IN s /\ y IN t ==> set_dist m(s,t) <= dist m(x,y)
+Proof
+  REPEAT GEN_TAC THEN REWRITE_TAC[set_dist_def] THEN
+  COND_CASES_TAC THENL [ASM_SET_TAC[], ALL_TAC] THEN
+  MP_TAC(ISPEC ``{dist m(x,y) | x IN s /\ y IN t}`` INF) THEN
+  SIMP_TAC std_ss [FORALL_IN_GSPEC] THEN
+  KNOW_TAC ``{dist m(x,y) | x IN s /\ y IN t} <> {} /\
+             (?b. !x y. x IN s /\ y IN t ==> b <= dist m(x,y))`` THENL
+   [CONJ_TAC THENL
+    [SIMP_TAC std_ss [EXTENSION, GSPECIFICATION, EXISTS_PROD] THEN
+     ASM_SET_TAC[],
+     Q.EXISTS_TAC ‘0’ >> simp[MDIST_POS_LE]],
+     DISCH_TAC THEN ASM_REWRITE_TAC []] THEN
+  ASM_MESON_TAC[]
+QED
+
+Theorem REAL_LE_SET_DIST_EQ :
+   !d s t:'a->bool.
+        d <= set_dist m(s,t) <=>
+        (!x y. x IN s /\ y IN t ==> d <= dist m(x,y)) /\
+        ((s = {}) \/ (t = {}) ==> d <= &0)
+Proof
+  REPEAT GEN_TAC THEN MAP_EVERY ASM_CASES_TAC
+   [``s:'a->bool = {}``, ``t:'a->bool = {}``] THEN
+  ASM_REWRITE_TAC[SET_DIST_EMPTY, NOT_IN_EMPTY] THEN
+  ASM_MESON_TAC[REAL_LE_SET_DIST, SET_DIST_LE_DIST, REAL_LE_TRANS]
+QED
+
+Theorem REAL_SET_DIST_LT_EXISTS :
+   !s t:'a->bool b.
+        ~(s = {}) /\ ~(t = {}) /\ set_dist m(s,t) < b
+        ==> ?x y. x IN s /\ y IN t /\ dist m(x,y) < b
+Proof
+  REWRITE_TAC[GSYM REAL_NOT_LE, REAL_LE_SET_DIST_EQ] THEN MESON_TAC[]
+QED
+
+Theorem SET_DIST_REFL :
+   !s:'a->bool. set_dist m(s,s) = &0
+Proof
+  GEN_TAC THEN REWRITE_TAC[GSYM REAL_LE_ANTISYM, SET_DIST_POS_LE] THEN
+  ASM_CASES_TAC ``s:'a->bool = {}`` THENL
+   [ASM_REWRITE_TAC[set_dist_def, REAL_LE_REFL], ALL_TAC] THEN
+  ASM_MESON_TAC[SET_DIST_LE_DIST, MEMBER_NOT_EMPTY, MDIST_REFL]
+QED
+
+Theorem SET_DIST_SYM :
+   !s t. set_dist m(s,t) = set_dist m(t,s)
+Proof
+  REPEAT GEN_TAC THEN REWRITE_TAC[set_dist_def] THEN ONCE_REWRITE_TAC [DISJ_SYM] THEN
+  COND_CASES_TAC THEN ONCE_REWRITE_TAC [DISJ_SYM] THEN ASM_SIMP_TAC std_ss [] THEN
+  AP_TERM_TAC THEN SIMP_TAC std_ss [EXTENSION, GSPECIFICATION, EXISTS_PROD] THEN
+  METIS_TAC[MDIST_SYM]
+QED
+
+Theorem SET_DIST_TRIANGLE :
+   !s a t:'a->bool.
+        set_dist m(s,t) <= set_dist m(s,{a}) + set_dist m({a},t)
+Proof
+  REPEAT STRIP_TAC THEN ASM_CASES_TAC ``s:'a->bool = {}`` THEN
+  ASM_REWRITE_TAC[SET_DIST_EMPTY, REAL_ADD_LID, SET_DIST_POS_LE] THEN
+  ASM_CASES_TAC ``t:'a->bool = {}`` THEN
+  ASM_REWRITE_TAC[SET_DIST_EMPTY, REAL_ADD_RID, SET_DIST_POS_LE] THEN
+  ONCE_REWRITE_TAC[GSYM REAL_LE_SUB_RADD] THEN
+  MATCH_MP_TAC REAL_LE_SET_DIST THEN
+  ASM_SIMP_TAC std_ss [NOT_INSERT_EMPTY, IN_SING, CONJ_EQ_IMP,
+                  RIGHT_FORALL_IMP_THM, UNWIND_FORALL_THM2] THEN
+  X_GEN_TAC ``x:'a`` THEN DISCH_TAC THEN
+  ONCE_REWRITE_TAC[REAL_ARITH ``x - y <= z <=> x - z <= y:real``] THEN
+  MATCH_MP_TAC REAL_LE_SET_DIST THEN
+  ASM_REWRITE_TAC[NOT_INSERT_EMPTY, IN_SING, CONJ_EQ_IMP,
+                  RIGHT_FORALL_IMP_THM, UNWIND_FORALL_THM2] THEN
+  X_GEN_TAC ``y:'a`` THEN REPEAT STRIP_TAC THEN
+  REWRITE_TAC[REAL_LE_SUB_RADD] THEN MATCH_MP_TAC REAL_LE_TRANS THEN
+  EXISTS_TAC ``dist m(x:'a,y')`` THEN
+  ASM_SIMP_TAC std_ss [SET_DIST_LE_DIST] THEN
+  rename1 ‘z IN t’ THEN
+  Q.PAT_X_ASSUM ‘y = a’ (fs o wrap o SYM) \\
+  ONCE_REWRITE_TAC [REAL_ADD_COMM] \\
+  REWRITE_TAC [MDIST_TRIANGLE]
+QED
+
+Theorem SET_DIST_SINGS :
+   !x y. set_dist m({x},{y}) = dist m(x,y)
+Proof
+  REWRITE_TAC[set_dist_def, NOT_INSERT_EMPTY] THEN
+  ONCE_REWRITE_TAC [METIS [] ``dist m(x,y) = (\x y. dist m(x,y)) x y``] THEN
+  KNOW_TAC ``!f:'a->'a->real x y a b. {f x y | x IN {a} /\ y IN {b}} = {f a b}`` THENL
+  [SIMP_TAC std_ss [EXTENSION, GSPECIFICATION, EXISTS_PROD] THEN SET_TAC [],
+   DISCH_TAC] THEN ASM_REWRITE_TAC [] THEN
+  SIMP_TAC std_ss [INF_INSERT_FINITE, FINITE_EMPTY]
+QED
+
+Theorem SET_DIST_LIPSCHITZ :
+   !s t x y:'a. abs(set_dist m({x},s) - set_dist m({y},s)) <= dist m(x,y)
+Proof
+  REPEAT STRIP_TAC THEN REWRITE_TAC[GSYM SET_DIST_SINGS] THEN
+  REWRITE_TAC[REAL_ARITH
+   ``abs(x - y) <= z <=> x <= z + y /\ y <= z + x:real``] THEN
+  MESON_TAC[SET_DIST_TRIANGLE, SET_DIST_SYM]
+QED
+
+Theorem SET_DIST_SUBSET_RIGHT :
+   !s t u:'a->bool.
+    ~(t = {}) /\ t SUBSET u ==> set_dist m(s,u) <= set_dist m(s,t)
+Proof
+  REPEAT STRIP_TAC THEN
+  MAP_EVERY ASM_CASES_TAC [``s:'a->bool = {}``, ``u:'a->bool = {}``] THEN
+  ASM_SIMP_TAC std_ss [SET_DIST_EMPTY, SET_DIST_POS_LE, REAL_LE_REFL] THEN
+  ASM_REWRITE_TAC[set_dist_def] THEN MATCH_MP_TAC REAL_LE_INF_SUBSET THEN
+  ASM_SIMP_TAC std_ss [FORALL_IN_GSPEC, SUBSET_DEF, EXISTS_PROD, GSPECIFICATION] THEN
+  REPEAT(CONJ_TAC THENL
+  [ASM_SIMP_TAC std_ss [EXTENSION, EXISTS_PROD, GSPECIFICATION] THEN ASM_SET_TAC[],
+   ALL_TAC]) \\
+  Q.EXISTS_TAC ‘0’ >> rw [MDIST_POS_LE]
+QED
+
+Theorem SET_DIST_SUBSET_LEFT :
+   !s t u:'a->bool.
+    ~(s = {}) /\ s SUBSET t ==> set_dist m(t,u) <= set_dist m(s,u)
+Proof
+  MESON_TAC[SET_DIST_SUBSET_RIGHT, SET_DIST_SYM]
+QED
+
+Theorem SET_DIST_UNIQUE :
+   !s t a b:'a d.
+        a IN s /\ b IN t /\ (dist m(a,b) = d) /\
+        (!x y. x IN s /\ y IN t ==> dist m(a,b) <= dist m(x,y))
+        ==> (set_dist m(s,t) = d)
+Proof
+  REPEAT STRIP_TAC THEN REWRITE_TAC[GSYM REAL_LE_ANTISYM] THEN CONJ_TAC THENL
+   [ASM_MESON_TAC[SET_DIST_LE_DIST],
+    MATCH_MP_TAC REAL_LE_SET_DIST THEN ASM_SET_TAC[]]
+QED
+
+Theorem SET_DIST_UNIV :
+   (!s. set_dist m(s,univ(:'a)) = &0) /\
+   (!t. set_dist m(univ(:'a),t) = &0)
+Proof
+  GEN_REWR_TAC (RAND_CONV o ONCE_DEPTH_CONV) [SET_DIST_SYM] THEN
+  REWRITE_TAC[] THEN X_GEN_TAC ``s:'a->bool`` THEN
+  ASM_CASES_TAC ``s:'a->bool = {}`` THEN ASM_REWRITE_TAC[SET_DIST_EMPTY] THEN
+  MATCH_MP_TAC SET_DIST_UNIQUE THEN
+  SIMP_TAC std_ss [IN_UNIV, MDIST_EQ_0, RIGHT_EXISTS_AND_THM] THEN
+  ASM_REWRITE_TAC[UNWIND_THM1, MDIST_REFL, MDIST_POS_LE, MEMBER_NOT_EMPTY]
+QED
+
+Theorem SET_DIST_ZERO :
+   !s t:'a->bool. ~(DISJOINT s t) ==> (set_dist m(s,t) = &0)
+Proof
+  REPEAT STRIP_TAC THEN MATCH_MP_TAC SET_DIST_UNIQUE THEN
+  KNOW_TAC ``?a. a IN s /\ a IN t /\ (dist m(a,a) = 0) /\
+             !x y. x IN s /\ y IN t ==> dist m(a,a) <= dist m(x,y)`` THENL
+  [ALL_TAC, METIS_TAC []] THEN
+  ONCE_REWRITE_TAC[TAUT `p /\ q /\ r /\ s <=> r /\ p /\ q /\ s`] THEN
+  REWRITE_TAC[MDIST_EQ_0, UNWIND_THM2, MDIST_REFL, MDIST_POS_LE] THEN
+  ASM_SET_TAC[]
+QED
+
+Theorem SET_DIST_LE_SING :
+   !s t x:'a. x IN s ==> set_dist m(s,t) <= set_dist m({x},t)
+Proof
+  REPEAT STRIP_TAC THEN MATCH_MP_TAC SET_DIST_SUBSET_LEFT THEN ASM_SET_TAC[]
+QED
+
+Theorem SET_DIST_SING_IN_SET :
+   !x s. x IN s ==> (set_dist m({x},s) = &0)
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC SET_DIST_ZERO
+ >> rw [DISJOINT_ALT]
+QED
+
+Theorem SET_DIST_EQ_0_CLOSED :
+   !s x. closed_in (mtop m) s ==> (set_dist m({x},s) = &0 <=> (s = {}) \/ x IN s)
+Proof
+    rpt STRIP_TAC
+ >> reverse EQ_TAC
+ >- (STRIP_TAC >- rw [SET_DIST_EMPTY] \\
+     MATCH_MP_TAC SET_DIST_ZERO \\
+     rw [DISJOINT_ALT])
+ >> DISCH_TAC
+ >> Cases_on ‘s = {}’ >> rw []
+ >> fs [CLOSED_IN_METRIC, mspace]
+ >> CCONTR_TAC
+ >> Q.PAT_X_ASSUM ‘!x. x NOTIN s ==> _’ (MP_TAC o Q.SPEC ‘x’) >> rw []
+ >> STRONG_DISJ_TAC
+ >> rw [DISJOINT_ALT, IN_MBALL, mspace]
+ >> fs [set_dist_def]
+ >> qabbrev_tac ‘p = {dist m (x',y) | x' = x /\ y IN s}’
+ (* applying INF_CLOSE *)
+ >> Know ‘?x. x IN p /\ x < inf p + r’
+ >- (MATCH_MP_TAC INF_CLOSE >> art [] \\
+     fs [GSYM MEMBER_NOT_EMPTY] \\
+     rename1 ‘y IN s’ \\
+     Q.EXISTS_TAC ‘dist m (x,y)’ >> rw [Abbr ‘p’] \\
+     Q.EXISTS_TAC ‘y’ >> art [])
+ >> rw [Abbr ‘p’]
+ >> Q.EXISTS_TAC ‘y’ >> art []
+QED
+
+(* ------------------------------------------------------------------------- *)
+(*  Lipschitz continuous functions                                           *)
+(* ------------------------------------------------------------------------- *)
+
+Definition Lipschitz_condition_def :
+    Lipschitz_condition (E1,E2) k f <=>
+      !x y. dist E2 (f x,f y) <= k * dist E1 (x,y)
+End
+
+(* Definition 13.8 [1, p.249], cf. topologyTheory.continuous_map *)
+Definition Lipschitz_continuous_map :
+    Lipschitz_continuous_map (E1,E2) f <=>
+      ?k. 0 < k /\ Lipschitz_condition (E1,E2) k f
+End
+
+(* |- !E1 E2 f.
+        Lipschitz_continuous_map (E1,E2) f <=>
+        ?k. 0 < k /\ !x y. dist E2 (f x,f y) <= k * dist E1 (x,y)
+ *)
+Theorem Lipschitz_continuous_map_def =
+        Lipschitz_continuous_map |> REWRITE_RULE [Lipschitz_condition_def]
+
+Theorem Lipschitz_continuous_map_imp_continuous_map :
+    !E1 E2 f. Lipschitz_continuous_map (E1,E2) f ==>
+              continuous_map (mtop E1,mtop E2) f
+Proof
+    rw [Lipschitz_continuous_map_def, METRIC_CONTINUOUS_MAP, mspace]
+ >> ‘k <> 0’ by rw [REAL_LT_IMP_NE]
+ >> Q.EXISTS_TAC ‘e / k’ >> rw [REAL_LT_DIV]
+ >> Q_TAC (TRANS_TAC REAL_LET_TRANS) ‘k * dist E1 (a,x)’ >> art []
+QED
+
+(* Another form of SET_DIST_LIPSCHITZ *)
+Theorem Lipschitz_continuous_map_set_dist :
+    !E s. Lipschitz_continuous_map (E,mr1) (\x. set_dist E ({x},s))
+Proof
+    rw [Lipschitz_continuous_map_def]
+ >> Q.EXISTS_TAC ‘1’
+ >> rw [GSYM dist_def, dist, SET_DIST_LIPSCHITZ]
+QED
+
+(* Lemma 13.10 [1, p.249]
+   NOTE: The original antecedent “closed_in (mtop E) A” is not needed.
+ *)
+Theorem Lipschitz_continuous_map_exists :
+    !E A e. 0 < e ==>
+            ?f. Lipschitz_continuous_map (E,mr1) f /\
+               (!x. 0 <= f x /\ f x <= 1) /\
+               (!x. x IN A ==> f x = 1) /\
+                !x. e <= set_dist E ({x},A) ==> f x = 0
+Proof
+    rw [Lipschitz_continuous_map, IN_FUNSET]
+ >> qabbrev_tac ‘g :real -> real = \x. max 0 (min 1 x)’
+ >> ‘!x. 0 <= g x /\ g x <= 1’
+       by rw [Abbr ‘g’, REAL_LE_MAX, REAL_LE_MIN, REAL_MIN_LE, REAL_MAX_LE]
+ >> Know ‘!x. 0 <= x /\ x <= 1 ==> g x = x’
+ >- (RW_TAC real_ss [Abbr ‘g’, max_def, min_def] >| (* 2 subgoals *)
+     [ (* goal 1 (of 2) *)
+       rw [GSYM REAL_LE_ANTISYM],
+       (* goal 2 (of 2) *)
+       fs [GSYM real_lt] \\
+       Cases_on ‘1 <= x’ >> fs [] \\
+       rw [GSYM REAL_LE_ANTISYM, REAL_LT_IMP_LE] ])
+ >> DISCH_TAC
+ >> ‘!x. 1 <= x ==> g x = 1’ by rw [Abbr ‘g’, min_def]
+ >> qabbrev_tac ‘f = \x. 1 - g (set_dist E ({x},A) / e)’
+ >> Q.EXISTS_TAC ‘f’ >> simp [mspace]
+ >> Know ‘!x. 0 <= f x /\ f x <= 1’
+ >- (Q.X_GEN_TAC ‘x’ \\
+     simp [Abbr ‘f’, REAL_SUB_LE] \\
+     qmatch_abbrev_tac ‘1 - g y <= 1’ \\
+     Q.PAT_X_ASSUM ‘!x. 0 <= g x /\ g x <= 1’ (MP_TAC o Q.SPEC ‘y’) \\
+     REAL_ARITH_TAC)
+ >> DISCH_TAC
+ >> ‘!x. x IN A ==> f x = 1’ by rw [Abbr ‘f’, SET_DIST_SING_IN_SET]
+ >> simp []
+ >> reverse CONJ_TAC (* !x. e <= set_dist E ({x},A) ==> f x = 0 *)
+ >- (rw [Abbr ‘f’] \\
+     FIRST_X_ASSUM MATCH_MP_TAC \\
+     qmatch_abbrev_tac ‘1 <= z / e’ \\
+     MATCH_MP_TAC REAL_LE_RDIV >> rw [])
+ (* ?k. Lipschitz_condition (E,mr1) k f *)
+ >> simp [Lipschitz_condition_def, GSYM dist_def, dist, mspace]
+ >> ‘e <> 0’ by rw [REAL_LT_IMP_NE]
+ >> Q.EXISTS_TAC ‘1 / e’ >> rw [Abbr ‘f’]
+ >> qabbrev_tac ‘a = g (set_dist E ({x},A) / e)’
+ >> qabbrev_tac ‘b = g (set_dist E ({y},A) / e)’
+ >> simp [REAL_ARITH “1 - a - (1 - b) = b - (a :real)”]
+ (* stage work *)
+ >> Cases_on ‘x IN A’
+ >- (simp [Abbr ‘a’, SET_DIST_SING_IN_SET] \\
+    ‘abs b = b’ by rw [ABS_REFL, Abbr ‘b’] >> POP_ORW \\
+     qunabbrev_tac ‘b’ \\
+     Cases_on ‘y IN A’ >- rw [SET_DIST_SING_IN_SET, MDIST_POS_LE] \\
+     qmatch_abbrev_tac ‘e * g (z / e) <= _’ \\
+    ‘0 <= z’ by rw [Abbr ‘z’, SET_DIST_POS_LE] \\
+     Cases_on ‘e <= z’
+     >- (‘1 <= z / e’ by rw [REAL_LE_LDIV_EQ_NEG] \\
+         ‘g (z / e) = 1’ by rw [] >> rw [] \\
+         Q_TAC (TRANS_TAC REAL_LE_TRANS) ‘z’ >> art [] \\
+         simp [Abbr ‘z’, Once SET_DIST_SYM] \\
+         MATCH_MP_TAC SET_DIST_LE_DIST >> rw []) \\
+     fs [GSYM real_lt] \\
+    ‘z / e < 1’ by rw [REAL_LT_LDIV_EQ] \\
+     Know ‘g (z / e) = z / e’
+     >- (FIRST_X_ASSUM MATCH_MP_TAC >> rw [REAL_LT_IMP_LE]) >> Rewr' \\
+     simp [Abbr ‘z’, Once SET_DIST_SYM] \\
+     MATCH_MP_TAC SET_DIST_LE_DIST >> rw [])
+ >> Cases_on ‘y IN A’
+ >- (rw [Abbr ‘b’, SET_DIST_SING_IN_SET, MDIST_POS_LE] \\
+    ‘abs a = a’ by rw [ABS_REFL, Abbr ‘a’] >> POP_ORW \\
+     qunabbrev_tac ‘a’ \\
+     qmatch_abbrev_tac ‘e * g (z / e) <= _’ \\
+    ‘0 <= z’ by rw [Abbr ‘z’, SET_DIST_POS_LE] \\
+     Cases_on ‘e <= z’
+     >- (‘1 <= z / e’ by rw [REAL_LE_LDIV_EQ_NEG] \\
+         ‘g (z / e) = 1’ by rw [] >> rw [] \\
+         Q_TAC (TRANS_TAC REAL_LE_TRANS) ‘z’ >> art [] \\
+         simp [Abbr ‘z’] \\
+         MATCH_MP_TAC SET_DIST_LE_DIST >> rw []) \\
+     fs [GSYM real_lt] \\
+    ‘z / e < 1’ by rw [REAL_LT_LDIV_EQ] \\
+     Know ‘g (z / e) = z / e’
+     >- (FIRST_X_ASSUM MATCH_MP_TAC >> rw [REAL_LT_IMP_LE]) >> Rewr' \\
+     simp [Abbr ‘z’] \\
+     MATCH_MP_TAC SET_DIST_LE_DIST >> rw [])
+ (* applying SET_DIST_LIPSCHITZ *)
+ >> rw [Abbr ‘a’, Abbr ‘b’]
+ >> qmatch_abbrev_tac ‘e * abs (g (z1 / e) - g (z2 / e)) <= _’
+ >> ‘0 <= z1 /\ 0 <= z2’ by rw [Abbr ‘z1’, Abbr ‘z2’, SET_DIST_POS_LE]
+ >> Cases_on ‘e <= z1’
+ >- (‘1 <= z1 / e’ by rw [REAL_LE_LDIV_EQ_NEG] \\
+     ‘g (z1 / e) = 1’ by rw [] >> POP_ORW \\
+     Cases_on ‘e <= z2’
+     >- (‘1 <= z2 / e’ by rw [REAL_LE_LDIV_EQ_NEG] \\
+         ‘g (z2 / e) = 1’ by rw [] >> POP_ORW \\
+         simp [MDIST_POS_LE]) \\
+     fs [GSYM real_lt] \\
+    ‘z2 / e < 1’ by rw [REAL_LT_LDIV_EQ] \\
+     Know ‘g (z2 / e) = z2 / e’
+     >- (FIRST_X_ASSUM MATCH_MP_TAC >> rw [REAL_LT_IMP_LE]) >> Rewr' \\
+    ‘0 < 1 - z2 / e’ by rw [REAL_SUB_LT] \\
+    ‘abs (1 - z2 / e) = 1 - z2 / e’ by rw [ABS_REFL, REAL_LT_IMP_LE] \\
+     POP_ORW \\
+     simp [REAL_SUB_LDISTRIB, Abbr ‘z2’] \\
+     Q_TAC (TRANS_TAC REAL_LE_TRANS) ‘z1 - set_dist E ({x},A)’ \\
+     simp [REAL_LE_SUB_CANCEL2, Abbr ‘z1’] \\
+     rw [Once MDIST_SYM] \\
+     qmatch_abbrev_tac ‘(a :real) - b <= _’ \\
+     Q_TAC (TRANS_TAC REAL_LE_TRANS) ‘abs (a - b)’ >> rw [ABS_LE] \\
+     simp [Abbr ‘a’, Abbr ‘b’, SET_DIST_LIPSCHITZ])
+ >> fs [GSYM real_lt]
+ >> Cases_on ‘e <= z2’
+ >- (‘1 <= z2 / e’ by rw [REAL_LE_LDIV_EQ_NEG] \\
+     ‘g (z2 / e) = 1’ by rw [] >> POP_ORW \\
+     ‘z1 / e < 1’ by rw [REAL_LT_LDIV_EQ] \\
+     Know ‘g (z1 / e) = z1 / e’
+     >- (FIRST_X_ASSUM MATCH_MP_TAC >> rw [REAL_LT_IMP_LE]) >> Rewr' \\
+    ‘z1 / e - 1 < 0’ by rw [REAL_LT_SUB_RADD] \\
+    ‘abs (z1 / e - 1) = -(z1 / e - 1)’ by rw [ABS_EQ_NEG] >> POP_ORW \\
+     REWRITE_TAC [REAL_NEG_SUB] \\
+     simp [REAL_SUB_LDISTRIB, Abbr ‘z1’] \\
+     Q_TAC (TRANS_TAC REAL_LE_TRANS) ‘z2 - set_dist E ({y},A)’ \\
+     simp [REAL_LE_SUB_CANCEL2, Abbr ‘z2’] \\
+     qmatch_abbrev_tac ‘(a :real) - b <= _’ \\
+     Q_TAC (TRANS_TAC REAL_LE_TRANS) ‘abs (a - b)’ >> rw [ABS_LE] \\
+     simp [Abbr ‘a’, Abbr ‘b’, SET_DIST_LIPSCHITZ])
+ >> fs [GSYM real_lt]
+ >> ‘z1 / e < 1 /\ z2 / e < 1’ by rw [REAL_LT_LDIV_EQ]
+ >> Know ‘g (z1 / e) = z1 / e’
+ >- (FIRST_X_ASSUM MATCH_MP_TAC >> rw [REAL_LT_IMP_LE])
+ >> Rewr'
+ >> Know ‘g (z2 / e) = z2 / e’
+ >- (FIRST_X_ASSUM MATCH_MP_TAC >> rw [REAL_LT_IMP_LE])
+ >> Rewr'
+ >> rw [REAL_DIV_SUB, ABS_DIV]
+ >> ‘abs e = e’ by rw [ABS_REFL, REAL_LT_IMP_LE] >> POP_ORW
+ >> simp [Abbr ‘z1’, Abbr ‘z2’]
+ >> rw [Once MDIST_SYM, SET_DIST_LIPSCHITZ]
 QED
 
 val _ = remove_ovl_mapping "B" {Name = "B", Thy = "metric"};
 val _ = export_theory();
+
+(* References:
+
+  [1] Klenke, A.: Probability Theory: A Comprehensive Course. Second Edition.
+      Springer Science & Business Media, London (2013).
+ *)


### PR DESCRIPTION
Hi,

In `real_topologyTheory` there's a "distance" function `setdist" (originally from HOL-Light) for any two real sets (the shortest distance of two elements from each sets):
```
   [setdist]  Theorem      
      ⊢ ∀s t.
          setdist (s,t) =
          if s = ∅ ∨ t = ∅ then 0 else inf {dist (x,y) | x ∈ s ∧ y ∈ t}
```
I ever try to generalize this function to general metric space with the following new definition (that's why the above "definition" shows as a theorem):
```
   [set_dist_def]  Definition      
      ⊢ ∀d s t.
          set_dist d (s,t) =
          if s = ∅ ∨ t = ∅ then 0 else inf {dist d (x,y) | x ∈ s ∧ y ∈ t}
```
But I didn't prove any supporting theorem for this general `set_dist`. This PR moves the definition to `metricTheory` and finally proved a bunch of supporting theorems for it.  Most of these proofs are ported from their existing `mr1` versions in `real_topologyTheory` and once the general version is proven, e.g. (NOTE: the metric space `m` is put as a fixed variable in all these theorems, on purpose)
```
   [REAL_LE_SET_DIST]  Theorem      
      ⊢ ∀s t d.
          s ≠ ∅ ∧ t ≠ ∅ ∧ (∀x y. x ∈ s ∧ y ∈ t ⇒ d ≤ dist m (x,y)) ⇒
          d ≤ set_dist m (s,t)
```
Then the following SML function can be used to "transfer" it to `real_topologyTheory` (in this way this big theory gets slightly shorter):
```
fun mr1_xfer th = th |> INST_TYPE [alpha |-> “:real”]
                     |> INST [“m :real metric” |-> “mr1”]
                     |> REWRITE_RULE [GSYM dist_def] (* dist mr1 -> dist *)

Theorem REAL_LE_SETDIST_EQ     = mr1_xfer REAL_LE_SET_DIST_EQ

   [REAL_LE_SETDIST_EQ]  Theorem
      ⊢ ∀d s t.
          d ≤ setdist (s,t) ⇔
          (∀x y. x ∈ s ∧ y ∈ t ⇒ d ≤ dist (x,y)) ∧ (s = ∅ ∨ t = ∅ ⇒ d ≤ 0)
```

Furthermore, the so-called "Lipschitz continuous function/mapping" (needed by probability) is now defined in `metricTheory`:
```
   [Lipschitz_continuous_map_def]  Theorem      
      ⊢ ∀E1 E2 f.
          Lipschitz_continuous_map (E1,E2) f ⇔
          ∃k. 0 < k ∧ ∀x y. dist E2 (f x,f y) ≤ k * dist E1 (x,y)
```
First of all, "Lispschitz continuous" implies "continuous", in general metric space:
```
   [Lipschitz_continuous_map_imp_continuous_map]  Theorem      
      ⊢ ∀E1 E2 f.
          Lipschitz_continuous_map (E1,E2) f ⇒
          continuous_map (mtop E1,mtop E2) f
```
Then, there's one notable Lispschitz continuous mapping (from any metric space to MR1), the above `set_dist` function:
```
   [Lipschitz_continuous_map_set_dist]  Theorem      
      ⊢ ∀E s. Lipschitz_continuous_map (E,mr1) (λx. set_dist E ({x},s))
```
Finally, there's even a bounded Lispschitz continuous mapping (whose contruction is hidden but is based on `set_dist`):
```
   [Lipschitz_continuous_map_exists]  Theorem      
      ⊢ ∀E A e.
          0 < e ⇒
          ∃f. Lipschitz_continuous_map (E,mr1) f ∧
              (∀x. 0 ≤ f x ∧ f x ≤ 1) ∧ (∀x. x ∈ A ⇒ f x = 1) ∧
              ∀x. e ≤ set_dist E ({x},A) ⇒ f x = 0
```

P. S. HOL-Light doesn't have the above concepts in general metric space.

Besides, I also ported (but so far it's not very useful) a little from HOL-Light for the "compact" sets in general topological space:
```
   [compact_in]  Definition
      ⊢ ∀top s.
          compact_in top s ⇔
          s ⊆ topspace top ∧
          ∀U. (∀u. u ∈ U ⇒ open_in top u) ∧ s ⊆ BIGUNION U ⇒
              ∃V. FINITE V ∧ V ⊆ U ∧ s ⊆ BIGUNION V
   
   [compact_space]  Definition
      ⊢ ∀top. compact_space top ⇔ compact_in top (topspace top)
```
There are some basic supporting theorems for them. And the following bridging theorem shows that the existing `compact` definition in `real_topologyTheory` is equivalent to the above `compact_in` in Euclidean space:
```
   [compact_def]  Theorem      
      ⊢ ∀s. compact s ⇔ compact_in euclidean s
```

--Chun