### PR TITLE
[lambda] Initial semi_sensibleTheory

### DIFF
--- a/examples/lambda/barendregt/boehmScript.sml
+++ b/examples/lambda/barendregt/boehmScript.sml
@@ -345,7 +345,8 @@ Overload bot = “(NONE, SOME 0) :(BT_node # num option)”
 
 (* Unicode name: "base" *)
 val _ = Unicode.unicode_version {u = UTF8.chr 0x22A5, tmnm = "bot"};
-val _ = TeX_notation {hol = "bot", TeX = ("\\ensuremath{\\bot}", 1)};
+val _ = TeX_notation {hol = "bot", TeX = ("\\HOLTokenBottom}", 1)};
+val _ = TeX_notation {hol = UTF8.chr 0x22A5, TeX = ("\\HOLTokenBottom", 1) };
 
 Theorem BT_of_unsolvables :
     !X M r. unsolvable M ==> BT' X M r = bot
@@ -2033,116 +2034,6 @@ Proof
  >> MATCH_MP_TAC FV_tpm_lemma
  >> Q.EXISTS_TAC ‘r’ >> art []
  >> ASM_SET_TAC []
-QED
-
-(* NOTE: M may contain free variables from xs, but after the fresh tpm
-   there's no more xs variables, thus is disjoint with xs.
- *)
-Theorem FV_renaming_disjoint :
-    !xs ys M. ALL_DISTINCT xs /\ ALL_DISTINCT ys /\
-              LENGTH xs = LENGTH ys /\
-              DISJOINT (set xs) (set ys) /\
-              DISJOINT (set ys) (FV M)
-          ==> DISJOINT (FV (M ISUB ZIP (MAP VAR ys,xs))) (set xs)
-Proof
-    rpt STRIP_TAC
- >> Q.PAT_X_ASSUM ‘ALL_DISTINCT xs’ MP_TAC
- >> Q.PAT_X_ASSUM ‘ALL_DISTINCT ys’ MP_TAC
- >> Q.PAT_X_ASSUM ‘DISJOINT (set xs) (set ys)’ MP_TAC
- >> Q.PAT_X_ASSUM ‘DISJOINT (set ys) (FV M)’ MP_TAC
- >> qabbrev_tac ‘pi = ZIP (xs,ys)’
- >> ‘xs = MAP FST pi /\ ys = MAP SND pi’ by rw [Abbr ‘pi’, MAP_ZIP]
- >> NTAC 2 POP_ORW
- >> KILL_TAC
- >> Q.ID_SPEC_TAC ‘M’
- >> Induct_on ‘pi’ >- rw []
- >> simp [FORALL_PROD]
- >> qx_genl_tac [‘x’, ‘y’, ‘M’]
- >> qabbrev_tac ‘xs = MAP FST pi’
- >> qabbrev_tac ‘ys = MAP SND pi’
- >> NTAC 4 STRIP_TAC
- >> CONJ_TAC
- >- (FIRST_X_ASSUM irule >> art [] \\
-     simp [FV_SUB] \\
-     Cases_on ‘x IN FV M’ >> simp [] \\
-     MATCH_MP_TAC DISJOINT_SUBSET' \\
-     Q.EXISTS_TAC ‘FV M’ >> simp [Once DISJOINT_SYM])
- (* stage work *)
- >> qabbrev_tac ‘sub = ZIP (MAP VAR ys,xs)’
- >> fs []
- >> qabbrev_tac ‘t = [VAR y/x] M’
- >> Know ‘FV (t ISUB sub) SUBSET FV t UNION FVS sub’
- >- rw [FV_ISUB_upperbound]
- >> ‘LENGTH ys = LENGTH xs’ by rw [Abbr ‘xs’, Abbr ‘ys’]
- >> Know ‘FVS sub = set ys’
- >- (rw [Abbr ‘sub’, FVS_ALT, Once EXTENSION] \\
-     EQ_TAC >> rw []
-     >- (rename1 ‘MEM z ys’ \\
-         gvs [MEM_MAP] \\
-         POP_ASSUM MP_TAC \\
-         rw [MEM_ZIP, LENGTH_MAP] \\
-         gvs [EL_MAP] \\
-         simp [EL_MEM]) \\
-     simp [MEM_MAP] \\
-     rename1 ‘MEM z ys’ \\
-     Q.EXISTS_TAC ‘FV (VAR z)’ >> simp [] \\
-     fs [MEM_EL] \\
-     Q.EXISTS_TAC ‘(VAR (EL n ys),EL n xs)’ >> simp [] \\
-     Q.EXISTS_TAC ‘n’ >> simp [EL_ZIP, EL_MAP])
- >> Rewr'
- >> simp [Abbr ‘t’, FV_SUB]
- >> Cases_on ‘x IN FV M’ >> simp []
- >- (DISCH_TAC \\
-     CCONTR_TAC >> fs [] \\
-     Know ‘x IN {y} UNION (FV M DELETE x) UNION set ys’
-     >- METIS_TAC [SUBSET_DEF] \\
-     simp [IN_UNION])
- >> qabbrev_tac ‘t = [VAR y/x] M’
- >> DISCH_TAC
- >> CCONTR_TAC >> fs []
- >> Know ‘x IN FV M UNION set ys’ >- METIS_TAC [SUBSET_DEF]
- >> simp [IN_UNION]
-QED
-
-(* NOTE: M is disjoint with zs, and the tpm (not a fresh tpm) is irrelevant
-   with zs, thus after the tpm the resulting term is still disjoint with zs.
- *)
-Theorem FV_tpm_disjoint :
-    !zs xs ys M. ALL_DISTINCT xs /\ ALL_DISTINCT ys /\
-                 LENGTH xs = LENGTH ys /\
-                 DISJOINT (set xs) (set ys) /\
-                 DISJOINT (set xs) (set zs) /\
-                 DISJOINT (set ys) (set zs) /\
-                 DISJOINT (set zs) (FV M)
-             ==> DISJOINT (set zs) (FV (tpm (ZIP (xs,ys)) M))
-Proof
-    rpt STRIP_TAC
- >> Q.PAT_X_ASSUM ‘ALL_DISTINCT xs’ MP_TAC
- >> Q.PAT_X_ASSUM ‘ALL_DISTINCT ys’ MP_TAC
- >> Q.PAT_X_ASSUM ‘DISJOINT (set xs) (set ys)’ MP_TAC
- >> Q.PAT_X_ASSUM ‘DISJOINT (set ys) (set zs)’ MP_TAC
- >> Q.PAT_X_ASSUM ‘DISJOINT (set xs) (set zs)’ MP_TAC
- >> Q.PAT_X_ASSUM ‘DISJOINT (set zs) (FV M)’   MP_TAC
- >> qabbrev_tac ‘pi = ZIP (xs,ys)’
- >> ‘xs = MAP FST pi /\ ys = MAP SND pi’ by rw [Abbr ‘pi’, MAP_ZIP]
- >> NTAC 2 POP_ORW
- >> KILL_TAC
- >> Q.ID_SPEC_TAC ‘M’
- >> Induct_on ‘pi’ >- rw []
- >> simp [FORALL_PROD]
- >> qx_genl_tac [‘x’, ‘y’, ‘M’]
- >> qabbrev_tac ‘xs = MAP FST pi’
- >> qabbrev_tac ‘ys = MAP SND pi’
- >> rpt STRIP_TAC
- >> Q.PAT_X_ASSUM ‘!M. P’ (MP_TAC o Q.SPEC ‘M’) >> rw []
- >> simp [Once tpm_CONS]
- >> qabbrev_tac ‘t = tpm pi M’
- >> rw [DISJOINT_ALT', FV_tpm]
- >> rename1 ‘swapstr x y z IN FV t’
- >> Cases_on ‘x = z’ >> fs [swapstr_def]
- >> Cases_on ‘y = z’ >> fs []
- >> Q.PAT_X_ASSUM ‘DISJOINT (set zs) (FV t)’ MP_TAC
- >> rw [DISJOINT_ALT']
 QED
 
 (* In this special version, X = Y *)

--- a/examples/lambda/barendregt/chap3Script.sml
+++ b/examples/lambda/barendregt/chap3Script.sml
@@ -65,6 +65,11 @@ val ubeta_arrow = "-" ^ UnicodeChars.beta ^ "->"
 val _ = Unicode.unicode_version {u = ubeta_arrow, tmnm = "-b->"}
 val _ = Unicode.unicode_version {u = ubeta_arrow^"*", tmnm = "-b->*"}
 
+val _ = TeX_notation { hol = "-b->",
+        TeX = ("\\ensuremath{\\rightarrow}", 1) };
+
+val _ = TeX_notation { hol = "-b->*",
+        TeX = ("\\ensuremath{\\twoheadrightarrow}", 1) };
 
 Theorem permutative_beta[simp]:
   permutative beta
@@ -789,6 +794,16 @@ val lameq_consistent = store_thm(
   `S = K` by PROVE_TAC [corollary3_2_1] THEN
   FULL_SIMP_TAC (srw_ss()) [S_def, K_def]);
 
+Theorem incompatible_not_lameq :
+    !M N. incompatible M N ==> ~(M == N)
+Proof
+    rw [incompatible_def, inconsistent_def]
+ >> CCONTR_TAC >> fs []
+ >> ‘!P Q. P == Q’ by METIS_TAC [asmlam_absorb]
+ >> MP_TAC lameq_consistent
+ >> rw [consistent_def]
+QED
+
 val has_bnf_thm = store_thm(
   "has_bnf_thm",
   ``has_bnf M <=> ?N. M -b->* N /\ bnf N``,
@@ -1277,6 +1292,12 @@ val _ = set_fixity "-βη->" (Infix(NONASSOC, 450))
 val _ = set_fixity "-βη->*" (Infix(NONASSOC, 450))
 val _ = set_fixity "-η->" (Infix(NONASSOC, 450))
 val _ = set_fixity "-η->*" (Infix(NONASSOC, 450))
+
+val _ = TeX_notation { hol = "-η->",
+        TeX = ("\\ensuremath{\\rightarrow_{\\eta}}", 1) };
+
+val _ = TeX_notation { hol = "-η->*",
+        TeX = ("\\ensuremath{\\twoheadrightarrow_{\\eta}}", 1) };
 
 Theorem eta_FV_EQN:
   eta M N ⇒ FV N = FV M

--- a/examples/lambda/barendregt/chap4Script.sml
+++ b/examples/lambda/barendregt/chap4Script.sml
@@ -13,11 +13,72 @@ val _ = new_theory "chap4";
 
 val _ = hide "B"
 
-(* definition 4.1.1(i) is already in chap2, given name asmlam *)
+(* definition 4.1.1(i) is already in chap2, given name asmlam
 
+   NOTE: “lambdathy {}” is false, use “lambdathy (UNCURRY (==)” for the base theory.
+ *)
 Definition lambdathy_def:
   lambdathy A ⇔ consistent (asmlam A) ∧ UNCURRY (asmlam A) = A
 End
+
+Theorem asmlam_lameq_absorb :
+    asmlam (UNCURRY (==)) = (==)
+Proof
+    simp [FUN_EQ_THM, EQ_IMP_THM, FORALL_AND_THM]
+ >> CONJ_TAC
+ >- (HO_MATCH_MP_TAC asmlam_ind >> simp [] \\
+     METIS_TAC [lameq_rules])
+ >> HO_MATCH_MP_TAC lameq_ind
+ >> METIS_TAC [asmlam_rules]
+QED
+
+Theorem asmlam_lameta_absorb :
+    asmlam (UNCURRY lameta) = lameta
+Proof
+    simp [FUN_EQ_THM, EQ_IMP_THM, FORALL_AND_THM]
+ >> CONJ_TAC
+ >- (HO_MATCH_MP_TAC asmlam_ind >> simp [] \\
+     METIS_TAC [lameta_rules])
+ >> HO_MATCH_MP_TAC lameta_ind
+ >> REWRITE_TAC [CONJ_ASSOC]
+ >> CONJ_TAC >- METIS_TAC [asmlam_rules]
+ >> qx_genl_tac [‘t’, ‘y’] >> STRIP_TAC
+ >> MATCH_MP_TAC asmlam_eqn >> simp []
+ >> MATCH_MP_TAC lameta_ETA >> art []
+QED
+
+(* not used *)
+Theorem asmlam_conversion_absorb :
+    asmlam (UNCURRY (conversion R)) = asmlam (UNCURRY R)
+Proof
+    simp [FUN_EQ_THM, EQ_IMP_THM, FORALL_AND_THM]
+ >> reverse CONJ_TAC
+ >- (HO_MATCH_MP_TAC asmlam_ind >> simp [] \\
+     reverse CONJ_TAC >- METIS_TAC [asmlam_rules] \\
+     rpt STRIP_TAC \\
+     MATCH_MP_TAC asmlam_eqn >> rw [] \\
+     rw [conversion_rules])
+ >> HO_MATCH_MP_TAC asmlam_ind >> simp []
+ >> reverse CONJ_TAC >- METIS_TAC [asmlam_rules]
+ >> HO_MATCH_MP_TAC EQC_INDUCTION
+ >> reverse CONJ_TAC >- METIS_TAC [asmlam_rules]
+ >> HO_MATCH_MP_TAC compat_closure_ind
+ >> reverse CONJ_TAC >- METIS_TAC [asmlam_rules]
+ >> rpt STRIP_TAC
+ >> MATCH_MP_TAC asmlam_eqn >> rw []
+QED
+
+Theorem lambdathy_lameq :
+    lambdathy (UNCURRY (==))
+Proof
+    rw [lambdathy_def, asmlam_lameq_absorb, lameq_consistent]
+QED
+
+Theorem lambdathy_lameta :
+    lambdathy (UNCURRY lameta)
+Proof
+    rw [lambdathy_def, asmlam_lameta_absorb, lameta_consistent]
+QED
 
 Definition church1_def:
   church1 = LAM "x" (LAM "y" (VAR "x" @@ VAR "y"))
@@ -265,7 +326,7 @@ Proof
       METIS_TAC [conversion_rules],
       (* goal 6 (of 8) *)
       PROVE_TAC [conversion_compatible, compatible_def, rightctxt, rightctxt_thm],
-      (* goal 8 (of 8) *)
+      (* goal 7 (of 8) *)
       PROVE_TAC [conversion_compatible, compatible_def, leftctxt],
       (* goal 8 (of 8) *)
       PROVE_TAC [conversion_compatible, compatible_def, absctxt] ]

--- a/examples/lambda/barendregt/head_reductionScript.sml
+++ b/examples/lambda/barendregt/head_reductionScript.sml
@@ -39,6 +39,12 @@ val _ = overload_on ("-h->", ``hreduce1``)
 val _ = set_fixity "-h->*" (Infix(NONASSOC, 450))
 val _ = overload_on ("-h->*", ``hreduce1^*``)
 
+val _ = TeX_notation { hol = "-h->",
+        TeX = ("\\ensuremath{\\rightarrow_h}", 1) };
+
+val _ = TeX_notation { hol = "-h->*",
+        TeX = ("\\ensuremath{\\twoheadrightarrow_{h}}", 1) };
+
 Theorem hreduce1_beta_reduce[simp] :
      LAM h M @@ VAR h -h-> M
 Proof

--- a/examples/lambda/barendregt/lameta_completeScript.sml
+++ b/examples/lambda/barendregt/lameta_completeScript.sml
@@ -2,7 +2,7 @@
 (* FILE    : lameta_completeScript.sml (chap10_4Script.sml)                   *)
 (* TITLE   : Completeness of (Untyped) Lambda-Calculus [1, Chapter 10.4]      *)
 (*                                                                            *)
-(* AUTHORS : 2024-2025 The Australian National University (Chun Tian)         *)
+(* AUTHORS : 2024 - 2025 The Australian National University (Chun Tian)       *)
 (* ========================================================================== *)
 
 open HolKernel Parse boolLib bossLib;
@@ -5273,7 +5273,7 @@ Proof
 QED
 
 Theorem faithful_two' :
-    !X Ms pi r.
+    !X M N pi r.
        FINITE X /\ FV M UNION FV N SUBSET X UNION RANK r /\ 0 < r ==>
       (faithful' X [M; N] pi r <=>
          (solvable M <=> solvable (apply pi M)) /\
@@ -6683,7 +6683,11 @@ Proof
  >> simp []
 QED
 
-(* Theorem 10.4.2 (i) [1, p.256] *)
+(* Theorem 10.4.2 (i) [1, p.256]
+
+   NOTE: It is actually "eta-separability" because we have “lameta (apply pi M) P”
+   instead of “apply pi M == P”.
+ *)
 Theorem separability_thm :
     !X M N r.
        FINITE X /\ FV M UNION FV N SUBSET X UNION RANK r /\ 0 < r /\
@@ -6744,13 +6748,16 @@ Proof
       MATCH_MP_TAC Boehm_apply_lameta_cong >> art [] ]
 QED
 
-Theorem separability_thm_final :
+(* NOTE: We call it "final" if there's no “FINITE X /\ FV M SUBSET X UNION RANK r”
+   in antecedents.
+ *)
+Theorem separability_final :
     !M N. has_benf M /\ has_benf N /\ ~(lameta M N) ==>
           !P Q. ?pi. Boehm_transform pi /\
                      lameta (apply pi M) P /\ lameta (apply pi N) Q
 Proof
     rpt STRIP_TAC
- >> MP_TAC (Q.SPECL [‘FV M UNION FV N’, ‘M’, ‘N’, ‘1’] separability_thm) >> art []
+ >> MP_TAC (Q.SPECL [‘FV M UNION FV N’, ‘M’, ‘N’, ‘1’] separability_thm)
  >> simp []
  >> impl_tac >- SET_TAC []
  >> DISCH_THEN (STRIP_ASSUME_TAC o Q.SPECL [‘P’, ‘Q’])
@@ -6766,10 +6773,10 @@ Proof
     rpt STRIP_TAC
  >> ‘?pi. Boehm_transform pi /\
           lameta (apply pi M) P /\ lameta (apply pi N) Q’
-       by METIS_TAC [separability_thm_final]
- >> ‘?Ns. !M. closed M ==> apply pi M == M @* Ns’
+       by METIS_TAC [separability_final]
+ >> ‘?L. !M. closed M ==> apply pi M == M @* L’
        by METIS_TAC [Boehm_transform_lameq_appstar]
- >> Q.EXISTS_TAC ‘Ns’
+ >> Q.EXISTS_TAC ‘L’
  >> CONJ_TAC (* 2 subgoals *)
  >| [ (* goal 1 (of 2) *)
       MATCH_MP_TAC lameta_TRANS \\
@@ -6791,7 +6798,7 @@ Theorem distinct_benf_imp_inconsistent :
           inconsistent (conversion (RINSERT (beta RUNION eta) M N))
 Proof
     rw [inconsistent_def]
- >> MP_TAC (Q.SPECL [‘M’, ‘N’] separability_thm_final) >> rw []
+ >> MP_TAC (Q.SPECL [‘M’, ‘N’] separability_final) >> rw []
  >> POP_ASSUM (MP_TAC o Q.SPECL [‘M'’, ‘N'’])
  >> STRIP_TAC
  (* M' ~ apply pi M  ~ apply pi N ~ N' *)
@@ -6851,4 +6858,7 @@ val _ = html_theory "lameta_complete";
      Pubblicazioni dell'IAC 696, 1-19 (1968)
      English translation: "Some properties of beta-eta-normal forms in the
      lambda-K-calculus" (https://arxiv.org/abs/2502.05774)
+ [4] Coppo, M. et al.: (Semi-) separability of Finite Sets of Terms in Scott's
+     D-infinity-models of the Lambda-calculus. In: LNCS 62 - Automata, Languages
+     and Programming (ICALP 1978). Springer (1978).
  *)

--- a/examples/lambda/barendregt/semi_sensibleScript.sml
+++ b/examples/lambda/barendregt/semi_sensibleScript.sml
@@ -1,0 +1,223 @@
+(* ========================================================================== *)
+(* FILE    : semi_sensibleScript.sml (chap17_1Script.sml)                     *)
+(* TITLE   : Semi-sensible theories of lambda calculus [Barendregt 17.1]      *)
+(*                                                                            *)
+(* AUTHORS : 2025  The Australian National University (Chun Tian)             *)
+(* ========================================================================== *)
+
+open HolKernel Parse boolLib bossLib;
+
+open listTheory numLib hurdUtils pred_setTheory pred_setLib relationTheory
+     topologyTheory pairTheory;
+
+open termTheory chap2Theory chap3Theory chap4Theory horeductionTheory
+     boehmTheory lameta_completeTheory;
+
+(* These theorems usually give unexpected results, should be applied manually *)
+val _ = temp_delsimps [
+   "lift_disj_eq", "lift_imp_disj",
+   "IN_UNION",     (* |- !s t x. x IN s UNION t <=> x IN s \/ x IN t *)
+   "APPEND_ASSOC", (* |- !l1 l2 l3. l1 ++ (l2 ++ l3) = l1 ++ l2 ++ l3 *)
+   "SNOC_APPEND"   (* |- !x l. SNOC x l = l ++ [x] *)
+];
+
+val _ = hide "B";
+val _ = hide "C";
+val _ = hide "W";
+val _ = hide "Y";
+
+Overload FV  = “supp term_pmact”
+Overload VAR = “term$VAR”
+
+val _ = new_theory "semi_sensible";
+
+(* Definition 10.4.4 [1, p.256], but is generalized with a theory parameter.
+
+   This definition combined the cases of closed and open terms, cf. solvable_def
+ *)
+Definition gen_separable_def :
+    gen_separable R Ms <=>
+    lambdathy R /\
+    let X = BIGUNION (IMAGE FV (set Ms));
+       Fs = MAP (LAMl (SET_TO_LIST X)) Ms
+    in
+      !Ns. LENGTH Ns = LENGTH Ms ==>
+           ?f. !i. i < LENGTH Ms ==> R (f @@ (EL i Fs),EL i Ns)
+End
+
+Theorem gen_separable_mono :
+    !R1 R2 Ms. lambdathy R1 /\ lambdathy R2 /\ R1 SUBSET R2 /\
+               gen_separable R1 Ms ==> gen_separable R2 Ms
+Proof
+    rw [gen_separable_def]
+ >> qabbrev_tac ‘X = BIGUNION (IMAGE FV (set Ms))’
+ >> qabbrev_tac ‘vs = SET_TO_LIST X’
+ >> Q.PAT_X_ASSUM ‘!Ns. P’ (MP_TAC o Q.SPEC ‘Ns’) >> rw []
+ >> qabbrev_tac ‘n = LENGTH Ms’
+ >> Q.EXISTS_TAC ‘f’
+ >> rpt STRIP_TAC
+ >> fs [SUBSET_DEF, FORALL_PROD, IN_APP]
+QED
+
+(* Definition 10.4.4 (i) [1, p.256], now an equivalent theorem *)
+Theorem gen_separable_alt_closed :
+    !R Ms. EVERY closed Ms ==>
+          (gen_separable R Ms <=>
+           lambdathy R /\
+           !Ns. LENGTH Ns = LENGTH Ms ==>
+                ?f. !i. i < LENGTH Ms ==> R (f @@ (EL i Ms),EL i Ns))
+Proof
+    RW_TAC std_ss [EVERY_EL, gen_separable_def]
+ >> Know ‘X = {}’
+ >- (Cases_on ‘Ms = []’ >- rw [Abbr ‘X’] \\
+     rw [Abbr ‘X’, Once EXTENSION] \\
+     fs [closed_def] \\
+     EQ_TAC >> rw [MEM_EL] >> rw [] \\
+    ‘0 < LENGTH Ms’ by rw [LENGTH_NON_NIL] \\
+     Q.EXISTS_TAC ‘EL 0 Ms’ >> rw [] \\
+     Q.EXISTS_TAC ‘0’ >> rw [])
+ >> DISCH_THEN (fs o wrap)
+QED
+
+(* Lemma 10.4.5 [1, p.257] or Definition 17.1.3 (ii) [1, p.432] *)
+Theorem gen_separable_alt :
+    !R Ms. gen_separable R Ms <=>
+           lambdathy R /\
+           !Ns. LENGTH Ns = LENGTH Ms ==>
+                ?c. ctxt c /\
+                    !i. i < LENGTH Ms ==> R (c (EL i Ms),EL i Ns)
+Proof
+    RW_TAC std_ss [gen_separable_def]
+ >> qabbrev_tac ‘vs = SET_TO_LIST X’
+ >> EQ_TAC >> rw []
+ >- (Q.PAT_X_ASSUM ‘!Ns. LENGTH Ns = LENGTH Ms ==> _’
+       (MP_TAC o Q.SPEC ‘Ns’) >> rw [] \\
+     Q.EXISTS_TAC ‘\x. f @@ LAMl vs x’ \\
+     reverse CONJ_TAC
+     >- (POP_ASSUM MP_TAC >> rw [Abbr ‘Fs’, EL_MAP]) \\
+     HO_MATCH_MP_TAC ctxt_APPR \\
+     HO_MATCH_MP_TAC ctxt_LAMl >> rw [ctxt_I])
+ (* stage work *)
+ >> Q.PAT_X_ASSUM ‘!Ns. LENGTH Ns = LENGTH Ms ==> _’
+      (MP_TAC o Q.SPEC ‘Ns’) >> rw []
+ >> Know ‘set vs = X’
+ >- (qunabbrev_tac ‘vs’ \\
+     MATCH_MP_TAC SET_TO_LIST_INV \\
+     qunabbrev_tac ‘X’ \\
+     MATCH_MP_TAC FINITE_BIGUNION >> rw [] >> rw [])
+ >> DISCH_TAC
+ >> Know ‘!i. i < LENGTH Ms ==> FV (EL i Ms) SUBSET set vs’
+ >- (rw [Abbr ‘vs’] \\
+     rw [Abbr ‘X’, SUBSET_DEF] \\
+     Q.EXISTS_TAC ‘FV (EL i Ms)’ >> rw [] \\
+     Q.EXISTS_TAC ‘EL i Ms’ >> rw [EL_MEM])
+ >> DISCH_TAC
+ (* applying lameq_ctxt_app_lemma *)
+ >> MP_TAC (Q.SPECL [‘vs’, ‘c’] lameq_ctxt_app_lemma) >> rw []
+ >> Q.EXISTS_TAC ‘f’
+ >> rw [Abbr ‘Fs’, EL_MAP]
+ >> fs [lambdathy_def]
+ >> qabbrev_tac ‘A = UNCURRY R^+’
+ >> Q.PAT_X_ASSUM ‘A = R’ (fs o wrap o SYM)
+ >> fs [Abbr ‘A’]
+ >> Q_TAC (TRANS_TAC asmlam_trans) ‘c (EL i Ms)’ >> rw []
+ >> MATCH_MP_TAC asmlam_sym
+ >> MATCH_MP_TAC lameq_asmlam >> rw []
+QED
+
+(* The usual “separable” with empty theory (i.e. with beta-conversion only) *)
+Overload separable = “gen_separable (UNCURRY (==))”
+
+(* |- !Ms.
+        separable Ms <=>
+        !Ns.
+          LENGTH Ns = LENGTH Ms ==>
+          ?c. ctxt c /\ !i. i < LENGTH Ms ==> c (EL i Ms) == EL i Ns
+ *)
+Theorem separable_def =
+        gen_separable_alt |> Q.SPEC ‘UNCURRY (==)’
+                          |> SRULE [lambdathy_lameq]
+
+Theorem separable_incompatible :
+    !M N. separable [M; N] ==> M # N
+Proof
+    rw [separable_def, incompatible_def]
+ >> simp [inconsistent_def]
+ >> qx_genl_tac [‘P’, ‘Q’]
+ >> POP_ASSUM (MP_TAC o Q.SPEC ‘[P; Q]’) >> rw []
+ >> Know ‘c N == Q’
+ >- (POP_ASSUM (MP_TAC o Q.SPEC ‘1’) >> rw [])
+ >> Know ‘c M == P’
+ >- (POP_ASSUM (MP_TAC o Q.SPEC ‘0’) >> rw [])
+ >> POP_ASSUM K_TAC
+ >> NTAC 2 STRIP_TAC
+ >> Q_TAC (TRANS_TAC asmlam_trans) ‘c N’
+ >> reverse CONJ_TAC
+ >- (MATCH_MP_TAC lameq_asmlam >> art [])
+ >> Q_TAC (TRANS_TAC asmlam_trans) ‘c M’
+ >> CONJ_TAC
+ >- (MATCH_MP_TAC asmlam_sym \\
+     MATCH_MP_TAC lameq_asmlam >> art [])
+ >> irule asmlam_ctxt_cong >> art []
+ >> MATCH_MP_TAC asmlam_eqn >> rw []
+QED
+
+Theorem separable_not_lameq :
+    !M N. separable [M; N] ==> ~(M == N)
+Proof
+    METIS_TAC [separable_incompatible, incompatible_not_lameq]
+QED
+
+(* “eta_separable” is another common instance with beta- and eta-conversion. *)
+Overload eta_separable = “gen_separable (UNCURRY lameta)”
+
+(* |- !Ms.
+        eta_separable Ms <=>
+        !Ns.
+          LENGTH Ns = LENGTH Ms ==>
+          ?c. ctxt c /\ !i. i < LENGTH Ms ==> lameta (c (EL i Ms)) (EL i Ns)
+ *)
+Theorem eta_separable_def =
+        gen_separable_alt |> Q.SPEC ‘UNCURRY lameta’
+                          |> SRULE [lambdathy_lameta]
+
+Theorem eta_separable_thm :
+    !M N. has_benf M /\ has_benf N /\ ~(lameta M N) ==> eta_separable [M; N]
+Proof
+    rw [eta_separable_def]
+ >> MP_TAC (Q.SPECL [‘M’, ‘N’] separability_final) >> simp []
+ >> DISCH_THEN (MP_TAC o Q.SPECL [‘EL 0 Ns’, ‘EL 1 Ns’])
+ >> STRIP_TAC
+ >> ‘?c. ctxt c /\ !M. apply pi M == c M’
+      by PROVE_TAC [Boehm_transform_lameq_ctxt]
+ >> Q.EXISTS_TAC ‘c’ >> art []
+ >> CONV_TAC (BOUNDED_FORALL_CONV (SIMP_CONV list_ss []))
+ >> CONJ_TAC
+ >- (Q_TAC (TRANS_TAC lameta_TRANS) ‘apply pi N’ >> art [] \\
+     MATCH_MP_TAC lameta_SYM \\
+     MATCH_MP_TAC lameq_imp_lameta >> art [])
+ >> CONV_TAC (BOUNDED_FORALL_CONV (SIMP_CONV list_ss []))
+ >> ASM_SIMP_TAC bool_ss [GSYM EL]
+ >> Q_TAC (TRANS_TAC lameta_TRANS) ‘apply pi M’ >> art []
+ >> MATCH_MP_TAC lameta_SYM
+ >> MATCH_MP_TAC lameq_imp_lameta >> art []
+QED
+
+Theorem separable_imp_eta_separable :
+    !Ms. separable Ms ==> eta_separable Ms
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC gen_separable_mono
+ >> Q.EXISTS_TAC ‘UNCURRY (==)’
+ >> simp [lambdathy_lameq, lambdathy_lameta, SUBSET_DEF, FORALL_PROD]
+ >> rw [lameq_imp_lameta]
+QED
+
+val _ = export_theory ();
+val _ = html_theory "semi_sensible";
+
+(* References:
+
+ [1] Barendregt, H.P.: The lambda calculus, its syntax and semantics.
+     College Publications, London (1984).
+ *)

--- a/examples/lambda/barendregt/takahashiS3Script.sml
+++ b/examples/lambda/barendregt/takahashiS3Script.sml
@@ -32,6 +32,9 @@ End
 val _ = set_mapped_fixity {term_name = "peta", tok = "=η=>",
                            fixity = Infix(NONASSOC, 450)}
 
+val _ = TeX_notation { hol = "=η=>",
+        TeX = ("\\ensuremath{\\Rightarrow_{\\eta}}", 1) };
+
 Theorem peta_VAR[simp]:
   peta (VAR s) M ⇔ M = VAR s
 Proof

--- a/examples/lambda/basics/generic_termsScript.sml
+++ b/examples/lambda/basics/generic_termsScript.sml
@@ -1404,3 +1404,4 @@ Proof
 QED
 
 val _ = export_theory()
+val _ = html_theory "generic_terms";

--- a/src/TeX/holtexbasic.sty
+++ b/src/TeX/holtexbasic.sty
@@ -51,6 +51,7 @@
 \newcommand{\HOLTokenTilde}{\texttt{\char'176}}
 \newcommand{\HOLTokenDoubleQuote}{\texttt{\char'42}}
 \newcommand{\HOLTokenDoublePlus}{\ensuremath{\mathbin{+\mkern-10mu+}}}
+\newcommand{\HOLTokenDoublePlusL}{\ensuremath{\mathbin{+\mkern-10mu+}_{l}}}
 \newcommand{\HOLTokenUnderscore}{\texttt{\_}}
 \newcommand{\HOLTokenIn}{\ensuremath{\in}}
 \newcommand{\HOLTokenNotIn}{\ensuremath{\notin}}
@@ -104,6 +105,7 @@
 \newcommand{\HOLTokenLsl}{\ensuremath{\ll}} % {\texttt{<<}}
 \newcommand{\HOLTokenSupStar}{\ensuremath{{}^*}}
 \newcommand{\HOLTokenSupPlus}{\ensuremath{{}^+}}
+\newcommand{\HOLTokenSupMinus}{\ensuremath{{}^-}}
 \newcommand{\HOLTokenSupTwo}{\ensuremath{{}^2}}
 \newcommand{\HOLTokenSupThree}{\ensuremath{{}^3}}
 \newcommand{\HOLTokenSupFour}{\ensuremath{{}^4}}
@@ -133,3 +135,6 @@
 \newcommand{\HOLTokenIntegral}{\ensuremath{\int}}
 \newcommand{\HOLTokenIntegralPlus}{\ensuremath{\int^{+}}}
 \newcommand{\HOLTokenFUNION}{\ensuremath{\uplus}} % not ideal; the real symbol is available in unicode-math if you use xelatex...
+\newcommand{\HOLTokenLameq}{\ensuremath{\!=_\beta\!\!}}
+\newcommand{\HOLTokenLameta}{\ensuremath{\!=_{\beta\eta}\!\!}}
+\newcommand{\HOLTokenBottom}{\ensuremath{\bot}}

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -156,6 +156,7 @@ val _ = overload_on ("++", Term‘APPEND’);
 val _ = Unicode.unicode_version {u = UnicodeChars.doubleplus, tmnm = "++"}
 val _ = TeX_notation { hol = UnicodeChars.doubleplus,
                        TeX = ("\\HOLTokenDoublePlus", 1) }
+val _ = TeX_notation { hol = "++", TeX = ("\\HOLTokenDoublePlus", 1) };
 
 (* preserving old choice of quantification order *)
 Theorem APPEND[simp]:


### PR DESCRIPTION
Hi,

This PR continues the previous work on the lambda-calculus examples and slightly move forward.

I start with the existing `chap4Theory`, where there's the definition for `lambdathy`:
```
[lambdathy_def] (chap4Theory, existing)
⊢ ∀A. lambdathy A ⇔ consistent A⁺ ∧ UNCURRY A⁺ = A
```
I have proved that both `lameq` (`==`) and `lameta` satisfy the above definition:
```
[lambdathy_lameq]
⊢ lambdathy (UNCURRY $==)
[lambdathy_lameta]
⊢ lambdathy (UNCURRY $===)
```
Based on this `lambdathy`, I have added, in the new `semi_sensibleTheory`, the following `gen_separable` definition for the general concept of separability in a lambda theory (following Barendregt 10.4.4):
```
[gen_separable_def] (semi_sensibleTheory)
⊢ ∀R Ms.
    gen_separable R Ms ⇔
    lambdathy R ∧
    (let
       X = BIGUNION (IMAGE FV (set Ms));
       Fs = MAP (λt. LAMl (SET_TO_LIST X) t) Ms
     in
       ∀Ns.
         LENGTH Ns = LENGTH Ms ⇒
         ∃f. ∀i. i < LENGTH Ms ⇒ R (f @@ EL i Fs,EL i Ns))
```
Note two things here: 1) the list of terms `Fs` are closures of input term `Ms` using the union of all their free variables as the  binding variables (but the order is arbitrary chosen by `SET_TO_LIST`). 2) This general separation definition only asserts a single lambda term `f` instead of Böhm transformation or contexts, which is easier to understand.

If using contexts (`ctxt`) instead, there's the following simpler alternative definition for `gen_separable`:
```
[gen_separable_alt]
⊢ ∀R Ms.
    gen_separable R Ms ⇔
    lambdathy R ∧
    ∀Ns.
      LENGTH Ns = LENGTH Ms ⇒
      ∃c. ctxt c ∧ ∀i. i < LENGTH Ms ⇒ R (c (EL i Ms),EL i Ns)
```

The usual (beta)-separability is just `gen_separable` parameterised with `lameq` and eta-separability is parameterised with `lameta`:
```
Overload separable = “gen_separable (UNCURRY (==))”
Overload eta_separable = “gen_separable (UNCURRY lameta)”
```

With all these new devices, the version of Böhm's separability theorem we obtained previously, can be restated below:
```
[eta_separable_thm]
⊢ ∀M N. has_benf M ∧ has_benf N ∧ ¬(M === N) ⇒ eta_separable [M; N]
```

On the other hand, the usual (beta)separability implies incompatiblity (the other direction is not true):
```
[separable_incompatible]
⊢ ∀M N. separable [M; N] ⇒ M # N
```

Our goal here is to prove `|-? has_benf M ∧ has_benf N ∧ ¬(M === N) ⇒ separable [M; N]` (The original Böhm's separability theorem) or `|-? has_benf M ∧ has_benf N ∧ ¬(M === N) ⇒ M # N`. And this is true by the following unproved results:

```
|-? eta_separable [M; N] <=> separable [M; N]
```
or in general, if a theory T is "semi-sensible" (the definition is already in `chap4Theory`), then T-separability is equivalent to T-eta-separability.

--Chun