### PR TITLE
[listSimps] remove SNOC_APPEND from list normalisation

### DIFF
--- a/examples/AKS/machine/countPolyScript.sml
+++ b/examples/AKS/machine/countPolyScript.sml
@@ -730,7 +730,8 @@ val poly_extendM_value = store_thm(
     `k = 1` by decide_tac >>
     rw[PAD_RIGHT],
     `SUC (k - 1) = k` by decide_tac >>
-    `PAD_RIGHT 0 (k - 1) [0] ++ [0] = SNOC 0 (PAD_RIGHT 0 (k - 1) [0])` by rw[] >>
+    `PAD_RIGHT 0 (k - 1) [0] ++ [0] =
+     SNOC 0 (PAD_RIGHT 0 (k - 1) [0])` by rw[SNOC_APPEND] >>
     `_ = PAD_RIGHT 0 (SUC (k - 1)) [0]` by rw[PAD_RIGHT_SNOC] >>
     metis_tac[]
   ]);

--- a/examples/Crypto/DES/Holmakefile
+++ b/examples/Crypto/DES/Holmakefile
@@ -1,2 +1,21 @@
 INCLUDES = $(HOLDIR)/src/n-bit $(HOLDIR)/src/res_quan/src \
            $(HOLDIR)/src/probability
+
+HOLHEAP = heap
+EXTRA_CLEANS = $(HOLHEAP)
+
+all: $(DEFAULT_TARGETS)
+.PHONY: all
+
+ifdef POLY
+OBJS = n-bit/fcpTheory n-bit/fcpLib
+
+FULL_OBJPATHS = $(patsubst %,$(HOLDIR)/src/%.uo,$(OBJS)) \
+                $(HOLDIR)/sigobj/pred_setTheory.uo \
+                $(HOLDIR)/sigobj/pred_setLib.uo
+
+all: $(HOLHEAP)
+
+$(HOLHEAP): $(FULL_OBJPATHS) $(HOLDIR)/bin/hol.state
+	$(protect $(HOLDIR)/bin/buildheap) $(DEBUG_FLAG) -o $@ $(FULL_OBJPATHS)
+endif

--- a/examples/Crypto/DES/des_propScript.sml
+++ b/examples/Crypto/DES/des_propScript.sml
@@ -203,8 +203,7 @@ Proof
       rw[])
   >> RW_TAC fcp_ss[RoundKey_def,GENLIST,roundk_supp,REVERSE_DEF,roundk_R,roundk_L]
   >> Suff `HD ks = (c',c)`
-  >- (rw []\\
-      rw[Abbr `ks`])
+  >- rw[SNOC_APPEND, Abbr `ks`]
   >> rw[Abbr `ks`]
   >- (Q.PAT_X_ASSUM ‘HD (REVERSE (SNOC (c',c) (GENLIST (λi. (RK_L i k,RK_R i k)) n))) = _’ MP_TAC \\
       rw[HD_REVERSE])

--- a/examples/Hoare-for-divergence/div_logic_soundnessScript.sml
+++ b/examples/Hoare-for-divergence/div_logic_soundnessScript.sml
@@ -130,7 +130,8 @@ Proof
        \\ drule terminates_history \\ fs []
        \\ disch_then (qspec_then ‘SND t’ assume_tac) \\ fs []
        \\ goal_assum (first_assum o mp_then (Pos hd) mp_tac) \\ fs []
-       \\ Cases_on ‘s'’ \\ Cases_on ‘t’ \\ fs [guard_def,output_of_def,ADD1]
+       \\ Cases_on ‘s'’ \\ Cases_on ‘t’
+       \\ fs [guard_def,output_of_def,ADD1,SNOC_APPEND]
        \\ fs [ignores_output_def] \\ metis_tac [])
     \\ last_x_assum (qspec_then ‘i’ kall_tac)
     \\ conj_tac

--- a/examples/algebra/linear/VectorSpaceScript.sml
+++ b/examples/algebra/linear/VectorSpaceScript.sml
@@ -751,7 +751,7 @@ val stick_snoc = store_thm(
   "stick_snoc",
   ``!r:'a field. !(l:'a list) n. l IN sticks r (SUC n) <=>
                                 (?h t. h IN R /\ t IN sticks r n /\ (l = SNOC h t))``,
-  rw[EQ_IMP_THM] >| [
+  rw[EQ_IMP_THM, SNOC_APPEND] >| [
     `n < SUC n /\ (SUC n - SUC n = 0)` by decide_tac >>
     `EL n l IN R /\ TAKE n l IN sticks r n /\ DROP (SUC n) l IN sticks r 0` by metis_tac[stick_components_stick] >>
     qabbrev_tac `h = EL n l` >>

--- a/examples/algebra/polynomial/polyMonicScript.sml
+++ b/examples/algebra/polynomial/polyMonicScript.sml
@@ -3145,11 +3145,10 @@ val weak_snoc_eq_add_shift = store_thm(
   ``!r:'a ring. Ring r ==> !p c. weak p /\ c IN R /\ c <> #0 ==> (SNOC c p = p + [c] >> (LENGTH p))``,
   rpt strip_tac >>
   `poly [c]` by rw[poly_nonzero_element_poly] >>
-  Induct_on `p` >-
-  rw[] >>
+  Induct_on `p` >- rw[] >>
+  `SNOC c p <> |0|` by rw[NOT_SNOC_NIL] >>
   rpt strip_tac >>
   `h IN R /\ weak p` by metis_tac[weak_cons] >>
-  `SNOC c p <> |0|` by rw[NOT_SNOC_NIL] >>
   `weak [h] /\ weak [c]` by rw[] >>
   `SNOC c p = p + [c] >> LENGTH p` by metis_tac[] >>
   `poly (SNOC c p)` by rw[poly_add_weak_poly] >>

--- a/examples/algebra/polynomial/polyRingScript.sml
+++ b/examples/algebra/polynomial/polyRingScript.sml
@@ -2819,11 +2819,10 @@ val poly_snoc_eq_add_shift = store_thm(
   ``!r:'a ring. Ring r ==> !p c. poly p /\ c IN R /\ c <> #0 ==> (SNOC c p = p + [c] >> (LENGTH p))``,
   rpt strip_tac >>
   `poly [c]` by rw[poly_nonzero_element_poly] >>
-  Induct_on `p` >-
-  rw[] >>
+  Induct_on `p` >- rw[] >>
+  `SNOC c p <> |0|` by rw[NOT_SNOC_NIL] >>
   rpt strip_tac >>
   `h IN R /\ poly p` by metis_tac[poly_cons_poly] >>
-  `SNOC c p <> |0|` by rw[NOT_SNOC_NIL] >>
   Cases_on `h = #0` >| [
     `p <> |0|` by metis_tac[poly_cons_property, poly_zero] >>
     `SNOC c (#0::p) = #0::SNOC c p` by rw[] >>

--- a/examples/countchars/countcharsScript.sml
+++ b/examples/countchars/countcharsScript.sml
@@ -46,7 +46,7 @@ Proof
   ‘LHS = countchars fm (EL i s :: TAKE i s)’ by simp[Abbr‘LHS’] >>
   pop_assum SUBST1_TAC >> irule countchars_PERM >>
   simp[PERM_CONS_EQ_APPEND] >> map_every qexists_tac [‘TAKE i s’, ‘[]’] >>
-  simp[GSYM rich_listTheory.SNOC_EL_TAKE]
+  simp[rich_listTheory.TAKE_SUC] (* TAKE1_DROP is implicitly used *)
 QED
 
 Theorem countchars_EQN: countchars fm s = countchars_aux fm s (LENGTH s)

--- a/examples/fermat/twosq/hoppingScript.sml
+++ b/examples/fermat/twosq/hoppingScript.sml
@@ -1482,7 +1482,7 @@ Theorem path_alt:
   (!n. path n 0 = [(1,n DIV 4,1)]) /\
    !n k. path n (SUC k) = (path n k) ++ [(zagier o flip) (LAST (path n k))]
 Proof
-  simp[path_def]
+  simp[path_def, SNOC_APPEND]
 QED
 
 (* Theorem: path n 1 = [(1,n DIV 4,1); (1,1,n DIV 4)] *)

--- a/examples/formal-languages/FormalLangScript.sml
+++ b/examples/formal-languages/FormalLangScript.sml
@@ -885,7 +885,7 @@ End
 Triviality prefixes_snoc:
   prefixes (SNOC h t) = (SNOC h t) INSERT prefixes t
 Proof
-  rw[prefixes_def,EXTENSION,EQ_IMP_THM]
+  rw[prefixes_def,EXTENSION,EQ_IMP_THM, SNOC_APPEND]
   >- (strip_assume_tac (SNOC_CASES |> Q.SPEC ‘w2’) >>
       rw[] >> gvs[SNOC_APPEND])
   >- metis_tac[APPEND_NIL]

--- a/examples/formal-languages/context-free/simpleSexpParseScript.sml
+++ b/examples/formal-languages/context-free/simpleSexpParseScript.sml
@@ -97,9 +97,9 @@ val num_to_dec_string_eq_cons = Q.store_thm("num_to_dec_string_eq_cons",
   \\ rw[]
   \\ qspecl_then[`10`,`n`]mp_tac numposrepTheory.l2n_n2l \\ rw[]
   \\ Q.ISPEC_THEN`n2l 10 n`FULL_STRUCT_CASES_TAC SNOC_CASES
-  \\ fs[EVERY_SNOC] \\ rpt var_eq_tac
+  \\ fs[EVERY_SNOC, SNOC_APPEND] \\ rpt var_eq_tac
   \\ simp[UNHEX_HEX]
-  \\ simp[SNOC_APPEND,l2n_APPEND,numposrepTheory.l2n_def]
+  \\ simp[l2n_APPEND,numposrepTheory.l2n_def]
   \\ simp[s2n_def,MAP_MAP_o]
   \\ AP_TERM_TAC
   \\ fs[LIST_EQ_REWRITE,EL_MAP,EVERY_MEM,MEM_EL,PULL_EXISTS]

--- a/examples/formal-languages/regular/regularScript.sml
+++ b/examples/formal-languages/regular/regularScript.sml
@@ -897,6 +897,7 @@ Proof
       ‘LENGTH Q1 = LENGTH w + 2 ∧ LENGTH Q2 = LENGTH w + 2’ by decide_tac >>
       ‘∃qs1 q1. Q1 = SNOC q1 qs1 ∧ qs1 ≠ []’ by metis_tac[snoc2] >>
       ‘∃qs2 q2. Q2 = SNOC q2 qs2 ∧ qs2 ≠ []’ by metis_tac[snoc2] >> fs[] >>
+      ONCE_REWRITE_TAC [CONJ_SYM] \\
       irule (METIS_PROVE [] “(b' ⇒ a=a') ∧ (a' ⇒ b=b') ∧ a' ∧ b' ⇒ a ∧ b”) >>
       qexists_tac ‘qs1 = qs2’ >> qexists_tac ‘T’ >> simp[] >> conj_tac
       >- (first_x_assum irule >> rw[LENGTH_FRONT] >> fs[GSYM SNOC_APPEND]
@@ -906,7 +907,8 @@ Proof
           >- (‘EL (n+1) (SNOC q2 qs2) ∈
                N.delta (EL n (SNOC q2 qs2)) (EL n (SNOC a w))’ by rw[] >>
                rpt(forget_tac is_forall) >> pop_assum mp_tac >> simp[EL_SNOC]))
-      >- (rw[] >> forget_tac is_neg >> forget_tac is_eq >>
+      >- (fs [SNOC_APPEND] \\
+          rw[] >> forget_tac is_neg >> forget_tac is_eq >>
           fs [GSYM SNOC_APPEND] >> ‘LENGTH w < SUC (LENGTH w)’ by decide_tac >>
           first_x_assum drule >> fs [Once BOUNDED_FORALL_THM] >>
           ‘LENGTH w + 1 = LENGTH qs1’ by decide_tac >>
@@ -914,7 +916,8 @@ Proof
           ‘EL (LENGTH w) qs1 ∈ N.Q’ by
             (irule nfa_execution_last_state >> rw[] >> fs [is_dfa_def]) >>
           fs [is_dfa_def] >>
-          ‘∃qf. N.delta (EL (LENGTH w) qs1) a = {qf}’ by metis_tac[] >> gvs[])
+          ‘∃qf. N.delta (EL (LENGTH w) qs1) a = {qf}’ by metis_tac[] >>
+          gvs[])
      )
 QED
 

--- a/examples/formal-languages/regular/regular_automataScript.sml
+++ b/examples/formal-languages/regular/regular_automataScript.sml
@@ -1279,7 +1279,7 @@ Proof
   rw[munge_def,rich_listTheory.REPLICATE_APPEND]
   >> pop_assum mp_tac
   >> map_every qid_spec_tac [‘n2’, ‘n1’, ‘xnlist2’, ‘xnlist1’]
-  >> ho_match_mp_tac SNOC_INDUCT >> rw[Excl"APPEND_ASSOC"]
+  >> ho_match_mp_tac SNOC_INDUCT >> rw[Excl"APPEND_ASSOC", SNOC_APPEND]
   >> Cases_on‘xnlist1’ >> fs[]
   >> rename [‘SOME (FST cn)’] >> Cases_on‘cn’ >>
   simp[rich_listTheory.REPLICATE_APPEND]

--- a/examples/lambda/barendregt/boehmScript.sml
+++ b/examples/lambda/barendregt/boehmScript.sml
@@ -29,8 +29,7 @@ val _ = new_theory "boehm";
 val _ = temp_delsimps [
    "lift_disj_eq", "lift_imp_disj",
    "IN_UNION",     (* |- !s t x. x IN s UNION t <=> x IN s \/ x IN t *)
-   "APPEND_ASSOC", (* |- !l1 l2 l3. l1 ++ (l2 ++ l3) = l1 ++ l2 ++ l3 *)
-   "SNOC_APPEND"   (* |- !x l. SNOC x l = l ++ [x] *)
+   "APPEND_ASSOC"  (* |- !l1 l2 l3. l1 ++ (l2 ++ l3) = l1 ++ l2 ++ l3 *)
 ];
 
 val _ = hide "B";

--- a/examples/lambda/barendregt/head_reductionScript.sml
+++ b/examples/lambda/barendregt/head_reductionScript.sml
@@ -2184,7 +2184,7 @@ Proof
  >> Know ‘fm ' M = VAR y @* MAP VAR Y’
  >- (simp [Abbr ‘M’, ssub_appstar] \\
      Know ‘fm ' z = VAR y’
-     >- (‘z = EL n Z'’ by simp [Abbr ‘Z'’, EL_APPEND2] >> POP_ORW \\
+     >- (‘z = EL n Z'’ by simp [Abbr ‘Z'’, SNOC_APPEND, EL_APPEND2] >> POP_ORW \\
          simp [Abbr ‘fm’, LAST_EL] \\
          qabbrev_tac ‘Y' = SNOC y Y’ \\
          Know ‘fromPairs Z' (MAP VAR Y') ' (EL n Z') = EL n (MAP VAR Y')’
@@ -2200,7 +2200,7 @@ Proof
     ‘MEM (EL i Z) Z'’ by rw [EL_MEM, Abbr ‘Z'’] \\
      rw [Abbr ‘fm’] \\
      Know ‘EL i Z = EL i Z'’
-     >- (simp [Abbr ‘Z'’, EL_APPEND1]) >> Rewr' \\
+     >- (simp [Abbr ‘Z'’, SNOC_APPEND, EL_APPEND1]) >> Rewr' \\
      qabbrev_tac ‘Y' = SNOC y Y’ \\
      Know ‘EL i Y = EL i Y'’
      >- (SIMP_TAC std_ss [Once EQ_SYM_EQ, Abbr ‘Y'’] \\
@@ -2357,7 +2357,7 @@ Proof
  >> ‘DISJOINT (set L') X’ by rw [Abbr ‘L'’, LIST_TO_SET_REVERSE]
  >> ‘DISJOINT (set L') (BIGUNION (IMAGE FV (set Ns)))’
       by ASM_SIMP_TAC std_ss [Abbr ‘L'’, LIST_TO_SET_REVERSE]
- >> ‘SNOC y xs = REVERSE l’ by rw [Abbr ‘l’, REVERSE_SNOC] >> POP_ORW
+ >> ‘SNOC y xs = REVERSE l’ by rw [Abbr ‘l’, REVERSE_SNOC, SNOC_APPEND] >> POP_ORW
  >> simp []
  >> CONJ_TAC (* ALL_DISTINCT l *)
  >- (MATCH_MP_TAC IS_PREFIX_ALL_DISTINCT \\

--- a/examples/lambda/barendregt/lameta_completeScript.sml
+++ b/examples/lambda/barendregt/lameta_completeScript.sml
@@ -31,8 +31,7 @@ val _ = new_theory "lameta_complete";
 val _ = temp_delsimps [
    "lift_disj_eq", "lift_imp_disj",
    "IN_UNION",     (* |- !s t x. x IN s UNION t <=> x IN s \/ x IN t *)
-   "APPEND_ASSOC", (* |- !l1 l2 l3. l1 ++ (l2 ++ l3) = l1 ++ l2 ++ l3 *)
-   "SNOC_APPEND"   (* |- !x l. SNOC x l = l ++ [x] *)
+   "APPEND_ASSOC"  (* |- !l1 l2 l3. l1 ++ (l2 ++ l3) = l1 ++ l2 ++ l3 *)
 ];
 
 val _ = hide "B";

--- a/examples/lambda/barendregt/normal_orderScript.sml
+++ b/examples/lambda/barendregt/normal_orderScript.sml
@@ -897,7 +897,7 @@ Theorem norm_varhead0[local]:
 Proof
   HO_MATCH_MP_TAC normorder_strong_ind >>
   rw[lam_eq_appstar, app_eq_appstar_SNOC] >>
-  gvs[]
+  gvs[listTheory.SNOC_APPEND]
   >- (REWRITE_TAC [GSYM listTheory.APPEND_ASSOC] >>
       rpt $ irule_at Any EQ_REFL >> simp[]) >>
   first_assum $ irule_at (Pat ‘_ -n-> _’) >>

--- a/examples/lambda/barendregt/semi_sensibleScript.sml
+++ b/examples/lambda/barendregt/semi_sensibleScript.sml
@@ -17,8 +17,7 @@ open termTheory chap2Theory chap3Theory chap4Theory horeductionTheory
 val _ = temp_delsimps [
    "lift_disj_eq", "lift_imp_disj",
    "IN_UNION",     (* |- !s t x. x IN s UNION t <=> x IN s \/ x IN t *)
-   "APPEND_ASSOC", (* |- !l1 l2 l3. l1 ++ (l2 ++ l3) = l1 ++ l2 ++ l3 *)
-   "SNOC_APPEND"   (* |- !x l. SNOC x l = l ++ [x] *)
+   "APPEND_ASSOC"  (* |- !l1 l2 l3. l1 ++ (l2 ++ l3) = l1 ++ l2 ++ l3 *)
 ];
 
 val _ = hide "B";

--- a/examples/lambda/barendregt/takahashiS3Script.sml
+++ b/examples/lambda/barendregt/takahashiS3Script.sml
@@ -555,7 +555,7 @@ Theorem is_abs_eapp:
   is_abs (eapp M its) ⇔
   (∃p i t. its = p ++ [(i,t)] ∧ 0 < i) ∨ is_abs M ∧ its = []
 Proof
-  Cases_on ‘its’ using SNOC_CASES >> simp[] >>
+  Cases_on ‘its’ using SNOC_CASES >> simp[SNOC_APPEND] >>
   Cases_on ‘x’ >> simp[]
 QED
 
@@ -715,7 +715,7 @@ Proof
       gvs[LIST_REL_EL_EQN, MEM_EL] >> metis_tac[peta_FV]) >~
   [‘LAM u (LAMl vs _) = LAM w (M @@ VAR w)’]
   >- (gvs[LAM_eq_thm, app_eq_appstar_SNOC, FV_appstar, appstar_peta] >>
-      simp[DISJ_IMP_THM, FORALL_AND_THM]
+      simp[DISJ_IMP_THM, FORALL_AND_THM, SNOC_APPEND]
       >- metis_tac[] >>
       gvs[tpm_eqr, tpm_fresh, appstar_peta, FV_appstar] >> metis_tac[]) >~
   [‘u::vs = pvs ++ [w]’]

--- a/examples/logic/ltl/concrGBArepScript.sml
+++ b/examples/logic/ltl/concrGBArepScript.sml
@@ -29,9 +29,8 @@ val gba_trans_concr_def = Define`
   gba_trans_concr ts_lists =
                 FOLDR d_conj_concr [(concrEdge [] [] [])] ts_lists `;
 
-val GBA_TRANS_LEMM1 = store_thm
-  ("GBA_TRANS_LEMM1",
-   ``!x s. MEM x (gba_trans_concr s)
+Theorem GBA_TRANS_LEMM1 :
+    !x s. MEM x (gba_trans_concr s)
         ==> ((!l. MEM l s
                  ==> (?cE. MEM cE l
                    ∧ (MEM_SUBSET cE.pos x.pos)
@@ -50,135 +49,118 @@ val GBA_TRANS_LEMM1 = store_thm
                 ∧ (!q i. MEM (q,i) s_with_ind
                        ==> MEM (f (q,i)) q))
         ∧ (ALL_DISTINCT x.pos ∧ ALL_DISTINCT x.neg
-           ∧ ALL_DISTINCT x.sucs))``,
+           ∧ ALL_DISTINCT x.sucs))
+Proof
    Q.HO_MATCH_ABBREV_TAC
     `!x s. MEM x (gba_trans_concr s) ==> A x s ∧ B x s`
-   >> `!x s. MEM x (gba_trans_concr s) ==> A x s ∧ (A x s ==> B x s)`
+ >> `!x s. MEM x (gba_trans_concr s) ==> A x s ∧ (A x s ==> B x s)`
       suffices_by fs[]
-   >> qunabbrev_tac `A` >> qunabbrev_tac `B`
-   >> Induct_on `s` >> fs[gba_trans_concr_def] >> rpt strip_tac
-   >- (fs[cE_equiv_def,MEM_EQUAL_def,MEM_SUBSET_def])
-   >- (fs[cE_equiv_def,MEM_EQUAL_def,MEM_SUBSET_def]
-       >> fs[d_conj_concr_def,FOLDR_LEMM4] >> qexists_tac `e1` >> simp[]
-       >> metis_tac[MEM_SUBSET_APPEND,nub_set,MEM_SUBSET_SET_TO_LIST]
-      )
-   >- (fs[cE_equiv_def,MEM_EQUAL_def,MEM_SUBSET_def]
-       >> fs[d_conj_concr_def,FOLDR_LEMM4]
-       >> `∃cE.
-            MEM cE l ∧ MEM_SUBSET cE.pos e2.pos ∧
-            MEM_SUBSET cE.neg e2.neg ∧ MEM_SUBSET cE.sucs e2.sucs`
-          by metis_tac[]
-       >> qexists_tac `cE`
-       >> metis_tac[MEM_SUBSET_APPEND,MEM_SUBSET_TRANS,nub_set,
-                    MEM_SUBSET_SET_TO_LIST]
-      )
-   >- (Cases_on `s= []` >> fs[]
-    >- (fs[d_conj_concr_def,FOLDR_CONS,MEM_MAP]
-        >> qexists_tac `
-             λ(q,i).
-               if (q,i) = (h,0) then e1 else ARB`
-        >> simp[] >> fs[d_conj_concr_def,FOLDR_CONS,MEM_MAP]
-        >> simp[cE_equiv_def,nub_set,MEM_EQUAL_SET]
-       )
-    >- (fs[d_conj_concr_def,FOLDR_LEMM4]
-       >> first_x_assum (qspec_then `e2` mp_tac) >> simp[] >> strip_tac
-       >> qabbrev_tac `s_ind = (GENLIST (λn. (EL n s,n)) (LENGTH s))`
-       >> `∃f.
-           cE_equiv e2
-               (FOLDR
+ >> qunabbrev_tac `A` >> qunabbrev_tac `B`
+ >> Induct_on `s` >> fs[gba_trans_concr_def]
+ >> rpt strip_tac (* 7 subgoals *)
+ >| [ (* goal 1 (of 7) *)
+      fs[cE_equiv_def,MEM_EQUAL_def,MEM_SUBSET_def],
+      (* goal 2 (of 7) *)
+      fs[cE_equiv_def,MEM_EQUAL_def,MEM_SUBSET_def] \\
+      fs[d_conj_concr_def,FOLDR_LEMM4] >> qexists_tac `e1` >> simp[] \\
+      metis_tac[MEM_SUBSET_APPEND,nub_set,MEM_SUBSET_SET_TO_LIST],
+      (* goal 3 (of 7) *)
+      fs[cE_equiv_def,MEM_EQUAL_def,MEM_SUBSET_def] \\
+      fs[d_conj_concr_def,FOLDR_LEMM4] \\
+     `∃cE. MEM cE l ∧ MEM_SUBSET cE.pos e2.pos ∧
+           MEM_SUBSET cE.neg e2.neg ∧ MEM_SUBSET cE.sucs e2.sucs`
+          by metis_tac[] \\
+      qexists_tac `cE` \\
+      metis_tac[MEM_SUBSET_APPEND,MEM_SUBSET_TRANS,nub_set,MEM_SUBSET_SET_TO_LIST],
+      (* goal 4 (of 7) *)
+      Cases_on `s = []` >> fs[]
+      >- (fs[d_conj_concr_def,FOLDR_CONS,MEM_MAP] \\
+          qexists_tac `λ(q,i). if (q,i) = (h,0) then e1 else ARB` \\
+          simp[] >> fs[d_conj_concr_def,FOLDR_CONS,MEM_MAP] \\
+          simp[cE_equiv_def,nub_set,MEM_EQUAL_SET]) \\
+   (* s <> [] *)
+      fs[d_conj_concr_def,FOLDR_LEMM4] \\
+      first_x_assum (qspec_then `e2` mp_tac) >> simp[] >> strip_tac \\
+      qabbrev_tac `s_ind = (GENLIST (λn. (EL n s,n)) (LENGTH s))` \\
+     `∃f. cE_equiv e2
+            (FOLDR
               (λsF e.
                  <|pos := sF.pos ⧺ e.pos; neg := sF.neg ⧺ e.neg;
                   sucs := sF.sucs ⧺ e.sucs|>) (concrEdge [] [] [])
               (MAP f s_ind))
           ∧ (!q i. MEM (q,i) s_ind ==> MEM (f (q,i)) q)
           ∧ ALL_DISTINCT e2.pos ∧ ALL_DISTINCT e2.neg
-          ∧ ALL_DISTINCT e2.sucs` by metis_tac[]
-       >> qexists_tac `
-             λ(q,i).
-              if i = 0
-              then e1
-              else f (q,i-1)` >> simp[]
-       >> fs[FOLDR_CONCR_EDGE] >> fs[nub_append] >> rpt strip_tac
-       >> fs[concrEdge_component_equality]
-       >- (qunabbrev_tac `s_ind` >> fs[]
-            >> fs[cE_equiv_def] >> rw[MEM_EQUAL_SET,LIST_TO_SET_FILTER]
-            >> (simp[SET_EQ_SUBSET,SUBSET_DEF]
-                 >> strip_tac >> fs[GENLIST]
-                 >- (rpt strip_tac
-                     >> Q.HO_MATCH_ABBREV_TAC
-                         `MEM k (FOLDR (λe pr. (g e) ⧺ pr) [] L)`
-                     >- (`MEM e1 L`
+          ∧ ALL_DISTINCT e2.sucs` by metis_tac[] \\
+      qexists_tac `λ(q,i). if i = 0 then e1 else f (q,i-1)` >> simp[] \\
+      fs[FOLDR_CONCR_EDGE] >> fs[nub_append] >> rpt strip_tac \\
+      fs[concrEdge_component_equality] (* 2 subgoals *)
+      >- (fs[Abbr ‘s_ind’, cE_equiv_def] \\
+          rw[MEM_EQUAL_SET,LIST_TO_SET_FILTER] (* 3 subgoals, same tactics *)
+          >> (simp[SET_EQ_SUBSET,SUBSET_DEF] \\
+              strip_tac >> fs[GENLIST] (* 2 subgoals *)
+              >- (rpt strip_tac \\
+                  Q.HO_MATCH_ABBREV_TAC
+                    `MEM k (FOLDR (λe pr. (g e) ⧺ pr) [] L)` (* 2 subgoals *)
+                  >- (`MEM e1 L`
                            suffices_by metis_tac[MEM_SUBSET_SET_TO_LIST,
-                                                 FOLDR_APPEND_LEMM,SUBSET_DEF]
-                         >> qunabbrev_tac `L` >> simp[MEM_MAP]
-                         >> qexists_tac `(h,0)` >> fs[EL,MEM_GENLIST]
-                         >> simp[LENGTH_NOT_NULL,NULL_EQ]
-                        )
-                     >- (`?e. MEM e L ∧ (MEM k (g e))`
-                           suffices_by metis_tac[FOLDR_LEMM6]
-                         >> qunabbrev_tac `L` >> simp[MEM_MAP] >> fs[]
-                         >> `MEM k
-                              (FOLDR (λe pr. g e ⧺ pr) []
+                                                 FOLDR_APPEND_LEMM,SUBSET_DEF] \\
+                      simp[Abbr ‘L’, MEM_MAP] \\
+                      qexists_tac `(h,0)` >> fs[EL,MEM_GENLIST] \\
+                      simp[LENGTH_NOT_NULL,NULL_EQ]) \\
+                  `?e. MEM e L ∧ (MEM k (g e))`
+                           suffices_by metis_tac[FOLDR_LEMM6] \\
+                   qunabbrev_tac `L` >> simp[MEM_MAP] >> fs[] \\
+                  `MEM k (FOLDR (λe pr. g e ⧺ pr) []
                                (MAP f (GENLIST (λn. (EL n s,n)) (LENGTH s))))`
-                             by metis_tac[MEM_EQUAL_SET]
-                          >> fs[FOLDR_LEMM6] >> qexists_tac `a` >> strip_tac
-                          >- (fs[MEM_MAP] >> qexists_tac `(FST y,SND y+1)`
-                              >> simp[] >> fs[MEM_GENLIST]
-                              >> rename [‘n + 1 = LENGTH s’,
-                                         ‘EL (LENGTH s) (h::s)’]
-                              >> Cases_on `SUC n=LENGTH s` >> fs[]
-                              >> metis_tac[EL,TL,DECIDE ``n+1 = SUC n``]
-                             )
-                          >- fs[]
-                        )
-                    )
-                 >- (rpt strip_tac >> fs[FOLDR_LEMM6,MEM_MAP]
-                  >- (rw[] >> fs[] >> Cases_on `s = []` >> fs[]
-                      >> disj2_tac >> Q.HO_MATCH_ABBREV_TAC `MEM k (g e2)`
-                      >> `MEM k
-                           (FOLDR (λe pr. g e ⧺ pr) []
+                             by metis_tac[MEM_EQUAL_SET] \\
+                   fs[FOLDR_LEMM6] >> qexists_tac `a` >> strip_tac (* 2 subgoals *)
+                   >- (fs[MEM_MAP] >> qexists_tac `(FST y,SND y+1)` \\
+                       simp[] >> fs[MEM_GENLIST] \\
+                       rename [‘n + 1 = LENGTH s’, ‘EL (LENGTH s) (h::s)’] \\
+                       Cases_on `SUC n=LENGTH s` >> fs[] \\
+                       metis_tac[EL,TL,DECIDE ``n+1 = SUC n``]) \\
+                   fs[]) \\
+           (* stage work *)
+              rpt strip_tac >> fs[FOLDR_LEMM6,MEM_MAP] (* 2 subgoals *)
+              >- (rw[] >> fs[] >> Cases_on `s = []` >> fs[] \\
+                  disj2_tac >> Q.HO_MATCH_ABBREV_TAC `MEM k (g e2)` \\
+                 `MEM k (FOLDR (λe pr. g e ⧺ pr) []
                             (MAP f (GENLIST (λn. (EL n s,n)) (LENGTH s))))`
-                         suffices_by metis_tac[MEM_EQUAL_SET]
-                      >> simp[FOLDR_LEMM6,MEM_GENLIST,MEM_MAP]
-                      >> qexists_tac `f (EL (LENGTH s) (h::s),LENGTH s − 1)`
-                      >> simp[]
-                      >> qexists_tac `(EL (LENGTH s) (h::s),LENGTH s − 1)`
-                      >> fs[] >> `0 < LENGTH s` by (Cases_on `s` >> fs[])
-                      >> rw[]
-                      >> `?n. SUC n = LENGTH s`
-                         by (Cases_on `LENGTH s` >> simp[])
-                      >> `n = LENGTH s -1` by simp[] >> metis_tac[EL,TL]
-                     )
-                  >- (fs[MEM_GENLIST] >> rw[] >> fs[]
-                      >> rename [‘MEM x (_ (if n = 0 then _ else _))’]
-                      >> Cases_on `n = 0` >> fs[] >> disj2_tac
-                      >> Q.HO_MATCH_ABBREV_TAC `MEM k (g e2)`
-                      >> `MEM k
-                           (FOLDR (λe pr. g e ⧺ pr) []
+                         suffices_by metis_tac[MEM_EQUAL_SET] \\
+                  simp[FOLDR_LEMM6,MEM_GENLIST,MEM_MAP] \\
+                  qexists_tac `f (EL (LENGTH s) (h::s),LENGTH s − 1)` >> simp[] \\
+                  qexists_tac `(EL (LENGTH s) (h::s),LENGTH s − 1)` \\
+                  fs[] >> `0 < LENGTH s` by (Cases_on `s` >> fs[]) \\
+                  rw[] \\
+                 `?n. SUC n = LENGTH s` by (Cases_on `LENGTH s` >> simp[]) \\
+                 `n = LENGTH s -1` by simp[] >> metis_tac[EL,TL]) \\
+           (* stage work *)
+              fs[MEM_GENLIST] >> rw[] >> fs[] \\
+              rename [‘MEM x (_ (if n = 0 then _ else _))’] \\
+              Cases_on `n = 0` >> fs[] >> disj2_tac \\
+              Q.HO_MATCH_ABBREV_TAC `MEM k (g e2)` \\
+             `MEM k (FOLDR (λe pr. g e ⧺ pr) []
                               (MAP f (GENLIST (λn. (EL n s,n)) (LENGTH s))))`
-                          suffices_by metis_tac[MEM_EQUAL_SET]
-                      >> simp[FOLDR_LEMM6,MEM_GENLIST,MEM_MAP]
-                      >> qexists_tac `f (EL n (h::s),n-1)`
-                      >> simp[]
-                      >> qexists_tac `(EL n (h::s),n − 1)`
-                      >> fs[] >> `0 < n` by fs[]
-                      >> `?p. SUC p = n`
-                            by (Cases_on `n` >> simp[])
-                      >> `p = n -1` by simp[] >> metis_tac[EL,TL]
-                     )
-                  )
-                  )
-              )
-       >> qunabbrev_tac `s_ind` >> fs[]
-       >> Cases_on `i=0` >> fs[MEM_GENLIST]
-       >> `?p. SUC p = i` by (Cases_on `i` >> simp[])
-       >> rw[]
-       )
-       )
-   >- (fs[d_conj_concr_def] >> fs[FOLDR_LEMM4] >> fs[all_distinct_nub])
-   >- (fs[d_conj_concr_def] >> fs[FOLDR_LEMM4] >> fs[all_distinct_nub])
-   >- (fs[d_conj_concr_def] >> fs[FOLDR_LEMM4] >> fs[all_distinct_nub])
-  );
+                          suffices_by metis_tac[MEM_EQUAL_SET] \\
+              simp[FOLDR_LEMM6,MEM_GENLIST,MEM_MAP] \\
+              qexists_tac `f (EL n (h::s),n-1)` >> simp[] \\
+              qexists_tac `(EL n (h::s),n − 1)` >> fs [] \\
+             `0 < n` by fs[] \\
+             `?p. SUC p = n` by (Cases_on `n` >> simp[]) \\
+             `p = n - 1` by simp[] >> metis_tac[EL,TL]
+             ) (* end of shared tactics (for 3 subgoals) *)
+         ) (* end of subgoal *) \\
+      fs[Abbr ‘s_ind’] \\
+      Cases_on `i=0` >> fs[MEM_GENLIST] \\
+     `?p. SUC p = i` by (Cases_on `i` >> simp[]) \\
+      rw[],
+      (* goal 5 (of 7) *)
+      fs[d_conj_concr_def] >> fs[FOLDR_LEMM4] >> fs[all_distinct_nub],
+      (* goal 6 (of 7) *)
+      fs[d_conj_concr_def] >> fs[FOLDR_LEMM4] >> fs[all_distinct_nub],
+      (* goal 7 (of 7) *)
+      fs[d_conj_concr_def] >> fs[FOLDR_LEMM4] >> fs[all_distinct_nub] ]
+QED
 
 val GBA_TRANS_LEMM2 = store_thm
   ("GBA_TRANS_LEMM2",

--- a/examples/logic/ltl/concrRepScript.sml
+++ b/examples/logic/ltl/concrRepScript.sml
@@ -1947,6 +1947,8 @@ val ADDEDGE_FINAL_LEMM = store_thm
 
 val _ = set_trace "BasicProvers.var_eq_old" 1
 val _ = diminish_srw_ss ["ABBREV"]
+val _ = augment_srw_ss [rewrites [SNOC_APPEND]]
+
 Theorem ADDEDGE_LEMM:
    !g f e aP. wfg g ∧ MEM f (graphStates g)
             ∧ unique_node_formula g

--- a/examples/logic/modal-models/chap2_1Script.sml
+++ b/examples/logic/modal-models/chap2_1Script.sml
@@ -398,14 +398,11 @@ val prop_2_15_subgoal_1 = store_thm(
               >- fs[LENGTH]
               >- fs[HD])
            >- (fs[RESTRICT_def] >> rw[] (* 3 *)
-              >- (`w ++ [v'] = SNOC v' w` by fs[] >>
-                 `EL m (w ++ [v']) = EL m w` by rw[EL_SNOC] >>
-                 fs[] >>
+              >- (`EL m (w ++ [v']) = EL m w` by rw[EL_APPEND1] >>
                  Cases_on `m < LENGTH w - 1` (* 2 *)
                  >- (`m + 1 < LENGTH w` by fs[] >>
-                    `w ++ [v'] = SNOC v' w` by fs[] >>
-                    `EL (m + 1) (w ++ [v']) = EL (m + 1) w` by rw[EL_SNOC] >>
-                    fs[])
+                     `EL (m + 1) (w ++ [v']) = EL (m + 1) w` by rw[EL_APPEND1] >>
+                     fs[])
                  >- (`m = LENGTH w - 1` by fs[] >>
                     `LENGTH w <> 0` by (SPOSE_NOT_THEN ASSUME_TAC >> fs[]) >>
                     `w <> []` by fs[] >>
@@ -422,10 +419,8 @@ val prop_2_15_subgoal_1 = store_thm(
                     `EL m w = LAST w` by fs[] >>
                     `EL (m + 1) (w ++ [v']) = v'` by fs[] >> fs[]))
               >- (Cases_on `m < LENGTH w - 1` (* 2 *)
-                 >- (`SNOC v' w = w ++ [v']` by fs[] >>
-                    `EL m (w ++ [v']) = EL m w` by metis_tac[EL_SNOC] >> fs[])
-                 >- (`SNOC v' w = w ++ [v']` by fs[] >>
-                    `EL m (w ++ [v']) = EL m w` by metis_tac[EL_SNOC] >> fs[] >>
+                 >- (`EL m (w ++ [v']) = EL m w` by rw [EL_APPEND1] >> fs[])
+                 >- (`EL m (w ++ [v']) = EL m w` by rw[EL_APPEND1] >> fs[] >>
                     Cases_on `LENGTH w = 1`
                     >- (`m = 0` by fs[] >>
                        `EL m w = HD w` by fs[] >>
@@ -437,13 +432,11 @@ val prop_2_15_subgoal_1 = store_thm(
                        `LENGTH w - 2 + 1 = LENGTH w - 1` by fs[] >> fs[])))
               >- (Cases_on `m < LENGTH w - 2` (* 2 *)
                  >- (`m + 1 < LENGTH (w ++ [v'])` by fs[] >>
-                    `w ++ [v'] = SNOC v' w` by fs[] >>
-                    `EL (m + 1) (w ++ [v']) = EL (m + 1) w` by rw[EL_SNOC] >>
+                    `EL (m + 1) (w ++ [v']) = EL (m + 1) w` by rw[EL_APPEND1] >>
                     `m < LENGTH w - 1` by fs[] >> fs[])
                  >- (Cases_on `m < LENGTH w - 1` (* 2 *)
                     >- (`m + 1 < LENGTH w` by fs[] >>
-                       `w ++ [v'] = SNOC v' w` by fs[] >>
-                       `EL (m + 1) (w ⧺ [v']) = EL (m + 1) w` by rw[EL_SNOC] >>
+                       `EL (m + 1) (w ⧺ [v']) = EL (m + 1) w` by rw[EL_APPEND1] >>
                        fs[])
                     >- (`m = LENGTH w - 1` by fs[] >>
                        `m + 1 = LENGTH w` by fs[] >>
@@ -467,7 +460,7 @@ val prop_2_15_subgoal_1 = store_thm(
                  `w <> []`
                      by (SPOSE_NOT_THEN ASSUME_TAC >> fs[LENGTH]) >>
                  rw[LAST_EL] >> metis_tac[]))
-            >- (`w ++ [v'] = SNOC v' w` by fs[] >> metis_tac[EL_SNOC]))));
+            >- (rw [EL_APPEND1]))));
 
 
 val LAST_in_world = store_thm(
@@ -517,14 +510,12 @@ val prop_2_15_subgoal_2 = store_thm(
                  RESTRICT M.frame.rel M.frame.world (EL m y)
                    (EL (m + 1) y)` by fs[bounded_preimage_rooted_def] >>
               Cases_on `m < LENGTH y - 1`
-              >- (`y ++ [a'] = SNOC a' y` by fs[] >>
-                 `EL m (y ++ [a']) = EL m y` by rw[EL_SNOC] >>
+              >- (`EL m (y ++ [a']) = EL m y` by rw[EL_APPEND1] >>
                  `m + 1 < LENGTH y` by fs[] >>
-                 `EL (m + 1) (y ++ [a']) = EL (m + 1) y` by rw[EL_SNOC] >>
+                 `EL (m + 1) (y ++ [a']) = EL (m + 1) y` by rw[EL_APPEND1] >>
                  metis_tac[])
               >- (`m = LENGTH y - 1` by fs[] >>
-                 `y ++ [a'] = SNOC a' y` by fs[] >>
-                 `EL m (y ++ [a']) = EL m y` by rw[EL_SNOC] >>
+                 `EL m (y ++ [a']) = EL m y` by rw[EL_APPEND1] >>
                  `y <> []` by (SPOSE_NOT_THEN ASSUME_TAC >> fs[bounded_preimage_rooted_def]) >>
                  `LAST y = EL (PRE (LENGTH y)) y` by rw[LAST_EL] >>
                  `PRE (LENGTH y) = m` by fs[] >>
@@ -595,17 +586,17 @@ val prop_2_15_subgoal_4 = store_thm(
            `LENGTH l - 1 < LENGTH l` by fs[] >>
            `EL (LENGTH l - 1) (SNOC x' l) = LAST l /\
            EL ((LENGTH l - 1) + 1) (SNOC x' l) = x'` suffices_by metis_tac[] >> rw[] (* 2 *)
-           >- (`SNOC x' l = l ++ [x']` by fs[] >>
+           >- (`SNOC x' l = l ++ [x']` by fs[SNOC_APPEND] >>
               `EL (LENGTH l − 1) (SNOC x' l) = EL (LENGTH l − 1) l` by rw[EL_APPEND1] >>
               `l <> []` by (SPOSE_NOT_THEN ASSUME_TAC >> fs[]) >>
               `PRE (LENGTH l) = LENGTH l - 1` by fs[] >>
               `EL (LENGTH l - 1) l = LAST l` by rw[LAST_EL] >> fs[])
-           >-  (`SNOC x' l = l ++ [x']` by fs[] >>
+           >-  (`SNOC x' l = l ++ [x']` by fs[SNOC_APPEND] >>
                `PRE (LENGTH (l ++ [x'])) = LENGTH l` by fs[] >>
                `l ++ [x'] <> []` by fs[] >>
                `EL (LENGTH l) (l ++ [x']) = LAST (l ++ [x'])` by metis_tac[LAST_EL] >>
                `LAST (l ++ [x']) = x'` by fs[] >> metis_tac[]))
-        >- (`SNOC x' l = l ++ [x']` by fs[] >> metis_tac[EL_APPEND1]))
+        >- (`SNOC x' l = l ++ [x']` by fs[SNOC_APPEND] >> metis_tac[EL_APPEND1]))
      >- (`LENGTH t > 0` by fs[bounded_preimage_rooted_def] >>
         `LENGTH t <= 1` by (SPOSE_NOT_THEN ASSUME_TAC >> fs[]) >>
         `LENGTH t <> 0` by fs[] >>
@@ -637,17 +628,17 @@ val FRONT_rel = store_thm(
      `LENGTH l - 1 < LENGTH l` by fs[] >>
      `EL (LENGTH l - 1) (SNOC x' l) = LAST l /\
      EL ((LENGTH l - 1) + 1) (SNOC x' l) = x'` suffices_by metis_tac[] >> rw[] (* 2 *)
-     >- (`SNOC x' l = l ++ [x']` by fs[] >>
+     >- (`SNOC x' l = l ++ [x']` by fs[SNOC_APPEND] >>
         `EL (LENGTH l − 1) (SNOC x' l) = EL (LENGTH l − 1) l` by rw[EL_APPEND1] >>
         `l <> []` by (SPOSE_NOT_THEN ASSUME_TAC >> fs[]) >>
         `PRE (LENGTH l) = LENGTH l - 1` by fs[] >>
         `EL (LENGTH l - 1) l = LAST l` by rw[LAST_EL] >> fs[])
-     >-  (`SNOC x' l = l ++ [x']` by fs[] >>
+     >-  (`SNOC x' l = l ++ [x']` by fs[SNOC_APPEND] >>
          `PRE (LENGTH (l ++ [x'])) = LENGTH l` by fs[] >>
          `l ++ [x'] <> []` by fs[] >>
          `EL (LENGTH l) (l ++ [x']) = LAST (l ++ [x'])` by metis_tac[LAST_EL] >>
          `LAST (l ++ [x']) = x'` by fs[] >> metis_tac[]))
-  >- (`SNOC x' l = l ++ [x']` by fs[] >> metis_tac[EL_APPEND1]));
+  >- (`SNOC x' l = l ++ [x']` by fs[SNOC_APPEND] >> metis_tac[EL_APPEND1]));
 
 
 
@@ -771,9 +762,6 @@ val point_GENSUBMODEL_satis = store_thm(
   `w IN (point_GENSUBMODEL M w).frame.world` by fs[point_GENSUBMODEL_def] >>
   metis_tac[prop_2_6]);
 
-
-
-
 val prop_2_15_corollary = store_thm(
   "prop_2_15_corollary",
   ``!M (w:'b) form. satis M w form ==>
@@ -786,10 +774,5 @@ val prop_2_15_corollary = store_thm(
   qexists_tac `MODEL` >> rw[] >> qexists_tac `s` >> rw[] >>
   fs[bounded_mor_image_def] >>
   `s IN MODEL.frame.world` by metis_tac[tree_def] >> metis_tac[prop_2_14]);
-
-
-
-
-
 
 val _ = export_theory();

--- a/examples/machine-code/instruction-set-models/x86_64/prog_x64_extraScript.sml
+++ b/examples/machine-code/instruction-set-models/x86_64/prog_x64_extraScript.sml
@@ -742,7 +742,7 @@ val stack_ok_EL = store_thm("stack_ok_EL",
 val LENGTH_LESS_REV = prove(
   ``!xs m. m < LENGTH xs ==> ?ys z zs. (xs = ys ++ z::zs) /\ (LENGTH zs = m)``,
   recInduct SNOC_INDUCT \\ SIMP_TAC std_ss [LENGTH,LENGTH_SNOC]
-  \\ SIMP_TAC (srw_ss()) [] \\ REPEAT STRIP_TAC
+  \\ SIMP_TAC (srw_ss()) [SNOC_APPEND] \\ REPEAT STRIP_TAC
   \\ Cases_on `m` \\ FULL_SIMP_TAC std_ss [LENGTH_NIL,APPEND,CONS_11,APPEND_NIL]
   THEN1 (METIS_TAC []) \\ RES_TAC \\ Q.LIST_EXISTS_TAC [`ys`,`z`,`zs ++ [x]`]
   \\ FULL_SIMP_TAC std_ss [APPEND,LENGTH,GSYM APPEND_ASSOC,LENGTH_APPEND,ADD1]);

--- a/examples/machine-code/multiword/mc_multiwordScript.sml
+++ b/examples/machine-code/multiword/mc_multiwordScript.sml
@@ -6,7 +6,7 @@ local open mc_tailrecLib blastLib intLib in end
 
 val _ = new_theory "mc_multiword";
 val _ = ParseExtras.temp_loose_equality()
-val _ = temp_delsimps ["NORMEQ_CONV"]
+val _ = temp_delsimps ["NORMEQ_CONV", "TAKE1_DROP"];
 
 val REV = Tactical.REVERSE;
 
@@ -460,7 +460,7 @@ val mc_add_loop1_thm = prove(
   \\ FULL_SIMP_TAC (srw_ss()) [LENGTH_SNOC,ADD1,AC ADD_COMM ADD_ASSOC,mw_add_def,
        LET_DEF,single_add_def,b2n_thm]
   \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV)
-  \\ FULL_SIMP_TAC (srw_ss()) [b2w_def] \\ DECIDE_TAC);
+  \\ FULL_SIMP_TAC (srw_ss()) [b2w_def, SNOC_APPEND] \\ DECIDE_TAC);
 
 val mc_add_loop2_thm = prove(
   ``!(xs:'a word list) zs xs1 zs1 xs2 zs2 r8 c l.
@@ -507,7 +507,7 @@ val mc_add_loop2_thm = prove(
   \\ FULL_SIMP_TAC (srw_ss()) [LENGTH_SNOC,ADD1,AC ADD_COMM ADD_ASSOC,mw_add_def,
        LET_DEF,single_add_def,b2n_thm]
   \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV)
-  \\ FULL_SIMP_TAC (srw_ss()) [b2w_def]
+  \\ FULL_SIMP_TAC (srw_ss()) [b2w_def, SNOC_APPEND]
   \\ DECIDE_TAC)
 
 val mc_add_thm = prove(
@@ -781,7 +781,7 @@ val mc_sub_loop1_thm = prove(
   \\ FULL_SIMP_TAC (srw_ss()) [LENGTH_SNOC,ADD1,AC ADD_COMM ADD_ASSOC,mw_sub_def,
        LET_DEF,single_sub_def,b2n_thm,single_add_def]
   \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV)
-  \\ FULL_SIMP_TAC (srw_ss()) [b2w_def]
+  \\ FULL_SIMP_TAC (srw_ss()) [b2w_def, SNOC_APPEND]
   \\ DECIDE_TAC);
 
 val mc_sub_loop2_thm = prove(
@@ -827,7 +827,7 @@ val mc_sub_loop2_thm = prove(
   \\ FULL_SIMP_TAC (srw_ss()) [LENGTH_SNOC,ADD1,AC ADD_COMM ADD_ASSOC,mw_sub_def,
        LET_DEF,single_add_def,b2n_thm,single_sub_def]
   \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV)
-  \\ FULL_SIMP_TAC (srw_ss()) [b2w_def] \\ DECIDE_TAC);
+  \\ FULL_SIMP_TAC (srw_ss()) [b2w_def, SNOC_APPEND] \\ DECIDE_TAC);
 
 val mc_sub_thm = prove(
   ``!(xs:'a word list) ys zs zs2 l.
@@ -2488,7 +2488,7 @@ val mc_div_loop_thm = prove(
     \\ FULL_SIMP_TAC std_ss [rich_listTheory.EL_APPEND2,DECIDE ``n <= n + m:num``,
          GSYM APPEND_ASSOC,rich_listTheory.EL_APPEND1]
     \\ `(x::zs = []) \/ ?t1 t2. x::zs = SNOC t1 t2` by METIS_TAC [SNOC_CASES]
-    \\ FULL_SIMP_TAC (srw_ss()) [ADD1]
+    \\ FULL_SIMP_TAC (srw_ss()) [ADD1, SNOC_APPEND]
     \\ `LENGTH ys = LENGTH t2` by
      (`LENGTH (x::zs) = LENGTH (t2 ++ [t1])` by METIS_TAC []
       \\ FULL_SIMP_TAC std_ss [LENGTH_APPEND,LENGTH,ADD1])
@@ -3502,7 +3502,7 @@ val mc_div_sub_aux_thm = prove(
   \\ FULL_SIMP_TAC (srw_ss()) [LENGTH_SNOC,ADD1,AC ADD_COMM ADD_ASSOC,mw_sub_def,
        LET_DEF,single_sub_def,b2n_thm,single_add_def]
   \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV)
-  \\ FULL_SIMP_TAC (srw_ss()) [b2w_def]
+  \\ FULL_SIMP_TAC (srw_ss()) [b2w_def, SNOC_APPEND]
   \\ `(dimword(:'a) <= b2n ~c + (w2n h' + w2n (~h))) =
       ~(w2n h' < b2n c + w2n h)` by METIS_TAC [sub_borrow_lemma]
   \\ fs [])

--- a/examples/machine-code/multiword/multiwordScript.sml
+++ b/examples/machine-code/multiword/multiwordScript.sml
@@ -15,6 +15,7 @@ val RW = REWRITE_RULE;
 val RW1 = ONCE_REWRITE_RULE;
 val REV = Tactical.REVERSE;
 
+val _ = temp_delsimps ["TAKE1_DROP"];
 
 (* general *)
 
@@ -2369,21 +2370,21 @@ val tac_div_loop_test =
        FULL_SIMP_TAC std_ss[HD,TL,LENGTH] >>
        METIS_TAC[mw_div_test_thm];
 
-val mw_div_loop_thm = store_thm( "mw_div_loop_thm",
-``!(zs:'a word list) (ys:'a word list).
+Theorem mw_div_loop_thm :
+    !(zs:'a word list) (ys:'a word list).
   dimword(:'a) DIV 2 <= w2n (HD ys) /\
   LENGTH ys < LENGTH zs /\ 1 < LENGTH ys /\
   ((mw2n (REVERSE (TAKE (SUC (LENGTH ys)) zs)) DIV mw2n (REVERSE ys)) < dimword(:'a) ) ==>
   (let rslt = mw_div_loop zs ys in
    mw2n (REVERSE( BUTLASTN (LENGTH ys) rslt)) * mw2n (REVERSE ys) + mw2n (REVERSE (LASTN (LENGTH ys) rslt)) =
-   mw2n (REVERSE zs))``,
-
+   mw2n (REVERSE zs))
+Proof
   HO_MATCH_MP_TAC mw_div_loop_ind >> REPEAT strip_tac >>
   srw_tac[][Once mw_div_loop_def] >>
   markerLib.UNABBREV_TAC "rslt" >>
   Cases_on `mw_cmp (REVERSE us) q2ys = SOME T` >>
   srw_tac[][]
-
+ (* 2 subgoals here *)
 THENL[qpat_x_assum `!us. xxx` (K ALL_TAC) >>
       qpat_x_assum `!us. xxx` (fn x => ASSUME_TAC (Q.SPECL [`us`,`q`,`q2`,`q2ys`,`q3`,`q3ys`,`zs2'`] x)),
       qpat_x_assum `!us. xxx` (fn x => ASSUME_TAC (Q.SPECL [`us`,`q`,`q2`,`q2ys`,`zs2`] x)) >>
@@ -2407,6 +2408,7 @@ Q.PAT_ABBREV_TAC `zs2 = (REVERSE (FRONT w) ++ DROP (SUC (LENGTH ys)) zs)` >>
          `0 < dimword(:'a) DIV 2` by METIS_TAC[TWO,DIV_GT0,DECIDE``0<2``,TWO,LESS_EQ,ONE_LT_dimword] >>
          METIS_TAC[LESS_LESS_EQ_TRANS,ZERO_LT_EXP,ZERO_LT_dimword,LESS_EQ_ADD,ZERO_LESS_MULT,ADD_COMM]) >>
 sg `w2n q3 = mw2n (REVERSE us) DIV mw2n (REVERSE ys)`
+ (* 4 subgoals here *)
 THENL[`(w2n q2 = mw2n (REVERSE us) DIV mw2n (REVERSE ys)) \/(w2n q2 = SUC (mw2n (REVERSE us) DIV mw2n (REVERSE ys)))` by tac_div_loop_test
        THEN1(`mw2n (REVERSE us) < mw2n (mw_mul_by_single q2 (REVERSE ys))` by FULL_SIMP_TAC std_ss[ADD1,LENGTH,LENGTH_REVERSE,mw_mul_by_single_lemma,mw_cmp_thm] >>
             POP_ASSUM (fn x => ASSUME_TAC (RW[mw_mul_by_single_lemma] x)) >>
@@ -2422,6 +2424,7 @@ THENL[`(w2n q2 = mw2n (REVERSE us) DIV mw2n (REVERSE ys)) \/(w2n q2 = SUC (mw2n 
       qpat_x_assum `w2n q3 = xxx` (fn x => FULL_SIMP_TAC std_ss [x]) >>
       METIS_TAC[X_LE_DIV,NOT_LESS,DECIDE ``z < SUC z``],
       ALL_TAC] >>
+ (* 2 subgoals here *)
 `w <> [] /\ (LENGTH w = SUC(LENGTH ys))` by METIS_TAC[mw_sub_lemma,PAIR,LENGTH_REVERSE,NOT_NIL_EQ_LENGTH_NOT_0] >>
 `LENGTH zs = SUC (LENGTH zs2)` by (
       markerLib.UNABBREV_TAC "zs2" >>
@@ -2441,7 +2444,9 @@ THENL[`(w2n q2 = mw2n (REVERSE us) DIV mw2n (REVERSE ys)) \/(w2n q2 = SUC (mw2n 
                 METIS_TAC[DIV_thm4,LESS_TRANS,mw2n_lt,dimwords_dimword,LENGTH_REVERSE]) >>
        METIS_TAC[mw2n_msf_NIL,dimwords_dimword]) >>
 Cases_on `LENGTH ys < LENGTH zs2`
-THENL[tac_div_loop_1,tac_div_loop_2,tac_div_loop_1,tac_div_loop_2]);
+ (* 4 subgoals here *)
+THENL[tac_div_loop_1,tac_div_loop_2,tac_div_loop_1,tac_div_loop_2]
+QED
 
 val tac_div_loop_bis_1 =
     `0 < LENGTH zs2` by DECIDE_TAC >>
@@ -3067,7 +3072,8 @@ val num_to_dec_string_unroll = prove(
           SNOC (CHR (48 + n MOD 10))
                (if n < 10 then [] else num_to_dec_string (n DIV 10))``,
   SIMP_TAC std_ss [num_to_dec_string_def,n2s_def]
-  \\ SIMP_TAC std_ss [Once numposrepTheory.n2l_def] \\ SRW_TAC [] []
+  \\ SIMP_TAC std_ss [Once numposrepTheory.n2l_def]
+  \\ SRW_TAC [] [SNOC_APPEND]
   THEN1 (Cases_on `(n=0) \/ (n=1) \/ (n=2) \/ (n=3) \/ (n=4) \/
                    (n=5) \/ (n=6) \/ (n=7) \/ (n=8) \/ (n=9)`
          \\ FULL_SIMP_TAC std_ss [] \\ EVAL_TAC \\ `F` by DECIDE_TAC)
@@ -3144,7 +3150,7 @@ val mw_to_dec_thm = store_thm("mw_to_dec_thm",
     \\ FULL_SIMP_TAC std_ss [mw2n_mw_fix])
   \\ FULL_SIMP_TAC std_ss []
   \\ Cases_on `x2` \\ FULL_SIMP_TAC std_ss [mw2n_mw_fix]
-  \\ FULL_SIMP_TAC (srw_ss()) [word_add_n2w]
+  \\ FULL_SIMP_TAC (srw_ss()) [word_add_n2w, SNOC_APPEND]
   \\ `k MOD 10 < 10` by FULL_SIMP_TAC (srw_ss()) []
   \\ `48 + k MOD 10 < 256` by DECIDE_TAC
   \\ FULL_SIMP_TAC (srw_ss()) []

--- a/examples/theorem-prover/lisp-runtime/bytecode/lisp_compilerScript.sml
+++ b/examples/theorem-prover/lisp-runtime/bytecode/lisp_compilerScript.sml
@@ -1245,7 +1245,7 @@ val n_times_iCONST = prove(
 val MAP_EQ_GENLIST = prove(
   ``!xs. MAP (\x.b) xs = GENLIST (\x.b) (LENGTH xs)``,
   HO_MATCH_MP_TAC rich_listTheory.SNOC_INDUCT
-  \\ SRW_TAC [] [] \\ ASM_SIMP_TAC std_ss []
+  \\ SRW_TAC [] [SNOC_APPEND] \\ ASM_SIMP_TAC std_ss []
   \\ SIMP_TAC std_ss [GENLIST,GSYM ADD1,SNOC_APPEND]);
 
 val MAP_CONST_REVERSE = prove(

--- a/examples/theorem-prover/lisp-runtime/implementation/lisp_bigopsScript.sml
+++ b/examples/theorem-prover/lisp-runtime/implementation/lisp_bigopsScript.sml
@@ -1,5 +1,5 @@
-open HolKernel Parse boolLib bossLib; val _ = new_theory "lisp_bigops";
-val _ = ParseExtras.temp_loose_equality()
+open HolKernel Parse boolLib bossLib;
+
 open lisp_codegenTheory lisp_initTheory lisp_symbolsTheory lisp_sexpTheory
 open lisp_invTheory lisp_parseTheory lisp_opsTheory;
 
@@ -20,6 +20,10 @@ val _ = let
 
 val RW = REWRITE_RULE;
 val RW1 = ONCE_REWRITE_RULE;
+
+val _ = new_theory "lisp_bigops";
+val _ = ParseExtras.temp_loose_equality()
+val _ = augment_srw_ss [rewrites [SNOC_APPEND]];
 
 (*
 val _ = set_echo 3;

--- a/src/algebra/base/combinatoricsScript.sml
+++ b/src/algebra/base/combinatoricsScript.sml
@@ -8305,33 +8305,45 @@ val leibniz_zigzag_tail = store_thm(
            = x ++ [tb; tc] ++ y
    Therefore p1 zigzag p2                           by leibniz_zigzag_def
 *)
-val leibniz_horizontal_zigzag = store_thm(
-  "leibniz_horizontal_zigzag",
-  ``!n k. k <= n ==> TAKE (k + 1) (leibniz_horizontal (n + 1)) ++ DROP k (leibniz_horizontal n) zigzag
-                    TAKE (k + 2) (leibniz_horizontal (n + 1)) ++ DROP (k + 1) (leibniz_horizontal n)``,
+Theorem leibniz_horizontal_zigzag :
+    !n k. k <= n ==>
+          TAKE (k + 1) (leibniz_horizontal (n + 1)) ++
+          DROP k (leibniz_horizontal n)
+        zigzag
+          TAKE (k + 2) (leibniz_horizontal (n + 1)) ++
+          DROP (k + 1) (leibniz_horizontal n)
+Proof
   rpt strip_tac >>
   qabbrev_tac `x = TAKE k (leibniz_horizontal (n + 1))` >>
   qabbrev_tac `y = DROP (k + 1) (leibniz_horizontal n)` >>
   `k <= n + 1` by decide_tac >>
-  `EL k (leibniz_horizontal n) = ta` by rw_tac std_ss[triplet_def, leibniz_horizontal_el] >>
-  `EL k (leibniz_horizontal (n + 1)) = tb` by rw_tac std_ss[triplet_def, leibniz_horizontal_el] >>
-  `EL (k + 1) (leibniz_horizontal (n + 1)) = tc` by rw_tac std_ss[triplet_def, leibniz_horizontal_el] >>
+  `EL k (leibniz_horizontal n) = ta`
+     by rw_tac std_ss[triplet_def, leibniz_horizontal_el] >>
+  `EL k (leibniz_horizontal (n + 1)) = tb`
+     by rw_tac std_ss[triplet_def, leibniz_horizontal_el] >>
+  `EL (k + 1) (leibniz_horizontal (n + 1)) = tc`
+     by rw_tac std_ss[triplet_def, leibniz_horizontal_el] >>
   `k < n + 1` by decide_tac >>
   `k < LENGTH (leibniz_horizontal (n + 1))` by rw[leibniz_horizontal_len] >>
-  `TAKE (k + 1) (leibniz_horizontal (n + 1)) = TAKE (SUC k) (leibniz_horizontal (n + 1))` by rw[ADD1] >>
+  `TAKE (k + 1) (leibniz_horizontal (n + 1)) =
+   TAKE (SUC k) (leibniz_horizontal (n + 1))` by rw[ADD1] >>
   `_ = SNOC tb x` by rw[TAKE_SUC_BY_TAKE, Abbr`x`] >>
-  `_ = x ++ [tb]` by rw[] >>
+  `_ = x ++ [tb]` by rw[SNOC_APPEND] >>
   `SUC k < n + 2` by decide_tac >>
   `SUC k < LENGTH (leibniz_horizontal (n + 1))` by rw[leibniz_horizontal_len] >>
-  `TAKE (k + 2) (leibniz_horizontal (n + 1)) = TAKE (SUC (SUC k)) (leibniz_horizontal (n + 1))` by rw[ADD1] >>
+  `TAKE (k + 2) (leibniz_horizontal (n + 1)) =
+   TAKE (SUC (SUC k)) (leibniz_horizontal (n + 1))` by rw[ADD1] >>
   `_ = SNOC tc (SNOC tb x)` by rw_tac std_ss[TAKE_SUC_BY_TAKE, ADD1, Abbr`x`] >>
-  `_ = x ++ [tb; tc]` by rw[] >>
-  `DROP k (leibniz_horizontal n) = [ta] ++ y` by rw[DROP_BY_DROP_SUC, ADD1, Abbr`y`] >>
-  qabbrev_tac `p1 = TAKE (k + 1) (leibniz_horizontal (n + 1)) ++ DROP k (leibniz_horizontal n)` >>
+  `_ = x ++ [tb; tc]` by rw[SNOC_APPEND] >>
+  `DROP k (leibniz_horizontal n) = [ta] ++ y`
+     by rw[DROP_BY_DROP_SUC, ADD1, Abbr`y`] >>
+  qabbrev_tac `p1 = TAKE (k + 1) (leibniz_horizontal (n + 1)) ++
+                    DROP k (leibniz_horizontal n)` >>
   qabbrev_tac `p2 = TAKE (k + 2) (leibniz_horizontal (n + 1)) ++ y` >>
   `p1 = x ++ [tb; ta] ++ y` by rw[Abbr`p1`, Abbr`x`, Abbr`y`] >>
   `p2 = x ++ [tb; tc] ++ y` by rw[Abbr`p2`, Abbr`x`] >>
-  metis_tac[leibniz_zigzag_def]);
+  metis_tac[leibniz_zigzag_def]
+QED
 
 (* Theorem: (leibniz_up 1) zigzag (leibniz_horizontal 1) *)
 (* Proof:
@@ -8808,13 +8820,13 @@ val leibniz_seg_arm_zigzag_step = store_thm(
   `k < LENGTH (leibniz_seg_arm a b (n + 1))` by rw[leibniz_seg_arm_len] >>
   `TAKE (k + 1) (leibniz_seg_arm (a + 1) b (n + 1)) = TAKE (SUC k) (leibniz_seg_arm (a + 1) b (n + 1))` by rw[ADD1] >>
   `_ = SNOC t.b x` by rw[TAKE_SUC_BY_TAKE, Abbr`x`] >>
-  `_ = x ++ [t.b]` by rw[] >>
+  `_ = x ++ [t.b]` by rw[SNOC_APPEND] >>
   `SUC k < n + 1` by decide_tac >>
   `SUC k < LENGTH (leibniz_seg_arm (a + 1) b (n + 1))` by rw[leibniz_seg_arm_len] >>
   `k < LENGTH (leibniz_seg_arm (a + 1) b (n + 1))` by decide_tac >>
   `TAKE (k + 2) (leibniz_seg_arm (a + 1) b (n + 1)) = TAKE (SUC (SUC k)) (leibniz_seg_arm (a + 1) b (n + 1))` by rw[ADD1] >>
   `_ = SNOC t.c (SNOC t.b x)` by metis_tac[TAKE_SUC_BY_TAKE, ADD1] >>
-  `_ = x ++ [t.b; t.c]` by rw[] >>
+  `_ = x ++ [t.b; t.c]` by rw[SNOC_APPEND] >>
   `DROP k (leibniz_seg_arm a b n) = [t.a] ++ y` by rw[DROP_BY_DROP_SUC, ADD1, Abbr`y`] >>
   qabbrev_tac `p1 = TAKE (k + 1) (leibniz_seg_arm (a + 1) b (n + 1)) ++ DROP k (leibniz_seg_arm a b n)` >>
   qabbrev_tac `p2 = TAKE (k + 2) (leibniz_seg_arm (a + 1) b (n + 1)) ++ y` >>

--- a/src/coalgebras/llistScript.sml
+++ b/src/coalgebras/llistScript.sml
@@ -3393,11 +3393,10 @@ Proof
   \\ ho_match_mp_tac SNOC_INDUCT \\ rw []
   THEN1
    (qspec_then ‘ys’ mp_tac SNOC_CASES \\ rpt strip_tac
-    \\ asm_rewrite_tac [IS_SUFFIX] \\ fs [])
-  \\ rewrite_tac [GSYM SNOC_APPEND]
+    \\ asm_rewrite_tac [IS_SUFFIX] \\ fs [SNOC_APPEND])
   \\ qspec_then ‘ys’ mp_tac SNOC_CASES \\ rpt strip_tac
   \\ asm_rewrite_tac [IS_SUFFIX]
-  \\ fs [GSYM PULL_EXISTS]
+  \\ fs [GSYM PULL_EXISTS, SNOC_APPEND]
   \\ Cases_on ‘l = []’ \\ fs []
   \\ asm_rewrite_tac [IS_SUFFIX]
   \\ first_x_assum (qspec_then ‘l’ mp_tac)

--- a/src/coalgebras/ltreeScript.sml
+++ b/src/coalgebras/ltreeScript.sml
@@ -987,8 +987,7 @@ Theorem ltree_lookup_SNOC :
              ltree_lookup t (SNOC x xs) =
              ltree_lookup (THE (ltree_lookup t xs)) [x]
 Proof
-    rpt STRIP_TAC
- >> ‘SNOC x xs = xs ++ [x]’ by rw [] >> POP_ORW
+    rw [SNOC_APPEND]
  >> MATCH_MP_TAC ltree_lookup_append >> art []
 QED
 
@@ -1335,11 +1334,7 @@ Proof
        POP_ASSUM (fs o wrap) \\
        Cases_on ‘LNTH n ts’ >> fs [] ])
  (* stage work *)
- >> rpt STRIP_TAC
- >> ‘!q. SNOC n (h::p) ++ q = h::(SNOC n p ++ q)’ by rw []
- >> POP_ORW
- >> ‘SNOC n (h::p) = h::SNOC n p’ by rw []
- >> POP_ORW
+ >> rw []
  >> Cases_on ‘t’
  >> POP_ASSUM MP_TAC
  >> simp [ltree_el_def, ltree_lookup_def]
@@ -1392,14 +1387,14 @@ Proof
       simp [ltree_el_def, LNTH_LGENLIST] \\
       Cases_on ‘LLENGTH ts’ >> simp []
       >- (DISCH_TAC \\
-          Know ‘p ++ [n] ++ q IN ltree_paths (ltree_delete f x p)’
+          Know ‘SNOC n p ++ q IN ltree_paths (ltree_delete f x p)’
           >- rw [ltree_paths_alt_ltree_el] \\
           Q.PAT_X_ASSUM ‘!t a n. P’ (MP_TAC o Q.SPECL [‘x’, ‘a’, ‘n’]) \\
           simp []) \\
       rename1 ‘LLENGTH ts = SOME N’ \\
       Cases_on ‘h < N’ >> simp [] \\
       DISCH_TAC \\
-      Know ‘p ++ [n] ++ q IN ltree_paths (ltree_delete f x p)’
+      Know ‘SNOC n p ++ q IN ltree_paths (ltree_delete f x p)’
       >- rw [ltree_paths_alt_ltree_el] \\
       Q.PAT_X_ASSUM ‘!t a n. P’ (MP_TAC o Q.SPECL [‘x’, ‘a’, ‘n’]) \\
       simp [],
@@ -1712,11 +1707,7 @@ Proof
        rw [LFINITE_LNTH_IS_SOME] \\
        CCONTR_TAC >> fs [] ])
  (* stage work *)
- >> rpt STRIP_TAC
- >> ‘!q. SNOC n (h::p) ++ q = h::(SNOC n p ++ q)’ by rw []
- >> POP_ORW
- >> ‘SNOC n (h::p) = h::SNOC n p’ by rw []
- >> POP_ORW
+ >> rw []
  >> Cases_on ‘t’
  >> POP_ASSUM MP_TAC
  >> simp [ltree_el_def, ltree_lookup_def]
@@ -1807,15 +1798,15 @@ Proof
       (* goal 3 (of 3) *)
       simp [ltree_el_def, LNTH_LGENLIST] \\
       Cases_on ‘LLENGTH ts’ >> simp []
-      >- (Know ‘ltree_el (ltree_insert f x p t0) (p ++ [n] ++ q) <> NONE <=>
-                p ++ [n] ++ q IN ltree_paths (ltree_insert f x p t0)’
+      >- (Know ‘ltree_el (ltree_insert f x p t0) (SNOC n p ++ q) <> NONE <=>
+                SNOC n p ++ q IN ltree_paths (ltree_insert f x p t0)’
           >- rw [ltree_paths_alt_ltree_el] >> Rewr' \\
           Q.PAT_X_ASSUM ‘!t a n. P’ (MP_TAC o Q.SPECL [‘x’, ‘a’, ‘n’]) \\
           simp []) \\
       rename1 ‘LLENGTH ts = SOME N’ \\
       Cases_on ‘h < N’ >> simp []
-      >- (Know ‘ltree_el (ltree_insert f x p t0) (p ++ [n] ++ q) <> NONE <=>
-                p ++ [n] ++ q IN ltree_paths (ltree_insert f x p t0)’
+      >- (Know ‘ltree_el (ltree_insert f x p t0) (SNOC n p ++ q) <> NONE <=>
+                SNOC n p ++ q IN ltree_paths (ltree_insert f x p t0)’
           >- rw [ltree_paths_alt_ltree_el] >> Rewr' \\
           Q.PAT_X_ASSUM ‘!t a n. P’ (MP_TAC o Q.SPECL [‘x’, ‘a’, ‘n’]) \\
           simp []) \\
@@ -2602,8 +2593,7 @@ Theorem ltree_path_lt_sibling' :
 Proof
     rpt STRIP_TAC
  >> MATCH_MP_TAC ltree_path_lt_sibling
- >> REWRITE_TAC [FRONT_SNOC, LAST_SNOC]
- >> simp []
+ >> rw [FRONT_SNOC, LAST_SNOC]
 QED
 
 Theorem finite_branching_ltree_el_cases :

--- a/src/list/src/listRangeScript.sml
+++ b/src/list/src/listRangeScript.sml
@@ -456,9 +456,9 @@ val listRangeINC_EXISTS_EVERY = store_thm(
 val listRangeINC_SNOC = store_thm(
   "listRangeINC_SNOC",
   ``!m n. m <= n + 1 ==> ([m .. (n + 1)] = SNOC (n + 1) [m .. n])``,
-  rw[listRangeINC_def] >>
+  rw[listRangeINC_def, SNOC_APPEND] >>
   `(n + 2 - m = 1 + (n + 1 - m)) /\ (n + 1 - m + m = n + 1)` by decide_tac >>
-  rw_tac std_ss[GENLIST_APPEND, GENLIST_1]);
+  rw_tac std_ss [GENLIST_APPEND, GENLIST_1]);
 
 (* Theorem: m <= n + 1 ==> (FRONT [m .. (n + 1)] = [m .. n]) *)
 (* Proof:

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -2098,7 +2098,7 @@ Theorem TAKE1:
 Proof Induct_on ‘l’ >> srw_tac[][]
 QED
 
-Theorem TAKE1_DROP:
+Theorem TAKE1_DROP[simp]:
   !n l. n < LENGTH l ==> (TAKE 1 (DROP n l) = [EL n l])
 Proof
   Induct_on ‘l’ >> rw[] >> Cases_on ‘n’ >> fs[EL_restricted]
@@ -2808,6 +2808,7 @@ val FRONT_SNOC = store_thm(
   RW_TAC bool_ss [SNOC]);
 val _ = export_rewrites ["FRONT_SNOC"]
 
+(* NOTE: Do NOT put [simp] here! *)
 val SNOC_APPEND = store_thm("SNOC_APPEND",
    “!x (l:('a) list). SNOC x l = APPEND l [x]”,
    GEN_TAC THEN LIST_INDUCT_TAC THEN ASM_REWRITE_TAC [SNOC, APPEND]);
@@ -2836,11 +2837,13 @@ val EL_LENGTH_SNOC = store_thm("EL_LENGTH_SNOC",
     (“!l:'a list. !x. EL (LENGTH l) (SNOC x l) = x”),
     LIST_INDUCT_TAC THEN ASM_REWRITE_TAC[EL, SNOC, HD, TL, LENGTH]);
 
-val APPEND_SNOC = store_thm("APPEND_SNOC",
-    (“!l1 (x:'a) l2. APPEND l1 (SNOC x l2) = SNOC x (APPEND l1 l2)”),
-    LIST_INDUCT_TAC THEN ASM_REWRITE_TAC[APPEND, SNOC]);
+Theorem APPEND_SNOC[simp] :
+    !l1 (x:'a) l2. APPEND l1 (SNOC x l2) = SNOC x (APPEND l1 l2)
+Proof
+    LIST_INDUCT_TAC THEN ASM_REWRITE_TAC[APPEND, SNOC]
+QED
 
-Theorem EVERY_SNOC:
+Theorem EVERY_SNOC[simp] :
   !P (x:'a) l. EVERY P (SNOC x l) <=> EVERY P l /\ P x
 Proof
     GEN_TAC THEN GEN_TAC THEN LIST_INDUCT_TAC

--- a/src/list/src/listSimps.sml
+++ b/src/list/src/listSimps.sml
@@ -82,13 +82,15 @@ fun APPEND_SIMPLE_LISTS_ASSOC_CONV t =
 (*       REVERSE (x5::x6::x7::(l3 ++ l4 ++ l5)) ++ [x8;x9]))) =          *)
 (*    [x1; x2] ++ l1 ++ [x4] ++ l2 ++ REVERSE l5 ++ REVERSE l4 ++        *)
 (*       REVERSE l3 ++ [x7; x6; x5; x8; x9; x3]                          *)
+(*                                                                       *)
+(* NOTE: SNOC is now considered as an alternative normal form of lists,  *)
+(* and therefore SNOC_APPEND has been eliminated from this conversion.   *)
 (* --------------------------------------------------------------------- *)
 
 val NORM_CONS_APPEND_NO_EVAL_CONV =
    (TOP_DEPTH_CONV NORM_CONS_CONV) THENC
    (PURE_REWRITE_CONV [listTheory.APPEND_NIL, listTheory.APPEND_ASSOC,
-                      listTheory.SNOC_APPEND, listTheory.REVERSE_APPEND,
-                      listTheory.REVERSE_DEF]) THENC
+                       listTheory.REVERSE_APPEND, listTheory.REVERSE_DEF]) THENC
    (DEPTH_CONV ((QCHANGED_CONV APPEND_SIMPLE_LISTS_ASSOC_CONV) ORELSEC
                 (QCHANGED_CONV APPEND_SIMPLE_LISTS_CONV)))
 

--- a/src/string/stringScript.sml
+++ b/src/string/stringScript.sml
@@ -365,7 +365,7 @@ Proof
   \\ `?y ys. x::xs = SNOC y ys` by metis_tac[SNOC_CASES,list_distinct]
   \\ full_simp_tac std_ss [FRONT_SNOC,LAST_SNOC] \\ rpt BasicProvers.VAR_EQ_TAC
   \\ qmatch_goalsub_rename_tac`SPLITP P (SNOC y (w ++ z))`
-  \\ Cases_on`NULL z` \\ fs[NULL_EQ]
+  \\ Cases_on`NULL z` \\ fs[NULL_EQ, SNOC_APPEND]
   >- (
     simp[SPLITP_APPEND]
     \\ full_simp_tac std_ss [GSYM NOT_EXISTS]


### PR DESCRIPTION
Hi,

The theorem `SNOC_APPEND` (`|- !x l. SNOC x l = l ++ [x]`) is part of `listSimps.NORM_CONS_APPEND_NO_EVAL_CONV` (and is therefore part of `list_ss`, `srw_ss()`, `rw`, `simp`, `fs`, etc.)  The problem is that, it _unconditionally_ eliminates all `SNOC x l` occurred in user's proof, making other simplification rules on `SNOC` inapplicable. In general, when designing a simplification rule set, the order of rules in it shouldn't matter (because the simplifier doesn't support priority of rules).

This PR removes `SNOC_APPEND` from the above conversion and from now on users must explicitly apply it on need.  I think this change should be done even with costs of breaking some proofs.

There are totally about 35 broken proofs in the entire code base (tested with `-t3`), which can be roughly classified into several groups:

1. The proof explicitly needs `SNOC_INDUCT` or `SNOC_CASES` which involves `SNOC` but immediately a call of `simp[]` eliminates SNOC without using other SNOC-specific theorems.   In this case `SNOC_APPEND` must be explicitly added into the next simplification tactic, e.g. `simp[SNOC_APPEND]` for the proof to work.
2. The proof systematically uses `SNOC` and related theorems, including explicit calls of `SNOC_APPEND`, and the proof engineer is aware of the present issue and therefore only work with `std_ss` plus explicit list theorems. But sometimes `srw_ss()` is used as the ending tactics for list normalisation, which must now add `SNOC_APPEND`.
3. The proof does not involve `SNOC` in terms but uses some SNOC-theorems like `EL_SNOC` (`|- !n l. n < LENGTH l ==> !x. EL n (SNOC x l) = EL n l`) and immediately eliminate `SNOC` (by implicit `SNOC_APPEND`). These proofs actually should use `EL_APPEND1` (`|- !n l1 l2. n < LENGTH l1 ==> (EL n (l1 ++ l2) = EL n l1)`) instead.
4. In rare cases, the proof involves non-deterministic rewritings where assumptions and simp rules give different results depending on which one is handled first. There seems to be subtle changes on order of rules when `SNOC_APPEND` is removed. Essentially this is a robust issue of concrete proofs.

In general, by calling `augment_srw_ss` with `SNOC_APPEND` added back, some complex long proofs can be fixed. 

Besides, I added `TAKE1_DROP` (`|- !n l. n < LENGTH l ==> (TAKE 1 (DROP n l) = [EL n l])`) into `srw_ss`, so that, when combining with the existing `TAKE_SUC` (`|- !n x. TAKE (SUC n) x = TAKE n x ++ TAKE 1 (DROP n x)`) some broken proofs are fixed with minimal changes.   But this change has broken one proof where the user just don't want to simplify `TAKE 1 (DROP n l)` and use it as atom. I had to remove `TAKE1_DROP` from `srw_ss` in the beginning of the corresponding theory. There's only one such case if I remember correctly.

I have fixed all broken proofs when building with `-t3`, but I'm using `--expk`. Perhaps the CI tests will show a few more.

--Chun