### PR TITLE
[pi-calculus] Update nominal setup with built-in support of free names

### DIFF
--- a/examples/formal-languages/pi-calculus/Holmakefile
+++ b/examples/formal-languages/pi-calculus/Holmakefile
@@ -1,1 +1,3 @@
 INCLUDES = $(HOLDIR)/examples/lambda/basics
+
+EXTRA_CLEANS = $(patsubst %Theory.uo,%Theory.html,$(DEFAULT_TARGETS))

--- a/examples/formal-languages/pi-calculus/open_bisimulationScript.sml
+++ b/examples/formal-languages/pi-calculus/open_bisimulationScript.sml
@@ -1,13 +1,13 @@
 (* ========================================================================== *)
 (* FILE          : open_bisimulationScript.sml                                *)
-(* DESCRIPTION   : Open bisimulation for the pi-calculus with mismatch        *)
+(* DESCRIPTION   : Open bisimulation for the pi-calculus                      *)
 (*                                                                            *)
 (* Copyright 2025  The Australian National University (Author: Chun Tian)     *)
 (* ========================================================================== *)
 
 open HolKernel Parse boolLib bossLib;
 
-open pairTheory pred_setTheory set_relationTheory hurdUtils;
+open pairTheory pred_setTheory relationTheory hurdUtils;
 
 open nomsetTheory NEWLib pi_agentTheory;
 
@@ -16,158 +16,22 @@ val _ = new_theory "open_bisimulation";
 (* some proofs here are large with too many assumptions *)
 val _ = set_trace "Goalstack.print_goal_at_top" 0;
 
-Overload sc = “symmetric_closure”
-
-(* ----------------------------------------------------------------------
-   Pi-calculus as a nominal datatype in HOL4
-
-   HOL4 syntax ('free and 'bound are special type variables (alias of string)
-
-   Nominal_datatype :
-
-           name = Name 'free
-
-           pi   = Nil                      (* 0 *)
-                | Tau pi                   (* tau.P *)
-                | Input name 'bound pi     (* a(x).P *)
-                | Output name name pi      (* {a}b.P *)
-                | Match name name pi       (* [a == b] P *)
-                | Mismatch name name pi    (* [a <> b] P *)
-                | Sum pi pi                (* P + Q *)
-                | Par pi pi                (* P | Q *)
-                | Res 'bound pi            (* nu x. P *)
-
-       residual = TauR pi
-                | InputS name 'bound pi
-                | FreeOutput name name pi
-                | BoundOutput name 'bound pi
-   End
-
-   NOTE: Replication ("!") is not supported.
-   ---------------------------------------------------------------------- *)
-
-(* NOTE: We fallback to “:(string # string) -> bool” for the need of permutation
-   on pairs in the dist set.
- *)
-Type dist[pp] = “:(string # string) -> bool”
-
-(* NOTE: We use uncurried relation (HOL preferred) given in relationTheory *)
-Definition distinction_def :
-    distinction (D :dist) <=> FINITE D /\ symmetric D UNIV /\ irreflexive D UNIV
-End
-
-Overload FV = “domain :dist -> string set”
-Overload "#" = “\v (D :dist). v NOTIN FV D”
-
-Theorem domain_alt :
-    !r. domain r = IMAGE FST r
-Proof
-    rw [Once EXTENSION, in_domain]
- >> EQ_TAC >> rw []
- >- (Q.EXISTS_TAC ‘(x,y)’ >> rw [])
- >> rename1 ‘z IN r’
- >> PairCases_on ‘z’
- >> Q.EXISTS_TAC ‘z1’ >> rw []
-QED
-
-(* |- !D. FV D = IMAGE FST D *)
-Theorem FV_distinction =
-        domain_alt |> INST_TYPE [alpha |-> “:string”, beta |-> “:string”]
-                   |> Q.SPEC ‘D’ |> GEN_ALL
-
-Theorem FV_distinction_alt :
-    !D. distinction D ==> FV D = IMAGE SND D
-Proof
-    rw [distinction_def, domain_alt, symmetric_def]
- >> simp [Once EXTENSION, EXISTS_PROD]
-QED
-
-Theorem finite_domain[simp] :
-    distinction D ==> FINITE (FV D)
-Proof
-    rw [distinction_def, domain_alt]
-QED
-
-Theorem distinction_empty[simp] :
-    distinction {}
-Proof
-    rw [distinction_def, symmetric_def, irreflexive_def]
-QED
-
-Theorem distinction_union :
-    !D1 D2. distinction D1 /\ distinction D2 ==> distinction (D1 UNION D2)
-Proof
-    rw [distinction_def]
- >- (MATCH_MP_TAC symmetric_union >> art [])
- >> MATCH_MP_TAC irreflexive_union >> art []
-QED
-
-(* NOTE: This is permutation operation on distinction *)
-Overload dpm[local] = “setpm (pair_pmact string_pmact string_pmact)”
-
-Theorem distinction_dpm_lemma[local] :
-    !pi d. distinction d ==> distinction (dpm pi d)
-Proof
-    rw [distinction_def]
- >- fs [symmetric_def]
- >> fs [irreflexive_def]
-QED
-
-Theorem distinction_dpm[simp] :
-    distinction (dpm pi d) <=> distinction d
-Proof
-    reverse EQ_TAC
- >- rw [distinction_dpm_lemma]
- >> STRIP_TAC
- >> MP_TAC (Q.SPECL [‘REVERSE pi’, ‘dpm pi d’] distinction_dpm_lemma)
- >> simp []
-QED
-
-Theorem dpm_unchanged_lemma[local] :
-    !D. FINITE D ==> !pi. DISJOINT (set (MAP FST pi)) (IMAGE FST D) /\
-                          DISJOINT (set (MAP FST pi)) (IMAGE SND D) /\
-                          DISJOINT (set (MAP SND pi)) (IMAGE FST D) /\
-                          DISJOINT (set (MAP SND pi)) (IMAGE SND D) ==>
-                          dpm pi D = D
-Proof
-    HO_MATCH_MP_TAC FINITE_INDUCT
- >> rw [pmact_INSERT]
- >> PairCases_on ‘e’ >> fs []
- >> Know ‘lswapstr pi e0 = e0’
- >- (MATCH_MP_TAC lswapstr_unchanged' >> art [])
- >> Rewr'
- >> Know ‘lswapstr pi e1 = e1’
- >- (MATCH_MP_TAC lswapstr_unchanged' >> art [])
- >> Rewr
-QED
-
-Theorem dpm_unchanged :
-    !D pi. distinction D /\
-           DISJOINT (set (MAP FST pi)) (FV D) /\
-           DISJOINT (set (MAP SND pi)) (FV D) ==> dpm pi D = D
-Proof
-    rpt STRIP_TAC
- >> irule dpm_unchanged_lemma
- >> simp [GSYM FV_distinction, GSYM FV_distinction_alt]
- >> fs [distinction_def]
-QED
-
 (* The original open transition relation *)
 Inductive TRANS :
 [TAU]
-    !P.       TRANS (Tau P) (TauR P)
+    !P. TRANS (Tau P) (TauR P)
 [INPUT]
-    !a x P.   x <> a ==> TRANS (Input (Name a) x P) (InputS (Name a) x P)
+    !a x P. x <> a ==> TRANS (Input a x P) (InputS a x P)
 [OUTPUT]
-    !a b P.   TRANS (Output (Name a) (Name b) P) (FreeOutput (Name a) (Name b) P)
+    !a b P. TRANS (Output a b P) (FreeOutput a b P)
 [MATCH]
-    !P Rs b.   TRANS P Rs ==> TRANS (Match (Name b) (Name b) P) Rs
+    !P Rs b. TRANS P Rs ==> TRANS (Match b b P) Rs
 [MISMACH]
-    !P Rs a b. TRANS P Rs /\ a <> b ==> TRANS (Mismatch (Name a) (Name b) P) Rs
+    !P Rs a b. TRANS P Rs /\ a <> b ==> TRANS (Mismatch a b P) Rs
 
 [OPEN]
-    !P P' a b. TRANS P (FreeOutput (Name a) (Name b) P') /\ a <> b ==>
-               TRANS (Res b P) (BoundOutput (Name a) b P')
+    !P P' a b. TRANS P (FreeOutput a b P') /\ a <> b ==>
+               TRANS (Res b P) (BoundOutput a b P')
 [SUM1]
     !P Q Rs. TRANS P Rs ==> TRANS (Sum P Q) Rs
 [SUM2]
@@ -175,401 +39,445 @@ Inductive TRANS :
 
 [PAR1_I]
     !P P' Q a x.
-       TRANS P (InputS (Name a) x P') /\ x # P /\ x # Q /\ x <> a ==>
-       TRANS (Par P Q) (InputS (Name a) x (Par P' Q))
+       TRANS P (InputS a x P') /\ x # P /\ x # Q /\ x <> a ==>
+       TRANS (Par P Q) (InputS a x (Par P' Q))
 [PAR1_BO]
     !P P' Q a x.
-       TRANS P (BoundOutput (Name a) x P') /\ x # P /\ x # Q /\ x <> a ==>
-       TRANS (Par P Q) (BoundOutput (Name a) x (Par P' Q))
+       TRANS P (BoundOutput a x P') /\ x # P /\ x # Q /\ x <> a ==>
+       TRANS (Par P Q) (BoundOutput a x (Par P' Q))
 [PAR1_FO]
     !P P' Q a b.
-       TRANS P (FreeOutput (Name a) (Name b) P') ==>
-       TRANS (Par P Q) (FreeOutput (Name a) (Name b) (Par P' Q))
+       TRANS P (FreeOutput a b P') ==>
+       TRANS (Par P Q) (FreeOutput a b (Par P' Q))
 [PAR1_T]
     !P P' Q. TRANS P (TauR P') ==> TRANS (Par P Q) (TauR (Par P' Q))
 
 [PAR2_I]
     !P Q Q' a x.
-       TRANS Q (InputS (Name a) x Q') /\ x # Q /\ x # P /\ x <> a ==>
-       TRANS (Par P Q) (InputS (Name a) x (Par P Q'))
+       TRANS Q (InputS a x Q') /\ x # Q /\ x # P /\ x <> a ==>
+       TRANS (Par P Q) (InputS a x (Par P Q'))
 [PAR2_BO]
     !P Q Q' a x.
-       TRANS Q (BoundOutput (Name a) x Q') /\ x # Q /\ x # P /\ x <> a ==>
-       TRANS (Par P Q) (BoundOutput (Name a) x (Par P Q'))
+       TRANS Q (BoundOutput a x Q') /\ x # Q /\ x # P /\ x <> a ==>
+       TRANS (Par P Q) (BoundOutput a x (Par P Q'))
 [PAR2_FO]
     !P Q Q' a b.
-       TRANS Q (FreeOutput (Name a) (Name b) Q') ==>
-       TRANS (Par P Q) (FreeOutput (Name a) (Name b) (Par P Q'))
+       TRANS Q (FreeOutput a b Q') ==>
+       TRANS (Par P Q) (FreeOutput a b (Par P Q'))
 [PAR2_T]
     !P Q Q'. TRANS Q (TauR Q') ==> TRANS (Par P Q) (TauR (Par P Q'))
 
 [COMM1] (* TODO: tpm should change to SUB *)
     !P P' Q Q' a b x.
-       TRANS P (InputS (Name a) x P') /\ TRANS Q (FreeOutput (Name a) (Name b) Q') /\
+       TRANS P (InputS a x P') /\ TRANS Q (FreeOutput a b Q') /\
        x # P /\ x # Q /\ x <> a /\ x <> b /\ x # Q' ==>
        TRANS (Par P Q) (TauR (Par (tpm [(x,b)] P') Q'))
 [COMM2] (* TODO: tpm should change to SUB *)
     !P P' Q Q' a b x.
-       TRANS P (FreeOutput (Name a) (Name b) P') /\ TRANS Q (InputS (Name a) x Q') /\
+       TRANS P (FreeOutput a b P') /\ TRANS Q (InputS a x Q') /\
        x # Q /\ x # P /\ x <> a /\ x <> b /\ x # P' ==>
        TRANS (Par P Q) (TauR (Par P' (tpm [(x,b)] Q')))
 [CLOSE1] (* TODO: tpm should change to SUB *)
     !P P' Q Q' a x y.
-       TRANS P (InputS (Name a) x P') /\
-       TRANS Q (BoundOutput (Name a) y Q') /\
+       TRANS P (InputS a x P') /\
+       TRANS Q (BoundOutput a y Q') /\
        x # P /\ x # Q /\ y # P /\ y # Q /\
        x <> a /\ x # Q' /\ y <> a /\ y # P' /\ x <> y ==>
        TRANS (Par P Q) (TauR (Res y (Par (tpm [(x,y)] P') Q')))
 [CLOSE2] (* TODO: tpm should change to SUB *)
     !P P' Q Q' a x y.
-       TRANS P (BoundOutput (Name a) y P') /\
-       TRANS Q (InputS (Name a) x Q') /\
+       TRANS P (BoundOutput a y P') /\
+       TRANS Q (InputS a x Q') /\
        x # P /\ x # Q /\ y # P /\ y # Q /\
        x <> a /\ x # P' /\ y <> a /\ y # Q' /\ x <> y ==>
        TRANS (Par P Q) (TauR (Res y (Par P' (tpm [(x,y)] Q'))))
 [RES_I]
     !P P' a x y.
-       TRANS P (InputS (Name a) x P') /\
+       TRANS P (InputS a x P') /\
        y <> a /\ y <> x /\ x # P /\ x <> a ==>
-       TRANS (Res y P) (InputS (Name a) x (Res y P'))
+       TRANS (Res y P) (InputS a x (Res y P'))
 [RES_BO]
     !P P' a x y.
-       TRANS P (BoundOutput (Name a) x P') /\
+       TRANS P (BoundOutput a x P') /\
        y <> a /\ y <> x /\ x # P /\ x <> a ==>
-       TRANS (Res y P) (BoundOutput (Name a) x (Res y P'))
+       TRANS (Res y P) (BoundOutput a x (Res y P'))
 [RES_FO]
     !P P' a b y.
-       TRANS P (FreeOutput (Name a) (Name b) P') /\
+       TRANS P (FreeOutput a b P') /\
        y <> a /\ y <> b ==>
-       TRANS (Res y P) (FreeOutput (Name a) (Name b) (Res y P'))
+       TRANS (Res y P) (FreeOutput a b (Res y P'))
 [RES_T]
     !P P' y.
        TRANS P (TauR P') ==> TRANS (Res y P) (TauR (Res y P'))
 End
 
-(* Open transition relation w.r.t. distinction *)
-Inductive DTRANS :
-[DTAU]
-    !D P. DTRANS (D :dist) (Tau P) (TauR P)
-[DINPUT]
-    !D a x P. x <> a ==> DTRANS D (Input (Name a) x P) (InputS (Name a) x P)
-[DOUTPUT]
-    !D a b P. DTRANS D (Output (Name a) (Name b) P)
-                       (FreeOutput (Name a) (Name b) P)
-[DMATCH]
-    !D P Rs b. DTRANS D P Rs ==> DTRANS D (Match (Name b) (Name b) P) Rs
-[DMISMACH]
-    !D P Rs a b.
-       distinction D /\ (a,b) IN D /\ DTRANS D P Rs ==>
-       DTRANS D (Mismatch (Name a) (Name b) P) Rs
-
-[DOPEN]
-    !D D' P P' a b.
-    (* begin extra antecedents *)
-       distinction D /\ b # D /\
-       D' = D UNION sc {(a,s) | s IN FV (Res b P)} /\
-    (* end extra antecedents *)
-       DTRANS D' P (FreeOutput (Name a) (Name b) P') /\ a <> b ==>
-       DTRANS D (Res b P) (BoundOutput (Name a) b P')
-[DSUM1]
-    !D P Q Rs. DTRANS D P Rs ==> DTRANS D (Sum P Q) Rs
-[DSUM2]
-    !D P Q Rs. DTRANS D Q Rs ==> DTRANS D (Sum P Q) Rs
-
-[DPAR1_I]
-    !D P P' Q a x.
-       DTRANS D P (InputS (Name a) x P') /\ x # P /\ x # Q /\ x <> a ==>
-       DTRANS D (Par P Q) (InputS (Name a) x (Par P' Q))
-[DPAR1_BO]
-    !D P P' Q a x.
-       DTRANS D P (BoundOutput (Name a) x P') /\ x # P /\ x # Q /\ x <> a ==>
-       DTRANS D (Par P Q) (BoundOutput (Name a) x (Par P' Q))
-[DPAR1_FO]
-    !D P P' Q a b.
-       DTRANS D P (FreeOutput (Name a) (Name b) P') ==>
-       DTRANS D (Par P Q) (FreeOutput (Name a) (Name b) (Par P' Q))
-[DPAR1_T]
-    !D P P' Q. DTRANS D P (TauR P') ==> DTRANS D (Par P Q) (TauR (Par P' Q))
-
-[DPAR2_I]
-    !D P Q Q' a x.
-       DTRANS D Q (InputS (Name a) x Q') /\ x # Q /\ x # P /\ x <> a ==>
-       DTRANS D (Par P Q) (InputS (Name a) x (Par P Q'))
-[DPAR2_BO]
-    !D P Q Q' a x.
-       DTRANS D Q (BoundOutput (Name a) x Q') /\ x # Q /\ x # P /\ x <> a ==>
-       DTRANS D (Par P Q) (BoundOutput (Name a) x (Par P Q'))
-[DPAR2_FO]
-    !D P Q Q' a b.
-       DTRANS D Q (FreeOutput (Name a) (Name b) Q') ==>
-       DTRANS D (Par P Q) (FreeOutput (Name a) (Name b) (Par P Q'))
-[DPAR2_T]
-    !D P Q Q'. DTRANS D Q (TauR Q') ==> DTRANS D (Par P Q) (TauR (Par P Q'))
-
-[DCOMM1] (* TODO: tpm should change to SUB *)
-    !D P P' Q Q' a b x.
-       DTRANS D P (InputS (Name a) x P') /\
-       DTRANS D Q (FreeOutput (Name a) (Name b) Q') /\
-       x # P /\ x # Q /\ x <> a /\ x <> b /\ x # Q' ==>
-       DTRANS D (Par P Q) (TauR (Par (tpm [(x,b)] P') Q'))
-[DCOMM2] (* TODO: tpm should change to SUB *)
-    !D P P' Q Q' a b x.
-       DTRANS D P (FreeOutput (Name a) (Name b) P') /\
-       DTRANS D Q (InputS (Name a) x Q') /\
-       x # Q /\ x # P /\ x <> a /\ x <> b /\ x # P' ==>
-       DTRANS D (Par P Q) (TauR (Par P' (tpm [(x,b)] Q')))
-[DCLOSE1] (* TODO: tpm should change to SUB *)
-    !D P P' Q Q' a x y.
-       DTRANS D P (InputS (Name a) x P') /\
-       DTRANS D Q (BoundOutput (Name a) y Q') /\
-       x # P /\ x # Q /\ y # P /\ y # Q /\
-       x <> a /\ x # Q' /\ y <> a /\ y # P' /\ x <> y ==>
-       DTRANS D (Par P Q) (TauR (Res y (Par (tpm [(x,y)] P') Q')))
-[DCLOSE2] (* TODO: tpm should change to SUB *)
-    !D P P' Q Q' a x y.
-       DTRANS D P (BoundOutput (Name a) y P') /\
-       DTRANS D Q (InputS (Name a) x Q') /\
-       x # P /\ x # Q /\ y # P /\ y # Q /\
-       x <> a /\ x # P' /\ y <> a /\ y # Q' /\ x <> y ==>
-       DTRANS D (Par P Q) (TauR (Res y (Par P' (tpm [(x,y)] Q'))))
-
-[DRES_I]
-    !D D' P P' a x y.
-    (* begin extra antecedents *)
-       distinction D /\
-       D' = D UNION sc {(y,s) | s IN FV (Res y P)} /\
-    (* end extra antecedents *)
-       DTRANS D' P (InputS (Name a) x P') /\
-       y <> a /\ y <> x /\ x # P /\ x <> a ==>
-       DTRANS D (Res y P) (InputS (Name a) x (Res y P'))
-[DRES_BO]
-    !D D' P P' a x y.
-    (* begin extra antecedents *)
-       distinction D /\
-       D' = D UNION sc {(y,s) | s IN FV (Res y P)} /\
-    (* end extra antecedents *)
-       DTRANS D' P (BoundOutput (Name a) x P') /\
-       y <> a /\ y <> x /\ x # P /\ x <> a ==>
-       DTRANS D (Res y P) (BoundOutput (Name a) x (Res y P'))
-[DRES_FO]
-    !D D' P P' a b y.
-    (* begin extra antecedents *)
-       distinction D /\
-       D' = D UNION sc {(y,s) | s IN FV (Res y P)} /\
-    (* end extra antecedents *)
-       DTRANS D' P (FreeOutput (Name a) (Name b) P') /\
-       y <> a /\ y <> b ==>
-       DTRANS D (Res y P) (FreeOutput (Name a) (Name b) (Res y P'))
-[DRES_T]
-    !D D' P P' y.
-    (* begin extra antecedents *)
-       distinction D /\
-       D' = D UNION sc {(y,s) | s | s IN FV (Res y P)} /\
-    (* end extra antecedents *)
-       DTRANS D' P (TauR P') ==> DTRANS D (Res y P) (TauR (Res y P'))
-End
-
-(* NOTE: "simulation" is a property of 3-way relation R as tuples (P, Q, D), where
-   P and Q are pi-agents, D is a distinction.
- *)
-Definition dist_simulation_def :
-    dist_simulation (R :(pi # pi # dist) set) <=>
-    !P Q D. (P,Q,D) IN R ==>
-    (* 0 *)
-       distinction D /\
+Definition open_simulation_def :
+    open_simulation (R :pi -> pi -> bool) <=>
+    !P Q. R P Q ==>
     (* 1 *)
-      (!pi. (tpm pi P, tpm pi Q, dpm pi D) IN R) /\
-    (* 2 *)
-      (!D'. D SUBSET D' /\ distinction D' ==> (P,Q,D') IN R) /\
+      (!pi. R (tpm pi P) (tpm pi Q)) /\
     (* 3a *)
-      (!P'. DTRANS D P (TauR P') ==>
-            ?Q'. DTRANS D Q (TauR Q') /\ (P',Q',D) IN R) /\
-    (* 3b: enriched with ‘x # D /\ x # P’ *)
-      (!a x P'. DTRANS D P (InputS (Name a) x P') /\ x # D /\ x # P /\ x # Q ==>
-                ?Q'. DTRANS D Q (InputS (Name a) x Q') /\ (P',Q',D) IN R) /\
+      (!P'. TRANS P (TauR P') ==> ?Q'. TRANS Q (TauR Q') /\ R P' Q') /\
+    (* 3b *)
+      (!x z P'. TRANS P (InputS x z P') /\
+                z # P /\ z # Q /\ x <> z ==>
+               ?Q'. TRANS Q (InputS x z Q') /\ R P' Q') /\
     (* 3c *)
-      (!a b P'. DTRANS D P (FreeOutput (Name a) (Name b) P') ==>
-                ?Q'. DTRANS D Q (FreeOutput (Name a) (Name b) Q') /\
-                    (P',Q',D) IN R) /\
+      (!a b P'. TRANS P (FreeOutput a b P') ==>
+               ?Q'. TRANS Q (FreeOutput a b Q') /\ R P' Q') /\
     (* 4 *)
-      (!b x P'. DTRANS D P (BoundOutput (Name b) x P') ==>
-                ?Q' D'. DTRANS D Q (BoundOutput (Name b) x Q') /\
-                        D' = D UNION sc {(b, x) | x | x IN FV (Res b Q)} /\
-                       (P',Q',D') IN R)
+      (!x z P'. TRANS P (BoundOutput x z P') /\
+                z # P /\ z # Q /\ x <> z ==>
+               ?Q'. TRANS Q (BoundOutput x z Q') /\ R P' Q')
 End
 
-Theorem dist_simulation_id :
-    dist_simulation {x | ?P D. x = (P,P,D) /\ distinction D}
-Proof
-    rw [dist_simulation_def]
- >> MATCH_MP_TAC distinction_union >> art []
- >> rw [distinction_def]
- >- (MATCH_MP_TAC finite_sc \\
-     qmatch_abbrev_tac ‘FINITE s’ \\
-     irule SUBSET_FINITE \\
-     Q.EXISTS_TAC ‘{(b,y) | y | y IN FV P}’ \\
-     qunabbrev_tac ‘s’ \\
-     reverse CONJ_TAC >- rw [SUBSET_DEF] \\
-     qmatch_abbrev_tac ‘FINITE s’ \\
-     Know ‘s = IMAGE (\y. (b,y)) (FV P)’
-     >- rw [Abbr ‘s’, Once EXTENSION] >> Rewr' \\
-     MATCH_MP_TAC IMAGE_FINITE >> rw [])
- >> MATCH_MP_TAC sc_irreflexive
- >> rw [irreflexive_def]
-QED
-
-Theorem dist_simulation_union :
-    !R1 R2. dist_simulation R1 /\ dist_simulation R2 ==>
-            dist_simulation (R1 UNION R2)
-Proof
-    rw [dist_simulation_def] (* 7+7 subgoals *)
- (* goal 1 (of 14) *)
- >- (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R1 ==> _’
-      (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [])
- (* goal 2 (of 14) *)
- >- (DISJ1_TAC \\
-     Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R1 ==> _’
-       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [])
- (* goal 3 (of 14) *)
- >- (DISJ1_TAC \\
-     Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R1 ==> _’
-       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [])
- (* goal 4 (of 14) *)
- >- (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R1 ==> _’
-       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [] \\
-     Q.PAT_X_ASSUM ‘!P'. DTRANS D P (TauR P') ==> _’
-       (MP_TAC o Q.SPEC ‘P'’) >> rw [] \\
-     Q.EXISTS_TAC ‘Q'’ >> rw [])
- (* goal 5 (of 14) *)
- >- (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R1 ==> _’
-       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [] \\
-     Q.PAT_X_ASSUM ‘!a x P'.
-                       DTRANS D P (InputS (Name a) x P') /\ _ ==> _’
-       (MP_TAC o Q.SPECL [‘a’, ‘x’, ‘P'’]) >> rw [] \\
-     Q.EXISTS_TAC ‘Q'’ >> rw [])
- (* goal 6 (of 14) *)
- >- (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R1 ==> _’
-       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [] \\
-     Q.PAT_X_ASSUM ‘!a b P'.
-                       DTRANS D P (FreeOutput (Name a) (Name b) P') ==> _’
-       (MP_TAC o Q.SPECL [‘a’, ‘b’, ‘P'’]) >> rw [] \\
-     Q.EXISTS_TAC ‘Q'’ >> rw [])
- (* goal 7 (of 14) *)
- >- (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R1 ==> _’
-       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [] \\
-     Q.PAT_X_ASSUM ‘!b x P'. DTRANS D P (BoundOutput (Name b) x P') ==> _’
-       (MP_TAC o Q.SPECL [‘b’, ‘x’, ‘P'’]) >> rw [] \\
-     Q.EXISTS_TAC ‘Q'’ >> rw [])
- (* goal 8 (of 14) *)
- >- (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R2 ==> _’
-       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [])
- (* goal 9 (of 14) *)
- >- (DISJ2_TAC \\
-     Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R2 ==> _’
-       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [])
- (* goal 10 (of 14) *)
- >- (DISJ2_TAC \\
-     Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R2 ==> _’
-       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [])
- (* goal 11 (of 14) *)
- >- (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R2 ==> _’
-       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [] \\
-     Q.PAT_X_ASSUM ‘!P'. DTRANS D P (TauR P') ==> _’
-       (MP_TAC o Q.SPEC ‘P'’) >> rw [] \\
-     Q.EXISTS_TAC ‘Q'’ >> rw [])
- (* goal 12 (of 14) *)
- >- (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R2 ==> _’
-       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [] \\
-     Q.PAT_X_ASSUM ‘!a x P'.
-                       DTRANS D P (InputS (Name a) x P') /\ _ ==> _’
-       (MP_TAC o Q.SPECL [‘a’, ‘x’, ‘P'’]) >> rw [] \\
-     Q.EXISTS_TAC ‘Q'’ >> rw [])
- (* goal 13 (of 14) *)
- >- (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R2 ==> _’
-       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [] \\
-     Q.PAT_X_ASSUM ‘!a b P'.
-                       DTRANS D P (FreeOutput (Name a) (Name b) P') ==> _’
-       (MP_TAC o Q.SPECL [‘a’, ‘b’, ‘P'’]) >> rw [] \\
-     Q.EXISTS_TAC ‘Q'’ >> rw [])
- (* goal 14 (of 14) *)
- >> (Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R2 ==> _’
-       (MP_TAC o Q.SPECL [‘P’, ‘Q’, ‘D’]) >> rw [] \\
-     Q.PAT_X_ASSUM ‘!b x P'. DTRANS D P (BoundOutput (Name b) x P') ==> _’
-       (MP_TAC o Q.SPECL [‘b’, ‘x’, ‘P'’]) >> rw [] \\
-     Q.EXISTS_TAC ‘Q'’ >> rw [])
-QED
-
-Theorem dist_simulation_imp_distinction :
-    !R P Q D. dist_simulation R /\ (P,Q,D) IN R ==> distinction D
-Proof
-    rw [dist_simulation_def]
- >> FIRST_X_ASSUM drule >> rw []
-QED
-
-Theorem dist_simulation_open_distinction :
-    !R P Q D D'. dist_simulation R /\ (P,Q,D) IN R /\ D SUBSET D' /\
-                 distinction D' ==> (P,Q,D') IN R
-Proof
-    rw [dist_simulation_def]
- >> Q.PAT_X_ASSUM ‘!P Q D. (P,Q,D) IN R ==> _’ drule >> rw []
-QED
-
-Definition dist_bisimulation_def :
-    dist_bisimulation (R :(pi # pi # dist) set) <=>
-    dist_simulation R /\ dist_simulation {(Q,P,D) | (P,Q,D) IN R}
+Definition open_bisimulation_def :
+    open_bisimulation (R :pi -> pi -> bool) <=>
+    open_simulation R /\ open_simulation (\x y. R y x)
 End
 
-Definition dist_bisimilar :
-    dist_bisimilar P Q D <=> ?R. dist_bisimulation R /\ (P,Q,D) IN R
+Definition open_bisimilar :
+    open_bisimilar P Q <=> ?R. open_bisimulation R /\ R P Q
 End
 
-(* |- !P Q D.
-        dist_bisimilar P Q D <=>
-        ?R. (dist_simulation R /\ dist_simulation {(Q,P,D) | (P,Q,D) IN R}) /\
-            (P,Q,D) IN R
+(* |- !P Q.
+        open_bisimilar P Q <=>
+        ?R. (open_simulation R /\ open_simulation (\x y. R y x)) /\ R P Q
  *)
-Theorem dist_bisimilar_def =
-        dist_bisimilar |> REWRITE_RULE [dist_bisimulation_def]
+Theorem open_bisimilar_def =
+        open_bisimilar |> REWRITE_RULE [open_bisimulation_def]
 
-Theorem dist_bisimilar_imp_distinction :
-    !P Q D. dist_bisimilar P Q D ==> distinction D
+Theorem open_simulation_id :
+    open_simulation Id
 Proof
-    rw [dist_bisimilar_def, dist_simulation_def]
- >> FIRST_X_ASSUM drule >> rw []
+    rw [open_simulation_def]
 QED
 
-Theorem dist_bisimilar_reflexive :
-    !P D. distinction D ==> dist_bisimilar P P D
+Theorem open_bisimilar_reflexive :
+    !P. open_bisimilar P P
 Proof
-    rw [dist_bisimilar_def]
- >> Q.EXISTS_TAC ‘{x | ?P D. x = (P,P,D) /\ distinction D}’
- >> simp [dist_simulation_id]
- >> qmatch_abbrev_tac ‘dist_simulation R’
- >> Suff ‘R = {x | (?P D. x = (P,P,D) /\ distinction D)}’
- >- rw [dist_simulation_id]
- >> rw [Abbr ‘R’, Once EXTENSION]
+    rw [open_bisimilar_def]
+ >> Q.EXISTS_TAC ‘Id’
+ >> ‘(\x y :pi. y = x) = Id’ by METIS_TAC []
+ >> simp [open_simulation_id]
 QED
 
-Theorem dist_bisimilar_symmetric :
-    !P Q D. dist_bisimilar P Q D ==> dist_bisimilar Q P D
+Theorem open_simulation_union :
+    !R1 R2. open_simulation R1 /\ open_simulation R2 ==>
+            open_simulation (R1 RUNION R2)
 Proof
-    rw [dist_bisimilar_def]
- >> qabbrev_tac ‘R' = {(Q,P,D) | (P,Q,D) IN R}’
- >> Q.EXISTS_TAC ‘R UNION R'’
- >> reverse CONJ_TAC
- >- (simp [] \\
-     DISJ2_TAC >> rw [Abbr ‘R'’])
+    rw [open_simulation_def, RUNION] (* 5+5 subgoals *)
+ (* goal 1 (of 10) *)
+ >- (Q.PAT_X_ASSUM ‘!P Q. R1 P Q ==> _’ (MP_TAC o Q.SPECL [‘P’, ‘Q’]) >> rw [])
+ (* goal 2 (of 10) *)
+ >- (Q.PAT_X_ASSUM ‘!P Q. R1 P Q ==> _’ (MP_TAC o Q.SPECL [‘P’, ‘Q’]) >> rw [] \\
+     Q.PAT_X_ASSUM ‘!P'. TRANS P (TauR P') ==> _’ (MP_TAC o Q.SPEC ‘P'’) >> rw [] \\
+     Q.EXISTS_TAC ‘Q'’ >> rw [])
+ (* goal 3 (of 10) *)
+ >- (Q.PAT_X_ASSUM ‘!P Q. R1 P Q ==> _’ (MP_TAC o Q.SPECL [‘P’, ‘Q’]) >> rw [] \\
+     Q.PAT_X_ASSUM ‘!x z P'. TRANS P (InputS x z P') /\ _ ==> _’
+       (MP_TAC o Q.SPECL [‘x’, ‘z’, ‘P'’]) >> rw [] \\
+     Q.EXISTS_TAC ‘Q'’ >> rw [])
+ (* goal 4 (of 10) *)
+ >- (Q.PAT_X_ASSUM ‘!P Q. R1 P Q ==> _’ (MP_TAC o Q.SPECL [‘P’, ‘Q’]) >> rw [] \\
+     Q.PAT_X_ASSUM ‘!a b P'. TRANS P (FreeOutput a b P') ==> _’
+       (MP_TAC o Q.SPECL [‘a’, ‘b’, ‘P'’]) >> rw [] \\
+     Q.EXISTS_TAC ‘Q'’ >> rw [])
+ (* goal 5 (of 10) *)
+ >- (Q.PAT_X_ASSUM ‘!P Q. R1 P Q ==> _’ (MP_TAC o Q.SPECL [‘P’, ‘Q’]) >> rw [] \\
+     Q.PAT_X_ASSUM ‘!x z P'. TRANS P (BoundOutput x z P') /\ _ ==> _’
+       (MP_TAC o Q.SPECL [‘x’, ‘z’, ‘P'’]) >> rw [] \\
+     Q.EXISTS_TAC ‘Q'’ >> rw [])
+ (* goal 6 (of 10) *)
+ >- (Q.PAT_X_ASSUM ‘!P Q. R2 P Q ==> _’ (MP_TAC o Q.SPECL [‘P’, ‘Q’]) >> rw [])
+ (* goal 7 (of 10) *)
+ >- (Q.PAT_X_ASSUM ‘!P Q. R2 P Q ==> _’ (MP_TAC o Q.SPECL [‘P’, ‘Q’]) >> rw [] \\
+     Q.PAT_X_ASSUM ‘!P'. TRANS P (TauR P') ==> _’ (MP_TAC o Q.SPEC ‘P'’) >> rw [] \\
+     Q.EXISTS_TAC ‘Q'’ >> rw [])
+ (* goal 8 (of 10) *)
+ >- (Q.PAT_X_ASSUM ‘!P Q. R2 P Q ==> _’ (MP_TAC o Q.SPECL [‘P’, ‘Q’]) >> rw [] \\
+     Q.PAT_X_ASSUM ‘!x z P'. TRANS P (InputS x z P') /\ _ ==> _’
+       (MP_TAC o Q.SPECL [‘x’, ‘z’, ‘P'’]) >> rw [] \\
+     Q.EXISTS_TAC ‘Q'’ >> rw [])
+ (* goal 9 (of 10) *)
+ >- (Q.PAT_X_ASSUM ‘!P Q. R2 P Q ==> _’ (MP_TAC o Q.SPECL [‘P’, ‘Q’]) >> rw [] \\
+     Q.PAT_X_ASSUM ‘!a b P'. TRANS P (FreeOutput a b P') ==> _’
+       (MP_TAC o Q.SPECL [‘a’, ‘b’, ‘P'’]) >> rw [] \\
+     Q.EXISTS_TAC ‘Q'’ >> rw [])
+ (* goal 10 (of 10) *)
+ >> (Q.PAT_X_ASSUM ‘!P Q. R2 P Q ==> _’ (MP_TAC o Q.SPECL [‘P’, ‘Q’]) >> rw [] \\
+     Q.PAT_X_ASSUM ‘!x z P'. TRANS P (BoundOutput x z P') /\ _ ==> _’
+       (MP_TAC o Q.SPECL [‘x’, ‘z’, ‘P'’]) >> rw [] \\
+     Q.EXISTS_TAC ‘Q'’ >> rw [])
+QED
+
+Theorem open_bisimilar_symmetric :
+    !P Q. open_bisimilar P Q ==> open_bisimilar Q P
+Proof
+    rw [open_bisimilar_def]
+ >> qabbrev_tac ‘R' = \x y. R y x’
+ >> Q.EXISTS_TAC ‘R RUNION R'’
+ >> reverse CONJ_TAC >- simp [RUNION, Abbr ‘R'’]
  >> CONJ_TAC
- >- (MATCH_MP_TAC dist_simulation_union >> art [])
- >> qmatch_abbrev_tac ‘dist_simulation R2’
- >> Suff ‘R2 = R UNION R'’
- >- (Rewr' \\
-     MATCH_MP_TAC dist_simulation_union >> art [])
- >> rw [Once EXTENSION, Abbr ‘R2’, Abbr ‘R'’]
- >> EQ_TAC >> rw []
- >> PairCases_on ‘x’ (* this asserts (x0,x1,x2) *)
- >> rename1 ‘(P',Q',D') IN R’
- >> qexistsl_tac [‘P'’, ‘Q'’, ‘D'’] >> simp []
+ >- (MATCH_MP_TAC open_simulation_union >> art [])
+ >> rw [RUNION, Abbr ‘R'’]
+ >> ‘(\x y. R y x \/ R x y) = (\x y. R y x) RUNION R’
+      by rw [FUN_EQ_THM, RUNION]
+ >> POP_ORW
+ >> MATCH_MP_TAC open_simulation_union >> art []
+QED
+
+Theorem FV_InputS_lemma[local] :
+    !P Q. TRANS P Q ==>
+         !P' x z. Q = InputS x z P' /\ x <> z /\ z # P /\
+                      !y. y # P /\ y <> z ==> y # P'
+Proof
+    cheat
+QED
+
+Theorem FV_InputS :
+    !P P' x z y. TRANS P (InputS x z P') /\ x <> z /\ z # P /\
+                 y # P /\ y <> z ==> y # P'
+Proof
+    METIS_TAC [FV_InputS_lemma]
+QED
+
+Theorem FV_BoundOutput_lemma[local] :
+    !P Q. TRANS P Q ==>
+          !P' x z. Q = BoundOutput x z P' /\ x <> z /\ z # P /\
+                       !y. y # P /\ y <> z ==> y # P'
+Proof
+    cheat
+QED
+
+Theorem FV_BoundOutput :
+    !P P' x z y. TRANS P (BoundOutput x z P') /\ x <> z /\ z # P /\
+                 y # P /\ y <> z ==> y # P'
+Proof
+    METIS_TAC [FV_BoundOutput_lemma]
+QED
+
+Theorem open_bisimilar_transitive :
+    !P1 P2 P3. open_bisimilar P1 P2 /\ open_bisimilar P2 P3 ==> open_bisimilar P1 P3
+Proof
+    rw [open_bisimilar_def]
+ >> Q.EXISTS_TAC ‘R' O R’
+ >> simp [O_DEF]
+ >> reverse CONJ_TAC
+ >- (Q.EXISTS_TAC ‘P2’ >> art [])
+ >> Q.PAT_X_ASSUM ‘R  P1 P2’ K_TAC
+ >> Q.PAT_X_ASSUM ‘R' P2 P3’ K_TAC
+ >> rw [open_simulation_def, O_DEF] (* 5+5 subgoals *)
+ >| [ (* goal 1 (of 10) *)
+      Q.PAT_X_ASSUM ‘open_simulation R’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      Q.PAT_X_ASSUM ‘open_simulation R'’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      Q.EXISTS_TAC ‘tpm pi y’ >> rw [],
+      (* goal 2 (of 10) *)
+      Q.PAT_X_ASSUM ‘open_simulation R’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      Q.PAT_X_ASSUM ‘!P Q P'. R P Q ==> TRANS P (TauR P') ==> _’
+        (MP_TAC o Q.SPECL [‘P’, ‘y’, ‘P'’]) >> rw [] \\
+      Q.PAT_X_ASSUM ‘open_simulation R'’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      rename1 ‘TRANS y (TauR y')’ \\
+      Q.PAT_X_ASSUM ‘!P Q P'. R' P Q ==> TRANS P (TauR P') ==> _’
+        (MP_TAC o Q.SPECL [‘y’, ‘Q’, ‘y'’]) >> rw [] \\
+      Q.EXISTS_TAC ‘Q'’ >> rw [] \\
+      Q.EXISTS_TAC ‘y'’ >> rw [],
+      (* goal 3 (of 10) *)
+      Q.PAT_X_ASSUM ‘open_simulation R’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      qabbrev_tac ‘X = {z} UNION {x} UNION FV y UNION FV P UNION FV Q UNION FV P'’ \\
+     ‘FINITE X’ by rw [Abbr ‘X’] \\
+      Q_TAC (NEW_TAC "z'") ‘X’ \\
+      Q.PAT_X_ASSUM ‘FINITE X’ K_TAC >> fs [Abbr ‘X’, IN_UNION] \\
+      Know ‘InputS x z P' = InputS x z' (tpm [(z',z)] P')’
+      >- (MATCH_MP_TAC tpm_ALPHA_InputS >> art []) \\
+      DISCH_THEN (fs o wrap) \\
+      qabbrev_tac ‘P'' = tpm [(z',z)] P'’ \\
+      Q.PAT_X_ASSUM ‘!P Q x z P'. R P Q ==> TRANS P (InputS x z P') /\ _ ==> _’
+        (MP_TAC o Q.SPECL [‘P’, ‘y’, ‘x’, ‘z'’, ‘P''’]) >> rw [] \\
+      rename1 ‘TRANS y (InputS x z' y')’ \\
+      Q.PAT_X_ASSUM ‘open_simulation R'’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      Q.PAT_X_ASSUM ‘!P Q x z P'. R' P Q ==> TRANS P (InputS x z P') /\ _ ==> _’
+        (MP_TAC o Q.SPECL [‘y’, ‘Q’, ‘x’, ‘z'’, ‘y'’]) >> rw [] \\
+      Know ‘InputS x z' Q' = InputS x z (tpm [(z,z')] Q')’
+      >- (MATCH_MP_TAC tpm_ALPHA_InputS >> art [] \\
+          irule FV_InputS \\
+          qexistsl_tac [‘Q’, ‘x’, ‘z'’] >> rw []) \\
+      DISCH_THEN (fs o wrap) \\
+      qabbrev_tac ‘Q'' = tpm [(z,z')] Q'’ \\
+      Q.EXISTS_TAC ‘Q''’ >> art [] \\
+     ‘P' = tpm [(z',z)] P''’ by rw [Abbr ‘P''’] >> POP_ORW \\
+     ‘tpm [(z',z)] P'' = tpm [(z,z')] P''’
+        by rw [Once pmact_flip_args] >> POP_ORW \\
+      Q.EXISTS_TAC ‘tpm [(z,z')] y'’ >> simp [Abbr ‘Q''’],
+      (* goal 4 (of 10) *)
+      Q.PAT_X_ASSUM ‘open_simulation R’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      Q.PAT_X_ASSUM ‘!P Q a b P'. R P Q ==>
+                                  TRANS P (FreeOutput a b P') ==> _’
+        (MP_TAC o Q.SPECL [‘P’, ‘y’, ‘a’, ‘b’, ‘P'’]) >> rw [] \\
+      rename1 ‘TRANS y (FreeOutput a b y')’ \\
+      Q.PAT_X_ASSUM ‘open_simulation R'’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      Q.PAT_X_ASSUM ‘!P Q a b P'. R' P Q ==>
+                                  TRANS P (FreeOutput a b P') ==> _’
+        (MP_TAC o Q.SPECL [‘y’, ‘Q’, ‘a’, ‘b’, ‘y'’]) >> rw [] \\
+      Q.EXISTS_TAC ‘Q'’ >> rw [] \\
+      Q.EXISTS_TAC ‘y'’ >> rw [],
+      (* goal 5 (of 10) *)
+      Q.PAT_X_ASSUM ‘open_simulation R’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      qabbrev_tac ‘X = {z} UNION {x} UNION FV y UNION FV P UNION FV Q UNION FV P'’ \\
+     ‘FINITE X’ by rw [Abbr ‘X’] \\
+      Q_TAC (NEW_TAC "z'") ‘X’ \\
+      Q.PAT_X_ASSUM ‘FINITE X’ K_TAC >> fs [Abbr ‘X’, IN_UNION] \\
+      Know ‘BoundOutput x z P' = BoundOutput x z' (tpm [(z',z)] P')’
+      >- (MATCH_MP_TAC tpm_ALPHA_BoundOutput >> art []) \\
+      DISCH_THEN (fs o wrap) \\
+      qabbrev_tac ‘P'' = tpm [(z',z)] P'’ \\
+      Q.PAT_X_ASSUM ‘!P Q x z P'. R P Q ==>
+                                  TRANS P (BoundOutput x z P') /\ _ ==> _’
+        (MP_TAC o Q.SPECL [‘P’, ‘y’, ‘x’, ‘z'’, ‘P''’]) >> rw [] \\
+      rename1 ‘TRANS y (BoundOutput x z' y')’ \\
+      Q.PAT_X_ASSUM ‘open_simulation R'’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      Q.PAT_X_ASSUM ‘!P Q x z P'. R' P Q ==>
+                                  TRANS P (BoundOutput x z P') /\ _ ==> _’
+        (MP_TAC o Q.SPECL [‘y’, ‘Q’, ‘x’, ‘z'’, ‘y'’]) >> rw [] \\
+      Know ‘BoundOutput x z' Q' = BoundOutput x z (tpm [(z,z')] Q')’
+      >- (MATCH_MP_TAC tpm_ALPHA_BoundOutput >> art [] \\
+          irule FV_BoundOutput \\
+          qexistsl_tac [‘Q’, ‘x’, ‘z'’] >> rw []) \\
+      DISCH_THEN (fs o wrap) \\
+      qabbrev_tac ‘Q'' = tpm [(z,z')] Q'’ \\
+      Q.EXISTS_TAC ‘Q''’ >> art [] \\
+     ‘P' = tpm [(z',z)] P''’ by rw [Abbr ‘P''’] >> POP_ORW \\
+     ‘tpm [(z',z)] P'' = tpm [(z,z')] P''’
+        by rw [Once pmact_flip_args] >> POP_ORW \\
+      Q.EXISTS_TAC ‘tpm [(z,z')] y'’ >> simp [Abbr ‘Q''’],
+      (* goal 6 (of 10) *)
+      rename1 ‘R P y'’ >> rename1 ‘R' y Q’ \\
+      Q.PAT_X_ASSUM ‘open_simulation R’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      Q.PAT_X_ASSUM ‘open_simulation R'’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      Q.EXISTS_TAC ‘tpm pi y’ >> rw [],
+      (* goal 7 (of 10) *)
+      rename1 ‘R P y'’ >> rename1 ‘R' y Q’ \\
+      rename1 ‘TRANS Q (TauR Q')’ \\
+      Q.PAT_X_ASSUM ‘open_simulation (\x y. R' y x)’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      Q.PAT_X_ASSUM ‘!x y x'. R' y x ==> TRANS x (TauR x') ==> _’
+        (MP_TAC o Q.SPECL [‘Q’, ‘y’, ‘Q'’]) >> rw [] \\
+      Q.PAT_X_ASSUM ‘open_simulation (\x y. R y x)’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      Q.PAT_X_ASSUM ‘!x y x''. R y x ==> TRANS x (TauR x') ==> _’
+        (MP_TAC o Q.SPECL [‘y’, ‘P’, ‘y'’]) >> rw [] \\
+      rename1 ‘TRANS P (TauR P')’ \\
+      Q.EXISTS_TAC ‘P'’ >> rw [] \\
+      Q.EXISTS_TAC ‘y'’ >> rw [],
+      (* goal 8 (of 10) *)
+      rename1 ‘R P y'’ >> rename1 ‘R' y Q’ \\
+      rename1 ‘TRANS Q (InputS x z Q')’ \\
+      Q.PAT_X_ASSUM ‘open_simulation (\x y. R' y x)’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      qabbrev_tac ‘X = {z} UNION {x} UNION FV y UNION FV P UNION FV Q UNION FV Q'’ \\
+     ‘FINITE X’ by rw [Abbr ‘X’] \\
+      Q_TAC (NEW_TAC "z'") ‘X’ \\
+      Q.PAT_X_ASSUM ‘FINITE X’ K_TAC >> fs [Abbr ‘X’, IN_UNION] \\
+      Know ‘InputS x z Q' = InputS x z' (tpm [(z',z)] Q')’
+      >- (MATCH_MP_TAC tpm_ALPHA_InputS >> art []) \\
+      DISCH_THEN (fs o wrap) \\
+      qabbrev_tac ‘Q'' = tpm [(z',z)] Q'’ \\
+      Q.PAT_X_ASSUM
+        ‘!x y x' z x''. R' y x ==> TRANS x (InputS x' z x'') /\ _ ==> _’
+        (MP_TAC o Q.SPECL [‘Q’, ‘y’, ‘x’, ‘z'’, ‘Q''’]) >> rw [] \\
+      Q.PAT_X_ASSUM ‘open_simulation (\x y. R y x)’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      Q.PAT_X_ASSUM
+        ‘!x y x' z x''. R y x ==> TRANS x (InputS x' z x'') /\ _ ==> _’
+        (MP_TAC o Q.SPECL [‘y’, ‘P’, ‘x’, ‘z'’, ‘y'’]) >> rw [] \\
+      rename1 ‘TRANS P (InputS x z' P')’ \\
+      Know ‘InputS x z' P' = InputS x z (tpm [(z,z')] P')’
+      >- (MATCH_MP_TAC tpm_ALPHA_InputS >> art [] \\
+          irule FV_InputS \\
+          qexistsl_tac [‘P’, ‘x’, ‘z'’] >> rw []) \\
+      DISCH_THEN (fs o wrap) \\
+      qabbrev_tac ‘P'' = tpm [(z,z')] P'’ \\
+      Q.EXISTS_TAC ‘P''’ >> art [] \\
+     ‘Q' = tpm [(z',z)] Q''’ by rw [Abbr ‘Q''’] >> POP_ORW \\
+     ‘tpm [(z',z)] Q'' = tpm [(z,z')] Q''’
+        by rw [Once pmact_flip_args] >> POP_ORW \\
+      Q.EXISTS_TAC ‘tpm [(z,z')] y'’ >> simp [Abbr ‘P''’],
+      (* goal 9 (of 10) *)
+      rename1 ‘R P y'’ >> rename1 ‘R' y Q’ \\
+      rename1 ‘TRANS Q (FreeOutput a b Q')’ \\
+      Q.PAT_X_ASSUM ‘open_simulation (\x y. R' y x)’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      Q.PAT_X_ASSUM ‘!x y a b x'. R' y x ==>
+                                  TRANS x (FreeOutput a b x') ==> _’
+        (MP_TAC o Q.SPECL [‘Q’, ‘y’, ‘a’, ‘b’, ‘Q'’]) >> rw [] \\
+      Q.PAT_X_ASSUM ‘open_simulation (\x y. R y x)’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      Q.PAT_X_ASSUM ‘!x y a b x'. R y x ==>
+                                  TRANS x (FreeOutput a b x') ==> _’
+        (MP_TAC o Q.SPECL [‘y’, ‘P’, ‘a’, ‘b’, ‘y'’]) >> rw [] \\
+      rename1 ‘TRANS P (FreeOutput a b P')’ \\
+      Q.EXISTS_TAC ‘P'’ >> rw [] \\
+      Q.EXISTS_TAC ‘y'’ >> rw [],
+      (* goal 10 (of 10) *)
+      rename1 ‘R P y'’ >> rename1 ‘R' y Q’ \\
+      rename1 ‘TRANS Q (BoundOutput x z Q')’ \\
+      Q.PAT_X_ASSUM ‘open_simulation (\x y. R' y x)’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      qabbrev_tac ‘X = {z} UNION {x} UNION FV y UNION FV P UNION FV Q UNION FV Q'’ \\
+     ‘FINITE X’ by rw [Abbr ‘X’] \\
+      Q_TAC (NEW_TAC "z'") ‘X’ \\
+      Q.PAT_X_ASSUM ‘FINITE X’ K_TAC >> fs [Abbr ‘X’, IN_UNION] \\
+      Know ‘BoundOutput x z Q' = BoundOutput x z' (tpm [(z',z)] Q')’
+      >- (MATCH_MP_TAC tpm_ALPHA_BoundOutput >> art []) \\
+      DISCH_THEN (fs o wrap) \\
+      qabbrev_tac ‘Q'' = tpm [(z',z)] Q'’ \\
+      Q.PAT_X_ASSUM ‘!x y x' z x''. R' y x ==>
+                                    TRANS x (BoundOutput x' z x'') /\ _ ==> _’
+        (MP_TAC o Q.SPECL [‘Q’, ‘y’, ‘x’, ‘z'’, ‘Q''’]) >> rw [] \\
+      Q.PAT_X_ASSUM ‘open_simulation (\x y. R y x)’
+        (STRIP_ASSUME_TAC o SIMP_RULE (std_ss ++ DNF_ss) [open_simulation_def]) \\
+      Q.PAT_X_ASSUM ‘!x y x' z x''. R y x ==>
+                                    TRANS x (BoundOutput x' z x'') /\ _ ==> _’
+        (MP_TAC o Q.SPECL [‘y’, ‘P’, ‘x’, ‘z'’, ‘y'’]) >> rw [] \\
+      rename1 ‘TRANS P (BoundOutput x z' P')’ \\
+      Know ‘BoundOutput x z' P' = BoundOutput x z (tpm [(z,z')] P')’
+      >- (MATCH_MP_TAC tpm_ALPHA_BoundOutput >> art [] \\
+          irule FV_BoundOutput \\
+          qexistsl_tac [‘P’, ‘x’, ‘z'’] >> rw []) \\
+      DISCH_THEN (fs o wrap) \\
+      qabbrev_tac ‘P'' = tpm [(z,z')] P'’ \\
+      Q.EXISTS_TAC ‘P''’ >> art [] \\
+     ‘Q' = tpm [(z',z)] Q''’ by rw [Abbr ‘Q''’] >> POP_ORW \\
+     ‘tpm [(z',z)] Q'' = tpm [(z,z')] Q''’
+        by rw [Once pmact_flip_args] >> POP_ORW \\
+      Q.EXISTS_TAC ‘tpm [(z,z')] y'’ >> simp [Abbr ‘P''’] ]
+QED
+
+Theorem equivalence_open_bisimilar :
+    equivalence open_bisimilar
+Proof
+    rw [equivalence_def]
+ >| [ (* goal 1 (of 3) *)
+      rw [reflexive_def, open_bisimilar_reflexive],
+      (* goal 2 (of 3) *)
+      rw [symmetric_def] \\
+      EQ_TAC >> rw [open_bisimilar_symmetric],
+      (* goal 3 (of 3) *)
+      rw [transitive_def] \\
+      MATCH_MP_TAC open_bisimilar_transitive \\
+      Q.EXISTS_TAC ‘y’ >> art [] ]
 QED
 
 val _ = export_theory ();

--- a/examples/formal-languages/pi-calculus/pi_agentScript.sml
+++ b/examples/formal-languages/pi-calculus/pi_agentScript.sml
@@ -2,14 +2,17 @@
 (* FILE          : pi_agentScript.sml                                         *)
 (* DESCRIPTION   : Nominal type for process (agent) of pi-calculus            *)
 (*                                                                            *)
-(* Copyright 2025  The Australian National University (Author: Chun Tian)     *)
+(* Copyright 2025  Michael Norrish and Chun Tian                              *)
 (* ========================================================================== *)
 
 open HolKernel Parse boolLib bossLib;
 
-open pred_setTheory listTheory;
+open pred_setTheory listTheory listLib alistTheory;
 
-open generic_termsTheory binderLib nomsetTheory nomdatatype;
+open basic_swapTheory generic_termsTheory binderLib nomsetTheory nomdatatype;
+
+(* only for its syntax of SUB *)
+local open termTheory in end;
 
 val _ = new_theory "pi_agent";
 
@@ -20,35 +23,24 @@ val _ = new_theory "pi_agent";
 
    Nominal_datatype :
 
-           name = Name string
-
            pi   = Nil                      (* 0 *)
                 | Tau pi                   (* tau.P *)
-                | Input name ''name pi     (* a(x).P *)
-                | Output name name pi      (* {a}b.P *)
-                | Match name name pi       (* [a == b] P *)
-                | Mismatch name name pi    (* [a <> b] P *)
+                | Input 'free 'bound pi    (* a(x).P *)
+                | Output 'free 'free pi    (* {a}b.P *)
+                | Match 'free 'free pi     (* [a == b] P *)
+                | Mismatch 'free 'free pi  (* [a <> b] P *)
                 | Sum pi pi                (* P + Q *)
                 | Par pi pi                (* P | Q *)
-                | Res ''name pi            (* nu x. P *)
+                | Res 'bound pi            (* nu x. P *)
 
        residual = TauR pi
-                | InputS name ''name pi      (* Input *)
-                | BoundOutput name ''name pi (* Bound output *)
-                | FreeOutput name name pi    (* Free output *)
+                | InputS 'free 'bound pi      (* Input *)
+                | BoundOutput 'free 'bound pi (* Bound output *)
+                | FreeOutput 'free 'free pi   (* Free output *)
    End
 
-   NOTE: Replication ("!") is not need so far.
+   NOTE: Replication ("!") is not needed so far, but can be supported later.
    ---------------------------------------------------------------------- *)
-
-val tyname0 = "name";
-val tyname1 = "pi";
-val tyname2 = "residual";
-
-(* "Name" is under GVAR (of type 0); There's an extra "Var" under type 1 *)
-val unit_t = “:unit”;
-val u_tm = mk_var("u", unit_t);
-val vp = “(\n ^u_tm. n = 0)”;
 
 Datatype:
   repcode = rNil | rTau | rInput | rOutput | rMatch | rMismatch | rSum
@@ -56,41 +48,32 @@ Datatype:
           | rTauR | rInputS | rBoundOutput | rFreeOutput
 End
 
+val tyname1 = "pi";
+val tyname2 = "residual";
+
 (* type 0 = name; 1 = pi; 2 = residual *)
 val rep_t = “:repcode”
 val d_tm = mk_var("d", rep_t);
 val lp =
-  “(\n d tns uns.
-     n = 1 /\ d = rNil ∧ tns = [] ∧ uns = [] \/
-     n = 1 /\ d = rTau ∧ tns = [] /\ uns = [1] \/
-     n = 1 /\ d = rInput ∧ tns = [1] /\ uns = [0] \/
-     n = 1 /\ d = rOutput ∧ tns = [] /\ uns = [0; 0; 1] \/
-     n = 1 /\ d = rMatch ∧ tns = [] /\ uns = [0; 0; 1] \/
-     n = 1 /\ d = rMismatch ∧ tns = [] /\ uns = [0; 0; 1] \/
-     n = 1 /\ d = rSum ∧ tns = [] /\ uns = [1; 1] \/
-     n = 1 /\ d = rPar ∧ tns = [] /\ uns = [1; 1] \/
-     n = 1 /\ d = rRes ∧ tns = [1] /\ uns = [] \/
+  “(\n lfvs d tns uns.
+     n = 1 /\ lfvs = 0 /\ d = rNil ∧ tns = [] ∧ uns = [] \/
+     n = 1 /\ lfvs = 0 /\ d = rTau ∧ tns = [] /\ uns = [1] \/
+     n = 1 /\ lfvs = 1 /\ d = rInput ∧ tns = [1] /\ uns = [] \/
+     n = 1 /\ lfvs = 2 /\ d = rOutput ∧ tns = [] /\ uns = [1] \/
+     n = 1 /\ lfvs = 2 /\ d = rMatch ∧ tns = [] /\ uns = [1] \/
+     n = 1 /\ lfvs = 2 /\ d = rMismatch ∧ tns = [] /\ uns = [1] \/
+     n = 1 /\ lfvs = 0 /\ d = rSum ∧ tns = [] /\ uns = [1; 1] \/
+     n = 1 /\ lfvs = 0 /\ d = rPar ∧ tns = [] /\ uns = [1; 1] \/
+     n = 1 /\ lfvs = 0 /\ d = rRes ∧ tns = [1] /\ uns = [] \/
 
-     n = 2 /\ d = rTauR ∧ tns = [] ∧ uns = [1] \/
-     n = 2 /\ d = rInputS ∧ tns = [1] /\ uns = [0] \/
-     n = 2 /\ d = rBoundOutput ∧ tns = [1] /\ uns = [0] \/
-     n = 2 /\ d = rFreeOutput ∧ tns = [] /\ uns = [0; 0; 1]
+     n = 2 /\ lfvs = 0 /\ d = rTauR ∧ tns = [] ∧ uns = [1] \/
+     n = 2 /\ lfvs = 1 /\ d = rInputS ∧ tns = [1] /\ uns = [] \/
+     n = 2 /\ lfvs = 1 /\ d = rBoundOutput ∧ tns = [1] /\ uns = [] \/
+     n = 2 /\ lfvs = 2 /\ d = rFreeOutput ∧ tns = [] /\ uns = [1]
     )”;
 
 (* This is often useful for debugging purposes *)
 Overload LP = lp;
-
-(* type 0 (:name) *)
-val {term_ABS_pseudo11 = term_ABS_pseudo11_0,
-     term_REP_11 = term_REP_11_0,
-     genind_term_REP = genind_term_REP0,
-     genind_exists = genind_exists0,
-     termP = termP0,
-     absrep_id = absrep_id0,
-     repabs_pseudo_id = repabs_pseudo_id0,
-     term_REP_t = term_REP_t0,
-     term_ABS_t = term_ABS_t0,
-     newty = newty0, ...} = new_type_step1 tyname0 0 [] {vp = vp, lp = lp};
 
 (* type 1 (:pi) *)
 val {term_ABS_pseudo11 = term_ABS_pseudo11_1,
@@ -102,7 +85,7 @@ val {term_ABS_pseudo11 = term_ABS_pseudo11_1,
      repabs_pseudo_id = repabs_pseudo_id1,
      term_REP_t = term_REP_t1,
      term_ABS_t = term_ABS_t1,
-     newty = newty1, ...} = new_type_step1 tyname1 1 [] {vp = vp, lp = lp};
+     newty = newty1, ...} = new_type_step1 tyname1 1 [] {lp = lp};
 
 (* type 2 (:residual) *)
 val {term_ABS_pseudo11 = term_ABS_pseudo11_2,
@@ -115,254 +98,188 @@ val {term_ABS_pseudo11 = term_ABS_pseudo11_2,
      term_REP_t = term_REP_t2,
      term_ABS_t = term_ABS_t2,
      newty = newty2, ...} =
-     new_type_step1 tyname2 2 [genind_exists0, genind_exists1] {vp = vp, lp = lp};
+     new_type_step1 tyname2 2 [genind_exists1] {lp = lp};
 
 (* ----------------------------------------------------------------------
     Pi-calculus operators
    ---------------------------------------------------------------------- *)
 
-val [gvar,glam] = genind_rules |> SPEC_ALL |> CONJUNCTS;
-
-Theorem GLAM_NIL_ELIM[local]:
-  GLAM u bv [] ts = GLAM ARB bv [] ts
-Proof
-  simp[GLAM_NIL_EQ]
-QED
-
-(* "Name" of type 0 (:name) *)
-val Name_t = mk_var("Name", “:string -> ^newty0”);
-val Name_def = new_definition(
-   "Name_def", “^Name_t s = ^term_ABS_t0 (GVAR s ())”);
-val Name_termP = prove(
-    mk_comb(termP0, Name_def |> SPEC_ALL |> concl |> rhs |> rand),
-    srw_tac [][genind_rules]);
-val Name_t = defined_const Name_def;
+val glam = genind_lam
+Overload pilp[local] = “genind ^lp”
+fun toArb t = subst [“uu:string” |-> “ARB:string”] t
 
 (* Nil *)
 val Nil_t = mk_var("Nil", “:^newty1”);
+val Nil_pattern = “GLAM uu [] rNil [][]”;
 val Nil_def = new_definition(
    "Nil_def",
-  “^Nil_t = ^term_ABS_t1 (GLAM ARB rNil [] [])”);
+  “^Nil_t = ^term_ABS_t1 ^(toArb Nil_pattern)”);
 val Nil_termP = prove(
-   “^termP1 (GLAM x rNil [] [])”,
+    mk_comb(termP1, Nil_pattern),
     match_mp_tac glam >> srw_tac [][genind_term_REP1]);
 val Nil_t = defined_const Nil_def;
 val Nil_def' = prove(
-  “^term_ABS_t1 (GLAM v rNil [] []) = ^Nil_t”,
+  “^term_ABS_t1 ^Nil_pattern = ^Nil_t”,
     srw_tac [][Nil_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Nil_termP]);
 
 (* Tau prefix *)
 val Tau_t = mk_var("Tau", “:^newty1 -> ^newty1”);
+val Tau_pattern = “GLAM uu [] rTau [] [^term_REP_t1 P]”;
 val Tau_def = new_definition(
    "Tau_def",
-  “^Tau_t P = ^term_ABS_t1 (GLAM ARB rTau [] [^term_REP_t1 P])”);
+  “^Tau_t P = ^term_ABS_t1 ^(toArb Tau_pattern)”);
 val Tau_termP = prove(
-   “^termP1 (GLAM x rTau [] [^term_REP_t1 P])”,
+    mk_comb(termP1, Tau_pattern),
     match_mp_tac glam >> srw_tac [][genind_term_REP1]);
 val Tau_t = defined_const Tau_def;
 val Tau_def' = prove(
-  “^term_ABS_t1 (GLAM v rTau [] [^term_REP_t1 P]) = ^Tau_t P”,
+  “^term_ABS_t1 ^Tau_pattern = ^Tau_t P”,
     srw_tac [][Tau_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Tau_termP]);
 
 (* Input prefix *)
-val Input_t = mk_var("Input", “:^newty0 -> string -> ^newty1 -> ^newty1”);
+val Input_t = mk_var("Input", “:string -> string -> ^newty1 -> ^newty1”);
+val Input_pattern = “GLAM x [a] rInput [^term_REP_t1 P] []”;
 val Input_def = new_definition(
    "Input_def",
-  “^Input_t a x P =
-   ^term_ABS_t1 (GLAM x rInput [^term_REP_t1 P] [^term_REP_t0 a])”);
+  “^Input_t a x P = ^term_ABS_t1 ^Input_pattern”);
 val Input_termP = prove(
-    mk_comb(termP1, Input_def |> SPEC_ALL |> concl |> rhs |> rand),
-    match_mp_tac glam >> srw_tac [][genind_term_REP0, genind_term_REP1]);
+    mk_comb(termP1, Input_pattern),
+    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
 val Input_t = defined_const Input_def;
 
 (* Output prefix *)
-val Output_t = mk_var("Output", “:^newty0 -> ^newty0 -> ^newty1 -> ^newty1”);
+val Output_t = mk_var("Output", “:string -> string -> ^newty1 -> ^newty1”);
+val Output_pattern = “GLAM uu [a; b] rOutput [] [^term_REP_t1 P]”;
 val Output_def = new_definition(
    "Output_def",
-  “^Output_t a b P =
-   ^term_ABS_t1 (GLAM ARB rOutput [] [^term_REP_t0 a; ^term_REP_t0 b;
-                                      ^term_REP_t1 P])”);
+  “^Output_t a b P = ^term_ABS_t1 ^(toArb Output_pattern)”);
 val Output_termP = prove(
-   “^termP1
-      (GLAM x rOutput [] [^term_REP_t0 a; ^term_REP_t0 b; ^term_REP_t1 P])”,
-    match_mp_tac glam >> srw_tac [][genind_term_REP0,genind_term_REP1]);
+    mk_comb(termP1, Output_pattern),
+    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
 val Output_t = defined_const Output_def;
 val Output_def' = prove(
-  “^term_ABS_t1
-     (GLAM v rOutput [] [^term_REP_t0 a; ^term_REP_t0 b; ^term_REP_t1 P]) =
-   ^Output_t a b P”,
-  srw_tac [][Output_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Output_termP]);
+  “^term_ABS_t1 ^Output_pattern = ^Output_t a b P”,
+    srw_tac [][Output_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Output_termP]);
 
 (* Match *)
-val Match_t = mk_var("Match", “:^newty0 -> ^newty0 -> ^newty1 -> ^newty1”);
+val Match_t = mk_var("Match", “:string -> string -> ^newty1 -> ^newty1”);
+val Match_pattern = “GLAM uu [a; b] rMatch [] [^term_REP_t1 P]”;
 val Match_def = new_definition(
    "Match_def",
-  “^Match_t a b P =
-   ^term_ABS_t1 (GLAM ARB rMatch [] [^term_REP_t0 a; ^term_REP_t0 b;
-                                     ^term_REP_t1 P])”);
+  “^Match_t a b P = ^term_ABS_t1 ^(toArb Match_pattern)”);
 val Match_termP = prove(
-  “^termP1 (GLAM x rMatch [] [^term_REP_t0 a; ^term_REP_t0 b; ^term_REP_t1 P])”,
-    match_mp_tac glam >> srw_tac [][genind_term_REP0,genind_term_REP1]);
+    mk_comb(termP1, Match_pattern),
+    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
 val Match_t = defined_const Match_def;
 val Match_def' = prove(
-  “^term_ABS_t1 (GLAM v rMatch [] [^term_REP_t0 a; ^term_REP_t0 b;
-                                   ^term_REP_t1 P]) = ^Match_t a b P”,
+  “^term_ABS_t1 ^Match_pattern = ^Match_t a b P”,
     srw_tac [][Match_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Match_termP]);
 
 (* Mismatch *)
-val Mismatch_t = mk_var("Mismatch", “:^newty0 -> ^newty0 -> ^newty1 -> ^newty1”);
+val Mismatch_t = mk_var("Mismatch", “:string -> string -> ^newty1 -> ^newty1”);
+val Mismatch_pattern = “GLAM uu [a; b] rMismatch [] [^term_REP_t1 P]”;
 val Mismatch_def = new_definition(
    "Mismatch_def",
-  “^Mismatch_t a b P =
-   ^term_ABS_t1 (GLAM ARB rMismatch []
-                          [^term_REP_t0 a; ^term_REP_t0 b; ^term_REP_t1 P])”);
+  “^Mismatch_t a b P = ^term_ABS_t1 ^(toArb Mismatch_pattern)”);
 val Mismatch_termP = prove(
-   “^termP1 (GLAM x rMismatch []
-                          [^term_REP_t0 a; ^term_REP_t0 b; ^term_REP_t1 P])”,
-    match_mp_tac glam >> srw_tac [][genind_term_REP0,genind_term_REP1]);
+    mk_comb(termP1, Mismatch_pattern),
+    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
 val Mismatch_t = defined_const Mismatch_def;
 val Mismatch_def' = prove(
-  “^term_ABS_t1 (GLAM v rMismatch []
-                          [^term_REP_t0 a;
-                           ^term_REP_t0 b;
-                           ^term_REP_t1 P]) = ^Mismatch_t a b P”,
+  “^term_ABS_t1 ^Mismatch_pattern = ^Mismatch_t a b P”,
     srw_tac [][Mismatch_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Mismatch_termP]);
 
 (* Sum (Choice) *)
 val Sum_t = mk_var("Sum", “:^newty1 -> ^newty1 -> ^newty1”);
+val Sum_pattern = “GLAM uu [] rSum [] [^term_REP_t1 P; ^term_REP_t1 Q]”;
 val Sum_def = new_definition(
    "Sum_def",
-  “^Sum_t P Q =
-   ^term_ABS_t1 (GLAM ARB rSum [] [^term_REP_t1 P; ^term_REP_t1 Q])”);
+  “^Sum_t P Q = ^term_ABS_t1 ^(toArb Sum_pattern)”);
 val Sum_termP = prove(
-   “^termP1 (GLAM x rSum [] [^term_REP_t1 P; ^term_REP_t1 Q])”,
+    mk_comb(termP1, Sum_pattern),
     match_mp_tac glam >> srw_tac [][genind_term_REP1]);
 val Sum_t = defined_const Sum_def;
 val Sum_def' = prove(
-  “^term_ABS_t1 (GLAM v rSum [] [^term_REP_t1 P; ^term_REP_t1 Q]) = ^Sum_t P Q”,
+  “^term_ABS_t1 ^Sum_pattern = ^Sum_t P Q”,
     srw_tac [][Sum_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Sum_termP]);
 
 (* Parallel Composition *)
 val Par_t = mk_var("Par", “:^newty1 -> ^newty1 -> ^newty1”);
+val Par_pattern = “GLAM uu [] rPar [] [^term_REP_t1 P; ^term_REP_t1 Q]”;
 val Par_def = new_definition(
    "Par_def",
-  “^Par_t P Q =
-   ^term_ABS_t1 (GLAM ARB rPar [] [^term_REP_t1 P; ^term_REP_t1 Q])”);
+  “^Par_t P Q = ^term_ABS_t1 ^(toArb Par_pattern)”);
 val Par_termP = prove(
-   “^termP1 (GLAM x rPar [] [^term_REP_t1 P; ^term_REP_t1 Q])”,
+    mk_comb(termP1, Par_pattern),
     match_mp_tac glam >> srw_tac [][genind_term_REP1]);
 val Par_t = defined_const Par_def;
 val Par_def' = prove(
-  “^term_ABS_t1 (GLAM v rPar [] [^term_REP_t1 P; ^term_REP_t1 Q]) = ^Par_t P Q”,
+  “^term_ABS_t1 ^Par_pattern = ^Par_t P Q”,
     srw_tac [][Par_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Par_termP]);
 
 (* Restriction *)
 val Res_t = mk_var("Res", “:string -> ^newty1 -> ^newty1”);
+val Res_pattern = “GLAM v [] rRes [^term_REP_t1 P] []”;
 val Res_def = new_definition(
    "Res_def",
-  “^Res_t v P =
-   ^term_ABS_t1 (GLAM v rRes [^term_REP_t1 P] [])”);
-val Res_tm = Res_def |> concl |> strip_forall |> snd |> rhs |> rand;
+  “^Res_t v P = ^term_ABS_t1 ^Res_pattern”);
 val Res_termP = prove(
-    mk_comb (termP1, Res_tm),
+    mk_comb (termP1, Res_pattern),
     match_mp_tac glam >> srw_tac [][genind_term_REP1]);
 val Res_t = defined_const Res_def;
 
 (* TauR *)
 val TauR_t = mk_var("TauR", “:^newty1 -> ^newty2”);
+val TauR_pattern = “GLAM uu [] rTauR [] [^term_REP_t1 P]”;
 val TauR_def = new_definition(
    "TauR_def",
-  “^TauR_t P =
-   ^term_ABS_t2 (GLAM ARB rTauR [] [^term_REP_t1 P])”);
-val TauR_tm = TauR_def |> concl |> strip_forall |> snd |> rhs |> rand;
+  “^TauR_t P = ^term_ABS_t2 ^(toArb TauR_pattern)”);
 val TauR_termP = prove(
-   “^termP2 (GLAM x rTauR [] [^term_REP_t1 P])”,
+    mk_comb(termP2, TauR_pattern),
     match_mp_tac glam >> srw_tac [][genind_term_REP1]);
 val TauR_t = defined_const TauR_def;
 val TauR_def' = prove(
-  “^term_ABS_t2 (GLAM v rTauR [] [^term_REP_t1 P]) = ^TauR_t P”,
+  “^term_ABS_t2 ^TauR_pattern = ^TauR_t P”,
     srw_tac [][TauR_def, GLAM_NIL_EQ, term_ABS_pseudo11_2, TauR_termP]);
 
 (* Bound output (residual) *)
 val BoundOutput_t =
-    mk_var("BoundOutput", “:^newty0 -> string -> ^newty1 -> ^newty2”);
+    mk_var("BoundOutput", “:string -> string -> ^newty1 -> ^newty2”);
+val BoundOutput_pattern = “GLAM x [a] rBoundOutput [^term_REP_t1 P] []”;
 val BoundOutput_def = new_definition(
    "BoundOutput_def",
-  “^BoundOutput_t a x P =
-   ^term_ABS_t2 (GLAM x rBoundOutput [^term_REP_t1 P] [^term_REP_t0 a])”);
+  “^BoundOutput_t a x P = ^term_ABS_t2 ^BoundOutput_pattern”);
 val BoundOutput_termP = prove(
-    mk_comb(termP2, BoundOutput_def |> SPEC_ALL |> concl |> rhs |> rand),
-    match_mp_tac glam >> srw_tac [][genind_term_REP0, genind_term_REP1]);
+    mk_comb(termP2, BoundOutput_pattern),
+    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
 val BoundOutput_t = defined_const BoundOutput_def;
 
 (* Input residual *)
-val InputS_t = mk_var("InputS", “:^newty0 -> string -> ^newty1 -> ^newty2”);
+val InputS_t = mk_var("InputS", “:string -> string -> ^newty1 -> ^newty2”);
+val InputS_pattern = “GLAM x [a] rInputS [^term_REP_t1 P] []”;
 val InputS_def = new_definition(
    "InputS_def",
-  “^InputS_t a x P =
-   ^term_ABS_t2 (GLAM x rInputS [^term_REP_t1 P] [^term_REP_t0 a])”);
+  “^InputS_t a x P = ^term_ABS_t2 ^InputS_pattern”);
 val InputS_termP = prove(
-    mk_comb(termP2, InputS_def |> SPEC_ALL |> concl |> rhs |> rand),
-    match_mp_tac glam >> srw_tac [][genind_term_REP0, genind_term_REP1]);
+    mk_comb(termP2, InputS_pattern),
+    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
 val InputS_t = defined_const InputS_def;
 
 (* Free output (residual) *)
 val FreeOutput_t =
-    mk_var("FreeOutput", “:^newty0 -> ^newty0 -> ^newty1 -> ^newty2”);
+    mk_var("FreeOutput", “:string -> string -> ^newty1 -> ^newty2”);
+val FreeOutput_pattern = “GLAM uu [a; b] rFreeOutput [] [^term_REP_t1 P]”;
 val FreeOutput_def = new_definition(
    "FreeOutput_def",
-  “^FreeOutput_t a b P =
-   ^term_ABS_t2 (GLAM ARB rFreeOutput []
-                      [^term_REP_t0 a; ^term_REP_t0 b; ^term_REP_t1 P])”);
+  “^FreeOutput_t a b P = ^term_ABS_t2 ^(toArb FreeOutput_pattern)”);
 val FreeOutput_termP = prove(
-   “^termP2 (GLAM x rFreeOutput
-                    [] [^term_REP_t0 a; ^term_REP_t0 b; ^term_REP_t1 P])”,
-    match_mp_tac glam >> srw_tac [][genind_term_REP0, genind_term_REP1]);
+    mk_comb(termP2, FreeOutput_pattern),
+    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
 val FreeOutput_t = defined_const FreeOutput_def;
 val FreeOutput_def' = prove(
-  “^term_ABS_t2 (GLAM v rFreeOutput
-                        [] [^term_REP_t0 a; ^term_REP_t0 b; ^term_REP_t1 P]) =
-   ^FreeOutput_t a b P”,
+  “^term_ABS_t2 ^FreeOutput_pattern = ^FreeOutput_t a b P”,
     srw_tac [][FreeOutput_def, GLAM_NIL_EQ, term_ABS_pseudo11_2,
                FreeOutput_termP]);
-
-(* ----------------------------------------------------------------------
-    npm - permutation of pi-calculus names
-   ---------------------------------------------------------------------- *)
-
-val ncons_info = [{con_termP = Name_termP, con_def = Name_def}];
-val npm_name_pfx = "n";
-
-val {tpm_thm = npm_thm,
-     term_REP_tpm = term_REP_npm,
-     t_pmact_t = n_pmact_t,
-     tpm_t = npm_t} =
-    define_permutation {name_pfx = npm_name_pfx, name = tyname0,
-                        term_REP_t = term_REP_t0,
-                        term_ABS_t = term_ABS_t0,
-                        absrep_id = absrep_id0,
-                        repabs_pseudo_id = repabs_pseudo_id0,
-                        cons_info = ncons_info,
-                        newty = newty0,
-                        genind_term_REP = genind_term_REP0};
-
-Theorem npm_eqr :
-    t = npm pi u <=> npm (REVERSE pi) t = (u :name)
-Proof
-    METIS_TAC [pmact_inverse]
-QED
-
-Theorem npm_eql :
-    npm pi t = u <=> t = npm (REVERSE pi) (u :name)
-Proof
-    simp[npm_eqr]
-QED
-
-Theorem npm_CONS :
-    npm ((x,y)::pi) (t :name) = npm [(x,y)] (npm pi t)
-Proof
-    SRW_TAC [][GSYM pmact_decompose]
-QED
 
 (* ----------------------------------------------------------------------
     tpm - permutation of pi-calculus binding variables
@@ -390,8 +307,25 @@ val {tpm_thm, term_REP_tpm, t_pmact_t, tpm_t} =
                         newty = newty1,
                         genind_term_REP = genind_term_REP1};
 
+(* |- (!pi. tpm pi Nil = Nil) /\ (!pi P. tpm pi (Tau P) = Tau (tpm pi P)) /\
+      (!x pi a P.
+         tpm pi (Input a x P) =
+         Input (lswapstr pi a) (lswapstr pi x) (tpm pi P)) /\
+      (!pi b a P.
+         tpm pi (Output a b P) =
+         Output (lswapstr pi a) (lswapstr pi b) (tpm pi P)) /\
+      (!pi b a P.
+         tpm pi (Match a b P) =
+         Match (lswapstr pi a) (lswapstr pi b) (tpm pi P)) /\
+      (!pi b a P.
+         tpm pi (Mismatch a b P) =
+         Mismatch (lswapstr pi a) (lswapstr pi b) (tpm pi P)) /\
+      (!pi Q P. tpm pi (Sum P Q) = Sum (tpm pi P) (tpm pi Q)) /\
+      (!pi Q P. tpm pi (Par P Q) = Par (tpm pi P) (tpm pi Q)) /\
+      !v pi P. tpm pi (Res v P) = Res (lswapstr pi v) (tpm pi P)
+ *)
 Theorem tpm_thm[allow_rebind] =
-        tpm_thm |> REWRITE_RULE [GSYM term_REP_npm, GSYM Input_def, Output_def',
+        tpm_thm |> REWRITE_RULE [GSYM Input_def, Output_def',
                                  Match_def', Mismatch_def'];
 
 Theorem tpm_eqr :
@@ -437,9 +371,20 @@ val {tpm_thm = rpm_thm,
                         newty = newty2,
                         genind_term_REP = genind_term_REP2};
 
+(* |- (!pi P. rpm pi (TauR P) = TauR (tpm pi P)) /\
+      (!x pi a P.
+         rpm pi (BoundOutput a x P) =
+         BoundOutput (lswapstr pi a) (lswapstr pi x) (tpm pi P)) /\
+      (!x pi a P.
+         rpm pi (InputS a x P) =
+         InputS (lswapstr pi a) (lswapstr pi x) (tpm pi P)) /\
+      !pi b a P.
+        rpm pi (FreeOutput a b P) =
+        FreeOutput (lswapstr pi a) (lswapstr pi b) (tpm pi P)
+ *)
 Theorem rpm_thm[allow_rebind] =
         rpm_thm
-     |> REWRITE_RULE [GSYM term_REP_npm, GSYM term_REP_tpm, TauR_def',
+     |> REWRITE_RULE [GSYM term_REP_tpm, TauR_def',
                       GSYM BoundOutput_def, GSYM InputS_def, FreeOutput_def']
 
 Theorem rpm_eqr :
@@ -459,74 +404,6 @@ Theorem rpm_CONS :
 Proof
     SRW_TAC [][GSYM pmact_decompose]
 QED
-
-(* ----------------------------------------------------------------------
-    support (supp) and FV (for type :name)
-   ---------------------------------------------------------------------- *)
-
-val name_REP_eqv = prove(
-   “support (fn_pmact ^n_pmact_t gt_pmact) ^term_REP_t0 {}”,
-    srw_tac [][support_def, fnpm_def, FUN_EQ_THM, term_REP_npm, pmact_sing_inv]);
-
-val supp_name_REP = prove(
-   “supp (fn_pmact ^n_pmact_t gt_pmact) ^term_REP_t0 = {}”,
-    REWRITE_TAC [GSYM SUBSET_EMPTY]
- >> MATCH_MP_TAC (GEN_ALL supp_smallest)
- >> srw_tac [][name_REP_eqv]);
-
-val npm_def' =
-    term_REP_npm |> AP_TERM term_ABS_t0 |> PURE_REWRITE_RULE [absrep_id0];
-
-val t = mk_var("t", newty0);
-
-val supp_npm_support = prove(
-   “support ^n_pmact_t ^t (supp gt_pmact (^term_REP_t0 ^t))”,
-    srw_tac [][support_def, npm_def', supp_fresh, absrep_id0]);
-
-val supp_npm_apart = prove(
-   “x IN supp gt_pmact (^term_REP_t0 ^t) /\ y NOTIN supp gt_pmact (^term_REP_t0 ^t)
-    ==> ^npm_t [(x,y)] ^t <> ^t”,
-    srw_tac [][npm_def']
- >> DISCH_THEN (MP_TAC o AP_TERM term_REP_t0)
- >> srw_tac [][repabs_pseudo_id0, genind_gtpm_eqn, genind_term_REP0, supp_apart]);
-
-val supp_npm = prove(
-   “supp ^n_pmact_t ^t = supp gt_pmact (^term_REP_t0 ^t)”,
-    match_mp_tac (GEN_ALL supp_unique_apart)
- >> srw_tac [][supp_npm_support, supp_npm_apart, FINITE_GFV]);
-
-val _ = overload_on ("FV", “supp ^n_pmact_t”);
-
-val _ = set_fixity "#" (Infix(NONASSOC, 450));
-val _ = overload_on ("#", “\v (P :name). v NOTIN FV P”);
-
-Theorem FINITE_FV_name[simp] :
-    FINITE (FV (n :name))
-Proof
-    srw_tac [][supp_npm, FINITE_GFV]
-QED
-
-Theorem FV_EMPTY_name :
-    FV n = {} <=> !v. v NOTIN FV (n :name)
-Proof
-    SIMP_TAC (srw_ss()) [EXTENSION]
-QED
-
-fun nsupp_clause {con_termP, con_def} = let
-  val t = mk_comb(“supp ^n_pmact_t”, lhand (concl (SPEC_ALL con_def)))
-in
-  t |> REWRITE_CONV [supp_npm, con_def, MATCH_MP repabs_pseudo_id0 con_termP,
-                     GFV_thm]
-    |> REWRITE_RULE [supp_listpm, EMPTY_DELETE, UNION_EMPTY]
-    |> REWRITE_RULE [GSYM supp_npm]
-    |> GEN_ALL
-end
-
-Theorem FV_name_thm[simp] = LIST_CONJ (map nsupp_clause ncons_info)
-
-Theorem FV_npm[simp] = “x IN FV (npm p (n :name))”
-                       |> REWRITE_CONV [perm_supp, pmact_IN]
-                       |> GEN_ALL
 
 (* ----------------------------------------------------------------------
     support (supp) and FV (for type :pi)
@@ -583,13 +460,23 @@ fun supp_clause {con_termP, con_def} = let
 in
   t |> REWRITE_CONV [supp_tpm, con_def, MATCH_MP repabs_pseudo_id1 con_termP,
                      GFV_thm]
-    |> REWRITE_RULE [supp_listpm, EMPTY_DELETE, UNION_EMPTY]
-    |> REWRITE_RULE [GSYM supp_tpm, GSYM supp_npm]
+    |> REWRITE_RULE [supp_listpm, EMPTY_DELETE, LIST_TO_SET, UNION_EMPTY]
+    |> REWRITE_RULE [GSYM supp_tpm]
     |> GEN_ALL
 end
 
+(* |- FV Nil = {} /\ (!P. FV (Tau P) = FV P) /\
+      (!x a P. FV (Input a x P) = FV P DELETE x UNION {a}) /\
+      (!b a P. FV (Output a b P) = FV P UNION {a; b}) /\
+      (!b a P. FV (Match a b P) = FV P UNION {a; b}) /\
+      (!b a P. FV (Mismatch a b P) = FV P UNION {a; b}) /\
+      (!Q P. FV (Sum P Q) = FV P UNION FV Q) /\
+      (!Q P. FV (Par P Q) = FV P UNION FV Q) /\
+      !v P. FV (Res v P) = FV P DELETE v
+ *)
 Theorem FV_thm[simp] = LIST_CONJ (map supp_clause cons_info)
 
+(* |- !x t p. x IN FV (tpm p t) <=> lswapstr (REVERSE p) x IN FV t *)
 Theorem FV_tpm[simp] = “x IN FV (tpm p (t :pi))”
                        |> REWRITE_CONV [perm_supp, pmact_IN]
                        |> GEN_ALL
@@ -649,13 +536,19 @@ fun rsupp_clause {con_termP, con_def} = let
 in
   t |> REWRITE_CONV [supp_rpm, con_def, MATCH_MP repabs_pseudo_id2 con_termP,
                      GFV_thm]
-    |> REWRITE_RULE [supp_listpm, EMPTY_DELETE, UNION_EMPTY]
-    |> REWRITE_RULE [GSYM supp_tpm, GSYM supp_npm]
+    |> REWRITE_RULE [supp_listpm, EMPTY_DELETE, LIST_TO_SET, UNION_EMPTY]
+    |> REWRITE_RULE [GSYM supp_tpm]
     |> GEN_ALL
 end
 
+(* |- (!P. FV (TauR P) = FV P) /\
+      (!x a P. FV (BoundOutput a x P) = FV P DELETE x UNION {a}) /\
+      (!x a P. FV (InputS a x P) = FV P DELETE x UNION {a}) /\
+      !b a P. FV (FreeOutput a b P) = FV P UNION {a; b}
+ *)
 Theorem FV_residual_thm[simp] = LIST_CONJ (map rsupp_clause rcons_info)
 
+(* |- !x t p. x IN FV (rpm p t) <=> lswapstr (REVERSE p) x IN FV t *)
 Theorem FV_rpm[simp] = “x IN FV (rpm p (t :residual))”
                        |> REWRITE_CONV [perm_supp, pmact_IN]
                        |> GEN_ALL
@@ -676,30 +569,30 @@ end
 val LIST_REL_CONS1 = listTheory.LIST_REL_CONS1;
 val LIST_REL_NIL = listTheory.LIST_REL_NIL;
 
-val term_ind =
+val term_ind1 =
     bvc_genind
-        |> INST_TYPE [alpha |-> rep_t, beta |-> unit_t]
-        |> Q.INST [‘vp’ |-> ‘^vp’, ‘lp’ |-> ‘^lp’]
+        |> INST_TYPE [alpha |-> rep_t]
+        |> Q.INST [‘lp’ |-> ‘^lp’]
         |> SIMP_RULE std_ss [LIST_REL_CONS1, RIGHT_AND_OVER_OR,
                              LEFT_AND_OVER_OR, DISJ_IMP_THM, LIST_REL_NIL]
         |> Q.SPECL [‘\n t0 x. n = 1 ==> Q t0 x’, ‘fv’]
         |> UNDISCH |> Q.SPEC ‘1’ |> DISCH_ALL
         |> SIMP_RULE (std_ss ++ DNF_ss)
-                     [sumTheory.FORALL_SUM, supp_listpm,
+                     [sumTheory.FORALL_SUM, supp_listpm, LENGTH_NIL,
+                      LENGTH1, LENGTH2,
                       IN_UNION, NOT_IN_EMPTY, oneTheory.FORALL_ONE,
-                      genind_exists0,
                       genind_exists1,
                       genind_exists2,
                       LIST_REL_CONS1, LIST_REL_NIL]
         |> Q.INST [‘Q’ |-> ‘\t. P (^term_ABS_t1 t)’]
         |> SIMP_RULE std_ss [absrep_id1,
-                             GSYM Name_def,
                              Nil_def', Tau_def', GSYM Input_def,
                              Output_def', Match_def', Mismatch_def',
-                             Sum_def', Par_def', GSYM Res_def]
-        |> SIMP_RULE (srw_ss()) [GSYM supp_tpm, GSYM supp_npm]
+                             Sum_def', Par_def', GSYM Res_def,
+                             LENGTH_NIL]
+        |> SIMP_RULE (srw_ss()) [GSYM supp_tpm]
         |> elim_unnecessary_atoms {finite_fv = FINITE_FV}
-                                  [ASSUME “!x:'c. FINITE (fv x:string set)”]
+                                  [ASSUME “!x:'b. FINITE (fv x:string set)”]
         |> SPEC_ALL |> UNDISCH
         |> genit |> DISCH_ALL |> Q.GENL [‘P’, ‘fv’];
 
@@ -708,13 +601,13 @@ fun mkX_ind th = th |> Q.SPECL [‘\t x. Q t’, ‘\x. X’]
                     |> Q.INST [‘Q’ |-> ‘P’] |> Q.GEN ‘P’;
 
 (* NOTE: not recommended unless in generated theorems *)
-Theorem nc_INDUCTION[local] = mkX_ind term_ind
+Theorem nc_INDUCTION[local] = mkX_ind term_ind1
 
 (* The recommended induction theorem containing correctly namedbinding variables. *)
 Theorem nc_INDUCTION2 :
     !P X.
         P Nil /\ (!E. P E ==> P (Tau E)) /\
-        (!a x E. P E /\ x NOTIN X /\ x # a ==> P (Input a x E)) /\
+        (!a x E. P E /\ x NOTIN X ==> P (Input a x E)) /\
         (!a b E. P E ==> P (Output a b E)) /\
         (!a b E. P E ==> P (Match a b E)) /\
         (!a b E. P E ==> P (Mismatch a b E)) /\
@@ -728,7 +621,7 @@ Proof
 QED
 
 (* |- !P. P Nil /\ (!E. P E ==> P (Tau E)) /\
-          (!a x E. P E /\ x # a ==> P (Input a x E)) /\
+          (!a x E. P E ==> P (Input a x E)) /\
           (!a b E. P E ==> P (Output a b E)) /\
           (!a b E. P E ==> P (Match a b E)) /\
           (!a b E. P E ==> P (Mismatch a b E)) /\
@@ -742,6 +635,63 @@ Theorem simple_induction =
                   |> REWRITE_RULE [FINITE_EMPTY, NOT_IN_EMPTY]
                   |> Q.GEN ‘P’
 
+val term_ind2 =
+    bvc_genind
+        |> INST_TYPE [alpha |-> rep_t]
+        |> Q.INST [‘lp’ |-> ‘^lp’]
+        |> SIMP_RULE std_ss [LIST_REL_CONS1, RIGHT_AND_OVER_OR,
+                             LEFT_AND_OVER_OR, DISJ_IMP_THM, LIST_REL_NIL]
+        |> Q.SPECL [‘\n t0 x. n = 2 ==> Q t0 x’, ‘fv’]
+        |> UNDISCH |> Q.SPEC ‘2’ |> DISCH_ALL
+        |> SIMP_RULE (std_ss ++ DNF_ss)
+                     [sumTheory.FORALL_SUM, supp_listpm, LENGTH_NIL,
+                      LENGTH1, LENGTH2,
+                      IN_UNION, NOT_IN_EMPTY, oneTheory.FORALL_ONE,
+                      genind_exists1,
+                      genind_exists2,
+                      LIST_REL_CONS1, LIST_REL_NIL]
+        |> Q.INST [‘Q’ |-> ‘\t. P (^term_ABS_t2 t)’]
+        |> SIMP_RULE std_ss [absrep_id1, absrep_id2,
+                             Nil_def', Tau_def', GSYM Input_def,
+                             Output_def', Match_def', Mismatch_def',
+                             Sum_def', Par_def', GSYM Res_def,
+                             GSYM BoundOutput_def,
+                             GSYM InputS_def,
+                             TauR_def', FreeOutput_def']
+        |> SIMP_RULE (srw_ss()) [GSYM supp_tpm, GSYM supp_rpm]
+        |> elim_unnecessary_atoms {finite_fv = FINITE_FV_residual}
+                                  [ASSUME “!x:'b. FINITE (fv x:string set)”]
+        |> SPEC_ALL |> UNDISCH
+        |> genit |> DISCH_ALL |> Q.GENL [‘P’, ‘fv’];
+
+Theorem residual_INDUCTION[local] = mkX_ind term_ind2
+
+Theorem residual_INDUCTION2 :
+    !P X.
+        (!E. P (TauR E)) /\
+        (!a x E. x NOTIN X ==> P (BoundOutput a x E)) /\
+        (!a x E. x NOTIN X ==> P (InputS a x E)) /\
+        (!a b E. P (FreeOutput a b E)) /\ FINITE X ==> !E. P E
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC residual_INDUCTION
+ >> Q.EXISTS_TAC ‘X’ >> rw []
+QED
+
+(* |- !P. (!E. P (TauR E)) /\ (!a x E. P (BoundOutput a x E)) /\
+          (!a x E. x # a ==> P (InputS a x E)) /\
+          (!a b E. P (FreeOutput a b E)) ==>
+          !E. P E
+ *)
+Theorem simple_induction_residual =
+    residual_INDUCTION2 |> Q.SPECL [‘P’, ‘{}’]
+                        |> REWRITE_RULE [FINITE_EMPTY, NOT_IN_EMPTY]
+                        |> Q.GEN ‘P’
+
+(* ----------------------------------------------------------------------
+    Alpha conversions of constructors involving bound names
+   ---------------------------------------------------------------------- *)
+
 (* |- !u v t1 t2.
         Res u t1 = Res v t2 <=>
         u = v /\ t1 = t2 \/ u <> v /\ u # t2 /\ t1 = tpm [(u,v)] t2
@@ -753,7 +703,7 @@ Theorem Res_eq_thm =
                               GSYM supp_tpm]
      |> Q.GENL [‘u’, ‘v’, ‘t1’, ‘t2’]
 
-Theorem Res_tpm_ALPHA :
+Theorem tpm_ALPHA_Res :
     v # (u :pi) ==> Res x u = Res v (tpm [(v,x)] u)
 Proof
     SRW_TAC [boolSimps.CONJ_ss][Res_eq_thm, pmact_flip_args]
@@ -767,11 +717,11 @@ QED
 Theorem Input_eq_thm =
   “Input a x t1 = Input b y (t2 :pi)”
      |> SIMP_CONV (srw_ss()) [Input_def, Input_termP, term_ABS_pseudo11_1,
-                              GLAM_eq_thm, term_REP_11_0, term_REP_11_1,
+                              GLAM_eq_thm, term_REP_11_1,
                               GSYM term_REP_tpm, GSYM supp_tpm]
      |> Q.GENL [‘a’, ‘b’, ‘x’, ‘y’, ‘t1’, ‘t2’]
 
-Theorem Input_tpm_ALPHA :
+Theorem tpm_ALPHA_Input :
     v # (u :pi) ==> Input a x u = Input a v (tpm [(v,x)] u)
 Proof
     SRW_TAC [boolSimps.CONJ_ss][Input_eq_thm, pmact_flip_args]
@@ -786,15 +736,198 @@ Theorem InputS_eq_thm =
   “InputS a x t1 = InputS b y (t2 :pi)”
      |> SIMP_CONV (srw_ss()) [InputS_def, InputS_termP, term_ABS_pseudo11_2,
                               GLAM_eq_thm,
-                              term_REP_11_0, term_REP_11_1, term_REP_11_2,
+                              term_REP_11_1, term_REP_11_2,
                               GSYM term_REP_tpm, GSYM term_REP_rpm,
                               GSYM supp_tpm, GSYM supp_rpm]
      |> Q.GENL [‘a’, ‘b’, ‘x’, ‘y’, ‘t1’, ‘t2’]
 
-Theorem InputS_tpm_ALPHA :
+Theorem tpm_ALPHA_InputS :
     v # (u :pi) ==> InputS a x u = InputS a v (tpm [(v,x)] u)
 Proof
     SRW_TAC [boolSimps.CONJ_ss][InputS_eq_thm, pmact_flip_args]
+QED
+
+(* |- !a b x y t1 t2.
+        BoundOutput a x t1 = BoundOutput b y t2 <=>
+        x = y /\ t1 = t2 /\ a = b \/
+        x <> y /\ x # t2 /\ t1 = tpm [(x,y)] t2 /\ a = b
+ *)
+Theorem BoundOutput_eq_thm =
+  “BoundOutput a x t1 = BoundOutput b y (t2 :pi)”
+     |> SIMP_CONV (srw_ss()) [BoundOutput_def, BoundOutput_termP, term_ABS_pseudo11_2,
+                              GLAM_eq_thm,
+                              term_REP_11_1, term_REP_11_2,
+                              GSYM term_REP_tpm, GSYM term_REP_rpm,
+                              GSYM supp_tpm, GSYM supp_rpm]
+     |> Q.GENL [‘a’, ‘b’, ‘x’, ‘y’, ‘t1’, ‘t2’]
+
+Theorem tpm_ALPHA_BoundOutput :
+    v # (u :pi) ==> BoundOutput a x u = BoundOutput a v (tpm [(v,x)] u)
+Proof
+    SRW_TAC [boolSimps.CONJ_ss][BoundOutput_eq_thm, pmact_flip_args]
+QED
+
+(* ----------------------------------------------------------------------
+    cases, distinct and one-one theorems
+   ---------------------------------------------------------------------- *)
+
+Theorem pi_cases :
+    !t. (t = Nil) \/ (?P. t = Tau P) \/
+        (?a x P. t = Input a x P) \/ (?a b P. t = Output a b P) \/
+        (?a b P. t = Match a b P) \/ (?a b P. t = Mismatch a b P) \/
+        (?P Q. t = Sum P Q) \/ (?P Q. t = Par P Q) \/
+         ?v P. t = Res v P
+Proof
+    HO_MATCH_MP_TAC simple_induction
+ >> SRW_TAC [][] (* 216 subgoals here *)
+ >> METIS_TAC []
+QED
+
+Theorem residual_cases :
+    !t. (?P. t = TauR P) \/
+        (?a x P. t = BoundOutput a x P) \/
+        (?a b P. t = FreeOutput a b P) \/
+        (?a x P. t = InputS a x P)
+Proof
+    HO_MATCH_MP_TAC simple_induction_residual
+ >> SRW_TAC [][] (* 4 subgoals here *)
+ >> METIS_TAC []
+QED
+
+Theorem pi_distinct[simp] :
+    (Nil <> Tau P) /\
+    (Nil <> Input a x P) /\
+    (Nil <> Output a b P) /\
+    (Nil <> Match a b P) /\
+    (Nil <> Mismatch a b P) /\
+    (Nil <> Sum P Q) /\
+    (Nil <> Par P Q) /\
+    (Nil <> Res v P) /\
+    (Tau P <> Input a x Q) /\
+    (Tau P <> Output a b Q) /\
+    (Tau P <> Match a b Q) /\
+    (Tau P <> Mismatch a b Q) /\
+    (Tau P <> Sum P1 P2) /\
+    (Tau P <> Par P1 P2) /\
+    (Tau P <> Res v Q) /\
+    (Input a x P <> Output b y Q) /\
+    (Input a x P <> Match b c Q) /\
+    (Input a x P <> Mismatch b c Q) /\
+    (Input a x P <> Sum P1 P2) /\
+    (Input a x P <> Par P1 P2) /\
+    (Input a x P <> Res v Q) /\
+    (Output a b P <> Match c d Q) /\
+    (Output a b P <> Mismatch c d Q) /\
+    (Output a b P <> Sum P1 P2) /\
+    (Output a b P <> Par P1 P2) /\
+    (Output a b P <> Res v Q) /\
+    (Match a b P <> Mismatch c d Q) /\
+    (Match a b P <> Sum P1 P2) /\
+    (Match a b P <> Par P1 P2) /\
+    (Match a b P <> Res v Q) /\
+    (Mismatch a b P <> Sum P1 P2) /\
+    (Mismatch a b P <> Par P1 P2) /\
+    (Mismatch a b P <> Res v Q) /\
+    (Sum P1 P2 <> Par P3 P4) /\
+    (Sum P1 P2 <> Res v Q) /\
+    (Par P1 P2 <> Res v Q)
+Proof
+    rw [Nil_def, Nil_termP, Tau_def, Tau_termP,
+        Input_def, Input_termP, Output_def, Output_termP,
+        Match_def, Match_termP, Mismatch_def, Mismatch_termP,
+        Sum_def, Sum_termP, Par_def, Par_termP,
+        Res_def, Res_termP,
+        term_ABS_pseudo11_1, GLAM_eq_thm]
+QED
+
+Theorem residual_distinct[simp] :
+    (TauR P <> BoundOutput a x Q) /\
+    (TauR P <> InputS a x Q) /\
+    (TauR P <> FreeOutput a b Q) /\
+    (BoundOutput a x P <> InputS b y Q) /\
+    (BoundOutput a x P <> FreeOutput b c Q) /\
+    (InputS a x P <> FreeOutput b c Q)
+Proof
+    rw [TauR_def, TauR_termP, BoundOutput_def, BoundOutput_termP,
+        InputS_def, InputS_termP, FreeOutput_def, FreeOutput_termP,
+        term_ABS_pseudo11_2, GLAM_eq_thm]
+QED
+
+Theorem pi_one_one[simp] :
+    (!P Q. Tau P = Tau Q <=> P = Q) /\
+    (!a b P c d Q. Output a b P = Output c d Q <=> a = c /\ b = d /\ P = Q) /\
+    (!a b P c d Q. Match a b P = Match c d Q <=> a = c /\ b = d /\ P = Q) /\
+    (!a b P c d Q. Mismatch a b P = Mismatch c d Q <=> a = c /\ b = d /\ P = Q) /\
+    (!P1 P2 Q1 Q2. Sum P1 P2 = Sum Q1 Q2 <=> P1 = Q1 /\ P2 = Q2) /\
+    (!P1 P2 Q1 Q2. Par P1 P2 = Par Q1 Q2 <=> P1 = Q1 /\ P2 = Q2)
+Proof
+    srw_tac [] [Tau_def, Tau_termP, Output_def, Output_termP,
+                Match_def, Match_termP, Mismatch_def, Mismatch_termP,
+                Sum_def, Sum_termP, Par_def, Par_termP,
+                term_ABS_pseudo11_1, gterm_11, term_REP_11_1]
+ >> rw [CONJ_ASSOC]
+QED
+
+Theorem residual_one_one[simp] :
+    (!P Q. TauR P = TauR Q <=> P = Q) /\
+    (!a b P c d Q. FreeOutput a b P = FreeOutput c d Q <=> a = c /\ b = d /\ P = Q)
+Proof
+    srw_tac [] [TauR_def, TauR_termP, FreeOutput_def, FreeOutput_termP,
+                term_ABS_pseudo11_2, gterm_11,
+                term_REP_11_1, term_REP_11_2]
+ >> rw [CONJ_ASSOC]
+QED
+
+Theorem pi_distinct_exists :
+    !(p :pi). ?q. q <> p
+Proof
+    Q.X_GEN_TAC ‘p’
+ >> MP_TAC (Q.SPEC ‘p’ pi_cases) >> rw []
+ >- (Q.EXISTS_TAC ‘Tau P’ >> rw [])
+ >> Q.EXISTS_TAC ‘Nil’
+ >> rw [pi_distinct]
+QED
+
+Theorem pi_distinct_exists_FV :
+    !X (p :pi). FINITE X ==> ?q. q <> p /\ DISJOINT (FV q) X
+Proof
+    rpt STRIP_TAC
+ >> Q_TAC (NEW_TAC "z") ‘X’
+ >> MP_TAC (Q.SPEC ‘p’ pi_cases) >> rw []
+ >- (Q.EXISTS_TAC ‘Tau Nil’ >> rw [])
+ >> Q.EXISTS_TAC ‘Nil’
+ >> rw [pi_distinct]
+QED
+
+val _ = overload_on ("+", “Sum”); (* priority: 500 *)
+val _ = TeX_notation { hol = "+", TeX = ("\\ensuremath{+}", 1) };
+val _ = set_mapped_fixity {fixity = Infixl 600,
+                           tok = "||", term_name = "Par"};
+val _ = TeX_notation { hol = "||", TeX = ("\\ensuremath{\\mid}", 1) };
+
+Theorem Sum_acyclic :
+    !t1 t2 :pi. t1 <> t1 + t2 /\ t1 <> t2 + t1
+Proof
+    HO_MATCH_MP_TAC simple_induction >> SRW_TAC [][]
+QED
+
+Theorem Par_acyclic :
+    !t1 t2 :pi. t1 <> t1 || t2 /\ t1 <> t2 || t1
+Proof
+    HO_MATCH_MP_TAC simple_induction >> SRW_TAC [][]
+QED
+
+Theorem FORALL_TERM :
+    (!(t :pi). P t) <=> P Nil /\
+    (!E. P (Tau E)) /\ (!a x E. P (Input a x E)) /\
+    (!a b E. P (Output a b E)) /\
+    (!a b E. P (Match a b E)) /\
+    (!a b E. P (Mismatch a b E)) /\
+    (!t1 t2. P (t1 + t2)) /\ (!t1 t2. P (t1 || t2)) /\
+    (!v E. P (Res v E))
+Proof
+    EQ_TAC >> SRW_TAC [][]
+ >> Q.SPEC_THEN ‘t’ STRUCT_CASES_TAC pi_cases >> SRW_TAC [][]
 QED
 
 (* ----------------------------------------------------------------------
@@ -802,20 +935,8 @@ QED
    ---------------------------------------------------------------------- *)
 
 (* NOTE: all 3 types have the same repty *)
-val (_, repty) = dom_rng (type_of term_REP_t0);
+val (_, repty) = dom_rng (type_of term_REP_t1);
 val repty' = ty_antiq repty;
-
-val termP_elim0 = prove(
-   “(!g. ^termP0 g ==> P g) <=> (!t. P (^term_REP_t0 t))”,
-    srw_tac [][EQ_IMP_THM] >- srw_tac [][genind_term_REP0]
- >> first_x_assum (qspec_then ‘^term_ABS_t0 g’ mp_tac)
- >> srw_tac [][repabs_pseudo_id0]);
-
-val termP_removal0 =
-    nomdatatype.termP_removal {
-      elimth = termP_elim0, absrep_id = absrep_id0,
-      tpm_def = AP_TERM term_ABS_t0 term_REP_npm |> REWRITE_RULE [absrep_id0],
-      termP = termP0, repty = repty};
 
 val termP_elim1 = prove(
    “(!g. ^termP1 g ==> P g) <=> (!t. P (^term_REP_t1 t))”,
@@ -842,42 +963,31 @@ val termP_removal2 =
       termP = termP2, repty = repty};
 
 val termP' = prove(
-   “genind ^vp ^lp n t <=>
-      ^termP0 t /\ n = 0 \/
+   “genind ^lp n t <=>
       ^termP1 t /\ n = 1 \/
       ^termP2 t /\ n = 2”,
     EQ_TAC >> simp_tac (srw_ss()) [] >> strip_tac >> rw []
- >> qsuff_tac ‘n = 0 \/ n = 1 \/ n = 2’ >- (strip_tac >> srw_tac [][])
+ >> qsuff_tac ‘n = 1 \/ n = 2’ >- (strip_tac >> srw_tac [][])
  >> pop_assum mp_tac
  >> Q.ISPEC_THEN ‘t’ STRUCT_CASES_TAC gterm_cases
- >> srw_tac [][genind_GVAR, genind_GLAM_eqn]);
-
-(* “tvf :string -> 'q -> 'r” *)
-val tvf = “λ(s :string) (u :unit) (p :'q). tvf s p :'r”; (* Name *)
+ >> srw_tac [][genind_GLAM_eqn]);
 
 (* Type of constants (all constructors are included) occurring in tlf:
 
    Nil:    “tnf :('q -> 'r)”
    Tau:    “ttf :('q -> 'r) -> pi -> ('q -> 'r)”
-   Input:  “tif :('q -> 'r) -> string -> ('q -> 'r) ->
-                 name -> pi -> ('q -> 'r)”
-   Output: “tof :('q -> 'r) -> ('q -> 'r) -> ('q -> 'r) ->
-                 name -> name -> pi -> ('q -> 'r)”
-   Match:  “tmf :('q -> 'r) -> ('q -> 'r) -> ('q -> 'r) ->
-                 name -> name -> pi -> ('q -> 'r)”
-   Mismatch: “tuf :('q -> 'r) -> ('q -> 'r) -> ('q -> 'r) ->
-                   name -> name -> pi -> ('q -> 'r)”
+   Input:  “tif :string -> string -> ('q -> 'r) -> pi -> ('q -> 'r)”
+   Output: “tof :string -> string -> ('q -> 'r) -> pi -> ('q -> 'r)”
+   Match:  “tmf :string -> string -> ('q -> 'r) -> pi -> ('q -> 'r)”
+   Mismatch: “tuf :string -> string -> ('q -> 'r) -> pi -> ('q -> 'r)”
    Sum:    “tsf :('q -> 'r) -> ('q -> 'r) -> pi -> pi -> ('q -> 'r)”
    Par:    “tpf :('q -> 'r) -> ('q -> 'r) -> pi -> pi -> ('q -> 'r)”
    Res:    “tcf :string -> ('q -> 'r) -> pi -> ('q -> 'r)”
 
    TauR:        “taf :('q -> 'r) -> pi -> ('q -> 'r)”
-   InputS:      “trf :('q -> 'r) -> string -> ('q -> 'r) ->
-                      name -> pi -> ('q -> 'r)”
-   BoundOutput: “tbf :('q -> 'r) -> string -> ('q -> 'r) ->
-                      name -> pi -> ('q -> 'r)”
-   FreeOutput:  “tff :('q -> 'r) -> ('q -> 'r) -> ('q -> 'r) ->
-                      name -> name -> pi -> ('q -> 'r)”
+   InputS:      “trf :string -> string -> ('q -> 'r) -> pi -> ('q -> 'r)”
+   BoundOutput: “tbf :string -> string -> ('q -> 'r) -> pi -> ('q -> 'r)”
+   FreeOutput:  “tff :string -> string -> ('q -> 'r) -> pi -> ('q -> 'r)”
 
    NOTE: ds1 is the list of (bounded) recursive parameters as functions ('q -> 'r).
          ts1 is the list of (bounded) actual arguments in the same position.
@@ -896,25 +1006,20 @@ val u_tm = mk_var("u", rep_t);
              ('a, 'b) gterm list -> ('a, 'b) gterm list -> 'q -> 'c)
  *)
 val tlf =
-   “λ(v :string) ^u_tm (ds1 :('q -> 'r) list) (ds2 :('q -> 'r) list)
-                       (ts1 :^repty' list) (ts2 :^repty' list) (p :'q).
+   “λ(v :string) (fvs :string list) ^u_tm
+     (ds1 :('q -> 'r) list) (ds2 :('q -> 'r) list)
+     (ts1 :^repty' list) (ts2 :^repty' list) (p :'q).
       case u of
         rNil => tnf p : 'r
       | rTau => ttf (HD ds2) (^term_ABS_t1 (HD ts2)) p :'r
-      | rInput => tif (HD ds2) v (HD ds1)
-                      (^term_ABS_t0 (HD ts2)) (^term_ABS_t1 (HD ts1)) p :'r
-      | rOutput => tof (HD ds2) (HD (TL ds2)) (HD (TL (TL ds2)))
-                       (^term_ABS_t0 (HD ts2))
-                       (^term_ABS_t0 (HD (TL ts2)))
-                       (^term_ABS_t1 (HD (TL (TL ts2)))) p :'r
-      | rMatch => tmf (HD ds2) (HD (TL ds2)) (HD (TL (TL ds2)))
-                      (^term_ABS_t0 (HD ts2))
-                      (^term_ABS_t0 (HD (TL ts2)))
-                      (^term_ABS_t1 (HD (TL (TL ts2)))) p :'r
-      | rMismatch => tuf (HD ds2) (HD (TL ds2)) (HD (TL (TL ds2)))
-                         (^term_ABS_t0 (HD ts2))
-                         (^term_ABS_t0 (HD (TL ts2)))
-                         (^term_ABS_t1 (HD (TL (TL ts2)))) p :'r
+      | rInput => tif (HD fvs) v (HD ds1)
+                      (^term_ABS_t1 (HD ts1)) p :'r
+      | rOutput => tof (HD fvs) (HD (TL fvs)) (HD ds2)
+                       (^term_ABS_t1 (HD ts2)) p :'r
+      | rMatch => tmf (HD fvs) (HD (TL fvs)) (HD ds2)
+                      (^term_ABS_t1 (HD ts2)) p :'r
+      | rMismatch => tuf (HD fvs) (HD (TL fvs)) (HD ds2)
+                         (^term_ABS_t1 (HD ts2)) p :'r
       | rSum => tsf (HD ds2) (HD (TL ds2))
                     (^term_ABS_t1 (HD ts2))
                     (^term_ABS_t1 (HD (TL ts2))) p :'r
@@ -923,31 +1028,32 @@ val tlf =
                     (^term_ABS_t1 (HD (TL ts2))) p :'r
       | rRes => tcf v (HD ds1) (^term_ABS_t1 (HD ts1)) p :'r
       | rTauR => taf (HD ds2) (^term_ABS_t1 (HD ts2)) p :'r
-      | rInputS => trf (HD ds2) v (HD ds1)
-                       (^term_ABS_t0 (HD ts2)) (^term_ABS_t1 (HD ts1)) p :'r
-      | rBoundOutput =>
-          tbf (HD ds2) v (HD ds1)
-              (^term_ABS_t0 (HD ts2)) (^term_ABS_t1 (HD ts1)) p :'r
-      | rFreeOutput => tof (HD ds2) (HD (TL ds2)) (HD (TL (TL ds2)))
-                           (^term_ABS_t0 (HD ts2))
-                           (^term_ABS_t0 (HD (TL ts2)))
-                           (^term_ABS_t1 (HD (TL (TL ts2)))) p :'r”;
+      | rInputS => trf (HD fvs) v (HD ds1)
+                       (^term_ABS_t1 (HD ts1)) p :'r
+      | rBoundOutput => tbf (HD fvs) v (HD ds1)
+                            (^term_ABS_t1 (HD ts1)) p :'r
+      | rFreeOutput => tff (HD fvs) (HD (TL fvs)) (HD ds2)
+                           (^term_ABS_t1 (HD ts2)) p :'r”;
 
 Overload TLF = tlf
 
-val FN = mk_var("FN", “:(repcode,unit) gterm -> ρ -> 'r”)
-val fn0_def_t = “fn0 = λn. ^FN (name_REP n)”
+val FN = mk_var("FN", “:repcode gterm -> 'q -> 'r”)
 val fn1_def_t = “fn1 = λp. ^FN (pi_REP p)”
 val fn2_def_t = “fn2 = λr. ^FN (residual_REP r)”
 
-val testcase = [(fn0_def_t, repabs_pseudo_id0, [Name_def]),
-                (fn1_def_t, repabs_pseudo_id1,
+val testcase = [(fn1_def_t, repabs_pseudo_id1,
                  [SYM Nil_def', Input_def, SYM Output_def', SYM Tau_def',
                   SYM Match_def', SYM Mismatch_def', SYM Sum_def', SYM Par_def',
                   Res_def]),
                 (fn2_def_t, repabs_pseudo_id2,
                  [InputS_def, SYM FreeOutput_def', BoundOutput_def,
                   SYM TauR_def'])]
+
+Theorem GLAM_NIL_ELIM[local]:
+  GLAM u fvs bv [] ts = GLAM ARB fvs bv [] ts
+Proof
+  simp[GLAM_NIL_EQ]
+QED
 
 fun case1 (tm_def, repabs, defs) =
   let
@@ -960,11 +1066,10 @@ fun case1 (tm_def, repabs, defs) =
             ASSUME_TAC d >>
             asm_simp_tac bool_ss [GLAM_NIL_ELIM] >> AP_TERM_TAC >>
             SYM_TAC >> MATCH_MP_TAC repabs >>
-            simp_tac bool_ss [genind_GLAM_eqn, genind_GVAR,
+            simp_tac list_ss [genind_GLAM_eqn,
                               TypeBase.distinct_of “:repcode”,
                               LIST_REL_NIL, LIST_REL_CONS1, PULL_EXISTS,
-                              CONS_11, genind_term_REP1, genind_term_REP0,
-                              genind_term_REP2]
+                              CONS_11, genind_term_REP1, genind_term_REP2]
           val goal =
                 mk_eq (mk_comb(FN, rand (rhs eq)), mk_comb (c, lhs eq))
         in
@@ -976,33 +1081,29 @@ fun case1 (tm_def, repabs, defs) =
 
 val fn_rewrites = map case1 testcase
 
-Theorem parameter_tm_recursion0 =
+val parameter_tm_recursion0 =
   parameter_gtm_recursion
-      |> INST_TYPE [alpha |-> rep_t, beta |-> unit_t, gamma |-> “:'r”]
-      |> Q.INST [‘lf’ |-> ‘^tlf’, ‘vf’ |-> ‘^tvf’, ‘vp’ |-> ‘^vp’,
-                 ‘lp’ |-> ‘^lp’]
+      |> INST_TYPE [alpha |-> rep_t, gamma |-> “:'r”]
+      |> Q.INST [‘lf’ |-> ‘^tlf’, ‘lp’ |-> ‘^lp’]
       |> SIMP_RULE (srw_ss()) [sumTheory.FORALL_SUM, FORALL_AND_THM,
                                GSYM RIGHT_FORALL_IMP_THM, IMP_CONJ_THM,
                                GSYM RIGHT_EXISTS_AND_THM,
                                GSYM LEFT_EXISTS_AND_THM,
                                GSYM LEFT_FORALL_IMP_THM,
-                               LIST_REL_CONS1, genind_GVAR,
+                               LIST_REL_CONS1,
                                genind_GLAM_eqn, sidecond_def,
                                NEWFCB_def, relsupp_def,
                                LENGTH_NIL_SYM, LENGTH1, LENGTH2]
       |> ONCE_REWRITE_RULE [termP']
       |> SIMP_RULE (srw_ss() ++ DNF_ss) [LENGTH1, LENGTH2, LENGTH_NIL]
-      |> CONV_RULE (DEPTH_CONV termP_removal0)
       |> CONV_RULE (DEPTH_CONV termP_removal1)
       |> CONV_RULE (DEPTH_CONV termP_removal2)
-      |> SIMP_RULE (srw_ss()) [GSYM supp_npm, SYM term_REP_npm,
-                               GSYM supp_tpm, SYM term_REP_tpm,
-                               GSYM supp_rpm, SYM term_REP_rpm]
+      |> SIMP_RULE (srw_ss()) [GSYM supp_tpm, SYM term_REP_tpm,
+                               GSYM supp_rpm, SYM term_REP_rpm,
+                               relsupp_def]
       |> UNDISCH
       |> rpt_hyp_dest_conj
 
-val rwt0 =
-  EQ_MP (SCONV [Once FUN_EQ_THM] fn0_def_t) (ASSUME fn0_def_t) |> GSYM
 val rwt1 =
   EQ_MP (SCONV [Once FUN_EQ_THM] fn1_def_t) (ASSUME fn1_def_t) |> GSYM
 val rwt2 =
@@ -1011,8 +1112,7 @@ val rwt2 =
 val (exv, body) = dest_exists (concl parameter_tm_recursion0)
 val cs = CONJUNCTS (ASSUME (body |> subst[exv |-> FN]))
 
-
-val cs' = map (SIMP_RULE bool_ss (rwt0:: rwt1:: rwt2:: GLAM_NIL_ELIM ::
+val cs' = map (SIMP_RULE bool_ss (rwt1:: rwt2:: GLAM_NIL_ELIM ::
                                   List.concat fn_rewrites)) cs
 
 val th0 = LIST_CONJ cs'
@@ -1020,78 +1120,244 @@ val eqns = List.filter is_eq (hyp th0)
 val th1 = itlist Prim_rec.EXISTS_EQUATION eqns th0
 val th = CHOOSE (FN, parameter_tm_recursion0) th1
 
-th |> DISCH_ALL |> elim_unnecessary_atoms {finite_fv = FINITE_FV}
-                                          [ASSUME “FINITE (A:string set)”,
-                                            ASSUME “∀p:'q. FINITE (supp ppm p)”]
-   |> UNDISCH_ALL |> DISCH_ALL
-      |> REWRITE_RULE [AND_IMP_INTRO]
-      |> CONV_RULE (LAND_CONV (REWRITE_CONV [GSYM CONJ_ASSOC]))
-      |> Q.INST [‘tvf’ |-> ‘vr’, (* Name? *)
-                 ‘tnf’ |-> ‘f0’, (* Nil *)
-                 ‘ttf’ |-> ‘f1’, (* Tau *)
-                 ‘tif’ |-> ‘f2’, (* Input *)
-                 ‘tof’ |-> ‘f3’, (* Output *)
-                 ‘tmf’ |-> ‘f4’, (* Match *)
-                 ‘tuf’ |-> ‘f5’, (* Mismatch *)
-                 ‘tsf’ |-> ‘f6’, (* Sum *)
-                 ‘tpf’ |-> ‘f7’, (* Par *)
-                 ‘trf’ |-> ‘f8’, (* Res *)
-                 ‘dpm’ |-> ‘apm’]
-      |> CONV_RULE (REDEPTH_CONV sort_uvars)
-
-(* use Prim_rec.EXISTS_EQUATION to eliminate "definitions" of fn0, fn1, fn2 *)
-
-(*
-      |> lift_exfunction {repabs_pseudo_id = repabs_pseudo_id2,
-                          term_REP_t = term_REP_t2,
-                          cons_info = rcons_info}
-      |> lift_exfunction {repabs_pseudo_id = repabs_pseudo_id1,
-                          term_REP_t = term_REP_t1,
-                          cons_info = cons_info}
-      |> lift_exfunction {repabs_pseudo_id = repabs_pseudo_id0,
-                          term_REP_t = term_REP_t0,
-                          cons_info = ncons_info}
+Theorem parameter_tm_recursion = th
       |> DISCH_ALL
       |> elim_unnecessary_atoms {finite_fv = FINITE_FV}
-                                [ASSUME ``FINITE (A:string set)``,
-                                 ASSUME ``!p :'q. FINITE (supp ppm p)``]
+                                [ASSUME “FINITE (A:string set)”,
+                                 ASSUME “∀p:'q. FINITE (supp ppm p)”]
       |> UNDISCH_ALL |> DISCH_ALL
       |> REWRITE_RULE [AND_IMP_INTRO]
       |> CONV_RULE (LAND_CONV (REWRITE_CONV [GSYM CONJ_ASSOC]))
-      |> Q.INST [‘tvf’ |-> ‘vr’, (* Name? *)
-                 ‘tnf’ |-> ‘f0’, (* Nil *)
-                 ‘ttf’ |-> ‘f1’, (* Tau *)
-                 ‘tif’ |-> ‘f2’, (* Input *)
-                 ‘tof’ |-> ‘f3’, (* Output *)
-                 ‘tmf’ |-> ‘f4’, (* Match *)
-                 ‘tuf’ |-> ‘f5’, (* Mismatch *)
-                 ‘tsf’ |-> ‘f6’, (* Sum *)
-                 ‘tpf’ |-> ‘f7’, (* Par *)
-                 ‘trf’ |-> ‘f8’, (* Res *)
-                 ‘dpm’ |-> ‘apm’]
+      |> Q.INST
+      [‘tnf’ |-> ‘f0’, (* Nil :'q->'r *)
+       ‘ttf’ |-> ‘f1’, (* Tau :('q->'r) -> pi -> 'q->'r *)
+       ‘tif’ |-> ‘f2’, (* Input :string->string -> ('q->'r) -> pi -> 'q->'r *)
+       ‘tof’ |-> ‘f3’, (* Output :string->string -> ('q->'r) -> pi -> 'q->'r *)
+       ‘tmf’ |-> ‘f4’, (* Match :string->string -> ('q->'r) -> pi -> 'q->'r *)
+       ‘tuf’ |-> ‘f5’, (* Mismatch :string->string -> ('q->'r) -> pi -> 'q->'r *)
+       ‘tsf’ |-> ‘f6’, (* Sum :('q->'r) -> ('q->'r) -> pi -> pi -> 'q->'r *)
+       ‘tpf’ |-> ‘f7’, (* Par :('q->'r) -> ('q->'r) -> pi -> pi -> 'q->'r *)
+       ‘tcf’ |-> ‘f8’, (* Res :string -> ('q->'r) -> pi -> 'q->'r *)
+       ‘taf’ |-> ‘f9’, (* TauR :('q->'r) -> pi -> 'q->'r *)
+       ‘trf’ |-> ‘f10’, (* InputS :string->string -> ('q->'r) -> pi -> 'q->'r *)
+       ‘tbf’ |-> ‘f11’, (* BoundOutput :string->string -> ('q->'r) -> pi -> 'q->'r *)
+       ‘tff’ |-> ‘f12’, (* FreeOutput :string->string -> ('q->'r) -> pi -> 'q->'r *)
+       ‘dpm’ |-> ‘apm’]
       |> CONV_RULE (REDEPTH_CONV sort_uvars)
 
+(* (fn1 :pi -> 'r) (fn2 :residual -> 'r) *)
 Theorem tm_recursion =
   parameter_tm_recursion
       |> Q.INST_TYPE [‘:'q’ |-> ‘:unit’]
       |> Q.INST [‘ppm’ |-> ‘discrete_pmact’,
-                  ‘vr’ |-> ‘\s u. vru s’,
-                  ‘pf’ |-> ‘\r a t u. pfu (r()) a t’,
-                  ‘sm’ |-> ‘\r1 r2 t1 t2 u. smu (r1()) (r2()) t1 t2’,
-                  ‘pr’ |-> ‘\r1 r2 t1 t2 u. pru (r1()) (r2()) t1 t2’,
-                  ‘rs’ |-> ‘\r L t u. rsu (r()) L t’,
-                  ‘rl’ |-> ‘\r t rf u. rlu (r()) t rf’,
-                  ‘re’ |-> ‘\r v t u. reu (r()) v t’]
+                  ‘f0’ |-> ‘\u. g0’,
+                  ‘f1’ |-> ‘\r t u. g1 (r()) t’,
+                  ‘f2’ |-> ‘\a x r t u. g2 a x (r()) t’,
+                  ‘f3’ |-> ‘\a b r t u. g3 a b (r()) t’,
+                  ‘f4’ |-> ‘\a b r t u. g4 a b (r()) t’,
+                  ‘f5’ |-> ‘\a b r t u. g5 a b (r()) t’,
+                  ‘f6’ |-> ‘\r1 r2 t1 t2 u. g6 (r1()) (r2()) t1 t2’,
+                  ‘f7’ |-> ‘\r1 r2 t1 t2 u. g7 (r1()) (r2()) t1 t2’,
+                  ‘f8’ |-> ‘\s r t u. g8 s (r()) t’,
+                  ‘f9’ |-> ‘\r t u. g9 (r()) t’,
+                 ‘f10’ |-> ‘\a x r t u. g10 a x (r()) t’,
+                 ‘f11’ |-> ‘\a x r t u. g11 a x (r()) t’,
+                 ‘f12’ |-> ‘\a b r t u. g12 a b (r()) t’]
       |> SIMP_RULE (srw_ss()) [oneTheory.FORALL_ONE, oneTheory.FORALL_ONE_FN,
                                oneTheory.EXISTS_ONE_FN, fnpm_def]
       |> SIMP_RULE (srw_ss() ++ CONJ_ss) [supp_unitfn]
-      |> Q.INST [‘vru’ |-> ‘vr’,
-                 ‘pfu’ |-> ‘pf’,
-                 ‘smu’ |-> ‘sm’,
-                 ‘pru’ |-> ‘pr’,
-                 ‘rsu’ |-> ‘rs’,
-                 ‘rlu’ |-> ‘rl’,
-                 ‘reu’ |-> ‘re’]
-*)
+      |> Q.INST [ ‘g0’ |-> ‘f0’,
+                  ‘g1’ |-> ‘f1’,
+                  ‘g2’ |-> ‘f2’,
+                  ‘g3’ |-> ‘f3’,
+                  ‘g4’ |-> ‘f4’,
+                  ‘g5’ |-> ‘f5’,
+                  ‘g6’ |-> ‘f6’,
+                  ‘g7’ |-> ‘f7’,
+                  ‘g8’ |-> ‘f8’,
+                  ‘g9’ |-> ‘f9’,
+                 ‘g10’ |-> ‘f10’,
+                 ‘g11’ |-> ‘f11’,
+                 ‘g12’ |-> ‘f12’]
+
+(* ----------------------------------------------------------------------
+    Establish substitution function
+   ---------------------------------------------------------------------- *)
+
+Theorem tpm_COND[local] :
+    tpm pi (if P then x else y) = if P then tpm pi x else tpm pi y
+Proof
+    SRW_TAC [][]
+QED
+
+Theorem rpm_COND[local] :
+    rpm pi (if P then x else y) = if P then rpm pi x else rpm pi y
+Proof
+    SRW_TAC [][]
+QED
+
+Theorem tpm_apart :
+    !(t :pi). x # t /\ y IN FV t ==> tpm [(x,y)] t <> t
+Proof
+    metis_tac[supp_apart, pmact_flip_args]
+QED
+
+Theorem rpm_apart :
+    !(t :residual). x # t /\ y IN FV t ==> rpm [(x,y)] t <> t
+Proof
+    metis_tac[supp_apart, pmact_flip_args]
+QED
+
+Theorem tpm_fresh :
+    !(t :pi) x y. x # t /\ y # t ==> tpm [(x,y)] t = t
+Proof
+    srw_tac [][supp_fresh]
+QED
+
+Theorem rpm_fresh :
+    !(t :residual) x y. x # t /\ y # t ==> rpm [(x,y)] t = t
+Proof
+    srw_tac [][supp_fresh]
+QED
+
+Theorem tpm_Nil[simp] :
+    tpm pi Nil = Nil
+Proof
+    Induct_on ‘pi’ >- rw []
+ >> Q.X_GEN_TAC ‘h’
+ >> Cases_on ‘h’
+ >> rw [Once tpm_CONS]
+ >> MATCH_MP_TAC tpm_fresh >> rw []
+QED
+
+Theorem rewrite_pairing[local] :
+    (?f :pi -> (string # string) -> pi. P f) <=>
+    (?f :string -> string -> pi -> pi. P (\M (x,y). f y x M))
+Proof
+    EQ_TAC >> strip_tac
+ >| [ (* goal 1 (of 2) *)
+      qexists_tac ‘\y x M. f M (x,y)’ >> srw_tac [][] \\
+      CONV_TAC (DEPTH_CONV pairLib.PAIRED_ETA_CONV) \\
+      srw_tac [ETA_ss][],
+      (* goal 2 (of 2) *)
+      qexists_tac ‘\M (x,y). f y x M’ >> srw_tac [][] ]
+QED
+
+Overload NilR[local] = “TauR Nil” (* A closed term of :residual *)
+
+Overload I1[local] = “\(p :pi). (p,NilR)”
+Overload I2[local] = “\(r :residual). (Nil,r)”
+Overload O1[local] = “\(z :pi # residual). FST z”
+Overload O2[local] = “\(z :pi # residual). SND z”
+
+Definition subst_def :
+   subst ((k,v) :string # string) (s :string) =
+   if s = k then v else k
+End
+Overload SUB = “\v k s. subst (k,v) s”
+
+Theorem subst_swapstr[simp] :
+    swapstr x y ([E/u] e) = ([swapstr x y E/swapstr x y u] (swapstr x y e))
+Proof
+    rw [subst_def, swapstr_def] >> METIS_TAC []
+QED
+
+val subst_exists0 =
+    parameter_tm_recursion
+        |> INST_TYPE [“:'q” |-> “:string # string” (* (key,value) *),
+                      “:'r” |-> “:pi # residual”]
+        |> SPEC_ALL
+        |> Q.INST [
+              ‘A’ |-> ‘{}’, (* NOTE: only possible when closed term exists *)
+            ‘ppm’ |-> ‘pair_pmact string_pmact string_pmact’,
+            ‘apm’ |-> ‘pair_pmact pi_pmact residual_pmact’,
+            (* f0 ~ f8 is for the type :pi *)
+             ‘f0’ |-> ‘\u. I1 Nil’,
+             ‘f1’ |-> ‘\r t u. I1 (Tau (O1 (r u)))’,
+             ‘f2’ |-> ‘\a x r t u. I1 (Input (subst u a) x (O1 (r u)))’,
+             ‘f3’ |-> ‘\a b r t u. I1 (Output (subst u a) (subst u b) (O1 (r u)))’,
+             ‘f4’ |-> ‘\a b r t u. I1 (Match (subst u a) (subst u b) (O1 (r u)))’,
+             ‘f5’ |-> ‘\a b r t u. I1 (Mismatch (subst u a) (subst u b) (O1 (r u)))’,
+             ‘f6’ |-> ‘\r1 r2 t1 t2 u. I1 (Sum (O1 (r1 u)) (O1 (r2 u)))’,
+             ‘f7’ |-> ‘\r1 r2 t1 t2 u. I1 (Par (O1 (r1 u)) (O1 (r2 u)))’,
+             ‘f8’ |-> ‘\s r t u. I1 (Res s (O1 (r u)))’,
+            (* f9 ~ f12 is for the type :residual *)
+             ‘f9’ |-> ‘\r t u. I2 (TauR (O1 (r u)))’,
+            ‘f10’ |-> ‘\a x r t u. I2 (InputS (subst u a) x (O1 (r u)))’,
+            ‘f11’ |-> ‘\a x r t u. I2 (BoundOutput (subst u a) x (O1 (r u)))’,
+            ‘f12’ |-> ‘\a b r t u. I2 (FreeOutput (subst u a) (subst u b)
+                                                  (O1 (r u)))’]
+        |> CONV_RULE (LAND_CONV (SIMP_CONV (srw_ss()) [pairTheory.FORALL_PROD]))
+        |> SIMP_RULE (srw_ss()) [support_def, FUN_EQ_THM, fnpm_def,
+                                 tpm_COND, tpm_fresh, pmact_sing_inv,
+                                 rpm_COND, rpm_fresh, rpm_thm, tpm_thm,
+                                 basic_swapTheory.swapstr_eq_left]
+        |> SIMP_RULE (srw_ss()) [rewrite_pairing, pairTheory.FORALL_PROD]
+        |> CONV_RULE (DEPTH_CONV (rename_vars [("p_1", "u"), ("p_2", "E")]))
+
+(* debug
+val ppm = “pair_pmact pi_pmact residual_pmact”;
+val ppm2 = “pair_pmact string_pmact string_pmact”;
+val alphas = [tpm_ALPHA_Res, tpm_ALPHA_Input, tpm_ALPHA_InputS,
+              tpm_ALPHA_BoundOutput];
+val rwts :thm list = [];
+val th = subst_exists0;
+val th = rpt_hyp_dest_conj (UNDISCH th);
+val ths = hypset th;
+
+val h = el 1 (HOLset.listItems ths);
+set_goal ([], h);
+
+fun prove_alpha_fcbhyp {ppm, alphas, rwts} th = let
+  open nomsetTheory
+  val th = rpt_hyp_dest_conj (UNDISCH th)
+  fun foldthis (h,th) = let
+    val h_th =
+      TAC_PROOF(([], h),
+                rpt gen_tac >> strip_tac >>
+                FIRST (map (match_mp_tac o GSYM) alphas) >>
+                match_mp_tac (GEN_ALL notinsupp_fnapp) >>
+                EXISTS_TAC ppm \\
+                srw_tac [] rwts)
+  in
+    PROVE_HYP h_th th
+  end
+in
+  HOLset.foldl foldthis th (hypset th)
+end
+
+val subst_exists =
+    subst_exists0
+        |> prove_alpha_fcbhyp {ppm = ``pair_pmact string_pmact string_pmact``,
+                               rwts = [],
+                               alphas = [tpm_ALPHA_Res, tpm_ALPHA_Input,
+                                         tpm_ALPHA_InputS,
+                                         tpm_ALPHA_BoundOutput]};
+
+val SUB_DEF = new_specification("SUB_DEF", ["SUB"], subst_exists);
+
+Overload SUB = “SUB”; (* use the syntax already defined in termTheory *)
+
+val SUB_THMv = prove(
+  “([N/x](var x) = (N :'a CCS)) /\ (x <> y ==> [N/y](var x) = var x)”,
+  SRW_TAC [][SUB_DEF]);
+
+Theorem SUB_COMM = prove(
+   “!N x x' y (t :'a CCS).
+        x' <> x /\ x' # N ∧ y <> x /\ y # N ==>
+        (tpm [(x',y)] ([N/x] t) = [N/x] (tpm [(x',y)] t))”,
+  srw_tac [][SUB_DEF, supp_fresh]);
+
+val SUB_THM = save_thm("SUB_THM",
+  let val (eqns,_) = CONJ_PAIR SUB_DEF
+  in
+    CONJ (REWRITE_RULE [GSYM CONJ_ASSOC]
+                       (LIST_CONJ (SUB_THMv :: tl (CONJUNCTS eqns))))
+         SUB_COMM
+  end);
+val _ = export_rewrites ["SUB_THM"];
+
+ *)
+
 val _ = export_theory ();
 val _ = html_theory "pi_agent";

--- a/src/parallel_builds/core/Holmakefile
+++ b/src/parallel_builds/core/Holmakefile
@@ -46,6 +46,7 @@ EXDIRS = algebra/aat \
 	 formal-languages formal-languages/context-free \
          formal-languages/contig formal-languages/json \
          formal-languages/lambek formal-languages/regular/regular-play \
+         formal-languages/pi-calculus \
          fun-op-sem/coimp fun-op-sem/lprefix_lub fun-op-sem/for \
          hardware hfs \
          imperative ind_def \


### PR DESCRIPTION
Hi,

This PR updates the π-calculus example w.r.t. recent updates to the nominal package which supports builtin free names.  Details to be explained in private, but the proof goal below (part of `prove_alpha_fcbhyp`, modified) is what I'm facing on:

```
        v' NOTIN
        supp (fn_pmact (pair_pmact pi_pmact residual_pmact) pi_pmact) FST /\
        v' NOTIN supp (pair_pmact pi_pmact residual_pmact) (y' (u,E))
   ------------------------------------
    0.  v <> u
    1.  v <> E
    2.  v' # t
    3.  v' <> u
    4.  v' <> E
    5.  !x. x # t ==>
            x NOTIN
            supp
              (fn_pmact (pair_pmact string_pmact string_pmact)
                 (pair_pmact pi_pmact residual_pmact)) y'
```

I wonder if it's possible to prove `supp (fn_pmact (pair_pmact pi_pmact residual_pmact) pi_pmact) FST` is actually an empty set.

--Chun