### PR TITLE
Make it easy to build the CakeML compiler backend from HOL

### DIFF
--- a/examples/developers/build_cakeml/.hol_preexec
+++ b/examples/developers/build_cakeml/.hol_preexec
@@ -1,0 +1,1 @@
+[ -d "cakeml" ] || ./get-cakeml

--- a/examples/developers/build_cakeml/Holmakefile
+++ b/examples/developers/build_cakeml/Holmakefile
@@ -1,0 +1,1 @@
+INCLUDES = cakeml/compiler/backend/proofs

--- a/examples/developers/build_cakeml/cakeml_comp_thmsScript.sml
+++ b/examples/developers/build_cakeml/cakeml_comp_thmsScript.sml
@@ -1,0 +1,16 @@
+open HolKernel Parse boolLib bossLib;
+open backendProofTheory backend_itreeProofTheory;
+
+val _ = new_theory "cakeml_comp_thms";
+
+(* check that there are no cheats in key theorems of CakeML *)
+
+fun check_tag t = Tag.isEmpty t orelse Tag.isDisk t;
+val check_thm = Lib.assert (check_tag o Thm.tag);
+
+val _ = check_thm backendProofTheory.compile_correct;
+val _ = check_thm backendProofTheory.compile_correct_is_safe_for_space;
+val _ = check_thm backendProofTheory.compile_correct_eval;
+val _ = check_thm backend_itreeProofTheory.itree_compile_correct;
+
+val _ = export_theory();

--- a/examples/developers/build_cakeml/get-cakeml
+++ b/examples/developers/build_cakeml/get-cakeml
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+git clone https://github.com/CakeML/cakeml.git


### PR DESCRIPTION
This PR adds `examples/developers/build_cakeml` which is setup so that a run of Holmake there downloads the master branch of CakeML and builds `compiler/backend/proofs`, i.e. the correctness proof for the CakeML compiler backend.

This can be handy to run in case one wants to check whether changes to HOL break the CakeML compiler proofs.