### PR TITLE
[otknl] FTBFS due to new dependency (basicSize) of listTheory

### DIFF
--- a/src/boss/hol4-base-unint.thy
+++ b/src/boss/hol4-base-unint.thy
@@ -257,6 +257,7 @@ list {
   import: pred-set
   import: combin
   import: quotient
+  import: basic-size
   article: "../list/src/list.ot.art"
 }
 rich-list {


### PR DESCRIPTION
Hi,

The otknl build was broken by d4f326734f28060bf4db5a133b0499d7fbb998a9 because a new theorem `list_size_zip` used the constant `pair_size` (from `basicSizeTheory`).  The OT definition for `hol-base` (`src/boss/hol4-base-unint.thy`) previously didn't have `basic-size` listed as an imported theory. Now it must explicitly import it.

Unfortunately, when I check the file `list/src/.HOLMK/listScript.sml.d`, there's no `basicSizeTheory.uo` in it:
```
listScript.uo: /Users/binghe/ML/HOL.otknl/sigobj/Arith.uo /Users/binghe/ML/HOL.otknl/sigobj/BasicProvers.uo /Users/binghe/ML/HOL.otknl/sigobj/DB_dtype.uo /Users/binghe/ML/HOL.otknl/sigobj/Datatype.uo /Users/binghe/ML/HOL.otknl/sigobj/Defn.uo /Users/binghe/ML/HOL.otknl/sigobj/DefnBase.uo /Users/binghe/ML/HOL.otknl/sigobj/Ho_Rewrite.uo /Users/binghe/ML/HOL.otknl/sigobj/HolKernel.uo /Users/binghe/ML/HOL.otknl/sigobj/IndDefLib.uo /Users/binghe/ML/HOL.otknl/sigobj/Induction.uo /Users/binghe/ML/HOL.otknl/sigobj/Lib.uo /Users/binghe/ML/HOL.otknl/sigobj/Num_conv.uo /Users/binghe/ML/HOL.otknl/sigobj/OpenTheoryMap.uo /Users/binghe/ML/HOL.otknl/sigobj/Parse.uo /Users/binghe/ML/HOL.otknl/sigobj/Prim_rec.uo /Users/binghe/ML/HOL.otknl/sigobj/Q.uo /Users/binghe/ML/HOL.otknl/sigobj/Rewrite.uo /Users/binghe/ML/HOL.otknl/sigobj/Rsyntax.uo /Users/binghe/ML/HOL.otknl/sigobj/Tactical.uo /Users/binghe/ML/HOL.otknl/sigobj/Theory.uo /Users/binghe/ML/HOL.otknl/sigobj/TotalDefn.uo /Users/binghe/ML/HOL.otknl/sigobj/TypeBase.uo /Users/binghe/ML/HOL.otknl/sigobj/TypeBasePure.uo /Users/binghe/ML/HOL.otknl/sigobj/UnicodeChars.uo /Users/binghe/ML/HOL.otknl/sigobj/arithmeticTheory.uo /Users/binghe/ML/HOL.otknl/sigobj/boolLib.uo /Users/binghe/ML/HOL.otknl/sigobj/boolSimps.uo /Users/binghe/ML/HOL.otknl/sigobj/combinTheory.uo /Users/binghe/ML/HOL.otknl/sigobj/computeLib.uo /Users/binghe/ML/HOL.otknl/sigobj/markerLib.uo /Users/binghe/ML/HOL.otknl/sigobj/mesonLib.uo /Users/binghe/ML/HOL.otknl/sigobj/metisLib.uo /Users/binghe/ML/HOL.otknl/sigobj/monadsyntax.uo /Users/binghe/ML/HOL.otknl/sigobj/numLib.uo /Users/binghe/ML/HOL.otknl/sigobj/numSimps.uo /Users/binghe/ML/HOL.otknl/sigobj/numTheory.uo /Users/binghe/ML/HOL.otknl/sigobj/optionTheory.uo /Users/binghe/ML/HOL.otknl/sigobj/pairLib.uo /Users/binghe/ML/HOL.otknl/sigobj/pairTheory.uo /Users/binghe/ML/HOL.otknl/sigobj/pred_setLib.uo /Users/binghe/ML/HOL.otknl/sigobj/pred_setSimps.uo /Users/binghe/ML/HOL.otknl/sigobj/pred_setTheory.uo /Users/binghe/ML/HOL.otknl/sigobj/prim_recTheory.uo /Users/binghe/ML/HOL.otknl/sigobj/quotientLib.uo /Users/binghe/ML/HOL.otknl/sigobj/relationTheory.uo /Users/binghe/ML/HOL.otknl/sigobj/simpLib.uo /Users/binghe/ML/HOL.otknl/sigobj/tautLib.uo /Users/binghe/ML/HOL.otknl/sigobj/whileTheory.uo 
```
perhaps because the theorem `pair_size_def` is not explicit called. Therefore it seems PolyML does not list `basicSizeTheory.uo` as a necessary dependency when loading `listTheory`, even the HOL constant `pair_size` was indeed defined in `basicSizeTheory`?

Therefore it's still very hard to automatically generate those OT dependencies in .thy files, from information of existing building intermediate files.

--Chun