### PR TITLE
make all sml files parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.o
 .hol
 .holobjs
+.hollogs
 *.lex.sml
 *.grm.sig
 *.grm.sml

--- a/examples/acl2/examples/example_axiomsScript.ml
+++ b/examples/acl2/examples/example_axiomsScript.ml
@@ -16,7 +16,7 @@
 quietdec := true;                             (* suppress printing of output *)
 loadPath := "../ml" :: !loadPath;             (* add acl2/ml to load path    *)
 map                                           (* load infrastructure         *)
- load 
+ load
  ["sexp",
   "sexpTheory",
   "basic_defaxiomsTheory"];
@@ -70,18 +70,18 @@ use "example_axioms.lisp.ml";
 val [CAR_CDR_ELIM,CAR_CONS,CDR_CONS,CONS_EQUAL,BOOLEAN_CHARACTERP,
      ZERO,COMMUTATIVITY_OF_BINARY_ADD,DISTRIBUTIVITY,TRICHOTOMY,
      RATIONAL_IMPLIES2,LOWEST_TERMS,
-     COMPLETION_OF_SYMBOL_NAME, DEFAULT_SYMBOL_NAME, 
+     COMPLETION_OF_SYMBOL_NAME, DEFAULT_SYMBOL_NAME,
      COMPLETION_OF_SYMBOL_PACKAGE_NAME,
      INTERN_IN_PACKAGE_OF_SYMBOL_SYMBOL_NAME,
      SYMBOL_PACKAGE_NAME_PKG_WITNESS_NAME,NIL_IS_NOT_CIRCULAR,
-     COMPLETION_OF_BINARY_MULT] = 
- map 
-  (clean_acl2_term o #3 o def_to_term) 
+     COMPLETION_OF_BINARY_MULT] =
+ map
+  (clean_acl2_term o #3 o def_to_term)
   (!sexp.acl2_list_ref);
 
 (*
- map 
-  ((fn(x,y,z) => (x,y,clean_acl2_term z)) o def_to_term) 
+ map
+  ((fn(x,y,z) => (x,y,clean_acl2_term z)) o def_to_term)
   (!sexp.acl2_list_ref);
 
  map mk_def (!sexp.acl2_list_ref);
@@ -164,7 +164,7 @@ val DISTRIBUTIVITY_AX =
            ratTheory.RAT_SUB_LDISTRIB, ratTheory.RAT_SUB_RDISTRIB,
            ratTheory.RAT_LDISTRIB, ratTheory.RAT_RDISTRIB,
            complex_rationalTheory.complex_rational_11]
-    THEN METIS_TAC 
+    THEN METIS_TAC
           [ratTheory.RAT_ADD_ASSOC,ratTheory.RAT_ADD_COMM,
            ratTheory.RAT_RSUB_EQ,ratTheory.RAT_LSUB_EQ,
            ratTheory.RAT_MUL_LZERO, ratTheory.RAT_MUL_RZERO]);
@@ -173,10 +173,10 @@ val TRICHOTOMY_AX =
  time store_thm
   ("TRICHOTOMY_AX",
    ``|= ^TRICHOTOMY``,
-   Cases_on `x` 
+   Cases_on `x`
     THEN ACL2_SIMP_TAC
           [rat_0,int_def,cpx_def,ratTheory.RAT_0,ratTheory.RAT_LES_REF]
-    THEN Cases_on `c` 
+    THEN Cases_on `c`
     THEN FULL_SIMP_TAC arith_ss (!acl2_simps)
 
     THEN FULL_SIMP_TAC arith_ss
@@ -188,7 +188,7 @@ val TRICHOTOMY_AX =
            ratTheory.RAT_SUB_LDISTRIB, ratTheory.RAT_SUB_RDISTRIB,
            ratTheory.RAT_LDISTRIB, ratTheory.RAT_RDISTRIB,
            complex_rationalTheory.complex_rational_11]
-    THEN METIS_TAC 
+    THEN METIS_TAC
           [ratTheory.RAT_ADD_ASSOC,ratTheory.RAT_ADD_COMM,
            ratTheory.RAT_RSUB_EQ,ratTheory.RAT_LSUB_EQ,
            ratTheory.RAT_MUL_LZERO, ratTheory.RAT_MUL_RZERO]);
@@ -197,9 +197,9 @@ val RATIONAL_IMPLIES2_AX =
  time store_thm
   ("RATIONAL_IMPLIES2_AX",
    ``|= ^RATIONAL_IMPLIES2``,
-   Cases_on `x` 
+   Cases_on `x`
     THEN ACL2_SIMP_TAC[]
-    THEN Cases_on `c` 
+    THEN Cases_on `c`
     THEN FULL_SIMP_TAC arith_ss (!acl2_simps)
     THEN Cases_on `r0 = rat_0`
     THEN RW_TAC arith_ss []
@@ -213,7 +213,7 @@ val COMPLETION_OF_SYMBOL_NAME =
  time store_thm
   ("COMPLETION_OF_SYMBOL_NAME",
    ``|= ^COMPLETION_OF_SYMBOL_NAME``,
-   Cases_on `x` 
+   Cases_on `x`
     THEN ACL2_SIMP_TAC[]);
 
 val implies =
@@ -240,7 +240,7 @@ val DEFAULT_SYMBOL_NAME =
   ("DEFAULT_SYMBOL_NAME",
    ``|= ^DEFAULT_SYMBOL_NAME``,
    RW_TAC std_ss [implies,not]
-   Cases_on `x` 
+   Cases_on `x`
     THEN ACL2_SIMP_TAC[]
     THEN Cases_on `s = ""`
     THEN ACL2_SIMP_TAC[]
@@ -250,9 +250,9 @@ val COMPLETION_OF_SYMBOL_PACKAGE_NAME =
  time store_thm
   ("COMPLETION_OF_SYMBOL_PACKAGE_NAME",
    ``|= ^COMPLETION_OF_SYMBOL_PACKAGE_NAME``,
-   Cases_on `x` 
+   Cases_on `x`
     THEN SIMP_TAC std_ss [symbol_name_def,symbolp_def]
-    THEN SIMP_TAC std_ss [GSYM symbolp_def]
+    THEN SIMP_TAC std_ss [GSYM symbolp_def]);
 
 (*
    Should I try to prove:
@@ -323,14 +323,13 @@ val INTERN_IN_PACKAGE_OF_SYMBOL_SYMBOL_NAME_AX =
    ``|= ^INTERN_IN_PACKAGE_OF_SYMBOL_SYMBOL_NAME ``,
    Cases_on `x` THEN Cases_on `y`
     THEN ACL2_SIMP_TAC[]
-    THEN Cases_on `BASIC_INTERN s0 s = sym s s0` 
+    THEN Cases_on `BASIC_INTERN s0 s = sym s s0`
     THEN RW_TAC std_ss []
     THENL
      [POP_ASSUM(fn th => FULL_SIMP_TAC std_ss [th,sexp_11,T_NIL])
        THEN Cases_on `y`
-       THEN FULL_SIMP_TAC arith_ss (sexp_11::(!acl2_simps))
+       THEN FULL_SIMP_TAC arith_ss (sexp_11::(!acl2_simps))]);
 
-*)
 
 (*
 val _ = export_acl2_theory();

--- a/examples/bnf-datatypes/bnfAlgebraScript.sml
+++ b/examples/bnf-datatypes/bnfAlgebraScript.sml
@@ -198,7 +198,7 @@ val idx_tydef as
                termP_term_REP, ...} =
   newtypeTools.rich_new_type{
   tyname = "idx",
-  prove(“∃i : (α,β) alg. alg i”,
+  exthm = prove(“∃i : (α,β) alg. alg i”,
         simp[EXISTS_PROD] >> qexists_tac ‘UNIV’ >>
         simp[alg_def]),
   ABS = "mkIx",

--- a/examples/formal-languages/regular/regexpScript.sml
+++ b/examples/formal-languages/regular/regexpScript.sml
@@ -110,7 +110,7 @@ QED
 (* Datatype of extended regular expressions                                  *)
 (*---------------------------------------------------------------------------*)
 
-Datatype
+val _ = Datatype
  `regexp
     = Chset charset
     | Cat regexp regexp

--- a/examples/fun-op-sem/cbv-lc/typesScript.sml
+++ b/examples/fun-op-sem/cbv-lc/typesScript.sml
@@ -28,7 +28,7 @@ val _ = type_abbrev ("type_env", ``:type list``);
 
 (* The standard inductive relation for typing STLC.
  * Get a rules, induction and case split theorem back *)
-Inductive type:
+Inductive type_:
 [~lit:]
   !G i. type G (Lit (Int i)) Int
 [~var:]

--- a/examples/lambda/basics/precn.ML
+++ b/examples/lambda/basics/precn.ML
@@ -29,7 +29,7 @@ val lmf_support = prove(
 
 val lmf_fcond = prove(
   ``y ∉ FV x2 ∪ FINITE (supp (fnpm tpm tpm) r) ==> fcond tpm ^lmf0``,
-  srw_tac [][fcond_def] >>
+  srw_tac [][fcond_def] >> cheat);
 
 
 val precn0 =
@@ -95,6 +95,7 @@ val precn = provehyps(
               qexists_tac `{u;v;x;y} ∪ FV t ∪ FV x2 ∪ FV x'` >>
               srw_tac [][]) >>x
           srw_tac [][Abbr`f`]
+      )]);
 
 
 

--- a/examples/separationLogic/src/holfoot/holfootScript.sml
+++ b/examples/separationLogic/src/holfoot/holfootScript.sml
@@ -8088,10 +8088,10 @@ val holfoot___varlist_update_NO_VAR_THM =
  **************************************)
 
 val _ = type_abbrev_pp("holfoot_program",
-Type `:((holfoot_var list # num list), (*procedure args*)
-        string (*locks*),
-        string, (*procedure names*)
-        holfoot_state (*states*)
+  Type `:((holfoot_var list # num list), (*procedure args*)
+          string (*locks*),
+          string, (*procedure names*)
+          holfoot_state (*states*)
    ) asl_program`);
 
 

--- a/src/holyhammer/examples/hh_demoScript.sml
+++ b/src/holyhammer/examples/hh_demoScript.sml
@@ -32,7 +32,8 @@ open realTheory
 
 (* hh ([], ``a = b * 2 ==> b = a / 2``); *)
 val th = store_thm ("INV_DIV2",
-  METIS_TAC [REAL_DOUBLE, REAL_HALF_DOUBLE, REAL_MUL_ASSOC, real_div]
+  ``a = b * 2 ==> b = a / 2``,
+  METIS_TAC [REAL_DOUBLE, REAL_HALF_DOUBLE, REAL_MUL_ASSOC, real_div])
 
 (* -------------------------------------------------------------------------
    Example 3: Euler's formula
@@ -43,9 +44,10 @@ open complexTheory
 
 (* hh ([], ``exp (i * (2 * pi)) = 1``); set_timeout 60; *)
 val th = store_thm ("EXP_2PI",
+  ``exp (i * (2 * pi)) = 1``,
   METIS_TAC [EXP_IMAGINARY, complex_of_num, complex_of_real, REAL_ADD_LID,
     REAL_DOUBLE, REAL_NEGNEG, transcTheory.COS_0, transcTheory.COS_PERIODIC_PI,
-    transcTheory.SIN_0, transcTheory.SIN_PERIODIC_PI]
+    transcTheory.SIN_0, transcTheory.SIN_PERIODIC_PI])
 
 
 val _ = export_theory();

--- a/src/pfl/examples/tree.sml
+++ b/src/pfl/examples/tree.sml
@@ -141,6 +141,8 @@ val iintree_determ = Q.prove
 
 val iintree_monotone_step = Q.prove
 (`!d x tree. IS_SOME(iintree d x tree) ==> IS_SOME(iintree (SUC d) x tree)`,
+cheat
+(*
 e (Induct THENL [RW_TAC arith_ss [Once iintree_def],
                  ONCE_REWRITE_TAC [iintree_def]]);
 e (SIMP_TAC arith_ss [] THEN REPEAT GEN_TAC THEN
@@ -160,7 +162,9 @@ REPEAT STRIP_TAC THEN RW_TAC list_ss [Once iintree_def] THEN
  Q.PAT_ASSUM `IS_SOME thing` MP_TAC THEN
  ASM_SIMP_TAC list_ss [Once iintree_def] THEN CASE_TAC THEN RW_TAC list_ss []
 
- METIS_TAC [IS_SOME_EXISTS,NOT_SOME_NONE,SOME_11,iintree_determ]);
+ METIS_TAC [IS_SOME_EXISTS,NOT_SOME_NONE,SOME_11,iintree_determ]
+*)
+ );
 
 val iintree_monotone = Q.prove
 (`!d1 d2 x list.

--- a/tools-poly/Holmake/winNT-systeml.sml
+++ b/tools-poly/Holmake/winNT-systeml.sml
@@ -48,15 +48,15 @@ fun fullPath slist =
     normPath (List.foldl (fn (p1,p2) => Path.concat(p2,p1))
                          (hd slist) (tl slist))
 
-val HOLDIR =
-val MOSMLDIR =
-val OS =
-val DEPDIR =
-val GNUMAKE =
-val DYNLIB =
-val version =
-val release =
-val DOT_PATH =
+val HOLDIR = ""
+val MOSMLDIR = ""
+val OS = ""
+val DEPDIR = ""
+val GNUMAKE = ""
+val DYNLIB = false
+val version = 0
+val release = ""
+val DOT_PATH = NONE
 val POLY = ""
 val POLYC = ""
 val DEFAULT_STATE = fullPath [HOLDIR, "bin", "hol.state"]

--- a/tools/check-builds/check-builds.sml
+++ b/tools/check-builds/check-builds.sml
@@ -81,6 +81,9 @@ fun handleArgs slist =
 
 fun main() =
     let val cline = CommandLine.arguments()
-        val
+        val _ = ()
     in
       case cline of
+        _ => ()
+    end
+end


### PR DESCRIPTION
See discussion [on Zulip](https://hol.zulipchat.com/#narrow/channel/486798-.E2.9D.84.EF.B8.8F-HOL4/topic/HOL.20dev.20meetings/near/527280328). The only one of these which could have fallout is the change to `winNT-systeml.sml`, since this file is read by some tools to put in real values. As [pointed out](https://hol.zulipchat.com/#narrow/channel/486798-.E2.9D.84.EF.B8.8F-HOL4/topic/HOL.20dev.20meetings/near/527279662) by @ordinarymath , the unix version of this file uses dummy values and can be replaced just fine, so this should not cause any problems.