### PR TITLE
[pi] variable substitution of pi-calculus agents (and residuals)

### DIFF
--- a/examples/CCS/CCSScript.sml
+++ b/examples/CCS/CCSScript.sml
@@ -353,6 +353,8 @@ val lp =
      n = 0 /\ lfvs = 0 ∧ d = crec /\ tns = [0] /\ uns = []        (* 6. rec *)
     )”;
 
+Overload LP = “lp”
+
 val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
      termP, absrep_id, repabs_pseudo_id, term_REP_t, term_ABS_t, newty, ...} =
     new_type_step1 tyname 0 [] {lp = lp};
@@ -740,6 +742,12 @@ val termP0 = prove(
    restr:  “trf :('q -> 'r) -> ('a Label -> bool) -> 'a CCS -> 'q -> 'r”
    relab:  “tlf :('q -> 'r) -> 'a CCS -> 'a Relabeling -> 'q -> 'r”
    rec:    “tcf :('q -> 'r) -> string -> 'a CCS -> 'q -> 'r”
+
+   NOTE: ds2 is the list of recursive parameters as functions ('q -> 'r).
+         ts2 is the list of actual arguments in the same position.
+         non-recursive parameters are taken from the corresponding position of u (rep_t).
+         The "if condition" identifies the constructor.
+         v is the only binding variable.
  *)
 val u_tm = mk_var("u", rep_t);
 val tlf =
@@ -760,8 +768,7 @@ val tlf =
 Theorem parameter_tm_recursion =
   parameter_gtm_recursion
       |> INST_TYPE [alpha |-> rep_t, gamma |-> “:'r”]
-      |> Q.INST [‘lf’ |-> ‘^tlf’,
-                 ‘lp’ |-> ‘^lp’, ‘n’ |-> ‘0’]
+      |> Q.INST [‘lf’ |-> ‘^tlf’, ‘lp’ |-> ‘^lp’]
       |> SIMP_RULE (srw_ss()) [sumTheory.FORALL_SUM, FORALL_AND_THM,
                                GSYM RIGHT_FORALL_IMP_THM, IMP_CONJ_THM,
                                GSYM RIGHT_EXISTS_AND_THM,
@@ -1005,7 +1012,7 @@ val subst_exists =
                                  basic_swapTheory.swapstr_eq_left]
         |> SIMP_RULE (srw_ss()) [rewrite_pairing, pairTheory.FORALL_PROD]
         |> CONV_RULE (DEPTH_CONV (rename_vars [("p_1", "u"), ("p_2", "E")]))
-        |> prove_alpha_fcbhyp {ppm = ``pair_pmact string_pmact ^t_pmact_t``,
+        |> prove_alpha_fcbhyp {ppms = [``pair_pmact string_pmact ^t_pmact_t``],
                                rwts = [],
                                alphas = [tpm_ALPHA]};
 
@@ -1595,7 +1602,7 @@ val ssub_exists =
                                  fmpm_FDOM, notin_frange]
         |> SIMP_RULE (srw_ss()) [Once ordering]
         |> CONV_RULE (DEPTH_CONV (rename_vars [("p", "fm")]))
-        |> prove_alpha_fcbhyp {ppm = “fm_pmact string_pmact ^t_pmact_t”,
+        |> prove_alpha_fcbhyp {ppms = [“fm_pmact string_pmact ^t_pmact_t”],
                                rwts = [notin_frange, strterm_fmap_supp],
                                alphas = [tpm_ALPHA]};
 

--- a/examples/lambda/barendregt/finite_developmentsScript.sml
+++ b/examples/lambda/barendregt/finite_developmentsScript.sml
@@ -721,6 +721,7 @@ val ordering = prove(
     SRW_TAC [ETA_ss][],
     METIS_TAC []
   ]) ;
+
 val nlabel_exists =
     parameter_tm_recursion
         |> INST_TYPE [alpha |-> ``:lterm``, ``:ρ`` |-> ``:num # posn set``]
@@ -740,7 +741,7 @@ val nlabel_exists =
                                      {p | In::p IN ps} INTER redex_posns t))`]
             |> SIMP_RULE (srw_ss()) [pairTheory.FORALL_PROD, fnpm_def,
                                      ltpm_if, ordering]
-            |> prove_alpha_fcbhyp {ppm = ``discrete_pmact : (num # posn set) pmact``,
+            |> prove_alpha_fcbhyp {ppms = [``discrete_pmact :(num # posn set) pmact``],
                                    alphas = [ltpm_ALPHA],
                                    rwts = []}
             |> CONV_RULE (DEPTH_CONV

--- a/examples/lambda/barendregt/labelledTermsScript.sml
+++ b/examples/lambda/barendregt/labelledTermsScript.sml
@@ -385,7 +385,7 @@ val subst_exists =
                                  pmact_sing_inv, pairTheory.FORALL_PROD,
                                  reordering]
         |> elim_unnecessary_atoms {finite_fv = FINITE_FV} []
-        |> prove_alpha_fcbhyp {ppm = “pair_pmact string_pmact ^t_pmact_t”,
+        |> prove_alpha_fcbhyp {ppms = [“pair_pmact string_pmact ^t_pmact_t”],
                                alphas = [ltpm_ALPHA, ltpm_ALPHAi],
                                rwts = []}
         |> CONV_RULE (DEPTH_CONV

--- a/examples/lambda/basics/ctermScript.sml
+++ b/examples/lambda/basics/ctermScript.sml
@@ -425,7 +425,7 @@ val subst_exists =
                                  basic_swapTheory.swapstr_eq_left]
         |> SIMP_RULE (srw_ss()) [rewrite_pairing, pairTheory.FORALL_PROD]
         |> CONV_RULE (DEPTH_CONV (rename_vars [("p_1", "u"), ("p_2", "N")]))
-        |> prove_alpha_fcbhyp {ppm = ``pair_pmact string_pmact ^t_pmact_t``,
+        |> prove_alpha_fcbhyp {ppms = [``pair_pmact string_pmact ^t_pmact_t``],
                                rwts = [],
                                alphas = [ctpm_ALPHA]}
 
@@ -861,7 +861,7 @@ val ssub_exists =
                   fmpm_FDOM, notin_frange]
         |> SIMP_RULE (srw_ss()) [Once ordering]
         |> CONV_RULE (DEPTH_CONV (rename_vars [("p", "fm")]))
-        |> prove_alpha_fcbhyp {ppm = ``fm_pmact string_pmact ^t_pmact_t``,
+        |> prove_alpha_fcbhyp {ppms = [``fm_pmact string_pmact ^t_pmact_t``],
                                rwts = [notin_frange, strterm_fmap_supp],
                                alphas = [ctpm_ALPHA]}
 

--- a/examples/lambda/basics/nomdatatype.sig
+++ b/examples/lambda/basics/nomdatatype.sig
@@ -43,10 +43,8 @@ sig
   val lift_exfunction : {repabs_pseudo_id : thm, term_REP_t : term,
                          cons_info : coninfo list} ->
                         thm -> thm
-  val prove_alpha_fcbhyp : {ppm:term, alphas: thm list, rwts: thm list} ->
+  val prove_alpha_fcbhyp : {ppms :term list, alphas: thm list, rwts: thm list} ->
                            thm -> thm
   val defined_const : thm -> term
 
 end
-
-

--- a/examples/lambda/basics/termScript.sml
+++ b/examples/lambda/basics/termScript.sml
@@ -451,7 +451,7 @@ val subst_exists =
                                  basic_swapTheory.swapstr_eq_left]
         |> SIMP_RULE (srw_ss()) [rewrite_pairing, FORALL_PROD]
         |> CONV_RULE (DEPTH_CONV (rename_vars [("p_1", "u"), ("p_2", "N")]))
-        |> prove_alpha_fcbhyp {ppm = ``pair_pmact string_pmact ^t_pmact_t``,
+        |> prove_alpha_fcbhyp {ppms = [``pair_pmact string_pmact ^t_pmact_t``],
                                rwts = [],
                                alphas = [tpm_ALPHA]}
 
@@ -663,6 +663,27 @@ Proof
          SRW_TAC [][]) THEN
   POP_ASSUM SUBST_ALL_TAC THEN
   SRW_TAC [][pmact_flip_args]
+QED
+
+(* from Isabelle/HOL [3] *)
+Theorem fresh_fact[local] :
+    !z N y L. z # N /\ z # L ==> z # [L/y] N
+Proof
+    rw [FV_SUB]
+QED
+
+(* Lemma 2.1.16 (Substitution Lemma) [1, p.27] *)
+Theorem substitution_lemma :
+    !x N y L M. x <> y /\ x # L ==> [L/y] ([N/x] M) = [[L/y] N/x]([L/y] M)
+Proof
+    NTAC 4 GEN_TAC
+ >> HO_MATCH_MP_TAC nc_INDUCTION2
+ >> Q.EXISTS_TAC ‘{x; y} UNION FV N UNION FV L’
+ >> rw [fresh_fact]
+ (* NOTE: only one case (M = VAR s) is left *)
+ >> Cases_on ‘s = x’ >- rw []
+ >> Cases_on ‘s = y’ >- rw [Once EQ_SYM_EQ, lemma14b]
+ >> simp []
 QED
 
 (* ----------------------------------------------------------------------
@@ -1143,7 +1164,7 @@ val ssub_exists =
                                  fmpm_FDOM, notin_frange]
         |> SIMP_RULE (srw_ss()) [Once ordering]
         |> CONV_RULE (DEPTH_CONV (rename_vars [("p", "fm")]))
-        |> prove_alpha_fcbhyp {ppm = ``fm_pmact string_pmact ^t_pmact_t``,
+        |> prove_alpha_fcbhyp {ppms = [``fm_pmact string_pmact ^t_pmact_t``],
                                rwts = [notin_frange, strterm_fmap_supp],
                                alphas = [tpm_ALPHA]}
 
@@ -2069,4 +2090,6 @@ val _ = html_theory "term";
      College Publications, London (1984).
  [2] Hindley, J.R., Seldin, J.P.: Lambda-calculus and combinators, an introduction.
      Second Edition. Cambridge University Press, Cambridge (2008).
+ [3] Urban, C.: Nominal Techniques in Isabelle/HOL. J. Autom. Reason. 40,
+     327–356 (2008).
  *)


### PR DESCRIPTION
Hi,

Finally the variable substitution of pi-calculus agents (and transition residuals) is done. The following two theorems fully character the behavior of variable substitution (string -> string):

```
[pi_sub_thm]
⊢ (∀u E. [E/u] Nil = Nil) ∧ (∀u E t. [E/u] (Tau t) = Tau ([E/u] t)) ∧
  (∀v u E e t.
     v ≠ u ∧ v ≠ E ⇒ [E/u] (Input e v t) = Input ([E/u] e) v ([E/u] t)) ∧
  (∀u E a b t. [E/u] (Output a b t) = Output ([E/u] a) ([E/u] b) ([E/u] t)) ∧
  (∀u E a b t. [E/u] (Match a b t) = Match ([E/u] a) ([E/u] b) ([E/u] t)) ∧
  (∀u E a b t. [E/u] (Mismatch a b t) = Mismatch ([E/u] a) ([E/u] b) ([E/u] t)) ∧
  (∀u E t t'. [E/u] (t' + t) = [E/u] t' + [E/u] t) ∧
  (∀u E t t'. [E/u] (t' || t) = [E/u] t' || [E/u] t) ∧
  (∀v u E t. v ≠ u ∧ v ≠ E ⇒ [E/u] (Res v t) = Res v ([E/u] t)) ∧
  ∀u E x y t.
    tpm [(x,y)] ([E/u] t) = [swapstr x y E/swapstr x y u] (tpm [(x,y)] t)

[residual_sub_thm]
⊢ (∀u E t. [E/u] (TauR t) = TauR ([E/u] t)) ∧
  (∀v u E e t.
     v ≠ u ∧ v ≠ E ⇒ [E/u] (InputS e v t) = InputS ([E/u] e) v ([E/u] t)) ∧
  (∀v u E e t.
     v ≠ u ∧ v ≠ E ⇒
     [E/u] (BoundOutput e v t) = BoundOutput ([E/u] e) v ([E/u] t)) ∧
  (∀u E a b t.
     [E/u] (FreeOutput a b t) = FreeOutput ([E/u] a) ([E/u] b) ([E/u] t)) ∧
  ∀u E x y t.
    rpm [(x,y)] ([E/u] t) = [swapstr x y E/swapstr x y u] (rpm [(x,y)] t)
```

As uaual, the API function `prove_alpha_fcbhyp` (in `nomdatatype`) has been generalised: one of its argument (`ppm`) was a term, now is a list of terms (`ppms`):
```
  val prove_alpha_fcbhyp : {ppms :term list, alphas: thm list, rwts: thm list} -> thm -> thm
```
All existing function calls of it are modified to fit the new type of this function.

--Chun