### PR TITLE
LSP server, initial framework

### DIFF
--- a/src/portableML/json/JSONDecode.sig
+++ b/src/portableML/json/JSONDecode.sig
@@ -28,6 +28,8 @@ sig
     val decodeString : 'a decoder -> string -> 'a
     val decodeFile : 'a decoder -> string -> 'a
 
+    val ofRaw : (JSON.value -> 'a) -> 'a decoder
+
     val bool : bool decoder
     val int : int decoder
     val intInf : IntInf.int decoder

--- a/src/portableML/json/JSONDecode.sig
+++ b/src/portableML/json/JSONDecode.sig
@@ -41,10 +41,10 @@ sig
     (* returns the raw JSON value without further decoding *)
     val raw : JSON.value decoder
 
-    (* decides a JSON OBJECT into a list of labeled JSON values *)
+    (* decodes a JSON OBJECT into a list of labeled JSON values *)
     val rawObject : (string * JSON.value) list decoder
 
-    (* decides a JSON ARRAY into a vector of JSON values *)
+    (* decodes a JSON ARRAY into a vector of JSON values *)
     val rawArray : JSON.value vector decoder
 
     (* returns a decoder that maps the JSON `null` value to `NONE` and otherwise
@@ -69,6 +69,12 @@ sig
      * using the decoder `d`.
      *)
     val field : string -> 'a decoder -> 'a decoder
+
+    (* decode an optional field *)
+    val fieldO : string -> 'a decoder -> 'a option decoder
+
+    (* decode an optional field that has a default value *)
+    val fieldD : string -> 'a decoder -> 'a -> 'a decoder
 
     (* decode a required field *)
     val reqField : string -> 'a decoder -> ('a -> 'b) decoder -> 'b decoder
@@ -103,7 +109,7 @@ sig
      *)
     val fail : string -> 'a decoder
 
-    val andThen : ('a -> 'b decoder) -> 'a decoder -> 'b decoder
+    val andThen : 'a decoder -> ('a -> 'b decoder) -> 'b decoder
 
     (* `orElse (d1, d2)` returns a decoder that first trys `d1` and returns its
        result if it succeeds.  If `d1` fails, then it returns the result of

--- a/src/portableML/json/JSONDecode.sml
+++ b/src/portableML/json/JSONDecode.sml
@@ -17,6 +17,7 @@ datatype value = datatype JSON.value
 datatype 'a decoder = D of value -> 'a
 
 fun decode (D d) jv = d jv
+val ofRaw = D
 
 fun decodeString decoder s =
     (decode decoder (JSONParser.parse(JSONParser.openString s)))

--- a/src/portableML/json/JSONDecode.sml
+++ b/src/portableML/json/JSONDecode.sml
@@ -95,29 +95,21 @@ fun field key valueDecoder =
                   | _ => notObject jv
      (* end case *)))
 
-fun reqField key valueDecoder k = seq (field key valueDecoder) k
+fun fieldO key (D valueDecoder) = D (fn jv =>
+  case U.findField jv key of
+    SOME NULL => NONE
+  | SOME jv' => SOME (valueDecoder jv')
+  | NONE => NONE)
 
-fun optField key (D valueDecoder) (D objDecoder) = let
-  fun objDecoder' optFld jv = (objDecoder jv) optFld
-  fun decoder jv = (case U.findField jv key
-                     of SOME NULL => objDecoder' NONE jv
-                      | SOME jv' => objDecoder' (SOME(valueDecoder jv')) jv
-                      | NONE => objDecoder' NONE jv
-                   (* end case *))
-in
-  D decoder
-end
+fun fieldD key (D valueDecoder) dfltVal = D (fn jv =>
+  case U.findField jv key of
+    SOME NULL => dfltVal
+  | SOME jv' => valueDecoder jv
+  | NONE => dfltVal)
 
-fun dfltField key (D valueDecoder) dfltVal (D objDecoder) = let
-  fun objDecoder' fld jv = (objDecoder jv) fld
-  fun decoder jv = (case U.findField jv key
-                     of SOME NULL => objDecoder' dfltVal jv
-                      | SOME jv' => objDecoder' (valueDecoder jv') jv
-                      | NONE => objDecoder' dfltVal jv
-                   (* end case *))
-in
-  D decoder
-end
+fun reqField key valueDecoder = seq (field key valueDecoder)
+fun optField key valueDecoder = seq (fieldO key valueDecoder)
+fun dfltField key valueDecoder dfltVal = seq (fieldD key valueDecoder dfltVal)
 
 fun sub i (D d) =
     D(fn jv => (case jv of
@@ -138,7 +130,7 @@ fun succeed x = D(fn _ => x)
 
 fun fail msg = D(fn jv => failure(msg, jv))
 
-fun andThen f (D d) = D(fn jv => decode (f (d jv)) jv)
+fun andThen (D d) f = D(fn jv => decode (f (d jv)) jv)
 
 fun orElse (D d1, D d2) =
     (* try the first decoder.  If it fails with a `JSONError` exception, then
@@ -162,6 +154,6 @@ fun tuple2 (d1, d2) = map2 (fn x => x) (d1, d2)
 fun tuple3 (d1, d2, d3) = map3 (fn x => x) (d1, d2, d3)
 fun tuple4 (d1, d2, d3, d4) = map4 (fn x => x) (d1, d2, d3, d4)
 
-fun delay dd = andThen dd (succeed ())
+fun delay dd = andThen (succeed ()) dd
 
 end

--- a/tools-poly/buildheap.ML
+++ b/tools-poly/buildheap.ML
@@ -12,33 +12,45 @@ val _ = use "../tools/Holmake/FunctionalRecordUpdate.sml";
 val _ = use "holrepl.ML";
 val _ = use "execompile.ML";
 
+val _ = use "../src/portableML/json/JSON.sml";
+val _ = use "../src/portableML/json/JSONErrors.sig";
+val _ = use "../src/portableML/json/JSONErrors.sml";
+val _ = use "../src/portableML/json/JSONUtil.sig";
+val _ = use "../src/portableML/json/JSONUtil.sml";
+val _ = use "../src/portableML/json/JSONSource.sml";
+val _ = use "../src/portableML/json/JSONParser.sig";
+val _ = use "../src/portableML/json/JSONParser.sml";
+val _ = use "../src/portableML/json/JSONDecode.sig";
+val _ = use "../src/portableML/json/JSONDecode.sml";
+val _ = use "lsp-server.ML";
+
 val SIGOBJ = OS.Path.concat(Systeml.HOLDIR, "sigobj")
 local
   open FunctionalRecordUpdate
-  fun makeUpdateT z = makeUpdate15 z
+  fun makeUpdateT z = makeUpdate16 z
 in
 fun updateT z = let
   fun from all_forced base_state checkerr checkfors debug defaultout exe
-           extra_data forced_objs help multithread output quietp repl z_repl =
+           extra_data forced_objs help lsp multithread output quietp repl z_repl =
     {all_forced = all_forced, base_state = base_state,
      checkerr = checkerr, checkfors = checkfors, debug = debug,
      defaultout = defaultout, exe = exe,
      extra_data = extra_data, forced_objs = forced_objs, help = help,
-     multithread = multithread,
+     lsp = lsp, multithread = multithread,
      output = output, quietp = quietp, repl = repl, z_repl = z_repl}
-  fun from' z_repl repl quietp output multithread help forced_objs extra_data exe
+  fun from' z_repl repl quietp output multithread lsp help forced_objs extra_data exe
             defaultout debug checkfors checkerr base_state all_forced =
     {all_forced = all_forced, base_state = base_state, checkfors = checkfors,
      checkerr = checkerr, debug = debug,
      defaultout = defaultout, exe = exe,
      extra_data = extra_data, forced_objs = forced_objs, help = help,
-     multithread = multithread,
+     lsp = lsp, multithread = multithread,
      output = output, quietp = quietp, repl = repl, z_repl = z_repl}
   fun to f {all_forced, base_state, checkerr, checkfors, debug, defaultout, exe,
             extra_data,
-            forced_objs, help, multithread, output, quietp, repl, z_repl} =
+            forced_objs, help, lsp, multithread, output, quietp, repl, z_repl} =
     f all_forced base_state checkerr checkfors debug defaultout exe extra_data
-      forced_objs help multithread
+      forced_objs help lsp multithread
       output quietp repl z_repl
 in
   makeUpdateT (from, from', to)
@@ -63,6 +75,7 @@ datatype option_record = OR of {
   extra_data : string option,
   forced_objs : string list,
   help : bool,
+  lsp : bool,
   multithread : int option,
   output : string option,
   quietp : bool,
@@ -128,6 +141,8 @@ val cline_opts = [
    desc = mkBoolT #help},
   {help = "load holstate as base", long = ["holstate"], short = "b",
    desc = setStringOpt "filename" #base_state},
+  {help = "start an LSP server", long = ["lsp"], short = "",
+   desc = mkBoolT #lsp},
   {help = "thread count", long = ["mt"], short = "",
    desc = OptArg (set_threadcount, "c")},
   {help = "Don't use user config file in HOL repl", long = ["noconfig"], short = "",
@@ -153,6 +168,7 @@ val initial_cline = OR {all_forced = false,
                         extra_data = NONE,
                         forced_objs = [],
                         help = false,
+                        lsp = false,
                         multithread = NONE,
                         output = NONE,
                         quietp = false,
@@ -160,7 +176,7 @@ val initial_cline = OR {all_forced = false,
                         z_repl = false}
 end
 
-fun member s [] = false
+fun member _ [] = false
   | member s (h::t) = s = h orelse member s t
 
 fun fullPath ps = List.foldl (fn (p,acc) => OS.Path.concat(acc,p))
@@ -206,7 +222,7 @@ fun fix s =
 
 fun create_heap diag qp findMod (objs, outputheap) = let
   open Systeml TextIO
-  val p = if qp then fn s => () else fn s => print (s ^ "\n")
+  val p = if qp then fn _ => () else fn s => print (s ^ "\n")
   fun hload obj = (p ("Loading "^obj); load (fix obj))
                   handle e => die ("Loading "^obj^": "^General.exnMessage e)
 in
@@ -298,13 +314,13 @@ fun main() = let
                      errFn = die}
                     (CommandLine.arguments())
   val OR options = List.foldl (fn (f, opts) => f opts) initial_cline cline_upds
-  val {quietp = qp, output, base_state, all_forced, forced_objs,
+  val {quietp = qp, output, base_state, all_forced, forced_objs, lsp,
        repl, z_repl, help, debug, extra_data, defaultout, exe, ...} = options
-  val diag = if debug then (fn s => warn ("DIAG: "^s)) else (fn s => ())
+  val diag = if debug then (fn s => warn ("DIAG: "^s)) else (fn _ => ())
   val _ = not help orelse (print usage; OS.Process.exit OS.Process.success)
   val outrepl_error = "Can't simultaneously dump output and start REPL"
   val _ =
-      case (repl, output, defaultout) of
+      case (lsp orelse repl, output, defaultout) of
           (true, SOME _, _) => die outrepl_error
         | (true, _, SOME _) => die outrepl_error
         | _ => ()
@@ -314,7 +330,7 @@ fun main() = let
   val objs = if all_forced then forced_objs @ map force objs0
              else forced_objs @ map unforce objs0
   val _ = diag ("#objs = "^Int.toString (length objs))
-  val warn = if qp then (fn s => ()) else warn
+  val warn = if qp then (fn _ => ()) else warn
   val original_die = die
   fun die s = if qp then OS.Process.exit OS.Process.failure else original_die s
   val allincs = ReadHMF.find_includes (OS.FileSys.getDir())
@@ -378,7 +394,9 @@ in
                 NONE => []
               | SOME _ => [("poly_decide_threadcount.uo", false)]) @
            objs);
-        if repl then
+        if lsp then
+          LSPServer.start {diag = diag}
+        else if repl then
           (diag "Starting REPL";
            PolyML.print_depth 100;
            HOL_REPL.sigint_handler();

--- a/tools-poly/buildheap.ML
+++ b/tools-poly/buildheap.ML
@@ -22,6 +22,7 @@ val _ = use "../src/portableML/json/JSONParser.sig";
 val _ = use "../src/portableML/json/JSONParser.sml";
 val _ = use "../src/portableML/json/JSONDecode.sig";
 val _ = use "../src/portableML/json/JSONDecode.sml";
+val _ = use "holide.ML";
 val _ = use "lsp-server.ML";
 
 val SIGOBJ = OS.Path.concat(Systeml.HOLDIR, "sigobj")

--- a/tools-poly/holide.ML
+++ b/tools-poly/holide.ML
@@ -23,9 +23,9 @@ val moveUp: subtree -> subtree
 val moveDown: subtree -> subtree
 val moveLeft: subtree -> subtree
 val moveRight: subtree -> subtree
-val printTree: int -> subtree -> PolyML.pretty option
-val navigateTo: subtree -> {startOffset: int, endOffset: int} -> subtree
-val navigateTo': trees -> {startOffset: int, endOffset: int} -> subtree
+val printTree: FixedInt.int -> subtree -> PolyML.pretty option
+val navigateTo: subtree -> {startOffset: FixedInt.int, endOffset: FixedInt.int} -> subtree
+val navigateTo': trees -> {startOffset: FixedInt.int, endOffset: FixedInt.int} -> subtree
 
 end =
 struct

--- a/tools-poly/holide.ML
+++ b/tools-poly/holide.ML
@@ -1,0 +1,204 @@
+structure HOL_IDE: sig
+
+type error =
+  {context: PolyML.pretty option, hard: bool, location: PolyML.location, message: PolyML.pretty}
+
+type subtree = PolyML.parseTree option
+type trees = PolyML.parseTree list
+
+val initialize:
+  { text: string,
+    filename: string,
+    parseError: int * int -> string -> unit,
+    compilerOut: string -> unit,
+    toplevelOut: string -> unit,
+    progress: int -> unit,
+    error: error -> unit,
+    runtimeExn: exn -> unit,
+    mlParseTree: PolyML.parseTree -> unit,
+    holParseTree: HolParser.Simple.decl -> unit
+  } -> unit
+
+val moveUp: subtree -> subtree
+val moveDown: subtree -> subtree
+val moveLeft: subtree -> subtree
+val moveRight: subtree -> subtree
+val printTree: int -> subtree -> PolyML.pretty option
+val navigateTo: subtree -> {startOffset: int, endOffset: int} -> subtree
+val navigateTo': trees -> {startOffset: int, endOffset: int} -> subtree
+
+end =
+struct
+
+type error =
+  {context: PolyML.pretty option, hard: bool, location: PolyML.location, message: PolyML.pretty}
+
+type subtree = PolyML.parseTree option
+type trees = PolyML.parseTree list
+
+(* fun prelude () = let
+  val _ = PolyML.Compiler.reportUnreferencedIds := true
+  val _ = PolyML.Compiler.printInAlphabeticalOrder := false
+  val _ = PolyML.Compiler.maxInlineSize := 80
+  fun f (t, _) = mk_oracle_thm "fast_proof" ([], t)
+  fun f2 g = (
+    if current_theory () = "scratch"
+    then HOL_WARNING "HOL_IDE" "prove" "calling prove before new_theory"
+    else Tactical.set_prover f;
+    f g)
+  in Tactical.set_prover f2 end *)
+
+fun initialize {
+  text, filename, parseError, compilerOut, toplevelOut, progress, error,
+  runtimeExn, mlParseTree, holParseTree
+} = let
+  datatype Chunk
+    = RegularChunk of int * substring
+    | FlatChunk of int option * substring
+    | EOFChunk
+
+  val sr = ref text
+  val queue = ref []
+  fun push chunk = queue := chunk :: !queue
+  fun encode f (i, s) = let
+    val j = i + #2 (Substring.base s)
+    in f (fn s => push (FlatChunk (SOME j, Substring.full s))) (i, s) end
+  val {feed, regular, finish, doDecl, ...} =
+    HolParser.ToSML.mkPushTranslatorCore {
+      filename = filename, parseError = parseError, quietOpen = true,
+      read = fn _ => !sr before sr := ""
+    } {
+      regular = push o RegularChunk,
+      aux = fn s => push (FlatChunk (NONE, Substring.full s)),
+      strstr = encode HolParser.ToSML.strstr,
+      strcode = encode HolParser.ToSML.strcode
+    }
+  val atEnd = ref false
+  val pos = ref 0
+  fun readChunk () =
+    case !queue of
+      s :: rest => (queue := rest; s)
+    | [] => if !atEnd then EOFChunk else (
+      case feed () of
+        HolParser.Simple.TopDecl d => (holParseTree d; pos := doDecl true (!pos) d)
+      | HolParser.Simple.EOF p =>
+        (regular (!pos, p); finish (); pos := p; atEnd := true);
+      queue := rev (!queue);
+      readChunk ())
+
+  datatype State
+    = Reading of (int * bool) * int * int * string
+    | EOF of int
+  fun toState start = fn
+      EOFChunk => EOF start
+    | RegularChunk (base, ss) => let
+      val (s, lo, len) = Substring.base ss
+      in Reading ((base, true), lo, lo + len, s) end
+    | FlatChunk (i, ss) => let
+      val (s, lo, len) = Substring.base ss
+      in Reading ((Option.getOpt (i, start), false), lo, lo + len, s) end
+  val curToken = ref (toState 0 (readChunk ()))
+  fun read2 () =
+    case !curToken of
+      EOF _ => NONE
+    | Reading (base, lo, hi, s) =>
+      if lo+1 < hi then
+        (curToken := Reading (base, lo+1, hi, s); SOME (String.sub(s, lo)))
+      else (
+        curToken := toState (if #2 base then #1 base + hi else #1 base) (readChunk ());
+        if lo+1 = hi then SOME (String.sub(s, lo)) else read2 ())
+  fun getOffset () = case !curToken of
+      Reading ((base, reg), lo, _, _) => if reg then base + lo else base
+    | EOF pos => pos
+  val serial = ref 1
+  fun ptFn NONE = ()
+    | ptFn (SOME pt) = mlParseTree pt
+  fun codeFn NONE () = ()
+    | codeFn (SOME code) () = let
+      val {fixes, values, structures, signatures, functors, types} = code ()
+      fun enter f = app (f PolyML.globalNameSpace)
+      in enter #enterFix fixes; enter #enterType types; enter #enterSig signatures;
+         enter #enterStruct structures; enter #enterFunct functors; enter #enterVal values end
+  open PolyML.Compiler
+  val parameters = [
+    CPOutStream compilerOut,
+    CPPrintStream toplevelOut,
+    CPErrorMessageProc error,
+    CPCompilerResultFun (fn (pt, code) => (ptFn pt; codeFn code)),
+    CPLineOffset getOffset,
+    CPPrintInAlphabeticalOrder false,
+    CPBindingSeq (fn () => (fn n => n before serial := n + 1) (!serial))];
+  fun loop () = (
+    progress (getOffset ());
+    case !curToken of
+      EOF _ => ()
+    | _ => ((PolyML.compiler (read2, parameters) () handle e => runtimeExn e); loop ()))
+  in loop () end;
+
+fun moveUp NONE = NONE
+  | moveUp (SOME (_, props)) = let
+    fun find [] = NONE
+      | find (PolyML.PTparent p :: _) = SOME (p ())
+      | find (_ :: tl) = find tl
+    in find props end
+
+fun moveDown NONE = NONE
+  | moveDown (SOME (_, props)) = let
+    fun find [] = NONE
+      | find (PolyML.PTfirstChild p :: _) = SOME (p ())
+      | find (_ :: tl) = find tl
+    in find props end
+
+fun moveLeft NONE = NONE
+  | moveLeft (SOME (_, props)) = let
+    fun find [] = NONE
+      | find (PolyML.PTpreviousSibling p :: _) = SOME (p ())
+      | find (_ :: tl) = find tl
+    in find props end
+
+fun moveRight NONE = NONE
+  | moveRight (SOME (_, props)) = let
+    fun find [] = NONE
+      | find (PolyML.PTnextSibling p :: _) = SOME (p ())
+      | find (_ :: tl) = find tl
+    in find props end
+
+fun printTree _ NONE = NONE
+  | printTree n (SOME (_, props)) = let
+    fun find [] = NONE
+      | find (PolyML.PTprint p :: _) = SOME (p n)
+      | find (_ :: tl) = find tl
+    in find props end
+
+fun navigateTo NONE _ = NONE
+  | navigateTo (tree as (SOME ({ startPosition, endPosition, ... }, _)))
+               (target as {startOffset, endOffset}) =
+    if startOffset >= startPosition andalso endOffset <= endPosition
+    then (* It's this node or a child. *)
+      case moveDown tree of
+        NONE => tree (* No children. *)
+      | SOME child => let
+        (* See which child it is. *)
+        fun findChild (result as ({startPosition, endPosition, ...}, _)) =
+          if startOffset >= startPosition andalso endOffset <= endPosition
+          then SOME result
+          else
+            case moveRight (SOME result) of
+              NONE => NONE
+            | SOME next => findChild next
+        in
+          case findChild child of
+            NONE => tree (* In this *)
+          | SOME child => navigateTo (SOME child) target
+        end
+    else (* Must go out. *)
+      navigateTo (moveUp tree) target
+
+fun navigateTo' [] _ = NONE
+  | navigateTo' ((tree as ({ startPosition, ... }, _)) :: trees)
+                (target as {startOffset, ...}) =
+    if startOffset < startPosition
+    then navigateTo' trees target
+    else navigateTo (SOME tree) target
+
+end;

--- a/tools-poly/lsp-server.ML
+++ b/tools-poly/lsp-server.ML
@@ -97,7 +97,7 @@ fun mkResponse id r = Response {id = id, result = r}
 fun mkErr code message = Err {code = code, message = message, data = NONE}
 
 (* val ParseError = ~32700 *)
-(* val InvalidRequest = ~32600 *)
+val InvalidRequest = ~32600
 (* val MethodNotFound = ~32601 *)
 val InvalidParams = ~32602
 val InternalError = ~32603
@@ -137,6 +137,7 @@ val textDocumentPositionParams =
   map2 (fn (uri, pos) => {uri = uri, pos = pos})
     (field "textDocument" (field "uri" string), field "position" position)
 
+val cancelParams = field "id" req_id
 val evalParams = field "code" string
 end
 
@@ -161,33 +162,49 @@ fun encMessage (Request {id, method, params: encode}) print = (
     print "{\"jsonrpc\":\"2.0\",\"method\":"; encString method print;
     print ",\"params\":"; params print; print "}")
 
+exception Disconnected
 structure Channel: sig
 type 'a sender
 type 'a receiver
 val channel: unit -> 'a sender * 'a receiver
 val send: 'a sender -> 'a -> unit
+val closeSender: 'a sender -> exn option -> unit
 val recv: 'a receiver -> 'a
 end = struct
 
-type 'a sender = ConditionVar.conditionVar * Mutex.mutex * 'a option ref
+datatype 'a slot = Empty | Full of 'a | Disconn of exn option
+type 'a sender = ConditionVar.conditionVar * Mutex.mutex * 'a slot ref
 type 'a receiver = 'a sender
 
 fun channel () = let
-  val x = (ConditionVar.conditionVar (), Mutex.mutex (), ref NONE)
+  val x = (ConditionVar.conditionVar (), Mutex.mutex (), ref Empty)
   in (x, x) end
 
 fun send (cvar, mutex, r) v = let
   fun loop () =
     case !r of
-      NONE => (r := SOME v; Mutex.unlock mutex; ConditionVar.signal cvar)
-    | SOME _ => (ConditionVar.wait (cvar, mutex); loop ())
+      Disconn (SOME e) => PolyML.Exception.reraise e
+    | Disconn NONE => raise Disconnected
+    | Empty => (r := Full v; Mutex.unlock mutex; ConditionVar.signal cvar)
+    | Full _ => (ConditionVar.wait (cvar, mutex); loop ())
+  in Mutex.lock mutex; loop () end
+
+fun closeSender (cvar, mutex, r) e = let
+  fun loop () =
+    case !r of
+      Disconn (SOME e) => PolyML.Exception.reraise e
+    | Disconn NONE => raise Disconnected
+    | Full _ => (ConditionVar.wait (cvar, mutex); loop ())
+    | _ => (r := Disconn e; Mutex.unlock mutex; ConditionVar.signal cvar)
   in Mutex.lock mutex; loop () end
 
 fun recv (cvar, mutex, r) = let
   fun loop () =
     case !r of
-      SOME v => (r := NONE; Mutex.unlock mutex; ConditionVar.signal cvar; v)
-    | NONE => (ConditionVar.wait (cvar, mutex); loop ())
+      Disconn (SOME e) => PolyML.Exception.reraise e
+    | Disconn NONE => raise Disconnected
+    | Full v => (r := Empty; Mutex.unlock mutex; ConditionVar.signal cvar; v)
+    | Empty => (ConditionVar.wait (cvar, mutex); loop ())
   in Mutex.lock mutex; loop () end
 
 end
@@ -196,21 +213,30 @@ type connection = {recv: unit -> JSON.value message, send: encode message -> uni
 fun stdioConnection (): connection = let
   val recv = let
     val (send, recv) = Channel.channel ()
-    fun readerThread () =
+    fun readHeaders sz =
       case TextIO.inputLine TextIO.stdIn of
-        NONE => ()
-      | SOME line => let
-        val size =
-          if String.substring (line, size line - 2, size line) = "\r\n" andalso
-            String.substring (line, 0, 16) = "Content-Length: " then
-            case Int.fromString (String.substring (line, 16, size line - 2)) of
-              SOME n => n
+        NONE => NONE
+      | SOME line =>
+        case String.fields (fn x => x = #":") line of
+          ["\r\n"] => (case sz of SOME n => SOME n | NONE => raise MalformedData)
+        | ["Content-Length", n] => ((
+          if String.sub(n, 0) = #" " andalso String.substring(n, size n - 2, 2) = "\r\n" then
+            case Int.fromString (String.substring (n, 1, size n - 3)) of
+              SOME n => readHeaders (SOME n)
             | NONE => raise MalformedData
-          else raise MalformedData
-          handle Subscript => raise MalformedData
+          else raise MalformedData)
+          handle Subscript => raise MalformedData)
+        | _ => readHeaders sz
+    fun loop () =
+      case readHeaders NONE of
+        NONE => ()
+      | SOME size => let
         val inp = TextIO.inputN (TextIO.stdIn, size)
         val msg = JSONDecode.decodeString decMessage inp
-        in Channel.send send msg; readerThread () end
+        in Channel.send send msg; loop () end
+    fun readerThread () =
+      (loop (); Channel.closeSender send NONE)
+      handle e => (Channel.closeSender send (SOME e); PolyML.Exception.reraise e)
     val _ = Thread.fork (readerThread, [])
     in fn () => Channel.recv recv end
 
@@ -223,7 +249,7 @@ fun stdioConnection (): connection = let
       fun write (n, a :: buf, acc) = write (n + size a, buf, a :: acc)
         | write (n, [], acc) =
           TextIO.output (TextIO.stdOut,
-            String.concat ("Content-Length: " :: Int.toString n :: "\r\n" :: acc))
+            String.concat ("Content-Length: " :: Int.toString n :: "\r\n\r\n" :: acc))
       in write (0, !buf, []); writerThread () end
     val _ = Thread.fork (writerThread, [])
     in Channel.send send end
@@ -251,6 +277,7 @@ fun initialize ({send, recv}:connection) capabilities = let
 
 exception Todo
 fun start {diag} = let
+  val _ = PolyML.print_depth 100
   val conn as {send, recv} = stdioConnection ()
   val _ (*clientCapabilities*) = initialize conn (concat [
     "{\"textDocumentSync\":1", (* 1 = Full *)
@@ -262,7 +289,8 @@ fun start {diag} = let
     send (Notification {
       method = "window/logMessage",
       params = fn print => (
-        print "{\"typ\":4,\"message\":"; encString str print; print "}")})
+        print "{\"type\":4,\"message\":"; encString str print; print "}")})
+  val _ = diag "started"
   val _ = logMessage "started"
 
   val jobs = let
@@ -303,27 +331,37 @@ fun start {diag} = let
     val jobThread = Thread.fork (job, [])
     in jobs (fn js => (id, jobThread) :: js); () end
 
-  fun main () =
+  fun recvExit () =
+    case recv () of
+      Notification {method = "exit", ...} => ()
+    | _ => (diag "ignoring message after shutdown"; recvExit ())
+
+  exception Shutdown
+  fun main () = (
     case recv () of
       Request {method = "shutdown", id, ...} => (
-      send (mkResponse id (Ok encNull));
-      case recv () of
-        Notification {method = "exit", ...} => ()
-      | _ => raise ProtocolError)
+        diag "received shutdown request";
+        send (mkResponse id (Ok encNull));
+        recvExit ();
+        raise Shutdown)
     | Request {method = "textDocument/hover", id, params} =>
-      (spawnJob id params textDocumentPositionParams hover; main ())
+      spawnJob id params textDocumentPositionParams hover
     | Request {method = "textDocument/definition", id, params} =>
-      (spawnJob id params textDocumentPositionParams gotoDefinition; main ())
-    | Response _ => diag "response to unknown request"
-    | Notification {method = "$/cancelRequest", params} => let
-      open JSONDecode
-      val id = decode (field "id" req_id) params
-      val _ = app (fn (j,th) => if j = id then Thread.interrupt th else ()) (jobs I)
-      in main () end
+      spawnJob id params textDocumentPositionParams gotoDefinition
     | Request {method = "$/eval", id, params} =>
-      (spawnJob id params evalParams eval; main ())
-    | _ => main ()
-
-  in main () end
+      spawnJob id params evalParams eval
+    | Request {method, id, ...} =>
+      send (mkResponse id (mkErr InvalidRequest ("unknown method: " ^ method)))
+    | Notification {method = "$/cancelRequest", params} => let
+      val id = JSONDecode.decode cancelParams params
+      in app (fn (j,th) => if j = id then Thread.interrupt th else ()) (jobs I) end
+    | Response _ => diag "response to unknown request"
+    | Notification {method, ...} => diag ("unknown method: " ^ method);
+    main ())
+  in
+    main () handle
+      Shutdown => ()
+    | Disconnected => diag "early abort"
+  end
 
 end (* struct *)

--- a/tools-poly/lsp-server.ML
+++ b/tools-poly/lsp-server.ML
@@ -315,8 +315,9 @@ type range = int * int
 
 fun encPosLC lines = encPosition o getLineCol lines
 val encRangeLC = encRange o encPosLC
-(* fun encLocLC lines ({startPosition,endPosition,...}:PolyML.location) =
-  encRangeLC lines (startPosition, endPosition) *)
+fun locToRange ({startPosition,endPosition,...}:PolyML.location) =
+  (FixedInt.toInt startPosition, FixedInt.toInt endPosition)
+(* fun encLocLC lines = encRangeLC lines o locToRange *)
 
 fun encPretty textWidth pp print = let
   fun print' s = encStringContents s print
@@ -427,12 +428,12 @@ fun start {diag} = let
         compilerOut = fn s => report (CompilerOut [s]),
         toplevelOut = fn s => report (ToplevelOut [s]),
         progress = fn i => (lastPos := i; report (Progress i)),
-        error = fn {hard, location = {startPosition = p1, endPosition = p2, ...}, message, ...} =>
-          report (Error {hard = hard, pos = (p1, p2), msg = encPretty textWidth message}),
+        error = fn {hard, location, message, ...} => report (Error {
+          hard = hard, pos = locToRange location, msg = encPretty textWidth message}),
         runtimeExn = fn e => report (Error {hard = true,
           pos = case PolyML.Exception.exceptionLocation e of
             NONE => (case !lastPos of i => (i, i))
-          | SOME {startPosition, endPosition, ...} => (startPosition, endPosition),
+          | SOME l => locToRange l,
           msg = encPretty textWidth (exceptionMessage e)}),
         mlParseTree = fn _ => (),
         holParseTree = fn _ => () };

--- a/tools-poly/lsp-server.ML
+++ b/tools-poly/lsp-server.ML
@@ -1,0 +1,329 @@
+signature LSPServer =
+sig
+  val start : {diag: string -> unit} -> unit
+end;
+
+(* load "JSONDecode"; *)
+
+structure LSPServer :> LSPServer =
+struct
+
+(* structure Thread = PolyThread; *)
+open Thread
+
+fun I x = x
+
+type encode = (string -> unit) -> unit
+fun encOut str: encode = fn print => print str
+val encNull = encOut "null"
+fun encInt x = if x < 0 then encOut ("-" ^ Int.toString (~x)) else encOut (Int.toString x)
+
+local
+
+fun encodeSubstring {str, start, stop} print = let
+  fun cleanup start i =
+    if start < i then print (String.substring (str, start, i - start)) else ()
+  fun hexdigit n = Char.chr (n + (if n < 10 then 48 else 55))
+  fun inner start i =
+    if i >= stop then cleanup start i
+    else
+      let val c = String.sub (str, i) in
+        if #" " <= c then
+          if c = #"\\" then breakStreak start i "\\\\" else
+          if c = #"\"" then breakStreak start i "\\\"" else
+          inner start (i+1)
+        else breakStreak start i (case c of
+            #"\b" => "\\b"
+          | #"\f" => "\\f"
+          | #"\n" => "\\n"
+          | #"\r" => "\\r"
+          | #"\t" => "\\t"
+          | _ => let
+            val n = Char.ord c
+            in "\\u00" ^ String.implode [hexdigit (n div 16), hexdigit (n mod 16)] end)
+      end
+  and breakStreak start i next = (cleanup start i; print next; inner (i+1) (i+1))
+  in inner start start end
+
+in
+
+(* fun encSubstringContents str = let
+  val (str, start, length) = Substring.base str
+  in encodeSubstring {str=str, start=start, stop=start+length} end *)
+
+fun encStringContents str =
+  encodeSubstring {str=str, start=0, stop=String.size str}
+
+end
+
+fun encString str print = (print "\""; encStringContents str print; print "\"")
+
+(* fun encSubstring str print = (print "\""; encSubstringContents str print; print "\"") *)
+
+fun encArray encode ls print = case ls of
+    [] => print "[]"
+  | a :: ls => let
+    fun inner [] = print "]"
+      | inner (a :: ls) = (print ","; encode a print; inner ls)
+    val () = print "["
+    val () = encode a print
+    in inner ls end
+
+fun encPosition (line, col) print = (
+  print "{\"line\":"; encInt line print;
+  print ",\"character\":"; encInt col print;
+  print "}")
+
+fun encRange (start, stop) print = (
+  print "{\"start\":"; encPosition start print;
+  print ",\"end\":"; encPosition stop print;
+  print "}")
+
+fun encLocation {uri, range} print = (
+  print "{\"uri\":"; encString uri print;
+  print ",\"range\":"; encRange range print;
+  print "}")
+
+exception MalformedData
+
+datatype req_id = Id of int | Str of string
+datatype 'v result = Ok of 'v | Err of {code: int, message: string, data: 'v option}
+datatype 'v message =
+  Request of {id: req_id, method: string, params: 'v}
+| Response of {id: req_id, result: 'v result}
+| Notification of {method: string, params: 'v}
+
+fun mkResponse id r = Response {id = id, result = r}
+fun mkErr code message = Err {code = code, message = message, data = NONE}
+
+(* val ParseError = ~32700 *)
+(* val InvalidRequest = ~32600 *)
+(* val MethodNotFound = ~32601 *)
+val InvalidParams = ~32602
+val InternalError = ~32603
+(* val ServerErrorStart = ~32099 *)
+(* val ServerErrorEnd = ~32000 *)
+val ServerNotInitialized = ~32002
+(* val UnknownErrorCode = ~32001 *)
+(* val RequestCanceled = ~32800 *)
+(* val ContentModified = ~32801 *)
+(* val ServerCancelled = ~32802 *)
+(* val RequestFailed = ~32803 *)
+
+
+local
+  open JSONDecode JSON
+  val error = reqField "code" int (reqField "message" string (optField "data" raw
+    (succeed (fn data => fn message => fn code => {code = code, message = message, data = data}))))
+in
+val req_id = orElse (map Id int, map Str string)
+val decMessage: JSON.value message decoder = ofRaw (fn jv =>
+  case decode (optField "id" req_id (succeed I)) jv of
+    NONE => Notification {
+      method = decode (reqField "method" string (succeed I)) jv,
+      params = decode (dfltField "params" raw NULL (succeed I)) jv}
+  | SOME id => case decode (optField "method" string (succeed I)) jv of
+    SOME method => Request {
+      id = id, method = method,
+      params = decode (dfltField "params" raw NULL (succeed I)) jv}
+  | NONE => let
+    val result = case decode (optField "error" error (succeed I)) jv of
+      SOME e => Err e
+    | NONE => Ok (decode (reqField "result" raw (succeed I)) jv )
+    in Response {id = id, result = result} end)
+
+val position = tuple2 (field "line" int, field "character" int)
+val textDocumentPositionParams =
+  map2 (fn (uri, pos) => {uri = uri, pos = pos})
+    (field "textDocument" (field "uri" string), field "position" position)
+
+val evalParams = field "code" string
+end
+
+fun encReqId (Id id) = encInt id
+  | encReqId (Str s) = encString s
+
+fun encMessage (Request {id, method, params: encode}) print = (
+    print "{\"jsonrpc\":\"2.0\",\"id\":"; encReqId id print;
+    print ",\"method\":"; encString method print;
+    print ",\"params\":"; params print; print "}")
+  | encMessage (Response {id, result}) print = (
+    print "{\"jsonrpc\":\"2.0\",\"id\":"; encReqId id print;
+    case result of
+      Ok r => (print ",\"result\":"; r print)
+    | Err {code, message, data} => (
+      print ",\"error\":{\"code\":"; encInt code print;
+      print ",\"message\":"; encString message print;
+      case data of NONE => () | SOME data => (print ",\"data\":"; data print);
+      print "}");
+    print "}")
+  | encMessage (Notification {method, params}) print = (
+    print "{\"jsonrpc\":\"2.0\",\"method\":"; encString method print;
+    print ",\"params\":"; params print; print "}")
+
+structure Channel: sig
+type 'a sender
+type 'a receiver
+val channel: unit -> 'a sender * 'a receiver
+val send: 'a sender -> 'a -> unit
+val recv: 'a receiver -> 'a
+end = struct
+
+type 'a sender = ConditionVar.conditionVar * Mutex.mutex * 'a option ref
+type 'a receiver = 'a sender
+
+fun channel () = let
+  val x = (ConditionVar.conditionVar (), Mutex.mutex (), ref NONE)
+  in (x, x) end
+
+fun send (cvar, mutex, r) v = let
+  fun loop () =
+    case !r of
+      NONE => (r := SOME v; Mutex.unlock mutex; ConditionVar.signal cvar)
+    | SOME _ => (ConditionVar.wait (cvar, mutex); loop ())
+  in Mutex.lock mutex; loop () end
+
+fun recv (cvar, mutex, r) = let
+  fun loop () =
+    case !r of
+      SOME v => (r := NONE; Mutex.unlock mutex; ConditionVar.signal cvar; v)
+    | NONE => (ConditionVar.wait (cvar, mutex); loop ())
+  in Mutex.lock mutex; loop () end
+
+end
+
+type connection = {recv: unit -> JSON.value message, send: encode message -> unit}
+fun stdioConnection (): connection = let
+  val recv = let
+    val (send, recv) = Channel.channel ()
+    fun readerThread () =
+      case TextIO.inputLine TextIO.stdIn of
+        NONE => ()
+      | SOME line => let
+        val size =
+          if String.substring (line, size line - 2, size line) = "\r\n" andalso
+            String.substring (line, 0, 16) = "Content-Length: " then
+            case Int.fromString (String.substring (line, 16, size line - 2)) of
+              SOME n => n
+            | NONE => raise MalformedData
+          else raise MalformedData
+          handle Subscript => raise MalformedData
+        val inp = TextIO.inputN (TextIO.stdIn, size)
+        val msg = JSONDecode.decodeString decMessage inp
+        in Channel.send send msg; readerThread () end
+    val _ = Thread.fork (readerThread, [])
+    in fn () => Channel.recv recv end
+
+  val send = let
+    val (send, recv) = Channel.channel ()
+    fun writerThread () = let
+      val msg: encode message = Channel.recv recv
+      val buf = ref []
+      val () = encMessage msg (fn s => buf := s :: !buf)
+      fun write (n, a :: buf, acc) = write (n + size a, buf, a :: acc)
+        | write (n, [], acc) =
+          TextIO.output (TextIO.stdOut,
+            String.concat ("Content-Length: " :: Int.toString n :: "\r\n" :: acc))
+      in write (0, !buf, []); writerThread () end
+    val _ = Thread.fork (writerThread, [])
+    in Channel.send send end
+  in {send = send, recv = recv} end
+
+exception ProtocolError
+
+fun initialize ({send, recv}:connection) capabilities = let
+  fun init () =
+    case recv () of
+      Request {method = "initialize", id, params} => (id, params)
+    | Request {id, ...} => (
+      send (mkResponse id (mkErr ServerNotInitialized "expected initialize request"));
+      init ())
+    | Notification {method = "exit", ...} => raise ProtocolError
+    | Notification _ => init ()
+    | _ => raise ProtocolError
+  val (id, params) = init ()
+  val _ = send (mkResponse id (Ok (fn print => (
+    print "{\"capabilities\":"; print capabilities; print "}"))))
+  val _ = case recv () of
+    Notification {method = "initialized", ...} => ()
+  | _ => raise ProtocolError
+  in params end
+
+exception Todo
+fun start {diag} = let
+  val conn as {send, recv} = stdioConnection ()
+  val _ (*clientCapabilities*) = initialize conn (concat [
+    "{\"textDocumentSync\":1", (* 1 = Full *)
+    ",\"hoverProvider\":true",
+    ",\"definitionProvider\":true",
+    ",\"referencesProvider\":true",
+    "}"])
+  fun logMessage str =
+    send (Notification {
+      method = "window/logMessage",
+      params = fn print => (
+        print "{\"typ\":4,\"message\":"; encString str print; print "}")})
+  val _ = logMessage "started"
+
+  val jobs = let
+    val mutex = Mutex.mutex ()
+    val jobs = ref []
+    fun modify f = let
+      val _ = Mutex.lock mutex
+      val j = !jobs
+      val _ = jobs := f j
+      val _ = Mutex.unlock mutex
+      in j end
+    in modify end
+
+  fun hover {uri, pos} = let
+    (* TODO *)
+    in Ok encNull end
+
+  fun gotoDefinition {uri, pos} = let
+    (* TODO *)
+    val ls = []
+    in Ok (encArray encLocation ls) end
+
+  fun eval code = let
+    (* TODO *)
+    in Ok (encString "val it = ()") end
+
+  fun spawnJob id params decode f = let
+    fun job () = let
+      val result = f (JSONDecode.decode decode params) handle
+        JSONErrors.JSONError _ => mkErr InvalidParams "json decode failed"
+      | e => mkErr InternalError (exnMessage e)
+      val _ = send (mkResponse id result)
+      val _ = jobs (fn js => let
+        fun go (_, []) = js
+          | go (acc, j::js) = if #1 j = id then List.revAppend (acc, js) else go (j::acc, js)
+        in go ([], js) end)
+      in () end
+    val jobThread = Thread.fork (job, [])
+    in jobs (fn js => (id, jobThread) :: js); () end
+
+  fun main () =
+    case recv () of
+      Request {method = "shutdown", id, ...} => (
+      send (mkResponse id (Ok encNull));
+      case recv () of
+        Notification {method = "exit", ...} => ()
+      | _ => raise ProtocolError)
+    | Request {method = "textDocument/hover", id, params} =>
+      (spawnJob id params textDocumentPositionParams hover; main ())
+    | Request {method = "textDocument/definition", id, params} =>
+      (spawnJob id params textDocumentPositionParams gotoDefinition; main ())
+    | Response _ => diag "response to unknown request"
+    | Notification {method = "$/cancelRequest", params} => let
+      open JSONDecode
+      val id = decode (field "id" req_id) params
+      val _ = app (fn (j,th) => if j = id then Thread.interrupt th else ()) (jobs I)
+      in main () end
+    | Request {method = "$/eval", id, params} =>
+      (spawnJob id params evalParams eval; main ())
+    | _ => main ()
+
+  in main () end
+
+end (* struct *)

--- a/tools-poly/lsp-server.ML
+++ b/tools-poly/lsp-server.ML
@@ -74,14 +74,14 @@ fun encPosition (line, col) print = (
   print ",\"character\":"; encInt col print;
   print "}")
 
-fun encRange (start, stop) print = (
-  print "{\"start\":"; encPosition start print;
-  print ",\"end\":"; encPosition stop print;
+fun encRange encPos (start, stop) print = (
+  print "{\"start\":"; encPos start print;
+  print ",\"end\":"; encPos stop print;
   print "}")
 
 fun encLocation {uri, range} print = (
   print "{\"uri\":"; encString uri print;
-  print ",\"range\":"; encRange range print;
+  print ",\"range\":"; encRange encPosition range print;
   print "}")
 
 exception MalformedData
@@ -94,6 +94,7 @@ datatype 'v message =
 | Notification of {method: string, params: 'v}
 
 fun mkResponse id r = Response {id = id, result = r}
+fun mkNotif method params = Notification {method = method, params = params}
 fun mkErr code message = Err {code = code, message = message, data = NONE}
 
 (* val ParseError = ~32700 *)
@@ -110,26 +111,32 @@ val ServerNotInitialized = ~32002
 (* val ServerCancelled = ~32802 *)
 (* val RequestFailed = ~32803 *)
 
+datatype incremental = IncrNone | IncrChunk | IncrStream
 
 local
   open JSONDecode JSON
-  val error = reqField "code" int (reqField "message" string (optField "data" raw
-    (succeed (fn data => fn message => fn code => {code = code, message = message, data = data}))))
+  val error = map3 (fn (code, message, data) => {code = code, message = message, data = data})
+    (field "code" int, field "message" string, fieldO "data" raw)
+  exception NotIncr
+  val incr = ofRaw (fn jv =>
+    case decode int jv of
+      0 => IncrNone | 1 => IncrChunk | 2 => IncrStream
+    | _ => raise JSONError (NotIncr, jv))
 in
 val req_id = orElse (map Id int, map Str string)
 val decMessage: JSON.value message decoder = ofRaw (fn jv =>
-  case decode (optField "id" req_id (succeed I)) jv of
+  case decode (fieldO "id" req_id) jv of
     NONE => Notification {
-      method = decode (reqField "method" string (succeed I)) jv,
-      params = decode (dfltField "params" raw NULL (succeed I)) jv}
-  | SOME id => case decode (optField "method" string (succeed I)) jv of
+      method = decode (field "method" string) jv,
+      params = decode (fieldD "params" raw NULL) jv}
+  | SOME id => case decode (fieldO "method" string) jv of
     SOME method => Request {
       id = id, method = method,
-      params = decode (dfltField "params" raw NULL (succeed I)) jv}
+      params = decode (fieldD "params" raw NULL) jv}
   | NONE => let
-    val result = case decode (optField "error" error (succeed I)) jv of
+    val result = case decode (fieldO "error" error) jv of
       SOME e => Err e
-    | NONE => Ok (decode (reqField "result" raw (succeed I)) jv )
+    | NONE => Ok (decode (field "result" raw) jv )
     in Response {id = id, result = result} end)
 
 val position = tuple2 (field "line" int, field "character" int)
@@ -138,7 +145,8 @@ val textDocumentPositionParams =
     (field "textDocument" (field "uri" string), field "position" position)
 
 val cancelParams = field "id" req_id
-val evalParams = field "code" string
+val evalParams = map3 (fn (uri, code, incr) => {uri = uri, code = code, incr = incr})
+  (field "uri" string, field "code" string, fieldD "incr" incr IncrNone)
 end
 
 fun encReqId (Id id) = encInt id
@@ -275,6 +283,45 @@ fun initialize ({send, recv}:connection) capabilities = let
   | _ => raise ProtocolError
   in params end
 
+fun mkLineCounter str = let
+  fun loop i ls =
+    if i >= String.size str then Vector.fromList (List.rev ls)
+    else
+      let val c = String.sub (str, i)
+      in loop (i+1) (if c = #"\n" then i+1::ls else ls) end
+  in loop 0 [] end
+
+fun partitionPoint len pred = let
+  fun loop start len =
+    if len = 0 then start
+    else let
+      val half = len div 2
+      val middle = start + half
+      in
+        if pred middle
+        then loop (middle + 1) (len - (half + 1))
+        else loop start half
+      end
+  in loop 0 len end
+
+fun getLineCol lines index = let
+  val line = partitionPoint (Vector.length lines) (fn i => Vector.sub (lines, i) <= index)
+  in (line, index - (if line = 0 then 0 else Vector.sub (lines, line - 1))) end
+
+(* fun fromLineCol lines (line, col) =
+  if line = 0 then col else Vector.sub (lines, line - 1) + col *)
+
+type range = int * int
+
+fun encPosLC lines = encPosition o getLineCol lines
+val encRangeLC = encRange o encPosLC
+(* fun encLocLC lines ({startPosition,endPosition,...}:PolyML.location) =
+  encRangeLC lines (startPosition, endPosition) *)
+
+fun encPretty textWidth pp print = let
+  fun print' s = encStringContents s print
+  in print "\""; PolyML.prettyPrint (print', textWidth) pp; print "\"" end
+
 exception Todo
 fun start {diag} = let
   val _ = PolyML.print_depth 100
@@ -293,6 +340,9 @@ fun start {diag} = let
   val _ = diag "started"
   val _ = logMessage "started"
 
+  val textWidth = 100 (* configure? *)
+  val printDepth = 100
+
   val jobs = let
     val mutex = Mutex.mutex ()
     val jobs = ref []
@@ -304,6 +354,21 @@ fun start {diag} = let
       in j end
     in modify end
 
+  fun spawnJobCore id job = let
+    val jobThread = Thread.fork (job, [])
+    in jobs (fn js => (id, jobThread) :: js); () end
+
+  fun spawnJob id params decode f = spawnJobCore id (fn () => let
+    val result = f (JSONDecode.decode decode params) handle
+      JSONErrors.JSONError _ => mkErr InvalidParams "json decode failed"
+    | e => mkErr InternalError (exnMessage e)
+    val _ = send (mkResponse id result)
+    val _ = jobs (fn js => let
+      fun go (_, []) = js
+        | go (acc, j::js) = if #1 j = id then List.revAppend (acc, js) else go (j::acc, js)
+      in go ([], js) end)
+    in () end)
+
   fun hover {uri, pos} = let
     (* TODO *)
     in Ok encNull end
@@ -313,23 +378,99 @@ fun start {diag} = let
     val ls = []
     in Ok (encArray encLocation ls) end
 
-  fun eval code = let
-    (* TODO *)
-    in Ok (encString "val it = ()") end
+  fun eval id {uri, code, incr} = let
+    val lines = mkLineCounter code
 
-  fun spawnJob id params decode f = let
-    fun job () = let
-      val result = f (JSONDecode.decode decode params) handle
-        JSONErrors.JSONError _ => mkErr InvalidParams "json decode failed"
-      | e => mkErr InternalError (exnMessage e)
-      val _ = send (mkResponse id result)
-      val _ = jobs (fn js => let
-        fun go (_, []) = js
-          | go (acc, j::js) = if #1 j = id then List.revAppend (acc, js) else go (j::acc, js)
-        in go ([], js) end)
-      in () end
-    val jobThread = Thread.fork (job, [])
-    in jobs (fn js => (id, jobThread) :: js); () end
+    datatype report =
+      Error of {hard: bool, pos: range, msg: encode}
+    | CompilerOut of string
+    | ToplevelOut of string
+    | Progress of int
+    | Completed
+    | Interrupted
+
+    fun encReport (Error {hard, pos, msg}) print = (
+        print "{\"kind\":\"error\"";
+        print ",\"hard\":"; print (if hard then "true" else "false");
+        print ",\"pos\":"; encRangeLC lines pos print;
+        print ",\"msg\":"; msg print;
+        print "}")
+      | encReport (CompilerOut s) print = (
+        print "{\"kind\":\"compilerOut\"";
+        print ",\"body\":"; encString s print;
+        print "}")
+      | encReport (ToplevelOut s) print = (
+        print "{\"kind\":\"toplevelOut\"";
+        print ",\"body\":"; encString s print;
+        print "}")
+      | encReport (Progress i) print = (
+        print "{\"kind\":\"compileProgress\"";
+        print ",\"pos\":"; encPosLC lines i print;
+        print "}")
+      | encReport Completed print = print "{\"kind\":\"compileCompleted\"}"
+      | encReport Interrupted print = print "{\"kind\":\"interrupted\"}"
+
+    fun exceptionMessage (exn: exn) =
+      PolyML.PrettyBlock(0, false, [], [
+        PolyML.PrettyBlock(0, false, [], [PolyML.PrettyString "Exception"]),
+        PolyML.PrettyBreak(1, 3),
+        PolyML.prettyRepresentation(exn, printDepth),
+        PolyML.PrettyBreak(1, 3),
+        PolyML.PrettyString "raised"])
+
+    val lastPos = ref 0
+    fun compile report = (
+      HOL_IDE.initialize {
+        text = code,
+        filename = uri,
+        parseError = fn pos => fn s => report (Error {hard = true, pos = pos, msg = encString s}),
+        compilerOut = report o CompilerOut,
+        toplevelOut = report o ToplevelOut,
+        progress = fn i => (lastPos := i; report (Progress i)),
+        error = fn {hard, location = {startPosition = p1, endPosition = p2, ...}, message, ...} =>
+          report (Error {hard = hard, pos = (p1, p2), msg = encPretty textWidth message}),
+        runtimeExn = fn e => report (Error {hard = true,
+          pos = case PolyML.Exception.exceptionLocation e of
+            NONE => (case !lastPos of i => (i, i))
+          | SOME {startPosition, endPosition, ...} => (startPosition, endPosition),
+          msg = encPretty textWidth (exceptionMessage e)}),
+        mlParseTree = fn _ => (),
+        holParseTree = fn _ => () };
+      lastPos := size code)
+
+    in
+      case incr of
+        IncrNone => let
+        val buf = ref []
+        val _ = compile (fn Progress _ => () | msg => buf := msg :: !buf) handle
+          Thread.Interrupt => buf := Interrupted :: !buf
+        in Ok (encArray encReport (rev (!buf))) end
+      | IncrChunk => (
+        spawnJobCore id (fn () => let
+          val buf = ref []
+          val prev = ref 0
+          fun clearBuf complete = let
+            val buf = rev (!buf before buf := [])
+            fun params print = (
+              print "{\"id\":"; encReqId id print;
+              print ",\"pos\":"; encRangeLC lines (!prev before prev := !lastPos, !lastPos) print;
+              print ",\"out\":"; encArray encReport buf print;
+              if complete then print ",\"complete\":true" else (); print "}")
+            in send (mkNotif "$/eval/P" params) end
+          val _ = compile (fn Progress _ => clearBuf false | msg => buf := msg :: !buf) handle
+            Thread.Interrupt => buf := Interrupted :: !buf
+          in lastPos := size code; clearBuf true end);
+        Ok encNull)
+      | IncrStream => (
+        spawnJobCore id (fn () => let
+          fun sendMsg msg = send (mkNotif "$/eval/1" (fn print => (
+            print "{\"id\":"; encReqId id print;
+            print ",\"out\":"; encReport msg print; print "}")))
+          val ok = (compile sendMsg; true) handle
+            Thread.Interrupt => (sendMsg Interrupted; false)
+          in if ok then sendMsg Completed else () end);
+        Ok encNull)
+    end
 
   fun recvExit () =
     case recv () of
@@ -349,7 +490,7 @@ fun start {diag} = let
     | Request {method = "textDocument/definition", id, params} =>
       spawnJob id params textDocumentPositionParams gotoDefinition
     | Request {method = "$/eval", id, params} =>
-      spawnJob id params evalParams eval
+      spawnJob id params evalParams (eval id)
     | Request {method, id, ...} =>
       send (mkResponse id (mkErr InvalidRequest ("unknown method: " ^ method)))
     | Notification {method = "$/cancelRequest", params} => let

--- a/tools-poly/lsp-server.ML
+++ b/tools-poly/lsp-server.ML
@@ -383,8 +383,8 @@ fun start {diag} = let
 
     datatype report =
       Error of {hard: bool, pos: range, msg: encode}
-    | CompilerOut of string
-    | ToplevelOut of string
+    | CompilerOut of string list
+    | ToplevelOut of string list
     | Progress of int
     | Completed
     | Interrupted
@@ -397,11 +397,11 @@ fun start {diag} = let
         print "}")
       | encReport (CompilerOut s) print = (
         print "{\"kind\":\"compilerOut\"";
-        print ",\"body\":"; encString s print;
+        print ",\"body\":"; encString (concat (rev s)) print;
         print "}")
       | encReport (ToplevelOut s) print = (
         print "{\"kind\":\"toplevelOut\"";
-        print ",\"body\":"; encString s print;
+        print ",\"body\":"; encString (concat (rev s)) print;
         print "}")
       | encReport (Progress i) print = (
         print "{\"kind\":\"compileProgress\"";
@@ -424,8 +424,8 @@ fun start {diag} = let
         text = code,
         filename = uri,
         parseError = fn pos => fn s => report (Error {hard = true, pos = pos, msg = encString s}),
-        compilerOut = report o CompilerOut,
-        toplevelOut = report o ToplevelOut,
+        compilerOut = fn s => report (CompilerOut [s]),
+        toplevelOut = fn s => report (ToplevelOut [s]),
         progress = fn i => (lastPos := i; report (Progress i)),
         error = fn {hard, location = {startPosition = p1, endPosition = p2, ...}, message, ...} =>
           report (Error {hard = hard, pos = (p1, p2), msg = encPretty textWidth message}),
@@ -438,11 +438,16 @@ fun start {diag} = let
         holParseTree = fn _ => () };
       lastPos := size code)
 
+    fun mergeInto msg buf =
+      buf := (case (msg, !buf) of
+        (CompilerOut [s], CompilerOut ss :: rest) => CompilerOut (s :: ss) :: rest
+      | (ToplevelOut [s], ToplevelOut ss :: rest) => ToplevelOut (s :: ss) :: rest
+      | (msg, buf) => msg :: buf)
     in
       case incr of
         IncrNone => let
         val buf = ref []
-        val _ = compile (fn Progress _ => () | msg => buf := msg :: !buf) handle
+        val _ = compile (fn Progress _ => () | msg => mergeInto msg buf) handle
           Thread.Interrupt => buf := Interrupted :: !buf
         in Ok (encArray encReport (rev (!buf))) end
       | IncrChunk => (
@@ -457,7 +462,7 @@ fun start {diag} = let
               print ",\"out\":"; encArray encReport buf print;
               if complete then print ",\"complete\":true" else (); print "}")
             in send (mkNotif "$/eval/P" params) end
-          val _ = compile (fn Progress _ => clearBuf false | msg => buf := msg :: !buf) handle
+          val _ = compile (fn Progress _ => clearBuf false | msg => mergeInto msg buf) handle
             Thread.Interrupt => buf := Interrupted :: !buf
           in lastPos := size code; clearBuf true end);
         Ok encNull)


### PR DESCRIPTION
Currently it doesn't actually do anything, but this implements:

* a `--lsp` flag to start the server
* a multithreaded backend which dispatches request jobs
* parsing for the LSP protocol for a few commands:
  * hovers
  * go to definition
  * `$/eval`, a custom LSP extension which will be used to run SML code from the client