### PR TITLE
Add string argument to cv_trans_pre and friends

### DIFF
--- a/doc/next-release.md
+++ b/doc/next-release.md
@@ -89,6 +89,11 @@ Incompatibilities:
 -   `numLib.prefer_num` has been renamed to `numLib.temp_prefer_num`, which name better describes its semantics.
     The `prefer_num` entry-point is now used to make a change “permanent” (again following the naming convention used by many parsing-related entry-points), which is to say that the overloads made by this function will be exported to child theories.
 
+-   The cv translator's entry points with `_pre` now take a new string argument, e.g., what used to be `cv_trans_pre foo_def` is now `cv_trans_pre "foo_pre" foo_def`.
+    Mutually recursive functions require a name for each functions. In the string argument, multiple names are given either with
+    spaces separating them, e.g., `"foo_pre foo_list_pre"`, or commas separating them, e.g., `"foo_pre,foo_list_pre"` or `"foo_pre, foo_list_pre"`.
+    The old behaviour (inventing names) is supported by passing the empty string `""` as the name, i.e., `cv_trans_pre "" foo_def`.
+
 -   Editor mode implementations have moved in the HOL sources to `tools/editor-modes/{editor-name}`.
     This may affect editor initialisations/configurations, particularly if they hard-code a reference to a particular path.
     For example, in the recommended setup for `emacs`, users will need to change

--- a/examples/bootstrap/compiler_funs_cvScript.sml
+++ b/examples/bootstrap/compiler_funs_cvScript.sml
@@ -10,7 +10,7 @@ Libs
 val res = cv_auto_trans codegenTheory.even_len_def;
 val res = cv_auto_trans codegenTheory.c_pops_def;
 
-val res = cv_auto_trans_pre_rec codegenTheory.c_exp_def
+val res = cv_auto_trans_pre_rec "c_exp_pre c_exps_pre" codegenTheory.c_exp_def
  (WF_REL_TAC ‘inv_image (measure I LEX measure I)
     (λx. case x of INL (t,l,vs,fs,x) => (cv_size x, cv$c2n t)
                  | INR (l,vs,fs,xs) => (cv_size xs, 0))’
@@ -26,14 +26,14 @@ Proof
   ho_match_mp_tac codegenTheory.c_exp_ind \\ rw [] \\ simp [Once res]
 QED
 
-val res = cv_auto_trans_pre printingTheory.is_comment_def;
+val res = cv_auto_trans_pre "is_comment_pre" printingTheory.is_comment_def;
 Theorem is_comment_pre[cv_pre]:
   ∀v. is_comment_pre v
 Proof
   ho_match_mp_tac printingTheory.is_comment_ind \\ rw [] \\ simp [Once res]
 QED
 
-val pre = cv_trans_pre_rec printingTheory.num2str_def
+val pre = cv_trans_pre_rec "num2str_pre" printingTheory.num2str_def
   (WF_REL_TAC ‘measure cv_size’ \\ Cases \\ gvs [] \\ rw [] \\ gvs []);
 
 Theorem num2str_pre[cv_pre]:
@@ -43,14 +43,14 @@ Proof
   \\ ‘n MOD 10 < 10’ by fs [] \\ decide_tac
 QED
 
-val pre = cv_trans_pre printingTheory.num2ascii_def
+val pre = cv_trans_pre "num2ascii_pre" printingTheory.num2ascii_def
 Theorem num2ascii_pre[cv_pre]:
   ∀n. num2ascii_pre n
 Proof
   ho_match_mp_tac printingTheory.num2ascii_ind \\ rw [] \\ simp [Once pre]
 QED
 
-val pre = cv_trans_pre printingTheory.ascii_name_def
+val pre = cv_trans_pre "ascii_name_pre" printingTheory.ascii_name_def
 Theorem ascii_name_pre[cv_pre]:
   ∀n. ascii_name_pre n
 Proof
@@ -58,7 +58,7 @@ Proof
   \\ gvs [AllCaseEqs()]
 QED
 
-val pre = cv_trans_pre x64asm_syntaxTheory.num_def;
+val pre = cv_trans_pre "num_pre" x64asm_syntaxTheory.num_def;
 Theorem num_pre[cv_pre]:
   ∀n s. num_pre n s
 Proof
@@ -96,7 +96,7 @@ QED
 val v2pretty_eq =
   CONJ (printingTheory.v2pretty_def |> SRULE [GSYM vs2pretty_def]) vs2pretty_thm;
 
-val pre = cv_auto_trans_pre_rec v2pretty_eq
+val pre = cv_auto_trans_pre_rec "" v2pretty_eq
   (WF_REL_TAC ‘measure $ λx. case x of INL v => cv_size v
                                      | INR v => cv_size v’
    \\ rw [] \\ cv_termination_tac
@@ -229,7 +229,7 @@ Proof
   rw[AllCaseEqs()] >> gvs[] >> cv_termination_tac
 QED
 
-val pre = cv_auto_trans_pre_rec exp2v_def
+val pre = cv_auto_trans_pre_rec "" exp2v_def
   (
     WF_REL_TAC ‘measure $ λx. case x of
                                | INL v => cv_size v + 3

--- a/src/num/theories/cv_compute/automation/cv_stdScript.sml
+++ b/src/num/theories/cv_compute/automation/cv_stdScript.sml
@@ -58,7 +58,7 @@ QED
 val res = cv_trans ISL;
 val res = cv_trans ISR;
 
-val res = cv_trans_pre OUTL;
+val res = cv_trans_pre "OUTL_pre" OUTL;
 
 Theorem OUTL_pre[cv_pre]:
   OUTL_pre x <=> ISL x
@@ -66,7 +66,7 @@ Proof
   Cases_on ‘x’ \\ fs [res]
 QED
 
-val res = cv_trans_pre OUTR;
+val res = cv_trans_pre "OUTR_pre" OUTR;
 
 Theorem OUTR_pre[cv_pre]:
   OUTR_pre x <=> ISR x
@@ -103,7 +103,7 @@ val res = cv_trans TAKE_def;
 
 val res = cv_trans DROP_def;
 
-val res = cv_trans_pre EL_def;
+val res = cv_trans_pre "EL_pre" EL_def;
 
 Theorem EL_pre[cv_pre]:
   !n xs. EL_pre n xs <=> n < LENGTH xs
@@ -126,7 +126,7 @@ Proof
   Cases_on ‘xs’ \\ gvs [FRONT_DEF]
 QED
 
-val res = cv_trans_pre FRONT;
+val res = cv_trans_pre "FRONT_pre" FRONT;
 
 Theorem FRONT_pre[cv_pre]:
   !xs. FRONT_pre xs <=> xs <> []
@@ -142,7 +142,7 @@ Proof
   Cases_on ‘xs’ \\ gvs [LAST_DEF]
 QED
 
-val res = cv_trans_pre LAST;
+val res = cv_trans_pre "LAST_pre" LAST;
 
 Theorem LAST_pre[cv_pre]:
   !xs. LAST_pre xs <=> xs <> []
@@ -209,7 +209,7 @@ Proof
   \\ rename [‘_ = SOME y’] \\ PairCases_on ‘y’ \\ gvs []
 QED
 
-val res = cv_trans_pre index_of;
+val res = cv_trans_pre "INDEX_OF_pre" index_of;
 
 Theorem INDEX_OF_pre[cv_pre]:
   ∀x y. INDEX_OF_pre x y
@@ -384,7 +384,7 @@ val toAList_foldi_eq = sptreeTheory.foldi_def
                   |> LIST_CONJ |> REWRITE_RULE [GSYM toAList_foldi_def]
                   |> SIMP_RULE std_ss [];
 
-val res = cv_trans_pre toAList_foldi_eq;
+val res = cv_trans_pre "toAList_foldi_pre" toAList_foldi_eq;
 
 Theorem toAList_foldi_pre[cv_pre]:
   !a0 a1 a2. toAList_foldi_pre a0 a1 a2

--- a/src/num/theories/cv_compute/automation/cv_transLib.sig
+++ b/src/num/theories/cv_compute/automation/cv_transLib.sig
@@ -3,13 +3,13 @@ sig
   include Abbrev
 
   val cv_trans          : thm -> unit
-  val cv_trans_pre      : thm -> thm
-  val cv_trans_pre_rec  : thm -> tactic -> thm
+  val cv_trans_pre      : (* pre name *) string -> thm -> thm
+  val cv_trans_pre_rec  : (* pre name *) string -> thm -> tactic -> thm
   val cv_trans_rec      : thm -> tactic -> unit
 
   val cv_auto_trans          : thm -> unit
-  val cv_auto_trans_pre      : thm -> thm
-  val cv_auto_trans_pre_rec  : thm -> tactic -> thm
+  val cv_auto_trans_pre      : (* pre name *) string -> thm -> thm
+  val cv_auto_trans_pre_rec  : (* pre name *) string -> thm -> tactic -> thm
   val cv_auto_trans_rec      : thm -> tactic -> unit
 
   (* The conv should evaluate `from <deep_embedding>` *)


### PR DESCRIPTION
Users of `cv_trans_pre` (and its variants) have lamented that, each time one calls `cv_trans_pre`, the automation generates a different name for the precondition it defines. 

The change in this PR allows (and strongly encourages) users to specify what name the defined constant should have.

The simplest way to port old proofs to this new setting is to search-and-replace:
```
         cv_trans_pre → cv_trans_pre ""
     cv_trans_pre_rec → cv_trans_pre_rec ""
    cv_auto_trans_pre → cv_auto_trans_pre ""
cv_auto_trans_pre_rec → cv_auto_trans_pre_rec ""
```
