### PR TITLE
Use Theory in src/1

### DIFF
--- a/src/1/ConseqConvScript.sml
+++ b/src/1/ConseqConvScript.sml
@@ -1,7 +1,8 @@
-open HolKernel Parse Drule Tactical Tactic Conv Rewrite boolTheory;
-
-val _ = new_theory "ConseqConv";
-
+Theory ConseqConv[bare]
+Ancestors
+  bool
+Libs
+  HolKernel Parse Drule Tactical Tactic Conv Rewrite
 
 val forall_eq_thm = store_thm ("forall_eq_thm",
    ``(!s:'a. (P s = Q s)) ==> ((!s. P s) = (!s. Q s))``,
@@ -148,4 +149,3 @@ REWRITE_TAC[ASM_MARKER_DEF] THEN
 BETA_TAC THEN REWRITE_TAC [])
 
 
-val _ = export_theory();

--- a/src/1/theory_tests/SGAUnicodeMergeA1Script.sml
+++ b/src/1/theory_tests/SGAUnicodeMergeA1Script.sml
@@ -1,9 +1,8 @@
-open HolKernel Parse boolLib
-
-val _ = new_theory "SGAUnicodeMergeA1";
+Theory SGAUnicodeMergeA1[bare]
+Libs
+  HolKernel Parse boolLib
 
 val UNION_def = new_definition(
   "UNION_def",
   ``UNION P Q x <=> P x \/ Q x``);
 
-val _ = export_theory();

--- a/src/1/theory_tests/SGAUnicodeMergeA2Script.sml
+++ b/src/1/theory_tests/SGAUnicodeMergeA2Script.sml
@@ -1,6 +1,6 @@
-open HolKernel Parse boolLib
-
-val _ = new_theory "SGAUnicodeMergeA2";
+Theory SGAUnicodeMergeA2[bare]
+Libs
+  HolKernel Parse boolLib
 
 val INTER_def = new_definition(
   "INTER_def",
@@ -16,4 +16,3 @@ val funion_symbol = UTF8.chr 0x228C
 val _ = set_fixity funion_symbol (Infixl 500)
 val _ = overload_on (funion_symbol, ``FUNION``)
 
-val _ = export_theory();

--- a/src/1/theory_tests/SGAUnicodeMergeBScript.sml
+++ b/src/1/theory_tests/SGAUnicodeMergeBScript.sml
@@ -1,10 +1,10 @@
-open HolKernel Parse boolLib
+Theory SGAUnicodeMergeB[bare]
+Ancestors
+  SGAUnicodeMergeA1 SGAUnicodeMergeA2
+Libs
+  HolKernel Parse boolLib
 
-open SGAUnicodeMergeA1Theory SGAUnicodeMergeA2Theory
-
-val _ = new_theory "SGAUnicodeMergeB";
 val _ = set_grammar_ancestry ["SGAUnicodeMergeA1", "SGAUnicodeMergeA2"]
-
 
 val numfails = ref 0
 
@@ -22,5 +22,3 @@ val _ = if !numfails > 0 then
           raise mk_HOL_ERR "SGA Unicode Test" ""
                 (Int.toString (!numfails) ^ " failures")
         else ()
-
-val _ = export_theory();

--- a/src/1/theory_tests/addDBScript.sml
+++ b/src/1/theory_tests/addDBScript.sml
@@ -1,6 +1,6 @@
-open HolKernel Parse boolLib
-
-val _ = new_theory "addDB";
+Theory addDB[bare]
+Libs
+  HolKernel Parse boolLib
 
 val _ = set_trace "Theory.allow_rebinds" 1
 
@@ -34,4 +34,3 @@ val _ = delete_const "bar"
 val _ = length (DB.definitions "-") = 1 orelse raise Fail "bad DB.definitions"
 
 
-val _ = export_theory();

--- a/src/1/theory_tests/addMLdep1Script.sml
+++ b/src/1/theory_tests/addMLdep1Script.sml
@@ -1,10 +1,9 @@
-open HolKernel Parse boolLib
-
-val _ = new_theory "addMLdep1";
+Theory addMLdep1[bare]
+Libs
+  HolKernel Parse boolLib
 
 val _ = add_ML_dependency "MLdepLib"
 
 val thm = save_thm("thm", TRUTH);
 
 
-val _ = export_theory();

--- a/src/1/theory_tests/addMLdep2Script.sml
+++ b/src/1/theory_tests/addMLdep2Script.sml
@@ -1,7 +1,8 @@
-open HolKernel Parse boolLib
-open addMLdep1Theory
-
-val _ = new_theory "addMLdep2";
+Theory addMLdep2[bare]
+Ancestors
+  addMLdep1
+Libs
+  HolKernel Parse boolLib
 
 fun grep s fname =
   let
@@ -18,5 +19,3 @@ val _ = if grep "MLdepLib" "addMLdep1Theory.sml" then ()
         else OS.Process.exit OS.Process.failure
 
 val _ = save_thm("thm2", TRUTH);
-
-val _ = export_theory();

--- a/src/1/theory_tests/gh168aScript.sml
+++ b/src/1/theory_tests/gh168aScript.sml
@@ -1,8 +1,8 @@
-open HolKernel Parse boolLib
-
-open gh294aTheory gh294bTheory
-
-val _ = new_theory "gh168a";
+Theory gh168a[bare]
+Ancestors
+  gh294a gh294b
+Libs
+  HolKernel Parse boolLib
 
 val thy =
     Binarymap.find(type_grammar.privileged_abbrevs (type_grammar()), "foo")
@@ -14,4 +14,3 @@ val s = type_to_string ``:bool -> bool -> bool``
 val _ = if thy = "gh294a" then assert (equal ":gh294b$foo") s
         else assert (equal ":bool -> gh294a$foo") s
 
-val _ = export_theory();

--- a/src/1/theory_tests/gh168bScript.sml
+++ b/src/1/theory_tests/gh168bScript.sml
@@ -1,8 +1,8 @@
-open HolKernel Parse boolLib
-
-open gh294aTheory gh294bTheory testutils
-
-val _ = new_theory "gh168b";
+Theory gh168b[bare]
+Ancestors
+  gh294a gh294b
+Libs
+  HolKernel Parse boolLib testutils
 
 val _ = remove_type_abbrev "foo"
 
@@ -25,4 +25,3 @@ val _ = tprint "type_grammar abbrevs map is empty"
 val _ = if Binarymap.numItems (type_grammar.parse_map tyg) = 4 then OK()
         else die "FAILED!"
 
-val _ = export_theory();

--- a/src/1/theory_tests/gh168cScript.sml
+++ b/src/1/theory_tests/gh168cScript.sml
@@ -1,8 +1,8 @@
-open HolKernel Parse boolLib
-
-open gh294aTheory gh294bTheory testutils
-
-val _ = new_theory "gh168c";
+Theory gh168c[bare]
+Ancestors
+  gh294a gh294b
+Libs
+  HolKernel Parse boolLib testutils
 
 val tyg0 = type_grammar()
 val privthy = Binarymap.find(type_grammar.privileged_abbrevs tyg0, "foo")
@@ -29,4 +29,3 @@ val _ = typrinttest ":bool -> bool -> bool"
                      else ":gh294b$foo")
 
 
-val _ = export_theory();

--- a/src/1/theory_tests/gh168dScript.sml
+++ b/src/1/theory_tests/gh168dScript.sml
@@ -1,8 +1,8 @@
-open HolKernel Parse boolLib
-
-open gh294aTheory gh294bTheory testutils
-
-val _ = new_theory "gh168d";
+Theory gh168d[bare]
+Ancestors
+  gh294a gh294b
+Libs
+  HolKernel Parse boolLib testutils
 
 val b2b = bool --> bool
 val b2b2b = bool --> b2b
@@ -12,4 +12,3 @@ val ty2 = ``:gh294b$foo``
 val _ = assert (equal b2b) ty1
 val _ = assert (equal b2b2b) ty2
 
-val _ = export_theory();

--- a/src/1/theory_tests/gh168eScript.sml
+++ b/src/1/theory_tests/gh168eScript.sml
@@ -1,8 +1,8 @@
-open HolKernel Parse boolLib
-
-open gh294aTheory gh294bTheory testutils
-
-val _ = new_theory "gh168e";
+Theory gh168e[bare]
+Ancestors
+  gh294a gh294b
+Libs
+  HolKernel Parse boolLib testutils
 
 val b2b = bool --> bool
 val b2b2b = bool --> b2b
@@ -22,4 +22,3 @@ val _ = temp_thytype_abbrev ({Name = "foo", Thy = unprivthy}, unprivty, true)
 val ty = ``:foo``
 val _ = assert (equal unprivty) ty
 
-val _ = export_theory();

--- a/src/1/theory_tests/gh225aScript.sml
+++ b/src/1/theory_tests/gh225aScript.sml
@@ -1,9 +1,8 @@
-open HolKernel Parse boolLib
-
-val _ = new_theory "gh225a";
+Theory gh225a[bare]
+Libs
+  HolKernel Parse boolLib
 
 val _ = save_thm("Empty", TRUTH);
 val _ = save_thm("GREATER", TRUTH);
 
 
-val _ = export_theory();

--- a/src/1/theory_tests/gh225bScript.sml
+++ b/src/1/theory_tests/gh225bScript.sml
@@ -1,9 +1,8 @@
-open HolKernel Parse boolLib
-
-open gh225aTheory
-
-val _ = new_theory "gh225b";
+Theory gh225b[bare]
+Ancestors
+  gh225a
+Libs
+  HolKernel Parse boolLib
 
 val _ = save_thm("TRUTH", TRUTH);
 
-val _ = export_theory();

--- a/src/1/theory_tests/gh294aScript.sml
+++ b/src/1/theory_tests/gh294aScript.sml
@@ -1,8 +1,7 @@
-open HolKernel Parse boolLib
-
-val _ = new_theory "gh294a";
+Theory gh294a[bare]
+Libs
+  HolKernel Parse boolLib
 
 val _ = type_abbrev_pp("foo", ``:bool -> bool``)
 
 
-val _ = export_theory();

--- a/src/1/theory_tests/gh294bScript.sml
+++ b/src/1/theory_tests/gh294bScript.sml
@@ -1,8 +1,7 @@
-open HolKernel Parse boolLib
-
-val _ = new_theory "gh294b";
+Theory gh294b[bare]
+Libs
+  HolKernel Parse boolLib
 
 val _ = type_abbrev_pp("foo", ``:bool -> bool -> bool``)
 
 
-val _ = export_theory();

--- a/src/1/theory_tests/gh294cScript.sml
+++ b/src/1/theory_tests/gh294cScript.sml
@@ -1,8 +1,8 @@
-open HolKernel Parse boolLib
-
-open gh294aTheory gh294bTheory
-
-val _ = new_theory "gh294c";
+Theory gh294c[bare]
+Ancestors
+  gh294a gh294b
+Libs
+  HolKernel Parse boolLib
 
 val _ = disable_tyabbrev_printing "foo"
 
@@ -11,4 +11,3 @@ val s = type_to_string ``:bool -> bool -> bool`` = ":bool -> bool -> bool"
         raise Fail "Test fails"
 
 
-val _ = export_theory();

--- a/src/1/theory_tests/gh403aScript.sml
+++ b/src/1/theory_tests/gh403aScript.sml
@@ -1,7 +1,6 @@
-open HolKernel boolLib
-
-val _ = new_theory "gh403a"
+Theory gh403a[bare]
+Libs
+  HolKernel boolLib
 
 val _ = save_thm("print",TRUTH);
 
-val _ = export_theory();

--- a/src/1/theory_tests/gh403bScript.sml
+++ b/src/1/theory_tests/gh403bScript.sml
@@ -1,7 +1,8 @@
-open HolKernel boolLib gh403aTheory
-
-val _ = new_theory "gh403b";
+Theory gh403b[bare]
+Ancestors
+  gh403a
+Libs
+  HolKernel boolLib
 
 val _ = save_thm("foo", TRUTH)
 
-val _ = export_theory();

--- a/src/1/theory_tests/github115aScript.sml
+++ b/src/1/theory_tests/github115aScript.sml
@@ -1,6 +1,6 @@
-open HolKernel Parse boolLib
-
-val _ = new_theory "github115a"
+Theory github115a[bare]
+Libs
+  HolKernel Parse boolLib
 
 val v1 = mk_var("v", bool --> bool)
 val v2 = mk_var("v", bool)
@@ -17,4 +17,3 @@ val _ = assert
 
 val th = save_thm("th", DISCH_ALL (ASSUME t))
 
-val _ = export_theory()

--- a/src/1/theory_tests/github115bScript.sml
+++ b/src/1/theory_tests/github115bScript.sml
@@ -1,6 +1,8 @@
-open HolKernel Parse boolLib
-
-open github115aTheory
+Theory github115b[bare]
+Ancestors
+  github115a
+Libs
+  HolKernel Parse boolLib
 
 (* this theory is in the test-case solely to force Holmake to check that the
    github115aTheory.sml file is loadable (it isn't when the bug is evident
@@ -8,8 +10,5 @@ open github115aTheory
    corrupt Theory.sml file)
 *)
 
-val _ = new_theory "github115b"
-
 val sample2 = save_thm("sample2", AND_CLAUSES)
 
-val _ = export_theory()

--- a/src/1/theory_tests/github130aScript.sml
+++ b/src/1/theory_tests/github130aScript.sml
@@ -1,7 +1,6 @@
-open HolKernel Parse boolLib
-
-open github130Lib
-val _ = new_theory "github130a";
+Theory github130a[bare]
+Libs
+  HolKernel Parse boolLib github130Lib
 
 val foo_def = new_definition("foo_def", ``foo f x = f x``)
 val _ = export_gh130 "foo_def"
@@ -9,4 +8,3 @@ val _ = Feedback.WARNINGs_as_ERRs := false
 val _ = delete_const "foo"
 
 
-val _ = export_theory();

--- a/src/1/theory_tests/github130bScript.sml
+++ b/src/1/theory_tests/github130bScript.sml
@@ -1,9 +1,9 @@
-open HolKernel Parse boolLib
-
-open github130Lib github130aTheory
-val _ = new_theory "github130b";
+Theory github130b[bare]
+Ancestors
+  github130a
+Libs
+  HolKernel Parse boolLib github130Lib
 
 val _ = save_thm("gh130b", boolTheory.AND_CLAUSES);
 
 
-val _ = export_theory();

--- a/src/1/theory_tests/github234aScript.sml
+++ b/src/1/theory_tests/github234aScript.sml
@@ -1,8 +1,7 @@
-open HolKernel Parse boolLib
-
-val _ = new_theory "github234a";
+Theory github234a[bare]
+Libs
+  HolKernel Parse boolLib
 
 val _ = Globals.max_print_depth := 5;
 val _ = overload_on("foo",``\t1 t2. !t. (t1 ==> t2 ==> t) ==> t``);
 
-val _ = export_theory();

--- a/src/1/theory_tests/github234bScript.sml
+++ b/src/1/theory_tests/github234bScript.sml
@@ -1,10 +1,9 @@
-open HolKernel Parse boolLib
-
-open github234aTheory
-
-val _ = new_theory "github234b";
+Theory github234b[bare]
+Ancestors
+  github234a
+Libs
+  HolKernel Parse boolLib
 
 val _ = save_thm("T", TRUTH)
 
 
-val _ = export_theory();

--- a/src/1/theory_tests/mergeGrammarsA1Script.sml
+++ b/src/1/theory_tests/mergeGrammarsA1Script.sml
@@ -1,6 +1,6 @@
-open HolKernel Parse boolLib
-
-val _ = new_theory "mergeGrammarsA1";
+Theory mergeGrammarsA1[bare]
+Libs
+  HolKernel Parse boolLib
 
 (* demonstrating what should happen when a theory ancestry graph looks like
 
@@ -47,4 +47,3 @@ val a_theorem = store_thm(
   ``x:bool = x /\ y = y``,
   REWRITE_TAC[]);
 
-val _ = export_theory();

--- a/src/1/theory_tests/mergeGrammarsA2Script.sml
+++ b/src/1/theory_tests/mergeGrammarsA2Script.sml
@@ -1,6 +1,6 @@
-open HolKernel Parse boolLib
-
-val _ = new_theory "mergeGrammarsA2";
+Theory mergeGrammarsA2[bare]
+Libs
+  HolKernel Parse boolLib
 
 (* see comment at head of mergeGrammarsA1Script for description of what is
    being tested
@@ -12,4 +12,3 @@ val a_theorem = store_thm(
   REWRITE_TAC[]);
 
 
-val _ = export_theory();

--- a/src/1/theory_tests/mergeGrammarsBScript.sml
+++ b/src/1/theory_tests/mergeGrammarsBScript.sml
@@ -1,13 +1,12 @@
-open HolKernel Parse boolLib
+Theory mergeGrammarsB[bare]
+Libs
+  HolKernel Parse boolLib
 
 (* see comment at head of mergeGrammarsA1Script.sml for explanation of
    what is being tested here
 *)
 
-val _ = new_theory "mergeGrammarsB";
-
 val my_theorem = save_thm(
   "my_theorem",
   CONJ mergeGrammarsA1Theory.a_theorem mergeGrammarsA2Theory.a_theorem);
 
-val _ = export_theory();

--- a/src/1/theory_tests/mergeGrammarsCScript.sml
+++ b/src/1/theory_tests/mergeGrammarsCScript.sml
@@ -1,9 +1,8 @@
-open HolKernel Parse boolLib
-
-
-open mergeGrammarsBTheory
-
-val _ = new_theory "mergeGrammarsC";
+Theory mergeGrammarsC[bare]
+Ancestors
+  mergeGrammarsB
+Libs
+  HolKernel Parse boolLib
 
 val _ = temp_set_grammars $ valOf $ grammarDB{thyname="mergeGrammarsB"}
 val _ = set_trace "ambiguous grammar warning" 2
@@ -11,4 +10,3 @@ val _ = set_trace "ambiguous grammar warning" 2
 val _ = store_thm("true_dat", ``T``, REWRITE_TAC [])
 
 
-val _ = export_theory();

--- a/src/1/theory_tests/parseUnicodeLambdaScript.sml
+++ b/src/1/theory_tests/parseUnicodeLambdaScript.sml
@@ -1,12 +1,11 @@
-open HolKernel Parse boolLib
-
-val _ = new_theory "parseUnicodeLambda";
+Theory parseUnicodeLambda[bare]
+Ancestors[qualified]
+  bool
+Libs
+  HolKernel Parse boolLib
 
 val _ = set_grammar_ancestry ["bool"]
 
 val t = ``λi. P i``;
 
 val th = save_thm("made_it", TRUTH);
-
-
-val _ = export_theory();

--- a/src/1/theory_tests/readthm1Script.sml
+++ b/src/1/theory_tests/readthm1Script.sml
@@ -1,8 +1,7 @@
-open HolKernel Parse boolLib
-
-val _ = new_theory "readthm1";
+Theory readthm1[bare]
+Libs
+  HolKernel Parse boolLib
 
 val read = save_thm("read", TRUTH);
 
 
-val _ = export_theory();

--- a/src/1/theory_tests/readthm2Script.sml
+++ b/src/1/theory_tests/readthm2Script.sml
@@ -1,10 +1,9 @@
-open HolKernel Parse boolLib
-
-open readthm1Theory
-
-val _ = new_theory "readthm2";
+Theory readthm2[bare]
+Ancestors
+  readthm1
+Libs
+  HolKernel Parse boolLib
 
 val next_thm = save_thm("next_thm", CONJ read read)
 
 
-val _ = export_theory();

--- a/src/1/theory_tests/stored_grammars_unicodeScript.sml
+++ b/src/1/theory_tests/stored_grammars_unicodeScript.sml
@@ -1,6 +1,6 @@
-open HolKernel Parse boolLib
-
-val _ = new_theory "stored_grammars_unicode";
+Theory stored_grammars_unicode[bare]
+Libs
+  HolKernel Parse boolLib
 
 val (typarse, tmparse) =
   parse_from_grammars $ valOf $ Parse.grammarDB{thyname="bool"}
@@ -11,4 +11,3 @@ val th = store_thm(
   t,
   REWRITE_TAC[]);
 
-val _ = export_theory();

--- a/src/1/theory_tests/vartypeAbbrev1Script.sml
+++ b/src/1/theory_tests/vartypeAbbrev1Script.sml
@@ -1,9 +1,8 @@
-open HolKernel Parse boolLib
-
-val _ = new_theory "vartypeAbbrev1";
+Theory vartypeAbbrev1[bare]
+Libs
+  HolKernel Parse boolLib
 
 val _ = type_abbrev("foo", ``:'aa -> bool``)
 val _ = save_thm("T", TRUTH)
 
 
-val _ = export_theory();

--- a/src/1/theory_tests/vartypeAbbrev2Script.sml
+++ b/src/1/theory_tests/vartypeAbbrev2Script.sml
@@ -1,10 +1,9 @@
-open HolKernel Parse boolLib
-
-open vartypeAbbrev1Theory
-
-val _ = new_theory "vartypeAbbrev2";
+Theory vartypeAbbrev2[bare]
+Ancestors
+  vartypeAbbrev1
+Libs
+  HolKernel Parse boolLib
 
 val _ = save_thm("T", TRUTH)
 
 
-val _ = export_theory();


### PR DESCRIPTION
The “interesting” part here is how to deal with the test files. Since they explicitly do not open `bossLib`, and most of them do not use `set_grammar_ancestry`, and they appear to be testing things about the grammar, I decided to be conservative in this case and use `bare`, while keeping the few invocations of `set_grammar_ancestry` (2, if I recall correctly) around.