### PR TITLE
[HolParser] Don't call set_grammar_ancestry with empty list

### DIFF
--- a/src/TeX/theory_tests/foo248Script.sml
+++ b/src/TeX/theory_tests/foo248Script.sml
@@ -1,5 +1,4 @@
-open HolKernel boolLib bossLib Parse
-val _ = new_theory"foo248";
+Theory foo248
+
 val _ = Define`foo a b = (a < b)`;
 val _ = overload_on("<:",``\a b. foo b a``);
-val _ = export_theory();

--- a/tools/Holmake/HolParser.sml
+++ b/tools/Holmake/HolParser.sml
@@ -411,7 +411,7 @@ structure ToSML = struct
           setState Closed;
           app aux [" val _ = Theory.new_theory ", mlquote (ss name)];
           isTheory := true;
-          if !bare then () else
+          if !bare orelse List.null (!grammar) then () else
             app aux [" val _ = Parse.set_grammar_ancestry [",
               String.concatWith "," (map (mlquote o ss) (rev (!grammar))), "]"];
           if !opening andalso quietOpen then aux " val _ = HOL_Interactive.end_open()" else ();


### PR DESCRIPTION
This previously happened when the Theory syntax was used without any Ancestors. To avoid this, we first check whether there are any Ancestors before generating set_grammar_ancestry.

Fixes #1572