### PR TITLE
Use Theory in bool

### DIFF
--- a/src/bool/boolScript.sml
+++ b/src/bool/boolScript.sml
@@ -9,10 +9,10 @@
 (*                 mind.                                                 *)
 (* ===================================================================== *)
 
-open HolKernel Parse
-open Unicode TexTokenMap
-
-val _ = new_theory "bool";
+Theory bool[bare]
+Libs
+  HolKernel Parse Parse.Unicode TexTokenMap Portable
+  GrammarSpecials[qualified] boolpp[qualified]
 
 (*---------------------------------------------------------------------------*
  *             BASIC DEFINITIONS                                             *
@@ -160,7 +160,6 @@ val TYPE_DEFINITION = def (#(FILE), #(LINE))
  *   Parsing directives for some of the basic operators.                     *
  *---------------------------------------------------------------------------*)
 
-open Portable;
 Overload "~" = “~”
 Overload "¬" = “~”
 val _ = add_rule {term_name   = "~",
@@ -4146,10 +4145,9 @@ val _ = new_constant(GrammarSpecials.case_split_special,
 val _ = new_constant(GrammarSpecials.case_arrow_special,
                      “:'a -> 'b -> 'a -> 'b”);
 
-val _ = let open GrammarSpecials
-        in app (fn s => remove_ovl_mapping s {Name=s,Thy="bool"})
-               [case_split_special, case_arrow_special]
-        end
+val _ = app (fn s => remove_ovl_mapping s {Name=s,Thy="bool"})
+            [GrammarSpecials.case_split_special,
+             GrammarSpecials.case_arrow_special]
 
 val _ = add_rule{pp_elements = [HardSpace 1, TOK "=>", BreakSpace(1,2)],
                  fixity = Infix(NONASSOC, 12),
@@ -4452,7 +4450,6 @@ val _ = TeX_notation {hol="<=/=>", TeX = ("\\HOLTokenNotEquiv{}",3)}
 val _ = TeX_notation {hol=UChar.not_iff,
                       TeX = ("\\HOLTokenNotEquiv{}",3)}
 
-local open boolpp in end
 val _ = add_ML_dependency "boolpp"
 val _ = add_user_printer ("bool.COND", “COND gd tr fl”)
 val _ = add_user_printer ("bool.LET", “LET f x”)
@@ -4481,5 +4478,3 @@ val CONTRAPOS_THM = thm (#(FILE), #(LINE)) ("CONTRAPOS_THM",
     MONO_NOT_EQ |> SYM
                 |> INST [“x:bool” |-> “t1:bool”, “y:bool” |-> “t2:bool”]
                 |> GENL [“t1:bool”, “t2:bool”]);
-
-val _ = export_theory();

--- a/tools/Holmake/HolLex
+++ b/tools/Holmake/HolLex
@@ -238,6 +238,7 @@ id_with_attributes = {alphaMLid}({ws}*{attributes})?;
 MLid =  {alphaMLid} | {symbolident};
 QUALMLid = {MLid} ("." {MLid})*;
 QUALalphaMLid = {alphaMLid} ("." {alphaMLid})*;
+qid_with_attributes = {QUALalphaMLid}({ws}*{attributes})?;
 locpragma = "(*#loc" {ws}+ {digit}* {ws}+ {digit}* {ws}* "*)";
 lowergreek = "\206" [\177-\191] | "\207" [\128-\137];
 fullquotebegin = "``" | "\226\128\156";
@@ -481,7 +482,7 @@ ProofLine = {newline}"Proof"({ws}*"["{optallws}{defn_attribute_list}{optallws}"]
   OpenEnd yypos
 );
 <opens>{QUALalphaMLid} => (OpenId (yypos, yytext));
-<headerthy>{id_with_attributes} => (HeaderThy (yypos, yytext));
+<headerthy>{qid_with_attributes} => (HeaderThy (yypos, yytext));
 <opens,headerthy>. => (
   yybufpos := !yybufpos - 1; (* unread token *)
   OpenEnd yypos


### PR DESCRIPTION
As `bool` depends on `Unicode,` which is a substructure of `Parse` since commit https://github.com/HOL-Theorem-Prover/HOL/commit/721dd13f6c30158f542e9f28e0b66870374ae92d, we want to be able to mention `Parse.Unicode` in `Libs`, since by the time we hit `Unicode`, I assume that the relevant bindings from `Parse` are not yet available.

Thanks to Irvin (@ordinarymath) for finding the relevant commit and mentioning how splitting `open` could make a difference.

Also worth mentioning:
- Technically, the parser does not error out now when someone uses qualified identifiers in `Ancestors`. I doubt that's a big deal, since nothing stopped people from doing the same using `open` (Indeed, one can still write fun things like `open foo.barTheory` today :D)
- I also took the liberty to move some better hidden `open`s in `bool` into the header.