### PR TITLE
make ASSUME_NAMED_TAC smarter

### DIFF
--- a/src/marker/markerLib.sml
+++ b/src/marker/markerLib.sml
@@ -361,7 +361,27 @@ val DEST_LABELS_TAC = CONV_TAC DEST_LABELS_CONV THEN RULE_ASSUM_TAC DEST_LABELS
 
 fun MK_LABEL(s, th) = EQ_MP (SYM (SPECL [mk_label_var s, concl th] label_def)) th
 
-fun ASSUME_NAMED_TAC s bth : tactic = LAST_ASSUME_TAC (MK_LABEL(s, bth))
+local
+fun splitp p [] = ([], [])
+  | splitp p (x::xs) =
+    if p x then
+      ([], x::xs)
+    else
+      let
+        val (ys, zs) = splitp p xs
+      in
+        (x::ys, zs)
+      end
+in
+fun ASSUME_NAMED_TAC s bth (g as (asl,w)) =
+  let
+    val label_thm = MK_LABEL(s, bth)
+    val (xs,ys) = splitp (not o is_label) (List.rev (asl))
+    val asl' = List.revAppend (ys,(concl label_thm::(List.rev xs)))
+  in
+   ([(asl',w)],(fn resths => PROVE_HYP label_thm (hd resths)))
+  end
+end;
 
 (*---------------------------------------------------------------------------*)
 (* Given an LB encoded label reference, finds a corresponding term in the    *)


### PR DESCRIPTION
The idea is that named assumptions should be at the top but the addition of new named assumptions should not be higher than existing named assumptions.
This two examples show the difference.
ASSUME_NAMED_TAC "hi" TRUTH ([``bar``],``foo``)
ASSUME_NAMED_TAC "hi" TRUTH ([``baz :- T``],``foo``) Note that this code is designed to ignore when there's a named example in the middle eg. in this case bar is ignored
ASSUME_NAMED_TAC "hi" TRUTH ([``foo``,``bar :- T``,``baz``],``foo``) Note that this is implementation is fairly inefficient for code with huge number of assumptions but should not be encountered in practice.