### PR TITLE
Add holTheory and use it in Theory syntax

### DIFF
--- a/examples/lambda/examples/lambda_holScript.sml
+++ b/examples/lambda/examples/lambda_holScript.sml
@@ -4,7 +4,7 @@ open pred_setTheory
 
 open basic_swapTheory nomsetTheory NEWLib
 
-val _ = new_theory "hol"
+val _ = new_theory "lambda_hol"
 
 (* a theory of higher order logic terms, as modelled in systems such as
    HOL4, Isabelle/HOL and HOL Light *)
@@ -421,7 +421,3 @@ Proof
 QED
 
 val _ = export_theory()
-
-
-
-

--- a/src/boss/Holmakefile
+++ b/src/boss/Holmakefile
@@ -10,21 +10,21 @@ HOLHEAP = $(HOLDIR)/src/num/termination/numheap
 boss_deps = listTheory pred_setTheory arithmeticTheory numLib \
             pred_setLib pred_setSimps numSimps optionTheory \
             RecordType rich_listTheory
-DEPS = bossLib.uo $(patsubst %,$(dprot $(SIGOBJ)/%.uo),$(boss_deps))
+DEPS = holTheory.uo bossLib.uo $(patsubst %,$(dprot $(SIGOBJ)/%.uo),$(boss_deps))
 
 all: $(TARGET)
 
 $(TARGET): $(DEPS)
-	$(protect $(HOLDIR)/bin/buildheap) $(DEBUG_FLAG) -o $(TARGET) -b $(HOLHEAP) $(boss_deps) bossLib
+	$(protect $(HOLDIR)/bin/buildheap) $(DEBUG_FLAG) -o $(TARGET) -b $(HOLHEAP) $(boss_deps) bossLib holTheory
 
 endif
 
-UOFILES = bossLib.uo selftest.uo
+UOFILES = holTheory.uo selftest.uo
 
 all: selftest.exe $(UOFILES)
 .PHONY: all
 
-selftest.exe: selftest.uo bossLib.uo
+selftest.exe: selftest.uo holTheory.uo
 	$(HOLMOSMLC) -o $@ $<
 
 ifeq ($(KERNELID),otknl)

--- a/src/boss/holScript.sml
+++ b/src/boss/holScript.sml
@@ -1,0 +1,4 @@
+(* Defines the standard context. *)
+Theory hol[bare]
+Libs
+  HolKernel Parse boolLib bossLib

--- a/src/pred_set/src/more_theories/countable_typesScript.sml
+++ b/src/pred_set/src/more_theories/countable_typesScript.sml
@@ -1,8 +1,8 @@
-open HolKernel bossLib boolTheory pred_setTheory;
-
-open Tactic Tactical;
-
-val _ = new_theory "countable_types";
+Theory countable_types
+Ancestors
+  bool pred_set
+Libs
+  Tactic Tactical
 
 Theorem unit_countable:
   countable (UNIV : unit set)
@@ -74,6 +74,3 @@ Proof
     \\ metis_tac [prim_recTheory.LESS_SUC_REFL]
   )
 QED
-
-val _ = export_theory ();
-

--- a/tools/Holmake/HolParser.sml
+++ b/tools/Holmake/HolParser.sml
@@ -406,14 +406,15 @@ structure ToSML = struct
               processList p2 isThy hAttrs thys ls
             end
         in
-          if !bare then () else (setState Open; aux " HolKernel boolLib bossLib Parse");
+          if !bare then () else (setState Open; aux " HolKernel boolLib bossLib Parse holTheory");
           process p elems;
           setState Closed;
           app aux [" val _ = Theory.new_theory ", mlquote (ss name)];
           isTheory := true;
-          if !bare orelse List.null (!grammar) then () else
-            app aux [" val _ = Parse.set_grammar_ancestry [",
-              String.concatWith "," (map (mlquote o ss) (rev (!grammar))), "]"];
+          if !bare then () else let
+            val grammarNames = "hol"::(map ss (rev (!grammar)))
+            in app aux [" val _ = Parse.set_grammar_ancestry [",
+                        String.concatWith "," (map mlquote grammarNames), "]"] end;
           if !opening andalso quietOpen then aux " val _ = HOL_Interactive.end_open()" else ();
           aux ";"
         end


### PR DESCRIPTION
To my understanding, a normal hol session has at least indexedLists and patternMatches as parents:
```
> parents "-";
val it = ["indexedLists", "patternMatches"]: string list
```

It also appears that some theories depend on this. For example, if one were to take countable_types from pred_set, and set its grammar ancestry to the theories it explicitly opens (bool and pred_set), the proofs will break. This is problematic, as this is exactly what the Theory syntax does.

This PR/commit deals with this issue by
- creating a new theory called "hol", which represents the standard context of something starting in the hol heap
- changes the Theory syntax to load/open holTheory, and include hol in set_grammar_ancestry calls