### PR TITLE
kak hol mode updates

### DIFF
--- a/tools/editor-modes/kak/README.md
+++ b/tools/editor-modes/kak/README.md
@@ -1,16 +1,14 @@
 # hol.kak
 
-This is a HOL mode for Kakoune. It depends on the Kakoune [`repl` interface](https://github.com/mawww/kakoune/tree/master/rc/windowing/repl) which itself requires a multiplexer of sorts, like tmux or kitty (untested). You must be running kak in tmux.
-
-Install by placing this somewhere in the autoload directory in your config. Beware the issue with a [local config autoload](https://github.com/mawww/kakoune/issues/554); if you haven't set up a proper config with autoload yet, you probably want to symlink the `share/kak/autoload` to your local autoload.
+This is a HOL mode for Kakoune. Install by placing this somewhere in the autoload directory in your config. Beware the issue with a [local config autoload](https://github.com/mawww/kakoune/issues/554); if you haven't set up a proper config with autoload yet, you probably want to symlink the `share/kak/autoload` to your local autoload.
 
 The plugin only supplies commands with the prefix `hol-`; there are no default keybinds, but I may eventually pick some. For now that can be up to you. Clippy will explain to you roughly what every command does, which should be familiar if you have used a HOL mode in one of the other supported editors before.
 
+Before starting a session, you should make sure that `$HOLDIR` is set. You may start a HOL session by running `hol-start`, which will open a new terminal window which `hol.kak` will interface with through its other commands.
+
 Starting a session sets up a hook to load theory dependencies on opening a new file, but does not load dependencies for files you already have open. You can force a load by running `hol-load-deps-current` on your open file.
 
-There is no sanitisation at all right now, so `Definitions` must be `End`ed, tactics can't have loose operators, etc. You will probably also make sure to send in semicolons `;` after ML syntax. Note that you can just send an `End` or `;` after you have already sent something and that will just complete it.
-
-When starting the HOL session with tmux, the focus shifts to the HOL session and you need to shift it back to kak. You can do this by typing the tmux leader (default `C+b`) then left, or probably `h` works too. I don't know how to keep the focus yet, but maybe there is a way.
+There is no sanitisation of tactics yet, so sending tactics with dangling infix operators (e.g. `>>`) or mismatched brackets will fail.
 
 ## Nix-specific
 

--- a/tools/editor-modes/kak/README.md
+++ b/tools/editor-modes/kak/README.md
@@ -6,9 +6,9 @@ The plugin only supplies commands with the prefix `hol-`; there are no default k
 
 Before starting a session, you should make sure that `$HOLDIR` is set. You may start a HOL session by running `hol-start`, which will open a new terminal window which `hol.kak` will interface with through its other commands.
 
-Starting a session sets up a hook to load theory dependencies on opening a new file, but does not load dependencies for files you already have open. You can force a load by running `hol-load-deps-current` on your open file.
-
 There is no sanitisation of tactics yet, so sending tactics with dangling infix operators (e.g. `>>`) or mismatched brackets will fail.
+
+Note that you may interrupt HOL with a `SIGINT` by pressing Ctrl+C directly in the terminal in which it is running, rather than through kak.
 
 ## Nix-specific
 

--- a/tools/editor-modes/kak/hol.kak
+++ b/tools/editor-modes/kak/hol.kak
@@ -33,7 +33,7 @@ hol-start: start HOL instance in new terminal window, from HOLDIR' %{
         printf "set-option current holfifo '%s'" "$holfifo"
     }
     terminal sh -i -c %sh{
-        printf "%s\n\n" "cat > $kak_opt_holfifo & $HOLDIR/bin/hol --zero < $kak_opt_holfifo"
+        printf "%s\n\n" "cat > $kak_opt_holfifo & (tee -i >($HOLDIR/bin/hol --zero)) < $kak_opt_holfifo"
     }
 
     hol-load-deps-all

--- a/tools/editor-modes/kak/hol.kak
+++ b/tools/editor-modes/kak/hol.kak
@@ -1,55 +1,63 @@
+declare-option str holfifo
+
 define-command hol-start -docstring '
-hol-start: start HOL instance in new tmux pane, from HOLDIR' %{
-    evaluate-commands %{
-        repl-new;
-        repl-send-text %sh{printf "$HOLDIR/bin/hol --zero\n "};
-        hook global BufOpenFile .*\.sml hol-load-deps-current
+hol-start: start HOL instance in new terminal window, from HOLDIR' %{
+    hook global BufOpenFile .*\.sml hol-load-deps-current
+    evaluate-commands %sh{
+        holfifo=$(mktemp -d /tmp/kak-fifo.XXXXXXXX)/fifo
+        mkfifo $holfifo
+        printf "set-option current holfifo '%s'" "$holfifo"
+    }
+    terminal sh -i -c %sh{
+        printf "%s\n\n" "cat > $kak_opt_holfifo & $HOLDIR/bin/hol --zero < $kak_opt_holfifo"
     }
 }
 
 define-command hol-send -docstring '
 hol-send: send selection verbatim to HOL' %{
-    evaluate-commands %{repl-send-text %sh{printf "%s\n\0 " "$kak_selection"}}
+    nop %sh{printf "%s\n\0" "$kak_selection" > "$kak_opt_holfifo"}
 }
 
 define-command hol-goal-send -docstring '
 hol-goal-send: send selection as new goal to HOL' %{
-    evaluate-commands %{repl-send-text %sh{printf "g(\`%s\`);\n\0 " "$kak_selection"}}
+    nop %sh{printf "g(\`%s\`);\n\0" "$kak_selection" > "$kak_opt_holfifo"}
 }
 
 define-command hol-tactic -docstring '
 hol-tactic: send selection as tactic to HOL' %{
-    evaluate-commands %{repl-send-text %sh{printf "e(%s);\n\0 " "$kak_selection"}}
+    nop %sh{printf "e(%s);\n\0" "$kak_selection" > "$kak_opt_holfifo"}
 }
 
 define-command hol-show-goal -docstring '
 hol-show-goal: show current goal in HOL' %{
-    evaluate-commands %{repl-send-text %sh{printf "p();\n\0 "}}
+    nop %sh{printf "p();\n\0" > "$kak_opt_holfifo"}
 }
 
 define-command hol-backup -docstring '
 hol-backup: step back in proof in HOL' %{
-    evaluate-commands %{repl-send-text %sh{printf "b();\n\0 "}}
+    nop %sh{printf "b();\n\0" > "$kak_opt_holfifo"}
 }
 
 define-command hol-drop -docstring '
 hol-drop: drop goal in HOL' %{
-    evaluate-commands %{repl-send-text %sh{printf "drop();\n\0 "}}
+    nop %sh{printf "drop();\n\0" > "$kak_opt_holfifo"}
 }
 
 define-command hol-rotate -docstring '
 hol-rotate <n>: rotate subgoals n times in HOL' -params 1 %{
-    evaluate-commands %{repl-send-text %sh{printf "r $1;\n\0 "}}
+    nop %sh{printf "r $1;\n\0" > "$kak_opt_holfifo"}
 }
 
 define-command hol-restart-proof -docstring '
 hol-restart-proof: restart proof in HOL' %{
-    evaluate-commands %{repl-send-text %sh{printf "restart();\n\0 "}}
+    nop %sh{printf "restart();\n\0" > "$kak_opt_holfifo"}
 }
 
 define-command hol-load-deps-for -docstring '
 hol-load-deps-for: load dependencies for a HOL file' -params 1 %{
-    evaluate-commands %{repl-send-text %sh{$HOLDIR/bin/holdeptool.exe $1 | sed 's/.*/qload "&" handle _ => (); /'}}
+    nop %sh{
+        $HOLDIR/bin/holdeptool.exe $1 | sed 's/.*/qload "&" handle _ => (); /' > "$kak_opt_holfifo"
+    }
 }
 
 define-command hol-load-deps-current -docstring '


### PR DESCRIPTION
To overcome a selection size limit issue, `hol.kak` now uses a FIFO and opens a new terminal window running HOL. Dependencies autoload on start. Added syntax highlighting and indentation.