### PR TITLE
add Parse.grammar_ancestry

### DIFF
--- a/src/parse/Parse.sig
+++ b/src/parse/Parse.sig
@@ -16,6 +16,7 @@ signature Parse = sig
   type grammarDB_info = type_grammar.grammar * term_grammar.grammar
   val grammarDB : {thyname:string} -> grammarDB_info option
   val set_grammar_ancestry : string list -> unit
+  val grammar_ancestry : string -> string list
 
   (* Parsing Types *)
 

--- a/src/parse/Parse.sml
+++ b/src/parse/Parse.sml
@@ -1057,7 +1057,7 @@ fun gparents {thyname} =
     | thys => thys
 
 val {merge = merge_grammars0, set_parents = set_grammar_ancestry0,
-     DB = grammarDB0, parents = gparents} =
+     DB = grammarDB0, parents = grammar_ancestry0} =
     let
       open GrammarDeltas
       fun apply (TYD tyd) (tyG, tmG) = (type_grammar.apply_delta tyd tyG, tmG)
@@ -1101,6 +1101,8 @@ fun set_grammar_ancestry slist =
       type_grammar_changed := true;
       term_grammar_changed := true
     end
+
+fun grammar_ancestry thyname = grammar_ancestry0 {thyname = thyname}
 
 val _ = let
   val rawpp_thm =


### PR DESCRIPTION
The setter is exposed but not the getter. This is useful for writing `set_grammar_ancestry` calls to know what is there by default.