### PR TITLE
Vim mode: use holdep to determine loads

### DIFF
--- a/tools/editor-modes/vim/README.md
+++ b/tools/editor-modes/vim/README.md
@@ -77,8 +77,7 @@ Command  | Description
 :------- | :------------------------------------
 `hs`     | Send region to HOL.
 `hu`     | Send region to HOL in quiet mode.
-`hL`     | Send region to be split into words and each word `load`ed.
-`hl`     | Same as above, but also send the region as a command afterwards.
+`hl`     | Process `load`s for the selected region (e.g. a script file header), as determined by `holdep`.
 `hg`     | Send region (should be a quotation) to `g`, to start a new proof.
 `hG`     | Send region to `new_goalstack` after quoting it, to start a new proof. Any trailing `Proof[...]` modifiers are passed to HOL too.
 `he`     | Send region (should be a tactic) to `e`, to expand a tactic.
@@ -123,8 +122,6 @@ The terminal buffer that is hosting the HOL repl can be navigated as usual (if i
 In vim, to leave insert mode of a terminal buffer and return to Terminal-Normal mode press `CTRL-\ CTRL-N`, as documented in [`:help terminal-typing`](https://vimhelp.org/terminal.txt.html#terminal-typing).
 
 ## Automatic stripping
-
-`hL` and `hl` don't `load` these words: `local` `open` `in` `end.`
 
 `hg` strips commas from the end of the region.
 

--- a/tools/editor-modes/vim/hol.src
+++ b/tools/editor-modes/vim/hol.src
@@ -58,19 +58,15 @@ endf
 
 fu! HOLLoadSetup()
   keepjumps silent normal P
-  keepjumps silent %s/\s/\r/ge
-  keepjumps silent %s/\<local\>\|\<open\>\|\<in\>\|\<end\>\|;//ge
-  keepjumps silent g/^\s*$/d_
+  let l:temp = tempname()
+  silent exe "w" . l:temp
+  keepjumps %d_
+  silent exe "read !" .. $HOLDIR .. "/bin/holdeptool.exe" l:temp
   keepjumps silent g/./normal ival _ = load"
   keepjumps silent g/./normal $a";
 endf
 
 fu! HOLLoad()
-  call HOLLoadSetup()
-  call HOLLoadMessage("HOLLoad",line("$"))
-endf
-
-fu! HOLLoadSendQuiet()
   call HOLLoadSetup()
   exe "keepjumps normal Go" . s:holtogglequiet
   let l:l = line(".")-1
@@ -222,8 +218,7 @@ endf
 if !(exists("maplocalleader"))
   let maplocalleader = "\\"
 endif
-vn <buffer><silent> <LocalLeader>l :call YankThenHOLCall(function("HOLLoadSendQuiet"),[])<CR>
-vn <buffer><silent> <LocalLeader>L :call YankThenHOLCall(function("HOLLoad"),[])<CR>
+vn <buffer><silent> <LocalLeader>l :call YankThenHOLCall(function("HOLLoad"),[])<CR>
 vn <buffer><silent> <LocalLeader>s :call YankThenHOLCall(function("HOLSend"),[])<CR>
 vn <buffer><silent> <LocalLeader>u :call YankThenHOLCall(function("HOLSendQuiet"),[])<CR>
 vn <buffer><silent> <LocalLeader>g :call YankThenHOLCall(function("HOLGoal"),[])<CR>
@@ -233,7 +228,6 @@ vn <buffer><silent> <LocalLeader>S :call YankThenHOLCall(function("HOLSubgoal"),
 vn <buffer><silent> <LocalLeader>F :call YankThenHOLCall(function("HOLSuffices"),[])<CR>
 vn <buffer><silent> <LocalLeader>P :call YankThenHOLCall(function("HOLPattern"),[])<CR>
 nm <buffer><silent><expr> <LocalLeader>l "V".maplocalleader."l"
-nm <buffer><silent><expr> <LocalLeader>L "V".maplocalleader."L"
 nm <buffer><silent><expr> <LocalLeader>s "V".maplocalleader."s"
 nm <buffer><silent><expr> <LocalLeader>u "V".maplocalleader."u"
 nm <buffer><silent><expr> <LocalLeader>g "V".maplocalleader."g"


### PR DESCRIPTION
Remove the hL command and change the hl command to process the selected region with holdeptool.exe and load its results, instead of trying to figure out what to load within vim.

A temporary file is written for this purpose since it seems that holdeptool.exe does not work correctly if used as a filter (i.e. reading from stdin) and needs a filename instead.