### PR TITLE
[docker-ci] pandoc 3.7.0.2 on Docker CI images

### DIFF
--- a/developers/docker-ci/latest/Dockerfile
+++ b/developers/docker-ci/latest/Dockerfile
@@ -108,9 +108,23 @@ fi
 ENV HOL4_SMV_EXECUTABLE=/ML/solvers/NuRV
 
 # more packages for buliding HOL manuals (+pandoc for Markdown), etc.
+RUN apt-get update
 RUN apt-get install -qy texlive-latex-recommended
-RUN apt-get install -qy pandoc latexmk texlive-latex-extra
+RUN apt-get install -qy latexmk texlive-latex-extra
 RUN apt-get install -qy texlive-fonts-extra texlive-science
 RUN apt-get clean
 
-RUN apt-get clean
+# finally, install a recent pandoc (>= 3.4, with c/line option --table-caption-position=below)
+ARG PANDOC_VERSION="3.7.0.2"
+
+RUN if [ "linux/amd64" = "$TARGETPLATFORM" ]; then \
+    wget -q https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-amd64.deb; \
+    dpkg -i pandoc-${PANDOC_VERSION}-1-amd64.deb; \
+    rm -f pandoc-${PANDOC_VERSION}-1-amd64.deb; \
+fi
+
+RUN if [ "linux/arm64" = "$TARGETPLATFORM" ]; then \
+    wget -q https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-arm64.deb; \
+    dpkg -i pandoc-${PANDOC_VERSION}-1-arm64.deb; \
+    rm -f pandoc-${PANDOC_VERSION}-1-arm64.deb; \
+fi


### PR DESCRIPTION
Hi,

Yesterday I have installed pandoc 3.7.0.2 (latest release) on Docker CI images for HOL builds, to support the need of the new HOL documentation building. The Docker image (`binghelisp/hol-dev:latest`) is hosted in my personal Docker Hub and is already in use. This PR contains the changed `Dockerfile` which is just for archive purposes. 

P.S. I chose to download binary Debian packages from pandoc official instead of building it from sources, because to build `pandoc` package on Debian, the entire Haskel toolchain (of ~500 packages) must be (temporarily) installed.

--Chun