### PR TITLE
[docker-ci] Updated CI images to Debian 13 with Poly/ML 5.9.2 release

### DIFF
--- a/developers/docker-ci/Dockerfile
+++ b/developers/docker-ci/Dockerfile
@@ -25,6 +25,9 @@ ARG Z3_VERSION
 ARG CVC_VERSION
 ARG YICES_VERSION
 
+# this overrides the PATH environment from upstream images
+ENV PATH=/ML/HOL/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
 # if --build-arg Z3_VERSION=anything, set HOL4_Z3_EXECUTABLE to system-installed z3
 ENV HOL4_Z3_EXECUTABLE=${Z3_VERSION:+/ML/z3-${Z3_VERSION}/bin/z3}
 RUN if [ "" != "${Z3_VERSION}" ]; then \
@@ -47,12 +50,17 @@ fi
 # remove potential local poly-includes.ML for docker builds
 RUN rm -f tools-poly/poly-includes.ML
 
-# Building HOL itself
-RUN ${SML} < tools/smart-configure.sml 
+# Building HOL itself (PolyML is now installed in non-system directories)
+RUN if [ "poly" = "$SML" ]; then \
+    /ML/polyml/bin/${SML} < tools/smart-configure.sml; \
+else \
+    ${SML} < tools/smart-configure.sml; \
+fi
+
 RUN bin/build ${BUILDOPTS}
 
 # Building HOL manuals when PolyML is used
-RUN if [ "poly" = "${SML}" ]; then \
+RUN if [ "poly" = "${SML}" ] && [ "linux/amd64" = "$TARGETPLATFORM" ]; then \
     if echo ${BUILDOPTS} | grep -q "otknl"; then \
        echo Skip manual building; \
     else \

--- a/developers/docker-ci/base/Dockerfile
+++ b/developers/docker-ci/base/Dockerfile
@@ -5,7 +5,7 @@
 # e.g. docker buildx build --platform linux/amd64,linux/arm64v8 .
 
 # GitHub Actions recommends Debian-based systems as base images
-FROM debian:bookworm
+FROM debian:trixie
 
 LABEL org.opencontainers.image.authors="Chun Tian (binghe) <binghe.lisp@gmail.com>"
 
@@ -21,14 +21,13 @@ VOLUME /ML
 
 # Use this mode when you need zero interaction while installing or upgrading the system via apt
 ENV DEBIAN_FRONTEND=noninteractive
-ENV LD_LIBRARY_PATH=/usr/local/lib
-ENV PATH=/ML/HOL/bin:$PATH
+ENV LD_LIBRARY_PATH=/usr/local/lib:/ML/polyml/lib
+ENV PATH=/ML/polyml/bin:/ML/HOL/bin:$PATH
 
 # Some necessary Debian packages
 # NOTE: GCC 13 is necessary for building Moscow ML (default compiler is now GCC 14).
 RUN apt-get update -qy
 RUN apt-get install -qy build-essential git libgmp-dev wget curl procps file unzip vim
-RUN apt-get clean
 
 # for Unicode display, learnt from Magnus Myreen
 RUN apt-get install -qy locales-all terminfo
@@ -36,13 +35,16 @@ RUN apt-get install -qy locales-all terminfo
 # Extra graphics-related tools
 RUN apt-get install -qy graphviz emacs-nox
 
+# GCC-13 for Moscow ML
+RUN apt-get install -qy gcc-13
+
 # clean up downloaded packages after installation (this reduces Docker image sizes)
 RUN apt-get clean
 
 # 1. install Moscow ML (https://github.com/kfl/mosml.git) with GCC 13
-# COPY mosml-gcc-13.patch /ML
+COPY mosml-gcc-13.patch /ML
 RUN wget -q -O - https://github.com/kfl/mosml/archive/refs/tags/ver-2.10.1.tar.gz | tar xzf -
-# RUN cd mosml-ver-2.10.1/src; patch -p0 < /ML/mosml-gcc-13.patch;
+RUN cd mosml-ver-2.10.1/src; patch -p0 < /ML/mosml-gcc-13.patch;
 RUN cd mosml-ver-2.10.1; make -C src world install
 RUN rm -rf mosml-ver-2.10.1 *.patch
 
@@ -58,11 +60,13 @@ RUN if [ "master" = "$POLY_VERSION" ]; then \
     fi
 
 RUN if [ "linux/386" = "$TARGETPLATFORM" ]; then \
-       cd polyml-${POLY_VERSION} && ./configure --build=i686-pc-linux-gnu --enable-intinf-as-int; \
+       cd polyml-${POLY_VERSION} && \
+       ./configure --prefix=/ML/polyml --build=i686-pc-linux-gnu --enable-intinf-as-int; \
     elif [ "linux/riscv64" = "$TARGETPLATFORM" ]; then \
-       cd polyml-${POLY_VERSION} && ./configure --build=riscv64-pc-linux-gnu --enable-intinf-as-int; \
+       cd polyml-${POLY_VERSION} && \
+       ./configure --prefix=/ML/polyml --build=riscv64-pc-linux-gnu --enable-intinf-as-int; \
     else \
-       cd polyml-${POLY_VERSION} && ./configure --enable-intinf-as-int; \
+       cd polyml-${POLY_VERSION} && ./configure --prefix=/ML/polyml --enable-intinf-as-int; \
     fi
 
 RUN make -C polyml-${POLY_VERSION} -j4

--- a/developers/docker-ci/base/Makefile
+++ b/developers/docker-ci/base/Makefile
@@ -1,8 +1,8 @@
 DOCKER_IMAGE=binghelisp/hol-dev:base
+PLATFORMS=linux/386,linux/amd64,linux/arm64,linux/riscv64
 
 build:
-	docker buildx build --platform linux/386,linux/amd64,linux/arm64 \
-		-t $(DOCKER_IMAGE) .
+	docker buildx build --platform $(PLATFORMS) -t $(DOCKER_IMAGE) .
 
 push:
 	docker push $(DOCKER_IMAGE)

--- a/developers/docker-ci/latest/Makefile
+++ b/developers/docker-ci/latest/Makefile
@@ -1,8 +1,8 @@
 DOCKER_IMAGE=binghelisp/hol-dev:latest
+PLATFORMS=linux/386,linux/amd64,linux/arm64,linux/riscv64
 
 build:
-	docker buildx build --platform linux/386,linux/amd64,linux/arm64 \
-		-t $(DOCKER_IMAGE) .
+	docker buildx build --platform  $(PLATFORMS) -t $(DOCKER_IMAGE) .
 
 push:
 	docker push $(DOCKER_IMAGE)

--- a/help/src-sml/Holmakefile
+++ b/help/src-sml/Holmakefile
@@ -8,19 +8,19 @@ all: makebase.exe Doc2Html.exe Doc2Tex.exe Doc2Txt.exe Doc2markdown.exe
 
 ifdef POLY
 Doc2markdown.exe: poly-Doc2Md.ML Doc2markdown.uo ParseDoc.uo Flash.uo
-	polyc -o $@ $<
+	$(POLYC) -o $@ $<
 
 Doc2Tex.exe: poly-Doc2Tex.ML Doc2Tex.uo ParseDoc.uo Flash.uo
-	polyc -o $@ $<
+	$(POLYC) -o $@ $<
 
 Doc2Html.exe: poly-Doc2Html.ML Doc2Html.uo Flash.uo
-	polyc -o $@ $<
+	$(POLYC) -o $@ $<
 
 makebase.exe: poly-makebase.ML makebase.sml
-	polyc -o $@ $<
+	$(POLYC) -o $@ $<
 
 Md2TeX.exe: poly-Md2TeX.ML Md2TeX.uo
-	polyc -o $@ $<
+	$(POLYC) -o $@ $<
 
 else
 makebase.uo: makebase.sml MyDatabase.ui Htmlsigs.ui Parsspec.uo Keepers.uo Printbase.uo HOLPage.uo

--- a/tools/Holmake/tests/time-logging/Holmakefile
+++ b/tools/Holmake/tests/time-logging/Holmakefile
@@ -3,7 +3,7 @@ HM = $(protect $(HOLDIR)/bin/Holmake)
 
 ifdef POLY
 CMD = $(HM) --holstate=$(HOLDIR)/bin/hol.state0 --logging
-SMLCMD = poly -q
+SMLCMD = $(POLY) -q
 else
 CMD = $(HM) --logging
 SMLCMD = mosml -quietdec -P full


### PR DESCRIPTION
Hi,

Recently Debian 13 (trixie) is finally released. It provides GCC 14 as default C/C++ compiler (but note that Moscow ML's C source code requires GCC 13) and updated versions of many packages (But the version of Pandoc is still not enough.) And Debian now officially supports RISC-V architecture. Almost at the same time (yesterday), Poly/ML 5.9.2 is finally released with important bugfix for recent versions of macOS (and Linux).

The updated Docker CI images (hosted in my personal Docker Hub repository, `binghelisp/hol-dev`) now provides 4 architectures (`i386`, `amd64`, `arm64`, `riscv64`), Poly/ML 5.9.2 release, Moscow ML, MLton, and many external solvers.  More importantly, now PolyML is installed at non-system location (`/ML/polyml/`) which can be excluded from the `PATH` environment variable (after this PR is merged). This means that, calling `poly` will not work if it's still inside any HOL's makefiles.   This feature was requested by some users and I think is to also prevent issues with user environments having multiple PolyML versions installed.

The new Docker images are already in use, but the HOL building process only starts to not see Poly/ML in `PATH` after merging the file `developers/docker-ci/Dockerfile` in this PR.

--Chun
