### PR TITLE
[kak] fixed holscript detection, added close command and hook

### DIFF
--- a/tools/editor-modes/kak/hol-kak.nix
+++ b/tools/editor-modes/kak/hol-kak.nix
@@ -4,6 +4,6 @@
 
 buildKakounePluginFrom2Nix {
   pname = "hol-kak";
-  version = "0.0.1";
+  version = "0.1.1";
   src = lib.sources.sourceFilesBySuffices ./. [".kak"];
 }


### PR DESCRIPTION
Fixes a filetype detection issue, so that kak now should always be able to detect script files automatically. Can close HOL instance with command, which also runs on closing kak.