### PR TITLE
fix breakage caused by #1451

### DIFF
--- a/src/n-bit/bitstringScript.sml
+++ b/src/n-bit/bitstringScript.sml
@@ -86,7 +86,7 @@ Definition w2v_def:
     GENLIST (\i. w ' (dimindex(:'a) - 1 - i)) (dimindex(:'a))
 End
 
-Definition v2w_def:
+Definition v2w_def[nocompute]:
   v2w v : 'a word = FCP i. testbit i v
 End
 


### PR DESCRIPTION
The syntax upgrades did causes changes
Making w2v_def and v2w_def nocompute