### PR TITLE
Speedup free vars

### DIFF
--- a/src/0/Term.sml
+++ b/src/0/Term.sml
@@ -141,13 +141,14 @@ end;
  * The free variables of a lambda term. Tail recursive (from Ken Larsen).    *
  *---------------------------------------------------------------------------*)
 
-local fun FV (v as Fv _) A k   = k (Lib.insert v A)
-        | FV (Comb(f,x)) A k   = FV f A (fn q => FV x q k)
-        | FV (Abs(_,Body)) A k = FV Body A k
-        | FV (t as Clos _) A k = FV (push_clos t) A k
-        | FV _ A k = k A
+local fun FV ((v as Fv _)::t) A = FV t (Lib.insert v A)
+        | FV ((Comb(f,x))::t) A = FV (f::x::t) A
+        | FV ((Abs(_,Body))::t) A = FV (Body::t) A
+        | FV ((M as Clos _)::t) A = FV (push_clos M::t) A
+        | FV (_::t) A = FV t A
+        | FV [] A = A
 in
-fun free_vars tm = FV tm [] Lib.I
+fun free_vars tm = FV [tm] []
 end;
 
 (*---------------------------------------------------------------------------*


### PR DESCRIPTION
depends on 
1.  #1619


Speedup up free_vars
FV was not recursive due to continuation calling FV.
results from before and after change using `time bin/build`
real    11m7.854s
user    22m42.042s
sys 3m33.477s

real    10m55.458s
user    22m24.558s
sys 3m24.907s