### PR TITLE
make is_{select,forall,exists,exists1} faster for stdknl

### DIFF
--- a/src/1/boolSyntax.sml
+++ b/src/1/boolSyntax.sml
@@ -170,10 +170,10 @@ end (* local *)
 val is_eq           = can dest_eq
 val is_imp          = can dest_imp
 val is_imp_only     = can dest_imp_only
-val is_select       = can dest_select
-val is_forall       = can dest_forall
-val is_exists       = can dest_exists
-val is_exists1      = can dest_exists1
+val is_select       = is_binder select
+val is_forall       = is_binder universal
+val is_exists       = is_binder existential
+val is_exists1      = is_binder exists1
 val is_conj         = can dest_conj
 val is_disj         = can dest_disj
 val is_neg          = can dest_neg

--- a/src/postkernel/HolKernel.sml
+++ b/src/postkernel/HolKernel.sml
@@ -66,6 +66,13 @@ in
       end
 end
 
+fun is_binder c M =
+    let val (c1,abs) = dest_comb M
+    in
+       same_const c c1 andalso is_abs abs
+    end
+    handle HOL_ERR _ => false
+
 local
    fun dest M =
       let val (Rator, Rand) = dest_comb M in (dest_thy_const Rator, Rand) end

--- a/src/postkernel/HolKernelDoc.sig
+++ b/src/postkernel/HolKernelDoc.sig
@@ -16,6 +16,7 @@ sig
   val dest_monop: term -> exn -> term -> term
   val dest_quadop: term -> exn -> term -> term * term * term * term
   val dest_triop: term -> exn -> term -> term * term * term
+  val is_binder: term -> term -> bool
   val disch: term * term list -> term list
   val find_maximal_terms: (term -> bool) -> term -> term set
   val find_term: (term -> bool) -> term -> term


### PR DESCRIPTION
Make is_{select,forall,exists,exists1} faster for stdknl
Code now takes constant time
results from before and after change using `time bin/build`
real    10m55.458s
user    22m24.558s
sys 3m24.907s

real	10m37.510s
user	21m43.869s
sys	3m12.949s