### PR TITLE
Speedup spec all

### DIFF
--- a/src/0/Term.sml
+++ b/src/0/Term.sml
@@ -141,13 +141,14 @@ end;
  * The free variables of a lambda term. Tail recursive (from Ken Larsen).    *
  *---------------------------------------------------------------------------*)
 
-local fun FV (v as Fv _) A k   = k (Lib.insert v A)
-        | FV (Comb(f,x)) A k   = FV f A (fn q => FV x q k)
-        | FV (Abs(_,Body)) A k = FV Body A k
-        | FV (t as Clos _) A k = FV (push_clos t) A k
-        | FV _ A k = k A
+local fun FV ((v as Fv _)::t) A = FV t (Lib.insert v A)
+        | FV ((Comb(f,x))::t) A = FV (f::x::t) A
+        | FV ((Abs(_,Body))::t) A = FV (Body::t) A
+        | FV ((M as Clos _)::t) A = FV (push_clos M::t) A
+        | FV (_::t) A = FV t A
+        | FV [] A = A
 in
-fun free_vars tm = FV tm [] Lib.I
+fun free_vars tm = FV [tm] []
 end;
 
 (*---------------------------------------------------------------------------*

--- a/src/1/Drule.sml
+++ b/src/1/Drule.sml
@@ -782,7 +782,7 @@ in
       if is_forall (concl th) then
          let
             val (hvs, con) = (HOLset.listItems ## I) (hyp_frees th, concl th)
-            val fvs = free_vars con
+            val fvs = HOLset.listItems (FVL [con] empty_tmset)
             val vars = fst (strip_forall con)
          in
             SPECL (snd (itlist varyAcc vars (hvs @ fvs, []))) th

--- a/src/1/boolSyntax.sml
+++ b/src/1/boolSyntax.sml
@@ -170,10 +170,10 @@ end (* local *)
 val is_eq           = can dest_eq
 val is_imp          = can dest_imp
 val is_imp_only     = can dest_imp_only
-val is_select       = can dest_select
-val is_forall       = can dest_forall
-val is_exists       = can dest_exists
-val is_exists1      = can dest_exists1
+val is_select       = is_binder select
+val is_forall       = is_binder universal
+val is_exists       = is_binder existential
+val is_exists1      = is_binder exists1
 val is_conj         = can dest_conj
 val is_disj         = can dest_disj
 val is_neg          = can dest_neg

--- a/src/n-bit/bitstringScript.sml
+++ b/src/n-bit/bitstringScript.sml
@@ -86,7 +86,7 @@ Definition w2v_def:
     GENLIST (\i. w ' (dimindex(:'a) - 1 - i)) (dimindex(:'a))
 End
 
-Definition v2w_def:
+Definition v2w_def[nocompute]:
   v2w v : 'a word = FCP i. testbit i v
 End
 

--- a/src/postkernel/HolKernel.sml
+++ b/src/postkernel/HolKernel.sml
@@ -66,6 +66,13 @@ in
       end
 end
 
+fun is_binder c M =
+    let val (c1,abs) = dest_comb M
+    in
+       same_const c c1 andalso is_abs abs
+    end
+    handle HOL_ERR _ => false
+
 local
    fun dest M =
       let val (Rator, Rand) = dest_comb M in (dest_thy_const Rator, Rand) end


### PR DESCRIPTION
Note that reusing set from hyp_frees is actually slower.
times using `time bin/build`
before
real 10m37.510s
user 21m43.869s
sys 3m12.949s
reusing set from hyp_frees
real 10m40.847s
user    21m49.628s
sys     3m16.913s
without reusing set from hyp_frees
real    10m29.285s
user    21m9.849s
sys 3m10.606s
note depends on #1623 