### PR TITLE
Change the parser to use HOLdict instead of Binarymap

### DIFF
--- a/doc/next-release.md
+++ b/doc/next-release.md
@@ -34,6 +34,8 @@ New examples:
 
 Incompatibilities:
 ------------------
+-   The return types of `parse_term.mk_prec_matrix`, `type_grammar.parse_map`, `type_grammar.privileged_abbrevs` 
+    have been changed to return maps of type HOLdict instead of Binarymap.
 
 * * * * *
 

--- a/doc/next-release.md
+++ b/doc/next-release.md
@@ -1,0 +1,45 @@
+% Release notes for HOL4, ??????
+
+<!-- search and replace ?????? strings corresponding to release name -->
+<!-- indent code within bulleted lists to column 11 -->
+
+(Released: xxxxxx)
+
+We are pleased to announce the ????? release of HOL4.
+
+Contents
+--------
+
+-   [New features](#new-features)
+-   [Bugs fixed](#bugs-fixed)
+-   [New theories](#new-theories)
+-   [New tools](#new-tools)
+-   [New Examples](#new-examples)
+-   [Incompatibilities](#incompatibilities)
+
+New features:
+-------------
+
+Bugs fixed:
+-----------
+
+New theories:
+-------------
+
+New tools:
+----------
+
+New examples:
+-------------
+
+Incompatibilities:
+------------------
+
+* * * * *
+
+<div class="footer">
+*[HOL4, ?????](http://hol-theorem-prover.org)*
+
+[Release notes for the previous version](trindemossen-2.release.html)
+
+</div>

--- a/src/1/TypeBase.sml
+++ b/src/1/TypeBase.sml
@@ -197,11 +197,11 @@ fun tyi_from_name s =
         let
           val tyg = Parse.type_grammar()
         in
-          case Binarymap.peek(privileged_abbrevs tyg, nm) of
+          case HOLdict.peek(privileged_abbrevs tyg, nm) of
               NONE => raise ERR "tyi_from_name"
                             ("Ty-grammar doesn't know name: "^nm)
             | SOME thy =>
-              (case Binarymap.peek(parse_map tyg, {Thy = thy, Name = nm}) of
+              (case HOLdict.peek(parse_map tyg, {Thy = thy, Name = nm}) of
                    NONE => raise ERR "tyi_from_name"
                                  ("Ty-grammar has bad abbrev-map for name: "^nm)
                  | SOME (TYOP {Thy,Tyop,...}) => tyi_from_kid Thy Tyop

--- a/src/1/theory_tests/gh168aScript.sml
+++ b/src/1/theory_tests/gh168aScript.sml
@@ -5,7 +5,7 @@ Libs
   HolKernel Parse boolLib
 
 val thy =
-    Binarymap.find(type_grammar.privileged_abbrevs (type_grammar()), "foo")
+    HOLdict.find(type_grammar.privileged_abbrevs (type_grammar()), "foo")
 
 val _ = disable_tyabbrev_printing (thy^"$foo")
 

--- a/src/1/theory_tests/gh168bScript.sml
+++ b/src/1/theory_tests/gh168bScript.sml
@@ -22,6 +22,6 @@ fun typrinttest s =
 val _ = typrinttest ":bool -> bool"
 val _ = typrinttest ":bool -> bool -> bool"
 val _ = tprint "type_grammar abbrevs map is empty"
-val _ = if Binarymap.numItems (type_grammar.parse_map tyg) = 4 then OK()
+val _ = if HOLdict.numItems (type_grammar.parse_map tyg) = 4 then OK()
         else die "FAILED!"
 

--- a/src/1/theory_tests/gh168cScript.sml
+++ b/src/1/theory_tests/gh168cScript.sml
@@ -5,7 +5,7 @@ Libs
   HolKernel Parse boolLib testutils
 
 val tyg0 = type_grammar()
-val privthy = Binarymap.find(type_grammar.privileged_abbrevs tyg0, "foo")
+val privthy = HOLdict.find(type_grammar.privileged_abbrevs tyg0, "foo")
 val unprivthy = if privthy = "gh294a" then "gh294b" else "gh294a"
 
 val _ = remove_type_abbrev (privthy ^ "$foo")

--- a/src/1/theory_tests/gh168eScript.sml
+++ b/src/1/theory_tests/gh168eScript.sml
@@ -8,7 +8,7 @@ val b2b = bool --> bool
 val b2b2b = bool --> b2b
 
 val tyg0 = type_grammar()
-val privthy = Binarymap.find(type_grammar.privileged_abbrevs tyg0, "foo")
+val privthy = HOLdict.find(type_grammar.privileged_abbrevs tyg0, "foo")
 val unprivthy = if privthy = "gh294a" then "gh294b" else "gh294a"
 
 val (privty, unprivty) = if privthy = "gh294a" then (b2b, b2b2b)

--- a/src/parse/FCNet.sml
+++ b/src/parse/FCNet.sml
@@ -278,7 +278,7 @@ fun lookup tm net =
           (follow tm net)  [];
 
 (* term match *)
-structure Map = Binarymap
+structure Map = HOLdict
 fun bvar_free (bvmap, tm) = let
   (* return true if none of the free variables occur as keys in bvmap *)
   fun recurse bs t =

--- a/src/parse/LVTermNet.sig
+++ b/src/parse/LVTermNet.sig
@@ -1,7 +1,7 @@
 signature LVTermNet =
 sig
 
-  (* signature names modelled on Binarymap's *)
+  (* signature names modelled on HOLdict's *)
   type 'a lvtermnet
   type term = Term.term
   type key = Term.term list * Term.term

--- a/src/parse/LVTermNet.sml
+++ b/src/parse/LVTermNet.sml
@@ -27,8 +27,8 @@ fun labcmp (p as (l1, l2)) =
     | (_, Lam _) => GREATER
     | (LV p1, LV p2) => pair_compare (String.compare, Int.compare) (p1, p2)
 
-datatype 'a N = LF of (key,'a list) Binarymap.dict
-              | ND of (label,'a N) Binarymap.dict
+datatype 'a N = LF of (key,'a list) HOLdict.dict
+              | ND of (label,'a N) HOLdict.dict
               | EMPTY
 (* redundant EMPTY constructor is used to get around value polymorphism problem
    when creating a single value for empty below *)
@@ -37,7 +37,7 @@ type 'a lvtermnet = 'a N * int
 
 val empty = (EMPTY, 0)
 
-fun mkempty () = ND (Binarymap.mkDict labcmp)
+fun mkempty () = ND (HOLdict.mkDict labcmp)
 
 fun ndest_term (fvs, tm) = let
   val (f, args) = strip_comb tm
@@ -53,14 +53,14 @@ in
 end
 
 fun cons_insert (bmap, k, i) =
-    case Binarymap.peek(bmap,k) of
-      NONE => Binarymap.insert(bmap,k,[i])
-    | SOME items => Binarymap.insert(bmap,k,i::items)
+    case HOLdict.peek(bmap,k) of
+      NONE => HOLdict.insert(bmap,k,[i])
+    | SOME items => HOLdict.insert(bmap,k,i::items)
 
 fun insert ((net,sz), k, item) = let
   fun newnode labs =
       case labs of
-        [] => LF (Binarymap.mkDict tlt_compare)
+        [] => LF (HOLdict.mkDict tlt_compare)
       | _ => mkempty()
   fun trav (net, tms) =
       case (net, tms) of
@@ -69,11 +69,11 @@ fun insert ((net,sz), k, item) = let
           val (lab, rest) = ndest_term k
           val ks = rest @ ks0
           val n' =
-              case Binarymap.peek(d,lab) of
+              case HOLdict.peek(d,lab) of
                 NONE => trav(newnode ks, ks)
               | SOME n => trav(n, ks)
         in
-          ND (Binarymap.insert(d, lab, n'))
+          ND (HOLdict.insert(d, lab, n'))
         end
       | (EMPTY, ks) => trav(mkempty(), ks)
       | _ => raise Fail "LVTermNet.insert: catastrophic invariant failure"
@@ -85,11 +85,11 @@ fun listItems (net, sz) = let
   fun cons'(k,vs,acc) = List.foldl (fn (v,acc) => (k,v)::acc) acc vs
   fun trav (net, acc) =
       case net of
-        LF d => Binarymap.foldl cons' acc d
+        LF d => HOLdict.foldl cons' acc d
       | ND d => let
           fun foldthis (k,v,acc) = trav(v,acc)
         in
-          Binarymap.foldl foldthis acc d
+          HOLdict.foldl foldthis acc d
         end
       | EMPTY => []
 in
@@ -101,11 +101,11 @@ fun numItems (net, sz) = sz
 fun peek ((net,sz), k) = let
   fun trav (net, tms) =
       case (net, tms) of
-        (LF d, []) => (valOf (Binarymap.peek(d, k)) handle Option => [])
+        (LF d, []) => (valOf (HOLdict.peek(d, k)) handle Option => [])
       | (ND d, k::ks) => let
           val (lab, rest) = ndest_term k
         in
-          case Binarymap.peek(d, lab) of
+          case HOLdict.peek(d, lab) of
             NONE => []
           | SOME n => trav(n, rest @ ks)
         end
@@ -131,7 +131,7 @@ fun conslistItems (d, acc) = let
   fun listfold k (v,acc) = (k,v)::acc
   fun mapfold (k,vs,acc) = List.foldl (listfold k) acc vs
 in
-  Binarymap.foldl mapfold acc d
+  HOLdict.foldl mapfold acc d
 end
 
 fun match ((net,sz), tm) = let
@@ -140,7 +140,7 @@ fun match ((net,sz), tm) = let
         (EMPTY, _) => []
       | (LF d, []) => conslistItems (d, acc)
       | (ND d, k::ks0) => let
-          val varresult = case Binarymap.peek(d, V 0) of
+          val varresult = case HOLdict.peek(d, V 0) of
                             NONE => acc
                           | SOME n => trav acc (n, ks0)
           val (lab, rest) = lookup_label k
@@ -149,7 +149,7 @@ fun match ((net,sz), tm) = let
             fun recurse acc n =
               if n = 0 then acc
               else
-                case Binarymap.peek (d, V n) of
+                case HOLdict.peek (d, V n) of
                     NONE => recurse acc (n - 1)
                   | SOME m => recurse
                                 (trav acc (m, List.drop(rest, restn - n) @ ks0))
@@ -158,7 +158,7 @@ fun match ((net,sz), tm) = let
             recurse varresult (length (#2 (strip_comb k)))
           end
         in
-          case Binarymap.peek (d, lab) of
+          case HOLdict.peek (d, lab) of
             NONE => varhead_results
           | SOME n => trav varhead_results (n, rest @ ks0)
         end
@@ -170,28 +170,28 @@ end
 fun delete ((net,sz), k) = let
   fun trav (p as (net, ks)) =
       case p of
-        (EMPTY, _) => raise Binarymap.NotFound
+        (EMPTY, _) => raise HOLdict.NotFound
       | (LF d, []) => let
-          val (d',removed) = Binarymap.remove(d, k)
+          val (d',removed) = HOLdict.remove(d, k)
         in
-          if Binarymap.numItems d' = 0 then (NONE, removed)
+          if HOLdict.numItems d' = 0 then (NONE, removed)
           else (SOME (LF d'), removed)
         end
       | (ND d, k::ks) => let
           val (lab, rest) = ndest_term k
         in
-          case Binarymap.peek(d, lab) of
-            NONE => raise Binarymap.NotFound
+          case HOLdict.peek(d, lab) of
+            NONE => raise HOLdict.NotFound
           | SOME n => let
             in
               case trav (n, rest @ ks) of
                 (NONE, removed) => let
-                  val (d',_) = Binarymap.remove(d, lab)
+                  val (d',_) = HOLdict.remove(d, lab)
                 in
-                  if Binarymap.numItems d' = 0 then (NONE, removed)
+                  if HOLdict.numItems d' = 0 then (NONE, removed)
                   else (SOME (ND d'), removed)
                 end
-              | (SOME n', removed) => (SOME (ND (Binarymap.insert(d,lab,n'))),
+              | (SOME n', removed) => (SOME (ND (HOLdict.insert(d,lab,n'))),
                                        removed)
             end
         end
@@ -205,8 +205,8 @@ end
 fun app f (net, sz) = let
   fun trav n =
       case n of
-        LF d => Binarymap.app f d
-      | ND d => Binarymap.app (fn (lab, n) => trav n) d
+        LF d => HOLdict.app f d
+      | ND d => HOLdict.app (fn (lab, n) => trav n) d
       | EMPTY => ()
 in
   trav net
@@ -216,14 +216,14 @@ fun consfoldl f acc d = let
   fun listfold k (d, acc) = f (k, d, acc)
   fun mapfold (k,vs,acc) = List.foldl (listfold k) acc vs
 in
-  Binarymap.foldl mapfold acc d
+  HOLdict.foldl mapfold acc d
 end
 
 fun fold f acc (net, sz) = let
   fun trav acc n =
       case n of
         LF d => consfoldl f acc d
-      | ND d => Binarymap.foldl (fn (lab,n',acc) => trav acc n') acc d
+      | ND d => HOLdict.foldl (fn (lab,n',acc) => trav acc n') acc d
       | EMPTY => acc
 in
   trav acc net
@@ -233,17 +233,17 @@ fun consmap f d = let
   fun foldthis (k,vs,acc) = let
     val bs = map (fn v => f(k,v)) vs
   in
-    Binarymap.insert(acc,k,bs)
+    HOLdict.insert(acc,k,bs)
   end
 in
-  Binarymap.foldl foldthis (Binarymap.mkDict tlt_compare) d
+  HOLdict.foldl foldthis (HOLdict.mkDict tlt_compare) d
 end
 
 fun map f (net, sz) = let
   fun trav n =
       case n of
         LF d => LF (consmap f d)
-      | ND d => ND (Binarymap.transform trav d)
+      | ND d => ND (HOLdict.transform trav d)
       | EMPTY => EMPTY
 in
   (trav net, sz)

--- a/src/parse/TypeNet.sig
+++ b/src/parse/TypeNet.sig
@@ -1,7 +1,7 @@
 signature TypeNet =
 sig
 
-  (* signature names modelled on Binarymap's *)
+  (* signature names modelled on HOLdict's *)
   type 'a typenet
   type hol_type = Type.hol_type
 

--- a/src/parse/parse_term.sig
+++ b/src/parse/parse_term.sig
@@ -21,6 +21,6 @@ sig
   datatype mx_order = datatype parse_term_dtype.mx_order
   val mk_prec_matrix :
       term_grammar.grammar ->
-      ((stack_terminal * bool) * stack_terminal, mx_order) Binarymap.dict Uref.t
+      ((stack_terminal * bool) * stack_terminal, mx_order) HOLdict.dict Uref.t
 
 end

--- a/src/parse/parse_type.sml
+++ b/src/parse/parse_type.sml
@@ -122,18 +122,18 @@ fun parse_type_fns tyfns allow_unknown_suffixes G = let
       in
         if is_numeric s then generate_fcpbit((s,locn), args)
         else
-          case Binarymap.peek(privabbs, s) of
+          case HOLdict.peek(privabbs, s) of
             NONE => pType((s,locn), args)
           | SOME thy => let
             in
-              case Binarymap.peek(abbrevs, {Name = s, Thy = thy}) of
+              case HOLdict.peek(abbrevs, {Name = s, Thy = thy}) of
                   NONE => raise Fail
                             "parse_tyop.apply_tyop: probably shouldn't happen"
                 | SOME st => structure_to_value (s,locn) args st
             end
       end
     | QTypeIdent(thy,ty) =>
-        (case Binarymap.peek(abbrevs, {Name = ty, Thy = thy}) of
+        (case HOLdict.peek(abbrevs, {Name = ty, Thy = thy}) of
              NONE => qtyop{Thy=thy,Tyop=ty,Locn=locn,Args=args}
          |   SOME st => structure_to_value (ty,locn) args st)
     | _ => raise Fail "parse_type.apply_tyop: can't happen"

--- a/src/parse/term_pp.sml
+++ b/src/parse/term_pp.sml
@@ -532,7 +532,7 @@ fun pp_term (G : grammar) TyG backend = let
     fun val_insert (tstamp,r) NONE = [(n,tstamp,r)]
       | val_insert (tstamp,r) (SOME l) = sortinsert (tstamp,r) l
     fun myinsert ((k, (tstamp, r)), acc) = let
-      val existing = Binarymap.peek(acc, k)
+      val existing = HOLdict.peek(acc, k)
       val newvalue =
         case existing of
           NONE => [(n,tstamp,r)]
@@ -541,15 +541,15 @@ fun pp_term (G : grammar) TyG backend = let
           if tstamp > t' then (n,tstamp,r)::old::rest
           else old::(n,tstamp,r)::rest
     in
-      Binarymap.insert(acc, k, newvalue)
+      HOLdict.insert(acc, k, newvalue)
     end
   in
     (List.foldl myinsert acc keys_n_rules)
   end
   val rule_table = List.foldl insert
-                              (Binarymap.mkDict String.compare)
+                              (HOLdict.mkDict String.compare)
                               (term_grammar.rules G)
-  fun lookup_term s = Binarymap.peek(rule_table, s)
+  fun lookup_term s = HOLdict.peek(rule_table, s)
   val comb_prec = #1 (hd (valOf (lookup_term fnapp_special)))
     handle Option =>
       raise PP_ERR "pp_term" "Grammar has no function application"

--- a/src/parse/type_grammar.sig
+++ b/src/parse/type_grammar.sig
@@ -15,9 +15,9 @@ sig
   val min_grammar      : grammar
   val rules            : grammar -> {infixes: (int * grammar_rule) list,
                                      suffixes : string list}
-  val parse_map    : grammar -> (kernelname,type_structure) Binarymap.dict
+  val parse_map    : grammar -> (kernelname,type_structure) HOLdict.dict
   val print_map    : grammar -> (int * kernelname) TypeNet.typenet
-  val privileged_abbrevs : grammar -> (string,string) Binarymap.dict
+  val privileged_abbrevs : grammar -> (string,string) HOLdict.dict
 
   val abb_dest_type : grammar -> Type.hol_type ->
                       {Thy : string option, Tyop : string,

--- a/src/parse/type_pp.sml
+++ b/src/parse/type_pp.sml
@@ -187,7 +187,7 @@ fun pp_type0 (G:grammar) (backend: PPBackEnd.t) = let
                 let
                   val knm = {Thy = thy, Name = abop}
                 in
-                  case Binarymap.peek (abbs, knm) of
+                  case HOLdict.peek (abbs, knm) of
                       NONE => realtype ty (* probably shouldn't happen *)
                     | SOME st => doabbrev st
                 end
@@ -195,13 +195,13 @@ fun pp_type0 (G:grammar) (backend: PPBackEnd.t) = let
                 let
                   val privabbs = type_grammar.privileged_abbrevs G
                 in
-                  case Binarymap.peek (privabbs, abop) of
+                  case HOLdict.peek (privabbs, abop) of
                       NONE => realtype ty
                     | SOME thy =>
                       let
                         val knm = {Thy = thy, Name = abop}
                       in
-                        case Binarymap.peek (abbs, knm) of
+                        case HOLdict.peek (abbs, knm) of
                             NONE => raise Fail "Very confused tyabbrev"
                           | SOME st => doabbrev st
                       end


### PR DESCRIPTION
Experiments revealed that this speeds the time of
bin/build by around around 30 seconds.
This change is observable if you only
change the use Binarymap to HOLdict in parse_term but
I decided to just make the most of parse use HOLdict anyway.