### PR TITLE
Strengthening Bayes rule by removing an unnecessary precondition.

### DIFF
--- a/src/probability/probabilityScript.sml
+++ b/src/probability/probabilityScript.sml
@@ -9322,10 +9322,12 @@ QED
 
 Theorem BAYES_RULE :
     !p A B. prob_space p /\ A IN events p /\ B IN events p /\
-            prob p A <> 0 /\ prob p B <> 0 ==>
+            prob p A <> 0 ==>
            (cond_prob p B A = (cond_prob p A B) * (prob p B) / (prob p A))
 Proof
     RW_TAC std_ss []
+ >> Cases_on ‘prob p B = 0’
+ >- gvs[zero_div, cond_prob_def, PROB_ZERO_INTER]
  >> `prob p A <> PosInf /\ prob p A <> NegInf` by METIS_TAC [PROB_FINITE]
  >> `prob p A < PosInf` by METIS_TAC [lt_infty]
  >> `0 < prob p A` by METIS_TAC [le_lt, PROB_POSITIVE]


### PR DESCRIPTION
Strengthening Bayes rule by removing an unnecessary precondition. While it is true that allowing the probability of the event B to be zero will implicitly cause us to be dividing a value by zero, in HOL4, division by zero has some value, and since anything multiplied by zero is zero, the left-hand-side and the right-hand-side will both be zero in this case.