### PR TITLE
speedup Solve_ineqs

### DIFF
--- a/src/num/arith/src/Solve_ineqs.sml
+++ b/src/num/arith/src/Solve_ineqs.sml
@@ -294,22 +294,22 @@ fun VAR_ELIM coeffsl =
         else from::(upto (from + one) to)
      fun left_ineqs var icoeffsl =
         let fun left_ineq icoeffs =
-               not (null (filter
+                         (List.exists
                           (fn (name,coeff) => (name = var) andalso (coeff < zero))
-                          (snd (snd icoeffs))))
+                          (snd (snd icoeffs)))
         in  filter left_ineq icoeffsl
         end
      fun right_ineqs var icoeffsl =
         let fun right_ineq icoeffs =
-               not (null (filter
+                         (List.exists
                           (fn (name,coeff) => (name = var) andalso (coeff > zero))
-                          (snd (snd icoeffs))))
+                          (snd (snd icoeffs)))
         in  filter right_ineq icoeffsl
         end
      fun no_var_ineqs var icoeffsl =
         let fun no_var_ineq icoeffs =
-               null
-                (filter
+               not
+                (List.exists
                  (fn (name,coeff) => (name = var) andalso (not (coeff = zero)))
                  (snd (snd icoeffs)))
         in  filter no_var_ineq icoeffsl


### PR DESCRIPTION
PolyML doesn't support tail mod cons and has to
waste time and memory allocating a list for it to be only checked if it's null.