### PR TITLE
More alternative definitions of "convergence in distribution"

### DIFF
--- a/src/probability/borelScript.sml
+++ b/src/probability/borelScript.sml
@@ -8752,6 +8752,108 @@ Proof
  >> rw [SUBSET_DEF] >> simp []
 QED
 
+(* NOTE: This proof is tedious but easy to work out, based on the existing
+   borel_measurable_real_set.
+ *)
+Theorem borel_measurable_image_real :
+    !s. s IN subsets Borel ==> IMAGE real s IN subsets borel
+Proof
+    rpt STRIP_TAC
+ >> Cases_on ‘PosInf IN s’ >> Cases_on ‘NegInf IN s’ (* 4 subgoals *)
+ >| [ (* goal 1 (of 4) *)
+      qabbrev_tac ‘t = s DIFF ({PosInf} UNION {NegInf})’ \\
+      Know ‘t IN subsets Borel’
+      >- (qunabbrev_tac ‘t’ \\
+          MATCH_MP_TAC SIGMA_ALGEBRA_DIFF >> rw [SIGMA_ALGEBRA_BOREL] \\
+          MATCH_MP_TAC SIGMA_ALGEBRA_UNION \\
+          simp [SIGMA_ALGEBRA_BOREL, BOREL_MEASURABLE_SETS]) >> DISCH_TAC \\
+     ‘PosInf NOTIN t /\ NegInf NOTIN t’ by ASM_SET_TAC [] \\
+     ‘s = t UNION {PosInf; NegInf}’ by ASM_SET_TAC [] >> POP_ORW \\
+      Know ‘IMAGE real (t UNION {PosInf; NegInf}) = real_set t UNION {0}’
+      >- (rw [Once EXTENSION, real_set_def] \\
+          EQ_TAC >> rw [] >> simp [] >| (* 3 subgoals left *)
+          [ (* goal 1.1 (of 3) *)
+            rename1 ‘y IN t’ \\
+           ‘y <> PosInf /\ y <> NegInf’ by METIS_TAC [] \\
+           ‘?r. y = Normal r’ by METIS_TAC [extreal_cases] \\
+            simp [] >> DISJ1_TAC \\
+            Q.EXISTS_TAC ‘y’ >> simp [],
+            (* goal 1.2 (of 3) *)
+            rename1 ‘y IN t’ \\
+           ‘?r. y = Normal r’ by METIS_TAC [extreal_cases] \\
+            simp [] \\
+            Q.EXISTS_TAC ‘y’ >> simp [],
+            (* goal 1.3 (of 3) *)
+            Q.EXISTS_TAC ‘PosInf’ >> simp [] ]) >> Rewr' \\
+      MATCH_MP_TAC SIGMA_ALGEBRA_UNION \\
+      simp [sigma_algebra_borel, borel_measurable_sets] \\
+      MATCH_MP_TAC borel_measurable_real_set >> art [],
+      (* goal 2 (of 4) *)
+      qabbrev_tac ‘t = s DIFF {PosInf}’ \\
+      Know ‘t IN subsets Borel’
+      >- (qunabbrev_tac ‘t’ \\
+          MATCH_MP_TAC SIGMA_ALGEBRA_DIFF >> rw [SIGMA_ALGEBRA_BOREL]) \\
+      DISCH_TAC \\
+     ‘PosInf NOTIN t /\ NegInf NOTIN t’ by ASM_SET_TAC [] \\
+     ‘s = t UNION {PosInf}’ by ASM_SET_TAC [] >> POP_ORW \\
+      Know ‘IMAGE real (t UNION {PosInf}) = real_set t UNION {0}’
+      >- (rw [Once EXTENSION, real_set_def] \\
+          EQ_TAC >> rw [] >> simp [] >| (* 3 subgoals left *)
+          [ (* goal 2.1 (of 3) *)
+            rename1 ‘y IN t’ \\
+           ‘y <> PosInf /\ y <> NegInf’ by METIS_TAC [] \\
+           ‘?r. y = Normal r’ by METIS_TAC [extreal_cases] \\
+            simp [] >> DISJ1_TAC \\
+            Q.EXISTS_TAC ‘y’ >> simp [],
+            (* goal 2.2 (of 3) *)
+            rename1 ‘y IN t’ \\
+           ‘?r. y = Normal r’ by METIS_TAC [extreal_cases] \\
+            simp [] >> Q.EXISTS_TAC ‘y’ >> simp [],
+            (* goal 2.3 (of 3) *)
+            Q.EXISTS_TAC ‘PosInf’ >> simp [] ]) >> Rewr' \\
+      MATCH_MP_TAC SIGMA_ALGEBRA_UNION \\
+      simp [sigma_algebra_borel, borel_measurable_sets] \\
+      MATCH_MP_TAC borel_measurable_real_set >> art [],
+      (* goal 3 (of 4) *)
+      qabbrev_tac ‘t = s DIFF {NegInf}’ \\
+      Know ‘t IN subsets Borel’
+      >- (qunabbrev_tac ‘t’ \\
+          MATCH_MP_TAC SIGMA_ALGEBRA_DIFF >> rw [SIGMA_ALGEBRA_BOREL]) \\
+      DISCH_TAC \\
+     ‘PosInf NOTIN t /\ NegInf NOTIN t’ by ASM_SET_TAC [] \\
+     ‘s = t UNION {NegInf}’ by ASM_SET_TAC [] >> POP_ORW \\
+      Know ‘IMAGE real (t UNION {NegInf}) = real_set t UNION {0}’
+      >- (rw [Once EXTENSION, real_set_def] \\
+          EQ_TAC >> rw [] >> simp [] >| (* 3 subgoals left *)
+          [ (* goal 3.1 (of 3) *)
+            rename1 ‘y IN t’ \\
+           ‘y <> PosInf /\ y <> NegInf’ by METIS_TAC [] \\
+           ‘?r. y = Normal r’ by METIS_TAC [extreal_cases] \\
+            simp [] >> DISJ1_TAC \\
+            Q.EXISTS_TAC ‘y’ >> simp [],
+            (* goal 3.2 (of 3) *)
+            rename1 ‘y IN t’ \\
+           ‘?r. y = Normal r’ by METIS_TAC [extreal_cases] \\
+            simp [] >> Q.EXISTS_TAC ‘y’ >> simp [],
+            (* goal 3.3 (of 3) *)
+            Q.EXISTS_TAC ‘NegInf’ >> simp [] ]) >> Rewr' \\
+      MATCH_MP_TAC SIGMA_ALGEBRA_UNION \\
+      simp [sigma_algebra_borel, borel_measurable_sets] \\
+      MATCH_MP_TAC borel_measurable_real_set >> art [],
+      (* goal 4 (of 4) *)
+      Know ‘IMAGE real s = real_set s’
+      >- (rw [Once EXTENSION, real_set_def] \\
+          EQ_TAC >> rw [] >> simp [] >| (* 2 subgoals left *)
+          [ (* goal 4.1 (of 2) *)
+            rename1 ‘y IN s’ \\
+           ‘y <> PosInf /\ y <> NegInf’ by METIS_TAC [] \\
+            Q.EXISTS_TAC ‘y’ >> simp [],
+            (* goal 4.2 (of 2) *)
+            rename1 ‘y IN t’ \\
+            Q.EXISTS_TAC ‘y’ >> simp [] ]) >> Rewr' \\
+      MATCH_MP_TAC borel_measurable_real_set >> art [] ]
+QED
+
 (* References:
 
   [1] Schilling, R.L.: Measures, Integrals and Martingales (Second Edition).

--- a/src/probability/extrealScript.sml
+++ b/src/probability/extrealScript.sml
@@ -7023,6 +7023,19 @@ Proof
  >> simp []
 QED
 
+(* NOTE: “|- Lipschitz_continuous_map (extreal_mr1,mr1) real” doesn't hold *)
+Theorem Lipschitz_continuous_map_normal :
+     Lipschitz_continuous_map (mr1,extreal_mr1) Normal
+Proof
+    rw [Lipschitz_continuous_map_def, GSYM dist_def, dist]
+ >> Q.EXISTS_TAC ‘1’ >> rw []
+ >> rw [extreal_mr1_normal]
+ >> MATCH_MP_TAC REAL_LE_LDIV
+ >> qabbrev_tac ‘z = abs (x - y)’
+ >> simp [REAL_LDISTRIB]
+ >> Q_TAC (TRANS_TAC REAL_LTE_TRANS) ‘1’ >> rw [Abbr ‘z’]
+QED
+
 (* ------------------------------------------------------------------------- *)
 (*  Preliminary for Radon-Nikodym Theorem                                    *)
 (* ------------------------------------------------------------------------- *)

--- a/src/probability/martingaleScript.sml
+++ b/src/probability/martingaleScript.sml
@@ -676,7 +676,8 @@ Proof
         ‘?b. f x   = Normal b’ by METIS_TAC [extreal_cases] >> POP_ORW \\
          rw [extreal_sub_def, extreal_abs_def]) >> Rewr' \\
      RW_TAC std_ss [abs_abs, GSYM extreal_lt_eq] \\
-     Suff ‘Normal (real (abs (u i x - f x))) = abs (u i x - f x)’ >- RW_TAC std_ss [] \\
+     Suff ‘Normal (real (abs (u i x - f x))) = abs (u i x - f x)’
+     >- RW_TAC std_ss [] \\
      MATCH_MP_TAC normal_real \\
     ‘?a. u i x = Normal a’ by METIS_TAC [extreal_cases] >> POP_ORW \\
     ‘?b. f x   = Normal b’ by METIS_TAC [extreal_cases] >> POP_ORW \\
@@ -806,7 +807,8 @@ Theorem pos_fn_integral_distr :
               f IN measurable (m_space M, measurable_sets M) B /\
               u IN measurable B Borel /\
              (!x. x IN space B ==> 0 <= u x) ==>
-             (pos_fn_integral (space B,subsets B,distr M f) u = pos_fn_integral M (u o f))
+             (pos_fn_integral (space B,subsets B,distr M f) u =
+              pos_fn_integral M (u o f))
 Proof
     rpt STRIP_TAC
  >> ‘measure_space (space B,subsets B,distr M f)’ by PROVE_TAC [measure_space_distr]
@@ -840,18 +842,20 @@ Proof
           pos_fn_integral M (\x. sup (IMAGE (\n. fn_seq (space B,subsets B,distr M f)
                                                         u n (f x)) UNIV))’
  >- (MATCH_MP_TAC pos_fn_integral_cong >> ASM_SIMP_TAC std_ss [] \\
-     CONJ_TAC >- (rpt STRIP_TAC >> FIRST_X_ASSUM MATCH_MP_TAC \\
-                  Q.PAT_X_ASSUM ‘f IN measurable (m_space M,measurable_sets M) B’ MP_TAC \\
-                  rw [IN_MEASURABLE, IN_FUNSET]) \\
-     CONJ_TAC >- (rw [le_sup', IN_IMAGE, IN_UNIV] \\
-                  MATCH_MP_TAC le_trans \\
-                  Q.EXISTS_TAC ‘fn_seq (space B,subsets B,distr M f) u 0 (f x)’ \\
-                  reverse CONJ_TAC >- (POP_ASSUM MATCH_MP_TAC \\
-                                       Q.EXISTS_TAC ‘0’ >> REWRITE_TAC []) \\
-                  MATCH_MP_TAC lemma_fn_seq_positive \\
-                  FIRST_X_ASSUM MATCH_MP_TAC \\
-                  Q.PAT_X_ASSUM ‘f IN measurable (m_space M,measurable_sets M) B’ MP_TAC \\
-                  rw [IN_MEASURABLE, IN_FUNSET]) \\
+     CONJ_TAC
+     >- (rpt STRIP_TAC >> FIRST_X_ASSUM MATCH_MP_TAC \\
+         Q.PAT_X_ASSUM ‘f IN measurable (m_space M,measurable_sets M) B’ MP_TAC \\
+         rw [IN_MEASURABLE, IN_FUNSET]) \\
+     CONJ_TAC
+     >- (rw [le_sup', IN_IMAGE, IN_UNIV] \\
+         MATCH_MP_TAC le_trans \\
+         Q.EXISTS_TAC ‘fn_seq (space B,subsets B,distr M f) u 0 (f x)’ \\
+         reverse CONJ_TAC >- (POP_ASSUM MATCH_MP_TAC \\
+                              Q.EXISTS_TAC ‘0’ >> REWRITE_TAC []) \\
+         MATCH_MP_TAC lemma_fn_seq_positive \\
+         FIRST_X_ASSUM MATCH_MP_TAC \\
+         Q.PAT_X_ASSUM ‘f IN measurable (m_space M,measurable_sets M) B’ MP_TAC \\
+         rw [IN_MEASURABLE, IN_FUNSET]) \\
      rpt STRIP_TAC >> FIRST_X_ASSUM MATCH_MP_TAC \\
      Q.PAT_X_ASSUM ‘f IN measurable (m_space M,measurable_sets M) B’ MP_TAC \\
      rw [IN_MEASURABLE, IN_FUNSET]) >> Rewr'
@@ -1019,10 +1023,10 @@ Proof
  (* LHS simplification *)
  >> Know ‘pos_fn_integral (space B,subsets B,distr M f)
            (\x. SIGMA
-                  (\k. (\k x. &k / 2 pow N *
-                              indicator_fn
-                                {x | x IN space B /\ &k / 2 pow N <= u x /\
-                                     u x < (&k + 1) / 2 pow N} x) k x) (count (4 ** N))) =
+               (\k. (\k x. &k / 2 pow N *
+                           indicator_fn
+                          {x | x IN space B /\ &k / 2 pow N <= u x /\
+                               u x < (&k + 1) / 2 pow N} x) k x) (count (4 ** N))) =
           SIGMA (\k. pos_fn_integral (space B,subsets B,distr M f)
                       ((\k x. &k / 2 pow N *
                               indicator_fn
@@ -1187,10 +1191,10 @@ Proof
       MATCH_MP_TAC IN_MEASURABLE_BOREL_FN_MINUS >> art [] ]
 QED
 
-Theorem pos_fn_integral_cong_measure :
+Theorem pos_fn_integral_cong_measure_old[local] :
     !sp sts u v f.
         measure_space (sp,sts,u) /\ measure_space (sp,sts,v) /\
-        (!s. s IN sts ==> (u s = v s)) /\ (!x. x IN sp ==> 0 <= f x) ==>
+        (!s. s IN sts ==> u s = v s) /\ (!x. x IN sp ==> 0 <= f x) ==>
         (pos_fn_integral (sp,sts,u) f = pos_fn_integral (sp,sts,v) f)
 Proof
     rw [pos_fn_integral_def]
@@ -1213,15 +1217,39 @@ Proof
       fs [positive_def] )
 QED
 
-Theorem pos_fn_integral_cong_measure' :
+Theorem pos_fn_integral_cong_measure :
+    !sp sts u v f.
+        measure_space (sp,sts,u) /\
+       (!s. s IN sts ==> u s = v s) /\ (!x. x IN sp ==> 0 <= f x) ==>
+        pos_fn_integral (sp,sts,u) f = pos_fn_integral (sp,sts,v) f
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC pos_fn_integral_cong_measure_old >> art []
+ >> MATCH_MP_TAC measure_space_eq
+ >> Q.EXISTS_TAC ‘(sp,sts,u)’ >> simp []
+QED
+
+Theorem pos_fn_integral_cong_measure_old'[local] :
     !m1 m2 f. measure_space m1 /\ measure_space m2 /\ measure_space_eq m1 m2 /\
              (!x. x IN m_space m1 ==> 0 <= f x) ==>
-             (pos_fn_integral m1 f = pos_fn_integral m2 f)
+              pos_fn_integral m1 f = pos_fn_integral m2 f
 Proof
     RW_TAC std_ss [measure_space_eq_def]
  >> MP_TAC (Q.SPECL [‘m_space m1’, ‘measurable_sets m1’, ‘measure m1’,
                      ‘measure m2’, ‘f’] pos_fn_integral_cong_measure)
  >> rw []
+QED
+
+Theorem pos_fn_integral_cong_measure' :
+    !m1 m2 f. measure_space m1 /\ measure_space_eq m1 m2 /\
+             (!x. x IN m_space m1 ==> 0 <= f x) ==>
+              pos_fn_integral m1 f = pos_fn_integral m2 f
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC pos_fn_integral_cong_measure_old' >> art []
+ >> MATCH_MP_TAC measure_space_eq
+ >> Q.EXISTS_TAC ‘m1’
+ >> fs [measure_space_eq_def]
 QED
 
 Theorem pos_fn_integral_distr_of :
@@ -1273,7 +1301,7 @@ Proof
  >> rw [FN_PLUS_POS, FN_MINUS_POS]
 QED
 
-Theorem integral_cong_measure :
+Theorem integral_cong_measure_old[local] :
     !sp sts u v f.
         measure_space (sp,sts,u) /\ measure_space (sp,sts,v) /\
        (!s. s IN sts ==> (u s = v s)) ==>
@@ -1282,17 +1310,38 @@ Proof
     PROVE_TAC [integral_cong_measure_base]
 QED
 
-Theorem integral_cong_measure' :
+Theorem integral_cong_measure :
+    !sp sts u v f.
+        measure_space (sp,sts,u) /\ (!s. s IN sts ==> u s = v s) ==>
+        integral (sp,sts,u) f = integral (sp,sts,v) f
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC integral_cong_measure_old >> art []
+ >> MATCH_MP_TAC measure_space_eq
+ >> Q.EXISTS_TAC ‘(sp,sts,u)’ >> simp []
+QED
+
+Theorem integral_cong_measure_old'[local] :
     !m1 m2 f. measure_space m1 /\ measure_space m2 /\ measure_space_eq m1 m2 ==>
              (integral m1 f = integral m2 f)
 Proof
     RW_TAC std_ss [measure_space_eq_def]
  >> MP_TAC (Q.SPECL [‘m_space m1’, ‘measurable_sets m1’, ‘measure m1’,
-                     ‘measure m2’, ‘f’] integral_cong_measure)
- >> rw []
+                     ‘measure m2’, ‘f’] integral_cong_measure) >> rw []
 QED
 
-Theorem integrable_cong_measure :
+Theorem integral_cong_measure' :
+    !m1 m2 f. measure_space m1 /\ measure_space_eq m1 m2 ==>
+              integral m1 f = integral m2 f
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC integral_cong_measure_old' >> art []
+ >> MATCH_MP_TAC measure_space_eq
+ >> Q.EXISTS_TAC ‘m1’
+ >> fs [measure_space_eq_def]
+QED
+
+Theorem integrable_cong_measure_old[local] :
     !sp sts u v f.
         measure_space (sp,sts,u) /\ measure_space (sp,sts,v) /\
        (!s. s IN sts ==> (u s = v s)) ==>
@@ -1301,15 +1350,35 @@ Proof
     PROVE_TAC [integral_cong_measure_base]
 QED
 
-(* NOTE: changed to use ‘measure_space_eq m1 m2’ *)
-Theorem integrable_cong_measure' :
+Theorem integrable_cong_measure :
+    !sp sts u v f.
+        measure_space (sp,sts,u) /\ (!s. s IN sts ==> (u s = v s)) ==>
+       (integrable (sp,sts,u) f <=> integrable (sp,sts,v) f)
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC integrable_cong_measure_old >> art []
+ >> MATCH_MP_TAC measure_space_eq
+ >> Q.EXISTS_TAC ‘(sp,sts,u)’ >> simp []
+QED
+
+Theorem integrable_cong_measure_old'[local] :
     !m1 m2 f. measure_space m1 /\ measure_space m2 /\ measure_space_eq m1 m2 ==>
              (integrable m1 f <=> integrable m2 f)
 Proof
     RW_TAC std_ss [measure_space_eq_def]
  >> MP_TAC (Q.SPECL [‘m_space m1’, ‘measurable_sets m1’, ‘measure m1’,
-                     ‘measure m2’, ‘f’] integrable_cong_measure)
- >> rw []
+                     ‘measure m2’, ‘f’] integrable_cong_measure) >> rw []
+QED
+
+Theorem integrable_cong_measure' :
+    !m1 m2 f. measure_space m1 /\ measure_space_eq m1 m2 ==>
+             (integrable m1 f <=> integrable m2 f)
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC integrable_cong_measure_old' >> art []
+ >> MATCH_MP_TAC measure_space_eq
+ >> Q.EXISTS_TAC ‘m1’
+ >> fs [measure_space_eq_def]
 QED
 
 (* ------------------------------------------------------------------------- *)
@@ -1710,7 +1779,7 @@ Theorem sigma_algebra_general_sigma :
 Proof
     RW_TAC std_ss [general_sigma_def]
  >> MATCH_MP_TAC SIGMA_ALGEBRA_SIGMA
- >> RW_TAC std_ss [subset_class_def, IN_general_prod, GSPECIFICATION, IN_general_cross]
+ >> rw [subset_class_def, IN_general_prod, GSPECIFICATION, IN_general_cross]
  >> fs [subset_class_def]
  >> RW_TAC std_ss [SUBSET_DEF, IN_general_cross]
  >> qexistsl_tac [‘a'’, ‘b'’] >> art []

--- a/src/probability/measureScript.sml
+++ b/src/probability/measureScript.sml
@@ -116,9 +116,17 @@ val increasing_def = Define
      s IN measurable_sets m /\ t IN measurable_sets m /\ s SUBSET t ==>
      measure m s <= measure m t`;
 
-val measure_space_def = Define
-   `measure_space m <=>
-      sigma_algebra (m_space m, measurable_sets m) /\ positive m /\ countably_additive m`;
+Definition measure_space_def :
+    measure_space m <=>
+    sigma_algebra (m_space m, measurable_sets m) /\
+    positive m /\ countably_additive m
+End
+
+Theorem MEASURE_SPACE_COUNTABLY_ADDITIVE :
+    !m. measure_space m ==> countably_additive m
+Proof
+    PROVE_TAC [measure_space_def]
+QED
 
 (* ‘measurable_space m’ is the sigma_algebra of ‘measure_space m’ *)
 Overload measurable_space = “\m. (m_space m, measurable_sets m)”

--- a/src/probability/sigma_algebraScript.sml
+++ b/src/probability/sigma_algebraScript.sml
@@ -1683,6 +1683,13 @@ val SIGMA_ALGEBRA_ALT = store_thm
    >> Q.PAT_X_ASSUM `BIJ i j k` MP_TAC
    >> RW_TAC std_ss [BIJ_DEF, SURJ_DEF, IN_UNIV]);
 
+Theorem SIGMA_ALGEBRA_BIGUNION :
+    !a f. sigma_algebra a /\ (!n. f n IN subsets a) ==>
+          BIGUNION (IMAGE f univ(:num)) IN subsets a
+Proof
+    rw [SIGMA_ALGEBRA_ALT, IN_FUNSET]
+QED
+
 val SIGMA_ALGEBRA_ALT_MONO = store_thm
   ("SIGMA_ALGEBRA_ALT_MONO",
    ``!a.
@@ -2480,7 +2487,7 @@ Proof
          MATCH_MP_TAC disjointI \\
          NTAC 2 GEN_TAC >> SIMP_TAC std_ss [IN_IMAGE, IN_COUNT] \\
          rpt STRIP_TAC \\
-         rename [‘a ≠ b’, ‘a = f i ∩ f' i1’, ‘b = f i ∩ f' i2’] \\
+         rename [‘a <> b’, ‘a = f i INTER f' i1’, ‘b = f i INTER f' i2’] \\
          Cases_on `i1 = i2` >- (`a = b` by METIS_TAC []) \\
          ASM_REWRITE_TAC [DISJOINT_ALT] \\
          RW_TAC std_ss [IN_INTER] \\
@@ -2493,7 +2500,7 @@ Proof
          METIS_TAC []) \\
      RW_TAC std_ss [SUBSET_DEF, IN_IMAGE, IN_COUNT] \\
   (* f i INTER f' i' IN S *)
-     rename [‘f i ∩ g j ∈ S’] >>
+     rename [‘f i INTER g j IN S’] >>
      Know `(IMAGE f (count n)) SUBSET sts`
      >- (Q.PAT_X_ASSUM `BIGUNION (IMAGE f (count n)) IN S` MP_TAC \\
          Q.UNABBREV_TAC `S` >> SIMP_TAC std_ss [GSPECIFICATION] >> METIS_TAC []) \\
@@ -5851,6 +5858,15 @@ Proof
  >> Q.X_GEN_TAC ‘n’
  >> FIRST_X_ASSUM MATCH_MP_TAC
  >> Q.EXISTS_TAC ‘n’ >> art []
+QED
+
+Theorem SIGMA_ALGEBRA_BIGINTER :
+    !a f. sigma_algebra a /\ (!n. f n IN subsets a) ==>
+          BIGINTER (IMAGE f univ(:num)) IN subsets a
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC SIGMA_ALGEBRA_COUNTABLE_INTER
+ >> rw [image_countable, SUBSET_DEF] >> art []
 QED
 
 (* NOTE: The following overloads as variants of “countable” and “FINITE” are

--- a/src/real/extreal_baseScript.sml
+++ b/src/real/extreal_baseScript.sml
@@ -3661,6 +3661,13 @@ Proof
     simp [real_set_def]
 QED
 
+Theorem real_set_infty[simp] :
+    real_set {PosInf} = {} /\ real_set {NegInf} = {}
+Proof
+    simp [real_set_def]
+ >> rw [Once EXTENSION, NOT_IN_EMPTY]
+QED
+
 Theorem normal_real_set :
     !(s :extreal set). s INTER (IMAGE Normal UNIV) = IMAGE Normal (real_set s)
 Proof


### PR DESCRIPTION
Hi,

Following #1645, this PR adds more alternative definitions of "convergence in distribution" (`converge_in_dist`) for the (future) proof of CLT (central limit theorem):

```
[converge_in_dist_alt_Lipschitz_real] (distributionTheory)
⊢ ∀X Y p.
    prob_space p ∧ (∀n. real_random_variable (X n) p) ∧
    real_random_variable Y p ⇒
    ((X ⟶ Y) (in_distribution p) ⇔
     ∀f. f ∈ BL mr1 ⇒
         ((λn. expectation p (Normal ∘ f ∘ real ∘ X n)) ⟶
          expectation p (Normal ∘ f ∘ real ∘ Y)) sequentially)
```

This theorem is the starting point of further restricting the involved function class (`f`) to from bounded Lipschitz to higher differentiable functions, because the type of `f` is back to `:real -> real`, aligned with calculus. All intermediate definitions and lemmas serve for this proof.

--Chun