### PR TITLE
Speedup SPECL on stdknl using explicit substitutions

### DIFF
--- a/src/1/Drule.sml
+++ b/src/1/Drule.sml
@@ -308,10 +308,24 @@ fun EQT_ELIM th =
  *      |- !x1 ... xn. t[xi]                                                 *
  *    --------------------------    SPECL [t1, ..., tn]                      *
  *          |-  t[ti]                                                        *
+ *                                                                           *
+ * OLD CODE: Slow due to SPEC repeatedly traversing the whole term           *
+ * NOTE: Does not speed up expknl due to it not supporting                   *
+ * explicit substitutions                                                    *
+ *                                                                           *
+ * fun SPECL tml th =                                                        *
+ *    rev_itlist SPEC tml th handle HOL_ERR _ => raise ERR "SPECL" ""        *
  *---------------------------------------------------------------------------*)
 
 fun SPECL tml th =
-   rev_itlist SPEC tml th handle HOL_ERR _ => raise ERR "SPECL" ""
+   let
+   fun loop [] tm = tm
+     | loop [x] tm = SPEC x tm
+     | loop (x::xs) tm = loop xs (Specialize x tm)
+   in
+     loop tml th
+     handle HOL_ERR _ => raise ERR "SPECL" ""
+   end
 
 (*---------------------------------------------------------------------------*
  * SELECT introduction                                                       *


### PR DESCRIPTION
Note that SPEC will get rid of every internal closures so this code ensure resulting term is the same. 

I would ideally want to do https://github.com/HOL-Theorem-Prover/HOL/issues/1643 but I don't have enough time to think whether I'm doing it correctly.