### PR TITLE
More theorems of Higher Order Derivatives and Differentiability

### DIFF
--- a/src/real/analysis/limScript.sml
+++ b/src/real/analysis/limScript.sml
@@ -2677,3 +2677,64 @@ Proof
  >> qexists ‘n'’ >> rw [Abbr ‘g’]
  >> MATCH_MP_TAC higher_differentiable_imp_n1 >> simp []
 QED
+
+Theorem higher_differentiable_0 :
+    ∀n x. higher_differentiable n (λx. 0) x
+Proof
+    Induct_on ‘n’ >- (gs [higher_differentiable_def])
+ >> rw [higher_differentiable_def, FORALL_AND_THM]
+ >> qexists ‘0’ >> rw []
+ >> Induct_on ‘n’ >- (gs [higher_differentiable_def, DIFF_CONST])
+ >> rw [GSYM diffn_SUC, diffn_const]
+ >> ‘∀x. higher_differentiable n (λx. 0) x’
+   by (rw [] >> MATCH_MP_TAC higher_differentiable_mono >> qexists ‘SUC n’ >> gs [])
+ >> gs [higher_differentiable_def]
+QED
+
+Theorem diffn_const_0 :
+    ∀n x. (diffn n (λx. 0) diffl 0) x
+Proof
+    Induct_on ‘n’ >> rw [DIFF_CONST]
+ >> MATCH_MP_TAC diffn_imp_diffl
+ >> MP_TAC (Q.SPECL [‘SUC (SUC n)’] higher_differentiable_0) >> rw []
+ >> MP_TAC (Q.SPECL [‘SUC n’] higher_differentiable_0) >> rw []
+ >> MP_TAC (Q.SPECL [‘n’, ‘λx. 0’] diffl_imp_diffn) >> rw []
+ >> rw [diffn_def] >> SELECT_ELIM_TAC
+ >> CONJ_TAC >- (fs [higher_differentiable_def])
+ >> ‘diffn (SUC n) (λx. 0) = λx. 0’ by METIS_TAC [FUN_EQ_THM, ETA_AX]
+ >> POP_ORW >> rw []
+ >> MP_TAC (Q.SPECL [‘0’, ‘x’] DIFF_CONST) >> rw []
+ >> METIS_TAC [DIFF_UNIQ]
+QED
+
+Theorem higher_differentiable_const :
+    ∀n k x. higher_differentiable n (λx. k) x
+Proof
+    Induct_on ‘n’ >- (gs [higher_differentiable_def])
+ >> rw [higher_differentiable_def, FORALL_AND_THM]
+ >> qexists ‘0’ >> rw []
+ >> Induct_on ‘n’ >- (gs [higher_differentiable_def, DIFF_CONST])
+ >> rw [GSYM diffn_SUC, diffn_const]
+ >> METIS_TAC [diffn_const_0]
+QED
+
+Theorem higher_differentiable_neg_sub :
+    ∀n f a.
+      (∀x. higher_differentiable n f x) ⇒
+      ∀x. higher_differentiable n (λx. f (a − x)) x
+Proof
+    Induct_on ‘n’ >- (gs [higher_differentiable_def])
+ >> rw [FORALL_AND_THM]
+ >> MATCH_MP_TAC higher_differentiable_chain
+ >> rw [higher_differentiable_def]
+ >- (Cases_on ‘n = 0’ >> gs []
+     >- (qexists ‘-1’ >> rw [diffl] \\
+         ‘∀h. a − (x + h) − (a − x) = -h’ by REAL_ARITH_TAC >> POP_ORW \\
+         MP_TAC (Q.SPECL [‘λh. -h / h’, ‘λx. -1’, ‘-1’, ‘0’] LIM_EQUAL) \\
+         rw [] >> METIS_TAC [LIM_CONST]) \\
+     MP_TAC (Q.SPECL [‘a’, ‘SUC n’] higher_differentiable_sub_linear) >> rw [] \\
+     fs [higher_differentiable_def, FORALL_AND_THM] \\
+     Q.PAT_X_ASSUM ‘∀x. ∃y. (diffn n (λx. a − x) diffl y) x’ (STRIP_ASSUME_TAC o Q.SPEC ‘x’) \\
+     qexists ‘y’ >> METIS_TAC [])
+ >> METIS_TAC [higher_differentiable_sub_linear]
+QED

--- a/src/real/analysis/limScript.sml
+++ b/src/real/analysis/limScript.sml
@@ -2679,20 +2679,20 @@ Proof
 QED
 
 Theorem higher_differentiable_0 :
-    ∀n x. higher_differentiable n (λx. 0) x
+    !n x. higher_differentiable n (λx. 0) x
 Proof
     Induct_on ‘n’ >- (gs [higher_differentiable_def])
  >> rw [higher_differentiable_def, FORALL_AND_THM]
  >> qexists ‘0’ >> rw []
  >> Induct_on ‘n’ >- (gs [higher_differentiable_def, DIFF_CONST])
  >> rw [GSYM diffn_SUC, diffn_const]
- >> ‘∀x. higher_differentiable n (λx. 0) x’
+ >> ‘!x. higher_differentiable n (λx. 0) x’
    by (rw [] >> MATCH_MP_TAC higher_differentiable_mono >> qexists ‘SUC n’ >> gs [])
  >> gs [higher_differentiable_def]
 QED
 
 Theorem diffn_const_0 :
-    ∀n x. (diffn n (λx. 0) diffl 0) x
+    !n x. (diffn n (λx. 0) diffl 0) x
 Proof
     Induct_on ‘n’ >> rw [DIFF_CONST]
  >> MATCH_MP_TAC diffn_imp_diffl
@@ -2708,7 +2708,7 @@ Proof
 QED
 
 Theorem higher_differentiable_const :
-    ∀n k x. higher_differentiable n (λx. k) x
+    !n k x. higher_differentiable n (λx. k) x
 Proof
     Induct_on ‘n’ >- (gs [higher_differentiable_def])
  >> rw [higher_differentiable_def, FORALL_AND_THM]
@@ -2719,9 +2719,9 @@ Proof
 QED
 
 Theorem higher_differentiable_neg_sub :
-    ∀n f a.
-      (∀x. higher_differentiable n f x) ⇒
-      ∀x. higher_differentiable n (λx. f (a − x)) x
+    !n f a.
+      (!x. higher_differentiable n f x) ==>
+      !x. higher_differentiable n (λx. f (a - x)) x
 Proof
     Induct_on ‘n’ >- (gs [higher_differentiable_def])
  >> rw [FORALL_AND_THM]
@@ -2729,12 +2729,12 @@ Proof
  >> rw [higher_differentiable_def]
  >- (Cases_on ‘n = 0’ >> gs []
      >- (qexists ‘-1’ >> rw [diffl] \\
-         ‘∀h. a − (x + h) − (a − x) = -h’ by REAL_ARITH_TAC >> POP_ORW \\
+         ‘!h. a - (x + h) - (a - x) = -h’ by REAL_ARITH_TAC >> POP_ORW \\
          MP_TAC (Q.SPECL [‘λh. -h / h’, ‘λx. -1’, ‘-1’, ‘0’] LIM_EQUAL) \\
          rw [] >> METIS_TAC [LIM_CONST]) \\
      MP_TAC (Q.SPECL [‘a’, ‘SUC n’] higher_differentiable_sub_linear) >> rw [] \\
      fs [higher_differentiable_def, FORALL_AND_THM] \\
-     Q.PAT_X_ASSUM ‘∀x. ∃y. (diffn n (λx. a − x) diffl y) x’ (STRIP_ASSUME_TAC o Q.SPEC ‘x’) \\
+     Q.PAT_X_ASSUM ‘!x. ?y. (diffn n (λx. a - x) diffl y) x’ (STRIP_ASSUME_TAC o Q.SPEC ‘x’) \\
      qexists ‘y’ >> METIS_TAC [])
  >> METIS_TAC [higher_differentiable_sub_linear]
 QED

--- a/src/real/realScript.sml
+++ b/src/real/realScript.sml
@@ -5314,9 +5314,9 @@ Proof
 QED
 
 Theorem POW_2_LT_1:
-    ∀x. -1 < x ∧ x < 1 ⇒ x² < 1
+    !x. -1 < x /\ x < 1 ==> x² < 1
 Proof
-    rw[] >> wlog_tac ‘0 ≤ x’ [‘x’]
+    rw[] >> wlog_tac ‘0 <= x’ [‘x’]
     >- (first_x_assum $ qspec_then ‘-x’ mp_tac >> simp[] >>
         disch_then irule >> irule_at Any $ iffLR REAL_LT_NEG >>
         simp[REAL_NEG_NEG,Excl "REAL_LT_NEG"] >>
@@ -5325,9 +5325,9 @@ Proof
 QED
 
 Theorem POW_2_1_LT:
-    ∀x. x < -1 ∨ 1 < x ⇒ 1 < x²
+    !x. x < -1 \/ 1 < x ==> 1 < x²
 Proof
-    strip_tac >> wlog_tac ‘0 ≤ x’ [‘x’]
+    strip_tac >> wlog_tac ‘0 <= x’ [‘x’]
     >- (first_x_assum $ qspec_then ‘-x’ mp_tac >>
         gs[REAL_NOT_LE,REAL_LE_LT] >> rw[] >> first_x_assum irule >> simp[] >>
         disj2_tac >> irule_at Any $ iffLR REAL_LT_NEG >>
@@ -5337,42 +5337,42 @@ Proof
 QED
 
 Theorem SQRT_POW_2_ABS:
-    ∀x. sqrt x² = abs x
+    !x. sqrt x² = abs x
 Proof
-    rw[] >> Cases_on ‘0 ≤ x’ >- simp[POW_2_SQRT] >> simp[abs] >>
-    ‘0 ≤ -x’ by gs[REAL_NOT_LE,REAL_LE_LT] >>
+    rw[] >> Cases_on ‘0 <= x’ >- simp[POW_2_SQRT] >> simp[abs] >>
+    ‘0 <= -x’ by gs[REAL_NOT_LE,REAL_LE_LT] >>
     dxrule_then (SUBST1_TAC o SYM) POW_2_SQRT >> simp[]
 QED
 
 Theorem SQUARE_ROOTS:
-    ∀x y. x² = y ⇒ x = sqrt y ∨ x = -sqrt y
+    !x y. x² = y ==> x = sqrt y \/ x = -sqrt y
 Proof
-    rw[] >> Cases_on ‘0 ≤ x’ >- simp[POW_2_SQRT] >> disj2_tac >>
+    rw[] >> Cases_on ‘0 <= x’ >- simp[POW_2_SQRT] >> disj2_tac >>
     qspec_then ‘-x’ mp_tac $ GENL [“x:real”] POW_2_SQRT >>
-    ‘0 ≤ -x’ by gs[REAL_NOT_LE,REAL_LE_LT] >> simp[]
+    ‘0 <= -x’ by gs[REAL_NOT_LE,REAL_LE_LT] >> simp[]
 QED
 
 Theorem REAL_EQ_RDIV_EQ':
-    ∀x y z. z ≠ 0 ⇒ (x = y / z ⇔ x * z = y)
+    !x y z. z <> 0 ==> (x = y / z <=> x * z = y)
 Proof
     rw[real_div] >> eq_tac >> rw[] >>
     simp[GSYM REAL_MUL_ASSOC,REAL_MUL_RINV,REAL_MUL_LINV]
 QED
 
 Theorem QUADRATIC_FORMULA:
-    ∀a b c x. a ≠ 0 ⇒ a * x² + b * x + c = 0 ⇒
-        x = (-b + sqrt(b² - 4 * a * c)) / (2 * a) ∨
+    !a b c x. a <> 0 ==> a * x² + b * x + c = 0 ==>
+        x = (-b + sqrt(b² - 4 * a * c)) / (2 * a) \/
         x = (-b - sqrt(b² - 4 * a * c)) / (2 * a)
 Proof
     rw[real_sub,REAL_EQ_RDIV_EQ'] >>
-    ‘∀x y. x = -b + y ⇔ x + b = y’ by
+    ‘!x y. x = -b + y <=> x + b = y’ by
         simp[Once REAL_ADD_COMM,GSYM real_sub,REAL_EQ_SUB_LADD] >>
     simp[] >> pop_assum kall_tac >> simp[GSYM real_sub] >>
     irule SQUARE_ROOTS >> simp[ADD_POW_2,POW_MUL,REAL_EQ_SUB_LADD] >>
     (* I'm sure there is a better way to do this, I don't know it *)
     pop_assum $ mp_tac o AP_TERM “λy. 4r * a * y + b²” >>
     simp[REAL_ADD_LDISTRIB,REAL_POW_2] >>
-    qmatch_abbrev_tac ‘l1:real = r ⇒ l2 = r’ >> ‘l1 = l2’ suffices_by simp[] >>
+    qmatch_abbrev_tac ‘l1:real = r ==> l2 = r’ >> ‘l1 = l2’ suffices_by simp[] >>
     UNABBREV_ALL_TAC >> ‘2r * 2 = 4’ by simp[] >> simp[REAL_MUL_ASSOC] >>
     ‘2 * x * 2 * a * b = (2 * 2) * a * b * x’ by metis_tac[REAL_MUL_COMM,REAL_MUL_ASSOC] >>
     ntac 2 $ pop_assum SUBST1_TAC >>

--- a/src/real/realScript.sml
+++ b/src/real/realScript.sml
@@ -914,6 +914,12 @@ val REAL_ADD_SUB2 = store_thm("REAL_ADD_SUB2",
   “!x y. x - (x + y) = ~y”,
   REAL_ARITH_TAC);
 
+Theorem REAL_ADDL_LE[simp]:
+    !x y. (x :real) + y <= y <=> x <= 0
+Proof
+    REAL_ARITH_TAC
+QED
+
 val REAL_MEAN = store_thm("REAL_MEAN",
   “!x y. x < y ==> ?z. x < z /\ z < y”,
   REPEAT GEN_TAC THEN


### PR DESCRIPTION
Hi,

This extends PR [#1646](https://github.com/HOL-Theorem-Prover/HOL/pull/1646). 
In `limTheory` I add the zero/constant higher-derivative facts and a small reflection lemma for `x |-> f (a - x)` . 

```
[higher_differentiable_neg_sub]  Theorem
∀n f a.
      (∀x. higher_differentiable n f x) ⇒
      ∀x. higher_differentiable n (λx. f (a − x)) x
```

In `transTheory` I complete the symmetric side of Taylor: 
- the case `x < a` (`TAYLOR_THEOREM_NEG`), 
- its **SIGMA form** (`TAYLOR_THEOREM_NEG'`), 
- and a general version that covers both sides (`TAYLOR_THEOREM_ALL_LT`). 

All Taylor results are derived from the existing `MCLAURIN_NEG` / `MCLAURIN_ALL_LT`.

--Kai