### PR TITLE
Rename theory while to while_

### DIFF
--- a/Manual/Description/theories.stex
+++ b/Manual/Description/theories.stex
@@ -5005,11 +5005,11 @@ It is a curious fact that higher order logic, although a logic of
 total functions, allows the definition of functions that don't
 seem total, at least from a computational perspective. An example
 is \holtxt{WHILE}-loops. The following equation is derived in theory
-\theoryimp{while}:
+\theoryimp{while\_}:
 %
 \begin{hol}
 \begin{alltt}
->>__ open whileTheory
+>>__ open while_Theory
 ##thm WHILE
 \end{alltt}
 \end{hol}
@@ -5104,7 +5104,7 @@ If one wants a specified result even when the predicate is everywhere false, the
 \end{alltt}
 \end{hol}
 
-More theorems for reasoning about \holtxt{LEAST}, \holtxt{OLEAST} and \holtxt{WHILE} may be found in theory \theoryimp{while}.
+More theorems for reasoning about \holtxt{LEAST}, \holtxt{OLEAST} and \holtxt{WHILE} may be found in theory \theoryimp{while\_}.
 
 
 %\section{Partial orders}

--- a/doc/next-release.md
+++ b/doc/next-release.md
@@ -42,6 +42,7 @@ Incompatibilities
 
 -   `Preterm.eq` has been replaced with `Preterm.veq` which returns `true` if and only if the two arguments are variables with the same names and types.
 
+-   `whileTheory` has been renamed to `while_Theory`
 * * * * *
 
 <div class="footer">

--- a/examples/AKS/compute/computeBasicScript.sml
+++ b/examples/AKS/compute/computeBasicScript.sml
@@ -7,14 +7,14 @@
 Theory computeBasic
 Ancestors
   pred_set list arithmetic logroot divides gcd gcdset number
-  combinatorics prime while
+  combinatorics prime while_
 Libs
   jcLib
 
 (* ------------------------------------------------------------------------- *)
 
 (* val _ = load "jcLib"; *)
-(* val _ = load "whileTheory"; *)
+(* val _ = load "while_Theory"; *)
 val _ = temp_overload_on("SQ", ``\n. n * n``);
 val _ = temp_overload_on("HALF", ``\n. n DIV 2``);
 val _ = temp_overload_on("TWICE", ``\n. 2 * n``);

--- a/examples/AKS/compute/computePolyScript.sml
+++ b/examples/AKS/compute/computePolyScript.sml
@@ -8,7 +8,7 @@
 Theory computePoly
 Ancestors
   pred_set list rich_list arithmetic number combinatorics divides
-  gcd logroot while ring polynomial polyWeak polyRing polyField
+  gcd logroot while_ ring polynomial polyWeak polyRing polyField
   polyMonic polyEval polyDivision polyFieldDivision
   polyFieldModulo polyBinomial computeBasic computeOrder
 Libs

--- a/examples/Crypto/Keccak/keccakScript.sml
+++ b/examples/Crypto/Keccak/keccakScript.sml
@@ -1,6 +1,6 @@
 Theory keccak
 Ancestors
-  option pair arithmetic combin list rich_list while bit divides
+  option pair arithmetic combin list rich_list while_ bit divides
   words indexedLists numposrep numeral_bit bitstring logroot byte
   sptree cv cv_std
 Libs
@@ -3950,7 +3950,7 @@ Triviality while1_thm:
     while1 a tt ww x y w z a'
 Proof
   ho_match_mp_tac while1_ind \\ rw []
-  \\ simp [Once whileTheory.WHILE]
+  \\ simp [Once while_Theory.WHILE]
   \\ simp [Once while1_def]
   \\ IF_CASES_TAC \\ gvs []
 QED
@@ -3979,7 +3979,7 @@ Theorem while2_thm:
     while2 a w ww x y t a'
 Proof
   ho_match_mp_tac while2_ind \\ rw []
-  \\ simp [Once whileTheory.WHILE]
+  \\ simp [Once while_Theory.WHILE]
   \\ simp [Once while2_def]
   \\ IF_CASES_TAC \\ gvs []
 QED

--- a/examples/PSL/1.01/executable-semantics/ExecuteSemanticsScript.sml
+++ b/examples/PSL/1.01/executable-semantics/ExecuteSemanticsScript.sml
@@ -22,7 +22,7 @@ app load ["bossLib","metisLib","intLib","res_quanTools","pred_setLib",
 
 Theory ExecuteSemantics
 Ancestors
-  list rich_list arithmetic while regexp matcher FinitePSLPath
+  list rich_list arithmetic while_ regexp matcher FinitePSLPath
   PSLPath Syntax SyntacticSugar UnclockedSemantics
   ClockedSemantics Properties
 Libs

--- a/examples/PSL/1.1/official-semantics/ProjectionScript.sml
+++ b/examples/PSL/1.1/official-semantics/ProjectionScript.sml
@@ -22,14 +22,14 @@ loadPath
  "../official-semantics" :: "../../regexp" :: "../../path" :: !loadPath;
 map load
  ["UnclockedSemanticsTheory",
-  "SyntacticSugarTheory", "ClockedSemanticsTheory", "RewritesTheory", "whileTheory",
+  "SyntacticSugarTheory", "ClockedSemanticsTheory", "RewritesTheory", "while_Theory",
   "rich_listTheory", "intLib", "res_quanLib", "res_quanTheory",
   "LemmasTheory","RewritesPropertiesTheory"];
 open FinitePSLPathTheory PSLPathTheory SyntaxTheory SyntacticSugarTheory
      UnclockedSemanticsTheory ClockedSemanticsTheory RewritesTheory
-     arithmeticTheory whileTheory listTheory rich_listTheory
+     arithmeticTheory while_Theory listTheory rich_listTheory
      res_quanLib res_quanTheory
-     arithmeticTheory listTheory whileTheory rich_listTheory res_quanLib res_quanTheory
+     arithmeticTheory listTheory while_Theory rich_listTheory res_quanLib res_quanTheory
      ClockedSemanticsTheory LemmasTheory RewritesPropertiesTheory;
 quietdec := false;
 *)
@@ -39,8 +39,8 @@ Theory Projection
 Ancestors
   FinitePSLPath PSLPath Syntax SyntacticSugar UnclockedSemantics
   ClockedSemantics Rewrites arithmetic list rich_list res_quan
-  while ClockedSemantics Lemmas RewritesProperties arithmetic
-  list while rich_list res_quan ClockedSemantics Lemmas
+  while_ ClockedSemantics Lemmas RewritesProperties arithmetic
+  list while_ rich_list res_quan ClockedSemantics Lemmas
   RewritesProperties FinitePSLPath PSLPath
 Libs
   res_quanLib res_quanLib

--- a/examples/acl2/examples/fmapExample.sml
+++ b/examples/acl2/examples/fmapExample.sml
@@ -8,11 +8,11 @@ set_trace "Unicode" 0;
 set_trace "pp_annotations" 0;
 
 app load ["acl2encodeLib", "stringLib", "finite_mapTheory", "intLib",
-          "pred_setTheory","whileTheory","optionTheory","unwindLib", "finite_mapTheory"];
+          "pred_setTheory","while_Theory","optionTheory","unwindLib", "finite_mapTheory"];
 open HolKernel Parse boolLib bossLib
      stringLib IndDefLib IndDefRules finite_mapTheory relationTheory
      arithmeticTheory prim_recTheory
-     pred_setTheory whileTheory combinTheory optionTheory unwindLib;
+     pred_setTheory while_Theory combinTheory optionTheory unwindLib;
 intLib.deprecate_int();
 clear_overloads_on "TC"; (* Stop TC R printing as TC^+ *)
 
@@ -3158,7 +3158,7 @@ val SOME_ITER_NONE =
                 [BETA_RULE
                   (ISPEC
                     ``\n:num. IS_SOME(SOME_FUNPOW g n x) /\ P(THE(SOME_FUNPOW g n x))``
-                       whileTheory.LEAST_EXISTS_IMP),option_CLAUSES],
+                       while_Theory.LEAST_EXISTS_IMP),option_CLAUSES],
          RW_TAC (srw_ss()) []
           THEN METIS_TAC [option_CLAUSES]],
       METIS_TAC[option_CLAUSES]]);
@@ -3180,7 +3180,7 @@ val SOME_ITER_SOME1 =
           [BETA_RULE
             (ISPEC
               ``\n:num. IS_SOME(SOME_FUNPOW g n x) /\ P(THE(SOME_FUNPOW g n x))``
-                 whileTheory.LEAST_EXISTS_IMP),option_CLAUSES]);
+                 while_Theory.LEAST_EXISTS_IMP),option_CLAUSES]);
 
 val SOME_ITER_SOME2 =
  prove

--- a/examples/algorithms/unification/triangular/first-order/compilation/tcallUnifScript.sml
+++ b/examples/algorithms/unification/triangular/first-order/compilation/tcallUnifScript.sml
@@ -1,6 +1,6 @@
 Theory tcallUnif
 Ancestors
-  pair walk walkstar unifDef while subst rmfmap cps relation
+  pair walk walkstar unifDef while_ subst rmfmap cps relation
   sptree pred_set finite_map option
 Libs
   cpsLib

--- a/examples/algorithms/unification/triangular/first-order/substScript.sml
+++ b/examples/algorithms/unification/triangular/first-order/substScript.sml
@@ -1,6 +1,6 @@
 Theory subst
 Ancestors
-  pred_set relation finite_map term while prim_rec arithmetic bag
+  pred_set relation finite_map term while_ prim_rec arithmetic bag
   list
 Libs
   ramanaLib

--- a/examples/arm/ARM_security_properties/model/arm_coretypesScript.sml
+++ b/examples/arm/ARM_security_properties/model/arm_coretypesScript.sml
@@ -387,15 +387,15 @@ val word_index = Q.prove(
 val BIT_EXISTS = METIS_PROVE [BIT_LOG2] ``!n. ~(n = 0) ==> ?b. BIT b n``;
 
 val LEAST_BIT_INTRO =
- (SIMP_RULE (srw_ss()) [] o Q.SPEC `\i. BIT i n`)  whileTheory.LEAST_INTRO;
+ (SIMP_RULE (srw_ss()) [] o Q.SPEC `\i. BIT i n`)  while_Theory.LEAST_INTRO;
 
 val LOWEST_SET_BIT_ELIM =
   (SIMP_RULE (srw_ss()) [AND_IMP_INTRO] o
    SIMP_RULE (srw_ss()) [BIT_EXISTS] o Q.DISCH `~(n = 0)` o
-   Q.SPECL [`\x. x < dimindex (:'a)`,`\i. BIT i n`]) whileTheory.LEAST_ELIM;
+   Q.SPECL [`\x. x < dimindex (:'a)`,`\i. BIT i n`]) while_Theory.LEAST_ELIM;
 
 val LOWEST_SET_BIT_LESS_LEAST =
-  (SIMP_RULE (srw_ss()) [] o Q.SPEC `\i. BIT i n`) whileTheory.LESS_LEAST;
+  (SIMP_RULE (srw_ss()) [] o Q.SPEC `\i. BIT i n`) while_Theory.LESS_LEAST;
 
 val LOWEST_SET_BIT_LT_DIMINDEX = Q.prove(
   `!n. ~(n = 0) /\ n < dimword(:'a) ==> (LEAST i. BIT i n) < dimindex(:'a)`,

--- a/examples/arm/arm6-verification/correctness/blockScript.sml
+++ b/examples/arm/arm6-verification/correctness/blockScript.sml
@@ -13,7 +13,7 @@
 *)
 Theory block
 Ancestors
-  arithmetic while rich_list bit sum_num words io_onestep my_list
+  arithmetic while_ rich_list bit sum_num words io_onestep my_list
   arm core lemmas interrupts
 Libs
   Q wordsLib armLib iclass_compLib

--- a/examples/arm/arm6-verification/correctness/coprocessorScript.sml
+++ b/examples/arm/arm6-verification/correctness/coprocessorScript.sml
@@ -55,7 +55,7 @@ val BUSY_WAIT_LEM = prove(
                       (cpsri \/ PROJ_NIRQ (i (t - 2))))`,
   NTAC 2 STRIP_TAC
     \\ REWRITE_TAC [BUSY_WAIT_def,BUSY_WAIT_DONE_def,CP_INTERRUPT_def]
-    \\ STRIP_TAC \\ IMP_RES_TAC whileTheory.LESS_LEAST \\ POP_ASSUM MP_TAC
+    \\ STRIP_TAC \\ IMP_RES_TAC while_Theory.LESS_LEAST \\ POP_ASSUM MP_TAC
     \\ PAT_X_ASSUM `~IS_RESET i t` MP_TAC
     \\ SIMP_TAC std_ss [IS_RESET_def,IS_BUSY_def,IS_ABSENT_def,IS_ABORT_def,
          IS_IRQ_def,IS_FIQ_def]
@@ -145,7 +145,7 @@ val EXISTS_BUSY_WAIT = prove(
     \\ METIS_TAC []);
 
 val LEAST_BETA = prove(`!n P. (LEAST n. P n) = $LEAST P`,
-  METIS_TAC [whileTheory.LEAST_DEF]);
+  METIS_TAC [while_Theory.LEAST_DEF]);
 
 val EXISTS_BUSY_WAIT_IMP_BUSY_WAIT_DONE = save_thm
   ("EXISTS_BUSY_WAIT_IMP_BUSY_WAIT_DONE",
@@ -153,7 +153,7 @@ val EXISTS_BUSY_WAIT_IMP_BUSY_WAIT_DONE = save_thm
       (GSYM o SPECL [`n`,`BUSY_WAIT_DONE x i`]) LEAST_BETA] o
     DISCH `i IN STRM_ARM6` o DISCH `Abbrev (t = $LEAST (BUSY_WAIT_DONE x i))` o
     SIMP_RULE std_ss [DECIDE ``a /\ b ==> b``] o
-    SPECL [`BUSY_WAIT_DONE x i`,`BUSY_WAIT_DONE x i`]) whileTheory.LEAST_ELIM);
+    SPECL [`BUSY_WAIT_DONE x i`,`BUSY_WAIT_DONE x i`]) while_Theory.LEAST_ELIM);
 
 val BUSY_WAIT_COR = prove(
   `!i t. i IN STRM_ARM6 /\
@@ -312,7 +312,7 @@ val BUSY_EXISTS_COR =
      DISCH `inp IN STRM_ARM6 /\
        Abbrev (b = BUSY_WAIT (onfq,ooonfq,oniq,oooniq,f,i,pipebabt) inp) /\
        ~IS_BUSY inp b` o
-     SPEC `\n. IS_BUSY (ADVANCE b inp) n`) whileTheory.LEAST_EXISTS
+     SPEC `\n. IS_BUSY (ADVANCE b inp) n`) while_Theory.LEAST_EXISTS
   in
     (GEN_ALL o SIMP_RULE std_ss [IS_BUSY_def,ADVANCE_def])
       (MATCH_MP (METIS_PROVE [] ``(a ==> b) /\ (a ==> (b = c)) ==> (a ==> c)``)

--- a/examples/arm/arm6-verification/correctness/interruptsScript.sml
+++ b/examples/arm/arm6-verification/correctness/interruptsScript.sml
@@ -56,7 +56,7 @@ val LEAST_NOT_RESET = save_thm("LEAST_NOT_RESET",
   GEN_ALL (MATCH_MP (PROVE [] ``((a ==> b) /\ (b ==> c)) ==> (a ==> c)``)
     (CONJ (SPEC_ALL EXISTS_LEAST_NOT_RESET) ((SIMP_RULE std_ss [] o
        SPEC `\t. IS_RESET i t /\ ~IS_RESET i (t + 1) /\ ~IS_RESET i (t + 2)`)
-         whileTheory.LEAST_EXISTS_IMP))));
+         while_Theory.LEAST_EXISTS_IMP))));
 
 val IS_RESET_LEM = prove(
   `!i t. ~IS_RESET i t ==> FST (i t)`,

--- a/examples/arm/arm6-verification/correctness/multScript.sml
+++ b/examples/arm/arm6-verification/correctness/multScript.sml
@@ -12,7 +12,7 @@
 *)
 Theory mult
 Ancestors
-  arithmetic while bit words io_onestep arm core lemmas
+  arithmetic while_ bit words io_onestep arm core lemmas
   interrupts
 Libs
   Q wordsLib iclass_compLib

--- a/examples/arm/arm6-verification/io_onestepScript.sml
+++ b/examples/arm/arm6-verification/io_onestepScript.sml
@@ -111,7 +111,7 @@ val OSMPL_def = Define`
 val LEAST_THM = store_thm("LEAST_THM",
   `!n. (!m. m < n ==> ~P m) /\ P n ==> ($LEAST P = n)`,
   REPEAT STRIP_TAC
-    \\ IMP_RES_TAC whileTheory.FULL_LEAST_INTRO
+    \\ IMP_RES_TAC while_Theory.FULL_LEAST_INTRO
     \\ Cases_on `$LEAST P = n` >- ASM_REWRITE_TAC []
     \\ `$LEAST P < n` by DECIDE_TAC
     \\ PROVE_TAC []);
@@ -191,7 +191,7 @@ val lem2 = prove(
          (SPECL_THEN [`x`,`x + 1`] (ASSUME_TAC o SIMP_RULE arith_ss []))
     \\ IMP_RES_TAC LESS_EQ_LESS_TRANS
     \\ METIS_TAC [(SIMP_RULE std_ss [] o SPECL
-         [`\t. x < imm (t + 1)`,`\t. x < imm (t + 1)`]) whileTheory.LEAST_ELIM]
+         [`\t. x < imm (t + 1)`,`\t. x < imm (t + 1)`]) while_Theory.LEAST_ELIM]
 );
 
 val lem3 = prove(

--- a/examples/arm/v7/arm_coretypesScript.sml
+++ b/examples/arm/v7/arm_coretypesScript.sml
@@ -384,15 +384,15 @@ val word_index = Q.prove(
 val BIT_EXISTS = METIS_PROVE [BIT_LOG2] ``!n. ~(n = 0) ==> ?b. BIT b n``;
 
 val LEAST_BIT_INTRO =
- (SIMP_RULE (srw_ss()) [] o Q.SPEC `\i. BIT i n`)  whileTheory.LEAST_INTRO;
+ (SIMP_RULE (srw_ss()) [] o Q.SPEC `\i. BIT i n`)  while_Theory.LEAST_INTRO;
 
 val LOWEST_SET_BIT_ELIM =
   (SIMP_RULE (srw_ss()) [AND_IMP_INTRO] o
    SIMP_RULE (srw_ss()) [BIT_EXISTS] o Q.DISCH `~(n = 0)` o
-   Q.SPECL [`\x. x < dimindex (:'a)`,`\i. BIT i n`]) whileTheory.LEAST_ELIM;
+   Q.SPECL [`\x. x < dimindex (:'a)`,`\i. BIT i n`]) while_Theory.LEAST_ELIM;
 
 val LOWEST_SET_BIT_LESS_LEAST =
-  (SIMP_RULE (srw_ss()) [] o Q.SPEC `\i. BIT i n`) whileTheory.LESS_LEAST;
+  (SIMP_RULE (srw_ss()) [] o Q.SPEC `\i. BIT i n`) while_Theory.LESS_LEAST;
 
 val LOWEST_SET_BIT_LT_DIMINDEX = Q.prove(
   `!n. ~(n = 0) /\ n < dimword(:'a) ==> (LEAST i. BIT i n) < dimindex(:'a)`,

--- a/examples/computability/kolmog/kolmog_incomputableScript.sml
+++ b/examples/computability/kolmog/kolmog_incomputableScript.sml
@@ -1,6 +1,6 @@
 Theory kolmog_incomputable
 Ancestors
-  arithmetic while logroot pred_set list churchoption churchlist
+  arithmetic while_ logroot pred_set list churchoption churchlist
   recfuns numsAsCompStates kolmogorov_complexity
   invarianceResults boolLists churchDB recursivefns primrecfns
   prterm unary_recfns

--- a/examples/computability/kolmog/kolmog_inequalitiesScript.sml
+++ b/examples/computability/kolmog/kolmog_inequalitiesScript.sml
@@ -1,6 +1,6 @@
 Theory kolmog_inequalities
 Ancestors
-  arithmetic while logroot pred_set list churchoption churchlist
+  arithmetic while_ logroot pred_set list churchoption churchlist
   recfuns numsAsCompStates kolmogorov_complexity
   invarianceResults boolLists churchDB recursivefns primrecfns
   prterm unary_recfns numsAsCompStates pfreefns

--- a/examples/computability/kolmog/pfreefnsScript.sml
+++ b/examples/computability/kolmog/pfreefnsScript.sml
@@ -1,6 +1,6 @@
 Theory pfreefns
 Ancestors
-  arithmetic while logroot pred_set list churchoption churchlist
+  arithmetic while_ logroot pred_set list churchoption churchlist
   recfuns kolmogorov_complexity invarianceResults boolLists
   churchDB recursivefns primrecfns prterm unary_recfns
 Libs

--- a/examples/computability/kolmog/plain_kolmog_inequalitiesScript.sml
+++ b/examples/computability/kolmog/plain_kolmog_inequalitiesScript.sml
@@ -1,6 +1,6 @@
 Theory plain_kolmog_inequalities
 Ancestors
-  arithmetic while logroot pred_set list churchoption churchlist
+  arithmetic while_ logroot pred_set list churchoption churchlist
   recfuns numsAsCompStates kolmogorov_complexity
   invarianceResults boolLists churchDB recursivefns primrecfns
   prterm unary_recfns numsAsCompStates kolmog_incomputable

--- a/examples/computability/lambda/numsAsCompStatesScript.sml
+++ b/examples/computability/lambda/numsAsCompStatesScript.sml
@@ -46,7 +46,7 @@ Theorem correctness_on_termination:
   (Phi i n = SOME (cs_to_num (steps m cs0)))
 Proof
   simp[mk_initial_state_def, terminated_def, comp_count_def, steps_pr_steps] >>
-  DEEP_INTRO_TAC whileTheory.OLEAST_INTRO >> simp[] >>
+  DEEP_INTRO_TAC while_Theory.OLEAST_INTRO >> simp[] >>
   Cases_on ‘steps m cs0’ >> simp[cs_to_num_def, terminated_def] >>
   rw[] >> fs[steps_pr_steps] >>
   REWRITE_TAC [GSYM recPhi_correct, recPhi_def] >>
@@ -97,7 +97,7 @@ Proof
                                            |> SIMP_RULE bool_ss[]) >>
       simp[]) >>
   fs[comp_count_def, mk_initial_state_def, pr_steps_correct] >>
-  pop_assum mp_tac >> DEEP_INTRO_TAC whileTheory.OLEAST_INTRO >>
+  pop_assum mp_tac >> DEEP_INTRO_TAC while_Theory.OLEAST_INTRO >>
   simp[terminated_def] >> fs[recfunsTheory.Phi_def] >>
   simp[cs_to_num_def] >> rw[] >>
   qabbrev_tac ‘M = toTerm (numdB i) @@ church n’ >>
@@ -147,7 +147,7 @@ Theorem terminated_imp:
 Proof
   rw[] >> fs[Phi_steps] >> ‘comp_count (mk_initial_state M x) = SOME t’
     suffices_by fs[] >>
-  fs[comp_count_def] >> fs[whileTheory.OLEAST_EQ_SOME] >> rw[] >> strip_tac >>
+  fs[comp_count_def] >> fs[while_Theory.OLEAST_EQ_SOME] >> rw[] >> strip_tac >>
   rename [‘n < t’] >>
   ‘∃c.0<c ∧ n+c = t’ by (qexists_tac‘t-n’ >> fs[]) >> rw[] >>
   ‘steps (n + c) (mk_initial_state M x) =
@@ -227,7 +227,7 @@ Proof
   rw[] >> `Phi m y = SOME (cs_to_num (steps x (mk_initial_state m y)))` by fs[terminated_imp]>>
   fs[Phi_steps] >> Cases_on`comp_count (mk_initial_state m y)` >> fs[] >>
   `(∀a. a<=x-1 ==> (¬terminated (steps a (mk_initial_state m y))))` by
-    metis_tac[non_terminated_down] >>  fs[comp_count_def,whileTheory.OLEAST_def] >> rw[]>>
+    metis_tac[non_terminated_down] >>  fs[comp_count_def,while_Theory.OLEAST_def] >> rw[]>>
   numLib.LEAST_ELIM_TAC >> rw[] >- metis_tac[] >>
   `(∀a. a<x ==> (¬terminated (steps a (mk_initial_state m y))))` by fs[] >>
   metis_tac[DECIDE``x:num < y ∨ x=y ∨ y<x ``]
@@ -255,7 +255,7 @@ Proof
   rw[] >> Cases_on`t=0`
   >- ( fs[Phi_steps] >> `comp_count (mk_initial_state M x) = SOME t`
       suffices_by fs[] >>
-      fs[comp_count_def] >> fs[whileTheory.OLEAST_EQ_SOME] >> rw[] >> strip_tac  ) >>
+      fs[comp_count_def] >> fs[while_Theory.OLEAST_EQ_SOME] >> rw[] >> strip_tac  ) >>
   `¬terminated (steps (t − 1) (mk_initial_state M x))` by
     (strip_tac >> fs[] >> `t<=t-1` by fs[] >> fs[PRE_SUB1])  >>
   fs[terminated_imp]
@@ -269,7 +269,7 @@ Proof
   rw[] >> Cases_on`t=0`
   >- (`Phi m y = SOME (cs_to_num (steps t (mk_initial_state m y)))` by fs[terminated_imp2]>>
       `comp_count (mk_initial_state m y) = SOME t` suffices_by fs[] >>
-      fs[comp_count_def] >> fs[whileTheory.OLEAST_EQ_SOME] >> rw[] >> strip_tac  ) >>
+      fs[comp_count_def] >> fs[while_Theory.OLEAST_EQ_SOME] >> rw[] >> strip_tac  ) >>
   `¬terminated (steps (t − 1) (mk_initial_state m y))` by
     (strip_tac >> fs[] >> `t<=t-1` by fs[] >> fs[])  >> fs[comp_count_terminated]
 QED

--- a/examples/computability/recdegrees/recdegreesScript.sml
+++ b/examples/computability/recdegrees/recdegreesScript.sml
@@ -1,6 +1,6 @@
 Theory recdegrees
 Ancestors
-  arithmetic while logroot pred_set list recursivefns prnlist
+  arithmetic while_ logroot pred_set list recursivefns prnlist
   primrecfns prterm nlist recfuns recsets churchDB
 Libs
   reductionEval

--- a/examples/computability/register/rmModelScript.sml
+++ b/examples/computability/register/rmModelScript.sml
@@ -1,6 +1,6 @@
 Theory rmModel
 Ancestors
-  arithmetic combin while indexedLists numeral primrecfns list
+  arithmetic combin while_ indexedLists numeral primrecfns list
   bool numpair pred_set
 Libs
   mp_then

--- a/examples/computability/register/rmRecursiveFuncsScript.sml
+++ b/examples/computability/register/rmRecursiveFuncsScript.sml
@@ -1,6 +1,6 @@
 Theory rmRecursiveFuncs
 Ancestors
-  arithmetic combin while indexedLists numeral primrecfns list
+  arithmetic combin while_ indexedLists numeral primrecfns list
   bool numpair pred_set rmModel rmTools rmToPair
 Libs
   mp_then

--- a/examples/computability/register/rmSampleMachinesScript.sml
+++ b/examples/computability/register/rmSampleMachinesScript.sml
@@ -1,6 +1,6 @@
 Theory rmSampleMachines
 Ancestors
-  arithmetic combin while indexedLists numeral primrecfns list
+  arithmetic combin while_ indexedLists numeral primrecfns list
   bool numpair pred_set rmModel rmTools
 Libs
   mp_then
@@ -561,14 +561,14 @@ Theorem exp_loop1_1:
      , SOME 7)
 Proof
   Induct_on `rs 2` >> rw[]
-    >- (rw[Once whileTheory.WHILE, run_machine_1_def, exponential_def] >>
+    >- (rw[Once while_Theory.WHILE, run_machine_1_def, exponential_def] >>
           `rs 2 = 0` by simp[] >> fs[] >> rw[combinTheory.APPLY_UPDATE_THM] >>
           qmatch_abbrev_tac`WHILE _ _ (rs1, _) = WHILE _ _ (rs2, _)` >>
           `rs1 = rs2` suffices_by simp[] >>
           simp[Abbr `rs1`, Abbr`rs2`, FUN_EQ_THM, combinTheory.APPLY_UPDATE_THM] >>
           rw[] >> rw[])
     >> qmatch_abbrev_tac`_ = goal` >>
-      rw[Ntimes whileTheory.WHILE 3, run_machine_1_def, exponential_def] >>
+      rw[Ntimes while_Theory.WHILE 3, run_machine_1_def, exponential_def] >>
       rw[combinTheory.APPLY_UPDATE_THM] >>
       `rs 2 = SUC v` by simp[] >> fs[] >>
       fs[exponential_def, combinTheory.APPLY_UPDATE_THM] >>
@@ -585,13 +585,13 @@ Theorem exp_loop1_2:
      , SOME 2)
 Proof
   Induct_on `rs 4` >> rw[]
-    >- (rw[Once whileTheory.WHILE, run_machine_1_def, exponential_def] >>
+    >- (rw[Once while_Theory.WHILE, run_machine_1_def, exponential_def] >>
           `rs 4 = 0` by simp[] >> fs[] >> rw[combinTheory.APPLY_UPDATE_THM] >>
           qmatch_abbrev_tac`WHILE _ _ (rs1, _) = WHILE _ _ (rs2, _)` >>
           `rs1 = rs2` suffices_by simp[] >>
           simp[Abbr `rs1`, Abbr`rs2`, FUN_EQ_THM, combinTheory.APPLY_UPDATE_THM] >>
           rw[] >> rw[])
-    >> rw[SimpLHS, Ntimes whileTheory.WHILE 2, run_machine_1_def, exponential_def] >>
+    >> rw[SimpLHS, Ntimes while_Theory.WHILE 2, run_machine_1_def, exponential_def] >>
       rw[combinTheory.APPLY_UPDATE_THM] >>
       `rs 4 = SUC v` by simp[] >> fs[] >>
       fs[exponential_def, combinTheory.APPLY_UPDATE_THM] >>
@@ -611,13 +611,13 @@ Theorem exp_loop1:
      , SOME 9))
 Proof
   Induct_on `rs 1` >> rw[]
-    >- (rw[Once whileTheory.WHILE, run_machine_1_def, exponential_def] >>
+    >- (rw[Once while_Theory.WHILE, run_machine_1_def, exponential_def] >>
           `rs 1 = 0` by simp[] >> fs[] >> rw[combinTheory.APPLY_UPDATE_THM] >>
           qmatch_abbrev_tac`WHILE _ _ (rs1, _) = WHILE _ _ (rs2, _)` >>
           `rs1 = rs2` suffices_by simp[] >>
           simp[Abbr `rs1`, Abbr`rs2`, FUN_EQ_THM, combinTheory.APPLY_UPDATE_THM] >>
           rw[] >> rw[])
-    >> rw[SimpLHS, Ntimes whileTheory.WHILE 2, run_machine_1_def]
+    >> rw[SimpLHS, Ntimes while_Theory.WHILE 2, run_machine_1_def]
     >> rw[exp_loop1_1, combinTheory.APPLY_UPDATE_THM]
     >> rw[exp_loop1_2, combinTheory.APPLY_UPDATE_THM]
     >> `rs 1 = SUC v` by simp[] >> fs[]
@@ -640,13 +640,13 @@ Theorem exp_loop2:
      , SOME 11)
 Proof
   Induct_on `rs 5` >> rw[]
-    >- (rw[Once whileTheory.WHILE, run_machine_1_def, exponential_def] >>
+    >- (rw[Once while_Theory.WHILE, run_machine_1_def, exponential_def] >>
           `rs 5 = 0` by simp[] >> fs[] >> rw[combinTheory.APPLY_UPDATE_THM] >>
           qmatch_abbrev_tac`WHILE _ _ (rs1, _) = WHILE _ _ (rs2, _)` >>
           `rs1 = rs2` suffices_by simp[] >>
           simp[Abbr `rs1`, Abbr`rs2`, FUN_EQ_THM, combinTheory.APPLY_UPDATE_THM] >>
           rw[] >> rw[])
-    >> rw[SimpLHS, Ntimes whileTheory.WHILE 2, run_machine_1_def, exponential_def] >>
+    >> rw[SimpLHS, Ntimes while_Theory.WHILE 2, run_machine_1_def, exponential_def] >>
       rw[combinTheory.APPLY_UPDATE_THM] >>
       `rs 5 = SUC v` by simp[] >> fs[] >>
       fs[exponential_def, combinTheory.APPLY_UPDATE_THM] >>
@@ -663,13 +663,13 @@ Theorem exp_loop3:
      , SOME 12)
 Proof
   Induct_on `rs 2` >> rw[]
-    >- (rw[Once whileTheory.WHILE, run_machine_1_def, exponential_def] >>
+    >- (rw[Once while_Theory.WHILE, run_machine_1_def, exponential_def] >>
           `rs 2 = 0` by simp[] >> fs[] >> rw[combinTheory.APPLY_UPDATE_THM] >>
           qmatch_abbrev_tac`WHILE _ _ (rs1, _) = WHILE _ _ (rs2, _)` >>
           `rs1 = rs2` suffices_by simp[] >>
           simp[Abbr `rs1`, Abbr`rs2`, FUN_EQ_THM, combinTheory.APPLY_UPDATE_THM] >>
           rw[] >> rw[])
-    >> rw[SimpLHS, Once whileTheory.WHILE, run_machine_1_def, exponential_def] >>
+    >> rw[SimpLHS, Once while_Theory.WHILE, run_machine_1_def, exponential_def] >>
       rw[combinTheory.APPLY_UPDATE_THM] >>
       `rs 2 = SUC v` by simp[] >> fs[] >>
       fs[exponential_def, combinTheory.APPLY_UPDATE_THM] >>
@@ -687,13 +687,13 @@ WHILE (λ(rs,so). so ≠ NONE) (run_machine_1 exponential) (rs, SOME 12)
      , SOME 1)
 Proof
   Induct_on `rs 3` >> rw[]
-    >- (rw[Once whileTheory.WHILE, run_machine_1_def, exponential_def] >>
+    >- (rw[Once while_Theory.WHILE, run_machine_1_def, exponential_def] >>
           `rs 3 = 0` by simp[] >> fs[] >> rw[combinTheory.APPLY_UPDATE_THM] >>
           qmatch_abbrev_tac`WHILE _ _ (rs1, _) = WHILE _ _ (rs2, _)` >>
           `rs1 = rs2` suffices_by simp[] >>
           simp[Abbr `rs1`, Abbr`rs2`, FUN_EQ_THM, combinTheory.APPLY_UPDATE_THM] >>
           rw[] >> rw[])
-    >> rw[SimpLHS, Ntimes whileTheory.WHILE 2, run_machine_1_def, exponential_def] >>
+    >> rw[SimpLHS, Ntimes while_Theory.WHILE 2, run_machine_1_def, exponential_def] >>
       rw[combinTheory.APPLY_UPDATE_THM] >>
       `rs 3 = SUC v` by simp[] >> fs[] >>
       fs[exponential_def, combinTheory.APPLY_UPDATE_THM] >>
@@ -713,10 +713,10 @@ Proof
      (FST (WHILE gd (r m) (rs0, SOME 1)) 2 = (rs0 1 ** rs0 0) * rs0 2)`
      suffices_by rw[Abbr`init`, APPLY_UPDATE_THM, findi_def] >> rw[] >>
   Induct_on `rs0 0`
-    >- (rw[exponential_def, Ntimes whileTheory.WHILE 2, Abbr`gd`, Abbr`r`, Abbr`m`, run_machine_1_def] >>
+    >- (rw[exponential_def, Ntimes while_Theory.WHILE 2, Abbr`gd`, Abbr`r`, Abbr`m`, run_machine_1_def] >>
         `rs0 0 = 0` by simp[] >> fs[])
     >> rw[]
-    >> rw[Once whileTheory.WHILE, run_machine_1_def, Abbr`gd`, Abbr`r`, Abbr`m`]
+    >> rw[Once while_Theory.WHILE, run_machine_1_def, Abbr`gd`, Abbr`r`, Abbr`m`]
     >> rw[APPLY_UPDATE_THM, exp_loop1]
     >> rw[APPLY_UPDATE_THM, exp_loop2]
     >> rw[APPLY_UPDATE_THM, exp_loop3]
@@ -772,14 +772,14 @@ Theorem fac_loop1_1:
      , SOME 7)
 Proof
   Induct_on `rs 2` >> rw[]
-    >- (rw[Once whileTheory.WHILE, run_machine_1_def, factorial_def] >>
+    >- (rw[Once while_Theory.WHILE, run_machine_1_def, factorial_def] >>
           `rs 2 = 0` by simp[] >> fs[] >> rw[combinTheory.APPLY_UPDATE_THM] >>
           qmatch_abbrev_tac`WHILE _ _ (rs1, _) = WHILE _ _ (rs2, _)` >>
           `rs1 = rs2` suffices_by simp[] >>
           simp[Abbr `rs1`, Abbr`rs2`, FUN_EQ_THM, combinTheory.APPLY_UPDATE_THM] >>
           rw[] >> rw[])
     >> qmatch_abbrev_tac`_ = goal` >>
-      rw[Ntimes whileTheory.WHILE 3, run_machine_1_def, factorial_def] >>
+      rw[Ntimes while_Theory.WHILE 3, run_machine_1_def, factorial_def] >>
       rw[combinTheory.APPLY_UPDATE_THM] >>
       `rs 2 = SUC v` by simp[] >> fs[] >>
       fs[factorial_def, combinTheory.APPLY_UPDATE_THM] >>
@@ -796,13 +796,13 @@ Theorem fac_loop1_2:
      , SOME 3)
 Proof
   Induct_on `rs 4` >> rw[]
-    >- (rw[Once whileTheory.WHILE, run_machine_1_def, factorial_def] >>
+    >- (rw[Once while_Theory.WHILE, run_machine_1_def, factorial_def] >>
           `rs 4 = 0` by simp[] >> fs[] >> rw[combinTheory.APPLY_UPDATE_THM] >>
           qmatch_abbrev_tac`WHILE _ _ (rs1, _) = WHILE _ _ (rs2, _)` >>
           `rs1 = rs2` suffices_by simp[] >>
           simp[Abbr `rs1`, Abbr`rs2`, FUN_EQ_THM, combinTheory.APPLY_UPDATE_THM] >>
           rw[] >> rw[])
-    >> rw[SimpLHS, Ntimes whileTheory.WHILE 2, run_machine_1_def, factorial_def] >>
+    >> rw[SimpLHS, Ntimes while_Theory.WHILE 2, run_machine_1_def, factorial_def] >>
       rw[combinTheory.APPLY_UPDATE_THM] >>
       `rs 4 = SUC v` by simp[] >> fs[] >>
       fs[factorial_def, combinTheory.APPLY_UPDATE_THM] >>
@@ -822,7 +822,7 @@ Theorem fac_loop1:
      , SOME 9))
 Proof
   Induct_on `rs 1` >> rw[]
-    >- (rw[Once whileTheory.WHILE, run_machine_1_def, factorial_def] >>
+    >- (rw[Once while_Theory.WHILE, run_machine_1_def, factorial_def] >>
           `rs 1 = 0` by simp[] >> fs[] >> rw[combinTheory.APPLY_UPDATE_THM] >>
           qmatch_abbrev_tac`WHILE _ _ (rs1, _) = WHILE _ _ (rs2, _)` >>
           `rs1 = rs2` suffices_by simp[] >>
@@ -878,7 +878,7 @@ Proof
      suffices_by rw[Abbr`init`, APPLY_UPDATE_THM, FACT] >>
   rw[] >>
   Induct_on `rs0 0` >> rw[Abbr`r`, Abbr`m`, Abbr`gd`]
-    >- (rw[APPLY_UPDATE_THM, factorial_def, Ntimes whileTheory.WHILE 2, run_machine_1_def] >>
+    >- (rw[APPLY_UPDATE_THM, factorial_def, Ntimes while_Theory.WHILE 2, run_machine_1_def] >>
         `rs0 0 = 0` by simp[] >> fs[] >> rw[numeralTheory.numeral_fact]
         >>rw[Once WHILE, run_machine_1_def] >> rw[APPLY_UPDATE_THM])
     >> rw[Once WHILE, run_machine_1_def]

--- a/examples/computability/register/rmToPairScript.sml
+++ b/examples/computability/register/rmToPairScript.sml
@@ -1,6 +1,6 @@
 Theory rmToPair
 Ancestors
-  arithmetic combin while indexedLists numeral primrecfns list
+  arithmetic combin while_ indexedLists numeral primrecfns list
   bool numpair pred_set rmModel rmTools rmSampleMachines
 Libs
   mp_then

--- a/examples/computability/register/rmToolsScript.sml
+++ b/examples/computability/register/rmToolsScript.sml
@@ -1,6 +1,6 @@
 Theory rmTools
 Ancestors
-  arithmetic combin while indexedLists numeral primrecfns list
+  arithmetic combin while_ indexedLists numeral primrecfns list
   bool numpair pred_set rmModel
 Libs
   mp_then

--- a/examples/computability/register/testingScript.sml
+++ b/examples/computability/register/testingScript.sml
@@ -1,6 +1,6 @@
 Theory testing
 Ancestors
-  arithmetic combin while indexedLists numeral rmModel rmToPair
+  arithmetic combin while_ indexedLists numeral rmModel rmToPair
   rmRecursiveFuncs rmTools rmSampleMachines
 
 (*

--- a/examples/computability/turing/turing_machine_primeqScript.sml
+++ b/examples/computability/turing/turing_machine_primeqScript.sml
@@ -1,7 +1,7 @@
 Theory turing_machine_primeq
 Ancestors
   finite_map recursivefns prnlist primrecfns list arithmetic
-  numpair nlist pred_set turing_machine while logroot
+  numpair nlist pred_set turing_machine while_ logroot
 
 Triviality DISJ_IMP_EQ[simp]:
   ((x = y) ∨ P ⇔ (x ≠ y ⇒ P)) ∧

--- a/examples/computability/unary_recfnsScript.sml
+++ b/examples/computability/unary_recfnsScript.sml
@@ -322,7 +322,7 @@ Proof
       simp[] >> irule primrec_recfn >> simp[primrec_rules]) >>
   simp[minimise_def, recMin1_def, recCn_def, rec1_def] >> qx_gen_tac ‘N’ >>
   rw[]
-  >- (simp[whileTheory.OLEAST_EQ_SOME] >> SELECT_ELIM_TAC >> conj_tac
+  >- (simp[while_Theory.OLEAST_EQ_SOME] >> SELECT_ELIM_TAC >> conj_tac
       >- metis_tac[] >>
       simp[] >> rw[] >- metis_tac[] >>
       first_x_assum drule >> simp[PULL_EXISTS]) >>
@@ -431,7 +431,7 @@ Proof
       qexists_tac ‘recMin1 f1’ >> simp[recfn1_rules] >>
       simp[recMin1_def, minimise_def, GSYM ADD1] >> qx_gen_tac ‘N’ >>
       rw[] >> fs[]
-      >- (simp[whileTheory.OLEAST_EQ_SOME] >> SELECT_ELIM_TAC >>
+      >- (simp[while_Theory.OLEAST_EQ_SOME] >> SELECT_ELIM_TAC >>
           conj_tac >- metis_tac[] >>
           rw[] >- metis_tac[] >>
           first_x_assum (drule_then strip_assume_tac) >> fs[]) >>

--- a/examples/dev/booth/boothScript.sml
+++ b/examples/dev/booth/boothScript.sml
@@ -1,7 +1,7 @@
 (* app load ["bitsLib","bitsTheory","word32Theory"]; *)
 Theory booth
 Ancestors
-  arithmetic while bits word32
+  arithmetic while_ bits word32
 Libs
   bitsLib simpLib Q
 

--- a/examples/dev/sw/ARMCompositionScript.sml
+++ b/examples/dev/sw/ARMCompositionScript.sml
@@ -3,13 +3,13 @@
 quietdec := true;
 loadPath := (concat Globals.HOLDIR "/examples/dev/sw") :: !loadPath;
 
-app load ["pred_setSimps","pred_setTheory","whileTheory","finite_mapTheory","rich_listTheory","prim_recTheory", "wordsTheory", "wordsLib", "preARMTheory"];
+app load ["pred_setSimps","pred_setTheory","while_Theory","finite_mapTheory","rich_listTheory","prim_recTheory", "wordsTheory", "wordsLib", "preARMTheory"];
 
 quietdec := false;
 *)
 Theory ARMComposition
 Ancestors
-  pred_set arithmetic words pair list while finite_map preARM
+  pred_set arithmetic words pair list while_ finite_map preARM
 Libs
   numLib pred_setSimps wordsLib
 

--- a/examples/dev/sw/ILScript.sml
+++ b/examples/dev/sw/ILScript.sml
@@ -4,14 +4,14 @@ quietdec := true;
 loadPath := (concat Globals.HOLDIR "/examples/dev/sw") :: !loadPath;
 
 app load ["pred_setSimps", "pred_setTheory",
-     "arithmeticTheory", "wordsTheory", "wordsLib", "pairTheory", "listTheory", "whileTheory", "finite_mapTheory", "preARMTheory", "ARMCompositionTheory",
+     "arithmeticTheory", "wordsTheory", "wordsLib", "pairTheory", "listTheory", "while_Theory", "finite_mapTheory", "preARMTheory", "ARMCompositionTheory",
           "relationTheory"];
 
 quietdec := false;
 *)
 Theory IL
 Ancestors
-  pred_set arithmetic words pair list while finite_map preARM
+  pred_set arithmetic words pair list while_ finite_map preARM
   ARMComposition relation
 Libs
   numLib pred_setSimps wordsLib

--- a/examples/dev/sw/mechReasoning.sml
+++ b/examples/dev/sw/mechReasoning.sml
@@ -13,7 +13,7 @@ app load ["pred_setLib","finite_mapTheory","rich_listTheory", "wordsLib",
 quietdec := true;
 open numLib pairLib relationTheory pairTheory arithmeticTheory listSyntax
      preARMTheory preARMSyntax Assem pred_setSimps pred_setTheory listTheory
-     rich_listTheory whileTheory finite_mapTheory declFuncs
+     rich_listTheory while_Theory finite_mapTheory declFuncs
      annotatedIR ILTheory rulesTheory wordsLib wordsTheory IRSyntax;
 quietdec := false;
 *)
@@ -24,7 +24,7 @@ local open
    HolKernel Parse boolLib bossLib numLib pairLib relationTheory
    pairTheory arithmeticTheory listSyntax preARMTheory preARMSyntax
    Assem pred_setSimps pred_setTheory listTheory rich_listTheory
-   whileTheory finite_mapTheory declFuncs annotatedIR ILTheory
+   while_Theory finite_mapTheory declFuncs annotatedIR ILTheory
    rulesTheory wordsLib wordsTheory IRSyntax
   infix ++ THENC THEN THENL |->
 in

--- a/examples/dev/sw/preARMScript.sml
+++ b/examples/dev/sw/preARMScript.sml
@@ -4,16 +4,16 @@ quietdec := true;
 loadPath := (concat Globals.HOLDIR "/examples/dev/sw") :: !loadPath;
 
 app load ["numLib", "pred_setSimps", "pred_setTheory",
-     "arithmeticTheory", "wordsTheory", "pairTheory", "listTheory", "whileTheory", "finite_mapTheory", "fcpLib", "wordsLib"];
+     "arithmeticTheory", "wordsTheory", "pairTheory", "listTheory", "while_Theory", "finite_mapTheory", "fcpLib", "wordsLib"];
 
 open numLib pred_setSimps pred_setTheory arithmeticTheory wordsTheory
-     pairTheory listTheory whileTheory finite_mapTheory wordsLib;
+     pairTheory listTheory while_Theory finite_mapTheory wordsLib;
 
 quietdec := false;
 *)
 Theory preARM
 Ancestors
-  pred_set arithmetic words pair list while finite_map
+  pred_set arithmetic words pair list while_ finite_map
 Libs
   numLib pred_setSimps wordsLib
 

--- a/examples/dev/sw/rulesScript.sml
+++ b/examples/dev/sw/rulesScript.sml
@@ -10,7 +10,7 @@ quietdec := false;
 *)
 Theory rules
 Ancestors
-  relation arithmetic preARM pair pred_set list rich_list while
+  relation arithmetic preARM pair pred_set list rich_list while_
   ARMComposition IL words
 Libs
   numLib pred_setSimps

--- a/examples/dev/sw/working/0.1/ARMCompositionScript.sml
+++ b/examples/dev/sw/working/0.1/ARMCompositionScript.sml
@@ -3,13 +3,13 @@
 quietdec := true;
 loadPath := (concat Globals.HOLDIR "/examples/dev/sw") :: !loadPath;
 
-app load ["pred_setSimps","pred_setTheory","whileTheory","finite_mapTheory","rich_listTheory","prim_recTheory", "wordsTheory", "wordsLib", "preARMTheory"];
+app load ["pred_setSimps","pred_setTheory","while_Theory","finite_mapTheory","rich_listTheory","prim_recTheory", "wordsTheory", "wordsLib", "preARMTheory"];
 
 quietdec := false;
 *)
 Theory ARMComposition
 Ancestors
-  pred_set arithmetic words pair list while finite_map preARM
+  pred_set arithmetic words pair list while_ finite_map preARM
 Libs
   numLib pred_setSimps wordsLib
 

--- a/examples/dev/sw/working/0.1/ILScript.sml
+++ b/examples/dev/sw/working/0.1/ILScript.sml
@@ -4,14 +4,14 @@ quietdec := true;
 loadPath := (concat Globals.HOLDIR "/examples/dev/sw") :: !loadPath;
 
 app load ["pred_setSimps", "pred_setTheory",
-     "arithmeticTheory", "wordsTheory", "wordsLib", "pairTheory", "listTheory", "whileTheory", "finite_mapTheory", "preARMTheory", "ARMCompositionTheory",
+     "arithmeticTheory", "wordsTheory", "wordsLib", "pairTheory", "listTheory", "while_Theory", "finite_mapTheory", "preARMTheory", "ARMCompositionTheory",
           "relationTheory"];
 
 quietdec := false;
 *)
 Theory IL
 Ancestors
-  pred_set arithmetic words pair list while finite_map preARM
+  pred_set arithmetic words pair list while_ finite_map preARM
   ARMComposition relation
 Libs
   numLib pred_setSimps wordsLib

--- a/examples/dev/sw/working/0.1/mechReasoning.sml
+++ b/examples/dev/sw/working/0.1/mechReasoning.sml
@@ -7,12 +7,12 @@ loadPath :=
             (concat Globals.HOLDIR "/examples/sep") ::
             !loadPath;
 
-app load ["relationTheory", "pred_setSimps","pred_setTheory","whileTheory","finite_mapTheory","rich_listTheory", "listSyntax",
+app load ["relationTheory", "pred_setSimps","pred_setTheory","while_Theory","finite_mapTheory","rich_listTheory", "listSyntax",
           "ILTheory", "rulesTheory", "preARMSyntax", "annotatedIR", "funCall", "preARMTheory", "wordsLib"];
 
 quietdec := true;
 open HolKernel Parse boolLib bossLib numLib pairLib relationTheory pairTheory arithmeticTheory listSyntax preARMTheory
-     preARMSyntax Assem pred_setSimps pred_setTheory listTheory rich_listTheory whileTheory finite_mapTheory
+     preARMSyntax Assem pred_setSimps pred_setTheory listTheory rich_listTheory while_Theory finite_mapTheory
      annotatedIR ILTheory rulesTheory wordsLib wordsTheory
      preARMTheory;
 quietdec := false;
@@ -21,7 +21,7 @@ quietdec := false;
 structure mechReasoning = struct
   local
   open HolKernel Parse boolLib bossLib numLib pairLib relationTheory pairTheory arithmeticTheory listSyntax preARMTheory
-     preARMSyntax Assem pred_setSimps pred_setTheory listTheory rich_listTheory whileTheory finite_mapTheory declFuncs
+     preARMSyntax Assem pred_setSimps pred_setTheory listTheory rich_listTheory while_Theory finite_mapTheory declFuncs
      annotatedIR ILTheory rulesTheory wordsLib wordsTheory IRSyntax
   in
 

--- a/examples/dev/sw/working/0.1/preARMScript.sml
+++ b/examples/dev/sw/working/0.1/preARMScript.sml
@@ -4,13 +4,13 @@ quietdec := true;
 loadPath := (concat Globals.HOLDIR "/examples/dev/sw") :: !loadPath;
 
 app load ["numLib", "pred_setSimps", "pred_setTheory",
-     "arithmeticTheory", "wordsTheory", "pairTheory", "listTheory", "whileTheory", "finite_mapTheory", "fcpLib", "wordsLib"];
+     "arithmeticTheory", "wordsTheory", "pairTheory", "listTheory", "while_Theory", "finite_mapTheory", "fcpLib", "wordsLib"];
 
 quietdec := false;
 *)
 Theory preARM
 Ancestors
-  pred_set arithmetic words pair list while finite_map
+  pred_set arithmetic words pair list while_ finite_map
 Libs
   numLib pred_setSimps wordsLib
 

--- a/examples/dev/sw/working/0.1/rulesScript.sml
+++ b/examples/dev/sw/working/0.1/rulesScript.sml
@@ -4,13 +4,13 @@ quietdec := true;
 loadPath := (concat Globals.HOLDIR "/examples/dev/sw") :: !loadPath;
 
 app load ["numLib", "relationTheory", "arithmeticTheory", "preARMTheory", "pairTheory",
-     "pred_setSimps", "pred_setTheory", "listTheory", "rich_listTheory", "whileTheory", "ARMCompositionTheory", "ILTheory", "wordsTheory"];
+     "pred_setSimps", "pred_setTheory", "listTheory", "rich_listTheory", "while_Theory", "ARMCompositionTheory", "ILTheory", "wordsTheory"];
 
 quietdec := false;
 *)
 Theory rules
 Ancestors
-  relation arithmetic preARM pair pred_set list rich_list while
+  relation arithmetic preARM pair pred_set list rich_list while_
   ARMComposition IL words
 Libs
   numLib pred_setSimps

--- a/examples/dev/sw/working/0.2/ARMCompositionScript.sml
+++ b/examples/dev/sw/working/0.2/ARMCompositionScript.sml
@@ -3,13 +3,13 @@
 quietdec := true;
 loadPath := (concat Globals.HOLDIR "/examples/dev/sw") :: !loadPath;
 
-app load ["pred_setSimps","pred_setTheory","whileTheory","finite_mapTheory","rich_listTheory","prim_recTheory", "wordsTheory", "wordsLib", "preARMTheory"];
+app load ["pred_setSimps","pred_setTheory","while_Theory","finite_mapTheory","rich_listTheory","prim_recTheory", "wordsTheory", "wordsLib", "preARMTheory"];
 
 quietdec := false;
 *)
 Theory ARMComposition
 Ancestors
-  pred_set arithmetic words pair list while finite_map preARM
+  pred_set arithmetic words pair list while_ finite_map preARM
 Libs
   numLib pred_setSimps wordsLib
 

--- a/examples/dev/sw/working/0.2/CFLScript.sml
+++ b/examples/dev/sw/working/0.2/CFLScript.sml
@@ -4,13 +4,13 @@ quietdec := true;
 loadPath := (concat Globals.HOLDIR "/examples/dev/sw") :: !loadPath;
 
 app load ["pred_setSimps", "pred_setTheory", "arithmeticTheory", "wordsTheory", "wordsLib", "pairTheory",
-"listTheory", "whileTheory", "finite_mapTheory", "preARMTheory", "ARMCompositionTheory"];
+"listTheory", "while_Theory", "finite_mapTheory", "preARMTheory", "ARMCompositionTheory"];
 
 quietdec := false;
 *)
 Theory CFL
 Ancestors
-  pred_set arithmetic words pair list while finite_map preARM
+  pred_set arithmetic words pair list while_ finite_map preARM
   ARMComposition
 Libs
   numLib pred_setSimps wordsLib

--- a/examples/dev/sw/working/0.2/CFL_RulesScript.sml
+++ b/examples/dev/sw/working/0.2/CFL_RulesScript.sml
@@ -4,14 +4,14 @@ quietdec := true;
 loadPath := (concat Globals.HOLDIR "/examples/dev/sw") :: !loadPath;
 
 app load ["numLib", "relationTheory", "arithmeticTheory", "preARMTheory", "pairTheory",
-     "pred_setSimps", "pred_setTheory", "listTheory", "rich_listTheory", "whileTheory", "ARMCompositionTheory",
+     "pred_setSimps", "pred_setTheory", "listTheory", "rich_listTheory", "while_Theory", "ARMCompositionTheory",
       "CFLTheory"];
 
 quietdec := false;
 *)
 Theory CFL_Rules
 Ancestors
-  relation arithmetic preARM pair pred_set list rich_list while
+  relation arithmetic preARM pair pred_set list rich_list while_
   ARMComposition CFL
 Libs
   numLib pred_setSimps

--- a/examples/dev/sw/working/0.2/HSL2CFLScript.sml
+++ b/examples/dev/sw/working/0.2/HSL2CFLScript.sml
@@ -2,11 +2,11 @@
 (*
 quietdec := true;
 
-app load ["arithmeticTheory", "wordsTheory", "wordsLib", "pairTheory", "listTheory", "whileTheory", "finite_mapTheory",
+app load ["arithmeticTheory", "wordsTheory", "wordsLib", "pairTheory", "listTheory", "while_Theory", "finite_mapTheory",
           "pred_setSimps", "pred_setTheory", "preARMTheory", "ARMCompositionTheory", "bigInstTheory", "funCallTheory",
           "CFLTheory", "HSLTheory", "simplifier"];
 
-open HolKernel Parse boolLib bossLib numLib arithmeticTheory wordsTheory wordsLib pairTheory listTheory whileTheory
+open HolKernel Parse boolLib bossLib numLib arithmeticTheory wordsTheory wordsLib pairTheory listTheory while_Theory
        pred_setSimps pred_setTheory finite_mapTheory preARMTheory bigInstTheory funCallTheory
        CFLTheory HSLTheory simplifier;
 
@@ -14,7 +14,7 @@ quietdec := false;
 *)
 Theory HSL2CFL
 Ancestors
-  arithmetic words pair list while pred_set finite_map preARM
+  arithmetic words pair list while_ pred_set finite_map preARM
   bigInst funCall CFL HSL
 Libs
   numLib wordsLib pred_setSimps simplifier

--- a/examples/dev/sw/working/0.2/HSLScript.sml
+++ b/examples/dev/sw/working/0.2/HSLScript.sml
@@ -4,17 +4,17 @@
 (*
 quietdec := true;
 
-app load ["arithmeticTheory", "wordsTheory", "wordsLib", "pairTheory", "listTheory", "whileTheory", "finite_mapTheory",
+app load ["arithmeticTheory", "wordsTheory", "wordsLib", "pairTheory", "listTheory", "while_Theory", "finite_mapTheory",
           "CFLTheory", "ACFTheory"];
 
-open HolKernel Parse boolLib bossLib numLib arithmeticTheory wordsTheory wordsLib pairTheory listTheory whileTheory
+open HolKernel Parse boolLib bossLib numLib arithmeticTheory wordsTheory wordsLib pairTheory listTheory while_Theory
      finite_mapTheory CFLTheory ACFTheory;
 
 quietdec := false;
 *)
 Theory HSL
 Ancestors
-  arithmetic words pair list while finite_map CFL ACF
+  arithmetic words pair list while_ finite_map CFL ACF
 Libs
   numLib wordsLib
 

--- a/examples/dev/sw/working/0.2/bigInstScript.sml
+++ b/examples/dev/sw/working/0.2/bigInstScript.sml
@@ -1,17 +1,17 @@
 (*
 quietdec := true;
 
-app load ["arithmeticTheory", "wordsTheory", "wordsLib", "pairTheory", "whileTheory", "finite_mapTheory",
+app load ["arithmeticTheory", "wordsTheory", "wordsLib", "pairTheory", "while_Theory", "finite_mapTheory",
           "listTheory", "pred_setSimps", "pred_setTheory", "preARMTheory", "CFLTheory", "simplifier"];
 
-open HolKernel Parse boolLib bossLib numLib arithmeticTheory wordsTheory wordsLib pairTheory whileTheory
+open HolKernel Parse boolLib bossLib numLib arithmeticTheory wordsTheory wordsLib pairTheory while_Theory
        listTheory pred_setSimps pred_setTheory finite_mapTheory preARMTheory CFLTheory simplifier;
 
 quietdec := false;
 *)
 Theory bigInst
 Ancestors
-  arithmetic words pair while list pred_set finite_map preARM CFL
+  arithmetic words pair while_ list pred_set finite_map preARM CFL
 Libs
   numLib wordsLib pred_setSimps simplifier
 

--- a/examples/dev/sw/working/0.2/funCallScript.sml
+++ b/examples/dev/sw/working/0.2/funCallScript.sml
@@ -1,11 +1,11 @@
 (*
 quietdec := true;
 
-app load ["arithmeticTheory", "wordsTheory", "wordsLib", "pairTheory", "whileTheory", "finite_mapTheory",
+app load ["arithmeticTheory", "wordsTheory", "wordsLib", "pairTheory", "while_Theory", "finite_mapTheory",
           "listTheory", "pred_setSimps", "pred_setTheory", "preARMTheory", "CFLTheory", "bigInstTheory",
           "simplifier", "HSLTheory"];
 
-open HolKernel Parse boolLib bossLib numLib arithmeticTheory wordsTheory wordsLib pairTheory whileTheory
+open HolKernel Parse boolLib bossLib numLib arithmeticTheory wordsTheory wordsLib pairTheory while_Theory
        listTheory pred_setSimps pred_setTheory finite_mapTheory preARMTheory CFLTheory bigInstTheory
        simplifier HSLTheory;
 
@@ -13,7 +13,7 @@ quietdec := false;
 *)
 Theory funCall
 Ancestors
-  arithmetic words pair while list pred_set finite_map preARM CFL
+  arithmetic words pair while_ list pred_set finite_map preARM CFL
   bigInst HSL
 Libs
   numLib wordsLib pred_setSimps simplifier

--- a/examples/dev/sw/working/0.2/preARMScript.sml
+++ b/examples/dev/sw/working/0.2/preARMScript.sml
@@ -4,13 +4,13 @@ quietdec := true;
 loadPath := (concat Globals.HOLDIR "/examples/dev/sw") :: !loadPath;
 
 app load ["numLib", "pred_setSimps", "pred_setTheory",
-     "arithmeticTheory", "wordsTheory", "pairTheory", "listTheory", "whileTheory", "finite_mapTheory"];
+     "arithmeticTheory", "wordsTheory", "pairTheory", "listTheory", "while_Theory", "finite_mapTheory"];
 
 quietdec := false;
 *)
 Theory preARM
 Ancestors
-  pred_set arithmetic words pair list while finite_map
+  pred_set arithmetic words pair list while_ finite_map
 Libs
   numLib pred_setSimps
 

--- a/examples/elliptic/groupScript.sml
+++ b/examples/elliptic/groupScript.sml
@@ -1165,7 +1165,7 @@ val cyclic_group_alt = store_thm
           (cyclic_group e f).mult (FUNPOW f i e) (FUNPOW f j e) =
           FUNPOW f ((i + j) MOD n) e)``,
    REPEAT GEN_TAC
-   ++ SIMP_TAC std_ss [whileTheory.LEAST_EXISTS]
+   ++ SIMP_TAC std_ss [while_Theory.LEAST_EXISTS]
    ++ Q.SPEC_TAC (`LEAST k. ~(k = 0) /\ (FUNPOW f k e = e)`,`k`)
    ++ GEN_TAC
    ++ STRIP_TAC
@@ -1315,7 +1315,7 @@ val cyclic_group = store_thm
    ++ MATCH_MP_TAC (PROVE [] ``a /\ (b ==> c) ==> ((a ==> b) ==> c)``)
    ++ CONJ_TAC >> (RW_TAC std_ss [] ++ METIS_TAC [])
    ++ POP_ASSUM MP_TAC
-   ++ SIMP_TAC std_ss [whileTheory.LEAST_EXISTS]
+   ++ SIMP_TAC std_ss [while_Theory.LEAST_EXISTS]
    ++ Q.SPEC_TAC (`LEAST n. ~(n = 0) /\ (FUNPOW f n e = e)`,`k`)
    ++ REPEAT GEN_TAC
    ++ STRIP_TAC

--- a/examples/elliptic/swsep/swsepLib.sml
+++ b/examples/elliptic/swsep/swsepLib.sml
@@ -19,7 +19,7 @@ struct
 
 
 open HolKernel boolLib bossLib Parse;
-open Portable Assem wordsTheory ANF pairTheory pairLib listTheory arithmeticTheory whileTheory  wordsLib PairedLambda mechReasoning IRSyntax;
+open Portable Assem wordsTheory ANF pairTheory pairLib listTheory arithmeticTheory while_Theory  wordsLib PairedLambda mechReasoning IRSyntax;
 open swsepTheory arm_progTheory progTheory pred_setTheory set_sepLib set_sepTheory arm_instTheory listTheory
    wordsTheory pairTheory wordsLib markerTheory
 

--- a/examples/fermat/little/patternScript.sml
+++ b/examples/fermat/little/patternScript.sml
@@ -575,7 +575,7 @@ Theorem cycle_order_period:
   !ls. ls <> [] ==> period ls (order ls)
 Proof
   rw[order_def] >>
-  metis_tac[cycle_period_exists, whileTheory.LEAST_INTRO]
+  metis_tac[cycle_period_exists, while_Theory.LEAST_INTRO]
 QED
 
 (* Idea: if k < list order, k is not a period. *)
@@ -592,7 +592,7 @@ Theorem cycle_order_minimal:
   !k ls. ls <> [] /\ k < order ls ==> ~(period ls k)
 Proof
   rw[order_def] >>
-  metis_tac[cycle_period_exists, whileTheory.LESS_LEAST]
+  metis_tac[cycle_period_exists, while_Theory.LESS_LEAST]
 QED
 
 (* Idea: the list order is positive and a period. *)

--- a/examples/fermat/twosq/helperTwosqScript.sml
+++ b/examples/fermat/twosq/helperTwosqScript.sml
@@ -6,7 +6,7 @@
 
 Theory helperTwosq
 Ancestors
-  arithmetic pred_set divides gcd number while combinatorics
+  arithmetic pred_set divides gcd number while_ combinatorics
   prime
 
 (* ------------------------------------------------------------------------- *)

--- a/examples/fermat/twosq/iterateComputeScript.sml
+++ b/examples/fermat/twosq/iterateComputeScript.sml
@@ -7,7 +7,7 @@
 Theory iterateCompute
 Ancestors
   arithmetic pred_set divides number list rich_list listRange
-  combinatorics while iteration
+  combinatorics while_ iteration
   helperTwosq  (* for WHILE_RULE_PRE_POST *)
 
 (* ------------------------------------------------------------------------- *)
@@ -660,7 +660,7 @@ Proof
     qabbrev_tac `p = iterate_period b a` >>
     qabbrev_tac `y = iterate a b c` >>
     `findi y ls = c` by metis_tac[iterate_trace_element_idx, DECIDE``c <= (c :num)``] >>
-    simp[whileTheory.HOARE_SPEC_DEF] >>
+    simp[while_Theory.HOARE_SPEC_DEF] >>
     rpt strip_tac >| [
       `x <> y` by metis_tac[NOT_LESS] >>
       metis_tac[iterate_trace_member],
@@ -687,7 +687,7 @@ QED
     ==> {iterate a b n} ((WHILE g b) a)  by HOARE_SPEC_DEF
      or WHILE g b a IN {iterate a b n}   by set as function
    Thus WHILE g b a = iterate a b n      by IN_SING
-> whileTheory.HOARE_SPEC_DEF;
+> while_Theory.HOARE_SPEC_DEF;
 val it = |- !P C Q. HOARE_SPEC P C Q <=> !s. P s ==> Q (C s): thm
 Put C = (WHILE g b)
 *)
@@ -699,7 +699,7 @@ Theorem iterate_while_thm_1:
 Proof
   rpt strip_tac >>
   `HOARE_SPEC {a} (WHILE g b) {iterate a b n}` by metis_tac[iterate_while_hoare] >>
-  fs[whileTheory.HOARE_SPEC_DEF]
+  fs[while_Theory.HOARE_SPEC_DEF]
 QED
 
 (* This is another milestone. Now depreciated, see iterate_while_thm below. *)
@@ -722,7 +722,7 @@ Proof
   qexists_tac `\x. x = a` >>
   qexists_tac `\x. 1` >>
   rw[] >>
-  rw[whileTheory.HOARE_SPEC_DEF]
+  rw[while_Theory.HOARE_SPEC_DEF]
 QED
 
 (* Theorem: ~g a ==> WHILE g b a = a *)
@@ -735,14 +735,14 @@ Theorem iterate_while_thm_0:
 Proof
   rpt strip_tac >>
   `HOARE_SPEC {a} (WHILE g b) {a}` by rw[iterate_while_hoare_0] >>
-  fs[whileTheory.HOARE_SPEC_DEF]
+  fs[while_Theory.HOARE_SPEC_DEF]
 QED
 
 (* ------------------------------------------------------------------------- *)
 (* Direct from WHILE definition.                                             *)
 (* ------------------------------------------------------------------------- *)
 
-(* from whileTheory:
+(* from while_Theory:
 
 WHILE
 |- !P g x. WHILE P g x = if P x then WHILE P g (g x) else x

--- a/examples/fermat/twosq/iterationScript.sml
+++ b/examples/fermat/twosq/iterationScript.sml
@@ -102,7 +102,7 @@ Theorem iterate_period_property:
 Proof
   rpt strip_tac >>
   simp[iterate_period_def] >>
-  DEEP_INTRO_TAC whileTheory.OLEAST_INTRO >>
+  DEEP_INTRO_TAC while_Theory.OLEAST_INTRO >>
   simp[]
 QED
 
@@ -113,7 +113,7 @@ Theorem iterate_period_minimal:
 Proof
   ntac 2 strip_tac >>
   simp[iterate_period_def] >>
-  DEEP_INTRO_TAC whileTheory.OLEAST_INTRO >>
+  DEEP_INTRO_TAC while_Theory.OLEAST_INTRO >>
   rw_tac std_ss[] >>
   metis_tac[DECIDE``~(0 < 0)``]
 QED
@@ -143,7 +143,7 @@ Proof
   simp[iterate_period_property] >-
   simp[iterate_period_minimal] >>
   simp[iterate_period_def] >>
-  DEEP_INTRO_TAC whileTheory.OLEAST_INTRO >>
+  DEEP_INTRO_TAC while_Theory.OLEAST_INTRO >>
   rw[] >>
   `~(n' < n) /\ ~(n < n')` by metis_tac[] >>
   decide_tac
@@ -295,7 +295,7 @@ Theorem iterate_period_eq_0:
   !f x. iterate_period f x = 0 <=> !n. 0 < n ==> FUNPOW f n x <> x
 Proof
   rw[iterate_period_def] >>
-  DEEP_INTRO_TAC whileTheory.OLEAST_INTRO >>
+  DEEP_INTRO_TAC while_Theory.OLEAST_INTRO >>
   simp[] >>
   metis_tac[NOT_ZERO]
 QED

--- a/examples/fermat/twosq/twoSquaresScript.sml
+++ b/examples/fermat/twosq/twoSquaresScript.sml
@@ -950,7 +950,7 @@ Theorem two_sq_while_thm:
 Proof
   rw_tac bool_ss[] >>
   drule_then strip_assume_tac two_sq_while_hoare >>
-  rfs[whileTheory.HOARE_SPEC_DEF] >>
+  rfs[while_Theory.HOARE_SPEC_DEF] >>
   qabbrev_tac `u = (1,1,p DIV 4)` >>
   `fixes zagier (mills p) = {u}` by rw[zagier_fixes_prime, Abbr`u`] >>
   last_x_assum (qspecl_then [`u`] strip_assume_tac) >>

--- a/examples/formal-languages/context-free/pegexecScript.sml
+++ b/examples/formal-languages/context-free/pegexecScript.sml
@@ -161,13 +161,13 @@ End
 Theorem coreloop_result[simp]:
   coreloop G (Result x) = SOME (Result x)
 Proof
-  simp[coreloop_def, Once whileTheory.OWHILE_THM]
+  simp[coreloop_def, Once while_Theory.OWHILE_THM]
 QED
 
 Theorem coreloop_Looped[simp]:
   coreloop G Looped = NONE
 Proof
-  simp[coreloop_def, whileTheory.OWHILE_EQ_NONE] >> Induct >>
+  simp[coreloop_def, while_Theory.OWHILE_EQ_NONE] >> Induct >>
   simp[arithmeticTheory.FUNPOW]
 QED
 
@@ -192,7 +192,7 @@ Proof
 QED
 
 fun inst_thm def (qs,ths) =
-    def |> SIMP_RULE (srw_ss()) [Once whileTheory.OWHILE_THM, coreloop_def]
+    def |> SIMP_RULE (srw_ss()) [Once while_Theory.OWHILE_THM, coreloop_def]
         |> SPEC_ALL
         |> Q.INST qs
         |> SIMP_RULE (srw_ss()) []

--- a/examples/generic_graphs/matchingScript.sml
+++ b/examples/generic_graphs/matchingScript.sml
@@ -1,7 +1,7 @@
 Theory matching
 Ancestors
   fsgraph pred_set arithmetic list genericGraph set_relation
-  rich_list integer combin topology while pair real prim_rec
+  rich_list integer combin topology while_ pair real prim_rec
 Libs
   pred_setLib hurdUtils tautLib
 

--- a/examples/hfs/hfsScript.sml
+++ b/examples/hfs/hfsScript.sml
@@ -89,7 +89,7 @@ Proof
   qx_gen_tac `n` >>
   qspec_then `λm. n < 2 ** m`
     (match_mp_tac o SIMP_RULE (srw_ss()) [arithmeticTheory.NOT_LESS])
-     whileTheory.LEAST_EXISTS_IMP >>
+     while_Theory.LEAST_EXISTS_IMP >>
   metis_tac[TWO_EXP_BOUNDS]
 QED
 

--- a/examples/l3-machine-code/common/tripleScript.sml
+++ b/examples/l3-machine-code/common/tripleScript.sml
@@ -1,6 +1,6 @@
 Theory triple
 Ancestors
-  arithmetic while pair pred_set prog
+  arithmetic while_ pair pred_set prog
 
 val _ = ParseExtras.temp_loose_equality()
 (* we define a total-correctness machine-code Hoare triple *)

--- a/examples/lambda/barendregt/normal_orderScript.sml
+++ b/examples/lambda/barendregt/normal_orderScript.sml
@@ -735,9 +735,9 @@ val lemma1 = prove(
   ``∀p. okpath (λM u N. M -n-> N) p ∧ finite p ⇒
         bnf (last p) ⇒ (bnf_of (first p) = SOME (last p))``,
   HO_MATCH_MP_TAC finite_okpath_ind THEN SRW_TAC [][] THENL [
-    SRW_TAC [][Once whileTheory.OWHILE_THM, bnf_of_def],
+    SRW_TAC [][Once while_Theory.OWHILE_THM, bnf_of_def],
     FULL_SIMP_TAC (srw_ss()) [] THEN
-    SRW_TAC [][Once whileTheory.OWHILE_THM, bnf_of_def] THENL [
+    SRW_TAC [][Once while_Theory.OWHILE_THM, bnf_of_def] THENL [
       SRW_TAC [][GSYM bnf_of_def] THEN
       METIS_TAC [noreduct_characterisation, optionTheory.THE_DEF],
       METIS_TAC [normorder_bnf]
@@ -747,7 +747,7 @@ val lemma1 = prove(
 val lemma2 = prove(
   ``∀N. (OWHILE ($~ o bnf) (THE o noreduct) M = SOME N) ⇒
         M -n->* N``,
-  HO_MATCH_MP_TAC whileTheory.OWHILE_INV_IND THEN SRW_TAC [][] THEN
+  HO_MATCH_MP_TAC while_Theory.OWHILE_INV_IND THEN SRW_TAC [][] THEN
   Cases_on `noreduct N` THENL [
     FULL_SIMP_TAC (srw_ss()) [noreduct_bnf],
     METIS_TAC [noreduct_characterisation, relationTheory.RTC_RULES_RIGHT1,
@@ -758,7 +758,7 @@ val bnf_of_SOME = store_thm(
   "bnf_of_SOME",
   ``(bnf_of M = SOME N) ⇒ M -n->* N ∧ bnf N``,
   SRW_TAC [][bnf_of_def] THEN
-  IMP_RES_TAC whileTheory.OWHILE_ENDCOND THEN
+  IMP_RES_TAC while_Theory.OWHILE_ENDCOND THEN
   FULL_SIMP_TAC (srw_ss()) [] THEN
   METIS_TAC [lemma2]);
 
@@ -783,8 +783,8 @@ val bnf_of_thm = store_thm(
   "bnf_of_thm",
   ``bnf_of M = if bnf M then SOME M else bnf_of (THE (noreduct M))``,
   SRW_TAC [][bnf_of_def] THEN1
-    SRW_TAC [][Once whileTheory.OWHILE_THM] THEN
-  SRW_TAC [][SimpLHS, Once whileTheory.OWHILE_THM]);
+    SRW_TAC [][Once while_Theory.OWHILE_THM] THEN
+  SRW_TAC [][SimpLHS, Once while_Theory.OWHILE_THM]);
 
 val nstar_bnf_of_SOME_I = store_thm(
   "nstar_bnf_of_SOME_I",

--- a/examples/logic/ltl/buechiAScript.sml
+++ b/examples/logic/ltl/buechiAScript.sml
@@ -1,6 +1,6 @@
 Theory buechiA
 Ancestors
-  pair pred_set arithmetic relation set_relation while word
+  pair pred_set arithmetic relation set_relation while_ word
   generalHelpers
 
 val _ = ParseExtras.temp_loose_equality()

--- a/examples/logic/ltl/generalHelpersScript.sml
+++ b/examples/logic/ltl/generalHelpersScript.sml
@@ -1,7 +1,7 @@
 Theory generalHelpers
 Ancestors
   pred_set relation set_relation arithmetic pair list option
-  prim_rec while rich_list sorting
+  prim_rec while_ rich_list sorting
 
 (* open relationTheoryHelperTheory *)
 

--- a/examples/logic/ltl/ltl2waaScript.sml
+++ b/examples/logic/ltl/ltl2waaScript.sml
@@ -1,6 +1,6 @@
 Theory ltl2waa
 Ancestors
-  pred_set relation arithmetic prim_rec pair set_relation while
+  pred_set relation arithmetic prim_rec pair set_relation while_
   generalHelpers ltl word alterA
 
 (*

--- a/examples/logic/ltl/waaSimplScript.sml
+++ b/examples/logic/ltl/waaSimplScript.sml
@@ -1,6 +1,6 @@
 Theory waaSimpl
 Ancestors
-  pair relation set_relation pred_set arithmetic while alterA ltl
+  pair relation set_relation pred_set arithmetic while_ alterA ltl
   ltl2waa
 
 val _ = ParseExtras.temp_loose_equality()

--- a/examples/machine-code/hoare-triple/tailrecScript.sml
+++ b/examples/machine-code/hoare-triple/tailrecScript.sml
@@ -1,7 +1,7 @@
 
 Theory tailrec
 Ancestors
-  pred_set arithmetic while sum
+  pred_set arithmetic while_ sum
 
 (* ---- definitions ----- *)
 

--- a/examples/machine-code/instruction-set-models/x86_64/prog_x64_extraScript.sml
+++ b/examples/machine-code/instruction-set-models/x86_64/prog_x64_extraScript.sml
@@ -2,7 +2,7 @@
 Theory prog_x64_extra
 Ancestors
   prog_x64 prog set_sep address temporal words list arithmetic
-  while pair relation combin option
+  while_ pair relation combin option
 Libs
   prog_x64Lib x64_encodeLib helperLib wordsLib
 

--- a/examples/miller/prob/probScript.sml
+++ b/examples/miller/prob/probScript.sml
@@ -2728,7 +2728,7 @@ Theorem PROB_WHILE_WITNESS_BIND:
     if c a then BIND (b a) (prob_while_witness c b) else UNIT a
 Proof
   simp[FUN_EQ_THM, prob_while_witness_def, UNIT_DEF, BIND_DEF] >>
-  simp[Once whileTheory.OWHILE_THM] >> rw[] >>
+  simp[Once while_Theory.OWHILE_THM] >> rw[] >>
   rename [‘_ = _ _ (b a s)’] >>
   Cases_on ‘b a s’ >> simp[prob_while_witness_def]
 QED
@@ -2807,7 +2807,7 @@ Proof
            UNIT_DEF, PULL_EXISTS]
    >> qx_gen_tac ‘y’ >> Cases_on ‘OWHILE (c o FST) (UNCURRY b) (a,y)’
    >> simp[]
-   >> gvs[whileTheory.OWHILE_def, AllCaseEqs()]
+   >> gvs[while_Theory.OWHILE_def, AllCaseEqs()]
    >> PROVE_TAC []
 QED
 
@@ -2843,8 +2843,8 @@ Proof
           (* 2 sub-goals here *)
        >> rename [‘OWHILE _ _ (a,x)’]
        >> Cases_on ‘OWHILE (c o FST) (UNCURRY b) (a,x)’
-       >> gs[whileTheory.OWHILE_EQ_NONE, PULL_EXISTS]
-       >> gvs[whileTheory.OWHILE_def, AllCaseEqs()]
+       >> gs[while_Theory.OWHILE_EQ_NONE, PULL_EXISTS]
+       >> gvs[while_Theory.OWHILE_def, AllCaseEqs()]
        >> numLib.LEAST_ELIM_TAC
        >> simp[SF SFY_ss]
        >> metis_tac[])
@@ -2945,8 +2945,8 @@ Proof
                          (* 2 sub-goals here *)
        >> rename [‘OWHILE _ _ (a,x)’]
        >> Cases_on ‘OWHILE (c o FST) (UNCURRY b) (a,x)’
-       >> gs[whileTheory.OWHILE_EQ_NONE, PULL_EXISTS]
-       >> gvs[whileTheory.OWHILE_def, AllCaseEqs()]
+       >> gs[while_Theory.OWHILE_EQ_NONE, PULL_EXISTS]
+       >> gvs[while_Theory.OWHILE_def, AllCaseEqs()]
        >> numLib.LEAST_ELIM_TAC
        >> simp[SF SFY_ss]
        >> metis_tac[])
@@ -3841,7 +3841,7 @@ Proof
        >> RW_TAC std_ss [IN_INSERT, DISJ_IMP_THM, FORALL_AND_THM]
        >> Know `?n'. c' n = c n'` >- PROVE_TAC []
        >> DISCH_THEN (MP_TAC o
-                      Ho_Rewrite.ONCE_REWRITE_RULE [whileTheory.LEAST_EXISTS])
+                      Ho_Rewrite.ONCE_REWRITE_RULE [while_Theory.LEAST_EXISTS])
        >> Q.SPEC_TAC (`LEAST n'. c' n = c n'`, `k`)
        >> Q.PAT_X_ASSUM `X = Y` K_TAC
        >> RW_TAC std_ss []
@@ -3911,7 +3911,7 @@ Proof
    >- (STRIP_TAC
        >> Suff `?h. c h = j m`
        >- (DISCH_THEN (MP_TAC o
-                       Ho_Rewrite.REWRITE_RULE [whileTheory.LEAST_EXISTS])
+                       Ho_Rewrite.REWRITE_RULE [while_Theory.LEAST_EXISTS])
            >> PROVE_TAC [])
        >> Suff `j m IN range (FST o f)`
        >- PROVE_TAC []

--- a/examples/misc/fibonacciScript.sml
+++ b/examples/misc/fibonacciScript.sml
@@ -121,16 +121,16 @@ Theorem fibA_thm:
   fibA i p t = SND (SND (WHILE Gd Body (i,p,t)))
 Proof
   map_every qid_spec_tac [‘p’, ‘t’] >> Induct_on ‘i’ >> simp[] >>
-  simp [Once whileTheory.WHILE, SimpRHS]
+  simp [Once while_Theory.WHILE, SimpRHS]
 QED
 
 Theorem WHILE_correct:
   HOARE_SPEC (Inv L) (WHILE Gd Body) (λs. Inv L s ∧ ¬Gd s)
 Proof
-  irule whileTheory.WHILE_RULE >> conj_tac
+  irule while_Theory.WHILE_RULE >> conj_tac
   >- (qexists_tac ‘inv_image $< FST’ >>
       simp[pairTheory.FORALL_PROD, relationTheory.WF_inv_image]) >>
-  simp[pairTheory.FORALL_PROD, whileTheory.HOARE_SPEC_DEF] >>
+  simp[pairTheory.FORALL_PROD, while_Theory.HOARE_SPEC_DEF] >>
   rpt strip_tac >> simp[Once fib_def, SimpRHS]
 QED
 
@@ -140,7 +140,7 @@ Proof
   rw[fastfib_def, fibA_thm]
   >- simp[Once fib_def] >>
   qmatch_abbrev_tac ‘SND (SND (prog _)) = _’>>
-  assume_tac (GEN_ALL $ SRULE[whileTheory.HOARE_SPEC_DEF] WHILE_correct) >>
+  assume_tac (GEN_ALL $ SRULE[while_Theory.HOARE_SPEC_DEF] WHILE_correct) >>
   gvs[] >>
   ‘Inv (n - 1) (n - 1, 0, 1)’
     by (simp[] >> conj_tac >> simp[Once fib_def]) >>

--- a/examples/probability/legacy/real_lebesgueScript.sml
+++ b/examples/probability/legacy/real_lebesgueScript.sml
@@ -3,7 +3,7 @@
 (* ========================================================================= *)
 Theory real_lebesgue
 Ancestors
-  num arithmetic pred_set list combin pair while real seq
+  num arithmetic pred_set list combin pair while_ real seq
   real_sigma transc lim iterate sigma_algebra real_measure
   real_borel
 Libs

--- a/examples/probability/legacy/real_measureScript.sml
+++ b/examples/probability/legacy/real_measureScript.sml
@@ -889,7 +889,7 @@ val INF_MEASURE_LE = store_thm
     >> Q.PAT_X_ASSUM `!x. P x` (MP_TAC o Q.SPEC `x`)
     >> RW_TAC std_ss []
     >> Know `?n. x IN f n` >- PROVE_TAC []
-    >> DISCH_THEN (MP_TAC o Ho_Rewrite.REWRITE_RULE [whileTheory.LEAST_EXISTS])
+    >> DISCH_THEN (MP_TAC o Ho_Rewrite.REWRITE_RULE [while_Theory.LEAST_EXISTS])
     >> RW_TAC std_ss []
     >> Q.EXISTS_TAC
        `f (LEAST n. x IN f n) DIFF

--- a/src/algebra/construction/groupScript.sml
+++ b/src/algebra/construction/groupScript.sml
@@ -9683,7 +9683,7 @@ val fn_cyclic_group_alt = store_thm(
   (* (!i. (fn_cyclic_group e f).inv (FUNPOW f i e) = FUNPOW f ((n - i MOD n) MOD n) e) /\ *)
      (!i j. (fn_cyclic_group e f).op (FUNPOW f i e) (FUNPOW f j e) = FUNPOW f ((i + j) MOD n) e)``,
   rpt gen_tac >>
-  simp_tac std_ss [whileTheory.LEAST_EXISTS] >>
+  simp_tac std_ss [while_Theory.LEAST_EXISTS] >>
   Q.SPEC_TAC (`LEAST k. k <> 0 /\ (FUNPOW f k e = e)`,`h`) >>
   gen_tac >>
   strip_tac >>
@@ -9765,7 +9765,7 @@ val fn_cyclic_group_group = store_thm(
   conj_tac >-
   rw[] >>
   pop_assum mp_tac >>
-  simp_tac std_ss [whileTheory.LEAST_EXISTS] >>
+  simp_tac std_ss [while_Theory.LEAST_EXISTS] >>
   qspec_tac (`LEAST n. n <> 0 /\ (FUNPOW f n e = e)`,`h`) >>
   gen_tac >>
   rpt strip_tac >>
@@ -9807,7 +9807,7 @@ val fn_cyclic_group_finite_abelian_group = store_thm(
   conj_tac >| [
     rw[],
     pop_assum mp_tac >>
-    simp_tac std_ss [whileTheory.LEAST_EXISTS] >>
+    simp_tac std_ss [while_Theory.LEAST_EXISTS] >>
     Q.SPEC_TAC (`LEAST n. n <> 0 /\ (FUNPOW f n e = e)`,`h`) >>
     gen_tac >>
     strip_tac >>

--- a/src/algebra/construction/monoidScript.sml
+++ b/src/algebra/construction/monoidScript.sml
@@ -1025,7 +1025,7 @@ val order_property = store_thm(
   ``!g:'a monoid. !x:'a. (x ** (ord x) = #e)``,
   ntac 2 strip_tac >>
   simp_tac std_ss[order_def, period_def] >>
-  DEEP_INTRO_TAC whileTheory.OLEAST_INTRO >>
+  DEEP_INTRO_TAC while_Theory.OLEAST_INTRO >>
   rw[]);
 
 (* Theorem: 0 < (ord x) ==> period g x (ord x) *)
@@ -1042,7 +1042,7 @@ Theorem order_minimal:
 Proof
   ntac 3 strip_tac >>
   simp_tac std_ss[order_def, period_def] >>
-  DEEP_INTRO_TAC whileTheory.OLEAST_INTRO >>
+  DEEP_INTRO_TAC while_Theory.OLEAST_INTRO >>
   rw_tac std_ss[] >>
   metis_tac[DECIDE “~(0 < 0)”]
 QED
@@ -1060,7 +1060,7 @@ Theorem order_eq_0:
 Proof
   ntac 2 strip_tac >>
   simp_tac std_ss[order_def, period_def] >>
-  DEEP_INTRO_TAC whileTheory.OLEAST_INTRO >>
+  DEEP_INTRO_TAC while_Theory.OLEAST_INTRO >>
   rw_tac std_ss[] >>
   metis_tac[DECIDE “~(0 < 0)”]
 QED
@@ -1088,7 +1088,7 @@ val order_thm = store_thm(
   rw[order_property] >-
   rw[order_minimal] >>
   simp_tac std_ss[order_def, period_def] >>
-  DEEP_INTRO_TAC whileTheory.OLEAST_INTRO >>
+  DEEP_INTRO_TAC while_Theory.OLEAST_INTRO >>
   rw_tac std_ss[] >-
   metis_tac[] >>
   `~(n' < n)` by metis_tac[] >>

--- a/src/algebra/construction/ringScript.sml
+++ b/src/algebra/construction/ringScript.sml
@@ -35,7 +35,7 @@ src\rational\ratRingScript.sml
 Theory ring
 Ancestors
   prim_rec arithmetic divides gcd gcdset pred_set list bag
-  container while sorting integer number combinatorics prime
+  container while_ sorting integer number combinatorics prime
   monoid group
 Libs
   jcLib dep_rewrite
@@ -11771,7 +11771,7 @@ Proof
   `FiniteRing (trivial_ring z)` by rw_tac std_ss[trivial_ring] >>
   rw[char_def] >>
   rw_tac std_ss[order_def, period_def, trivial_ring_def, monoid_exp_def] >>
-  DEEP_INTRO_TAC whileTheory.OLEAST_INTRO >>
+  DEEP_INTRO_TAC while_Theory.OLEAST_INTRO >>
   rw_tac std_ss[] >>
   spose_not_then strip_assume_tac >>
   `1 < n /\ 0 < 1` by decide_tac >>
@@ -11922,7 +11922,7 @@ Theorem ZN_char:
   !n. 0 < n ==> char (ZN n) = n
 Proof
   rw_tac std_ss[char_def, order_def, period_def] >>
-  DEEP_INTRO_TAC whileTheory.OLEAST_INTRO >>
+  DEEP_INTRO_TAC while_Theory.OLEAST_INTRO >>
   simp[Excl "lift_disj_eq", ZN_def, add_mod_def, times_mod_def,
        monoid_exp_def] >>
   rw[Excl "lift_disj_eq"] >| [ (* avoid srw_tac simplication *)
@@ -12318,7 +12318,7 @@ val ZN_order_mod_1 = store_thm(
   ``!n. ordz 1 n = 1``,
   rw[order_def, period_def, ZN_property] >>
   rw[ZN_1_exp] >>
-  DEEP_INTRO_TAC whileTheory.OLEAST_INTRO >>
+  DEEP_INTRO_TAC while_Theory.OLEAST_INTRO >>
   rw[] >>
   spose_not_then strip_assume_tac >>
   `1 < n /\ 1 <> 0` by decide_tac >>
@@ -13316,7 +13316,7 @@ Proof
   simp[char_def, order_def, period_def, symdiff_set_inter_def,
        monoid_exp_def, symdiff_set_def, set_inter_def] >>
   `FUNPOW (symdiff univ(:'a)) 2 {} = {}` by rw[FUNPOW_2, symdiff_def] >>
-  DEEP_INTRO_TAC whileTheory.OLEAST_INTRO >>
+  DEEP_INTRO_TAC while_Theory.OLEAST_INTRO >>
   rw[] >>
   `~(n < 2) /\ ~(2 < n)` suffices_by decide_tac >>
   spose_not_then strip_assume_tac >>
@@ -13455,7 +13455,7 @@ val WHILE_RULE_PRE_POST = Q.store_thm(
    (!x. Invariant x /\ ~Guard x ==> Postcond x) /\
    HOARE_SPEC (\x. Invariant x /\ Guard x) Cmd Invariant ==>
    HOARE_SPEC Precond (WHILE Guard Cmd) Postcond`,
-  simp[whileTheory.HOARE_SPEC_DEF] >>
+  simp[while_Theory.HOARE_SPEC_DEF] >>
   rpt strip_tac >>
   `!s. Invariant s ==> Postcond (WHILE Guard Cmd s)`
      suffices_by metis_tac[] >>
@@ -14955,7 +14955,7 @@ Theorem integral_domain_order_zero:
   !r:'a ring. IntegralDomain r ==> (order f* #0 = 0)
 Proof
   rw_tac std_ss[order_def, period_def] >>
-  DEEP_INTRO_TAC whileTheory.OLEAST_INTRO >>
+  DEEP_INTRO_TAC while_Theory.OLEAST_INTRO >>
   rw[] >>
   rfs[integral_domain_nonzero_mult_property] >>
   spose_not_then strip_assume_tac >>
@@ -14972,7 +14972,7 @@ val integral_domain_order_nonzero = store_thm(
   "integral_domain_order_nonzero",
   ``!r:'a ring. FiniteIntegralDomain r ==> !x. x IN R+ ==> (order f* x <> 0)``,
   rw_tac std_ss[order_def, period_def] >>
-  DEEP_INTRO_TAC whileTheory.OLEAST_INTRO >>
+  DEEP_INTRO_TAC while_Theory.OLEAST_INTRO >>
   rw[] >>
   `IntegralDomain r` by fs[FiniteIntegralDomain_def] >>
   metis_tac[finite_integral_domain_period_exists, integral_domain_nonzero_mult_property, NOT_ZERO_LT_ZERO]);

--- a/src/boss/Holmakefile
+++ b/src/boss/Holmakefile
@@ -44,7 +44,7 @@ ARTS = bool_defs.ot.art \
   ../num/theories/arithmetic.ot.art \
   ../num/theories/numeral.ot.art \
   ../num/theories/basicSize.ot.art \
-  ../num/theories/while.ot.art \
+  ../num/theories/while_.ot.art \
   ../num/extra_theories/numpair.ot.art \
   ../num/extra_theories/divides.ot.art \
   ../num/extra_theories/logroot.ot.art \

--- a/src/boss/hol4-base-unint.thy
+++ b/src/boss/hol4-base-unint.thy
@@ -145,7 +145,7 @@ while {
   import: relation
   import: arithmetic
   import: sum
-  article: "../num/theories/while.ot.art"
+  article: "../num/theories/while_.ot.art"
 }
 numpair {
   import: bool

--- a/src/boss/selftest.sml
+++ b/src/boss/selftest.sml
@@ -393,7 +393,7 @@ val _ = test_tac_Case "list ind" (K true)
 val _ = test_tac_Case "OLEAST deep intro" (K true)
   `THE (OLEAST n. n > SUC 3) < 8`
   (DEEP_INTRO_TAC
-      (name_ind_cases [] whileTheory.OLEAST_INTRO)
+      (name_ind_cases [] while_Theory.OLEAST_INTRO)
     \\ rpt strip_tac)
 
 val (is_rev_rules, is_rev_ind, is_rev_cases) = Hol_reln`

--- a/src/coalgebras/lbtreeScript.sml
+++ b/src/coalgebras/lbtreeScript.sml
@@ -610,7 +610,7 @@ val mindepth_def = Define`
 `;
 
 (* following tactic is used twice in theorem below - yerk *)
-val lelim = REWRITE_RULE [GSYM AND_IMP_INTRO] whileTheory.LEAST_ELIM
+val lelim = REWRITE_RULE [GSYM AND_IMP_INTRO] while_Theory.LEAST_ELIM
 val min_tac =
     SRW_TAC [ETA_ss][] THEN
     IMP_RES_THEN (fn th => th |> MATCH_MP lelim |> DEEP_INTRO_TAC) mem_depth >>

--- a/src/coalgebras/llistScript.sml
+++ b/src/coalgebras/llistScript.sml
@@ -5,7 +5,7 @@
 Theory llist
 Ancestors
   option combin option pair num arithmetic prim_rec list
-  rich_list while pair pred_set set_relation arithmetic
+  rich_list while_ pair pred_set set_relation arithmetic
 Libs
   BasicProvers boolSimps markerLib hurdUtils
 
@@ -4023,4 +4023,3 @@ Proof
   fs[Once LAPPEND_ASSOC]>>
   fs[LFINITE_fromList,LAPPEND11_FINITE1]>>metis_tac[]
 QED
-

--- a/src/emit/basis_emitScript.sml
+++ b/src/emit/basis_emitScript.sml
@@ -1,6 +1,6 @@
 Theory basis_emit
 Ancestors
-  combin pair numeral while arithmetic pred_set option basicSize
+  combin pair numeral while_ arithmetic pred_set option basicSize
   list rich_list string sum finite_map sorting bit numeral_bit
   fcp words integer integer_word numposrep ASCIInumbers pre_emit
 Libs

--- a/src/finite_maps/alistScript.sml
+++ b/src/finite_maps/alistScript.sml
@@ -307,7 +307,7 @@ pop_assum (assume_tac o SYM) >>
 qho_match_abbrev_tac `EL ($LEAST P) (MAP SND al) = v` >>
 `P n` by (
   unabbrev_all_tac >> rw[EL_MAP] ) >>
-qspecl_then [`P`,`n`] mp_tac whileTheory.LESS_LEAST >> rw[] >>
+qspecl_then [`P`,`n`] mp_tac while_Theory.LESS_LEAST >> rw[] >>
 numLib.LEAST_ELIM_TAC >>
 conj_tac >- (
   qexists_tac `n` >> rw[] ) >>

--- a/src/finite_maps/finite_mapScript.sml
+++ b/src/finite_maps/finite_mapScript.sml
@@ -3164,7 +3164,7 @@ Theorem LEAST_NOTIN_FDOM:
   (LEAST ptr. ptr NOTIN FDOM (refs:num|->'a)) NOTIN FDOM refs
 Proof
   ASSUME_TAC
-    (EXISTS_NOT_IN_FDOM_LEMMA |> SIMP_RULE std_ss [whileTheory.LEAST_EXISTS])>>
+    (EXISTS_NOT_IN_FDOM_LEMMA |> SIMP_RULE std_ss [while_Theory.LEAST_EXISTS])>>
    fs[]
 QED
 

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -3717,7 +3717,7 @@ val splitAtPki_EQN = store_thm(
     (ASM_SIMP_TAC (srw_ss()) [] THEN
      ‘(OLEAST i. i < SUC (LENGTH l) /\ P i (EL i (h::l))) = SOME 0’
         suffices_by SRW_TAC [] [] THEN
-     ASM_SIMP_TAC (srw_ss()) [whileTheory.OLEAST_EQ_SOME]) THEN
+     ASM_SIMP_TAC (srw_ss()) [while_Theory.OLEAST_EQ_SOME]) THEN
   SRW_TAC [] [] THEN
   Cases_on ‘OLEAST i. i < LENGTH l /\ P (SUC i) (EL i l)’ >> fs[]
   >- (‘(OLEAST i. i < SUC (LENGTH l) /\ P i (EL i (h::l))) = NONE’
@@ -3727,20 +3727,20 @@ val splitAtPki_EQN = store_thm(
   Q.RENAME_TAC [‘h::TAKE i t’] >>
   ‘(OLEAST i. i < SUC (LENGTH t) /\ P i (EL i (h::t))) = SOME (SUC i)’
       suffices_by SRW_TAC [] [] THEN
-  fs[whileTheory.OLEAST_EQ_SOME] >> Cases >> SRW_TAC[][]);
+  fs[while_Theory.OLEAST_EQ_SOME] >> Cases >> SRW_TAC[][]);
 
 val TAKE_splitAtPki = store_thm(
   "TAKE_splitAtPki",
   “TAKE n l = splitAtPki (K o (=) n) K l”,
   SRW_TAC [] [splitAtPki_EQN] THEN
-  DEEP_INTRO_TAC whileTheory.OLEAST_INTRO THEN
+  DEEP_INTRO_TAC while_Theory.OLEAST_INTRO THEN
   SRW_TAC[numSimps.ARITH_ss] [TAKE_LENGTH_TOO_LONG])
 
 val DROP_splitAtPki = store_thm(
   "DROP_splitAtPki",
   “DROP n l = splitAtPki (K o (=) n) (K I) l”,
   SRW_TAC [] [splitAtPki_EQN] THEN
-  DEEP_INTRO_TAC whileTheory.OLEAST_INTRO THEN
+  DEEP_INTRO_TAC while_Theory.OLEAST_INTRO THEN
   SRW_TAC[numSimps.ARITH_ss] [DROP_LENGTH_TOO_LONG]);
 
 Theorem splitAtPki_RAND:

--- a/src/num/extra_theories/bitScript.sml
+++ b/src/num/extra_theories/bitScript.sml
@@ -1492,7 +1492,7 @@ val EXISTS_BIT_LT = save_thm("EXISTS_BIT_LT",
 val LEAST_THM = Q.store_thm("LEAST_THM",
    `!n P. (!m. m < n ==> ~P m) /\ P n ==> ($LEAST P = n)`,
    REPEAT STRIP_TAC
-   \\ IMP_RES_TAC whileTheory.FULL_LEAST_INTRO
+   \\ IMP_RES_TAC while_Theory.FULL_LEAST_INTRO
    \\ Cases_on `$LEAST P = n`
    >- ASM_REWRITE_TAC []
    \\ `$LEAST P < n` by DECIDE_TAC

--- a/src/num/extra_theories/logrootScript.sml
+++ b/src/num/extra_theories/logrootScript.sml
@@ -238,7 +238,7 @@ val log_exists = Q.prove(
    REPEAT STRIP_TAC
    THEN Q.EXISTS_TAC `LEAST x. n < a ** SUC x`
    THEN CONV_TAC (UNBETA_CONV ``LEAST x. n < a ** SUC x``)
-   THEN MATCH_MP_TAC whileTheory.LEAST_ELIM
+   THEN MATCH_MP_TAC while_Theory.LEAST_ELIM
    THEN CONJ_TAC
    THENL [
       SRW_TAC [][EXP]

--- a/src/num/extra_theories/numeral_bitScript.sml
+++ b/src/num/extra_theories/numeral_bitScript.sml
@@ -515,7 +515,7 @@ QED
 (* ------------------------------------------------------------------------- *)
 
 val LEAST_BIT_INTRO =
-   (SIMP_RULE (srw_ss()) [] o Q.SPEC `\i. BIT i n`)  whileTheory.LEAST_INTRO
+   (SIMP_RULE (srw_ss()) [] o Q.SPEC `\i. BIT i n`)  while_Theory.LEAST_INTRO
 
 Theorem LOWEST_SET_BIT:
    !n. n <> 0 ==>
@@ -528,7 +528,7 @@ Proof
       Cases_on `(LEAST i. BIT i (n DIV 2)) = 0`
       >- FULL_SIMP_TAC (srw_ss()) [DECIDE ``m < 1 ==> (m = 0)``, BIT0_ODD]
       \\ IMP_RES_TAC (DECIDE ``~(a = 0) /\ m < a + 1 ==> (m - 1 < a)``)
-      \\ IMP_RES_TAC whileTheory.LESS_LEAST
+      \\ IMP_RES_TAC while_Theory.LESS_LEAST
       \\ FULL_SIMP_TAC (srw_ss()) [BIT_DIV2]
       \\ Cases_on `m = 0`
       \\ FULL_SIMP_TAC (srw_ss())

--- a/src/num/numLib.sml
+++ b/src/num/numLib.sml
@@ -274,7 +274,7 @@ fun BOUNDED_EXISTS_CONV cnv M =
     Picks an arbitrary LEAST-subterm if there are multiple such.
    ---------------------------------------------------------------------- *)
 
-val LEAST_ELIM_TAC = DEEP_INTRO_TAC whileTheory.LEAST_ELIM
+val LEAST_ELIM_TAC = DEEP_INTRO_TAC while_Theory.LEAST_ELIM
 
 (*---------------------------------------------------------------------------
     Simplification set for numbers (and booleans).

--- a/src/num/theories/cv_compute/tailrecLib.sml
+++ b/src/num/theories/cv_compute/tailrecLib.sml
@@ -29,7 +29,7 @@ fun auto_prove goal_tm (tac:tactic) = TAC_PROOF (([],goal_tm), tac)
     functions exist. The input function can only take one argument.
  *----------------------------------------------------------------------*)
 
-val TAILREC_def = whileTheory.TAILREC
+val TAILREC_def = while_Theory.TAILREC
                   |> CONV_RULE (DEPTH_CONV ETA_CONV)
                   |> REWRITE_RULE [GSYM combinTheory.I_EQ_IDABS];
 
@@ -83,7 +83,7 @@ fun prove_simple_tailrec_exists tm = let
   val sum_tm = mk_sum_term f_tm input_ty r
   val _ = not (exists (aconv f_tm) (free_vars sum_tm)) orelse fail()
   val abs_sum_tm = pairSyntax.mk_pabs(arg_tm,sum_tm)
-  val witness = ISPEC abs_sum_tm whileTheory.TAILREC |> SPEC_ALL
+  val witness = ISPEC abs_sum_tm while_Theory.TAILREC |> SPEC_ALL
                 |> concl |> dest_eq |> fst |> rator
   fun sum_case_exp tm = tm |> rator |> rator |> rand
   val sum_case_exp_conv = RATOR_CONV o RATOR_CONV o RAND_CONV

--- a/src/num/theories/numSyntax.sml
+++ b/src/num/theories/numSyntax.sml
@@ -2,7 +2,7 @@ structure numSyntax :> numSyntax =
 struct
   open HolKernel Abbrev;
 
-  local open arithmeticTheory whileTheory numeralTheory in end;
+  local open arithmeticTheory while_Theory numeralTheory in end;
 
   val ERR = mk_HOL_ERR "numSyntax";
 
@@ -39,8 +39,8 @@ struct
   val numeral_tm   = prim_mk_const {Name="NUMERAL", Thy="arithmetic"}
   val odd_tm       = prim_mk_const {Name="ODD",     Thy="arithmetic"}
   val plus_tm      = prim_mk_const {Name="+",       Thy="arithmetic"}
-  val least_tm     = prim_mk_const {Name="LEAST",   Thy="while"};
-  val while_tm     = prim_mk_const {Name="WHILE",   Thy="while"}
+  val least_tm     = prim_mk_const {Name="LEAST",   Thy="while_"};
+  val while_tm     = prim_mk_const {Name="WHILE",   Thy="while_"}
 
 
 (*---------------------------------------------------------------------------

--- a/src/num/theories/numeralScript.sml
+++ b/src/num/theories/numeralScript.sml
@@ -16,7 +16,7 @@
 
    fun mload s = (print ("Loading "^s^"\n"); load s);
    app mload ["simpLib", "boolSimps", "arithmeticTheory", "Q",
-              "mesonLib", "metisLib", "whileTheory",
+              "mesonLib", "metisLib", "while_Theory",
               "pairSyntax", "combinSyntax"];
 *)
 Theory numeral[bare]

--- a/src/num/theories/while_Script.sml
+++ b/src/num/theories/while_Script.sml
@@ -2,7 +2,7 @@
 (* Define WHILE loops, give Hoare rules, and define LEAST operator as a      *)
 (* binder.                                                                   *)
 (*===========================================================================*)
-Theory while[bare]
+Theory while_[bare]
 Ancestors
   combin option sum prim_rec arithmetic relation
 Libs
@@ -13,7 +13,7 @@ Libs
 local open OpenTheoryMap
   val ns = ["While"]
 in
-  fun ot0 x y = OpenTheory_const_name{const={Thy="while",Name=x},name=(ns,y)}
+  fun ot0 x y = OpenTheory_const_name{const={Thy="while_",Name=x},name=(ns,y)}
   fun ot x = ot0 x x
 end
 
@@ -522,4 +522,3 @@ val _ =
    ["WHILE"
    ,"LEAST_DEF"
    ,"TAILREC"];
-

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -11,7 +11,7 @@
 (* =====================================================================*)
 Theory pred_set[bare]
 Ancestors
-  numpair pair num prim_rec arithmetic while divides combin
+  numpair pair num prim_rec arithmetic while_ divides combin
   relation option
 Libs
   HolKernel Parse boolLib BasicProvers Prim_rec pairLib numLib
@@ -6610,7 +6610,7 @@ val MIN_SET_LEM = Q.store_thm
 ("MIN_SET_LEM",
  `!s. ~(s={}) ==> (MIN_SET s IN s) /\ !x. x IN s ==> MIN_SET s <= x`,
   METIS_TAC [GSYM MEMBER_NOT_EMPTY,MIN_SET_DEF,
-             IN_DEF,whileTheory.FULL_LEAST_INTRO]);
+             IN_DEF,while_Theory.FULL_LEAST_INTRO]);
 
 val SUBSET_MIN_SET = Q.store_thm
 ("SUBSET_MIN_SET",

--- a/src/real/realScript.sml
+++ b/src/real/realScript.sml
@@ -3,7 +3,7 @@
 (*---------------------------------------------------------------------------*)
 Theory real
 Ancestors
-  arithmetic num prim_rec while pred_set realax
+  arithmetic num prim_rec while_ pred_set realax
   marker[qualified] (* for unint *)
 Libs
   numLib reduceLib pairLib mesonLib tautLib simpLib Arithconv

--- a/src/transfer/examples/tailcallcvexampleScript.sml
+++ b/src/transfer/examples/tailcallcvexampleScript.sml
@@ -1,6 +1,6 @@
 Theory tailcallcvexample
 Ancestors
-  while cvxferExamples
+  while_ cvxferExamples
 
 fun tuplify t =
   let val (f, xs) = strip_comb t


### PR DESCRIPTION
In the long term, we may want to drop the "Theory" suffix from theories, which would cause issues with `whileTheory`, as `while` is a keyword in Standard ML.

Less importantly, the HOL + SML parser does not like the fact that there is a keyword in the list of ancestors, since already with the Theory syntax, the "Theory" suffix is not mentioned anymore.

Appending a keyword with "_" seems to be a common solution (see PEP 8). An additional upside is that if we go with snake case as the naming convention for theories (as is mostly the case in CakeML), `while_` would be valid (in contrast to `While`).
Also, `functor` was already renamed to `functor_`.