### PR TITLE
Lift out some calls to PURE_REWRITE_CONV

### DIFF
--- a/src/list/src/listSimps.sml
+++ b/src/list/src/listSimps.sml
@@ -266,6 +266,8 @@ local
 
    val APPEND_LEFT_ASSOC_CONV =
       PURE_REWRITE_CONV [GSYM listTheory.APPEND_ASSOC]
+   val SNOC_APPEND_CONV =
+      PURE_REWRITE_CONV [SNOC_APPEND]
 
    fun LIST_EQ_SIMP_CONV___internal t =
        let
@@ -290,7 +292,7 @@ in
             val (l1', _) = dest_eq t
             val _ = if is_list_type (type_of l1') then () else raise UNCHANGED
          in
-             let val th = PURE_REWRITE_CONV [SNOC_APPEND] t
+             let val th = SNOC_APPEND_CONV t
                  val (t1, t2) = dest_eq (concl th)
              in
                  (* If the list equation after eliminating SNOC actually cannot be

--- a/src/num/arith/src/Gen_arith.sml
+++ b/src/num/arith/src/Gen_arith.sml
@@ -120,9 +120,10 @@ val is_presburger = (all is_num_var) o non_presburger_subterms;
     non-numeral multiplicands always appear in the same order, and
     grouped together, possibly with an isolated numeral coefficient.
    ---------------------------------------------------------------------- *)
-
+local open arithmeticTheory numSyntax Psyntax
+val conv1 = PURE_REWRITE_CONV [LEFT_ADD_DISTRIB, RIGHT_ADD_DISTRIB]
+in
 fun EXPAND_NORM_MULTS_CONV tm = let
-  open arithmeticTheory numSyntax Psyntax
   fun norm_mult t = let
     val ms = strip_mult t
     val _ = Int.>(length ms, 1) orelse failwith "not a mult"
@@ -139,9 +140,10 @@ fun EXPAND_NORM_MULTS_CONV tm = let
       LAND_CONV reduceLib.REDUCE_CONV
   end t
 in
-  PURE_REWRITE_CONV [LEFT_ADD_DISTRIB, RIGHT_ADD_DISTRIB] THENC
+  conv1 THENC
   ONCE_DEPTH_CONV norm_mult
 end tm
+end
 
 
 (*---------------------------------------------------------------------------*)


### PR DESCRIPTION
This reduces the number of SPEC_ALL calls originating from PURE_REWRITE_CONV.