### PR TITLE
[docker-ci] Add GNU parallel; install NuRV (SMV) in riscv64 image

### DIFF
--- a/developers/docker-ci/base/Dockerfile
+++ b/developers/docker-ci/base/Dockerfile
@@ -27,7 +27,7 @@ ENV PATH=/ML/polyml/bin:/ML/HOL/bin:$PATH
 # Some necessary Debian packages
 # NOTE: GCC 13 is necessary for building Moscow ML (default compiler is now GCC 14).
 RUN apt-get update -qy
-RUN apt-get install -qy build-essential git libgmp-dev wget curl procps file unzip vim
+RUN apt-get install -qy build-essential git libgmp-dev wget curl procps file unzip vim parallel
 
 # for Unicode display, learnt from Magnus Myreen
 RUN apt-get install -qy locales-all terminfo

--- a/developers/docker-ci/latest/Dockerfile
+++ b/developers/docker-ci/latest/Dockerfile
@@ -102,7 +102,14 @@ RUN if [ "linux/arm64" = "$TARGETPLATFORM" ]; then \
     wget -q https://es-static.fbk.eu/tools/nurv/releases/NuRV-${SMV_VERSION}-linuxarm64.tar.bz2; \
     tar xjf NuRV-${SMV_VERSION}-linuxarm64.tar.bz2; \
     mv NuRV-${SMV_VERSION}-linuxarm64/NuRV solvers; \
-    rm -rf NuRV-${SMV_VERSION}-linuxx64*; \
+    rm -rf NuRV-${SMV_VERSION}-linuxarm64*; \
+fi
+
+RUN if [ "linux/riscv64" = "$TARGETPLATFORM" ]; then \
+    wget -q https://es-static.fbk.eu/tools/nurv/releases/NuRV-${SMV_VERSION}-linuxr64.tar.bz2; \
+    tar xjf NuRV-${SMV_VERSION}-linuxr64.tar.bz2; \
+    mv NuRV-${SMV_VERSION}-linuxr64/NuRV solvers; \
+    rm -rf NuRV-${SMV_VERSION}-linuxr64*; \
 fi
 
 ENV HOL4_SMV_EXECUTABLE=/ML/solvers/NuRV


### PR DESCRIPTION
Hi,

I've rebuilt Docker CI images with GNU parallel installed (#1661); Besides, the (useless) riscv64 image now has NuRV (SMV-compatible model checker) installed.  Rebuilding these images also gets latest Debian security updates.

This PR contains only the changed Dockerfile definitions; the actual images has already been uploaded (as `binghelisp/hol-dev:latest` in Docker Hub).

--Chun