### PR TITLE
vim: fix issue with `>>tac`

### DIFF
--- a/tools/editor-modes/vim/hol.src
+++ b/tools/editor-modes/vim/hol.src
@@ -126,7 +126,9 @@ let s:delim          = '\_[[:space:]()]'
 
 fu! HOLExpand()
   silent keepjumps normal pgg0
-  while search('\%^\_s*\%(\%('.s:stripBoth.'\|'.s:stripStart.'\)\|\%('.s:stripBothWords.'\)\)\ze'.s:delim,'cWe')
+  " The regex below in Perl syntax:
+  " ^ \s* (($stripBoth|$stripStart)(\b|$delim) | ($stripBothWords $delim))
+  while search('\%^\_s*\%(\%('.s:stripBoth.'\|'.s:stripStart.'\)\%(\<\|'.s:delim.'\)\|\%('.s:stripBothWords.s:delim.'\)\)\ze','cWe')
     silent keepjumps normal vgg0"_d
   endw
   while search('\%(\%('.s:stripBoth.'\|'.s:stripEnd.'\)\|'.s:delim.'\zs\%('.s:stripBothWords.'\)\)\_s*\%$','cW')


### PR DESCRIPTION
Make vim correctly strip leading `>>` without following space.

See https://hol.zulipchat.com/#narrow/channel/509224-.F0.9F.93.9D-Text-Editors/topic/vim.3A.20stripping.20leading.20tacticals/with/540800755