### PR TITLE
Refactor congprocs to use the UNCHANGED exception for failure

### DIFF
--- a/src/simp/src/Opening.sml
+++ b/src/simp/src/Opening.sml
@@ -252,7 +252,7 @@ in fn {relation,solver,depther,freevars} =>
     if allunch then
       (* note critical link between this exception and traversal code in
          Traverse.FIRSTCQC_CONV *)
-      raise mk_HOL_ERR "Opening" "CONGPROC" "Congruence gives no change"
+      raise UNCHANGED
     else (trace(3,PRODUCE(tm,"congruence rule",final_thm)); final_thm)
   end
 end;
@@ -292,7 +292,7 @@ fun EQ_CONGPROC {relation,depther,solver,freevars} tm =
               val Bth = depther ([],equality) Body
           in ABS Bvar Bth
           end
-   | _ => failwith "unchanged";
+   | _ => raise UNCHANGED
 
 
 end (* struct *)

--- a/src/simp/src/Traverse.sml
+++ b/src/simp/src/Traverse.sml
@@ -183,14 +183,8 @@ fun FIRSTCQC_CONV [] t = failwith "no conversion worked"
   | FIRSTCQC_CONV (c::cs) t = let
     in
       c t
-      handle e as HOL_ERR herr =>
-               if top_structure_of herr = "Opening" andalso
-                  top_function_of herr = "CONGPROC" andalso
-                  message_of herr = "Congruence gives no change"
-                then raise e
-                else FIRSTCQC_CONV cs t
-           | Interrupt => raise Interrupt
-           | otherwise => FIRSTCQC_CONV cs t
+      handle UNCHANGED => failwith "unchanged" (* Need to raise a HOL_ERR *)
+           | HOL_ERR _ => FIRSTCQC_CONV cs t
     end
 
 (* And another thing.  The current simplifer doesn't allow users to

--- a/src/simp/src/simpLib.sml
+++ b/src/simp/src/simpLib.sml
@@ -392,7 +392,7 @@ fun getlimit (SS ss) = #limit ss
        refl x
      end
    in
-     CONGPROC mk_refl th
+     QCHANGED_CONV o CONGPROC mk_refl th
    end
  in
    TRAVRULES {relations = rels,


### PR DESCRIPTION
Note that some other minor changes. congprocs that raise non HOL_ERR _ are no longer caught. Also EQ_CONGPROC raises UNCHANGED when enountering atoms e.g. variables or constants. This changes don't affect simplifier behavior only possibly affecting code that directly calls the traverser.