### PR TITLE
Use exn_to_string to display error in Vim plugin

### DIFF
--- a/tools/editor-modes/vim/vimhol.src
+++ b/tools/editor-modes/vim/vimhol.src
@@ -57,7 +57,7 @@ local
       (QUse.use tmp
        handle e => (
          checkTryRemove tmp;
-         TextIO.print ("Exception- " ^ exnMessage e ^ " raised\n");
+         TextIO.print ("Exception- " ^ exn_to_string e ^ " raised\n");
          PolyML.Exception.reraise e);
        checkTryRemove tmp)
     open Mutex ConditionVar


### PR DESCRIPTION
General.exnMessage seems to raise Match on the new HOL_ERR exceptions

Debugged with @dnezam and @ordinarymath 