### PR TITLE
Variance of normal random variables

### DIFF
--- a/src/real/realScript.sml
+++ b/src/real/realScript.sml
@@ -1,6 +1,7 @@
 (*---------------------------------------------------------------------------*)
 (* Develop the theory of reals                                               *)
 (*---------------------------------------------------------------------------*)
+
 Theory real
 Ancestors
   arithmetic num prim_rec While pred_set realax
@@ -9,7 +10,6 @@ Libs
   numLib reduceLib pairLib mesonLib tautLib simpLib Arithconv
   jrhUtils Canon_Port BasicProvers TotalDefn metisLib hurdUtils
   RealArith
-
 
 val TAUT_CONV   = jrhUtils.TAUT_CONV; (* conflict with tautLib.TAUT_CONV *)
 val GEN_ALL     = hol88Lib.GEN_ALL;   (* it has old reverted variable order *)
@@ -1499,6 +1499,14 @@ Theorem ABS_EQ_NEG :
     !(x :real). x < 0 ==> abs x = -x
 Proof
     RW_TAC std_ss [real_lt, real_abs]
+QED
+
+Theorem ABS_EQ_NEG' :
+    !(x :real). x <= 0 ==> abs x = -x
+Proof
+    RW_TAC std_ss [REAL_LE_LT]
+ >- (MATCH_MP_TAC ABS_EQ_NEG >> art [])
+ >> REWRITE_TAC [ABS_0, REAL_NEG_0]
 QED
 
 (* |- !n. abs (&n) = &n *)


### PR DESCRIPTION
Hi,

In this PR, as another demonstration of the recently added Lebesgue-Gauge equivalence, Ι proved that the variance of normal variables parametered by (μ,σ^2), is indeed σ^2:
```
[variance_of_normal_rv] (distributionTheory)
    ⊢ ∀p X mu sig.
        prob_space p ∧ normal_rv X p mu sig ∧ 0 < sig ⇒
        variance p (Normal ∘ X) = Normal sig²
```
This is done by first proving the variance of *standard* normal r.v.'s:
```
[variance_of_std_normal_rv]
    ⊢ ∀p X. prob_space p ∧ std_normal_rv X p ⇒ variance p (Normal ∘ X) = 1
```
and then use the general transformation formulas of the variance of *any* random variables:
```
   [variance_real_affine]  Theorem
      ⊢ ∀p X c.
          prob_space p ∧ real_random_variable X p ∧ integrable p X ∧
          c ≠ +∞ ∧ c ≠ −∞ ⇒
          variance p (λx. X x + c) = variance p X

   [variance_cmul]  Theorem      
      ⊢ ∀p X c.
          prob_space p ∧ real_random_variable X p ∧
          finite_second_moments p X ⇒
          variance p (λx. Normal c * X x) = Normal c² * variance p X
```
The key Gauge integral here is the following one, obtained from AXIOM:
```
   (5) -> integrate((x^2-1)*exp(-x^2/2),x)

                 2
                x
              - --
                 2
   (5)  - x %e
                                         Type: Union(Expression(Integer),...)
```

This work also completes another missing part of a previous thesis work [1].

P. S. Some of my proofs have used `limTheory.DIFF_POS_MONO_LT_CU`, contributed in #1606 (by @jdyeager ).

--Chun

[1] Qasim, M.: Formalization of Normal Random Variables, (2016).