### PR TITLE
[kak] quiet qload, Theory syntax, README

### DIFF
--- a/tools/editor-modes/kak/README.md
+++ b/tools/editor-modes/kak/README.md
@@ -4,7 +4,9 @@ This is a HOL mode for Kakoune. Install by placing this somewhere in the autoloa
 
 The plugin only supplies commands with the prefix `hol-`; there are no default keybinds, but I may eventually pick some. For now that can be up to you. Clippy will explain to you roughly what every command does, which should be familiar if you have used a HOL mode in one of the other supported editors before.
 
-Before starting a session, you should make sure that `$HOLDIR` is set. You may start a HOL session by running `hol-start`, which will open a new terminal window which `hol.kak` will interface with through its other commands.
+Before starting a session, you should make sure that `$HOLDIR` is set. You may start a HOL session by running `hol-start`, which will open a new terminal window using the [kak `terminal` command](https://github.com/mawww/kakoune/blob/master/rc/windowing/detection.kak), which `hol.kak` will interface with through its other commands.
+
+If you are using tmux (or other [supported multiplexers](https://github.com/mawww/kakoune/tree/master/rc/windowing)), you can customise how `hol-start` opens a new session through the [kak `windowing_placement` option](https://github.com/mawww/kakoune/blob/master/rc/windowing/detection.kak). For example, to split tmux horizontally rather than open a new window, run `set-option window windowing_placement horizontal`. Clippy will show you the other options if you partially write out this command. You can add this line to your kakrc config to make it default.
 
 There is no sanitisation of tactics yet, so sending tactics with dangling infix operators (e.g. `>>`) or mismatched brackets will fail.
 

--- a/tools/editor-modes/kak/hol.kak
+++ b/tools/editor-modes/kak/hol.kak
@@ -11,6 +11,7 @@ hook global WinSetOption filetype=holscript %{
     set buffer indentwidth 2
 
     hook window ModeChange pop:insert:.* -group hol-trim-indent hol-trim-indent
+    hook window InsertCompletionHide .* -group hol-trim-indent hol-indent-on-char
     hook window InsertChar .* -group hol-indent hol-indent-on-char
     hook window InsertChar \n -group hol-indent hol-indent-on-new-line
 }
@@ -91,7 +92,7 @@ hol-restart-proof: restart proof in HOL' %{
 define-command hol-load-deps-for -docstring '
 hol-load-deps-for: load dependencies for a HOL file' -params 1 %{
     nop %sh{
-        $HOLDIR/bin/holdeptool.exe $1 | sed 's/.*/qload "&" handle _ => (); /' > "$kak_opt_holfifo"
+        $HOLDIR/bin/holdeptool.exe $1 | sed 's/.*/val () = qload "&" handle _ => (); /' > "$kak_opt_holfifo"
     }
 }
 
@@ -100,7 +101,7 @@ hol-load-deps-for: load dependencies for all open HOL files' %{
     nop %sh{
         eval set -- "$kak_quoted_buflist"
         while [ $# -gt 0 ]; do
-            $HOLDIR/bin/holdeptool.exe $1 | sed 's/.*/qload "&" handle _ => (); /' > "$kak_opt_holfifo"
+            $HOLDIR/bin/holdeptool.exe $1 | sed 's/.*/val () = qload "&" handle _ => (); /' > "$kak_opt_holfifo"
             shift
         done
     }
@@ -125,7 +126,7 @@ set-face global listsep white,default,default
 add-highlighter shared/holsyntax group
 add-highlighter shared/holsyntax/ ref sml
 # custom regex hightlighting must come after ref to override
-add-highlighter shared/holsyntax/ regex '\b(Definition|(Co)?Inductive|Datatype|Theorem|Triviality|End|Termination|Proof|QED|Type|Overload)\b' 0:keyword
+add-highlighter shared/holsyntax/ regex '\b(Definition|(Co)?Inductive|Datatype|Theorem|Triviality|End|Termination|Proof|QED|Type|Overload|Theory|Ancestors|Libs)\b' 0:keyword
 add-highlighter shared/holsyntax/ regex '^\[(~?\w+):\]' 1:indrules
 add-highlighter shared/holsyntax/ regex '\bcheat\b' 0:cheat
 
@@ -173,7 +174,7 @@ define-command -hidden hol-indent-on-char %{
         # align closer token to its opener when alone on a line
         try %{ execute-keys -draft <a-h> <a-k> ^\h+[\]\)]$ <ret> m s \A|.\z <ret> 1<a-&> }
         # align HOL syntax to start
-        try %{ execute-keys -draft <a-h> <a-k> ^\h+(Proof|Termination|QED|End) <ret> x s ^\h+ <ret> d }
+        try %{ execute-keys -draft <a-h> <a-k> ^\h+(Proof|Termination|QED|End|Ancestors|Libs) <ret> x s ^\h+ <ret> d }
     }
 }
 
@@ -184,7 +185,7 @@ define-command -hidden hol-indent-on-new-line %{
         # filter previous line
         try %{ execute-keys -draft k : hol-trim-indent <ret> }
         # indent after lines beginning / ending with opener token
-        try %{ execute-keys -draft k x <a-k> [[\(]\h*$|^(Definition|(Co)?Inductive|Datatype|Theorem|Triviality).*:\W*$|^(Proof|Termination).*$|^\[~?\w+:\].*$ <ret> j <a-gt> }
+        try %{ execute-keys -draft k x <a-k> [[\(]\h*$|^(Definition|(Co)?Inductive|Datatype|Theorem|Triviality).*:\W*$|^(Proof|Termination|Ancestors|Libs).*$|^\[~?\w+:\].*$ <ret> j <a-gt> }
         # deindent closer token(s) when after cursor
         try %{ execute-keys -draft x <a-k> ^\h*[\]\)] <ret> gh / [\]\)] <ret> m <a-S> 1<a-&> }
     }


### PR DESCRIPTION
Some kak editor mode QOL changes, the README explains how to configure for multiplexer window splitting using a kak option.