### PR TITLE
Cumulative analysis/calculus updates

### DIFF
--- a/src/pred_set/src/more_theories/topologyScript.sml
+++ b/src/pred_set/src/more_theories/topologyScript.sml
@@ -3884,6 +3884,20 @@ Proof
  >> Q.EXISTS_TAC ‘y’ >> fs [IN_APP]
 QED
 
+Theorem limpt_alt :
+    !top x s. limpt top x s <=> x IN top derived_set_of s
+Proof
+    simp [derived_set_of_alt_limpt]
+QED
+
+Theorem limpt_mono :
+    !top x s t. limpt top x s /\ s SUBSET t ==> limpt top x t
+Proof
+    rw [limpt_alt]
+ >> Suff ‘top derived_set_of s SUBSET top derived_set_of t’ >- rw [SUBSET_DEF]
+ >> MATCH_MP_TAC DERIVED_SET_OF_MONO >> art []
+QED
+
 (* ------------------------------------------------------------------------- *)
 (* Compact sets and compact topological spaces (from HOL-Light's metric.ml)  *)
 (* ------------------------------------------------------------------------- *)

--- a/src/real/analysis/derivativeScript.sml
+++ b/src/real/analysis/derivativeScript.sml
@@ -37,6 +37,11 @@ val ASM_REAL_ARITH_TAC = REAL_ASM_ARITH_TAC; (* realLib *)
 val IMP_CONJ           = CONJ_EQ_IMP;        (* cardinalTheory *)
 val FINITE_SUBSET      = SUBSET_FINITE_I;    (* pred_setTheory *)
 val LIM                = LIM_DEF;            (* real_topologyTheory *)
+val REAL_SUB_EQ = REAL_SUB_0; (* cf. HOL-Light's VECTOR_SUB_EQ *)
+val ABS_POS_LT = GSYM ABS_NZ; (* cf. HOL-Light's NORM_POS_LT *)
+val REAL_LE_DIV2_EQ = REAL_LE_RDIV_CANCEL;
+
+val set_ss = std_ss ++ PRED_SET_ss;
 
 (* ------------------------------------------------------------------------- *)
 (* definition(s) moved from other theories                                   *)
@@ -49,7 +54,7 @@ Definition exp_def :
 End
 
 (* ------------------------------------------------------------------------- *)
-(* convex                                                                    *)
+(* Convexity (updated by HOL-Light's convex.ml).                             *)
 (* ------------------------------------------------------------------------- *)
 
 Definition convex[nocompute]:
@@ -74,6 +79,78 @@ Theorem IN_CONVEX_SET:
         ==> ((&1 - u) * a + u * b) IN s
 Proof
   MESON_TAC[CONVEX_ALT]
+QED
+
+Theorem CONVEX_CONTAINS_SEGMENT :
+    !s. convex s <=> !a b. a IN s /\ b IN s ==> segment[a,b] SUBSET s
+Proof
+    RW_TAC set_ss [CONVEX_ALT, segment, SUBSET_DEF]
+ >> METIS_TAC []
+QED
+
+Theorem CONVEX_CONTAINS_OPEN_SEGMENT :
+    !s. convex s <=> !a b. a IN s /\ b IN s ==> segment(a,b) SUBSET s
+Proof
+  ONCE_REWRITE_TAC[segment] THEN REWRITE_TAC[CONVEX_CONTAINS_SEGMENT] THEN
+  SET_TAC[]
+QED
+
+Theorem CONVEX_CONTAINS_SEGMENT_EQ :
+    !s:real->bool.
+        convex s <=> !a b. segment[a,b] SUBSET s <=> a IN s /\ b IN s
+Proof
+  REWRITE_TAC[CONVEX_CONTAINS_SEGMENT, SUBSET_DEF] THEN
+  MESON_TAC[ENDS_IN_SEGMENT]
+QED
+
+Theorem CONVEX_CONTAINS_SEGMENT_IMP :
+    !s a b. convex s ==> (segment[a,b] SUBSET s <=> a IN s /\ b IN s)
+Proof
+  SIMP_TAC std_ss [CONVEX_CONTAINS_SEGMENT_EQ]
+QED
+
+Theorem SEGMENT_SUBSET_CONVEX :
+    !s a b:real.
+        convex s /\ a IN s /\ b IN s ==> segment[a,b] SUBSET s
+Proof
+  MESON_TAC[CONVEX_CONTAINS_SEGMENT]
+QED
+
+Theorem CONVEX_CONTAINS :
+    !s a b x:real.
+        convex s /\ a IN s /\ b IN s /\ x IN segment[a,b] ==> x IN s
+Proof
+  MESON_TAC[SEGMENT_SUBSET_CONVEX, SUBSET_DEF]
+QED
+
+Theorem CONVEX_EMPTY :
+    convex {}
+Proof
+  REWRITE_TAC[convex, NOT_IN_EMPTY]
+QED
+
+Theorem CONVEX_SING :
+    !a. convex {a}
+Proof
+  SIMP_TAC std_ss[convex, IN_SING, GSYM REAL_ADD_RDISTRIB, REAL_MUL_LID]
+QED
+
+Theorem CONVEX_UNIV :
+    convex(UNIV:real->bool)
+Proof
+  REWRITE_TAC[convex, IN_UNIV]
+QED
+
+Theorem CONVEX_INTERS :
+    !f. (!s. s IN f ==> convex s) ==> convex(INTERS f)
+Proof
+  REWRITE_TAC[convex, IN_INTERS] THEN MESON_TAC[]
+QED
+
+Theorem CONVEX_INTER :
+    !s t. convex s /\ convex t ==> convex(s INTER t)
+Proof
+  REWRITE_TAC[convex, IN_INTER] THEN MESON_TAC[]
 QED
 
 Theorem LIMPT_OF_CONVEX :
@@ -303,7 +380,7 @@ Proof
 QED
 
 (* ------------------------------------------------------------------------- *)
-(*                                                                           *)
+(* Convex functions into the reals (from HOL-Light's convex.ml).             *)
 (* ------------------------------------------------------------------------- *)
 
 val _ = set_fixity "convex_on" (Infix(NONASSOC, 450));
@@ -313,6 +390,86 @@ Definition convex_on[nocompute]:
         !x y u v:real. x IN s /\ y IN s /\ &0 <= u /\ &0 <= v /\ (u + v = &1)
                   ==> f(u * x + v * y) <= u * f(x) + v * f(y)
 End
+
+Theorem CONVEX_ON_EMPTY :
+    !f:real->real. f convex_on {}
+Proof
+  REWRITE_TAC[convex_on, NOT_IN_EMPTY]
+QED
+
+Theorem CONVEX_ON_SUBSET :
+    !f s t. f convex_on t /\ s SUBSET t ==> f convex_on s
+Proof
+  REWRITE_TAC[convex_on, SUBSET_DEF] THEN MESON_TAC[]
+QED
+
+Theorem CONVEX_ON_EQ :
+    !f g s. convex s /\ (!x. x IN s ==> f x = g x) /\ f convex_on s
+           ==> g convex_on s
+Proof
+  REWRITE_TAC[convex_on, convex] THEN MESON_TAC[]
+QED
+
+Theorem CONVEX_ON_CONST :
+    !s a. (\x. a) convex_on s
+Proof
+  SIMP_TAC std_ss[convex_on, GSYM REAL_ADD_RDISTRIB, REAL_MUL_LID, REAL_LE_REFL]
+QED
+
+Theorem LINEAR_IMP_CONVEX_ON :
+    !f s:real->bool. linear f ==> f convex_on s
+Proof
+  REWRITE_TAC[linear, convex_on] THEN rw []
+QED
+
+Theorem CONVEX_ON_SING :
+    !f a:real. f convex_on {a}
+Proof
+  REPEAT GEN_TAC THEN MATCH_MP_TAC CONVEX_ON_EQ THEN
+  EXISTS_TAC ``\x:real. (f:real->real) a`` THEN
+  SIMP_TAC std_ss[IN_SING, CONVEX_SING, CONVEX_ON_CONST]
+QED
+
+Theorem CONVEX_ADD :
+    !s f g. f convex_on s /\ g convex_on s ==> (\x. f(x) + g(x)) convex_on s
+Proof
+  SIMP_TAC bool_ss [convex_on, AND_FORALL_THM] THEN
+  REPEAT(HO_MATCH_MP_TAC MONO_FORALL ORELSE GEN_TAC) THEN
+  HO_MATCH_MP_TAC(TAUT
+    `(b /\ c ==> d) ==> (a ==> b) /\ (a ==> c) ==> a ==> d`) THEN
+  REAL_ARITH_TAC
+QED
+
+Theorem CONVEX_ADD_EQ :
+    !a f s:real->bool. (\x. a + f x) convex_on s <=> f convex_on s
+Proof
+  REPEAT STRIP_TAC THEN EQ_TAC THEN
+  SIMP_TAC std_ss [CONVEX_ADD, CONVEX_ON_CONST] THEN
+  DISCH_THEN(MP_TAC o SPEC ``(\x. -a):real->real`` o
+    MATCH_MP (REWRITE_RULE[IMP_CONJ_ALT] CONVEX_ADD)) THEN
+  SIMP_TAC (std_ss ++ ETA_ss) [CONVEX_ON_CONST, REAL_ARITH ``-a + (a + x:real) = x``]
+QED
+
+(* NOTE: HOL-Light's [REAL_LE_LMUL] is HOL4's [REAL_LE_LMUL_IMP]. *)
+Theorem CONVEX_CMUL :
+    !s c f. &0 <= c /\ f convex_on s ==> (\x. c * f(x)) convex_on s
+Proof
+    RW_TAC std_ss [convex_on, REAL_LE_LMUL_IMP,
+           REAL_ARITH ``u * (c * fx) + v * (c * fy) = (c :real) * (u * fx + v * fy)``]
+QED
+
+Theorem CONVEX_MAX :
+    !f g s. f convex_on s /\ g convex_on s
+           ==> (\x. max (f x) (g x)) convex_on s
+Proof
+  SIMP_TAC std_ss[convex_on, REAL_MAX_LE] THEN REPEAT STRIP_TAC THEN
+  FIRST_X_ASSUM(fn th =>
+    W(MP_TAC o PART_MATCH (lhand o rand) th o lhand o snd)) THEN
+  ASM_REWRITE_TAC[] THEN
+  MATCH_MP_TAC(REWRITE_RULE[IMP_CONJ_ALT] REAL_LE_TRANS) THEN
+  MATCH_MP_TAC REAL_LE_ADD2 THEN CONJ_TAC THEN
+  MATCH_MP_TAC REAL_LE_LMUL_IMP THEN ASM_REAL_ARITH_TAC
+QED
 
 Theorem REAL_CONVEX_BOUND2_LT :
     !x y a b u v:real. x < a /\ y < b /\ &0 <= u /\ &0 <= v /\ (u + v = &1)
@@ -1226,7 +1383,8 @@ Proof
    [DISCH_TAC THEN ASM_REWRITE_TAC [] THEN POP_ASSUM K_TAC THEN
     STRIP_TAC THEN Q.EXISTS_TAC `x` THEN POP_ASSUM MP_TAC THEN
     ASM_SIMP_TAC std_ss [FUN_EQ_THM] THEN DISCH_THEN (MP_TAC o SPEC ``b - a:real``),
-    ASM_SIMP_TAC real_ss [CONTINUOUS_ON_SUB, CONTINUOUS_ON_CMUL, CONTINUOUS_ON_ID] THEN
+    ASM_SIMP_TAC real_ss [CONTINUOUS_ON_SUB, CONTINUOUS_ON_CMUL,
+                          CONTINUOUS_ON_ID] THEN
     CONJ_TAC THENL
      [REWRITE_TAC[REAL_ARITH
        ``(fa - k * a = fb - k * b) <=> (fb - fa = k * (b - a:real))``] THEN
@@ -1240,6 +1398,43 @@ Proof
       ASM_SIMP_TAC real_ss [HAS_DERIVATIVE_CMUL, HAS_DERIVATIVE_ID, ETA_AX]]] THEN
   `b - a <> 0` by (UNDISCH_TAC ``a < b:real`` THEN REAL_ARITH_TAC) THEN
   ASM_SIMP_TAC real_ss [REAL_DIV_RMUL] THEN REAL_ARITH_TAC
+QED
+
+Theorem MVT_SIMPLE :
+   !f:real->real f' a b.
+        a < b /\
+        (!x. x IN interval[a,b]
+             ==> (f has_derivative f'(x)) (at x within interval[a,b]))
+        ==> ?x. x IN interval(a,b) /\ (f(b) - f(a) = f'(x) (b - a))
+Proof
+  MP_TAC MVT THEN
+  REPEAT(HO_MATCH_MP_TAC MONO_FORALL THEN GEN_TAC) THEN
+  REPEAT STRIP_TAC THEN FIRST_X_ASSUM MATCH_MP_TAC THEN ASM_REWRITE_TAC[] THEN
+  CONJ_TAC THENL
+   [MATCH_MP_TAC DIFFERENTIABLE_IMP_CONTINUOUS_ON THEN
+    ASM_MESON_TAC[differentiable_on, differentiable],
+    ASM_MESON_TAC[HAS_DERIVATIVE_WITHIN_OPEN, OPEN_INTERVAL,
+                  HAS_DERIVATIVE_WITHIN_SUBSET, INTERVAL_OPEN_SUBSET_CLOSED,
+                  SUBSET_DEF]]
+QED
+
+Theorem MVT_VERY_SIMPLE :
+   !f:real->real f' a b.
+        a <= b /\
+        (!x. x IN interval[a,b]
+             ==> (f has_derivative f'(x)) (at x within interval[a,b]))
+        ==> ?x. x IN interval[a,b] /\ (f(b) - f(a) = f'(x) (b - a))
+Proof
+  REPEAT GEN_TAC THEN ASM_CASES_TAC ``b:real = a`` THENL
+   [ASM_REWRITE_TAC[REAL_SUB_REFL] THEN REPEAT STRIP_TAC THEN
+    FIRST_X_ASSUM(MP_TAC o Q.SPEC `a:real`) THEN
+    SIMP_TAC std_ss[INTERVAL_SING, IN_SING, has_derivative, UNWIND_THM2] THEN
+    MESON_TAC[LINEAR_0],
+   ‘a <> b’ by PROVE_TAC [] \\
+    ASM_REWRITE_TAC[REAL_LE_LT] THEN
+    DISCH_THEN(MP_TAC o MATCH_MP MVT_SIMPLE) THEN
+    HO_MATCH_MP_TAC MONO_EXISTS THEN
+    SIMP_TAC std_ss[REWRITE_RULE[SUBSET_DEF] INTERVAL_OPEN_SUBSET_CLOSED]]
 QED
 
 (* ------------------------------------------------------------------------- *)
@@ -2338,6 +2533,382 @@ Theorem CONTINUOUS_ON_EXP:
    !s. exp continuous_on s
 Proof
   METIS_TAC[CONTINUOUS_AT_IMP_CONTINUOUS_ON, CONTINUOUS_AT_EXP]
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Characterizations of convex functions in terms of secants.                *)
+(*  (Ported from HOL-Light's Multivariate/convex.ml)                         *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem CONVEX_ON_SECANT_MUL_combined[local] :
+   (!f s:real->bool.
+        f convex_on s <=>
+        !a b x. a IN s /\ b IN s /\ x IN segment[a,b]
+                ==> (f x - f a) * abs(b - a) <= (f b - f a) * abs(x - a)) /\
+   (!f s:real->bool.
+        f convex_on s <=>
+        !a b x. a IN s /\ b IN s /\ x IN segment[a,b]
+                ==> (f b - f a) * abs(b - x) <= (f b - f x) * abs(b - a)) /\
+   (!f s:real->bool.
+        f convex_on s <=>
+        !a b x. a IN s /\ b IN s /\ x IN segment[a,b]
+                ==> (f x - f a) * abs(b - x) <= (f b - f x) * abs(x - a))
+Proof
+  REPEAT CONJ_TAC THEN (* 3 subgoals, same tactics *)
+  REPEAT GEN_TAC THEN REWRITE_TAC[convex_on] THEN
+  AP_TERM_TAC THEN GEN_REWRITE_TAC I empty_rewrites [FUN_EQ_THM] THEN
+  Q.X_GEN_TAC `a:real` THEN BETA_TAC THEN
+  AP_TERM_TAC THEN GEN_REWRITE_TAC I empty_rewrites [FUN_EQ_THM] THEN
+  Q.X_GEN_TAC `b:real` THEN BETA_TAC THEN
+  ASM_CASES_TAC ``(a:real) IN s`` THEN ASM_REWRITE_TAC[] THEN
+  ASM_CASES_TAC ``(b:real) IN s`` THEN ASM_REWRITE_TAC[] THEN
+  SIMP_TAC pure_ss[IN_SEGMENT, LEFT_IMP_EXISTS_THM] THEN
+  Ho_Rewrite.ONCE_REWRITE_TAC [SWAP_FORALL_THM] THEN
+  AP_TERM_TAC THEN GEN_REWRITE_TAC I empty_rewrites [FUN_EQ_THM] THEN
+  Q.X_GEN_TAC `u:real` THEN BETA_TAC THEN
+  REWRITE_TAC[TAUT `a /\ x = y <=> x = y /\ a`,
+              TAUT `a /\ x = y /\ b <=> x = y /\ a /\ b`] THEN
+  REWRITE_TAC[REAL_ARITH ``v + u = &1 <=> v = &1 - u``] THEN
+  SIMP_TAC bool_ss[FORALL_UNWIND_THM2, IMP_CONJ] THEN
+  REWRITE_TAC[REAL_SUB_LE] THEN
+  ASM_CASES_TAC ``&0 <= u`` THEN ASM_REWRITE_TAC[] THEN
+  ASM_CASES_TAC ``u <= &1`` THEN ASM_REWRITE_TAC[] THEN
+  REWRITE_TAC[REAL_ARITH ``((&1 - u) * a + u * b) - a:real = u * (b - a)``,
+   REAL_ARITH ``b - ((&1 - u) * a + u * b):real = (&1 - u) * (b - a)``] THEN
+  REWRITE_TAC[ABS_MUL, REAL_MUL_ASSOC] THEN
+  (ASM_CASES_TAC ``b:real = a`` THENL
+   [ASM_REWRITE_TAC[REAL_SUB_REFL,
+                    REAL_ARITH ``(&1 - u) * a + u * a:real = a``] THEN
+    REAL_ARITH_TAC,
+   ‘0 < abs (b - a)’ by simp [GSYM ABS_NZ, REAL_SUB_0] THEN
+    ASM_SIMP_TAC std_ss[REAL_LE_RMUL] THEN
+    ASM_SIMP_TAC std_ss[REAL_ARITH
+     ``&0 <= u /\ u <= &1 ==> abs u = u /\ abs(&1 - u) = &1 - u``] THEN
+    REAL_ARITH_TAC])
+QED
+
+Theorem CONVEX_ON_LEFT_SECANT_MUL  = CONVEX_ON_SECANT_MUL_combined |> cj 1
+Theorem CONVEX_ON_RIGHT_SECANT_MUL = CONVEX_ON_SECANT_MUL_combined |> cj 2
+Theorem CONVEX_ON_MID_SECANT_MUL   = CONVEX_ON_SECANT_MUL_combined |> cj 3
+
+Theorem CONVEX_ON_SECANT_combined[local] :
+   (!f s:real->bool.
+      f convex_on s <=>
+        !a b x. a IN s /\ b IN s /\ x IN segment(a,b)
+                ==> (f x - f a) / abs(x - a) <= (f b - f a) / abs(b - a)) /\
+   (!f s:real->bool.
+      f convex_on s <=>
+        !a b x. a IN s /\ b IN s /\ x IN segment(a,b)
+                ==> (f b - f a) / abs(b - a) <= (f b - f x) / abs(b - x)) /\
+   (!f s:real->bool.
+      f convex_on s <=>
+        !a b x. a IN s /\ b IN s /\ x IN segment(a,b)
+                ==> (f x - f a) / abs(x - a) <= (f b - f x) / abs(b - x))
+Proof
+  REPEAT CONJ_TAC THEN REPEAT GEN_TAC THENL
+   [REWRITE_TAC[CONVEX_ON_LEFT_SECANT_MUL],
+    REWRITE_TAC[CONVEX_ON_RIGHT_SECANT_MUL],
+     REWRITE_TAC[CONVEX_ON_MID_SECANT_MUL]] THEN (* 3 subgoals, same tactics *)
+  AP_TERM_TAC THEN GEN_REWRITE_TAC I empty_rewrites[FUN_EQ_THM] THEN
+  Q.X_GEN_TAC `a:real` THEN BETA_TAC THEN
+  AP_TERM_TAC THEN GEN_REWRITE_TAC I empty_rewrites[FUN_EQ_THM] THEN
+  Q.X_GEN_TAC `b:real` THEN BETA_TAC THEN
+  ASM_CASES_TAC ``(a:real) IN s`` THEN ASM_REWRITE_TAC[] THEN
+  ASM_CASES_TAC ``(b:real) IN s`` THEN ASM_REWRITE_TAC[] THEN
+  ASM_CASES_TAC ``a:real = b`` THEN
+  ASM_REWRITE_TAC[SEGMENT_REFL, NOT_IN_EMPTY, REAL_SUB_REFL, ABS_0,
+                  REAL_MUL_LZERO, REAL_MUL_RZERO, REAL_LE_REFL] THEN
+ (* only subgoal for ‘a <> b’ is left here *)
+  SIMP_TAC bool_ss[IN_SING, FORALL_UNWIND_THM2, REAL_LE_REFL] THEN
+  AP_TERM_TAC THEN GEN_REWRITE_TAC I empty_rewrites[FUN_EQ_THM] THEN
+  Q.X_GEN_TAC `x:real` THEN BETA_TAC THEN
+  REWRITE_TAC[open_segment, IN_DIFF, IN_INSERT, NOT_IN_EMPTY] THEN
+  MAP_EVERY ASM_CASES_TAC [``x:real = a``, ``x:real = b``] THEN
+  ASM_REWRITE_TAC[REAL_LE_REFL, REAL_SUB_REFL, ABS_0,
+                  REAL_MUL_LZERO, REAL_MUL_RZERO] THEN (* one goal left *)
+  ASM_SIMP_TAC std_ss [REAL_LE_RDIV_EQ, GSYM REAL_LE_LDIV_EQ,
+                       GSYM ABS_NZ, REAL_SUB_0] THEN
+  AP_TERM_TAC THEN REAL_ARITH_TAC
+QED
+
+Theorem CONVEX_ON_LEFT_SECANT  = CONVEX_ON_SECANT_combined |> cj 1
+Theorem CONVEX_ON_RIGHT_SECANT = CONVEX_ON_SECANT_combined |> cj 2
+Theorem CONVEX_ON_MID_SECANT   = CONVEX_ON_SECANT_combined |> cj 3
+
+(* ------------------------------------------------------------------------- *)
+(* Various versions of Kachurovskii's theorem (reduced to R^1).              *)
+(*  (Ported from HOL-Light's Multivariate/derivatives.ml)                    *)
+(* ------------------------------------------------------------------------- *)
+
+Theorem CONVEX_ON_DERIVATIVE_SECANT_IMP :
+   !f f' s x y:real.
+        f convex_on s /\ segment[x,y] SUBSET s /\
+        (f has_derivative f') (at x within s)
+        ==> f'(y - x) <= f y - f x
+Proof
+  REPEAT STRIP_TAC THEN
+  SUBGOAL_THEN ``(x:real) IN s /\ (y:real) IN s`` ASSUME_TAC THENL
+   [ASM_MESON_TAC[SUBSET_DEF, ENDS_IN_SEGMENT], ALL_TAC] THEN
+  FIRST_X_ASSUM
+   (MP_TAC o GEN_REWRITE_RULE I empty_rewrites[has_derivative_within]) THEN
+  REWRITE_TAC[LIM_WITHIN, DIST_0, o_THM] THEN
+  STRIP_TAC THEN ASM_CASES_TAC ``y:real = x`` THENL
+   [FIRST_X_ASSUM(MP_TAC o MATCH_MP LINEAR_0) THEN
+    ASM_SIMP_TAC std_ss[REAL_SUB_REFL, REAL_LE_REFL],
+    ALL_TAC] THEN
+ (* stage work *)
+  Q.ABBREV_TAC `e = (f':real->real)(y - x) - (f y - f x)` THEN
+  ASM_CASES_TAC ``&0 < e`` THENL
+    [ALL_TAC, qunabbrev_tac ‘e’ >> ASM_REAL_ARITH_TAC] THEN
+  FIRST_X_ASSUM(MP_TAC o SPEC ``e / &2 / abs(y - x:real)``) THEN
+  ASM_SIMP_TAC std_ss[REAL_LT_DIV, REAL_HALF, ABS_POS_LT, REAL_SUB_EQ] THEN
+  DISCH_THEN(X_CHOOSE_THEN ``d:real`` (CONJUNCTS_THEN2 ASSUME_TAC MP_TAC)) THEN
+  Q.ABBREV_TAC `u = min (&1 / &2) (d / &2 / abs (y - x:real))` THEN
+  SUBGOAL_THEN ``&0 < u /\ u < &1`` STRIP_ASSUME_TAC THENL
+   [qunabbrev_tac ‘u’ THEN REWRITE_TAC[REAL_LT_MIN, REAL_MIN_LT] THEN
+    ASM_SIMP_TAC std_ss[REAL_LT_DIV, ABS_POS_LT, REAL_HALF, REAL_SUB_EQ] THEN
+    simp [],
+    ALL_TAC] THEN
+  Q.ABBREV_TAC `z:real = (&1 - u) * x + u * y` THEN
+  SUBGOAL_THEN ``(z:real) IN segment(x,y)`` MP_TAC THENL
+   [METIS_TAC [IN_SEGMENT], ALL_TAC] THEN
+  SIMP_TAC std_ss[open_segment, IN_DIFF, IN_INSERT, NOT_IN_EMPTY, DE_MORGAN_THM] THEN
+  STRIP_TAC THEN DISCH_THEN(MP_TAC o SPEC ``z:real``) THEN
+  SUBGOAL_THEN ``(z:real) IN s`` ASSUME_TAC THENL [ASM_SET_TAC[], ALL_TAC] THEN
+  impl_tac THENL
+   [ASM_SIMP_TAC std_ss[DIST_POS_LT] THEN
+    qunabbrev_tac ‘z’ THEN REWRITE_TAC[dist, ABS_MUL, REAL_ARITH
+     ``((&1 - u) * x + u * y) - x:real = u * (y - x)``] THEN
+    ASM_SIMP_TAC std_ss[GSYM REAL_LT_RDIV_EQ, ABS_POS_LT, REAL_SUB_EQ] THEN
+   ‘abs u = u’ by simp [ABS_REDUCE, REAL_LT_IMP_LE] >> POP_ORW \\
+    simp [Abbr ‘u’, REAL_MIN_LT],
+    ALL_TAC] THEN
+  FIRST_ASSUM(MP_TAC o
+              GEN_REWRITE_RULE I empty_rewrites[CONVEX_ON_LEFT_SECANT]) THEN
+  DISCH_THEN(MP_TAC o Q.SPECL [`x:real`, `y:real`, `z:real`]) THEN
+  ASM_REWRITE_TAC[open_segment, IN_DIFF, IN_INSERT, NOT_IN_EMPTY] THEN
+  SIMP_TAC std_ss
+   [REAL_ARITH ``inv y * (z - (x + d)):real = (z - x) / y - d / y``] THEN
+  REWRITE_TAC[IMP_IMP] THEN DISCH_THEN(MP_TAC o MATCH_MP (REAL_ARITH
+   ``z <= y / n /\ abs(z - d) < e / n ==> d <= (y + e) / n``)) THEN
+  SUBGOAL_THEN
+   ``(f':real->real)(z - x) / abs(z - x) = f'(y - x) / abs(y - x)``
+  SUBST1_TAC THENL
+   [qunabbrev_tac ‘z’ THEN
+    REWRITE_TAC[REAL_ARITH
+     ``((&1 - u) * x + u * y) - x:real = u * (y - x)``] THEN
+    FIRST_ASSUM(MP_TAC o MATCH_MP LINEAR_CMUL) THEN
+    DISCH_THEN(MP_TAC o Q.SPECL [`u:real`, `y - x:real`]) THEN
+    DISCH_THEN SUBST1_TAC THEN REWRITE_TAC[ABS_MUL] THEN
+   ‘abs u = u’ by simp [ABS_REDUCE, REAL_LT_IMP_LE] >> POP_ORW THEN
+    REWRITE_TAC[real_div, REAL_INV_MUL', REAL_MUL_ASSOC] THEN
+    AP_THM_TAC THEN AP_TERM_TAC THEN REWRITE_TAC[GSYM REAL_MUL_ASSOC] THEN
+    REWRITE_TAC[GSYM real_div] THEN MATCH_MP_TAC REAL_DIV_LMUL THEN
+    ASM_REAL_ARITH_TAC,
+    ASM_SIMP_TAC std_ss[REAL_LE_DIV2_EQ, ABS_POS_LT, REAL_SUB_EQ] THEN
+    qunabbrev_tac ‘e’ >> REAL_ARITH_TAC]
+QED
+
+Theorem CONVEX_ON_SECANT_DERIVATIVE_IMP :
+   !f f' s x y:real.
+        f convex_on s /\ segment[x,y] SUBSET s /\
+        (f has_derivative f') (at y within s)
+        ==> f y - f x <= f'(y - x)
+Proof
+  ONCE_REWRITE_TAC[SEGMENT_SYM] THEN REPEAT STRIP_TAC THEN
+  MP_TAC(Q.ISPECL
+   [`f:real->real`, `f':real->real`, `s:real->bool`,
+    `y:real`, `x:real`] CONVEX_ON_DERIVATIVE_SECANT_IMP) THEN
+  ASM_REWRITE_TAC[] THEN ONCE_REWRITE_TAC[SEGMENT_SYM] THEN
+  MATCH_MP_TAC(REAL_ARITH
+   ``f' = -f'' ==> f' <= x - y ==> y - x <= f'' :real``) THEN
+  GEN_REWRITE_TAC (LAND_CONV o RAND_CONV) empty_rewrites[GSYM REAL_NEG_SUB] THEN
+  Q.SPEC_TAC(`y - x:real`,`z:real`) THEN
+  MATCH_MP_TAC(REWRITE_RULE[RIGHT_FORALL_IMP_THM] LINEAR_NEG) THEN
+  ASM_MESON_TAC[has_derivative]
+QED
+
+Theorem CONVEX_ON_DERIVATIVES_IMP :
+   !f f'x f'y s x y:real.
+        f convex_on s /\ segment[x,y] SUBSET s /\
+        (f has_derivative f'x) (at x within s) /\
+        (f has_derivative f'y) (at y within s)
+        ==> f'x(y - x) <= f'y(y - x)
+Proof
+  ASM_MESON_TAC[CONVEX_ON_DERIVATIVE_SECANT_IMP,
+                CONVEX_ON_SECANT_DERIVATIVE_IMP,
+                SEGMENT_SYM, REAL_LE_TRANS]
+QED
+
+Theorem CONVEX_ON_DERIVATIVE_SECANT_combined[local] :
+   (!f f' s:real->bool.
+        convex s /\
+        (!x. x IN s ==> (f has_derivative (f'(x))) (at x within s))
+        ==> (f convex_on s <=>
+             !x y. x IN s /\ y IN s ==> f'(x)(y - x) <= f y - f x)) /\
+   (!f f' s:real->bool.
+        convex s /\
+        (!x. x IN s ==> (f has_derivative (f'(x))) (at x within s))
+        ==> (f convex_on s <=>
+             !x y. x IN s /\ y IN s ==> f'(x)(y - x) <= f'(y)(y - x)))
+Proof
+  SIMP_TAC bool_ss[AND_FORALL_THM] THEN REPEAT GEN_TAC THEN
+  REWRITE_TAC[TAUT `(a ==> b) /\ (a ==> c) <=> a ==> b /\ c`] THEN
+  STRIP_TAC THEN MATCH_MP_TAC(TAUT
+   `(a ==> b) /\ (b ==> c) /\ (c ==> a) ==> (a <=> b) /\ (a <=> c)`) THEN
+  REPEAT CONJ_TAC THENL
+  [ (* goal 1 (of 3) *)
+    REPEAT STRIP_TAC THEN MATCH_MP_TAC CONVEX_ON_DERIVATIVE_SECANT_IMP THEN
+    EXISTS_TAC ``s:real->bool`` THEN ASM_SIMP_TAC std_ss[] THEN
+    ASM_MESON_TAC[CONVEX_CONTAINS_SEGMENT],
+    (* goal 2 (of 3) *)
+    DISCH_TAC THEN MAP_EVERY Q.X_GEN_TAC [`x:real`, `y:real`] THEN
+    STRIP_TAC THEN FIRST_X_ASSUM(fn th =>
+     MP_TAC(Q.SPECL [`x:real`, `y:real`] th) THEN
+     MP_TAC(Q.SPECL [`y:real`, `x:real`] th)) THEN
+    ASM_REWRITE_TAC[] THEN MATCH_MP_TAC(REAL_ARITH
+     ``f''' = -f'' ==> f''' <= x - y ==> f' <= y - x ==> f' <= f''``) THEN
+    GEN_REWRITE_TAC (LAND_CONV o RAND_CONV) empty_rewrites[GSYM REAL_NEG_SUB] THEN
+    Q.SPEC_TAC(`y - x:real`,`z:real`) THEN
+    MATCH_MP_TAC(REWRITE_RULE[RIGHT_FORALL_IMP_THM] LINEAR_NEG) THEN
+    ASM_MESON_TAC[has_derivative],
+    (* goal 3 (of 3) *)
+    ALL_TAC] THEN
+  DISCH_TAC THEN REWRITE_TAC[convex_on] THEN
+  MAP_EVERY Q.X_GEN_TAC [`a:real`, `b:real`] THEN
+  ASM_SIMP_TAC bool_ss[Once SWAP_FORALL_THM] THEN
+  ONCE_REWRITE_TAC[TAUT `a /\ b /\ c /\ d /\ e <=> e /\ a /\ b /\ c /\ d`] THEN
+  REWRITE_TAC[IMP_CONJ, REAL_ARITH ``u + v = &1 <=> u = &1 - v``] THEN
+  SIMP_TAC bool_ss[FORALL_UNWIND_THM2, REAL_SUB_LE] THEN
+  Q.X_GEN_TAC `u:real` THEN
+  REPEAT STRIP_TAC THEN
+  ASM_CASES_TAC ``u = &0`` THEN
+  ASM_SIMP_TAC std_ss [REAL_SUB_RZERO, REAL_MUL_LZERO, REAL_MUL_LID,
+                       REAL_LE_REFL, REAL_ADD_RID] THEN
+  ASM_CASES_TAC ``u = &1`` THEN
+  ASM_SIMP_TAC std_ss [REAL_SUB_REFL, REAL_MUL_LZERO, REAL_MUL_LID,
+                       REAL_LE_REFL, REAL_ADD_LID] THEN
+  SUBGOAL_THEN ``&0 < u /\ u < &1`` STRIP_ASSUME_TAC THENL
+   [ASM_REWRITE_TAC[REAL_LT_LE] >> PROVE_TAC [], ALL_TAC] THEN
+  MP_TAC(Q.SPECL
+   [`(f:real->real) o (\u. (&1 - u) * a + u * b)`,
+    `\x:real. f'((&1 - x) * a + x * b) o
+     (\u. -u * a + u * b:real)`] MVT_VERY_SIMPLE) THEN
+  DISCH_THEN(fn th =>
+    MP_TAC(Q.SPECL [`0:real`, `u`] th) THEN
+    MP_TAC(Q.SPECL [`u`, `1:real`] th)) THEN
+  ASM_SIMP_TAC std_ss[o_THM] THEN
+  ASM_SIMP_TAC std_ss[REAL_MUL_LZERO, REAL_SUB_RZERO, REAL_LT_IMP_LE,
+                      REAL_ADD_RID, REAL_MUL_LID, REAL_SUB_RZERO] THEN
+  MATCH_MP_TAC(TAUT
+   `(a1 /\ a2) /\ (b1 ==> b2 ==> c) ==> (a1 ==> b1) ==> (a2 ==> b2) ==> c`) THEN
+  CONJ_TAC THENL
+  [ (* goal 1 (of 2) *)
+    CONJ_TAC THEN X_GEN_TAC ``v:real`` THEN DISCH_TAC THEN
+    (* 2 subgoals, same tactics *)
+    (REWRITE_TAC[o_ASSOC] THEN MATCH_MP_TAC DIFF_CHAIN_WITHIN THEN
+     REWRITE_TAC[] THEN CONJ_TAC THENL
+     [ (* goal 1.1 (of 2) *)
+       HO_MATCH_MP_TAC HAS_DERIVATIVE_ADD THEN CONJ_TAC THENL
+        [ONCE_REWRITE_TAC[REAL_ARITH ``(&1 - a) * x:real = x + -a * x``,
+                          REAL_ARITH ``-u * a:real = 0 + -u * a``] THEN
+         HO_MATCH_MP_TAC HAS_DERIVATIVE_ADD THEN
+         REWRITE_TAC[HAS_DERIVATIVE_CONST],
+         ALL_TAC] THEN
+       MATCH_MP_TAC HAS_DERIVATIVE_LINEAR THEN
+       REWRITE_TAC[linear] THEN REAL_ARITH_TAC,
+       (* goal 1.2 (of 2) *)
+       MATCH_MP_TAC HAS_DERIVATIVE_WITHIN_SUBSET THEN
+       BETA_TAC THEN
+       EXISTS_TAC ``s:real->bool`` THEN CONJ_TAC THENL
+        [FIRST_X_ASSUM MATCH_MP_TAC,
+         SIMP_TAC std_ss[SUBSET_DEF, FORALL_IN_IMAGE] THEN
+         Q.X_GEN_TAC ‘x’ THEN DISCH_TAC] THEN
+       FIRST_ASSUM(MATCH_MP_TAC o
+                   GEN_REWRITE_RULE I empty_rewrites[CONVEX_ALT]) THEN
+       FULL_SIMP_TAC std_ss [IN_INTERVAL] THEN
+       ASM_REAL_ARITH_TAC ]),
+    (* goal 2 (of 2) *)
+    REWRITE_TAC[REAL_SUB_REFL, REAL_MUL_LZERO, REAL_ADD_LID] THEN
+    SIMP_TAC std_ss [IN_INTERVAL] \\
+    REWRITE_TAC[REAL_ARITH ``-u * a + u * b:real = u * (b - a)``] THEN
+    SIMP_TAC std_ss[LEFT_IMP_EXISTS_THM, RIGHT_IMP_FORALL_THM] THEN
+    MAP_EVERY X_GEN_TAC [``w:real``, ``v:real``] THEN
+    DISCH_THEN(CONJUNCTS_THEN2 STRIP_ASSUME_TAC MP_TAC) THEN
+    ONCE_REWRITE_TAC[TAUT `a ==> b /\ c ==> d <=> b ==> a ==> c ==> d`] THEN
+    STRIP_TAC THEN REWRITE_TAC[IMP_IMP] THEN
+    DISCH_THEN(CONJUNCTS_THEN2 (MP_TAC o AP_TERM ``$* (u:real)``)
+                               (MP_TAC o AP_TERM ``$* (&1 - u:real)``)) THEN
+    MATCH_MP_TAC(REAL_ARITH
+     ``f1 <= f2 /\ (xa <= xb ==> a <= b)
+      ==> xa = f1 ==> xb = f2 ==> a <= b :real``) THEN
+    CONJ_TAC THENL [ALL_TAC, REAL_ARITH_TAC] THEN
+    SUBGOAL_THEN
+     ``((&1 - v) * a + v * b:real) IN s /\
+       ((&1 - w) * a + w * b:real) IN s``
+    STRIP_ASSUME_TAC THENL
+     [CONJ_TAC THEN
+      FIRST_X_ASSUM
+        (MATCH_MP_TAC o GEN_REWRITE_RULE I empty_rewrites[CONVEX_ALT]) THEN
+      ASM_REWRITE_TAC[] THEN ASM_REAL_ARITH_TAC,
+      ALL_TAC] THEN
+    SUBGOAL_THEN
+     ``linear((f'((&1 - v) * a + v * b:real):real->real)) /\
+       linear((f'((&1 - w) * a + w * b:real):real->real))``
+    MP_TAC THENL [ASM_MESON_TAC[has_derivative], ALL_TAC] THEN
+    DISCH_THEN(CONJUNCTS_THEN(MP_TAC o MATCH_MP LINEAR_CMUL)) THEN
+    REPEAT DISCH_TAC THEN ASM_REWRITE_TAC[] THEN
+    ONCE_REWRITE_TAC[REAL_ARITH ``(&1 - u) * (u * x) = u * ((&1 - u) * x)``] THEN
+    REPEAT(MATCH_MP_TAC REAL_LE_LMUL_IMP THEN
+           CONJ_TAC THENL [ASM_REAL_ARITH_TAC, ALL_TAC]) THEN
+    LAST_X_ASSUM(MP_TAC o SPECL
+     [``(&1 - v) * a + v * b:real``, ``(&1 - w) * a + w * b:real``]) THEN
+    ASM_REWRITE_TAC[REAL_ARITH
+     ``((&1 - v) * a + v * b) - ((&1 - w) * a + w * b):real =
+       (v - w) * (b - a)``] THEN
+    ASM_CASES_TAC ``v:real = w`` THEN ASM_SIMP_TAC std_ss[REAL_LE_REFL] THEN
+    SUBGOAL_THEN ``&0 < w - v`` (fn th => SIMP_TAC std_ss[th, REAL_LE_LMUL]) THEN
+    ASM_REAL_ARITH_TAC]
+QED
+
+(* |- !f f' s.
+        convex s /\ (!x. x IN s ==> (f has_derivative f' x) (at x within s)) ==>
+        (f convex_on s <=>
+         !x y. x IN s /\ y IN s ==> f' x (y - x) <= f y - f x)
+ *)
+Theorem CONVEX_ON_DERIVATIVE_SECANT =
+        CONVEX_ON_DERIVATIVE_SECANT_combined |> cj 1
+
+(* |- !f f' s.
+        convex s /\ (!x. x IN s ==> (f has_derivative f' x) (at x within s)) ==>
+        (f convex_on s <=>
+         !x y. x IN s /\ y IN s ==> f' x (y - x) <= f' y (y - x))
+ *)
+Theorem CONVEX_ON_DERIVATIVES =
+        CONVEX_ON_DERIVATIVE_SECANT_combined |> cj 2
+
+Theorem CONVEX_ON_SECANT_DERIVATIVE :
+   !f f' s:real->bool.
+        convex s /\
+        (!x. x IN s ==> (f has_derivative (f'(x))) (at x within s))
+        ==> (f convex_on s <=>
+             !x y. x IN s /\ y IN s ==> f y - f x <= f'(y)(y - x))
+Proof
+  REPEAT GEN_TAC THEN DISCH_TAC THEN
+  FIRST_ASSUM(SUBST1_TAC o MATCH_MP CONVEX_ON_DERIVATIVE_SECANT) THEN
+  Ho_Rewrite.GEN_REWRITE_TAC RAND_CONV [SWAP_FORALL_THM] THEN
+  AP_TERM_TAC THEN GEN_REWRITE_TAC I empty_rewrites[FUN_EQ_THM] THEN
+  Q.X_GEN_TAC `x:real` THEN BETA_TAC THEN
+  AP_TERM_TAC THEN GEN_REWRITE_TAC I empty_rewrites[FUN_EQ_THM] THEN
+  Q.X_GEN_TAC `y:real` THEN BETA_TAC THEN
+  MAP_EVERY ASM_CASES_TAC [``(x:real) IN s``, ``(y:real) IN s``] THEN
+  ASM_REWRITE_TAC[] THEN
+  MATCH_MP_TAC(REAL_ARITH
+   ``f' = -f'' ==> (f' <= y - x <=> x - y <= f'' :real)``) THEN
+  GEN_REWRITE_TAC (LAND_CONV o RAND_CONV) empty_rewrites[GSYM REAL_NEG_SUB] THEN
+  Q.SPEC_TAC(`x - y:real`,`z:real`) THEN
+  MATCH_MP_TAC(REWRITE_RULE[RIGHT_FORALL_IMP_THM] LINEAR_NEG) THEN
+  ASM_MESON_TAC[has_derivative]
 QED
 
 (* END *)

--- a/src/real/analysis/integrationScript.sml
+++ b/src/real/analysis/integrationScript.sml
@@ -10807,6 +10807,15 @@ Proof
   SIMP_TAC std_ss [COND_RAND, ABS_0]
 QED
 
+Theorem HAS_ABSOLUTE_INTEGRAL :
+   !(f :real->real) s y.
+        f absolutely_integrable_on s /\ integral s f = y <=>
+        f absolutely_integrable_on s /\ (f has_integral y) s
+Proof
+  MESON_TAC[ABSOLUTELY_INTEGRABLE_IMP_INTEGRABLE,
+            HAS_INTEGRAL_INTEGRABLE_INTEGRAL]
+QED
+
 Theorem ABSOLUTELY_INTEGRABLE_EQ:
    !f:real->real g s.
         (!x. x IN s ==> (f x = g x)) /\ f absolutely_integrable_on s

--- a/src/real/analysis/limScript.sml
+++ b/src/real/analysis/limScript.sml
@@ -2223,6 +2223,15 @@ Proof
  >> METIS_TAC [netsTheory.WITHIN_UNIV]
 QED
 
+Theorem higher_differentiable_1_eq_differentiable_on':
+    !f s. open s ==>
+          ((!x. x IN s ==> higher_differentiable 1 f x) <=>
+           f differentiable_on s)
+Proof
+    rw [higher_differentiable_1_eq_differentiable, differentiable_on]
+ >> METIS_TAC [DIFFERENTIABLE_WITHIN_OPEN]
+QED
+
 Theorem diffn_SUC :
     !m f. (!x. higher_differentiable (SUC m) f x) ==>
           (diffn m (diffn 1 f) = diffn (SUC m) f)
@@ -2302,6 +2311,25 @@ Proof
  >> gs []
 QED
 
+Theorem higher_differentiable_imp_mn :
+    !m n f. (!x. higher_differentiable (m + n) f x) ==>
+            (!x. higher_differentiable m (diffn n f) x)
+Proof
+    Q.X_GEN_TAC ‘m’
+ >> Induct_on ‘n’ >- simp []
+ >> rpt STRIP_TAC
+ >> Know ‘diffn (SUC n) f = diffn n (diff1 f)’
+ >- (SYM_TAC >> MATCH_MP_TAC diffn_SUC \\
+     Q.X_GEN_TAC ‘x’ \\
+     MATCH_MP_TAC higher_differentiable_mono \\
+     qexists ‘m + SUC n’ >> simp [])
+ >> Rewr'
+ >> FIRST_X_ASSUM MATCH_MP_TAC
+ >> MATCH_MP_TAC higher_differentiable_imp_n1
+ >> ‘SUC (m + n) = m + SUC n’ by ARITH_TAC
+ >> simp []
+QED
+
 Theorem diffn_chain :
     !f g. (!t. higher_differentiable 1 f t) /\ (!t. higher_differentiable 1 g t) ==>
           (diffn 1 (λx. f (g x)) = λx. diffn 1 f (g x) * diffn 1 g x)
@@ -2351,6 +2379,12 @@ Proof
  >> simp []
  >> METIS_TAC [DIFF_UNIQ]
 QED
+
+(* |- !f c x.
+        (!x. higher_differentiable 1 f x) ==>
+        diff1 (\x. c * f x) x = c * diff1 f x
+ *)
+Theorem diff1_cmul = diffn_cmul |> SRULE [FUN_EQ_THM, PULL_FORALL]
 
 Theorem diffl_imp_diffn :
     !m f x y. (diffn m f diffl y) x ==> (diffn (SUC m) f x = y)
@@ -2465,6 +2499,35 @@ Proof
  >> qmatch_abbrev_tac ‘y = l - m’
  >> MP_TAC (Q.SPECL [‘f’, ‘g’, ‘l’, ‘m’, ‘x’] DIFF_SUB) >> rw []
  >> METIS_TAC [DIFF_UNIQ]
+QED
+
+Theorem diff1_add :
+    !f g x. (!t. higher_differentiable 1 f t) /\
+            (!t. higher_differentiable 1 g t) ==>
+            (diff1 (\t. f t + g t) x = diff1 f x + diff1 g x)
+Proof
+    rpt STRIP_TAC
+ >> MP_TAC (Q.SPECL [‘f’, ‘g’] diffn_add) >> rw [FUN_EQ_THM]
+QED
+
+Theorem diff1_sub :
+    !f g x. (!t. higher_differentiable 1 f t) /\
+            (!t. higher_differentiable 1 g t) ==>
+            (diff1 (\t. f t - g t) x = diff1 f x - diff1 g x)
+Proof
+    rpt STRIP_TAC
+ >> MP_TAC (Q.SPECL [‘f’, ‘g’] diffn_sub) >> rw [FUN_EQ_THM]
+QED
+
+Theorem diff1_mul :
+    !f g x. (!t. higher_differentiable 1 f t) /\
+            (!t. higher_differentiable 1 g t) ==>
+            (diffn 1 (\t. f t * g t) x = diffn 1 f x * g x + f x * diffn 1 g x)
+Proof
+    rpt STRIP_TAC
+ >> ‘f x * diff1 g x = diff1 g x * f x’ by simp [Once REAL_MUL_COMM]
+ >> POP_ORW
+ >> MP_TAC (Q.SPECL [‘f’, ‘g’] diffn_mul) >> rw [FUN_EQ_THM]
 QED
 
 val higher_differentiable_n_imp_1_tactic =
@@ -2618,6 +2681,15 @@ Proof
  >> rw [higher_differentiable_def]
 QED
 
+Theorem higher_differentiable_compose :
+    !n f g. (!x. higher_differentiable n f x) /\
+            (!x. higher_differentiable n g x) ==>
+            (!x. higher_differentiable n (f o g) x)
+Proof
+    rw [o_DEF]
+ >> MATCH_MP_TAC higher_differentiable_chain >> art []
+QED
+
 Theorem diffn_linear :
     !a b. diffn 1 (λx. a * x + b) = λx. a
 Proof
@@ -2639,6 +2711,9 @@ Proof
  >> rw []
  >> METIS_TAC [DIFF_UNIQ]
 QED
+
+(* |- diff1 (\x. x) = (\x. 1) *)
+Theorem diff1_I = SRULE [] (Q.SPECL [‘1’, ‘0’] diffn_linear)
 
 Theorem diffn_linear' :
     !a b n. 2 <= n /\ (!t. higher_differentiable n (λx. a * x + b) t) ==>
@@ -2708,6 +2783,21 @@ Proof
  >> gs []
  >> qexists ‘0’
  >> METIS_TAC [DIFF_CONST]
+QED
+
+(* |- !k x. higher_differentiable k (\x. -x) x *)
+Theorem higher_differentiable_ainv =
+        higher_differentiable_sub_linear |> Q.SPEC ‘0’ |> SRULE []
+
+Theorem higher_differentiable_I :
+    !k x. higher_differentiable k (\x. x) x
+Proof
+    rpt GEN_TAC
+ >> qabbrev_tac ‘f = \x. -(x :real)’
+ >> ‘(\x. x) = \x. f (f x)’
+      by rw [FUN_EQ_THM, REAL_NEG_NEG, Abbr ‘f’] >> POP_ORW
+ >> MATCH_MP_TAC higher_differentiable_chain
+ >> simp [higher_differentiable_ainv, Abbr ‘f’]
 QED
 
 Theorem pow_neg_1[local] :
@@ -2846,7 +2936,7 @@ Proof
 QED
 
 Theorem higher_differentiable_neg_sub :
-    !n f a.
+    !a n f.
       (!x. higher_differentiable n f x) ==>
       !x. higher_differentiable n (λx. f (a - x)) x
 Proof
@@ -2865,6 +2955,154 @@ Proof
        (STRIP_ASSUME_TAC o Q.SPEC ‘x’) \\
      qexists ‘y’ >> METIS_TAC [])
  >> METIS_TAC [higher_differentiable_sub_linear]
+QED
+
+Theorem higher_differentiable_neg :
+    !n f. (!x. higher_differentiable n f x) ==>
+           !x. higher_differentiable n (\x. -f x) x
+Proof
+    rpt GEN_TAC >> DISCH_TAC
+ >> qabbrev_tac ‘g = \x. -(x :real)’
+ >> ‘!x. -f x = g (f x)’ by rw [Abbr ‘g’] >> POP_ORW
+ >> MATCH_MP_TAC higher_differentiable_chain
+ >> simp [higher_differentiable_ainv, Abbr ‘g’]
+QED
+
+(* |- !n f.
+        (!x. higher_differentiable n f x) ==>
+        !x. higher_differentiable n (\x. f (-x)) x
+ *)
+Theorem higher_differentiable_neg' =
+        higher_differentiable_neg_sub |> Q.SPEC ‘0’ |> SRULE []
+
+Theorem higher_differentiable_cmul :
+    !f c n. (!x. higher_differentiable n f x) ==>
+            (!x. higher_differentiable n (\x. c * f x) x)
+Proof
+    rpt GEN_TAC >> DISCH_TAC
+ >> HO_MATCH_MP_TAC higher_differentiable_mul
+ >> simp [higher_differentiable_const]
+QED
+
+Theorem higher_differentiable_cmul_eq :
+    !f c n. c <> 0 ==>
+           ((!x. higher_differentiable n (\x. c * f x) x) <=>
+            (!x. higher_differentiable n f x))
+Proof
+    rpt STRIP_TAC
+ >> reverse EQ_TAC
+ >- (DISCH_TAC \\
+     MATCH_MP_TAC higher_differentiable_cmul >> art [])
+ >> DISCH_TAC
+ >> qabbrev_tac ‘g = \x. c * f x’
+ >> MP_TAC (Q.SPECL [‘g’, ‘inv c’, ‘n’] higher_differentiable_cmul) >> art []
+ >> simp [Abbr ‘g’, REAL_MUL_LINV, SF ETA_ss]
+QED
+
+Theorem higher_differentiable_affine :
+    !a b n f. (!x. higher_differentiable n f x) ==>
+               !x. higher_differentiable n (λx. f (a * x + b)) x
+Proof
+    rpt GEN_TAC >> DISCH_TAC
+ >> HO_MATCH_MP_TAC higher_differentiable_chain >> art []
+ >> HO_MATCH_MP_TAC higher_differentiable_add
+ >> simp [higher_differentiable_const]
+ >> HO_MATCH_MP_TAC higher_differentiable_cmul
+ >> simp [higher_differentiable_I]
+QED
+
+Theorem higher_differentiable_linear :
+    !a b n x. higher_differentiable n (\x. a * x + b) x
+Proof
+    rpt GEN_TAC
+ >> MP_TAC (Q.SPECL [‘a’, ‘b’, ‘n’, ‘\x. x’] higher_differentiable_affine)
+ >> rw [higher_differentiable_I]
+QED
+
+Theorem diffn_cmul_general :
+    !c f n. (!x. higher_differentiable n f x) ==>
+             !x. diffn n (\t. c * f t) x = c * diffn n f x
+Proof
+    NTAC 2 GEN_TAC
+ >> Induct_on ‘n’ >- rw [diffn_0]
+ >> rw [diffn_def]
+ >> Know ‘!x. higher_differentiable n f x’
+ >- (Q.X_GEN_TAC ‘x’ \\
+     MATCH_MP_TAC higher_differentiable_mono \\
+     Q.EXISTS_TAC ‘SUC n’ >> simp [])
+ >> DISCH_TAC
+ >> gs []
+ >> qabbrev_tac ‘g = diffn n f’
+ >> ‘diffn n (\t. c * f t) = \x. c * g x’ by rw [FUN_EQ_THM]
+ >> POP_ORW
+ (* applying higher_differentiable_imp_1n *)
+ >> Know ‘!x. higher_differentiable 1 g x’
+ >- (qunabbrev_tac ‘g’ \\
+     MATCH_MP_TAC higher_differentiable_imp_1n >> art [])
+ >> DISCH_THEN (MP_TAC o Q.SPEC ‘x’)
+ >> RW_TAC std_ss [higher_differentiable_1]
+ >> Know ‘(@y. (g diffl y) x) = y’
+ >- (SELECT_ELIM_TAC \\
+     CONJ_TAC >- (Q.EXISTS_TAC ‘y’ >> art []) \\
+     Q.X_GEN_TAC ‘z’ >> DISCH_TAC \\
+     MATCH_MP_TAC DIFF_UNIQ \\
+     qexistsl_tac [‘g’, ‘x’] >> art [])
+ >> Rewr'
+ >> MP_TAC (Q.SPECL [‘g’, ‘c’, ‘y’, ‘x’] DIFF_CMUL) >> rw []
+ >> SELECT_ELIM_TAC
+ >> CONJ_TAC >- (Q.EXISTS_TAC ‘c * y’ >> art [])
+ >> Q.X_GEN_TAC ‘z’ >> DISCH_TAC
+ >> MATCH_MP_TAC DIFF_UNIQ
+ >> qexistsl_tac [‘\x. c * g x’, ‘x’] >> art []
+QED
+
+Theorem diffn_linear_general :
+    !a b f n. (!x. higher_differentiable n f x) ==>
+              (diffn n (\x. f (a * x + b)) =
+               \x. a pow n * diffn n f (a * x + b))
+Proof
+    NTAC 3 GEN_TAC
+ >> Induct_on ‘n’ >- rw []
+ >> rw [FUN_EQ_THM]
+ >> Know ‘!x. higher_differentiable n f x’
+ >- (Q.X_GEN_TAC ‘x’ \\
+     MATCH_MP_TAC higher_differentiable_mono \\
+     Q.EXISTS_TAC ‘SUC n’ >> simp [])
+ >> DISCH_TAC
+ >> qabbrev_tac ‘g = \x. a * x + b’ >> fs []
+ >> ‘!x. higher_differentiable (SUC n) g x’
+      by simp [Abbr ‘g’, higher_differentiable_linear]
+ >> ‘!x. higher_differentiable (SUC n) (\x. f (g x)) x’
+      by simp [higher_differentiable_chain]
+ >> Know ‘diffn (SUC n) (\x. f (g x)) = diff1 (diffn n (\x. f (g x)))’
+ >- (SYM_TAC >> MATCH_MP_TAC diffn_SUC' >> art [])
+ >> Rewr'
+ >> simp []
+ >> Know ‘diff1 (\x. a pow n * diffn n f (g x)) =
+          \x. a pow n * diff1 (\x. diffn n f (g x)) x’
+ >- (HO_MATCH_MP_TAC diffn_cmul \\
+     HO_MATCH_MP_TAC higher_differentiable_chain \\
+     reverse CONJ_TAC
+     >- (Q.X_GEN_TAC ‘x’ \\
+         MATCH_MP_TAC higher_differentiable_mono \\
+         Q.EXISTS_TAC ‘SUC n’ >> simp []) \\
+     MATCH_MP_TAC higher_differentiable_imp_1n >> art [])
+ >> Rewr'
+ >> simp []
+ >> Know ‘diff1 (\x. diffn n f (g x)) =
+          \x. diff1 (diffn n f) (g x) * diff1 g x’
+ >- (MATCH_MP_TAC diffn_chain \\
+     reverse CONJ_TAC
+     >- (Q.X_GEN_TAC ‘x’ \\
+         MATCH_MP_TAC higher_differentiable_mono \\
+         Q.EXISTS_TAC ‘SUC n’ >> simp []) \\
+     MATCH_MP_TAC higher_differentiable_imp_1n >> art [])
+ >> Rewr'
+ >> simp []
+ >> Know ‘diff1 (diffn n f) = diffn (SUC n) f’
+ >- (MATCH_MP_TAC diffn_SUC' >> art [])
+ >> Rewr'
+ >> simp [Abbr ‘g’, diffn_linear, pow]
 QED
 
 (* Temporarily re-enable printing of numeral bits for help documents *)

--- a/src/real/analysis/real_topologyScript.sml
+++ b/src/real/analysis/real_topologyScript.sml
@@ -52,6 +52,9 @@ Overload UNCOUNTABLE[inferior] = “uncountable”
 
 (* ------------------------------------------------------------------------- *)
 
+(* |- !P Q. (!x. P x) /\ (!x. Q x) <=> !x. P x /\ Q x *)
+Theorem AND_FORALL_THM = GSYM FORALL_AND_THM
+
 Theorem EXISTS_IN_INSERT:
    !P a s. (?x. x IN (a INSERT s) /\ P x) <=> P a \/ ?x. x IN s /\ P x
 Proof
@@ -5624,6 +5627,36 @@ QED
 (* Identify trivial limits, where we can't approach arbitrarily closely.     *)
 (* ------------------------------------------------------------------------- *)
 
+(* |- !a s. net_condition (at a) s <=> a limit_point_of s *)
+Theorem net_condition_at =
+        NET_CONDITION_AT
+     |> REWRITE_RULE [GSYM euclidean_def, GSYM limit_point_of_def]
+
+Theorem net_condition_open_in :
+    !a s. open s /\ a IN s ==> net_condition (at a) s
+Proof
+    rw [net_condition_at, LIMPT_OF_OPEN]
+QED
+
+Theorem limit_point_of_empty :
+    !a. ~(a limit_point_of {})
+Proof
+    rw [limit_point_of_def, euclidean_def, MTOP_LIMPT', GSYM dist_def]
+ >> Q.EXISTS_TAC ‘1’ >> simp []
+QED
+
+Theorem net_condition_interior :
+    !x s. x IN interior s ==> net_condition (at x) s
+Proof
+    RW_TAC std_ss [NET_CONDITION_AT]
+ >> FULL_SIMP_TAC std_ss [IN_INTERIOR]
+ >> MATCH_MP_TAC limpt_mono
+ >> Q.EXISTS_TAC ‘ball (x,e)’ >> art []
+ >> simp [GSYM euclidean_def, GSYM limit_point_of_def]
+ >> MATCH_MP_TAC LIMPT_OF_OPEN
+ >> simp [OPEN_BALL, CENTRE_IN_BALL]
+QED
+
 Theorem TRIVIAL_LIMIT_WITHIN :
     !a:real. trivial_limit (at a within s) <=> ~(a limit_point_of s)
 Proof
@@ -6004,6 +6037,14 @@ Proof
   DISCH_THEN(X_CHOOSE_THEN ``d2:real`` STRIP_ASSUME_TAC) THEN
   MP_TAC(SPECL [``d1:real``, ``d2:real``] REAL_DOWN2) THEN ASM_REWRITE_TAC[] THEN
   ASM_MESON_TAC[REAL_LT_TRANS]
+QED
+
+Theorem LIM_WITHIN_OPEN_CONG :
+   !f (l :real) (a :real) s t.
+       a IN s /\ open s /\ a IN t /\ open t ==>
+      ((f --> l)(at a within s) <=> (f --> l)(at a within t))
+Proof
+    rw [LIM_WITHIN_OPEN]
 QED
 
 (* ------------------------------------------------------------------------- *)
@@ -7037,6 +7078,13 @@ QED
 (* NOTE: This theorem is not from HOL-Light. *)
 Theorem LIM_WITHIN_CONG :
    !f g l r a s. (!x. ~(x = a) /\ x IN s ==> (f x - l = g x - r))
+  ==> ((f --> l) (at a within s) <=> ((g --> r) (at a within s)))
+Proof
+    rw [LIM_WITHIN, dist]
+QED
+
+Theorem LIM_WITHIN_ABS_CONG :
+   !f g l r a s. (!x. ~(x = a) /\ x IN s ==> (abs (f x - l) = abs (g x - r)))
   ==> ((f --> l) (at a within s) <=> ((g --> r) (at a within s)))
 Proof
     rw [LIM_WITHIN, dist]
@@ -9831,41 +9879,134 @@ QED
 
 (* NOTE: This proof is learnt from CONTINUOUS_WITHIN_SEQUENTIALLY, where the
    key device is FORALL_POS_MONO_1. The original proof from HOL-Light is a
-   specialisation of a more general theorem for general metric spaces
-  (LIMIT_ATPOINTOF_SEQUENTIALLY_WITHIN from HOL-Light's topology.ml).
+   specialisation of LIMIT_ATPOINTOF_SEQUENTIALLY_WITHIN (combined proof is
+   based on EVENTUALLY_ATPOINTOF_WITHIN_SEQUENTIALLY, etc.)
  *)
-Theorem LIM_WITHIN_SEQUENTIALLY :
-    !(f :real -> real) s a l.
-       ((f --> l) (at a within s) <=>
+Theorem LIM_WITHIN_SEQUENTIALLY_combined[local] :
+   (!f:real->real s a l.
+        (f --> l) (at a within s) <=>
         !x. (!n. x(n) IN s DELETE a) /\
+            (x --> a) sequentially
+            ==> ((f o x) --> l) sequentially) /\
+   (!f:real->real s a l.
+        (f --> l) (at a within s) <=>
+        !x. (!n. x(n) IN s DELETE a) /\
+            (!m n. x m = x n <=> m = n) /\
+            (x --> a) sequentially
+            ==> ((f o x) --> l) sequentially) /\
+   (!f:real->real s a l.
+        (f --> l) (at a within s) <=>
+        !x. (!n. x(n) IN s DELETE a) /\
+            (!m n. m < n ==> dist(x n,a) < dist(x m,a)) /\
             (x --> a) sequentially
             ==> ((f o x) --> l) sequentially)
 Proof
-  REPEAT GEN_TAC THEN REWRITE_TAC[LIM_WITHIN] THEN EQ_TAC THENL
-  [SIMP_TAC std_ss [LIM_SEQUENTIALLY, o_THM, IN_DELETE, GSYM DIST_NZ] THEN
-   MESON_TAC[], ALL_TAC] THEN
+  SIMP_TAC bool_ss [AND_FORALL_THM] THEN REPEAT GEN_TAC THEN
+  MATCH_MP_TAC(TAUT
+   `(r ==> s) /\ (q ==> r) /\ (p ==> q) /\ (s ==> p)
+    ==> (p <=> q) /\ (p <=> r) /\ (p <=> s)`) THEN
+  REPEAT CONJ_TAC THENL (* 4 subgoals *)
+  [ (* goal 1 (of 4): r ==> s *)
+    HO_MATCH_MP_TAC MONO_FORALL THEN Q.X_GEN_TAC `x` THEN
+    DISCH_THEN(fn th => STRIP_TAC THEN MP_TAC th) THEN ASM_REWRITE_TAC[] THEN
+    DISCH_THEN MATCH_MP_TAC THEN
+    HO_MATCH_MP_TAC WLOG_LT THEN REWRITE_TAC[] THEN
+    ASM_MESON_TAC[REAL_LT_REFL],
+    (* goal 2 (of 4): q ==> r *)
+    HO_MATCH_MP_TAC MONO_FORALL THEN MESON_TAC[],
+    (* goal 3 (of 4): p ==> q *)
+    REWRITE_TAC[LIM_WITHIN] THEN
+    SIMP_TAC std_ss [LIM_SEQUENTIALLY, o_THM, IN_DELETE, GSYM DIST_NZ] THEN
+    MESON_TAC[],
+    (* goal 4 (of 4): p ==> s *)
+    ALL_TAC ] THEN
+ (* remaining goal (p ==> s) *)
+  REWRITE_TAC[LIM_WITHIN] THEN
   ONCE_REWRITE_TAC[MONO_NOT_EQ] THEN
   SIMP_TAC std_ss [NOT_FORALL_THM, NOT_IMP, NOT_EXISTS_THM] THEN
   DISCH_THEN(X_CHOOSE_THEN ``e:real`` (CONJUNCTS_THEN2 ASSUME_TAC MP_TAC)) THEN
   DISCH_THEN(MP_TAC o GEN ``n:num`` o SPEC ``&1 / (&n + &1:real)``) THEN
   SIMP_TAC arith_ss [REAL_LT_DIV, REAL_LT, REAL_OF_NUM_LE, REAL_POS,
-   REAL_ARITH ``&0 <= n ==> &0 < n + &1:real``, NOT_FORALL_THM, SKOLEM_THM] THEN
-  DISCH_THEN (X_CHOOSE_TAC ``y:num->real``) THEN EXISTS_TAC ``y:num->real`` THEN
-  POP_ASSUM MP_TAC THEN SIMP_TAC std_ss [NOT_IMP, FORALL_AND_THM] THEN
-  SIMP_TAC std_ss [LIM_SEQUENTIALLY, o_THM, IN_DELETE, GSYM DIST_NZ] THEN
-  STRIP_TAC THEN CONJ_TAC THENL [ALL_TAC, ASM_MESON_TAC[LESS_EQ_REFL]] THEN
-  KNOW_TAC ``!e. (?N:num. !n. N <= n ==> dist (y n,a) < e) =
-             (\e. ?N:num. !n. N <= n ==> dist (y n,a) < e) e`` THENL
-  [FULL_SIMP_TAC std_ss [], ALL_TAC] THEN DISC_RW_KILL THEN
-  MATCH_MP_TAC FORALL_POS_MONO_1 THEN BETA_TAC THEN
-  CONJ_TAC THENL [ASM_MESON_TAC[REAL_LT_TRANS], ALL_TAC] THEN
-  X_GEN_TAC ``n:num`` THEN EXISTS_TAC ``n:num`` THEN X_GEN_TAC ``m:num`` THEN
-  DISCH_TAC THEN MATCH_MP_TAC REAL_LTE_TRANS THEN
-  EXISTS_TAC ``&1 / (&m + &1:real)`` THEN ASM_REWRITE_TAC[] THEN
-  ASM_SIMP_TAC std_ss
-  [REAL_LE_INV2, real_div, REAL_ARITH ``&0 <= x ==> &0 < x + &1:real``,
-   REAL_POS, REAL_MUL_LID, REAL_LE_RADD, REAL_OF_NUM_LE]
+   REAL_ARITH ``&0 <= n ==> &0 < n + &1:real``, NOT_FORALL_THM, SKOLEM_THM,
+   GSYM DIST_NZ] THEN
+  DISCH_THEN (X_CHOOSE_TAC ``y:num->real``) THEN
+ (* applying DEPENDENT_CHOICE *)
+  SUBGOAL_THEN
+    ``?x. (!n. x n IN s /\ ~(x n = a) /\
+               dist (x n,a) < 1 / (&n + &1) /\
+               ~(dist (f (x n),l) < e)) /\
+          (!n. dist (x(SUC n),a) < dist (x n,a))``
+    STRIP_ASSUME_TAC >-
+     (HO_MATCH_MP_TAC DEPENDENT_CHOICE THEN SIMP_TAC real_ss [] THEN
+      CONJ_TAC
+      >- (Q.EXISTS_TAC ‘y 0’ \\
+          POP_ASSUM (MP_TAC o Q.SPEC ‘0’) >> simp []) \\
+      MAP_EVERY Q.X_GEN_TAC [`n`, `x`] THEN STRIP_TAC THEN
+      SIMP_TAC bool_ss[TAUT `(p /\ q /\ r /\ s) /\ u <=>
+                             p /\ q /\ (r /\ u) /\ s`] THEN
+      REWRITE_TAC[GSYM REAL_LT_MIN] THEN
+      qabbrev_tac ‘d = min (1 / &(SUC n + 1)) (dist (x,a))’ \\
+      Know ‘0 < d’
+      >- (ASM_SIMP_TAC std_ss [Abbr ‘d’, REAL_LT_MIN, GSYM DIST_NZ] \\
+          simp []) >> DISCH_TAC \\
+     ‘?N. inv (&SUC N) < d’ by METIS_TAC [REAL_ARCH_INV_SUC] \\
+      Q.EXISTS_TAC ‘y N’ \\
+      Q.PAT_X_ASSUM ‘!n. P’ (MP_TAC o Q.SPEC ‘N’) >> RW_TAC std_ss [] \\
+      Q_TAC (TRANS_TAC REAL_LT_TRANS) ‘1 / (&N + 1)’ >> art [] \\
+      Q.PAT_X_ASSUM ‘inv (&SUC N) < d’ MP_TAC >> simp [ADD1]) \\
+ (* stage work *)
+  EXISTS_TAC ``x:num->real`` THEN
+  ASM_SIMP_TAC std_ss [IN_DELETE, GSYM CONJ_ASSOC] THEN
+  CONJ_ASM1_TAC (* !m n. m < n ==> dist (x n,a) < dist (x m,a) *)
+  >- (MATCH_MP_TAC
+        (SRULE [real_gt]
+               (ISPECL [“real_gt”, “\i:num. dist (x i,a)”]
+                       transitive_monotone)) >> art [] \\
+      simp [relationTheory.transitive_def, real_gt, Once CONJ_SYM] \\
+      METIS_TAC [REAL_LT_TRANS]) \\
+  CONJ_ASM1_TAC
+  >- (simp [LIM_SEQUENTIALLY] \\
+      Q.X_GEN_TAC ‘d’ >> DISCH_TAC \\
+     ‘?N. inv (&SUC N) < d’ by METIS_TAC [REAL_ARCH_INV_SUC] \\
+      Q.EXISTS_TAC ‘N’ >> rpt STRIP_TAC \\
+      Q_TAC (TRANS_TAC REAL_LT_TRANS) ‘1 / (&N + 1)’ >> art [] \\
+      reverse CONJ_TAC
+      >- (Q.PAT_X_ASSUM ‘inv (&SUC N) < d’ MP_TAC >> simp [ADD1]) \\
+     ‘n = N \/ N < n’ by simp [] >- art [] \\
+      Q_TAC (TRANS_TAC REAL_LT_TRANS) ‘dist (x N,a)’ >> art [] \\
+      FIRST_X_ASSUM MATCH_MP_TAC >> art []) \\
+ (* final goal *)
+  SIMP_TAC std_ss [LIM_SEQUENTIALLY, o_THM, IN_DELETE, GSYM DIST_NZ] \\
+  Q.EXISTS_TAC ‘e’ >> rw [] \\
+  Q.EXISTS_TAC ‘N’ >> simp []
 QED
+
+(* |- !f s a l.
+        (f --> l) (at a within s) <=>
+        !x. (!n. x n IN s DELETE a) /\ (x --> a) sequentially ==>
+            (f o x --> l) sequentially
+ *)
+Theorem LIM_WITHIN_SEQUENTIALLY =
+        LIM_WITHIN_SEQUENTIALLY_combined |> cj 1
+
+(* |- !f s a l.
+        (f --> l) (at a within s) <=>
+        !x. (!n. x n IN s DELETE a) /\ (!m n. x m = x n <=> m = n) /\
+            (x --> a) sequentially ==>
+            (f o x --> l) sequentially
+ *)
+Theorem LIM_WITHIN_SEQUENTIALLY_INJ =
+        LIM_WITHIN_SEQUENTIALLY_combined |> cj 2
+
+(* |- !f s a l.
+        (f --> l) (at a within s) <=>
+        !x. (!n. x n IN s DELETE a) /\
+            (!m n. m < n ==> dist (x n,a) < dist (x m,a)) /\
+            (x --> a) sequentially ==>
+            (f o x --> l) sequentially
+ *)
+Theorem LIM_WITHIN_SEQUENTIALLY_DECREASING =
+        LIM_WITHIN_SEQUENTIALLY_combined |> cj 3
 
 (* ------------------------------------------------------------------------- *)
 (* Combination results for pointwise continuity.                             *)
@@ -24819,7 +24960,30 @@ Proof
       REWRITE_TAC [CONTENT_EQ_0] >> ASM_REAL_ARITH_TAC ]
 QED
 
+Theorem CONNECTED_INTERVAL :
+    !a b. connected (interval (a,b)) /\
+          connected (interval [a,b])
+Proof
+    rpt STRIP_TAC
+ >| [ (* goal 1 (of 2) *)
+      Cases_on ‘b < a’
+      >- simp [iffLR (cj 2 INTERVAL_EQ_EMPTY), CONNECTED_EMPTY, REAL_LT_IMP_LE] \\
+      fs [REAL_NOT_LT] \\
+     ‘segment (a,b) = interval (a,b)’ by simp [SEGMENT] \\
+      POP_ASSUM (REWRITE_TAC o wrap o SYM) \\
+      simp [CONNECTED_SEGMENT],
+      (* goal 2 (of 2) *)
+      Cases_on ‘b < a’
+      >- simp [iffLR (cj 1 INTERVAL_EQ_EMPTY), CONNECTED_EMPTY] \\
+      fs [REAL_NOT_LT] \\
+     ‘segment [a,b] = interval [a,b]’ by simp [SEGMENT] \\
+      POP_ASSUM (REWRITE_TAC o wrap o SYM) \\
+      simp [CONNECTED_SEGMENT] ]
+QED
+
+(* END *)
+
 (* References:
 
-  [1] Bartle, R.G.: A Modern Theory of Integration. American Mathematical Soc. (2001).
+  [1] Bartle, R.G.: A Modern Theory of Integration. American Math. Soc. (2001).
  *)

--- a/src/real/analysis/transcScript.sml
+++ b/src/real/analysis/transcScript.sml
@@ -204,6 +204,31 @@ Proof
   REWRITE_TAC[REAL_LT, ONE, LESS_0]
 QED
 
+Theorem diffn_exp :
+    !n x. diffn n exp = exp
+Proof
+    Induct_on ‘n’ >- rw [diffn_0]
+ >> rw [FUN_EQ_THM, diffn_def]
+ >> SELECT_ELIM_TAC
+ >> CONJ_TAC
+ >- (Q.EXISTS_TAC ‘exp x’ \\
+     REWRITE_TAC [DIFF_EXP])
+ >> Q.X_GEN_TAC ‘y’ >> STRIP_TAC
+ >> MATCH_MP_TAC DIFF_UNIQ
+ >> qexistsl_tac [‘exp’, ‘x’]
+ >> simp [DIFF_EXP]
+QED
+
+Theorem higher_differentiable_exp :
+    !n x. higher_differentiable n exp x
+Proof
+    Induct_on ‘n’
+ >- simp [higher_differentiable_def]
+ >> rw [higher_differentiable_def, diffn_exp]
+ >> Q.EXISTS_TAC ‘exp x’
+ >> REWRITE_TAC [DIFF_EXP]
+QED
+
 Theorem DIFF_SIN[difftool]:
   !x. (sin diffl cos(x))(x)
 Proof

--- a/src/real/netsScript.sml
+++ b/src/real/netsScript.sml
@@ -4,17 +4,29 @@
 
 Theory nets
 Ancestors
-  pred_set pair arithmetic num prim_rec relation real topology
-  metric
+  pred_set pair combin arithmetic num prim_rec relation real topology
+  metric cardinal
 Libs
-  numLib reduceLib pairLib mesonLib RealArith hurdUtils jrhUtils
-  tautLib
+  numLib reduceLib pairLib mesonLib realLib hurdUtils jrhUtils tautLib
 
 val _ = Parse.reveal "B";
 
-val num_EQ_CONV = Arithconv.NEQ_CONV;
+val NUM_EQ_CONV = Arithconv.NEQ_CONV;
 val DISC_RW_KILL = DISCH_TAC THEN ONCE_ASM_REWRITE_TAC [] THEN
                    POP_ASSUM K_TAC;
+
+val ASM_REAL_ARITH_TAC = REAL_ASM_ARITH_TAC;
+
+(* !x. P x ==> Q x) ==> (!x. P x) ==> !x. Q x *)
+Theorem MONO_FORALL = MONO_ALL
+
+Theorem REAL_HALF :
+   (!e. &0 < e / &2 <=> &0 < e) /\
+   (!e. e / &2 + e / &2 = e) /\
+   (!e. &2 * (e / &2) = e)
+Proof
+    REAL_ARITH_TAC
+QED
 
 (*---------------------------------------------------------------------------*)
 (* Basic definitions: directed order, net, bounded net, pointwise limit [1]  *)
@@ -369,7 +381,7 @@ Proof
             THEN REWRITE_TAC[REAL_MUL_LID]) THEN
     CONJ_TAC THENL
      [ASM_REWRITE_TAC[ABS_NZ, ABS_ABS],
-      REWRITE_TAC[REAL_INJ] THEN CONV_TAC(RAND_CONV num_EQ_CONV) THEN
+      REWRITE_TAC[REAL_INJ] THEN CONV_TAC(RAND_CONV NUM_EQ_CONV) THEN
       REWRITE_TAC[]], ALL_TAC] THEN
   SUBGOAL_THEN “~(x(n:'a) = &0)” (SUBST1_TAC o MATCH_MP ABS_INV) THENL
    [ASM_REWRITE_TAC[ABS_NZ], ALL_TAC] THEN
@@ -786,7 +798,11 @@ Definition sequentially[nocompute]:
   sequentially = mk_net(\m:num n. m >= n)
 End
 
-(* NOTE: “within” only requires “x IN s” (next step) but not for “y” *)
+(* HOL-Light's definition:
+
+let within = new_definition
+  `net within s = mk_net (netfilter net relative_to s,netlimits net)`;;
+ *)
 Definition within[nocompute]:
   (net within s) = mk_net(\x y. netord net x y /\ x IN s)
 End
@@ -886,9 +902,7 @@ QED
 Theorem NET_WITHIN_UNIV :
     !net. (net within UNIV) = net
 Proof
-    rw [within]
- >> ‘(\x y. netord net x y) = netord net’ by rw [FUN_EQ_THM]
- >> simp [net_tybij]
+    RW_TAC std_ss [within, IN_UNIV, SF ETA_ss, net_tybij]
 QED
 
 Theorem WITHIN_UNIV :
@@ -905,109 +919,43 @@ Proof
 QED
 
 (* ------------------------------------------------------------------------- *)
-(* netfilter (compatible with HOL-Light)                                     *)
-(* ------------------------------------------------------------------------- *)
-
-Definition netfilter_def :
-    netfilter net = {{y | netord net y x} | x | T}
-End
-
-Theorem NETFILTER_AT_POSINFINITY :
-    netfilter at_posinfinity = {{x | a <= x} | a IN univ(:real)}
-Proof
-    simp [netfilter_def, AT_POSINFINITY, real_ge]
-QED
-
-Theorem NETFILTER_AT_NEGINFINITY :
-    netfilter at_neginfinity = {{x | x <= a} | a IN univ(:real)}
-Proof
-    simp [netfilter_def, AT_NEGINFINITY]
-QED
-
-Theorem NETFILTER_AT_INFINITY :
-    netfilter at_infinity = {{x | b <= abs x} | b IN univ(:real)}
-Proof
-    simp [netfilter_def, AT_INFINITY, real_ge]
- >> rw [Once EXTENSION]
- >> EQ_TAC >> rw []
- >- (Q.EXISTS_TAC ‘abs x'’ >> REFL_TAC)
- >> Cases_on ‘0 <= b’
- >- (Q.EXISTS_TAC ‘abs b’ >> simp [ABS_REDUCE])
- >> fs [REAL_NOT_LE]
- >> Know ‘!x. b <= abs x <=> 0 <= abs x’
- >- (Q.X_GEN_TAC ‘x’ \\
-     EQ_TAC >> rw [] \\
-     Q_TAC (TRANS_TAC REAL_LE_TRANS) ‘0’ >> simp [ABS_POS, REAL_LT_IMP_LE])
- >> Rewr'
- >> Q.EXISTS_TAC ‘0’ >> simp [ABS_0]
-QED
-
-Theorem NETFILTER_SEQUENTIALLY :
-    netfilter sequentially = {from n | n IN univ(:num)}
-Proof
-    simp [netfilter_def, SEQUENTIALLY, GREATER_EQ, from_def]
-QED
-
-Theorem NETFILTER_ATPOINTOF :
-    !m a. netfilter (atpointof m a) =
-            {{y | y <> a /\ dist m (y,a) <= dist m (x,a)} | x | T}
-Proof
-    simp [netfilter_def, ATPOINTOF, MDIST_POS_EQ]
-QED
-
-(* |- !a. netfilter (at a) =
-          {{y | y <> a /\ dist (y,a) <= dist (x,a)} | x | T}
- *)
-Theorem NETFILTER_AT =
-        NETFILTER_ATPOINTOF |> ISPEC “mr1”
-                            |> REWRITE_RULE [GSYM dist_def, GSYM at_DEF]
-
-(* NOTE: This theorem is HOL-Light's WITHIN *)
-Theorem NETFILTER_WITHIN :
-    !net s. netfilter (net within s) = netfilter net relative_to s
-Proof
-    rw [netfilter_def, WITHIN, RELATIVE_TO]
- >> rw [Once EXTENSION]
- >> EQ_TAC >> rw []
- >- (Q.EXISTS_TAC ‘{y | netord net y x'}’ \\
-     reverse CONJ_TAC >- (Q.EXISTS_TAC ‘x'’ >> REFL_TAC) \\
-     rw [Once EXTENSION] >> PROVE_TAC [])
- >> Q.EXISTS_TAC ‘x'’
- >> rw [Once EXTENSION]
- >> PROVE_TAC []
-QED
-
-(* ------------------------------------------------------------------------- *)
 (* It's also sometimes useful to extract the limit point from the net.       *)
 (* ------------------------------------------------------------------------- *)
 
-Definition netlimit :
+(* NOTE: adding “x <> a” after “!x.” will break proof of NETLIMIT_ATPOINTOF. *)
+Definition netlimit_def :
     netlimit net = @a. !x. ~(netord net x a)
 End
+
+(* NOTE: The definition of “netlimits” must be alighed with “netlimit”. *)
+Definition netlimits_def :
+    netlimits net = {a | !x. ~(netord net x a)}
+End
+
+(* NOTE: This theorem is the definition of “netlimit” in HOL-Light *)
+Theorem netlimit :
+    !n. netlimit n = (@x. x IN netlimits n)
+Proof
+    rw [netlimit_def, netlimits_def]
+QED
 
 Theorem NETLIMIT_ATPOINTOF :
     !m a. netlimit(atpointof m a) = a
 Proof
-    RW_TAC std_ss [netlimit, ATPOINTOF]
+    RW_TAC std_ss [netlimit_def, ATPOINTOF]
  >> SELECT_ELIM_TAC
  >> CONJ_TAC
  >- (Q.EXISTS_TAC ‘a’ \\
-     rw [MDIST_REFL, REAL_NOT_LE])
- >> rw [REAL_NOT_LE, REAL_NOT_LT]
+     rw [MDIST_REFL, REAL_NOT_LE, MDIST_POS_LT])
+ >> rw [REAL_NOT_LE, MDIST_POS_EQ]
  >> CCONTR_TAC
  >> Q.PAT_X_ASSUM ‘!x. P’ (MP_TAC o Q.SPEC ‘x’)
- >> simp [REAL_NOT_LE]
- >> rw [REAL_LT_LE, METRIC_NZ]
+ >> simp [REAL_NOT_LT, MDIST_REFL, MDIST_POS_LE, MDIST_POS_LT]
 QED
 
 (* |- !a. netlimit (at a) = a *)
 Theorem NETLIMIT_AT = NETLIMIT_ATPOINTOF |> ISPEC “mr1”
                    |> REWRITE_RULE [GSYM at_DEF]
-
-(* NOTE: This definition is compatible with HOL-Light *)
-Definition netlimits_def :
-    netlimits net = {a | !x. ~(netord net x a)}
-End
 
 Theorem NETLIMITS_ATPOINTOF :
     !m a. netlimits (atpointof m a) = {a}
@@ -1017,7 +965,8 @@ Proof
  >> reverse EQ_TAC >- rw [MDIST_REFL, MDIST_POS_EQ]
  >> rpt STRIP_TAC
  >> CCONTR_TAC
- >> Q.PAT_X_ASSUM ‘!x. P’ (MP_TAC o Q.SPEC ‘x’) >> simp []
+ >> Q.PAT_X_ASSUM ‘!x. P’ (MP_TAC o Q.SPEC ‘x’)
+ >> simp [REAL_NOT_LT, MDIST_REFL, MDIST_POS_LE]
 QED
 
 (* |- !a. netlimits (at a) = {a} *)
@@ -1052,8 +1001,240 @@ Proof
  >> Q.EXISTS_TAC ‘x’ >> simp []
 QED
 
+(* NOTE: This lemma shows that “within” makes netlimits potentially larger. *)
+Theorem NETLIMITS_WITHIN_lemma1[local] :
+    netlimits net SUBSET netlimits (net within s)
+Proof
+    rw [SUBSET_DEF, netlimits_def, WITHIN]
+QED
+
+Theorem NETLIMITS_WITHIN_lemma2[local] :
+    (!x. (!y. ~netord net y x \/ y NOTIN s) ==> x IN netlimits net) ==>
+    netlimits (net within s) SUBSET netlimits net
+Proof
+    rpt STRIP_TAC
+ >> simp [SUBSET_DEF, Once netlimits_def, WITHIN]
+QED
+
+Theorem NETLIMITS_WITHIN_lemma3[local] :
+    (!x. (!y. ~netord net y x \/ y NOTIN s) ==> x IN netlimits net) <=>
+    (!x. x NOTIN netlimits net ==> ?y. y IN s /\ netord net y x)
+Proof
+    METIS_TAC []
+QED
+
+(* NOTE: This definition is the exact condition for “NETLIMITS_WITHIN” to hold. *)
+Definition net_condition_def :
+    net_condition net s =
+      !x. x NOTIN netlimits net ==> ?y. y IN s /\ netord net y x
+End
+
+Theorem NET_CONDITION_MONO :
+    !net s t. net_condition net s /\ s SUBSET t ==> net_condition net t
+Proof
+    rw [net_condition_def, SUBSET_DEF]
+ >> METIS_TAC []
+QED
+
+Theorem NET_CONDITION_UNION :
+    !net s t. net_condition net s /\ net_condition net s ==>
+              net_condition net (s UNION t)
+Proof
+    rw [net_condition_def]
+ >> ‘?y. y IN s /\ netord net y x’ by PROVE_TAC []
+ >> Q.EXISTS_TAC ‘y’ >> art []
+QED
+
+Theorem NET_CONDITION_UNIV[simp] :
+    net_condition net UNIV
+Proof
+    rw [net_condition_def, netlimits_def]
+QED
+
+(* NOTE: This is key theorem for which the “net_condition” is defined. *)
+Theorem NETLIMITS_WITHIN :
+    !net s. net_condition net s ==> netlimits (net within s) = netlimits net
+Proof
+    RW_TAC std_ss [net_condition_def]
+ >> MATCH_MP_TAC SUBSET_ANTISYM
+ >> REWRITE_TAC [NETLIMITS_WITHIN_lemma1]
+ >> MATCH_MP_TAC NETLIMITS_WITHIN_lemma2
+ >> ASM_REWRITE_TAC [NETLIMITS_WITHIN_lemma3]
+QED
+
+Theorem NET_CONDITION_ATPOINTOF :
+    !m a s. limpt (mtop m) a s ==> net_condition (atpointof m a) s
+Proof
+    rw [ATPOINTOF, net_condition_def, NETLIMITS_ATPOINTOF, MTOP_LIMPT']
+ >> qabbrev_tac ‘e = dist m (x,a)’
+ >> ‘0 < e’ by simp [Abbr ‘e’, MDIST_POS_LT]
+ >> Q.PAT_X_ASSUM ‘!e. 0 < e ==> _’ (MP_TAC o Q.SPEC ‘e’) >> rw []
+ >> Q.EXISTS_TAC ‘y’
+ >> simp [MDIST_REFL, MDIST_POS_LE, MDIST_POS_LT, REAL_LT_IMP_LE, Once MDIST_SYM]
+QED
+
+Theorem NET_CONDITION_AT_lemma[local] :
+    !a s. net_condition (at a) s ==> limpt (mtop mr1) a s
+Proof
+    rw [AT, net_condition_def, NETLIMITS_AT, MTOP_LIMPT', GSYM dist_def]
+ (* NOTE: this subgoal property doesn't hold for metric space in general *)
+ >> Know ‘?x. x <> a /\ dist (a,x) = e / 2’
+ >- (Q.EXISTS_TAC ‘a - e / 2’ \\
+     simp [dist, REAL_SUB_SUB2] \\
+    ‘0 < e / 2’ by simp [REAL_HALF] \\
+     simp [ABS_REDUCE, REAL_LT_IMP_LE] \\
+     REAL_ASM_ARITH_TAC)
+ >> STRIP_TAC
+ >> Q.PAT_X_ASSUM ‘!x. x <> a ==> _’ (MP_TAC o Q.SPEC ‘x’) >> rw []
+ >> Q.EXISTS_TAC ‘y’
+ >> FULL_SIMP_TAC std_ss [GSYM DIST_NZ]
+ >> simp [Once DIST_SYM]
+ >> Q_TAC (TRANS_TAC REAL_LET_TRANS) ‘dist (x,a)’ >> art []
+ >> simp [Once DIST_SYM]
+QED
+
+(* |- !a s. net_condition (at a) s <=> limpt (mtop mr1) a s *)
+Theorem NET_CONDITION_AT :
+    !a s. net_condition (at a) s <=> limpt (mtop mr1) a s
+Proof
+    rpt GEN_TAC
+ >> EQ_TAC >- REWRITE_TAC [NET_CONDITION_AT_lemma]
+ >> REWRITE_TAC [at_DEF, NET_CONDITION_ATPOINTOF]
+QED
+
+Theorem NETLIMITS_ATPOINTOF_WITHIN :
+    !m a s. limpt (mtop m) a s ==>
+            netlimits ((atpointof m a) within s) = netlimits (atpointof m a)
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC NETLIMITS_WITHIN
+ >> MATCH_MP_TAC NET_CONDITION_ATPOINTOF >> art []
+QED
+
+(* |- !a s.
+        net_condition (at a) s ==>
+        netlimits (at a within s) = netlimits (at a)
+ *)
+Theorem NETLIMITS_AT_WITHIN =
+        NETLIMITS_ATPOINTOF_WITHIN |> ISPEC “mr1”
+     |> REWRITE_RULE [GSYM at_DEF, GSYM NET_CONDITION_AT]
+
+(* NOTE: The original NETLIMIT_WITHIN is still below *)
+Theorem NETLIMIT_WITHIN_NEW :
+    !a s. net_condition (at a) s ==> netlimit (at a within s) = a
+Proof
+    rpt STRIP_TAC
+ >> ASM_SIMP_TAC std_ss [netlimit, NETLIMITS_WITHIN]
+ >> REWRITE_TAC [GSYM netlimit, NETLIMIT_AT]
+QED
+
 (* ------------------------------------------------------------------------- *)
-(* Some property holds "sufficiently close" to the limit point.              *)
+(* netfilter (compatible with HOL-Light)                                     *)
+(* ------------------------------------------------------------------------- *)
+
+(* NOTE: “x NOTIN netlimits net” is necessary for EVENTUALLY_ATPOINTOF below.
+   And also, if it's replaced by “T” then “netfilter net <> {}” holds, making
+   the first part of “eventually” (below, unchangable) meaningless.
+ *)
+Definition netfilter_def :
+    netfilter net = {{y | netord net y x} | x | x NOTIN netlimits net}
+End
+
+Theorem EMPTY_NOTIN_NETFILTER :
+    !net. {} NOTIN netfilter net
+Proof
+    simp [netfilter_def, netlimits_def, Once EXTENSION] >> METIS_TAC []
+QED
+
+(* NOTE: This is the theorem [NET] of HOL-Light *)
+Theorem NETFILTER :
+    !n s t. s IN netfilter n /\ t IN netfilter n ==> s INTER t IN netfilter n
+Proof
+    rpt GEN_TAC
+ >> simp [netfilter_def]
+ >> DISCH_THEN (CONJUNCTS_THEN2
+                 (Q.X_CHOOSE_THEN ‘u’ STRIP_ASSUME_TAC)
+                 (Q.X_CHOOSE_THEN ‘v’ STRIP_ASSUME_TAC))
+ >> ‘s INTER t = {y | netord n y u /\ netord n y v}’ by ASM_SET_TAC []
+ >> POP_ORW
+ (* applying NET here! *)
+ >> STRIP_ASSUME_TAC (Q.SPECL [‘n’, ‘u’, ‘v’] NET)
+ >| [ (* goal 1 (of 2) *)
+      Q.EXISTS_TAC ‘u’ >> ASM_SET_TAC [],
+      (* goal 2 (of 2) *)
+      Q.EXISTS_TAC ‘v’ >> ASM_SET_TAC [] ]
+QED
+
+Theorem NETFILTER_AT_POSINFINITY :
+    netfilter at_posinfinity = {{x | a <= x} | a IN univ(:real)}
+Proof
+    simp [netfilter_def, NETLIMITS_AT_POSINFINITY, AT_POSINFINITY, real_ge]
+QED
+
+Theorem NETFILTER_AT_NEGINFINITY :
+    netfilter at_neginfinity = {{x | x <= a} | a IN univ(:real)}
+Proof
+    simp [netfilter_def, NETLIMITS_AT_NEGINFINITY, AT_NEGINFINITY]
+QED
+
+Theorem NETFILTER_AT_INFINITY :
+    netfilter at_infinity = {{x | b <= abs x} | b IN univ(:real)}
+Proof
+    simp [netfilter_def, NETLIMITS_AT_INFINITY, AT_INFINITY, real_ge]
+ >> rw [Once EXTENSION]
+ >> EQ_TAC >> rw []
+ >- (Q.EXISTS_TAC ‘abs x'’ >> REFL_TAC)
+ >> Cases_on ‘0 <= b’
+ >- (Q.EXISTS_TAC ‘abs b’ >> simp [ABS_REDUCE])
+ >> fs [REAL_NOT_LE]
+ >> Know ‘!x. b <= abs x <=> 0 <= abs x’
+ >- (Q.X_GEN_TAC ‘x’ \\
+     EQ_TAC >> rw [] \\
+     Q_TAC (TRANS_TAC REAL_LE_TRANS) ‘0’ >> simp [ABS_POS, REAL_LT_IMP_LE])
+ >> Rewr'
+ >> Q.EXISTS_TAC ‘0’ >> simp [ABS_0]
+QED
+
+Theorem NETFILTER_SEQUENTIALLY :
+    netfilter sequentially = {from n | n IN univ(:num)}
+Proof
+    simp [netfilter_def, NETLIMITS_SEQUENTIALLY, SEQUENTIALLY,
+          GREATER_EQ, from_def]
+QED
+
+Theorem NETFILTER_ATPOINTOF :
+    !m a. netfilter (atpointof m a) =
+          {{y | 0 < dist m (y,a) /\ dist m (y,a) <= dist m (x,a)} | x | x <> a}
+Proof
+    simp [netfilter_def, NETLIMITS_ATPOINTOF, ATPOINTOF, MDIST_POS_EQ]
+QED
+
+(* |- !a. netfilter (at a) =
+          {{y | 0 < dist (y,a) /\ dist (y,a) <= dist (x,a)} | x | x <> a}
+ *)
+Theorem NETFILTER_AT =
+        NETFILTER_ATPOINTOF |> ISPEC “mr1”
+                            |> REWRITE_RULE [GSYM dist_def, GSYM at_DEF]
+
+(* NOTE: This theorem is HOL-Light's WITHIN *)
+Theorem NETFILTER_WITHIN :
+    !net s. net_condition net s ==>
+           (netfilter (net within s) = netfilter net relative_to s)
+Proof
+    rw [netfilter_def, WITHIN, RELATIVE_TO, NETLIMITS_WITHIN]
+ >> rw [Once EXTENSION]
+ >> EQ_TAC >> rw []
+ >- (rename1 ‘x NOTIN netlimits net’ \\
+     Q.EXISTS_TAC ‘{y | netord net y x}’ \\
+     reverse CONJ_TAC >- (Q.EXISTS_TAC ‘x’ >> art []) \\
+     SET_TAC [])
+ >> rename1 ‘x NOTIN netlimits net’
+ >> Q.EXISTS_TAC ‘x’ >> art []
+ >> SET_TAC []
+QED
+
+(* ------------------------------------------------------------------------- *)
+(* Some property holds "sufficiently close" to the limit point (eventually). *)
 (* ------------------------------------------------------------------------- *)
 (* Identify trivial limits, where we can't approach arbitrarily closely.     *)
 (* ------------------------------------------------------------------------- *)
@@ -1275,7 +1456,7 @@ Theorem NETLIMIT_WITHIN :
    !a:real s. ~(trivial_limit (at a within s))
     ==> (netlimit (at a within s) = a)
 Proof
-  REWRITE_TAC[trivial_limit, netlimit, AT, WITHIN, DE_MORGAN_THM] THEN
+  REWRITE_TAC[trivial_limit, netlimit_def, AT, WITHIN, DE_MORGAN_THM] THEN
   REPEAT STRIP_TAC THEN MATCH_MP_TAC SELECT_UNIQUE THEN REWRITE_TAC[] THEN
   SUBGOAL_THEN
    ``!x:real. ~(&0 < dist(x,a) /\ dist(x,a) <= dist(a,a) /\ x IN s)``
@@ -1333,6 +1514,8 @@ Proof
  >> ‘f m IN P’ by rw [IN_APP]
  >> ‘f m IN N’ by PROVE_TAC [SUBSET_DEF] >> fs [IN_APP]
 QED
+
+(* END *)
 
 (* References:
 

--- a/src/real/realScript.sml
+++ b/src/real/realScript.sml
@@ -1446,7 +1446,14 @@ Proof
     REWRITE_TAC[abs, REAL_LT_REFL, REAL_LE_REFL]]
 QED
 
+(* |- !x. 0 < abs x <=> x <> 0 *)
 Theorem ABS_NZ'[simp] = GSYM ABS_NZ
+
+Theorem ABS_NOT_ZERO :
+    !(x :real). abs x <> 0 <=> x <> 0
+Proof
+    PROVE_TAC [ABS_ZERO]
+QED
 
 Theorem ABS_INV:
    !x. ~(x = 0) ==> (abs(inv x) = inv(abs(x)))
@@ -2859,6 +2866,18 @@ Theorem REAL_MUL_RNEG = REAL_MUL_RNEG;
 
 (* |- !x y. -x * y = -(x * y) *)
 Theorem REAL_MUL_LNEG = REAL_MUL_LNEG;
+
+Theorem REAL_DIV_RNEG :
+    !x y. x / -y = -(x / y)
+Proof
+    simp [real_div, REAL_INV_NEG, REAL_MUL_RNEG]
+QED
+
+Theorem REAL_DIV_LNEG :
+    !x y. -x / y = -(x / y)
+Proof
+    simp [real_div, REAL_INV_NEG, REAL_MUL_LNEG]
+QED
 
 Theorem REAL_LE_LMUL_NEG:
   !x y z. x < 0 ==> (x * y <= x * z <=> z <= y)


### PR DESCRIPTION
Hi,

This PR contains some cumulative additions to HOL4's core theories about calculus (mostly about derivatives), including some additional contents to the recently added `higher_derivative` in `limTheory`, and some theorems about `convex` (of sets), and `convex_on` (of funtions on sets), ported from HOL-Light. The mostly important theorems are the following two:

```
   [CONVEX_ON_SECANT_DERIVATIVE]  Theorem (derivativeTheory)      
      ⊢ ∀f f' s.
          convex s ∧ (∀x. x ∈ s ⇒ (f has_derivative f' x) (at x within s)) ⇒
          (f convex_on s ⇔ ∀x y. x ∈ s ∧ y ∈ s ⇒ f y − f x ≤ f' y (y − x))

   [CONVEX_ON_DERIVATIVE_SECANT]  Theorem      
      ⊢ ∀f f' s.
          convex s ∧ (∀x. x ∈ s ⇒ (f has_derivative f' x) (at x within s)) ⇒
          (f convex_on s ⇔ ∀x y. x ∈ s ∧ y ∈ s ⇒ f' x (y − x) ≤ f y − f x)
```

In `real_topologyTheory`, now I added all three versions of HOL-Light's `LIM_WITHIN_SEQUENTIALLY` theorems (with a combined proof learnt from HOL-Light):
```
   [LIM_WITHIN_SEQUENTIALLY]  Theorem      
      ⊢ ∀f s a l.
          (f ⟶ l) (at a within s) ⇔
          ∀x. (∀n. x n ∈ s DELETE a) ∧ (x ⟶ a) sequentially ⇒
              (f ∘ x ⟶ l) sequentially
   
   [LIM_WITHIN_SEQUENTIALLY_DECREASING]  Theorem      
      ⊢ ∀f s a l.
          (f ⟶ l) (at a within s) ⇔
          ∀x. (∀n. x n ∈ s DELETE a) ∧
              (∀m n. m < n ⇒ dist (x n,a) < dist (x m,a)) ∧
              (x ⟶ a) sequentially ⇒
              (f ∘ x ⟶ l) sequentially
   
   [LIM_WITHIN_SEQUENTIALLY_INJ]  Theorem      
      ⊢ ∀f s a l.
          (f ⟶ l) (at a within s) ⇔
          ∀x. (∀n. x n ∈ s DELETE a) ∧ (∀m n. x m = x n ⇔ m = n) ∧
              (x ⟶ a) sequentially ⇒
              (f ∘ x ⟶ l) sequentially
```

In `netsTheory`, some more HOL-Light compatibilty layers (and properties of `net_condition`) are added. These are safe changes (no change to existing definitions).

--Chun