### PR TITLE
Improve error messages for constructors in listSyntax

### DIFF
--- a/src/list/src/listSyntax.sml
+++ b/src/list/src/listSyntax.sml
@@ -64,51 +64,106 @@ fun eltype l = dest_list_type (type_of l);
  ---------------------------------------------------------------------------*)
 
 fun mk_nil ty    = inst [alpha |-> ty] nil_tm
+
 fun mk_cons(h,t) = list_mk_comb(inst [alpha |-> type_of h] cons_tm, [h,t])
+    handle HOL_ERR _ => raise ERR "mk_cons" ""
+
 fun mk_snoc(h,t) = list_mk_comb(inst [alpha |-> type_of h] snoc_tm, [h,t])
+    handle HOL_ERR _ => raise ERR "mk_snoc" ""
+
 fun mk_drop(n,l) = list_mk_comb(inst [alpha |-> eltype l] drop_tm, [n,l])
+    handle HOL_ERR _ => raise ERR "mk_drop" ""
+
 fun mk_take(n,l) = list_mk_comb(inst [alpha |-> eltype l] take_tm, [n,l])
+    handle HOL_ERR _ => raise ERR "mk_take" ""
+
 fun mk_isprefix(l1,l2) =
   list_mk_comb(inst [alpha |-> eltype l1] isprefix_tm, [l1,l2])
+    handle HOL_ERR _ => raise ERR "mk_isprefix" ""
+
 fun mk_null l    = mk_comb(inst[alpha |-> eltype l] null_tm,l)
+    handle HOL_ERR _ => raise ERR "mk_null" ""
+
 fun mk_hd l      = mk_comb(inst[alpha |-> eltype l] hd_tm,l)
+    handle HOL_ERR _ => raise ERR "mk_hd" ""
+
 fun mk_tl l      = mk_comb(inst[alpha |-> eltype l] tl_tm,l)
+    handle HOL_ERR _ => raise ERR "mk_tl" ""
+
 fun mk_append(l1,l2) = list_mk_comb(inst[alpha |-> eltype l1]append_tm,[l1,l2])
+    handle HOL_ERR _ => raise ERR "mk_append" ""
+
 fun mk_flat l    = mk_comb(inst[alpha |-> dest_list_type(eltype l)] flat_tm,l)
+    handle HOL_ERR _ => raise ERR "mk_flat" ""
+
 fun mk_length l  = mk_comb(inst[alpha |-> eltype l] length_tm,l)
+    handle HOL_ERR _ => raise ERR "mk_length" ""
+
 fun mk_map (f,l) =
   list_mk_comb(inst[alpha |-> eltype l,
                     beta  |-> snd(dom_rng (type_of f))] map_tm, [f,l])
+    handle HOL_ERR _ => raise ERR "mk_map" ""
+
 fun mk_map2(f,l1,l2) =
   list_mk_comb(inst[alpha |-> eltype l1,
                     beta  |-> eltype l2,
                     gamma |-> snd(strip_fun(type_of f))] map2_tm, [f,l1,l2])
+    handle HOL_ERR _ => raise ERR "mk_map2" ""
 
 fun mk_filter(P,l)  = list_mk_comb(inst[alpha |-> eltype l] filter_tm,[P,l])
+    handle HOL_ERR _ => raise ERR "mk_filter" ""
+
 fun mk_foldr(f,b,l) = list_mk_comb(inst[alpha |-> eltype l,
                                         beta  |-> type_of b] foldr_tm,[f,b,l])
+    handle HOL_ERR _ => raise ERR "mk_foldr" ""
+
 fun mk_foldl(f,b,l) = list_mk_comb(inst[alpha |-> eltype l,
                                         beta  |-> type_of b] foldl_tm,[f,b,l])
+    handle HOL_ERR _ => raise ERR "mk_foldl" ""
+
 fun mk_every(P,l)   = list_mk_comb(inst[alpha |-> eltype l] every_tm,[P,l])
+    handle HOL_ERR _ => raise ERR "mk_every" ""
+
 fun mk_exists(P,l)  = list_mk_comb(inst[alpha |-> eltype l] exists_tm,[P,l])
+    handle HOL_ERR _ => raise ERR "mk_exists" ""
+
 fun mk_el(n,l)      = list_mk_comb(inst[alpha |-> eltype l] el_tm,[n,l])
+    handle HOL_ERR _ => raise ERR "mk_el" ""
+
 fun mk_zip(l1,l2)   = mk_comb(inst[alpha |-> eltype l1,
                                    beta  |-> eltype l2] zip_tm,
                               pairSyntax.mk_pair(l1,l2))
+    handle HOL_ERR _ => raise ERR "mk_zip" ""
+
 fun mk_unzip l =
   let val (ty1,ty2) = pairSyntax.dest_prod (eltype l)
   in mk_comb(inst[alpha |-> ty1, beta |-> ty2] unzip_tm, l)
   end
+  handle HOL_ERR _ => raise ERR "mk_unzip" ""
 
-fun mk_sum l = mk_comb(sum_tm,l);
-fun mk_reverse l = mk_comb(inst[alpha |-> eltype l] reverse_tm,l);
-fun mk_last l = mk_comb(inst[alpha |-> eltype l] last_tm,l);
-fun mk_front l = mk_comb(inst[alpha |-> eltype l] front_tm,l);
-fun mk_all_distinct l = mk_comb(inst[alpha |-> eltype l] all_distinct_tm,l);
-fun mk_list_to_set l = mk_comb(inst[alpha |-> eltype l] list_to_set_tm,l);
+fun mk_sum l = mk_comb(sum_tm,l)
+  handle HOL_ERR _ => raise ERR "mk_sum" ""
+
+fun mk_reverse l = mk_comb(inst[alpha |-> eltype l] reverse_tm,l)
+  handle HOL_ERR _ => raise ERR "mk_reverse" ""
+
+fun mk_last l = mk_comb(inst[alpha |-> eltype l] last_tm,l)
+  handle HOL_ERR _ => raise ERR "mk_last" ""
+
+fun mk_front l = mk_comb(inst[alpha |-> eltype l] front_tm,l)
+  handle HOL_ERR _ => raise ERR "mk_front" ""
+
+fun mk_all_distinct l = mk_comb(inst[alpha |-> eltype l] all_distinct_tm,l)
+  handle HOL_ERR _ => raise ERR "mk_all_distinct" ""
+
+fun mk_list_to_set l = mk_comb(inst[alpha |-> eltype l] list_to_set_tm,l)
+  handle HOL_ERR _ => raise ERR "mk_list_to_set" ""
+
 fun mk_mem(x,l)     = pred_setSyntax.mk_in(x,mk_list_to_set l)
+  handle HOL_ERR _ => raise ERR "mk_mem" ""
 
 fun mk_nub l = mk_comb(inst[alpha |-> eltype l] nub_tm,l)
+  handle HOL_ERR _ => raise ERR "mk_nub" ""
 
 fun mk_genlist (f,n) =
   list_mk_comb (inst [alpha |-> (f |> Term.type_of
@@ -223,7 +278,8 @@ val s3 = HolKernel.syntax_fns3 "list"
 val (pad_left_tm, mk_pad_left, dest_pad_left, is_pad_left) = s3 "PAD_LEFT"
 val (pad_right_tm, mk_pad_right, dest_pad_right, is_pad_right) = s3 "PAD_RIGHT"
 
-fun mk_list (l,ty) = itlist (curry mk_cons) l (mk_nil ty);
+fun mk_list (l,ty) = itlist (curry mk_cons) l (mk_nil ty)
+    handle HOL_ERR _ => raise ERR "mk_list" ""
 
 fun dest_list M =
  let fun dest M =


### PR DESCRIPTION
Most of this code could probably be simplified with the use of HolKernel.syntax_fn{n} but those are stronger and might break stuff which I don't want to fix now.