### PR TITLE
termination_solve_simps: use ThmSetData API

### DIFF
--- a/src/boss/bossLib.sml
+++ b/src/boss/bossLib.sml
@@ -365,13 +365,7 @@ fun name_ind_cases nm_tms thm = let
 
 end
 
-(* ----------------------------------------------------------------------
-    useful for proving termination in fold and rose-tree settings
-   ---------------------------------------------------------------------- *)
 
-val _ = let
-  val sref = TotalDefn.termination_solve_simps
-in sref := ([listTheory.MEM_SPLIT] @ ! sref) end
 
 (* ----------------------------------------------------------------------
     convenient simplification aliases

--- a/src/list/src/listScript.sml
+++ b/src/list/src/listScript.sml
@@ -1092,7 +1092,8 @@ Proof
       Cases_on ‘p’ >> fs[])
 QED
 
-Theorem MEM_SPLIT:
+(* tfl_termsolve: useful for proving termination in fold and rose-tree settings *)
+Theorem MEM_SPLIT[tfl_termsolve]:
   !x l. (MEM x l) = ?l1 l2. (l = l1 ++ x::l2)
 Proof
  Induct_on ‘l’ THEN SRW_TAC [] [] THEN EQ_TAC THENL [

--- a/src/num/termination/TotalDefn.sig
+++ b/src/num/termination/TotalDefn.sig
@@ -25,7 +25,8 @@ sig
    val export_termsimp : string -> unit
    val temp_export_termsimp : string -> unit
 
-   val termination_solve_simps : thm list ref
+   val termination_solve_simps : unit -> thm list
+   val export_termsolve_simp : string -> unit
 
    val termination_ss  : unit -> simpset
    val TC_SIMP_TAC     : simpset -> thm list -> tactic

--- a/src/num/termination/TotalDefn.sml
+++ b/src/num/termination/TotalDefn.sml
@@ -557,7 +557,8 @@ fun SOLVES tac g =
 (* Extra rewrites, used only if they would solve a termination conjunct.     *)
 (*---------------------------------------------------------------------------*)
 
-val termination_solve_simps = ref ([] : thm list);
+val {getDB = termination_solve_simps, export = export_termsolve_simp, ...} =
+    ThmSetData.export_list {settype = "tfl_termsolve", initial = []}
 
 (*---------------------------------------------------------------------------*)
 (* Create TC simplifiers and provers. WF(-) formulas not handled             *)
@@ -581,7 +582,7 @@ fun termination_ss() =
 
 (* simplify then case split and simplify from asms *)
 fun TC_SIMP_TAC ss thl =
-    let val ss' = ss ++ rewrites (!termination_solve_simps @ thl)
+    let val ss' = ss ++ rewrites (termination_solve_simps() @ thl)
     in
       CONV_TAC (simpLib.SIMP_CONV ss' []) THEN
       BasicProvers.PRIM_STP_TAC ss' NO_TAC


### PR DESCRIPTION
Convert termination_solve_simps from a thm list ref to use the ThmSetData.export_list API with settype "tfl_termsolve".

This allows theorems to be added via the [tfl_termsolve] attribute at their definition site, matching the pattern used for tfl_WF.

Move MEM_SPLIT registration from bossLib to listScript using the new attribute.

Closes #1575