### PR TITLE
Slightly speed up term_pmatch

### DIFF
--- a/src/postkernel/HolKernel.sml
+++ b/src/postkernel/HolKernel.sml
@@ -569,11 +569,19 @@ local
             (insts', (env, ctm, vtm)::homs)
           end
         else let
-            val (lv, rv) = dest_comb vtm
-            val (lc, rc) = dest_comb ctm
-            val sofar' = term_pmatch lconsts env lv lc sofar
+            (* Avoid doing the head check multiple times *)
+            fun term_pmatch' lconsts env vtm ctm sofar =
+              if is_comb vtm then
+                let
+                  val (lv, rv) = dest_comb vtm
+                  val (lc, rc) = dest_comb ctm
+                  val sofar' = term_pmatch' lconsts env lv lc sofar
+                in
+                  term_pmatch lconsts env rv rc sofar'
+                end
+              else term_pmatch lconsts env vtm ctm sofar
           in
-            term_pmatch lconsts env rv rc sofar'
+            term_pmatch' lconsts env vtm ctm sofar
           end
       end
 


### PR DESCRIPTION
The speed up is from when you have a long comb term where it's like `f a1 a2 ... an` and the code would be doing
repeat rator `f a1 a2 ... an`
repeat rator `f a1 a2 ... a(n - 1)` etc to check if the head is a variable It's not a major perf issue but it does affect performance