### PR TITLE
Remove dead --lsp option from hol command

### DIFF
--- a/tools-poly/hol.ML
+++ b/tools-poly/hol.ML
@@ -30,30 +30,30 @@ val _ = use "lsp-server.ML";
 val SIGOBJ = OS.Path.concat(Systeml.HOLDIR, "sigobj")
 local
   open FunctionalRecordUpdate
-  fun makeUpdateT z = makeUpdate17 z
+  fun makeUpdateT z = makeUpdate16 z
 in
 fun updateT z = let
   fun from all_forced bare base_state checkerr checkfors debug defaultout exe
-           extra_data forced_objs help lsp multithread output quietp repl z_repl =
+           extra_data forced_objs help multithread output quietp repl z_repl =
     {all_forced = all_forced, bare = bare, base_state = base_state,
      checkerr = checkerr, checkfors = checkfors, debug = debug,
      defaultout = defaultout, exe = exe,
      extra_data = extra_data, forced_objs = forced_objs, help = help,
-     lsp = lsp, multithread = multithread,
+     multithread = multithread,
      output = output, quietp = quietp, repl = repl, z_repl = z_repl}
-  fun from' z_repl repl quietp output multithread lsp help forced_objs extra_data exe
+  fun from' z_repl repl quietp output multithread help forced_objs extra_data exe
             defaultout debug checkfors checkerr base_state bare all_forced =
     {all_forced = all_forced, bare = bare, base_state = base_state,
      checkfors = checkfors, checkerr = checkerr, debug = debug,
      defaultout = defaultout, exe = exe,
      extra_data = extra_data, forced_objs = forced_objs, help = help,
-     lsp = lsp, multithread = multithread,
+     multithread = multithread,
      output = output, quietp = quietp, repl = repl, z_repl = z_repl}
   fun to f {all_forced, bare, base_state, checkerr, checkfors, debug, defaultout,
             exe, extra_data,
-            forced_objs, help, lsp, multithread, output, quietp, repl, z_repl} =
+            forced_objs, help, multithread, output, quietp, repl, z_repl} =
     f all_forced bare base_state checkerr checkfors debug defaultout exe extra_data
-      forced_objs help lsp multithread
+      forced_objs help multithread
       output quietp repl z_repl
 in
   makeUpdateT (from, from', to)
@@ -127,7 +127,6 @@ datatype option_record = OR of {
   extra_data : string option,
   forced_objs : string list,
   help : bool,
-  lsp : bool,
   multithread : int option,
   output : string option,
   quietp : bool,
@@ -195,8 +194,6 @@ val cline_opts = [
    desc = mkBoolT #help},
   {help = "load holstate as base", long = ["holstate"], short = "b",
    desc = setStringOpt "filename" #base_state},
-  {help = "start an LSP server", long = ["lsp"], short = "",
-   desc = mkBoolT #lsp},
   {help = "thread count", long = ["mt"], short = "",
    desc = OptArg (set_threadcount, "c")},
   {help = "Don't use user config file in HOL repl", long = ["noconfig"], short = "",
@@ -223,7 +220,6 @@ val initial_cline = OR {all_forced = false,
                         extra_data = NONE,
                         forced_objs = [],
                         help = false,
-                        lsp = false,
                         multithread = NONE,
                         output = NONE,
                         quietp = false,
@@ -376,7 +372,7 @@ fun main() = let
     else ()
   val _ = List.app check_unknown_opt objs0
   val OR options = List.foldl (fn (f, opts) => f opts) initial_cline cline_upds
-  val {quietp = qp, output, base_state, all_forced, forced_objs, lsp,
+  val {quietp = qp, output, base_state, all_forced, forced_objs,
        bare, repl, z_repl, help, debug, extra_data, defaultout, exe, ...} = options
   (* Determine base_state:
      - --bare: use hol.state0


### PR DESCRIPTION
The --lsp option was parsed and stored in the options record but never used. The LSP server is triggered by the "lsp" subcommand (e.g., "hol lsp"), not by the --lsp flag.

Removed the lsp field from option_record and all related code.