### PR TITLE
TacticParse: handle backtick quotations as opaque tokens

### DIFF
--- a/src/parse/TacticParse.sml
+++ b/src/parse/TacticParse.sml
@@ -55,25 +55,12 @@ fun parseSMLSimple body = let
     #"\000" => ()
   | #"`" => (next (); if cur () = #"`" then next () else finishDoubleQuote ())
   | _ => (next (); finishDoubleQuote ())
-  (* Curly quotes are UTF-8 multibyte: ' = E2 80 98, ' = E2 80 99 *)
-  val u8_prefix = chr 226    (* 0xE2 *)
-  val u8_cont   = chr 128    (* 0x80 *)
-  val u8_lsquo  = chr 152    (* 0x98 - left single curly *)
-  val u8_rsquo  = chr 153    (* 0x99 - right single curly *)
-  val u8_ldquo  = chr 156    (* 0x9C - left double curly *)
-  val u8_rdquo  = chr 157    (* 0x9D - right double curly *)
-  fun finishCurlyQuote () = case cur () of
+  fun finishCurlyQuote c = case cur () of
     #"\000" => ()
-  | c => (next ();
-      if c = u8_prefix andalso cur () = u8_cont then (next ();
-        if cur () = u8_rsquo then next () else (next (); finishCurlyQuote ()))
-      else finishCurlyQuote ())
-  fun finishCurlyDoubleQuote () = case cur () of
-    #"\000" => ()
-  | c => (next ();
-      if c = u8_prefix andalso cur () = u8_cont then (next ();
-        if cur () = u8_rdquo then next () else (next (); finishCurlyDoubleQuote ()))
-      else finishCurlyDoubleQuote ())
+  | #"\226" => (next (); if cur () = #"\128" then (next ();
+      if cur () = c then next () else (next (); finishCurlyQuote c))
+    else finishCurlyQuote c)
+  | _ => (next (); finishCurlyQuote c)
   fun finishComment () = case cur () of
     #"\000" => ()
   | #"*" => (next (); if cur () = #")" then next () else finishComment ())
@@ -92,18 +79,20 @@ fun parseSMLSimple body = let
     #"\000" => (!pos, EOF)
   | #"\"" => (!pos, (next (); finishString (); OpaqueTk))
   | #"`" => (!pos, (next ();
-      if cur () = #"`" then (next (); finishDoubleQuote ()) else finishQuote ();
-      OpaqueTk))
+    if cur () = #"`" then (next (); finishDoubleQuote ()) else finishQuote ();
+    OpaqueTk))
+  | #"\226" => (!pos,
+    if cur () = #"\128" then (next ();
+      if cur () = #"\152" then (next (); finishCurlyQuote #"\153"; OpaqueTk) else
+      if cur () = #"\156" then (next (); finishCurlyQuote #"\157"; OpaqueTk) else
+      OpaqueTk)
+    else OpaqueTk)
   | #"(" => let
     val start = !pos
     val _ = next ()
     in if cur () = #"*" then (next (); finishComment (); token ()) else (start, Symbol #"(") end
   | c => (!pos, (next ();
-    if c = u8_prefix andalso cur () = u8_cont then (next ();
-      if cur () = u8_lsquo then (next (); finishCurlyQuote (); OpaqueTk)
-      else if cur () = u8_ldquo then (next (); finishCurlyDoubleQuote (); OpaqueTk)
-      else OpaqueTk)
-    else if Char.contains ")[]{},;" c then Symbol c else
+    if Char.contains ")[]{},;" c then Symbol c else
     if isIdSym c then (takeWhile isIdSym; finishId (); IdentTk) else
     if Char.isAlpha c then (takeWhile isIdRest; finishId (); IdentTk) else
     OpaqueTk)))


### PR DESCRIPTION
Fixes #1797

### Problem

`TacticParse.parseTacticBlock` stops parsing prematurely when it encounters backtick quotations (\`...\`) containing semicolons or other terminator characters. The backtick was listed in `isIdSym`, so \`do x; y od\` would tokenize as separate identifiers and the semicolon would terminate parsing.

### Fix

- Remove backtick from `isIdSym`
- Add `finishQuote()` function to consume characters until closing backtick
- Add case for backtick in tokenizer, producing `OpaqueTk` (same as double-quoted strings)

### Testing

Verified tokenizer behavior before/after with standalone test. Before: semicolon inside \`do x; y od s = z\` produced `Symbol #";"` token. After: entire backtick-quoted string is single `OpaqueTk`.