### PR TITLE
Updating the definition of a cycle

### DIFF
--- a/examples/generic_graphs/fsgraphScript.sml
+++ b/examples/generic_graphs/fsgraphScript.sml
@@ -679,7 +679,7 @@ Definition trail_def:
 End
 
 Definition cycle_def:
-  cycle g vs ⇔ walk g vs ∧ ALL_DISTINCT (TL vs) ∧ 3 ≤ LENGTH vs ∧
+  cycle g vs ⇔ walk g vs ∧ ALL_DISTINCT (TL vs) ∧ 4 ≤ LENGTH vs ∧
                HD vs = LAST vs
 End
 


### PR DESCRIPTION
Updating the definition of a cycle to exclude trivial cycles. A cycle in a simple finite graph ought to be at least 3 nodes long, because a cycle containing only two nodes is nothing more than traveling backwards and forwards on an edge, which is trivial. In particular, the definition of a tree as a connected graph with no cycles would make no sense if we allowed a cycle of length 2. The previous definition of a cycle required that the sequence of vertices was of at least length 3, however, this was a buggy implementation, because the first and last vertices are the same vertex, so a loop containing 3 vertices only contains 2 distinct vertices. So this should be updated to require a loop to contain at least 4 vertices, so that we have at least 3 distinct vertices, in order to exclude the trivial situation where we simply travel backwards and forwards on a single edge.