### PR TITLE
Cachekey: resolve sigobj symlinks to find .dat files

### DIFF
--- a/tools/Holmake/core/Holmake.sml
+++ b/tools/Holmake/core/Holmake.sml
@@ -1384,8 +1384,8 @@ fun do_cachekey thyname =
                                     val real_uo = OS.FileSys.realPath uo_fspath
                                     val real_dir = OS.Path.dir real_uo
                                     val dat_name = fromFile (DAT s)
-                                    val dat_fspath = toFSpath
-                                        (OS.Path.concat(real_dir, dat_name))
+                                    val dat_fspath =
+                                        OS.Path.concat(real_dir, dat_name)
                                   in
                                     dat_fspath
                                   end handle OS.SysErr _ => fspath

--- a/tools/Holmake/tests/cachekey/selftest.sml
+++ b/tools/Holmake/tests/cachekey/selftest.sml
@@ -121,6 +121,17 @@ val _ = if ok8 andalso size key8 = 40 andalso key8 <> key5 then OK()
         else die ("Expected different hash from " ^ key5 ^ ", got: \"" ^
                   key8 ^ "\"")
 
+(* Test 9: --cachekey succeeds when dependency is a Theory in sigobj
+   (regression test for GitHub issue #1828: sigobj only has symlinks
+   for .uo/.ui, not .dat, so the symlink must be resolved) *)
+val _ = HOLFileSys.chDir "../sigobj_symlink"
+val _ = tprint "Checking --cachekey resolves sigobj symlinks for .dat (GH #1828)"
+val (ok9, key9) = run_cachekey "sigtestTheory"
+val _ = if ok9 andalso size key9 = 40 then OK()
+        else die ("Expected success with 40-char hash, got: \"" ^ key9 ^ "\"")
+
+val _ = HOLFileSys.chDir "../depdir"
+
 (* Clean up depdir and restore baseScript.sml *)
 val _ = run_holmake ["cleanAll"]
 val _ = let val strm = TextIO.openOut "baseScript.sml"

--- a/tools/Holmake/tests/cachekey/sigobj_symlink/sigtestScript.sml
+++ b/tools/Holmake/tests/cachekey/sigobj_symlink/sigtestScript.sml
@@ -1,0 +1,3 @@
+Theory sigtest[bare]
+Ancestors arithmetic
+Theorem sigtest_thm = arithmeticTheory.ADD_0


### PR DESCRIPTION
When --cachekey converts a Theory .uo/.ui dependency to the corresponding .dat file, dependencies from sigobj/ would fail because only .uo/.ui files are symlinked there, not .dat files.

Fix by falling back to resolving the .uo symlink via realPath to discover the actual directory where the .dat file resides.

Closes #1828.