### PR TITLE
Vim/HOL: fix invisible syntax

### DIFF
--- a/tools/editor-modes/vim/hol4script.vim
+++ b/tools/editor-modes/vim/hol4script.vim
@@ -236,7 +236,7 @@ syn sync fromstart
 hi     link HOLSymbol    Type
 hi     link HOLOperator  Underlined
 hi     link HOLVars      NonText
-hi     link HOLIdents    Ignore
+hi     link HOLIdents    Normal
 hi     link HOLKeywords  PreProc
 hi     link HOLComment   Comment
 hi     link HOLString    String


### PR DESCRIPTION
Change HOLIdents to render as "Normal" class rather than "Ignore". The "Ignore" syntax class doesn't seem to be used much, isn't set by all colour schemes, and is invisible in the default "dark" theme (printing as black on black).

This affects the majority of HOL text (as opposed to ML text).

I will declare that I would also prefer to use Operator rather than Underlined for HOL operators, but I'll leave that as a matter of preference.