### PR TITLE
metis: on classify BUG, print the HOL_ERR

### DIFF
--- a/src/metis/metisTools.sml
+++ b/src/metis/metisTools.sml
@@ -414,7 +414,11 @@ local
     end;
 in
   fun classify fms = order (First,empty) fms
-    handle HOL_ERR _ => raise BUG "metisTools.classify" "shouldn't fail";
+    handle HOL_ERR e => (
+        print "metisTools.classify: error in classifying:\n";
+        HOLPP.prettyPrint (print, 1) (pp_hol_error e);
+        raise BUG "metisTools.classify" "shouldn't fail"
+    );
 end;
 
 fun METIS_TTAC (cs,ths) =


### PR DESCRIPTION
The "metisTools.classify: shouldn't fail" message appeared recently. The real culprit of the error was problematic use of delete_const elsewhere. However it would have helped if the BUG message didn't hide the contents of the HOL_ERR that was generated. Modify things so that the HOL_ERR is printed out, which might help a user diagnose a similar problem.