### PR TITLE
metis: BUG-print: more conventional err print

### DIFF
--- a/src/metis/metisTools.sml
+++ b/src/metis/metisTools.sml
@@ -416,7 +416,7 @@ in
   fun classify fms = order (First,empty) fms
     handle HOL_ERR e => (
         print "metisTools.classify: error in classifying:\n";
-        HOLPP.prettyPrint (print, 1) (pp_hol_error e);
+        print (format_ERR e);
         raise BUG "metisTools.classify" "shouldn't fail"
     );
 end;


### PR DESCRIPTION
Follow-up to previous PR.

Use format_ERR rather than a probably-incorrect HOLPP incantation. Thanks to Konrad Slind for spotting the issue.
