### PR TITLE
Add more arguments to compute_prf

### DIFF
--- a/src/opentheory/postbool/Logging.sml
+++ b/src/opentheory/postbool/Logging.sml
@@ -60,7 +60,7 @@ val proof_type = let open Thm fun
 |f (Mk_comb_prf _) = "Mk_comb"
 |f (Specialize_prf _) = "Specialize"
 |f (deductAntisym_prf _) = "deductAntisym"
-|f compute_prf = "compute"
+|f (compute_prf _) = "compute"
 in f end
 
 datatype log_state =
@@ -697,7 +697,7 @@ val (log_term, log_thm, log_clear,
                                   [alpha|->rty,beta|->aty]) Def_tyop_pth
       val _       = log_thm (proveHyp ra (proveHyp ar pth))
       in () end
-    | compute_prf => raise ERR "log_thm" "disabled in opentheory kernel";
+    | compute_prf _ => raise ERR "log_thm" "disabled in opentheory kernel";
     val _ = if !verbosity >= 4 then HOL_MESG("Finish proof for "^(Susp.force ths)) else ()
     (*
     val _ = log_comment(pt^")")

--- a/src/thm/otknl-thm.ML
+++ b/src/thm/otknl-thm.ML
@@ -153,7 +153,7 @@ and proof =
 | Def_const_list_prf of string * (string * hol_type) list * thm
 | Def_spec_prf of term list * thm
 | deductAntisym_prf of thm * thm
-| compute_prf
+| compute_prf of thm list * term
 
 fun proof (THM(_,_,_,p)) = !p
 fun delete_proof (THM(_,_,_,p)) = p := deleted_prf
@@ -1439,8 +1439,9 @@ in
             let
               val tm' = tc1 tm
               val eqn = safe_mk_eq tm tm'
+              val prf = compute_prf (code_eqs, tm)
             in
-              make_thm Count.Compute (tag1, empty_hyp, eqn, compute_prf)
+              make_thm Count.Compute (tag1, empty_hyp, eqn, prf)
             end
         end
     end;

--- a/src/thm/otknl-thmsig.ML
+++ b/src/thm/otknl-thmsig.ML
@@ -47,7 +47,7 @@ sig
   | Mk_comb_prf of thm * thm * thm
   | Specialize_prf of term * thm
   | deductAntisym_prf of thm * thm
-  | compute_prf
+  | compute_prf of thm list * term
 
   val proof : thm -> proof
   val delete_proof : thm -> unit


### PR DESCRIPTION
I think this is necessary for replay to work when using #1309. Possibly we also should add the initialisation arguments on the same proof constructor.