### PR TITLE
Support downloading pre-built theory files from an online Holmake cache

### DIFF
--- a/tools/Holmake/HolmakeCache.sml
+++ b/tools/Holmake/HolmakeCache.sml
@@ -110,7 +110,10 @@ fun fetch base_url cachekey talk =
                                 (fn v => { name = JSONUtil.asString (JSONUtil.lookupField v "name"),
                                            url  = JSONUtil.asString (JSONUtil.lookupField v "url") })
                                 (JSONUtil.lookupField json "files")
-		val to_dest_dir = HOLFileSys.writefn (fn s => s)
+		fun to_dest_dir s =
+		    case HFS_NameMunge.HOLtoFS s of
+		        NONE => s
+		      | SOME {fullfile, ...} => fullfile
 		val ok = List.all
 			     (fn {name, url} =>
 				 curl_get_to_file (base_url ^ url) (to_dest_dir name))

--- a/tools/Holmake/HolmakeCache.sml
+++ b/tools/Holmake/HolmakeCache.sml
@@ -1,0 +1,121 @@
+structure HolmakeCache =
+struct
+
+open Holmake_tools Holmake_types
+
+fun compute_deps (deps : dep list) =
+    let fun dep_to_hashable dep =
+            case hm_target.filepart dep of
+                DAT _ => SOME dep
+              | SML _ => SOME dep
+              | SIG _ => SOME dep
+              | ART _ => SOME dep
+              | UO (Theory s) =>
+                SOME (hm_target.setFile (DAT s) dep)
+              | UI (Theory s) =>
+                SOME (hm_target.setFile (DAT s) dep)
+              | _ => NONE
+        val depset =
+            List.foldl
+                (fn (dep, acc) =>
+                    case dep_to_hashable dep of
+                        SOME d => Binaryset.add(acc, d)
+                      | NONE => acc)
+                hm_target.empty_tgtset
+                deps
+        fun toFSpath s =
+            case HFS_NameMunge.HOLtoFS s of
+                NONE => s
+              | SOME {fullfile, ...} => fullfile
+    in
+        map (fn dep =>
+                let val p = tgt_toString dep
+                    val fspath = toFSpath p
+                    (* If this is a .dat converted from a .uo/.ui that
+                       lives in sigobj (symlinked), the .dat won't exist
+                       in sigobj. Resolve the .uo symlink to find the
+                       real directory where the .dat lives. *)
+                    val path =
+                        if OS.FileSys.access(fspath, []) then fspath
+                        else
+                            case hm_target.filepart dep of
+                                DAT s =>
+                                (let
+                                    val uoname = fromFile (UO (Theory s))
+                                    val dir = OS.Path.dir p
+                                    val uo_path =
+                                        if dir = "" then uoname
+                                        else OS.Path.concat(dir, uoname)
+                                    val uo_fspath = toFSpath uo_path
+                                    val real_uo = OS.FileSys.realPath uo_fspath
+                                    val real_dir = OS.Path.dir real_uo
+                                    val dat_name = fromFile (DAT s)
+                                    val dat_fspath =
+                                        OS.Path.concat(real_dir, dat_name)
+                                in
+                                    dat_fspath
+                                end handle OS.SysErr _ => fspath)
+                              | _ => fspath
+                in { name = fromFile (hm_target.filepart dep),
+                     path = path }
+                end)
+            (Binaryset.listItems depset)
+    end
+
+fun generate_cachekey deps =
+    let val hashed_deps =
+            map (fn {name, path} =>
+                    (name, SHA1.sha1_file {filename = path}))
+                deps
+        val sorted_hashes =
+            Listsort.sort (pair_compare (String.compare, String.compare))
+                          hashed_deps
+        val dep_hashes = map #2 sorted_hashes
+        val tmpfile = OS.FileSys.tmpName ()
+        val _ = let val out = TextIO.openOut tmpfile
+                in
+                    List.app (fn h => TextIO.output(out, h)) dep_hashes;
+                    TextIO.closeOut out
+                end
+        val cachekey = SHA1.sha1_file {filename = tmpfile}
+        val _ = OS.FileSys.remove tmpfile handle OS.SysErr _ => ()
+    in
+        cachekey
+    end
+
+val compute_deps_cachekey = generate_cachekey o compute_deps
+	
+fun curl_get_to_file url dest =
+    OS.Process.isSuccess (Systeml.systeml ["curl", "-s", "-f", "-o", dest, url])
+
+fun fetch base_url cachekey dest_dir =
+    let
+        val key_url = base_url ^ "/key/" ^ cachekey
+        val tmpfile = OS.FileSys.tmpName()
+        val hit = curl_get_to_file key_url tmpfile
+    in
+        if not hit then let
+	    val _ = OS.FileSys.remove tmpfile handle OS.SysErr _ => ()
+	in
+	    false
+	end
+        else
+            let
+                val src = JSONParser.openFile tmpfile
+                val json = JSONParser.parse src before JSONParser.close src
+                val _ = OS.FileSys.remove tmpfile handle OS.SysErr _ => ()
+                val files = JSONUtil.arrayMap
+                                (fn v => { name = JSONUtil.asString (JSONUtil.lookupField v "name"),
+                                           url  = JSONUtil.asString (JSONUtil.lookupField v "url") })
+                                (JSONUtil.lookupField json "files")
+            in
+                List.all
+                    (fn {name, url} =>
+                        curl_get_to_file (base_url ^ url)
+                                         (OS.Path.concat (dest_dir, name)))
+                    files
+            end
+            handle _ => false
+    end
+	
+end

--- a/tools/Holmake/HolmakeCache.sml
+++ b/tools/Holmake/HolmakeCache.sml
@@ -86,7 +86,13 @@ fun generate_cachekey deps =
 val compute_deps_cachekey = generate_cachekey o compute_deps
 
 fun curl_get_to_file url dest =
-    OS.Process.isSuccess (Systeml.systeml ["curl", "-s", "-f", "-o", dest, url])
+    (* curl
+       -s <silent mode; don't show progress meter etc.>
+       -f <return nonzero status code for http errors (e.g. 404s from a cache miss)>
+       -m <timeout in seconds>
+       -o <destination file loc>
+       <url to download from> *)
+    OS.Process.isSuccess (Systeml.systeml ["curl", "-s", "-f", "-m", "5", "-o", dest, url])
 
 fun fetch base_url cachekey talk =
     let

--- a/tools/Holmake/HolmakeCache.sml
+++ b/tools/Holmake/HolmakeCache.sml
@@ -88,14 +88,16 @@ val compute_deps_cachekey = generate_cachekey o compute_deps
 fun curl_get_to_file url dest =
     OS.Process.isSuccess (Systeml.systeml ["curl", "-s", "-f", "-o", dest, url])
 
-fun fetch base_url cachekey =
+fun fetch base_url cachekey talk =
     let
         val key_url = base_url ^ "/key/" ^ cachekey
         val tmpfile = OS.FileSys.tmpName()
+	val _ = talk "checking cache for prebuilt theory"
         val hit = curl_get_to_file key_url tmpfile
     in
         if not hit then let
-	    val _ = OS.FileSys.remove tmpfile handle OS.SysErr _ => ()
+	    val _ = OS.FileSys.remove tmpfile handle OS.SysErr _ => ()			
+	    val _ = talk "cache miss; theory will be built locally."
 	in
 	    false
 	end
@@ -108,14 +110,22 @@ fun fetch base_url cachekey =
                                 (fn v => { name = JSONUtil.asString (JSONUtil.lookupField v "name"),
                                            url  = JSONUtil.asString (JSONUtil.lookupField v "url") })
                                 (JSONUtil.lookupField json "files")
-		val to_dest_dir = HFS_NameMunge.toFSfn true (fn s => s)
+		val to_dest_dir = HOLFileSys.writefn (fn s => s)
+		val ok = List.all
+			     (fn {name, url} =>
+				 curl_get_to_file (base_url ^ url) (to_dest_dir name))
+			     files
+		val _ = if ok
+			then talk "cache hit! local theory building can be skipped."
+			else talk "only managed a partial cache hit. theory will be built locally."
             in
-                List.all
-                    (fn {name, url} =>
-                        curl_get_to_file (base_url ^ url) (to_dest_dir name))
-                    files
+                ok
             end
-            handle _ => false
+            handle _ => let
+		val _ = talk "something went wrong. theory will be built locally."
+	    in
+		false
+	    end
     end
 	
 end

--- a/tools/Holmake/HolmakeCache.sml
+++ b/tools/Holmake/HolmakeCache.sml
@@ -88,7 +88,7 @@ val compute_deps_cachekey = generate_cachekey o compute_deps
 fun curl_get_to_file url dest =
     OS.Process.isSuccess (Systeml.systeml ["curl", "-s", "-f", "-o", dest, url])
 
-fun fetch base_url cachekey dest_dir =
+fun fetch base_url cachekey =
     let
         val key_url = base_url ^ "/key/" ^ cachekey
         val tmpfile = OS.FileSys.tmpName()
@@ -108,11 +108,11 @@ fun fetch base_url cachekey dest_dir =
                                 (fn v => { name = JSONUtil.asString (JSONUtil.lookupField v "name"),
                                            url  = JSONUtil.asString (JSONUtil.lookupField v "url") })
                                 (JSONUtil.lookupField json "files")
+		val to_dest_dir = HFS_NameMunge.toFSfn true (fn s => s)
             in
                 List.all
                     (fn {name, url} =>
-                        curl_get_to_file (base_url ^ url)
-                                         (OS.Path.concat (dest_dir, name)))
+                        curl_get_to_file (base_url ^ url) (to_dest_dir name))
                     files
             end
             handle _ => false

--- a/tools/Holmake/HolmakeCache.sml
+++ b/tools/Holmake/HolmakeCache.sml
@@ -84,7 +84,7 @@ fun generate_cachekey deps =
     end
 
 val compute_deps_cachekey = generate_cachekey o compute_deps
-	
+
 fun curl_get_to_file url dest =
     OS.Process.isSuccess (Systeml.systeml ["curl", "-s", "-f", "-o", dest, url])
 
@@ -92,15 +92,15 @@ fun fetch base_url cachekey talk =
     let
         val key_url = base_url ^ "/key/" ^ cachekey
         val tmpfile = OS.FileSys.tmpName()
-	val _ = talk "checking cache for prebuilt theory"
+        val _ = talk "checking cache for prebuilt theory"
         val hit = curl_get_to_file key_url tmpfile
     in
         if not hit then let
-	    val _ = OS.FileSys.remove tmpfile handle OS.SysErr _ => ()			
-	    val _ = talk "cache miss; theory will be built locally."
-	in
-	    false
-	end
+            val _ = OS.FileSys.remove tmpfile handle OS.SysErr _ => ()
+            val _ = talk "cache miss; theory will be built locally."
+        in
+            false
+        end
         else
             let
                 val src = JSONParser.openFile tmpfile
@@ -110,25 +110,25 @@ fun fetch base_url cachekey talk =
                                 (fn v => { name = JSONUtil.asString (JSONUtil.lookupField v "name"),
                                            url  = JSONUtil.asString (JSONUtil.lookupField v "url") })
                                 (JSONUtil.lookupField json "files")
-		fun to_dest_dir s =
-		    case HFS_NameMunge.HOLtoFS s of
-		        NONE => s
-		      | SOME {fullfile, ...} => fullfile
-		val ok = List.all
-			     (fn {name, url} =>
-				 curl_get_to_file (base_url ^ url) (to_dest_dir name))
-			     files
-		val _ = if ok
-			then talk "cache hit! local theory building can be skipped."
-			else talk "only managed a partial cache hit. theory will be built locally."
+                fun to_dest_dir s =
+                    case HFS_NameMunge.HOLtoFS s of
+                        NONE => s
+                      | SOME {fullfile, ...} => fullfile
+                val ok = List.all
+                             (fn {name, url} =>
+                                 curl_get_to_file (base_url ^ url) (to_dest_dir name))
+                             files
+                val _ = if ok
+                        then talk "cache hit! local theory building can be skipped."
+                        else talk "only managed a partial cache hit. theory will be built locally."
             in
                 ok
             end
             handle _ => let
-		val _ = talk "something went wrong. theory will be built locally."
-	    in
-		false
-	    end
+                val _ = talk "something went wrong. theory will be built locally."
+            in
+                false
+            end
     end
-	
+
 end

--- a/tools/Holmake/HolmakeCacheKey.sml
+++ b/tools/Holmake/HolmakeCacheKey.sml
@@ -1,4 +1,4 @@
-structure HolmakeCache =
+structure HolmakeCacheKey =
 struct
 
 open Holmake_tools Holmake_types
@@ -84,57 +84,5 @@ fun generate_cachekey deps =
     end
 
 val compute_deps_cachekey = generate_cachekey o compute_deps
-
-fun curl_get_to_file url dest =
-    (* curl
-       -s <silent mode; don't show progress meter etc.>
-       -f <return nonzero status code for http errors (e.g. 404s from a cache miss)>
-       -m <timeout in seconds>
-       -o <destination file loc>
-       <url to download from> *)
-    OS.Process.isSuccess (Systeml.systeml ["curl", "-s", "-f", "-m", "5", "-o", dest, url])
-
-fun fetch base_url cachekey talk =
-    let
-        val key_url = base_url ^ "/key/" ^ cachekey
-        val tmpfile = OS.FileSys.tmpName()
-        val _ = talk "checking cache for prebuilt theory"
-        val hit = curl_get_to_file key_url tmpfile
-    in
-        if not hit then let
-            val _ = OS.FileSys.remove tmpfile handle OS.SysErr _ => ()
-            val _ = talk "cache miss; theory will be built locally."
-        in
-            false
-        end
-        else
-            let
-                val src = JSONParser.openFile tmpfile
-                val json = JSONParser.parse src before JSONParser.close src
-                val _ = OS.FileSys.remove tmpfile handle OS.SysErr _ => ()
-                val files = JSONUtil.arrayMap
-                                (fn v => { name = JSONUtil.asString (JSONUtil.lookupField v "name"),
-                                           url  = JSONUtil.asString (JSONUtil.lookupField v "url") })
-                                (JSONUtil.lookupField json "files")
-                fun to_dest_dir s =
-                    case HFS_NameMunge.HOLtoFS s of
-                        NONE => s
-                      | SOME {fullfile, ...} => fullfile
-                val ok = List.all
-                             (fn {name, url} =>
-                                 curl_get_to_file (base_url ^ url) (to_dest_dir name))
-                             files
-                val _ = if ok
-                        then talk "cache hit! local theory building can be skipped."
-                        else talk "only managed a partial cache hit. theory will be built locally."
-            in
-                ok
-            end
-            handle _ => let
-                val _ = talk "something went wrong. theory will be built locally."
-            in
-                false
-            end
-    end
 
 end

--- a/tools/Holmake/core/HM_Core_Cline.sig
+++ b/tools/Holmake/core/HM_Core_Cline.sig
@@ -3,6 +3,7 @@ sig
 
 type t = {
   cachekey : string option,
+  cache_url : string option,
   debug : {ins:string list, outs:string list} option,
   do_logging : bool,
   fast : bool,

--- a/tools/Holmake/core/HM_Core_Cline.sml
+++ b/tools/Holmake/core/HM_Core_Cline.sml
@@ -3,16 +3,17 @@ struct
 
 local
   open FunctionalRecordUpdate
-  fun makeUpdateT z = makeUpdate25 z
+  fun makeUpdateT z = makeUpdate26 z
 in
 fun updateT z = let
-  fun from cachekey debug do_logging fast help hmakefile holdir includes
+  fun from cache_url cachekey debug do_logging fast help hmakefile holdir includes
            interactive jobs json keep_going no_action no_hmakefile
            no_lastmaker_check no_overlay
            no_preexecs no_prereqs opentheory quiet
            quit_on_failure rebuild_deps recursive_build recursive_clean
            verbose =
-    {
+      {
+      cache_url = cache_url,
       cachekey = cachekey,
       debug = debug, do_logging = do_logging,
       fast = fast, help = help, hmakefile = hmakefile, holdir = holdir,
@@ -31,8 +32,9 @@ fun updateT z = let
             no_overlay no_lastmaker_check no_hmakefile no_action keep_going
             json jobs interactive
             includes holdir
-            hmakefile help fast do_logging debug cachekey =
+            hmakefile help fast do_logging debug cachekey cache_url =
     {
+      cache_url = cache_url,
       cachekey = cachekey,
       debug = debug, do_logging = do_logging,
       fast = fast, help = help, hmakefile = hmakefile, holdir = holdir,
@@ -46,13 +48,13 @@ fun updateT z = let
       rebuild_deps = rebuild_deps, recursive_build = recursive_build,
       recursive_clean = recursive_clean, verbose = verbose
     }
-  fun to f {cachekey, debug, do_logging, fast, help, hmakefile, holdir,
+  fun to f {cache_url, cachekey, debug, do_logging, fast, help, hmakefile, holdir,
             includes, interactive, jobs, json, keep_going, no_action,
             no_hmakefile, no_lastmaker_check,
             no_overlay, no_preexecs, no_prereqs, opentheory,
             quiet, quit_on_failure, rebuild_deps, recursive_build,
             recursive_clean, verbose} =
-    f cachekey debug do_logging fast help hmakefile holdir includes
+    f cache_url cachekey debug do_logging fast help hmakefile holdir includes
       interactive jobs json keep_going no_action no_hmakefile
       no_lastmaker_check no_overlay no_preexecs
       no_prereqs opentheory quiet
@@ -68,6 +70,7 @@ fun fupd_jobs f t = updateT t (U #jobs (f (#jobs t))) $$
 fun fupd_includes f t = updateT t (U #includes (f (#includes t))) $$
 
 type t = {
+  cache_url : string option,
   cachekey : string option,
   debug : {ins : string list, outs : string list} option,
   do_logging : bool,
@@ -97,6 +100,7 @@ type t = {
 
 val default_core_options : t =
 {
+  cache_url = NONE,
   cachekey = NONE,
   debug = NONE,
   do_logging = false,
@@ -169,6 +173,12 @@ fun set_cachekey s =
                wn "Multiple cachekey specs; ignoring earlier spec"
              else ();
              updateT t (U #cachekey (SOME s)) $$))
+fun set_cache_url s =
+  resfn (fn (wn, t) =>
+            (if isSome (#cache_url t) then
+               wn "Multiple cache_url specs; ignoring earlier spec"
+             else ();
+             updateT t (U #cache_url (SOME s)) $$))
 fun set_openthy s =
   resfn (fn (wn, t) =>
             (if isSome (#opentheory t) then
@@ -198,6 +208,8 @@ fun addDbg sopt =
               end)
 
 val core_option_descriptions = [
+  { help = "build and pull pre-built theories from url when possible",
+    long = ["cache-url"], short = "", desc = ReqArg (set_cache_url, "url") },
   { help = "print cache key for a theory target", long = ["cachekey"],
     short = "", desc = ReqArg (set_cachekey, "theory") },
   { help = "turn on diagnostic messages", long = ["dbg"], short = "d",

--- a/tools/Holmake/core/Holmake.sml
+++ b/tools/Holmake/core/Holmake.sml
@@ -1337,7 +1337,7 @@ fun do_cachekey thyname =
          For .uo/.ui of Theory files, substitute the corresponding
          .dat file (the actual theory content). Other .uo/.ui files
          and the holheap state are excluded. *)
-      val deps = HolmakeCache.compute_deps (map #2 (#dependencies nodeinfo))
+      val deps = HolmakeCacheKey.compute_deps (map #2 (#dependencies nodeinfo))
       val _ = List.app
                 (fn {name, path} =>
                     if OS.FileSys.access(path, [OS.FileSys.A_READ]) then ()
@@ -1348,7 +1348,7 @@ fun do_cachekey thyname =
          machine-independent ordering. Filename is the primary key; hash
          breaks ties if two dependencies from different directories happen
          to share a filename. *)
-      val cachekey = HolmakeCache.generate_cachekey deps
+      val cachekey = HolmakeCacheKey.generate_cachekey deps
     in
       print (cachekey ^ "\n");
       OS.Process.success

--- a/tools/Holmake/core/Holmake.sml
+++ b/tools/Holmake/core/Holmake.sml
@@ -1313,7 +1313,7 @@ fun work() =
               postmortem finish_logging outputfns (build_graph depgraph)
               handle e => die ("Exception: "^General.exnMessage e)
           end
-      end
+    end
 
 fun do_cachekey thyname =
     let
@@ -1337,64 +1337,7 @@ fun do_cachekey thyname =
          For .uo/.ui of Theory files, substitute the corresponding
          .dat file (the actual theory content). Other .uo/.ui files
          and the holheap state are excluded. *)
-      fun dep_to_hashable dep =
-          case hm_target.filepart dep of
-              DAT _ => SOME dep
-            | SML _ => SOME dep
-            | SIG _ => SOME dep
-            | ART _ => SOME dep
-            | UO (Theory s) =>
-                SOME (hm_target.setFile (DAT s) dep)
-            | UI (Theory s) =>
-                SOME (hm_target.setFile (DAT s) dep)
-            | _ => NONE
-      val deps =
-          let val depset =
-                  List.foldl
-                    (fn ((_, dep), acc) =>
-                        case dep_to_hashable dep of
-                            SOME d => Binaryset.add(acc, d)
-                          | NONE => acc)
-                    hm_target.empty_tgtset
-                    (#dependencies nodeinfo)
-          fun toFSpath s =
-              case HFS_NameMunge.HOLtoFS s of
-                  NONE => s
-                | SOME {fullfile, ...} => fullfile
-          in
-            map (fn dep =>
-                    let val p = tgt_toString dep
-                        val fspath = toFSpath p
-                        (* If this is a .dat converted from a .uo/.ui that
-                           lives in sigobj (symlinked), the .dat won't exist
-                           in sigobj. Resolve the .uo symlink to find the
-                           real directory where the .dat lives. *)
-                        val path =
-                            if OS.FileSys.access(fspath, []) then fspath
-                            else
-                              case hm_target.filepart dep of
-                                  DAT s =>
-                                  (let
-                                    val uoname = fromFile (UO (Theory s))
-                                    val dir = OS.Path.dir p
-                                    val uo_path =
-                                        if dir = "" then uoname
-                                        else OS.Path.concat(dir, uoname)
-                                    val uo_fspath = toFSpath uo_path
-                                    val real_uo = OS.FileSys.realPath uo_fspath
-                                    val real_dir = OS.Path.dir real_uo
-                                    val dat_name = fromFile (DAT s)
-                                    val dat_fspath =
-                                        OS.Path.concat(real_dir, dat_name)
-                                  in
-                                    dat_fspath
-                                  end handle OS.SysErr _ => fspath)
-                                | _ => fspath
-                    in { name = fromFile (hm_target.filepart dep),
-                         path = path }
-                    end)
-                (Binaryset.listItems depset)
-          end
+      val deps = HolmakeCache.compute_deps (map #2 (#dependencies nodeinfo))
       val _ = List.app
                 (fn {name, path} =>
                     if OS.FileSys.access(path, [OS.FileSys.A_READ]) then ()
@@ -1405,22 +1348,7 @@ fun do_cachekey thyname =
          machine-independent ordering. Filename is the primary key; hash
          breaks ties if two dependencies from different directories happen
          to share a filename. *)
-      val hashed_deps =
-          map (fn {name, path} =>
-                  (name, SHA1.sha1_file {filename = path}))
-              deps
-      val sorted_hashes =
-          Listsort.sort (pair_compare (String.compare, String.compare))
-                        hashed_deps
-      val dep_hashes = map #2 sorted_hashes
-      val tmpfile = OS.FileSys.tmpName ()
-      val _ = let val out = TextIO.openOut tmpfile
-              in
-                List.app (fn h => TextIO.output(out, h)) dep_hashes;
-                TextIO.closeOut out
-              end
-      val cachekey = SHA1.sha1_file {filename = tmpfile}
-      val _ = OS.FileSys.remove tmpfile handle OS.SysErr _ => ()
+      val cachekey = HolmakeCache.generate_cachekey deps
     in
       print (cachekey ^ "\n");
       OS.Process.success

--- a/tools/Holmake/core/Holmake.sml
+++ b/tools/Holmake/core/Holmake.sml
@@ -1313,7 +1313,7 @@ fun work() =
               postmortem finish_logging outputfns (build_graph depgraph)
               handle e => die ("Exception: "^General.exnMessage e)
           end
-    end
+      end
 
 fun do_cachekey thyname =
     let

--- a/tools/Holmake/hmcore.ML
+++ b/tools/Holmake/hmcore.ML
@@ -54,5 +54,6 @@ in
   app appjson ["JSONErrors"];
   myuse jsondir "JSONSource.sml";
   app appjson ["JSONParser", "JSONUtil"];
-  myuse hmakedir "HolmakeCache.sml"
+  myuse hmakedir "HolmakeCacheKey.sml";
+  myuse hmakedir "poly/HolmakeCacheFetch.sml"
 end;

--- a/tools/Holmake/hmcore.ML
+++ b/tools/Holmake/hmcore.ML
@@ -20,7 +20,9 @@ val _ = let
   val utildir = Systeml.HOLDIR ++ "tools" ++ "util"
   val portableMLdir = Systeml.HOLDIR ++ "src" ++ "portableML"
   val portableMLpolydir = portableMLdir ++ "poly"
+  val jsondir = portableMLdir ++ "json"
   fun appportable s = (myuse portableMLdir (s ^ ".sig"); myuse portableMLdir (s ^ ".sml"))
+  fun appjson s = (myuse jsondir (s ^ ".sig"); myuse jsondir (s ^ ".sml"))
   fun appthis s = (myuse hmakedir (s ^ ".sig"); myuse hmakedir (s ^ ".sml"))
   fun appcore s = (myuse coredir (s ^ ".sig"); myuse coredir (s ^ ".sml"))
   fun appdeps s = (myuse depsdir (s ^ ".sig"); myuse depsdir (s ^ ".sml"))
@@ -47,5 +49,10 @@ in
   myuse portableMLpolydir "SHA1_ML.sig";
   myuse portableMLpolydir
     (if Systeml.haveWord64 then "w64-SHA1.ML" else "SHA1-byexec.ML");
-  app appportable ["SHA1"]
+  app appportable ["SHA1"];
+  myuse jsondir "JSON.sml";
+  app appjson ["JSONErrors"];
+  myuse jsondir "JSONSource.sml";
+  app appjson ["JSONParser", "JSONUtil"];
+  myuse hmakedir "HolmakeCache.sml"
 end;

--- a/tools/Holmake/hmcore.mlb
+++ b/tools/Holmake/hmcore.mlb
@@ -49,7 +49,8 @@ hmf/ReadHMF.sml
 ../../src/portableML/json/JSONParser.sml
 ../../src/portableML/json/JSONUtil.sig
 ../../src/portableML/json/JSONUtil.sml
-HolmakeCache.sml
+HolmakeCacheKey.sml
+poly/HolmakeCacheFetch.sml
 ../util/GetOpt.sig
 ../util/GetOpt.sml
 ../util/FunctionalRecordUpdate.sml

--- a/tools/Holmake/hmcore.mlb
+++ b/tools/Holmake/hmcore.mlb
@@ -41,6 +41,15 @@ hmf/ReadHMF.sml
 ../../src/portableML/poly/w64-SHA1.ML
 ../../src/portableML/SHA1.sig
 ../../src/portableML/SHA1.sml
+../../src/portableML/json/JSON.sml
+../../src/portableML/json/JSONErrors.sig
+../../src/portableML/json/JSONErrors.sml
+../../src/portableML/json/JSONSource.sml
+../../src/portableML/json/JSONParser.sig
+../../src/portableML/json/JSONParser.sml
+../../src/portableML/json/JSONUtil.sig
+../../src/portableML/json/JSONUtil.sml
+HolmakeCache.sml
 ../util/GetOpt.sig
 ../util/GetOpt.sml
 ../util/FunctionalRecordUpdate.sml

--- a/tools/Holmake/mosml/HolmakeCacheFetch.sml
+++ b/tools/Holmake/mosml/HolmakeCacheFetch.sml
@@ -1,0 +1,10 @@
+structure HolmakeCacheFetch =
+struct
+
+fun fetch _ _ talk = let
+    val _ = talk "cache fetching is not supported with mosml-built Holmake"
+in 
+    false 
+end
+
+end

--- a/tools/Holmake/poly/BuildCommand.sml
+++ b/tools/Holmake/poly/BuildCommand.sml
@@ -294,7 +294,7 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
           case build_command g ii (Compile depinfo) scriptsml_file of
               BR_OK => true
             | BR_Failed => false
-            | BR_ClineK _ => raise Fail "Compilation resulted in commandline"
+            | _ => raise Fail "Compilation resulted in commandline"
       val _ = b orelse raise CompileFailed
       val _ = info ("Linking "^scriptuo^" to produce theory-builder executable")
       val objectfiles0 =
@@ -311,7 +311,7 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
     in
         ((script,[scriptuo,scriptui,script]), objectfiles)
     end
-    fun run_script g (extra:GraphExtra.t) (script, intermediates) objectfiles expecteds =
+    fun run_script use_cache deps g (extra:GraphExtra.t) (script, intermediates) objectfiles expecteds =
       let
         fun safedelete s = FileSys.remove s handle OS.SysErr _ => ()
         val _ = app safedelete expecteds
@@ -360,9 +360,19 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
                BuiltInCmd (BIC_BuildScript script_part, empty_incinfo))
               (* incinfos not consulted for comparison so empty value ok here *)
         end
+        val br_cline =
+            BR_ClineK { cline = (useScript, cline), job_kont = cont,
+                        other_nodes = other_nodes }
+        fun create_br_cache url =
+            BR_CacheK { base_url    = url,
+                        cachekey    = HolmakeCache.compute_deps_cachekey deps,
+                        dest_dir    = HOLFileSys.getDir(),
+                        other_nodes = other_nodes,
+                        fallback    = br_cline }
       in
-        BR_ClineK { cline = (useScript, cline), job_kont = cont,
-                    other_nodes = other_nodes }
+          case use_cache of
+              NONE => br_cline
+            | SOME url => create_br_cache url
       end
   in
     let
@@ -381,10 +391,10 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
           end
         | BuildScript (s, deps, extra : GraphExtra.t) =>
           let
-            val (scriptetc,objectfiles) = setup_script s (deps,extra) []
+              val (scriptetc, objectfiles) = setup_script s (deps, extra) []
           in
-            run_script g extra scriptetc objectfiles
-                       [s^"Theory.sml", s^"Theory.sig", s^"Theory.dat"]
+              run_script (#cache_url (#core optv)) deps g extra scriptetc objectfiles
+                         [s^"Theory.sml", s^"Theory.sig", s^"Theory.dat"]
           end
         | BuildArticle (s0, deps : dep list, extra) =>
           let
@@ -405,7 +415,7 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
             val ((script,inters),objectfiles) =
                 setup_script s (deps,extra) loggingextras
           in
-            run_script g extra (script,fakescript_str :: inters) objectfiles [s]
+            run_script NONE deps g extra (script,fakescript_str :: inters) objectfiles [s]
           end
         | ProcessArticle (s,extra) =>
           let
@@ -469,7 +479,10 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
     case bres of
         BR_OK => true
       | BR_ClineK{cline = (_,cl), job_kont = k, ...} =>
-          k warn (Systeml.systeml cl)
+        k warn (Systeml.systeml cl)
+      | BR_CacheK{base_url, cachekey, dest_dir, fallback, ...} =>
+	HolmakeCache.fetch base_url cachekey dest_dir orelse
+	interpret_bres fallback 
       | BR_Failed => false
 
 

--- a/tools/Holmake/poly/BuildCommand.sml
+++ b/tools/Holmake/poly/BuildCommand.sml
@@ -294,7 +294,7 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
           case build_command g ii (Compile depinfo) scriptsml_file of
               BR_OK => true
             | BR_Failed => false
-            | _ => raise Fail "Compilation resulted in commandline"
+            | BR_ClineK _ => raise Fail "Compilation resulted in commandline"
       val _ = b orelse raise CompileFailed
       val _ = info ("Linking "^scriptuo^" to produce theory-builder executable")
       val objectfiles0 =
@@ -363,8 +363,8 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
       in
           BR_ClineK { cline = (useScript, cline), job_kont = cont,
                       other_nodes = other_nodes,
-		      cache_url = use_cache,
-		      cachekey = HolmakeCache.compute_deps_cachekey deps}
+                      cache_url = use_cache,
+                      cachekey = HolmakeCache.compute_deps_cachekey deps}
       end
   in
     let
@@ -383,10 +383,10 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
           end
         | BuildScript (s, deps, extra : GraphExtra.t) =>
           let
-              val (scriptetc, objectfiles) = setup_script s (deps, extra) []
+            val (scriptetc,objectfiles) = setup_script s (deps,extra) []
           in
-              run_script (#cache_url (#core optv)) deps g extra scriptetc objectfiles
-                         [s^"Theory.sml", s^"Theory.sig", s^"Theory.dat"]
+            run_script (#cache_url (#core optv)) deps g extra scriptetc objectfiles
+                       [s^"Theory.sml", s^"Theory.sig", s^"Theory.dat"]
           end
         | BuildArticle (s0, deps : dep list, extra) =>
           let

--- a/tools/Holmake/poly/BuildCommand.sml
+++ b/tools/Holmake/poly/BuildCommand.sml
@@ -364,7 +364,7 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
           BR_ClineK { cline = (useScript, cline), job_kont = cont,
                       other_nodes = other_nodes,
                       cache_url = use_cache,
-                      cachekey = HolmakeCache.compute_deps_cachekey deps}
+                      cachekey = HolmakeCacheKey.compute_deps_cachekey deps}
       end
   in
     let
@@ -472,7 +472,7 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
         BR_OK => true
       | BR_ClineK{cline = (_,cl), job_kont = k, cache_url, cachekey, ...} =>
         (case cache_url of
-             SOME url => HolmakeCache.fetch url cachekey info orelse
+             SOME url => HolmakeCacheFetch.fetch url cachekey info orelse
                          k warn (Systeml.systeml cl)
            | NONE => k warn (Systeml.systeml cl))
       | BR_Failed => false

--- a/tools/Holmake/poly/BuildCommand.sml
+++ b/tools/Holmake/poly/BuildCommand.sml
@@ -360,18 +360,11 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
                BuiltInCmd (BIC_BuildScript script_part, empty_incinfo))
               (* incinfos not consulted for comparison so empty value ok here *)
         end
-        val br_cline =
-            BR_ClineK { cline = (useScript, cline), job_kont = cont,
-                        other_nodes = other_nodes }
-        fun create_br_cache url =
-            BR_CacheK { base_url    = url,
-                        cachekey    = HolmakeCache.compute_deps_cachekey deps,
-                        other_nodes = other_nodes,
-                        fallback    = br_cline }
       in
-          case use_cache of
-              NONE => br_cline
-            | SOME url => create_br_cache url
+          BR_ClineK { cline = (useScript, cline), job_kont = cont,
+                      other_nodes = other_nodes,
+		      cache_url = use_cache,
+		      cachekey = HolmakeCache.compute_deps_cachekey deps}
       end
   in
     let
@@ -428,7 +421,7 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
                   "opentheory info --article -o " ^ art ^ " " ^ raw_art])
           in
             BR_ClineK {cline = cline, job_kont = (fn _ => OS.Process.isSuccess),
-                       other_nodes = []}
+                       other_nodes = [], cache_url = NONE, cachekey = ""}
           end
     end handle CompileFailed => BR_Failed
              | FileNotFound  => BR_Failed
@@ -477,11 +470,11 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
   fun interpret_bres bres =
     case bres of
         BR_OK => true
-      | BR_ClineK{cline = (_,cl), job_kont = k, ...} =>
-        k warn (Systeml.systeml cl)
-      | BR_CacheK{base_url, cachekey, fallback, ...} =>
-	HolmakeCache.fetch base_url cachekey info orelse
-	interpret_bres fallback 
+      | BR_ClineK{cline = (_,cl), job_kont = k, cache_url, cachekey, ...} =>
+        (case cache_url of
+             SOME url => HolmakeCache.fetch url cachekey info orelse
+                         k warn (Systeml.systeml cl)
+           | NONE => k warn (Systeml.systeml cl))
       | BR_Failed => false
 
 

--- a/tools/Holmake/poly/BuildCommand.sml
+++ b/tools/Holmake/poly/BuildCommand.sml
@@ -366,7 +366,6 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
         fun create_br_cache url =
             BR_CacheK { base_url    = url,
                         cachekey    = HolmakeCache.compute_deps_cachekey deps,
-                        dest_dir    = HOLFileSys.getDir(),
                         other_nodes = other_nodes,
                         fallback    = br_cline }
       in
@@ -480,8 +479,8 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
         BR_OK => true
       | BR_ClineK{cline = (_,cl), job_kont = k, ...} =>
         k warn (Systeml.systeml cl)
-      | BR_CacheK{base_url, cachekey, dest_dir, fallback, ...} =>
-	HolmakeCache.fetch base_url cachekey dest_dir orelse
+      | BR_CacheK{base_url, cachekey, fallback, ...} =>
+	HolmakeCache.fetch base_url cachekey orelse
 	interpret_bres fallback 
       | BR_Failed => false
 

--- a/tools/Holmake/poly/BuildCommand.sml
+++ b/tools/Holmake/poly/BuildCommand.sml
@@ -480,7 +480,7 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
       | BR_ClineK{cline = (_,cl), job_kont = k, ...} =>
         k warn (Systeml.systeml cl)
       | BR_CacheK{base_url, cachekey, fallback, ...} =>
-	HolmakeCache.fetch base_url cachekey orelse
+	HolmakeCache.fetch base_url cachekey info orelse
 	interpret_bres fallback 
       | BR_Failed => false
 

--- a/tools/Holmake/poly/HolmakeCacheFetch.sml
+++ b/tools/Holmake/poly/HolmakeCacheFetch.sml
@@ -1,0 +1,58 @@
+structure HolmakeCacheFetch =
+struct
+
+open HolmakeCacheKey
+
+fun curl_get_to_file url dest =
+    (* curl
+       -s <silent mode; don't show progress meter etc.>
+       -f <return nonzero status code for http errors (e.g. 404s from a cache miss)>
+       -m <timeout in seconds>
+       -o <destination file loc>
+       <url to download from> *)
+    OS.Process.isSuccess (Systeml.systeml ["curl", "-s", "-f", "-m", "5", "-o", dest, url])
+
+fun fetch base_url cachekey talk =
+    let
+        val key_url = base_url ^ "/key/" ^ cachekey
+        val tmpfile = OS.FileSys.tmpName()
+        val _ = talk "checking cache for prebuilt theory"
+        val hit = curl_get_to_file key_url tmpfile
+    in
+        if not hit then let
+            val _ = OS.FileSys.remove tmpfile handle OS.SysErr _ => ()
+            val _ = talk "cache miss; theory will be built locally."
+        in
+            false
+        end
+        else
+            let
+                val src = JSONParser.openFile tmpfile
+                val json = JSONParser.parse src before JSONParser.close src
+                val _ = OS.FileSys.remove tmpfile handle OS.SysErr _ => ()
+                val files = JSONUtil.arrayMap
+                                (fn v => { name = JSONUtil.asString (JSONUtil.lookupField v "name"),
+                                           url  = JSONUtil.asString (JSONUtil.lookupField v "url") })
+                                (JSONUtil.lookupField json "files")
+                fun to_dest_dir s =
+                    case HFS_NameMunge.HOLtoFS s of
+                        NONE => s
+                      | SOME {fullfile, ...} => fullfile
+                val ok = List.all
+                             (fn {name, url} =>
+                                 curl_get_to_file (base_url ^ url) (to_dest_dir name))
+                             files
+                val _ = if ok
+                        then talk "cache hit! local theory building can be skipped."
+                        else talk "only managed a partial cache hit. theory will be built locally."
+            in
+                ok
+            end
+            handle _ => let
+                val _ = talk "something went wrong. theory will be built locally."
+            in
+                false
+            end
+    end
+
+end

--- a/tools/Holmake/poly/MB_Monitor.sml
+++ b/tools/Holmake/poly/MB_Monitor.sml
@@ -299,7 +299,7 @@ fun new {info,warn,genLogFile,time_limit,multidir} =
             val tb = tailbuffer.new {
                   numlines = 50,
                   patterns = [cheat_string, oracle_string, used_cheat_string,
-                              fastcheat_string]
+                              fastcheat_string, cachehit_string]
                 }
           in
             monitor_map :=
@@ -370,7 +370,7 @@ fun new {info,warn,genLogFile,time_limit,multidir} =
                     else if seen fastcheat_string then
                       tinfo (boldyellow, "F-CHEAT")
                     else if seen cachehit_string then
-                      tinfo (green, "OK (cache hit)")
+                      tinfo (green, "CACHED")
                     else
                       tinfo ((if seen oracle_string then boldyellow else green),
                              "OK")

--- a/tools/Holmake/poly/MB_Monitor.sml
+++ b/tools/Holmake/poly/MB_Monitor.sml
@@ -120,6 +120,7 @@ val cheat_string =      "Saved CHEAT _"
 val fastcheat_string =  "Saved FAST-CHEAT _"
 val oracle_string =   "Saved ORACLE thm _"
 val used_cheat_string = "(used CHEAT)"
+val cachehit_string = "cache hit!"
 
 fun delsml_sfx s =
   if String.isSuffix ".sml" s orelse String.isSuffix ".sig" s then
@@ -368,6 +369,8 @@ fun new {info,warn,genLogFile,time_limit,multidir} =
                       tinfo (boldyellow, "CHEATED")
                     else if seen fastcheat_string then
                       tinfo (boldyellow, "F-CHEAT")
+                    else if seen cachehit_string then
+                      tinfo (green, "OK (cache hit)")
                     else
                       tinfo ((if seen oracle_string then boldyellow else green),
                              "OK")

--- a/tools/Holmake/poly/ProcessMultiplexor.sig
+++ b/tools/Holmake/poly/ProcessMultiplexor.sig
@@ -4,6 +4,7 @@ sig
   type command = {executable: string, nm_args : string list, env : string list}
   type 'a job = {tag : string, command : command,
                  update : 'a * bool * Time.time -> 'a,
+                 try_cache : (string -> unit) -> bool,
                  dir : string}
   type jobkey = Posix.ProcEnv.pid * {tag : string, dir : string}
   val jobkey_compare : jobkey * jobkey -> order

--- a/tools/Holmake/poly/ProcessMultiplexor.sml
+++ b/tools/Holmake/poly/ProcessMultiplexor.sml
@@ -14,6 +14,7 @@ struct
 
   type command = {executable: string, nm_args : string list, env : string list}
   type 'a job = {tag : string, command : command, dir : string,
+                 try_cache : (string -> unit) -> bool,
                  update : 'a * bool * Time.time -> 'a}
   datatype 'a genjob_result =
            NoMoreJobs of 'a | NewJob of ('a job * 'a) | GiveUpAndDie of 'a
@@ -167,7 +168,7 @@ struct
   fun start_job (j : 'a job) : 'a working_job =
     let
       open Posix.Process Posix.IO
-      val {tag, command, update, dir} = j
+      val {tag, command, update, try_cache, dir} = j
       val _ = OS.Path.isAbsolute dir orelse
               raise Fail "Relative path in job directory"
       val {executable,env,nm_args} = command
@@ -186,7 +187,10 @@ struct
                                 ininfd, inoutfd]
             val _ = OS.FileSys.chDir dir
           in
-            exece(executable,nm_args,env)
+            if try_cache (fn s => print (s ^ "\n")) then
+              OS.Process.exit OS.Process.success
+            else
+              exece(executable,nm_args,env)
           end
         | SOME pid =>
           let
@@ -216,7 +220,7 @@ struct
     let
       open Posix.Process
       val j :int job = {tag = s, command = simple_shell s, update = K 0,
-                        dir = "."}
+                        try_cache = K false, dir = "."}
       val wj = start_job j
       fun read pfx acc strm k =
         case TextIO.inputLine strm of
@@ -451,7 +455,7 @@ struct
                     fupdAlist t (fn (c,_) => (c,Done b)) clist
               in
                 NewJob ({tag = t, command = simple_shell c, update = upd,
-                         dir = "."}, l)
+                         try_cache = K false, dir = "."}, l)
               end
         end
       val wl =

--- a/tools/Holmake/poly/multibuild.sml
+++ b/tools/Holmake/poly/multibuild.sml
@@ -10,6 +10,8 @@ datatype buildresult =
                         job_kont : (string -> unit) -> OS.Process.status ->
                                    bool,
                         other_nodes : HM_DepGraph.node list }
+       | BR_CacheK of { base_url : string, cachekey : string, dest_dir : string,
+			other_nodes : HM_DepGraph.node list, fallback : buildresult }
        | BR_Failed
 
 val RealFail = Failed{needed=true}
@@ -273,6 +275,27 @@ fun graphbuild optinfo g =
                                     command = cline_to_command cline,
                                     update = update},
                                    (updall Running g, true))
+                          end
+			| BR_CacheK{base_url, cachekey, dest_dir, other_nodes, fallback } =>
+                          let
+                            val (thyc,ndi) = count_theories_needed other_nodes
+                            val other_nodes =
+                                case hm_target.filepart (#target nI) of
+                                    ART _ => n::other_nodes
+                                  | _ => other_nodes
+                            fun updall s g =
+                              List.foldl (fn (n,g) => updnode(n,s) g)
+                                         g
+                                         other_nodes
+			    val t0 = Time.now()
+			    val ok = HolmakeCache.fetch base_url cachekey dest_dir
+			    val t = Time.-(Time.now(), t0)
+                          in
+                              if ok then
+				  (tgtcomplete(#dir nI, ndi, thyc, true, t);
+                                   (k true (updall Succeeded g)))
+			      else
+				  bresk fallback g
                           end
                     fun bc c f = pushdir dir (build_command g incinfo c) f
                     val _ = diag ("Handling builtin command " ^

--- a/tools/Holmake/poly/multibuild.sml
+++ b/tools/Holmake/poly/multibuild.sml
@@ -9,9 +9,8 @@ datatype buildresult =
        | BR_ClineK of { cline : string * string list,
                         job_kont : (string -> unit) -> OS.Process.status ->
                                    bool,
-                        other_nodes : HM_DepGraph.node list }
-       | BR_CacheK of { base_url : string, cachekey : string,
-			other_nodes : HM_DepGraph.node list, fallback : buildresult }
+                        other_nodes : HM_DepGraph.node list,
+			cache_url : string option, cachekey : string}
        | BR_Failed
 
 val RealFail = Failed{needed=true}
@@ -27,7 +26,8 @@ fun lmap_insert k v m =
 
 infix ++
 fun p1 ++ p2 = OS.Path.concat(p1, p2)
-val loggingdir = ".hol/logs"
+val loggingdir = ".hol/logs"	     
+fun K x y = x
 
 fun graph_dirinfo g =
     let
@@ -231,7 +231,8 @@ fun graphbuild optinfo g =
                               end
                         in
                           NewJob ({tag = tag, command = shell_command c,
-                                   update = update, dir = dir},
+                                   update = update, try_cache = K false,
+                                   dir = dir},
                                   (updall(g, Running), true))
                         end
                   end
@@ -243,7 +244,7 @@ fun graphbuild optinfo g =
                       case bres of
                           BR_OK => k true g
                         | BR_Failed => k false g
-                        | BR_ClineK{cline, job_kont, other_nodes} =>
+                        | BR_ClineK{cline, job_kont, other_nodes, cache_url, cachekey} =>
                           let
                             val (thyc,ndi) = count_theories_needed other_nodes
                             fun b2res b = if b then OS.Process.success
@@ -265,6 +266,10 @@ fun graphbuild optinfo g =
                                  (updall RealFail g, keep_going))
                             fun cline_str (c,l) = "["^c^"] " ^
                                                   String.concatWith " " l
+			    fun try_cache talk =
+				case cache_url of
+				    NONE => false
+				  | SOME url => HolmakeCache.fetch url cachekey talk
                           in
                             diag ("New graph job for "^target_s^
                                   " with c/line: " ^ cline_str cline);
@@ -273,32 +278,9 @@ fun graphbuild optinfo g =
                                         (map node_toString other_nodes));
                             NewJob({tag = tag, dir = dir,
                                     command = cline_to_command cline,
+				    try_cache = try_cache,
                                     update = update},
                                    (updall Running g, true))
-                          end
-			| BR_CacheK{base_url, cachekey, other_nodes, fallback} =>
-                          let
-                            val (thyc,ndi) = count_theories_needed other_nodes
-                            val other_nodes =
-                                case hm_target.filepart (#target nI) of
-                                    ART _ => n::other_nodes
-                                  | _ => other_nodes
-                            fun updall s g =
-                              List.foldl (fn (n,g) => updnode(n,s) g)
-                                         g
-                                         other_nodes
-                            val t0 = Time.now()
-                            val ok = HolmakeCache.fetch base_url cachekey
-                            val elapsed = Time.-(Time.now(), t0)
-                          in
-                            if ok then
-                              (info (dropthySuffix tag ^ " (cached)",
-                                     "(" ^ Time.toString elapsed ^ "s)" ^
-                                     green "     OK");
-                               tgtcomplete(#dir nI, ndi, thyc, true, elapsed);
-                               k true (updall Succeeded g))
-                            else
-                              bresk fallback g
                           end
                     fun bc c f = pushdir dir (build_command g incinfo c) f
                     val _ = diag ("Handling builtin command " ^

--- a/tools/Holmake/poly/multibuild.sml
+++ b/tools/Holmake/poly/multibuild.sml
@@ -276,7 +276,7 @@ fun graphbuild optinfo g =
                                     update = update},
                                    (updall Running g, true))
                           end
-			| BR_CacheK{base_url, cachekey, other_nodes, fallback } =>
+			| BR_CacheK{base_url, cachekey, other_nodes, fallback} =>
                           let
                             val (thyc,ndi) = count_theories_needed other_nodes
                             val other_nodes =

--- a/tools/Holmake/poly/multibuild.sml
+++ b/tools/Holmake/poly/multibuild.sml
@@ -10,7 +10,7 @@ datatype buildresult =
                         job_kont : (string -> unit) -> OS.Process.status ->
                                    bool,
                         other_nodes : HM_DepGraph.node list,
-			cache_url : string option, cachekey : string}
+                        cache_url : string option, cachekey : string}
        | BR_Failed
 
 val RealFail = Failed{needed=true}
@@ -26,7 +26,7 @@ fun lmap_insert k v m =
 
 infix ++
 fun p1 ++ p2 = OS.Path.concat(p1, p2)
-val loggingdir = ".hol/logs"	     
+val loggingdir = ".hol/logs"
 fun K x y = x
 
 fun graph_dirinfo g =
@@ -266,10 +266,10 @@ fun graphbuild optinfo g =
                                  (updall RealFail g, keep_going))
                             fun cline_str (c,l) = "["^c^"] " ^
                                                   String.concatWith " " l
-			    fun try_cache talk =
-				case cache_url of
-				    NONE => false
-				  | SOME url => HolmakeCache.fetch url cachekey talk
+                            funy try_cache talk =
+                              case cache_url of
+                                  NONE => false
+                                | SOME url => HolmakeCache.fetch url cachekey talk
                           in
                             diag ("New graph job for "^target_s^
                                   " with c/line: " ^ cline_str cline);
@@ -278,7 +278,7 @@ fun graphbuild optinfo g =
                                         (map node_toString other_nodes));
                             NewJob({tag = tag, dir = dir,
                                     command = cline_to_command cline,
-				    try_cache = try_cache,
+                                    try_cache = try_cache,
                                     update = update},
                                    (updall Running g, true))
                           end

--- a/tools/Holmake/poly/multibuild.sml
+++ b/tools/Holmake/poly/multibuild.sml
@@ -287,15 +287,18 @@ fun graphbuild optinfo g =
                               List.foldl (fn (n,g) => updnode(n,s) g)
                                          g
                                          other_nodes
-			    val t0 = Time.now()
-			    val ok = HolmakeCache.fetch base_url cachekey
-			    val t = Time.-(Time.now(), t0)
+                            val t0 = Time.now()
+                            val ok = HolmakeCache.fetch base_url cachekey
+                            val elapsed = Time.-(Time.now(), t0)
                           in
-                              if ok then
-				  (tgtcomplete(#dir nI, ndi, thyc, true, t);
-                                   (k true (updall Succeeded g)))
-			      else
-				  bresk fallback g
+                            if ok then
+                              (info (dropthySuffix tag ^ " (cached)",
+                                     "(" ^ Time.toString elapsed ^ "s)" ^
+                                     green "     OK");
+                               tgtcomplete(#dir nI, ndi, thyc, true, elapsed);
+                               k true (updall Succeeded g))
+                            else
+                              bresk fallback g
                           end
                     fun bc c f = pushdir dir (build_command g incinfo c) f
                     val _ = diag ("Handling builtin command " ^

--- a/tools/Holmake/poly/multibuild.sml
+++ b/tools/Holmake/poly/multibuild.sml
@@ -269,7 +269,7 @@ fun graphbuild optinfo g =
                             fun try_cache talk =
                               case cache_url of
                                   NONE => false
-                                | SOME url => HolmakeCache.fetch url cachekey talk
+                                | SOME url => HolmakeCacheFetch.fetch url cachekey talk
                           in
                             diag ("New graph job for "^target_s^
                                   " with c/line: " ^ cline_str cline);

--- a/tools/Holmake/poly/multibuild.sml
+++ b/tools/Holmake/poly/multibuild.sml
@@ -266,7 +266,7 @@ fun graphbuild optinfo g =
                                  (updall RealFail g, keep_going))
                             fun cline_str (c,l) = "["^c^"] " ^
                                                   String.concatWith " " l
-                            funy try_cache talk =
+                            fun try_cache talk =
                               case cache_url of
                                   NONE => false
                                 | SOME url => HolmakeCache.fetch url cachekey talk

--- a/tools/Holmake/poly/multibuild.sml
+++ b/tools/Holmake/poly/multibuild.sml
@@ -10,7 +10,7 @@ datatype buildresult =
                         job_kont : (string -> unit) -> OS.Process.status ->
                                    bool,
                         other_nodes : HM_DepGraph.node list }
-       | BR_CacheK of { base_url : string, cachekey : string, dest_dir : string,
+       | BR_CacheK of { base_url : string, cachekey : string,
 			other_nodes : HM_DepGraph.node list, fallback : buildresult }
        | BR_Failed
 
@@ -276,7 +276,7 @@ fun graphbuild optinfo g =
                                     update = update},
                                    (updall Running g, true))
                           end
-			| BR_CacheK{base_url, cachekey, dest_dir, other_nodes, fallback } =>
+			| BR_CacheK{base_url, cachekey, other_nodes, fallback } =>
                           let
                             val (thyc,ndi) = count_theories_needed other_nodes
                             val other_nodes =
@@ -288,7 +288,7 @@ fun graphbuild optinfo g =
                                          g
                                          other_nodes
 			    val t0 = Time.now()
-			    val ok = HolmakeCache.fetch base_url cachekey dest_dir
+			    val ok = HolmakeCache.fetch base_url cachekey
 			    val t = Time.-(Time.now(), t0)
                           in
                               if ok then

--- a/tools/configure.sml
+++ b/tools/configure.sml
@@ -371,6 +371,17 @@ val _ =
     compile ["-I", "mosml", "-I", "../../tools/Holmake"] "SHA1.sig";
     compile ["-I", "mosml", "-I", "../../tools/Holmake"] "SHA1.sml";
     FileSys.chDir "../../tools/Holmake";
+    FileSys.chDir "../../src/portableML/json";
+    compile [] "JSON.sml";
+    compile [] "JSONErrors.sig";
+    compile [] "JSONErrors.sml";
+    compile [] "JSONSource.sml";
+    compile [] "JSONParser.sig";
+    compile [] "JSONParser.sml";
+    compile [] "JSONUtil.sig";
+    compile [] "JSONUtil.sml";
+    FileSys.chDir "../../tools/Holmake";
+    compile ["-I", "core", "-I", "hfs", "-I", "hmf", "-I", "../parsing"] "HolmakeCache.sml";
     FileSys.chDir "../util";
     compile ["-I", "../Holmake"] "GetOpt.sig";
     compile ["-I", "../Holmake"] "GetOpt.sml";

--- a/tools/configure.sml
+++ b/tools/configure.sml
@@ -371,17 +371,12 @@ val _ =
     compile ["-I", "mosml", "-I", "../../tools/Holmake"] "SHA1.sig";
     compile ["-I", "mosml", "-I", "../../tools/Holmake"] "SHA1.sml";
     FileSys.chDir "../../tools/Holmake";
-    FileSys.chDir "../../src/portableML/json";
-    compile [] "JSON.sml";
-    compile [] "JSONErrors.sig";
-    compile [] "JSONErrors.sml";
-    compile [] "JSONSource.sml";
-    compile [] "JSONParser.sig";
-    compile [] "JSONParser.sml";
-    compile [] "JSONUtil.sig";
-    compile [] "JSONUtil.sml";
-    FileSys.chDir "../../tools/Holmake";
-    compile ["-I", "core", "-I", "hfs", "-I", "hmf", "-I", "../parsing"] "HolmakeCache.sml";
+    compile ["-I", "core", "-I", "hfs", "-I", "hmf", "-I", "../parsing",
+             "-I", "../../src/portableML", "-I", "../../src/portableML/mosml"] "HolmakeCacheKey.sml";
+    FileSys.chDir "mosml";
+    compile ["-I", "..", "-I", "../core", "-I", "../hfs", "-I", "../hmf", "-I", "../../parsing",
+             "-I", "../../../src/portableML", "-I", "../../../src/portableML/mosml"] "HolmakeCacheFetch.sml";
+    FileSys.chDir "..";
     FileSys.chDir "../util";
     compile ["-I", "../Holmake"] "GetOpt.sig";
     compile ["-I", "../Holmake"] "GetOpt.sml";

--- a/tools/util/FunctionalRecordUpdate.sml
+++ b/tools/util/FunctionalRecordUpdate.sml
@@ -28,6 +28,7 @@ local
   fun f23 z = next f22 z
   fun f24 z = next f23 z
   fun f25 z = next f24 z
+  fun f26 z = next f25 z
 
   fun  c0 from =  from
   fun  c1 from =  c0 (from  f1)
@@ -55,6 +56,7 @@ local
   fun c23 from = c22 (from f23)
   fun c24 from = c23 (from f24)
   fun c25 from = c24 (from f25)
+  fun c26 from = c25 (from f26)
 in
 
 structure Fold =
@@ -100,6 +102,7 @@ fun makeUpdate22 z = makeUpdate c22 z
 fun makeUpdate23 z = makeUpdate c23 z
 fun makeUpdate24 z = makeUpdate c24 z
 fun makeUpdate25 z = makeUpdate c25 z
+fun makeUpdate26 z = makeUpdate c26 z
 
 fun $$ (a,f) = f a
 fun U s v z =


### PR DESCRIPTION
This feature adds support for downloading pre-built theory files for Holmake using `--cache-url <url>`,
e.g. `Holmake --cache-url http://localhost:8080` or `Holmake fooTheory --cache-url http://localhost:8080`.

<img width="1440" height="85" alt="image" src="https://github.com/user-attachments/assets/97f1b0d4-2941-41b3-b84b-b98d5da8044a" />


Servers should implement the following specification [holmake-cache-server.yaml](https://github.com/user-attachments/files/26370100/holmake-cache-server.2.yaml). This can be viewed through the [Swagger editor](https://editor.swagger.io/).

The cachekey feature has also been refactored a little bit. Previously its logic was tied into the `--cachekey` CLI, but I needed a string-producing version. Its tests still pass. 