### PR TITLE
CI: Check that pre-Holmake works without mlton

### DIFF
--- a/developers/docker-ci/Dockerfile
+++ b/developers/docker-ci/Dockerfile
@@ -66,6 +66,11 @@ RUN rm -f tools-poly/poly-includes.ML
 
 # Building HOL itself (PolyML is now installed in non-system directories)
 RUN if [ "poly" = "$SML" ]; then \
+    # Ensure that building the pre-Holmake tools work without mlton
+    echo 'val MLTON = NONE;' > tools-poly/poly-includes.ML && \
+    /ML/polyml/bin/${SML} < tools/smart-configure.sml && \
+    rm tools-poly/poly-includes.ML && \
+    # Building using standard detection by smart-configure
     /ML/polyml/bin/${SML} < tools/smart-configure.sml; \
 else \
     ${SML} < tools/smart-configure.sml; \


### PR DESCRIPTION
At the moment it looks like nothing is explicitly checking that building the pre-Holmake tools without mlton works.
This change aims to fix this by first running smart-configure.sml with MLTON explicitly set to NONE first, followed by cleaning up and then building as usual.