### PR TITLE
Inapplicable of gauge_higher_differentiable_lemma

### DIFF
--- a/examples/probability/distributionScript.sml
+++ b/examples/probability/distributionScript.sml
@@ -3971,6 +3971,53 @@ Theorem x_std_normal_density_decreasing =
         REWRITE_RULE [REAL_MUL_LNEG, REAL_LE_NEG2]
                      neg_x_std_normal_density_increasing
 
+(* |- x < 0 ==> (x * y < 0 <=> 0 < y) *)
+Theorem lemma = REAL_LT_LMUL_NEG |> Q.SPECL [‘x’, ‘y’, ‘0’]
+                                 |> REWRITE_RULE [REAL_MUL_RZERO]
+Theorem REAL_MUL_NEG :
+    !x y. x < 0 /\ 0 < y ==> x * y < (0 :real)
+Proof
+    rpt STRIP_TAC
+ >> METIS_TAC [lemma]
+QED
+
+Theorem neg_x_std_normal_density_decreasing :
+    !x y. 0 <= x /\ 0 <= y /\ x <= y /\ y <= 1 ==>
+         -y * std_normal_density y <= -x * std_normal_density x
+Proof
+    rpt STRIP_TAC
+ >> ASSUME_TAC diffl_neg_x_std_normal_density
+ >> qabbrev_tac ‘f = \x. -x * std_normal_density x’
+ >> ASM_SIMP_TAC std_ss []
+ >> ‘x = y \/ x < y’ by PROVE_TAC [REAL_LE_LT] >- simp []
+ >> MATCH_MP_TAC REAL_LT_IMP_LE
+ >> irule DIFF_NEG_ANTIMONO_LT_CC >> art []
+ >> qexistsl_tac [‘0’, ‘1’] >> art []
+ >> Know ‘f contl 0’
+ >- (MATCH_MP_TAC DIFF_CONT \\
+     Q.EXISTS_TAC ‘(0 pow 2 - 1) * std_normal_density 0’ >> art [])
+ >> Rewr
+ >> Know ‘f contl 1’
+ >- (MATCH_MP_TAC DIFF_CONT \\
+     Q.EXISTS_TAC ‘(1 pow 2 - 1) * std_normal_density 1’ >> art [])
+ >> Rewr
+ >> rpt STRIP_TAC
+ >> Q.EXISTS_TAC ‘(z pow 2 - 1) * std_normal_density z’ >> art []
+ >> MATCH_MP_TAC REAL_MUL_NEG
+ >> REWRITE_TAC [std_normal_density_pos]
+ >> simp [REAL_SUB_LT_NEG]
+ >> ONCE_REWRITE_TAC [Q.SPEC ‘2’ (GSYM POW_ONE)]
+ >> MATCH_MP_TAC REAL_POW_LT2 >> simp [REAL_LT_IMP_LE]
+QED
+
+(* |- !x y.
+        0 <= x /\ 0 <= y /\ x <= y /\ y <= 1 ==>
+        x * std_normal_density x <= y * std_normal_density y
+ *)
+Theorem x_std_normal_density_increasing =
+        REWRITE_RULE [REAL_MUL_LNEG, REAL_LE_NEG2]
+                     neg_x_std_normal_density_decreasing
+
 Theorem has_integral_x_x_1_std_normal_density :
     !a b. a <= b ==>
          ((\x. (x pow 2 - 1) * std_normal_density x) has_integral
@@ -12057,6 +12104,108 @@ Proof
       (* goal 2 (of 2) *)
       qunabbrevl_tac [‘y'’, ‘y’] \\
       FIRST_X_ASSUM MATCH_MP_TAC >> art [] ]
+QED
+
+(* |- !f c x.
+        (!x. higher_differentiable 1 f x) ==>
+        diff1 (\x. c * f x) x = c * diff1 f x
+ *)
+Theorem diff1_cmul = SRULE [FUN_EQ_THM, PULL_FORALL] diffn_cmul
+
+(* |- !f g x.
+        (!t. higher_differentiable 1 f t) /\
+        (!t'. higher_differentiable 1 g t') ==>
+        diff1 (\x. f (g x)) x = diff1 f (g x) * diff1 g x
+ *)
+Theorem diff1_chain =
+        diffn_chain |> SRULE [FUN_EQ_THM, PULL_FORALL]
+                    |> SRULE [FORALL_AND_THM]
+
+Theorem ABS_EXP[simp] :
+    !x. abs (exp x) = exp (x :real)
+Proof
+    rw [ABS_REFL, EXP_POS_LE]
+QED
+
+(* NOTE: This theorem shows that the bound antecedent cannot be satisfied
+   when gauge_higher_differentiable_lemma is applied in C3 proof.
+ *)
+Theorem gauge_higher_differentiable_lemma_inapplicable :
+  !s. s <> 0 ==>
+     ?n f. 1 <= n /\ n <= 3 /\ bounded (IMAGE f UNIV) /\
+          ~?w. integrable lborel w /\ (!x. 0 <= w x /\ w x <> PosInf) /\
+               !t x. Normal
+                      (abs (diffn n
+                             (\t. f x * std_normal_density
+                                         (-inv s * t + inv s * x)) t)) <= w x
+Proof
+    rpt STRIP_TAC
+ >> qexistsl_tac [‘1’, ‘\x. 1’] >> simp []
+ >> CONJ_TAC
+ >- (rw [bounded_def] \\
+     Q.EXISTS_TAC ‘1’ >> simp [])
+ >> CCONTR_TAC >> fs []
+ >> Know ‘!x t. diff1
+                 (\t. std_normal_density (-inv s * t + inv s * x)) t =
+                diff1 std_normal_density (-inv s * t + inv s * x) *
+                diff1 (\t. -inv s * t + inv s * x) t’
+ >- (rpt GEN_TAC \\
+     qabbrev_tac ‘g = (\t. -inv s * t + inv s * x)’ \\
+     ASM_SIMP_TAC std_ss [] \\
+     MATCH_MP_TAC diff1_chain \\
+     simp [Abbr ‘g’, higher_differentiable_std_normal_density,
+           higher_differentiable_linear])
+ >> DISCH_THEN (fs o wrap)
+ >> fs [diffn_std_normal_density, Hermite_polynomial_1, diffn_linear]
+ >> qabbrev_tac ‘c = inv (sqrt (2 * pi))’ >> fs []
+ >> qabbrev_tac ‘d = c * inv s’
+ >> Know ‘!x y. Normal (abs (d * exp (-(y pow 2) / 2) * y)) <= w x’
+ >- (rpt GEN_TAC \\
+     Q.PAT_X_ASSUM ‘!t x. P’ (MP_TAC o Q.SPECL [‘x - s * y’, ‘x’]) \\
+     Suff ‘-inv s * (x - s * y) + inv s * x = y’ >- rw [] \\
+     simp [REAL_SUB_LDISTRIB, REAL_MUL_LNEG] \\
+     REAL_ARITH_TAC)
+ >> Q.PAT_X_ASSUM ‘!t x. P’ K_TAC
+ >> DISCH_TAC
+ >> rfs [ABS_MUL, Abbr ‘d’, ABS_INV]
+ >> qabbrev_tac ‘a = inv (abs s)’ >> fs []
+ >> Know ‘!y. a * abs c * abs y * exp (-(y pow 2) / 2) =
+              a * abs y * std_normal_density y’
+ >- (rw [Abbr ‘c’, std_normal_density_def] \\
+     Suff ‘0 <= sqrt (2 * pi)’ >- rw [] \\
+     MATCH_MP_TAC SQRT_POS_LE \\
+     MATCH_MP_TAC REAL_LE_MUL \\
+     simp [PI_POS, REAL_LT_IMP_LE])
+ >> DISCH_THEN (fs o wrap)
+ >> qabbrev_tac ‘z = sup (IMAGE (\y. a * abs y * std_normal_density y) UNIV)’
+ >> Know ‘!x. Normal z <= w x’
+ >- (Q.X_GEN_TAC ‘x’ \\
+     Q.PAT_X_ASSUM ‘!x y. P’ (MP_TAC o Q.SPEC ‘x’) \\
+    ‘w x <> NegInf’ by PROVE_TAC [pos_not_neginf] \\
+    ‘?r. 0 <= r /\ w x = Normal r’
+      by METIS_TAC [extreal_cases, extreal_of_num_def, extreal_le_eq] \\
+     rw [Abbr ‘z’] \\
+     MATCH_MP_TAC REAL_SUP_LE' >> simp [] \\
+     Q.X_GEN_TAC ‘z’ \\
+     DISCH_THEN (Q.X_CHOOSE_THEN ‘y’ STRIP_ASSUME_TAC) >> simp [])
+ >> DISCH_TAC
+ >> Know ‘0 < a’
+ >- (qunabbrev_tac ‘a’ \\
+     MATCH_MP_TAC REAL_INV_POS >> simp [GSYM ABS_NZ])
+ >> DISCH_TAC
+ >> Know ‘0 < z’
+ >- (qunabbrev_tac ‘z’ \\
+     qmatch_abbrev_tac ‘(0 :real) < sup P’ \\
+     Suff ‘P <> {} /\ (?z. !x. x IN P ==> x <= z) /\
+           (?x. x IN P /\ 0 < x)’ >- METIS_TAC [realTheory.REAL_SUP_LE'] \\
+     CONJ_TAC >- simp [Abbr ‘P’] \\
+     reverse CONJ_TAC
+     >- (Q.EXISTS_TAC ‘a * std_normal_density 1’ \\
+         simp [REAL_LT_MUL, std_normal_density_pos, Abbr ‘P’] \\
+         Q.EXISTS_TAC ‘1’ >> simp []) \\
+     cheat)
+ >> DISCH_TAC
+ >> cheat
 QED
 
 (* ------------------------------------------------------------------------- *)

--- a/examples/probability/distributionScript.sml
+++ b/examples/probability/distributionScript.sml
@@ -7525,12 +7525,15 @@ Proof
  >> Rewr
 QED
 
+(* NOTE: added “0 < n ==> _” into the bound antecedents to eliminate trivial
+   counterexamples (see also gauge_higher_differentiable_lemma_inapplicable).
+ *)
 Theorem gauge_higher_differentiable_lemma :
     !u. (!t. integrable lborel (Normal o u t)) /\
         (!n t x. higher_differentiable n (\t. u t x) t) /\
-        (!n. ?w. integrable lborel w /\
-                (!x. 0 <= w x /\ w x <> PosInf) /\
-                 !t x. Normal (abs (diffn n (\t. u t x) t)) <= w x)
+        (!n. 0 < n ==> ?w. integrable lborel w /\
+                          (!x. 0 <= w x /\ w x <> PosInf) /\
+                           !t x. Normal (abs (diffn n (\t. u t x) t)) <= w x)
      ==> !n t. higher_differentiable n (\t. integral univ(:real) (u t)) t /\
                integrable lborel (\x. Normal (diffn n (\t. u t x) t)) /\
                diffn n (\t. integral univ(:real) (u t)) t =
@@ -7570,7 +7573,7 @@ Proof
         ‘diffn n (\t. u t x) = (\t. f t x)’ by rw [Abbr ‘f’, FUN_EQ_THM] \\
          simp []) \\
      POP_ASSUM (REWRITE_TAC o wrap o GSYM) \\
-     Q.PAT_X_ASSUM ‘!n. ?w. P’ (MP_TAC o Q.SPEC ‘SUC n’) >> rw [])
+     Q.PAT_X_ASSUM ‘!n. 0 < n ==> ?w. P’ (MP_TAC o Q.SPEC ‘SUC n’) >> rw [])
  >> simp []
  >> DISCH_THEN (STRIP_ASSUME_TAC o SRULE [FORALL_AND_THM])
  >> qabbrev_tac ‘g = \t. integral univ(:real) (u t)’

--- a/examples/probability/distributionScript.sml
+++ b/examples/probability/distributionScript.sml
@@ -9158,6 +9158,12 @@ Proof
  >> simp [Abbr ‘c’, REAL_INV_1OVER]
 QED
 
+Theorem diffn_std_normal_density' :
+    !n x. diffn n std_normal_density x = -1 pow n * He n x * std_normal_density x
+Proof
+    rw [std_normal_density_def, diffn_std_normal_density]
+QED
+
 Theorem Hermite_polynomial_higher_differentiable :
     !m n x. higher_differentiable m (He n) x
 Proof

--- a/examples/probability/distributionScript.sml
+++ b/examples/probability/distributionScript.sml
@@ -12127,12 +12127,41 @@ Proof
     rw [ABS_REFL, EXP_POS_LE]
 QED
 
+Theorem abs_x_std_normmal_density_upper_bound_lemma[local] :
+    !y. 0 <= y ==> abs y * std_normal_density y <= std_normal_density 1
+Proof
+    rpt STRIP_TAC
+ >> ‘abs y = y’ by simp [ABS_REFL] >> POP_ORW
+ >> ‘std_normal_density 1 = 1 * std_normal_density 1’ by simp []
+ >> POP_ORW
+ >> ‘y <= 1 \/ 1 <= y’ by METIS_TAC [REAL_LE_TOTAL, REAL_LT_IMP_LE]
+ >| [ (* goal 1 (of 2) *)
+      MATCH_MP_TAC x_std_normal_density_increasing >> simp [],
+      (* goal 2 (of 2) *)
+      MATCH_MP_TAC x_std_normal_density_decreasing >> simp [] ]
+QED
+
+Theorem abs_x_std_normmal_density_upper_bound :
+    !y. abs y * std_normal_density y <= std_normal_density 1
+Proof
+    Q.X_GEN_TAC ‘y’
+ >> Cases_on ‘0 <= y’
+ >- (MATCH_MP_TAC abs_x_std_normmal_density_upper_bound_lemma >> art [])
+ >> fs [REAL_NOT_LE]
+ >> ‘0 <= -y’ by REAL_ASM_ARITH_TAC
+ >> ONCE_REWRITE_TAC [GSYM ABS_NEG]
+ >> ‘std_normal_density y = std_normal_density (-y)’
+      by REWRITE_TAC [std_normal_density_neg]
+ >> POP_ORW
+ >> MATCH_MP_TAC abs_x_std_normmal_density_upper_bound_lemma >> art []
+QED
+
 (* NOTE: This theorem shows that the bound antecedent cannot be satisfied
    when gauge_higher_differentiable_lemma is applied in C3 proof.
  *)
 Theorem gauge_higher_differentiable_lemma_inapplicable :
   !s. s <> 0 ==>
-     ?n f. 1 <= n /\ n <= 3 /\ bounded (IMAGE f UNIV) /\
+     ?n f. 1 <= n /\ n <= 3 /\ f IN BL mr1 /\
           ~?w. integrable lborel w /\ (!x. 0 <= w x /\ w x <> PosInf) /\
                !t x. Normal
                       (abs (diffn n
@@ -12141,8 +12170,8 @@ Theorem gauge_higher_differentiable_lemma_inapplicable :
 Proof
     rpt STRIP_TAC
  >> qexistsl_tac [‘1’, ‘\x. 1’] >> simp []
- >> CONJ_TAC
- >- (rw [bounded_def] \\
+ >> CONJ_TAC (* BL *)
+ >- (rw [BL_alt, bounded_def, Lipschitz_continuous_map_const] \\
      Q.EXISTS_TAC ‘1’ >> simp [])
  >> CCONTR_TAC >> fs []
  >> Know ‘!x t. diff1
@@ -12203,9 +12232,35 @@ Proof
      >- (Q.EXISTS_TAC ‘a * std_normal_density 1’ \\
          simp [REAL_LT_MUL, std_normal_density_pos, Abbr ‘P’] \\
          Q.EXISTS_TAC ‘1’ >> simp []) \\
-     cheat)
+     Q.EXISTS_TAC ‘a * std_normal_density 1’ \\
+     Q.X_GEN_TAC ‘x’ >> simp [Abbr ‘P’] \\
+     DISCH_THEN (Q.X_CHOOSE_THEN ‘y’ (REWRITE_TAC o wrap)) \\
+     REWRITE_TAC [GSYM REAL_MUL_ASSOC] \\
+     MATCH_MP_TAC REAL_LE_LMUL_IMP >> simp [REAL_LT_IMP_LE] \\
+     REWRITE_TAC [abs_x_std_normmal_density_upper_bound])
  >> DISCH_TAC
- >> cheat
+ >> ‘integral lborel w <> PosInf’
+      by METIS_TAC [integrable_finite_integral, measure_space_lborel]
+ >> qabbrev_tac ‘f = \(x :real). Normal z’
+ >> Know ‘integral lborel f = Normal z * measure lborel (m_space lborel)’
+ >- (qunabbrev_tac ‘f’ \\
+     MATCH_MP_TAC integral_const >> simp [measure_space_lborel])
+ >> ‘0 < Normal z’ by simp [extreal_of_num_def, extreal_lt_eq]
+ >> simp [space_lborel, lambda_univ, mul_infty]
+ >> REWRITE_TAC [lt_infty]
+ >> Q_TAC (TRANS_TAC let_trans) ‘integral lborel w’
+ >> simp [GSYM lt_infty]
+ >> Know ‘integral lborel f = pos_fn_integral lborel f’
+ >- (MATCH_MP_TAC integral_pos_fn \\
+     simp [measure_space_lborel, space_lborel, Abbr ‘f’, extreal_of_num_def] \\
+     MATCH_MP_TAC REAL_LT_IMP_LE >> art [])
+ >> Rewr'
+ >> Know ‘integral lborel w = pos_fn_integral lborel w’
+ >- (MATCH_MP_TAC integral_pos_fn \\
+     simp [measure_space_lborel, space_lborel])
+ >> Rewr'
+ >> MATCH_MP_TAC pos_fn_integral_mono
+ >> rw [Abbr ‘f’, space_lborel, REAL_LT_IMP_LE]
 QED
 
 (* ------------------------------------------------------------------------- *)

--- a/src/probability/borelScript.sml
+++ b/src/probability/borelScript.sml
@@ -5278,6 +5278,42 @@ Proof
  >> REWRITE_TAC [extreal_not_infty]
 QED
 
+Theorem lambda_univ :
+    lambda UNIV = PosInf
+Proof
+    qabbrev_tac ‘f = \n. interval (-&n,&n)’
+ >> Know ‘UNIV = BIGUNION (IMAGE f UNIV)’
+ >- (rw [Once EXTENSION, IN_BIGUNION_IMAGE] \\
+     MP_TAC (Q.SPEC ‘abs x’ SIMP_REAL_ARCH_SUC) >> rw [ABS_BOUNDS_LT] \\
+     Q.EXISTS_TAC ‘SUC n’ >> simp [Abbr ‘f’, IN_INTERVAL])
+ >> Rewr'
+ >> qmatch_abbrev_tac ‘lambda s = PosInf’
+ >> Know ‘measure lborel s = sup (IMAGE (measure lborel o f) UNIV)’
+ >- (SYM_TAC >> MATCH_MP_TAC MONOTONE_CONVERGENCE \\
+     simp [measure_space_lborel, sets_lborel] \\
+     CONJ_TAC
+     >- rw [IN_FUNSET, Abbr ‘f’, OPEN_interval, borel_measurable_sets] \\
+     rw [Abbr ‘f’, SUBSET_DEF, IN_INTERVAL] >| (* 2 subgoals *)
+     [ (* goal 1 (of 2) *)
+       Q_TAC (TRANS_TAC REAL_LT_TRANS) ‘-&n’ >> simp [],
+       (* goal 2 (of 2) *)
+       Q_TAC (TRANS_TAC REAL_LT_TRANS) ‘&n’ >> simp [] ])
+ >> Rewr'
+ >> Know ‘lambda o f = \n. Normal 2 * &n’
+ >- rw [o_DEF, FUN_EQ_THM, Abbr ‘f’, lambda_open_interval,
+        extreal_of_num_def, extreal_mul_eq, REAL_SUB_RNEG]
+ >> Rewr'
+ >> qabbrev_tac ‘g :num -> extreal = \n. &n’
+ >> simp []
+ >> Know ‘sup (IMAGE (\n. Normal 2 * g n) UNIV) =
+          Normal 2 * sup (IMAGE g UNIV)’
+ >- (MATCH_MP_TAC sup_cmul >> simp [])
+ >> Rewr'
+ >> ‘IMAGE g UNIV = \x. ?n. x = &n’ by rw [Once EXTENSION]
+ >> POP_ORW
+ >> simp [sup_num, mul_infty]
+QED
+
 (* ------------------------------------------------------------------------- *)
 (*  Extreal-based Borel measure space                                        *)
 (* ------------------------------------------------------------------------- *)

--- a/src/probability/extrealScript.sml
+++ b/src/probability/extrealScript.sml
@@ -5762,6 +5762,14 @@ Proof
  >> PROVE_TAC [let_antisym]
 QED
 
+Theorem FN_MINUS_REDUCE' :
+    !f x. f x <= 0 ==> (fn_minus f x = -f x)
+Proof
+    RW_TAC std_ss [fn_minus_def]
+ >> REWRITE_TAC [Once EQ_SYM_EQ, neg_eq0]
+ >> METIS_TAC [le_lt]
+QED
+
 (* don't put it into simp sets, ‘o’ may be eliminated *)
 Theorem FN_PLUS_ABS_SELF :
     !f. fn_plus (abs o f) = abs o f

--- a/src/probability/lebesgueScript.sml
+++ b/src/probability/lebesgueScript.sml
@@ -2201,8 +2201,9 @@ Proof
  >> METIS_TAC [pos_fn_integral_pos_simple_fn, pos_simple_fn_integral_indicator]
 QED
 
+(* NOTE: removed “measure m (m_space m) < PosInf” *)
 Theorem pos_fn_integral_const :
-    !m c. measure_space m /\ measure m (m_space m) < PosInf /\ 0 <= c ==>
+    !m c. measure_space m /\ 0 <= c ==>
          (pos_fn_integral m (\x. Normal c) = Normal c * measure m (m_space m))
 Proof
     rpt STRIP_TAC
@@ -6109,15 +6110,42 @@ Proof
                    fn_plus_def, fn_minus_def]
 QED
 
-Theorem integral_const:
-    !m c. measure_space m /\ measure m (m_space m) < PosInf ==>
-         (integral m (\x. Normal c) = Normal c * measure m (m_space m))
+(* NOTE: removed “measure m (m_space m) < PosInf” *)
+Theorem integral_const :
+    !m c. measure_space m ==>
+          integral m (\x. Normal c) = Normal c * measure m (m_space m)
 Proof
     rpt STRIP_TAC
- >> ONCE_REWRITE_TAC [MATCH_MP integral_mspace (ASSUME ``measure_space m``)]
- >> BETA_TAC
- >> MATCH_MP_TAC integral_cmul_indicator >> art []
- >> PROVE_TAC [MEASURE_SPACE_MSPACE_MEASURABLE]
+ >> ‘c = 0 \/ 0 < c \/ c < 0’ by PROVE_TAC [REAL_LT_TOTAL]
+ >| [ (* goal 1 (of 3) *)
+      simp [normal_0, integral_zero],
+      (* goal 2 (of 3) *)
+      REWRITE_TAC [integral_def] \\
+     ‘0 <= c’ by simp [REAL_LT_IMP_LE] \\
+      Know ‘(\x. Normal c)^+ = \x. Normal c’
+      >- (PURE_REWRITE_TAC [FUN_EQ_THM] \\
+          Q.X_GEN_TAC ‘x’ \\
+          MATCH_MP_TAC FN_PLUS_REDUCE \\
+          simp [extreal_of_num_def, extreal_le_eq]) >> Rewr' \\
+      Know ‘(\x. Normal c)^- = \x. 0’
+      >- (rw [FUN_EQ_THM] \\
+          MATCH_MP_TAC FN_MINUS_REDUCE \\
+          simp [extreal_of_num_def, extreal_le_eq]) >> Rewr' \\
+      simp [pos_fn_integral_const, pos_fn_integral_zero],
+      (* goal 3 (of 3) *)
+      REWRITE_TAC [integral_def] \\
+     ‘c <= 0’ by simp [REAL_LT_IMP_LE] \\
+      Know ‘(\x. Normal c)^+ = \x. 0’
+      >- (rw [FUN_EQ_THM] \\
+          MATCH_MP_TAC FN_PLUS_REDUCE' \\
+          simp [extreal_of_num_def, extreal_le_eq]) >> Rewr' \\
+      Know ‘(\x. Normal c)^- = \x. Normal (-c)’
+      >- (rw [FUN_EQ_THM, GSYM extreal_ainv_def] \\
+         ‘-Normal c = -((\x. Normal c) x)’ by simp [] >> POP_ORW \\
+          MATCH_MP_TAC FN_MINUS_REDUCE' \\
+          simp [extreal_of_num_def, extreal_le_eq]) >> Rewr' \\
+      simp [pos_fn_integral_const, pos_fn_integral_zero] \\
+      simp [GSYM extreal_ainv_def, mul_lneg, neg_neg] ]
 QED
 
 Theorem integral_cmul_infty:

--- a/src/real/metricScript.sml
+++ b/src/real/metricScript.sml
@@ -1954,6 +1954,13 @@ End
 Theorem Lipschitz_continuous_map_def =
         Lipschitz_continuous_map |> REWRITE_RULE [Lipschitz_condition_def]
 
+Theorem Lipschitz_continuous_map_const :
+    !E1 E2 c. Lipschitz_continuous_map (E1,E2) (\x. c)
+Proof
+    rw [Lipschitz_continuous_map_def, MDIST_REFL]
+ >> Q.EXISTS_TAC ‘1’ >> simp [MDIST_POS_LE]
+QED
+
 Theorem Lipschitz_continuous_map_imp_continuous_map :
     !E1 E2 f. Lipschitz_continuous_map (E1,E2) f ==>
               continuous_map (mtop E1,mtop E2) f


### PR DESCRIPTION
Hi,

The following theorem is the higher order version of `[gauge_differentiable_lemma]` added in PR #1737 (Parameter-Dependent Integrals):
```
[gauge_higher_differentiable_lemma] (distributionTheory)
⊢ ∀u. (∀t. integrable lborel (Normal ∘ u t)) ∧
      (∀n t x. higher_differentiable n (λt. u t x) t) ∧
      (∀n. 0 < n ⇒
           ∃w. integrable lborel w ∧ (∀x. 0 ≤ w x ∧ w x ≠ +∞) ∧
               ∀t x. Normal (abs (diffn n (λt. u t x) t)) ≤ w x) ⇒
      ∀n t.
        higher_differentiable n (λt. integral 𝕌(:real) (u t)) t ∧
        integrable lborel (λx. Normal (diffn n (λt. u t x) t)) ∧
        diffn n (λt. integral 𝕌(:real) (u t)) t =
        integral 𝕌(:real) (λx. diffn n (λt. u t x) t)
```
This theorem was added for proving central limit theorem, but when it's actually used, I found the antecedent `∃w. integrable lborel w ...` cannot be satisfied, i.e. no way to find the needed integrable function as the upper bound. In this PR, I formally proved this impossibility:
```
[gauge_higher_differentiable_lemma_inapplicable] (distributionTheory, newly added)
⊢ ∀s. s ≠ 0 ⇒
      ∃n f.
        1 ≤ n ∧ n ≤ 3 ∧ f ∈ BL mr1 ∧
        ¬∃w. integrable lborel w ∧ (∀x. 0 ≤ w x ∧ w x ≠ +∞) ∧
            ∀t x.
              Normal
                (abs
                   (diffn n
                      (λt. f x * std_normal_density (-s⁻¹ * t + s⁻¹ * x)) t)) ≤
              w x
```

Several useful theorems are added in upsteam theories. The theorem `integral_const` and `pos_fn_integral_const` are improved with less antecedents.

P. S. Please squash all commits when merging it.

--Chun
