### PR TITLE
Improved proofs of permutator_thm, selector_thm, etc.

### DIFF
--- a/examples/lambda/barendregt/boehmScript.sml
+++ b/examples/lambda/barendregt/boehmScript.sml
@@ -4,6 +4,7 @@
 (*                                                                            *)
 (* AUTHORS : 2023-2024 The Australian National University (Chun Tian)         *)
 (* ========================================================================== *)
+
 Theory boehm
 Ancestors
   option arithmetic pred_set list rich_list llist relation ltree
@@ -13,7 +14,6 @@ Ancestors
 Libs
   hurdUtils tautLib listLib numLib BasicProvers NEWLib
   reductionEval head_reductionLib monadsyntax
-
 
 (* enable basic monad support *)
 val _ = enable_monadsyntax ();
@@ -37,6 +37,8 @@ val _ = set_trace "Goalstack.print_goal_at_top" 0;
 (* Disable some conflicting overloads from labelledTermsTheory *)
 Overload FV  = “supp term_pmact”
 Overload VAR = “term$VAR”
+
+val _ = temp_clear_overloads_on "fEL";
 
 (*---------------------------------------------------------------------------*
  *  Boehm Trees (and subterms) - name after Corrado Böhm [2]                 *
@@ -180,8 +182,7 @@ QED
  *)
 Theorem solvable_appstar :
     !X M r M0 n n' vs.
-           FINITE X /\ FV M SUBSET X UNION RANK r /\
-           solvable M /\
+           FINITE X /\ FV M SUBSET X UNION RANK r /\ solvable M /\
            M0 = principal_hnf M /\
             n = LAMl_size M0 /\
            vs = RNEWS r n' X /\ n <= n'
@@ -245,8 +246,8 @@ Proof
  >> qexistsl_tac [‘X’, ‘M’, ‘r’, ‘n’, ‘n’] >> simp []
 QED
 
-(* Essentially, ‘hnf_children_size (principal_hnf M)’ is irrelevant with
-   the excluding list. This lemma shows the equivalence in defining ‘m’.
+(* NOTE: Essentially, ‘hnf_children_size (principal_hnf M)’ is irrelevant with
+   the excluding set ‘X’. This lemma shows the equivalence with ‘m = LENGTH Ms’.
  *)
 Theorem hnf_children_size_alt :
     !X M r M0 n vs M1 Ms.
@@ -411,63 +412,6 @@ Proof
  >> qexistsl_tac [‘X’, ‘N’, ‘SUC r’] >> rw [BT_def]
 QED
 
-Theorem subterm_rank_lemma :
-    !p X M N r r'. FINITE X /\ FV M SUBSET X UNION RANK r /\
-                   subterm X M p r = SOME (N,r')
-               ==> r' = r + LENGTH p /\ FV N SUBSET X UNION RANK r'
-Proof
-    Induct_on ‘p’ >- NTAC 2 (rw [])
- >> rpt GEN_TAC
- >> reverse (Cases_on ‘solvable M’) >- rw [subterm_def]
- >> UNBETA_TAC [subterm_of_solvables] “subterm X M (h::p) r”
- >> STRIP_TAC
- >> qabbrev_tac ‘M' = EL h Ms’
- >> Q.PAT_X_ASSUM ‘!X M N r r'. P’
-      (MP_TAC o (Q.SPECL [‘X’, ‘M'’, ‘N’, ‘SUC r’, ‘r'’]))
- >> simp []
- >> Suff ‘FV M' SUBSET X UNION RANK (SUC r)’
- >- rw []
- >> qunabbrev_tac ‘vs’
- >> Q_TAC (RNEWS_TAC (“vs :string list”, “r :num”, “n :num”)) ‘X’
- >> ‘DISJOINT (set vs) (FV M0)’ by METIS_TAC [subterm_disjoint_lemma']
- >> Q_TAC (HNF_TAC (“M0 :term”, “vs :string list”,
-                    “y :string”, “args :term list”)) ‘M1’
- >> ‘TAKE n vs = vs’ by rw []
- >> POP_ASSUM (rfs o wrap)
- >> ‘Ms = args’ by rw [Abbr ‘Ms’]
- >> POP_ASSUM (rfs o wrap o SYM)
- >> Know ‘!i. i < LENGTH Ms ==> FV (EL i Ms) SUBSET FV M1’
- >- (MATCH_MP_TAC hnf_children_FV_SUBSET \\
-     simp [hnf_appstar])
- >> DISCH_TAC
- >> qunabbrev_tac ‘M'’
- >> qabbrev_tac ‘Y  = RANK r’
- >> qabbrev_tac ‘Y' = RANK (SUC r)’
- (* transitivity no.1 *)
- >> Q_TAC (TRANS_TAC SUBSET_TRANS) ‘FV M1’
- >> CONJ_TAC >- (FIRST_X_ASSUM MATCH_MP_TAC >> rw [])
- (* transitivity no.2 *)
- >> Q_TAC (TRANS_TAC SUBSET_TRANS) ‘FV M0 UNION set vs’
- >> CONJ_TAC >- simp [FV_LAMl]
- (* transitivity no.3 *)
- >> Q_TAC (TRANS_TAC SUBSET_TRANS) ‘FV M UNION set vs’
- >> CONJ_TAC
- >- (Suff ‘FV M0 SUBSET FV M’ >- SET_TAC [] \\
-     qunabbrev_tac ‘M0’ \\
-     MATCH_MP_TAC principal_hnf_FV_SUBSET' >> art [])
- >> rw [SUBSET_DEF, IN_UNION]
- >- (Know ‘x IN X UNION Y’ >- METIS_TAC [SUBSET_DEF] \\
-     rw [IN_UNION] >- (DISJ1_TAC >> art []) \\
-     DISJ2_TAC \\
-     Suff ‘Y SUBSET Y'’ >- METIS_TAC [SUBSET_DEF] \\
-     qunabbrevl_tac [‘Y’, ‘Y'’] \\
-     MATCH_MP_TAC RANK_MONO >> rw [])
- >> DISJ2_TAC
- >> Suff ‘set vs SUBSET Y'’ >- METIS_TAC [SUBSET_DEF]
- >> qunabbrevl_tac [‘vs’, ‘Y'’]
- >> MATCH_MP_TAC RNEWS_SUBSET_RANK >> rw []
-QED
-
 Theorem subterm_induction_lemma :
     !X M r M0 n n' m vs M1 Ms h.
            FINITE X /\ FV M SUBSET X UNION RANK r /\
@@ -558,6 +502,33 @@ Proof
  >> qexistsl_tac [‘M’, ‘M0’, ‘n’, ‘n’, ‘m’, ‘vs’, ‘M1’] >> simp []
 QED
 
+Theorem subterm_rank_lemma :
+    !p X M N r r'. FINITE X /\ FV M SUBSET X UNION RANK r /\
+                   subterm X M p r = SOME (N,r')
+               ==> r' = r + LENGTH p /\ FV N SUBSET X UNION RANK r'
+Proof
+    Induct_on ‘p’ >- NTAC 2 (rw [])
+ >> rpt GEN_TAC
+ >> reverse (Cases_on ‘solvable M’) >- rw [subterm_def]
+ >> UNBETA_TAC [subterm_of_solvables] “subterm X M (h::p) r”
+ >> STRIP_TAC
+ >> qabbrev_tac ‘M' = EL h Ms’
+ >> Q.PAT_X_ASSUM ‘!X M N r r'. P’
+      (MP_TAC o (Q.SPECL [‘X’, ‘M'’, ‘N’, ‘SUC r’, ‘r'’]))
+ >> simp []
+ >> Suff ‘FV M' SUBSET X UNION RANK (SUC r)’ >- rw []
+ >> qunabbrev_tac ‘M'’
+ >> MATCH_MP_TAC subterm_induction_lemma'
+ >> qexistsl_tac [‘M’, ‘M0’, ‘n’, ‘m’, ‘vs’, ‘M1’] >> simp []
+ >> qunabbrev_tac ‘m’
+ >> SYM_TAC
+ >> MATCH_MP_TAC hnf_children_size_alt
+ >> qexistsl_tac [‘X’, ‘M’, ‘r’, ‘n’, ‘vs’, ‘M1’] >> simp []
+QED
+
+(* NOTE: This theorem provides a better estimates for “FV (EL h Ms)”, than the
+   above subterm_induction_lemma.
+ *)
 Theorem FV_subterm_lemma :
     !X M r M0 n m vs M1 Ms h.
            FINITE X /\ FV M SUBSET X UNION RANK r /\
@@ -6122,8 +6093,7 @@ Theorem BT_expand_lemma1 :
        BT_expand X (BT' X M r) p r = B /\ N = BT_to_term B ==>
        compat_closure eta N M /\ BT' X N r = B
 Proof
-    rpt GEN_TAC
- >> STRIP_TAC
+    rpt GEN_TAC >> STRIP_TAC
  >> simp []
  >> Suff ‘!R M r. (?p B. FV M SUBSET X UNION RANK r /\ bnf M /\
                          p IN ltree_paths (BT' X M r) /\
@@ -6782,10 +6752,10 @@ Proof
  (* Case 1 (m' < m):
 
        ((vs,y),m) at p'
-        / |  \
+       /  |  \
       /   |   \
-    /   p |    \
-   0     m'   (m-1)
+     /  p |    \
+    0     m'   (m-1)
 
    If m' < m, then p IN BT_paths B' = s0 UNION IMAGE f (count i).
    But p NOTIN s0, thus p IN IMAGE f (count i). This is impossible because
@@ -6806,10 +6776,10 @@ Proof
  (* Case 2:
 
        ((vs,y),m) at p'
-        / |  \  \__
+       /  |  \  \__
       /   |   \    \_ p
-    /     |    \     \
-   0     m-1   (m)     m'
+     /    |    \     \
+    0    m-1   (m)    m'
 
    If m < m' (LAST p), since p IN paths, we have
 
@@ -6875,8 +6845,7 @@ Definition Boehm_construction_def :
         vs0   = NEWS (n_max + SUC d_max + k) (X UNION X');
         vs    = TAKE n_max vs0;
         xs    = DROP n_max vs0;
-        M  i  = EL i Ms;
-        M0 i  = principal_hnf (M i);
+        M0 i  = principal_hnf (EL i Ms);
         M1 i  = principal_hnf (M0 i @* MAP VAR vs);
         y  i  = hnf_headvar (M1 i);
         P  i  = permutator (d_max + i);

--- a/examples/lambda/barendregt/chap2Script.sml
+++ b/examples/lambda/barendregt/chap2Script.sml
@@ -1477,163 +1477,62 @@ Proof
  >> rw [ALL_DISTINCT_SNOC]
 QED
 
-(* TODO: The proof can be simplified using the previous permutator_alt *)
 Theorem permutator_thm :
     !n N Ns. LENGTH Ns = n ==> permutator n @* Ns @@ N == N @* Ns
 Proof
-    RW_TAC std_ss [permutator_def]
- >> qabbrev_tac ‘n = LENGTH Ns’
- >> qabbrev_tac ‘Z = GENLIST n2s (SUC n)’
- >> qabbrev_tac ‘z = LAST Z’
- >> ‘ALL_DISTINCT Z /\ LENGTH Z = SUC n’ by rw [Abbr ‘Z’, ALL_DISTINCT_GENLIST]
- >> ‘Z <> []’ by rw [NOT_NIL_EQ_LENGTH_NOT_0]
- >> ‘MEM z Z’ by rw [Abbr ‘z’, MEM_LAST_NOT_NIL]
- >> qabbrev_tac ‘M = VAR z @* MAP VAR (FRONT Z)’
- (* preparing for LAMl_ALPHA_ssub *)
- >> qabbrev_tac ‘Y = NEWS (SUC n) (set Z UNION (BIGUNION (IMAGE FV (set Ns))))’
- >> Know ‘FINITE (set Z UNION (BIGUNION (IMAGE FV (set Ns))))’
- >- (rw [] >> rw [FINITE_FV])
- >> DISCH_TAC
- >> Know ‘ALL_DISTINCT Y /\
-          DISJOINT (set Y) (set Z UNION (BIGUNION (IMAGE FV (set Ns)))) /\
-          LENGTH Y = SUC n’
- >- (ASM_SIMP_TAC std_ss [NEWS_def, Abbr ‘Y’])
- >> rw []
- (* applying LAMl_ALPHA_ssub *)
- >> Know ‘LAMl Z M = LAMl Y ((FEMPTY |++ ZIP (Z,MAP VAR Y)) ' M)’
- >- (MATCH_MP_TAC LAMl_ALPHA_ssub >> rw [DISJOINT_SYM] \\
-     Suff ‘FV M = set Z’ >- METIS_TAC [DISJOINT_SYM] \\
-     rw [Abbr ‘M’, FV_appstar] \\
-    ‘Z = SNOC (LAST Z) (FRONT Z)’ by PROVE_TAC [SNOC_LAST_FRONT] \\
-     POP_ORW \\
-     simp [LIST_TO_SET_SNOC] \\
-     rw [Once EXTENSION, MEM_MAP] \\
-     EQ_TAC >> rw [] >> fs [] \\
-     DISJ2_TAC \\
-     Q.EXISTS_TAC ‘FV (VAR x)’ >> rw [] \\
-     Q.EXISTS_TAC ‘VAR x’ >> rw [])
- >> Rewr'
- >> ‘Y <> []’ by rw [NOT_NIL_EQ_LENGTH_NOT_0]
- >> REWRITE_TAC [GSYM fromPairs_def]
- >> qabbrev_tac ‘fm = fromPairs Z (MAP VAR Y)’
- >> ‘FDOM fm = set Z’ by rw [FDOM_fromPairs, Abbr ‘fm’]
- >> qabbrev_tac ‘y = LAST Y’
- (* postfix for LAMl_ALPHA_ssub *)
- >> ‘!t. LAMl Y t = LAMl (SNOC y (FRONT Y)) t’
-       by (ASM_SIMP_TAC std_ss [Abbr ‘y’, SNOC_LAST_FRONT]) >> POP_ORW
- >> REWRITE_TAC [LAMl_SNOC]
- >> Know ‘fm ' M = VAR y @* MAP VAR (FRONT Y)’
- >- (simp [Abbr ‘M’, ssub_appstar] \\
-     Know ‘fm ' z = VAR y’
-     >- (rw [Abbr ‘fm’, Abbr ‘z’, LAST_EL] \\
-         Know ‘fromPairs Z (MAP VAR Y) ' (EL n Z) = EL n (MAP VAR Y)’
-         >- (MATCH_MP_TAC fromPairs_FAPPLY_EL >> rw []) >> Rewr' \\
-         rw [EL_MAP, Abbr ‘y’, LAST_EL]) >> Rewr' \\
-     Suff ‘MAP ($' fm) (MAP VAR (FRONT Z)) = MAP VAR (FRONT Y)’ >- rw [] \\
-     rw [LIST_EQ_REWRITE, LENGTH_FRONT] \\
-     rename1 ‘i < n’ \\
-     simp [EL_MAP, LENGTH_FRONT] \\
-     Know ‘MEM (EL i (FRONT Z)) Z’
-     >- (rw [MEM_EL] \\
-         Q.EXISTS_TAC ‘i’ >> rw [] \\
-         MATCH_MP_TAC EL_FRONT >> rw [LENGTH_FRONT, NULL_EQ]) \\
-     rw [Abbr ‘fm’] \\
-     Know ‘EL i (FRONT Z) = EL i Z’
-     >- (MATCH_MP_TAC EL_FRONT >> rw [LENGTH_FRONT, NULL_EQ]) >> Rewr' \\
-     Know ‘EL i (FRONT Y) = EL i Y’
-     >- (MATCH_MP_TAC EL_FRONT >> rw [LENGTH_FRONT, NULL_EQ]) >> Rewr' \\
-     Know ‘fromPairs Z (MAP VAR Y) ' (EL i Z) = EL i (MAP VAR Y)’
-     >- (MATCH_MP_TAC fromPairs_FAPPLY_EL >> rw []) >> Rewr' \\
-     rw [EL_MAP])
- >> Rewr'
- (* stage work *)
- >> qabbrev_tac ‘t = LAM y (VAR y @* MAP VAR (FRONT Y))’
- >> MATCH_MP_TAC lameq_TRANS
- >> Q.EXISTS_TAC ‘((FEMPTY |++ ZIP (FRONT Y,Ns)) ' t) @@ N’
+    rpt STRIP_TAC
+ >> qabbrev_tac ‘X = BIGUNION (IMAGE FV (set Ns))’
+ >> ‘FINITE X’ by rw [Abbr ‘X’]
+ >> MP_TAC (Q.SPECL [‘X’, ‘n’] permutator_alt)
+ >> rw [ALL_DISTINCT_SNOC, LIST_TO_SET_SNOC, DISJOINT_INSERT]
+ >> POP_ORW
+ >> qabbrev_tac ‘t = LAM v (VAR v @* MAP VAR vs)’
+ >> Q_TAC (TRANS_TAC lameq_TRANS) ‘((FEMPTY |++ ZIP (vs,Ns)) ' t) @@ N’
  >> CONJ_TAC
  >- (MATCH_MP_TAC lameq_APPL \\
-     MATCH_MP_TAC lameq_LAMl_appstar_ssub \\
-     rw [ALL_DISTINCT_FRONT, LENGTH_FRONT] \\
-     MATCH_MP_TAC DISJOINT_SUBSET' \\
-     Q.EXISTS_TAC ‘set Y’ \\
-     reverse CONJ_TAC >- rw [SUBSET_DEF, MEM_FRONT_NOT_NIL] \\
-     ONCE_REWRITE_TAC [DISJOINT_SYM] \\
-     FIRST_X_ASSUM MATCH_MP_TAC \\
-     Q.EXISTS_TAC ‘x’ >> art [])
- (* cleanup ‘fm’ *)
- >> Q.PAT_X_ASSUM ‘FDOM fm = set Z’ K_TAC
- >> qunabbrev_tac ‘fm’
+     MATCH_MP_TAC lameq_LAMl_appstar_ssub >> art [] \\
+     ASM_SIMP_TAC std_ss [Once DISJOINT_SYM])
  (* stage work *)
  >> REWRITE_TAC [GSYM fromPairs_def]
- >> qabbrev_tac ‘fm = fromPairs (FRONT Y) Ns’
- >> ‘FDOM fm = set (FRONT Y)’ by rw [Abbr ‘fm’, FDOM_fromPairs, LENGTH_FRONT]
+ >> qabbrev_tac ‘fm = fromPairs vs Ns’
+ >> ‘FDOM fm = set vs’ by rw [Abbr ‘fm’, FDOM_fromPairs]
  >> qunabbrev_tac ‘t’
- >> qabbrev_tac ‘t = VAR y @* MAP VAR (FRONT Y)’
- >> Know ‘fm ' (LAM y t) = LAM y (fm ' t)’
- >- (MATCH_MP_TAC ssub_LAM \\
-     simp [Abbr ‘y’, LAST_EL] \\
-     CONJ_TAC
-     >- (simp [MEM_EL, LENGTH_FRONT, GSYM ADD1] \\
-         Q.X_GEN_TAC ‘i’ \\
-         ONCE_REWRITE_TAC [DECIDE “P ==> ~Q <=> Q ==> ~P”] \\
-         DISCH_TAC \\
-         Know ‘EL i (FRONT Y) = EL i Y’
-         >- (MATCH_MP_TAC EL_FRONT >> rw [LENGTH_FRONT, NULL_EQ, GSYM ADD1]) \\
-         Rewr' \\
-         rw [ALL_DISTINCT_EL_IMP]) \\
+ >> qabbrev_tac ‘t = VAR v @* MAP VAR vs’
+ >> Know ‘fm ' (LAM v t) = LAM v (fm ' t)’
+ >- (MATCH_MP_TAC ssub_LAM >> simp [] \\
      Q.X_GEN_TAC ‘y’ \\
-     rw [MEM_EL, GSYM ADD1] >> rename1 ‘i < LENGTH (FRONT Y)’ \\
+     rw [MEM_EL] >> rename1 ‘i < LENGTH Ns’ \\
      qunabbrev_tac ‘fm’ \\
-     Know ‘fromPairs (FRONT Y) Ns ' (EL i (FRONT Y)) = EL i Ns’
+     Know ‘fromPairs vs Ns ' (EL i vs) = EL i Ns’
      >- (MATCH_MP_TAC fromPairs_FAPPLY_EL \\
          rw [ALL_DISTINCT_FRONT, LENGTH_FRONT]) >> Rewr' \\
-     Know ‘DISJOINT (FV (EL i Ns)) (set Y)’
-     >- (FIRST_X_ASSUM MATCH_MP_TAC \\
-         Q.EXISTS_TAC ‘EL i Ns’ >> rw [MEM_EL] \\
-         Q.EXISTS_TAC ‘i’ >> rfs [LENGTH_FRONT]) \\
-     ONCE_REWRITE_TAC [DISJOINT_SYM] \\
-     rw [DISJOINT_ALT] \\
-     POP_ASSUM MATCH_MP_TAC >> rw [MEM_EL] \\
-     Q.EXISTS_TAC ‘n’ >> rw [])
+     CCONTR_TAC >> fs [] \\
+     Suff ‘FV (EL i Ns) SUBSET X’ >- METIS_TAC [SUBSET_DEF] \\
+     rw [SUBSET_DEF, Abbr ‘X’, IN_BIGUNION_IMAGE] \\
+     Q.EXISTS_TAC ‘EL i Ns’ >> simp [EL_MEM])
  >> Rewr'
- >> Q.PAT_X_ASSUM ‘FDOM fm = set (FRONT Y)’ K_TAC
+ >> Q.PAT_X_ASSUM ‘FDOM fm = set vs’ K_TAC
  >> simp [Abbr ‘fm’]
- >> ‘FDOM (fromPairs (FRONT Y) Ns) = set (FRONT Y)’
-       by rw [FDOM_fromPairs, LENGTH_FRONT]
- >> Know ‘~MEM y (FRONT Y)’
- >- (simp [Abbr ‘y’, MEM_EL, LAST_EL, LENGTH_FRONT, GSYM ADD1] \\
-     Q.X_GEN_TAC ‘i’ \\
-     ONCE_REWRITE_TAC [DECIDE “P ==> ~Q <=> Q ==> ~P”] \\
-     DISCH_TAC \\
-     Know ‘EL i (FRONT Y) = EL i Y’
-     >- (MATCH_MP_TAC EL_FRONT >> rw [LENGTH_FRONT, NULL_EQ]) >> Rewr' \\
-     rw [ALL_DISTINCT_EL_IMP])
- >> DISCH_TAC
+ >> ‘FDOM (fromPairs vs Ns) = set vs’ by rw [FDOM_fromPairs]
  >> simp [Abbr ‘t’, ssub_appstar]
- >> Know ‘MAP ($' (fromPairs (FRONT Y) Ns)) (MAP VAR (FRONT Y)) = Ns’
- >- (rw [LIST_EQ_REWRITE, LENGTH_FRONT] \\
-     rw [MAP_MAP_o, LENGTH_FRONT, EL_MAP]
-     >- (MATCH_MP_TAC fromPairs_FAPPLY_EL \\
-         rw [LENGTH_FRONT, ALL_DISTINCT_FRONT]) \\
+ >> Know ‘MAP ($' (fromPairs vs Ns)) (MAP VAR vs) = Ns’
+ >- (rw [LIST_EQ_REWRITE] \\
+     rw [MAP_MAP_o, EL_MAP]
+     >- (MATCH_MP_TAC fromPairs_FAPPLY_EL >> art []) \\
      NTAC 2 (POP_ASSUM MP_TAC) \\
-     simp [GSYM ADD1, MEM_EL, LENGTH_FRONT] \\
+     simp [MEM_EL] \\
      METIS_TAC [])
  >> Rewr'
- >> Suff ‘N @* Ns = [N/y] (VAR y @* Ns)’
- >- (Rewr' >> rw [lameq_BETA])
+ >> Suff ‘N @* Ns = [N/v] (VAR v @* Ns)’ >- (Rewr' >> rw [lameq_BETA])
  >> simp [appstar_SUB]
- >> Suff ‘MAP [N/y] Ns = Ns’ >- rw []
+ >> Suff ‘MAP [N/v] Ns = Ns’ >- rw []
  >> rw [LIST_EQ_REWRITE, EL_MAP]
- >> rename1 ‘i < n’
+ >> rename1 ‘i < LENGTH Ns’
  >> MATCH_MP_TAC lemma14b
- >> Know ‘DISJOINT (FV (EL i Ns)) (set Y)’
- >- (FIRST_X_ASSUM MATCH_MP_TAC \\
-     Q.EXISTS_TAC ‘EL i Ns’ >> rw [MEM_EL] \\
-     Q.EXISTS_TAC ‘i’ >> art [])
- >> ONCE_REWRITE_TAC [DISJOINT_SYM]
- >> rw [DISJOINT_ALT]
- >> POP_ASSUM MATCH_MP_TAC
- >> rw [Abbr ‘y’, MEM_LAST_NOT_NIL]
+ >> CCONTR_TAC >> fs []
+ >> Suff ‘FV (EL i Ns) SUBSET X’ >- METIS_TAC [SUBSET_DEF]
+ >> rw [SUBSET_DEF, Abbr ‘X’, IN_BIGUNION_IMAGE]
+ >> Q.EXISTS_TAC ‘EL i Ns’ >> simp [EL_MEM]
 QED
 
 Definition selector_def :
@@ -1691,72 +1590,37 @@ Proof
  >> rw [Abbr ‘y’]
 QED
 
-(* TODO: rework this proof by (the new) selector_alt *)
 Theorem selector_thm :
     !i n Ns. i < n /\ LENGTH Ns = n ==> selector i n @* Ns == EL i Ns
 Proof
-    RW_TAC std_ss [selector_def]
- >> qabbrev_tac ‘n = LENGTH Ns’
- >> qabbrev_tac ‘Z = GENLIST n2s n’
- >> ‘ALL_DISTINCT Z /\ LENGTH Z = n’ by rw [Abbr ‘Z’, ALL_DISTINCT_GENLIST]
- >> ‘Z <> []’ by rw [NOT_NIL_EQ_LENGTH_NOT_0]
- >> qabbrev_tac ‘z = n2s i’
- >> Know ‘MEM z Z’
- >- (rw [Abbr ‘Z’, Abbr ‘z’, MEM_GENLIST] \\
-     Q.EXISTS_TAC ‘i’ >> art [])
- >> DISCH_TAC
- (* preparing for LAMl_ALPHA_ssub *)
- >> qabbrev_tac
-     ‘Y = NEWS n (set Z UNION (BIGUNION (IMAGE FV (set Ns))))’
- >> Know ‘FINITE (set Z UNION (BIGUNION (IMAGE FV (set Ns))))’
- >- (rw [] >> rw [FINITE_FV])
- >> DISCH_TAC
- >> Know ‘ALL_DISTINCT Y /\
-          DISJOINT (set Y) (set Z UNION (BIGUNION (IMAGE FV (set Ns)))) /\
-          LENGTH Y = n’
- >- (ASM_SIMP_TAC std_ss [NEWS_def, Abbr ‘Y’])
- >> rw []
- (* applying LAMl_ALPHA_ssub *)
- >> Know ‘LAMl Z (VAR z) = LAMl Y ((FEMPTY |++ ZIP (Z,MAP VAR Y)) ' (VAR z))’
- >- (MATCH_MP_TAC LAMl_ALPHA_ssub >> rw [] \\
-     Q.PAT_X_ASSUM ‘DISJOINT (set Z) (set Y)’ MP_TAC \\
-     rw [DISJOINT_ALT])
- >> Rewr'
- >> ‘Y <> []’ by rw [NOT_NIL_EQ_LENGTH_NOT_0]
- >> REWRITE_TAC [GSYM fromPairs_def]
- >> qabbrev_tac ‘fm = fromPairs Z (MAP VAR Y)’
- >> ‘FDOM fm = set Z’ by rw [FDOM_fromPairs, Abbr ‘fm’]
- >> Know ‘fm ' (VAR z) = EL i (MAP VAR Y)’
- >- (rw [ssub_thm] \\
-     Know ‘z = EL i Z’
-     >- (simp [Abbr ‘Z’, Abbr ‘z’] \\
-         fs [LENGTH_GENLIST, EL_GENLIST]) >> Rewr' \\
-     qunabbrev_tac ‘fm’ \\
-     MATCH_MP_TAC fromPairs_FAPPLY_EL >> rw [])
- >> Rewr'
+    rpt STRIP_TAC
+ >> qabbrev_tac ‘X = BIGUNION (IMAGE FV (set Ns))’
+ >> ‘FINITE X’ by rw [Abbr ‘X’]
+ >> MP_TAC (Q.SPECL [‘X’, ‘i’, ‘n’] selector_alt)
+ >> RW_TAC std_ss []
+ >> POP_ORW
+ >> ‘VAR (EL i vs) = EL i (MAP VAR vs)’ by simp [EL_MAP]
+ >> POP_ORW
  (* stage work *)
- >> qabbrev_tac ‘t = EL i (MAP VAR Y)’
- >> Suff ‘EL i Ns = (FEMPTY |++ ZIP (Y,Ns)) ' t’
+ >> qabbrev_tac ‘t = EL i (MAP VAR vs)’
+ >> Suff ‘EL i Ns = (FEMPTY |++ ZIP (vs,Ns)) ' t’
  >- (Rewr' \\
      MATCH_MP_TAC lameq_LAMl_appstar_ssub >> rw [] \\
      ONCE_REWRITE_TAC [DISJOINT_SYM] \\
-     FIRST_X_ASSUM MATCH_MP_TAC \\
+     MATCH_MP_TAC DISJOINT_SUBSET' \\
+     Q.EXISTS_TAC ‘X’ >> art [] \\
+     rw [SUBSET_DEF, Abbr ‘X’, IN_BIGUNION_IMAGE] \\
      Q.EXISTS_TAC ‘x’ >> art [])
- (* cleanup ‘fm’ *)
- >> Q.PAT_X_ASSUM ‘FDOM fm = set Z’ K_TAC
- >> qunabbrev_tac ‘fm’
- (* stage work *)
  >> REWRITE_TAC [Once EQ_SYM_EQ, GSYM fromPairs_def]
- >> qabbrev_tac ‘fm = fromPairs Y Ns’
- >> ‘FDOM fm = set Y’ by rw [Abbr ‘fm’, FDOM_fromPairs]
+ >> qabbrev_tac ‘fm = fromPairs vs Ns’
+ >> ‘FDOM fm = set vs’ by rw [Abbr ‘fm’, FDOM_fromPairs]
  >> simp [Abbr ‘t’, EL_MAP]
- >> Know ‘MEM (EL i Y) Y’
- >- (rw [MEM_EL] \\
-     Q.EXISTS_TAC ‘i’ >> rw [])
+ >> Know ‘MEM (EL i vs) vs’
+ >- (MATCH_MP_TAC EL_MEM >> art [])
  >> Rewr
- >> Q.PAT_X_ASSUM ‘FDOM fm = set Y’ K_TAC
+ >> Q.PAT_X_ASSUM ‘FDOM fm = set vs’ K_TAC
  >> simp [Abbr ‘fm’]
- >> MATCH_MP_TAC fromPairs_FAPPLY_EL >> rw []
+ >> MATCH_MP_TAC fromPairs_FAPPLY_EL >> art []
 QED
 
 (* ----------------------------------------------------------------------

--- a/examples/lambda/barendregt/lameta_completeScript.sml
+++ b/examples/lambda/barendregt/lameta_completeScript.sml
@@ -1,19 +1,18 @@
 (* ========================================================================== *)
-(* FILE    : lameta_completeScript.sml (chap10_4Script.sml)                   *)
+(* FILE    : lameta_completeScript.sml                                        *)
 (* TITLE   : Completeness of (Untyped) Lambda-Calculus [1, Chapter 10.4]      *)
 (*                                                                            *)
 (* AUTHORS : 2024 - 2025 The Australian National University (Chun Tian)       *)
 (* ========================================================================== *)
+
 Theory lameta_complete
 Ancestors
-  combin arithmetic pred_set list rich_list llist ltree relation
-  topology iterate option nomset basic_swap term appFOLDL chap2
-  chap3 horeduction solvable takahashiS3 head_reduction
-  standardisation boehm chap4
+  combin option arithmetic pred_set list rich_list llist ltree relation iterate
+  topology nomset basic_swap term appFOLDL chap2 chap3 chap4 horeduction
+  solvable takahashiS3 head_reduction standardisation boehm
 Libs
-  hurdUtils tautLib numLib listLib NEWLib reductionEval
-  head_reductionLib monadsyntax
-
+  hurdUtils tautLib numLib listLib NEWLib reductionEval head_reductionLib
+  monadsyntax
 
 (* enable basic monad support *)
 val _ = enable_monadsyntax ();
@@ -43,6 +42,8 @@ val PRINT_TAC = goalStack.note_tac
 (* Disable some conflicting overloads from labelledTermsTheory *)
 Overload FV  = “supp term_pmact”
 Overload VAR = “term$VAR”
+
+val _ = temp_clear_overloads_on "fEL"; (* use old EL syntax *)
 
 (*---------------------------------------------------------------------------*
  *  head equivalence
@@ -209,11 +210,8 @@ Proof
  >> qabbrev_tac ‘Y = BIGUNION (IMAGE FV (set Ms))’
  >> ‘FINITE Y’ by (rw [Abbr ‘Y’] >> rw [])
  >> qabbrev_tac ‘pi' = Boehm_construction X Ms p’
- >> CONJ_ASM1_TAC
- >- rw [Abbr ‘pi'’, Boehm_construction_transform]
- (* original steps *)
- >> Q.PAT_X_ASSUM ‘EVERY _ Ms’ MP_TAC
- >> DISCH_THEN (STRIP_ASSUME_TAC o (REWRITE_RULE [EVERY_EL]))
+ >> CONJ_ASM1_TAC >- rw [Abbr ‘pi'’, Boehm_construction_transform]
+ >> Q.PAT_X_ASSUM ‘EVERY _ Ms’ (STRIP_ASSUME_TAC o (REWRITE_RULE [EVERY_EL]))
  >> qabbrev_tac ‘k = LENGTH Ms’
  >> qabbrev_tac ‘M = \i. EL i Ms’ >> fs []
  >> Know ‘!i. i < k ==> FV (M i) SUBSET X UNION RANK r’
@@ -224,14 +222,9 @@ Proof
      rw [Abbr ‘M’, EL_MEM])
  >> DISCH_TAC
  (* now derive some non-trivial assumptions *)
- >> ‘!i. i < k ==> (!q. q <<= p ==> subterm X (M i) q r <> NONE) /\
-                    !q. q <<= FRONT p ==> solvable (subterm' X (M i) q r)’
-       by METIS_TAC [subterm_solvable_lemma]
- (* convert previous assumption into easier forms for MATCH_MP_TAC *)
  >> ‘(!i q. i < k /\ q <<= p ==> subterm X (M i) q r <> NONE) /\
      (!i q. i < k /\ q <<= FRONT p ==> solvable (subterm' X (M i) q r))’
-       by PROVE_TAC []
- >> Q.PAT_X_ASSUM ‘!i. i < k ==> P /\ Q’ K_TAC
+       by METIS_TAC [subterm_solvable_lemma]
  (* In the original antecedents of this theorem, some M may be unsolvable,
     and that's the easy case.
   *)
@@ -240,10 +233,8 @@ Proof
      Q.PAT_X_ASSUM ‘!i q. i < k /\ q <<= FRONT p ==> solvable _’
        (MP_TAC o Q.SPECL [‘i’, ‘[]’]) >> simp [])
  >> DISCH_TAC
- >> Know ‘!i. i < k ==> p IN ltree_paths (BT' X (M i) r)’
- >- (rpt STRIP_TAC \\
-     irule (iffRL BT_ltree_paths_thm) >> rw [])
- >> DISCH_TAC
+ >> ‘!i. i < k ==> p IN ltree_paths (BT' X (M i) r)’
+      by METIS_TAC [BT_ltree_paths_thm]
  (* define M0 *)
  >> qabbrev_tac ‘M0 = \i. principal_hnf (M i)’
  >> Know ‘!i. i < k ==> hnf (M0 i)’
@@ -634,7 +625,7 @@ Proof
  >> ‘!i. LENGTH (l i) = m i + (n_max - n i) + SUC d_max + k’
        by rw [Abbr ‘l’, Abbr ‘m’, Abbr ‘args2’, Abbr ‘d_max’, MAP_DROP]
  >> ‘!i. d_max + k < LENGTH (l i)’ by rw []
- >> DISCH_TAC
+ >> DISCH_TAC (* !i. i < k ==> apply p3 _ = P (f i) @* l i *)
  (* applying TAKE_DROP_SUC to break l into 3 pieces
 
     NOTE: New the segmentation of ‘l’ also depends on ‘i’.
@@ -693,8 +684,8 @@ Proof
  >> DISCH_TAC
  >> Know ‘!i. i < k ==> ?b. EL (j i) xs = b /\ B i = VAR b’
  >- (rw [Abbr ‘B’, Abbr ‘l’] \\
-     Suff ‘EL (d_max' i) (args' i ++ args2 i ++ MAP VAR xs) = EL (j i) (MAP VAR xs)’
-     >- rw [EL_MAP] \\
+     Suff ‘EL (d_max' i) (args' i ++ args2 i ++ MAP VAR xs) =
+           EL (j i) (MAP VAR xs)’ >- rw [EL_MAP] \\
      SIMP_TAC bool_ss [Abbr ‘j’] \\
      MATCH_MP_TAC EL_APPEND2 \\
     ‘f i < k’ by rw [] \\


### PR DESCRIPTION
Hi,

This PR reworked several proofs in `examples/lambda/barendregt`. These are early proofs which can be proved easiler by later more general lemmas (some of them were left as TODOs), but no statements are changed.

--Chun