### PR TITLE
Implement backward seek for updateCursor, fixes a quadratic behavior in HOLSourceAST.mkFileline

### DIFF
--- a/tools/parsing/HOLSourceAST.sml
+++ b/tools/parsing/HOLSourceAST.sml
@@ -670,8 +670,31 @@ fun updateCursorSimple ({body, evts, file, pos, line, col, idx}: cursor, p) = le
   val (line, col) = firstLine pos
   in {body = body, evts = evts, file = file, pos = p, line = line, col = col, idx = idx} end
 
-fun updateCursor (cur: cursor as {body, evts, pos, ...}, p): cursor =
-  if p < pos then updateCursor (newCursor body evts, p) (* TODO walk backwards *)
+fun updateCursor (cur: cursor as {body, evts, pos, line, col, idx, ...}, p): cursor =
+  if p < pos then
+    (* Backward seek. Falls back to reset only when events (e.g. #line pragmas)
+       were applied in (p, pos] and would need to be undone. *)
+    let val eventsCrossed =
+          idx > 0 andalso
+          eventPos (DArray.sub (#evts evts, idx - 1)) > p
+    in if eventsCrossed then updateCursor (newCursor body evts, p)
+       else if p >= pos - col then
+         (* p is on the same line as pos: pos - col is the line start *)
+         {body = body, evts = evts, file = #file cur,
+          pos = p, line = line, col = col - (pos - p), idx = idx}
+       else
+         (* p is on an earlier line: one backward scan finds both the newline
+            count (for line) and the line start (for col) *)
+         let fun scan i nls =
+               if i < 0 then (nls, 0)
+               else if DString.sub (body, i) = #"\n" then
+                 if i >= p then scan (i-1) (nls+1) else (nls, i+1)
+               else scan (i-1) nls
+             val (nls, lineStart) = scan (pos-1) 0
+         in {body = body, evts = evts, file = #file cur,
+             pos = p, line = line - nls, col = p - lineStart, idx = idx}
+         end
+    end
   else let
     fun readEvts (cur as {evts, idx, ...}) =
       case SOME (DArray.sub (#evts evts, idx)) handle Subscript => NONE of


### PR DESCRIPTION
  ## Problem                                                                          
                                                                                      
  `bin/Holmake` hangs when processing large machine-generated HOL scripts             
  such as `armv86aScript.sml` (480K lines, 8117 definitions). The full HOL            
  source translator (`HOLSource.fileToReader`) is used by `holdeptool` to
  scan dependency information, and its runtime was O(N²) in the number of             
  definitions.                                                                        
                                                                                      
  ## Root cause                                                                       
                                                                                      
  `HOLSourceAST.updateCursor` always reset to byte position 0 on any                  
  backward seek:                                                                      
                                                            
      if p < pos then updateCursor (newCursor body evts, p) (* TODO walk backwards *) 
                                          
  Backward seeks arise because `expandDec` and `printDecs` share a single             
  `fileline` cursor but visit positions in opposite order within each                 
  declaration. For `val _ = Define \`...\``:  
                                                                                      
  1. `expandDec` calls `fileline` at the quote content position (just after
     the opening backtick)                                                            
  2. `printDecs` then calls `fileline` at the `val` keyword position (a few           
     bytes earlier)                                                                   
                                                                                      
  The backward seek is only ~20 bytes, but the old code reset to 0 and                
  rescanned from the start of the file each time. For definition K at byte            
  position B_K this cost O(B_K), giving O(N²) total.
                                                                                      
  ## Fix                                                    
                                                                                      
  Teach `updateCursor` to walk backwards directly. There are now three cases:
                                                                                      
  - **Same line** (`p >= pos - col`): `pos - col` is the line start, so
    `col` adjusts by `col - (pos - p)` in O(1) with no scan. This covers              
    the common case.                          
  - **Earlier line**: a single backward scan from `pos-1` counts newlines             
    in `[p, pos)` and stops at the first newline before `p`, giving both
    the line delta and new line start in one pass.                                    
  - **Events crossed** (e.g. `#line` pragmas applied in `(p, pos]`): fall
    back to reset, as before.                                                         
                                                            
  Total work across all definitions is O(N).   

Diagnosis by Claude here: [#❄️ HOL4 > Candidate SHAs for HOL4 master @ 💬](https://hol.zulipchat.com/#narrow/channel/486798-.E2.9D.84.EF.B8.8F-HOL4/topic/Candidate.20SHAs.20for.20HOL4.20master/near/585646485)