### PR TITLE
The "nominal_datatype" API (preliminary work)

### DIFF
--- a/examples/CCS/CCSScript.sml
+++ b/examples/CCS/CCSScript.sml
@@ -7,6 +7,7 @@
 (*                 2018-2019 Fondazione Bruno Kessler, Italy (Chun Tian)      *)
 (*                 2023-2024 The Australian National University (Chun Tian)   *)
 (******************************************************************************)
+
 Theory CCS
 Ancestors
   pred_set relation option list rich_list finite_map
@@ -14,8 +15,6 @@ Ancestors
   term[qualified]  (* for SUB's syntax only *)
 Libs
   pred_setLib CCSLib binderLib nomdatatype
-
-
 
 val set_ss = std_ss ++ PRED_SET_ss;
 
@@ -303,63 +302,40 @@ End
 (* !labl labl'.
      (RELAB labl = RELAB labl') <=> (Apply_Relab labl = Apply_Relab labl')
  *)
-val APPLY_RELAB_THM = save_thm (
-   "APPLY_RELAB_THM",
+Theorem APPLY_RELAB_THM =
     Q.GENL [`labl`, `labl'`]
       (REWRITE_RULE [GSYM RELAB_def]
         (MATCH_MP (MATCH_MP ABS_Relabeling_one_one
                             (Q.SPEC `labl` IS_RELABELING))
-                  (Q.SPEC `labl` IS_RELABELING))));
+                  (Q.SPEC `labl` IS_RELABELING)))
 
 (******************************************************************************)
 (*             Syntax of pure CCS (general formalization)                     *)
 (******************************************************************************)
 
-(* The nominal datatype with alpha conversion on recursion variables
-Nominal_datatype :
-          CCS = nil
-              | var name
+(* The nominal datatype with alpha conversion on recursion variables *)
+
+val _ = (repcode := "crep");
+val _ = (rprefix := "c");
+
+val {tynames, rep_t, lp} =
+    nominal_datatype
+         ‘CCS = var 'free
               | prefix ('a Action) CCS
               | sum CCS CCS
               | par CCS CCS
               | restr ('a Label set) CCS
               | relab CCS ('a Relabeling)
-              | rec ''name CCS
-End
- *)
+              | rec 'bound CCS’;
 
 (* The new way based on "examples/lambda/basics/generic_termsTheory
 
    NOTE: it defines “:'a CCS” where 'a is 'b of the old “:('a,'b) CCS”.
  *)
-val tyname = "CCS";
+val tyname = hd tynames; (* "CCS" *)
 
-Datatype:
-  crep = cvar
-       | cpfx ('a Action) | csum | cpar
-       | crestr ('a Label set)
-       | crelab ('a Relabeling)
-       | crec
-End
-
-val rep_t = “:'a crep”
+(* val rep_t = “:'a crep” *)
 val d_tm = mk_var("d", rep_t);
-
-(* NOTE: ‘nil’ is now defined by ‘rec "s" (var "s")’, no more primitive.
- *)
-val lp =
-  “(\n lfvs ^d_tm tns uns.
-     n = 0 /\ lfvs = 1 /\ d = cvar /\ tns = [] /\ uns = [] \/     (* 0. var *)
-     (?a. n = 0 /\ lfvs = 0 ∧ d = cpfx a /\ tns = [] ∧
-          uns = [0]) \/                                           (* 1. prefix *)
-     n = 0 /\ lfvs = 0 ∧ d = csum /\ tns = [] /\ uns = [0;0] \/   (* 2. sum *)
-     n = 0 /\ lfvs = 0 ∧ d = cpar /\ tns = [] /\ uns = [0;0] \/   (* 3. par *)
-     (?ls. n = 0 /\ lfvs = 0 ∧ d = crestr ls /\ tns = [] /\
-           uns = [0]) \/                                          (* 4. restr *)
-     (?rl. n = 0 /\ lfvs = 0 ∧ d = crelab rl /\ tns = [] /\
-           uns = [0]) \/                                          (* 5. relab *)
-     n = 0 /\ lfvs = 0 ∧ d = crec /\ tns = [0] /\ uns = []        (* 6. rec *)
-    )”;
 
 Overload LP = “lp”
 
@@ -391,7 +367,7 @@ val var_def' = prove(
 
 (* prefix *)
 val prefix_t = mk_var("prefix", “:'a Action -> ^newty -> ^newty”);
-val prefix_pattern = “GLAM uu [] (cpfx u) [] [^term_REP_t E]”
+val prefix_pattern = “GLAM uu [] (cprefix u) [] [^term_REP_t E]”
 val prefix_def = new_definition(
    "prefix_def",
   “^prefix_t u E = ^term_ABS_t ^(toArb prefix_pattern)”);
@@ -764,7 +740,7 @@ val tlf =
      (ts1:^repty' list) (ts2:^repty' list) (p :'q).
       case ^u_tm of
       | cvar => tvf (HD fvs) p : 'r
-      | cpfx a => tff (HD ds2) a (^term_ABS_t (HD ts2)) p :'r
+      | cprefix a => tff (HD ds2) a (^term_ABS_t (HD ts2)) p :'r
       | csum => tsf (HD ds2) (HD (TL ds2))
                     (^term_ABS_t (HD ts2)) (^term_ABS_t (HD (TL ts2))) p :'r
       | cpar => tpf (HD ds2) (HD (TL ds2))

--- a/examples/formal-languages/pi-calculus/pi_agentScript.sml
+++ b/examples/formal-languages/pi-calculus/pi_agentScript.sml
@@ -4,6 +4,7 @@
 (*                                                                            *)
 (* Copyright 2025  Michael Norrish and Chun Tian                              *)
 (* ========================================================================== *)
+
 Theory pi_agent
 Ancestors
   pair pred_set list basic_swap generic_terms nomset
@@ -11,62 +12,36 @@ Ancestors
 Libs
   listLib hurdUtils binderLib nomdatatype
 
-
 (* ----------------------------------------------------------------------
    Pi-calculus as a nominal datatype in HOL4
-
-   HOL4 syntax ('free and 'bound are special type variables (alias of string)
-
-   Nominal_datatype :
-
-           pi   = Nil                      (* 0 *)
-                | Tau pi                   (* tau.P *)
-                | Input 'free 'bound pi    (* a(x).P *)
-                | Output 'free 'free pi    (* {a}b.P *)
-                | Match 'free 'free pi     (* [a == b] P *)
-                | Mismatch 'free 'free pi  (* [a <> b] P *)
-                | Sum pi pi                (* P + Q *)
-                | Par pi pi                (* P | Q *)
-                | Res 'bound pi            (* nu x. P *)
-
-       residual = TauR pi
-                | InputS 'free 'bound pi      (* Input *)
-                | BoundOutput 'free 'bound pi (* Bound output *)
-                | FreeOutput 'free 'free pi   (* Free output *)
-   End
 
    NOTE: Replication ("!") is not needed so far, but can be supported later.
    ---------------------------------------------------------------------- *)
 
-Datatype:
-  repcode = rNil | rTau | rInput | rOutput | rMatch | rMismatch | rSum
-          | rPar | rRes
-          | rTauR | rInputS | rBoundOutput | rFreeOutput
-End
+(* calling nominal_datatype *)
+val _ = (repcode := "repcode");
 
-val tyname1 = "pi";
-val tyname2 = "residual";
+val {tynames, rep_t, lp} =
+    nominal_datatype
+          ‘pi   = Nil                         (* 0 *)
+                | Tau pi                      (* tau.P *)
+                | Input 'free 'bound pi       (* a(x).P *)
+                | Output 'free 'free pi       (* {a}b.P *)
+                | Match 'free 'free pi        (* [a == b] P *)
+                | Mismatch 'free 'free pi     (* [a <> b] P *)
+                | Sum pi pi                   (* P + Q *)
+                | Par pi pi                   (* P | Q *)
+                | Res 'bound pi               (* nu x. P *)
+                ;
+       residual = TauR pi                     (* tau.P *)
+                | InputS 'free 'bound pi      (* a(x).P *)
+                | BoundOutput 'free 'bound pi (* a{x}.P *)
+                | FreeOutput 'free 'free pi   (* {a}b.P *)’;
 
-(* type 0 = name; 1 = pi; 2 = residual *)
-val rep_t = “:repcode”
+val tyname1 = List.nth (tynames,0);
+val tyname2 = List.nth (tynames,1);
+
 val d_tm = mk_var("d", rep_t);
-val lp =
-  “(\n lfvs d tns uns.
-     n = 1 /\ lfvs = 0 /\ d = rNil ∧ tns = [] ∧ uns = [] \/
-     n = 1 /\ lfvs = 0 /\ d = rTau ∧ tns = [] /\ uns = [1] \/
-     n = 1 /\ lfvs = 1 /\ d = rInput ∧ tns = [1] /\ uns = [] \/
-     n = 1 /\ lfvs = 2 /\ d = rOutput ∧ tns = [] /\ uns = [1] \/
-     n = 1 /\ lfvs = 2 /\ d = rMatch ∧ tns = [] /\ uns = [1] \/
-     n = 1 /\ lfvs = 2 /\ d = rMismatch ∧ tns = [] /\ uns = [1] \/
-     n = 1 /\ lfvs = 0 /\ d = rSum ∧ tns = [] /\ uns = [1; 1] \/
-     n = 1 /\ lfvs = 0 /\ d = rPar ∧ tns = [] /\ uns = [1; 1] \/
-     n = 1 /\ lfvs = 0 /\ d = rRes ∧ tns = [1] /\ uns = [] \/
-
-     n = 2 /\ lfvs = 0 /\ d = rTauR ∧ tns = [] ∧ uns = [1] \/
-     n = 2 /\ lfvs = 1 /\ d = rInputS ∧ tns = [1] /\ uns = [] \/
-     n = 2 /\ lfvs = 1 /\ d = rBoundOutput ∧ tns = [1] /\ uns = [] \/
-     n = 2 /\ lfvs = 2 /\ d = rFreeOutput ∧ tns = [] /\ uns = [1]
-    )”;
 
 (* This is often useful for debugging purposes *)
 Overload LP = lp;
@@ -81,7 +56,7 @@ val {term_ABS_pseudo11 = term_ABS_pseudo11_1,
      repabs_pseudo_id = repabs_pseudo_id1,
      term_REP_t = term_REP_t1,
      term_ABS_t = term_ABS_t1,
-     newty = newty1, ...} = new_type_step1 tyname1 1 [] {lp = lp};
+     newty = newty1, ...} = new_type_step1 tyname1 0 [] {lp = lp};
 
 (* type 2 (:residual) *)
 val {term_ABS_pseudo11 = term_ABS_pseudo11_2,
@@ -94,7 +69,7 @@ val {term_ABS_pseudo11 = term_ABS_pseudo11_2,
      term_REP_t = term_REP_t2,
      term_ABS_t = term_ABS_t2,
      newty = newty2, ...} =
-     new_type_step1 tyname2 2 [genind_exists1] {lp = lp};
+     new_type_step1 tyname2 1 [genind_exists1] {lp = lp};
 
 (* ----------------------------------------------------------------------
     Pi-calculus operators
@@ -571,8 +546,8 @@ val term_ind1 =
         |> Q.INST [‘lp’ |-> ‘^lp’]
         |> SIMP_RULE std_ss [LIST_REL_CONS1, RIGHT_AND_OVER_OR,
                              LEFT_AND_OVER_OR, DISJ_IMP_THM, LIST_REL_NIL]
-        |> Q.SPECL [‘\n t0 x. n = 1 ==> Q t0 x’, ‘fv’]
-        |> UNDISCH |> Q.SPEC ‘1’ |> DISCH_ALL
+        |> Q.SPECL [‘\n t0 x. n = 0 ==> Q t0 x’, ‘fv’]
+        |> UNDISCH |> Q.SPEC ‘0’ |> DISCH_ALL
         |> SIMP_RULE (std_ss ++ DNF_ss)
                      [sumTheory.FORALL_SUM, supp_listpm, LENGTH_NIL,
                       LENGTH1, LENGTH2,
@@ -637,8 +612,8 @@ val term_ind2 =
         |> Q.INST [‘lp’ |-> ‘^lp’]
         |> SIMP_RULE std_ss [LIST_REL_CONS1, RIGHT_AND_OVER_OR,
                              LEFT_AND_OVER_OR, DISJ_IMP_THM, LIST_REL_NIL]
-        |> Q.SPECL [‘\n t0 x. n = 2 ==> Q t0 x’, ‘fv’]
-        |> UNDISCH |> Q.SPEC ‘2’ |> DISCH_ALL
+        |> Q.SPECL [‘\n t0 x. n = 1 ==> Q t0 x’, ‘fv’]
+        |> UNDISCH |> Q.SPEC ‘1’ |> DISCH_ALL
         |> SIMP_RULE (std_ss ++ DNF_ss)
                      [sumTheory.FORALL_SUM, supp_listpm, LENGTH_NIL,
                       LENGTH1, LENGTH2,
@@ -960,10 +935,10 @@ val termP_removal2 =
 
 val termP' = prove(
    “genind ^lp n t <=>
-      ^termP1 t /\ n = 1 \/
-      ^termP2 t /\ n = 2”,
+      ^termP1 t /\ n = 0 \/
+      ^termP2 t /\ n = 1”,
     EQ_TAC >> simp_tac (srw_ss()) [] >> strip_tac >> rw []
- >> qsuff_tac ‘n = 1 \/ n = 2’ >- (strip_tac >> srw_tac [][])
+ >> qsuff_tac ‘n = 0 \/ n = 1’ >- (strip_tac >> srw_tac [][])
  >> pop_assum mp_tac
  >> Q.ISPEC_THEN ‘t’ STRUCT_CASES_TAC gterm_cases
  >> srw_tac [][genind_GLAM_eqn]);
@@ -1063,7 +1038,7 @@ fun case1 (tm_def, repabs, defs) =
             asm_simp_tac bool_ss [GLAM_NIL_ELIM] >> AP_TERM_TAC >>
             SYM_TAC >> MATCH_MP_TAC repabs >>
             simp_tac list_ss [genind_GLAM_eqn,
-                              TypeBase.distinct_of “:repcode”,
+                              TypeBase.distinct_of rep_t,
                               LIST_REL_NIL, LIST_REL_CONS1, PULL_EXISTS,
                               CONS_11, genind_term_REP1, genind_term_REP2]
           val goal =

--- a/examples/lambda/barendregt/labelledTermsScript.sml
+++ b/examples/lambda/barendregt/labelledTermsScript.sml
@@ -4,17 +4,18 @@ Ancestors
 Libs
   BasicProvers boolSimps binderLib nomdatatype
 
-val tyname = "lterm"
+(* calling nominal_datatype *)
+val _ = (repcode := "lrep");
+val _ = (rprefix := "l");
 
+val {tynames, rep_t, lp} =
+    nominal_datatype
+      ‘lterm = VAR 'free
+             | APP lterm lterm
+             | LAM 'bound lterm
+             | LAMi num 'bound lterm lterm’;
 
-Datatype: lrep = lvar | lapp | llam | llmi num
-End
-
-val lp = “λn lfvs (d:lrep) tns uns.
-            n = 0 ∧ lfvs = 1 ∧ d = lvar ∧ tns = [] ∧ uns = [] ∨
-            n = 0 ∧ lfvs = 0 ∧ d = lapp ∧ tns = [] ∧ uns = [0;0] ∨
-            n = 0 ∧ lfvs = 0 ∧ d = llam ∧ tns = [0] ∧ uns = [] ∨
-            ∃m. n = 0 ∧ lfvs = 0 ∧ d = llmi m ∧ tns = [0] ∧ uns = [0]”;
+val tyname = hd tynames; (* "lterm" *)
 
 val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
      termP, absrep_id, repabs_pseudo_id, newty, term_REP_t, term_ABS_t,...} =
@@ -30,7 +31,7 @@ fun defined_const th = th |> concl |> strip_forall |> #2 |> lhs |> repeat rator
 val LAM_t = mk_var("LAM", “:string -> ^newty -> ^newty”)
 val LAM_def = new_definition(
   "LAM_def",
-  “^LAM_t v t = ^term_ABS_t (GLAM v [] llam [^term_REP_t t] [])”);
+  “^LAM_t v t = ^term_ABS_t (GLAM v [] lLAM [^term_REP_t t] [])”);
 val LAM_termP = prove(
   mk_comb(termP, LAM_def |> SPEC_ALL |> concl |> rhs |> rand),
   match_mp_tac glam >> srw_tac [][genind_term_REP])
@@ -41,14 +42,14 @@ val LAMi_t = mk_var("LAMi", “:num -> string -> ^newty -> ^newty -> ^newty”)
 val LAMi_def = new_definition(
   "LAMi_def",
   “^LAMi_t n v t1 t2 =
-      ^term_ABS_t (GLAM v [] (llmi n) [^term_REP_t t1] [^term_REP_t t2])”);
+      ^term_ABS_t (GLAM v [] (lLAMi n) [^term_REP_t t1] [^term_REP_t t2])”);
 val LAMi_termP = prove(
   mk_comb(termP, LAMi_def |> SPEC_ALL |> concl |> rhs |> rand),
   match_mp_tac glam >> srw_tac [][genind_term_REP]);
 val LAMi_t = defined_const LAMi_def
 
 val APP_t = mk_var("APP", “:^newty -> ^newty -> ^newty”)
-val APP_pattern = “GLAM v [] lapp [] [^term_REP_t t1; ^term_REP_t t2]”
+val APP_pattern = “GLAM v [] lAPP [] [^term_REP_t t1; ^term_REP_t t2]”
 val APP_def = new_definition(
   "APP_def",
   “^APP_t t1 t2 =
@@ -62,9 +63,8 @@ val APP_def' = prove(
   “^term_ABS_t ^APP_pattern = ^APP_t t1 t2”,
   srw_tac [][APP_def, GLAM_NIL_EQ, term_ABS_pseudo11, APP_termP]);
 
-
 val VAR_t = mk_var("VAR", “:string -> ^newty”)
-val VAR_pattern = “GLAM u [v] lvar [][]”
+val VAR_pattern = “GLAM u [v] lVAR [][]”
 val VAR_def = new_definition(
   "VAR_def",
   “^VAR_t v = ^term_ABS_t ^(subst [“u:string” |-> “ARB:string”] VAR_pattern)”);
@@ -211,12 +211,12 @@ val tlf =
                (ds1:(ρ -> α) list) (ds2:(ρ -> α) list)
                (ts1:^repty' list) (ts2:^repty' list) (p:ρ).
      case u of
-     | lvar => vr' (HD fvs) p
-     | lapp => ap (HD ds2) (HD (TL ds2))
+     | lVAR => vr' (HD fvs) p
+     | lAPP => ap (HD ds2) (HD (TL ds2))
                   (^term_ABS_t (HD ts2))
                   (^term_ABS_t (HD (TL ts2))) p: α
-     | llam => lm (HD ds1) v (^term_ABS_t (HD ts1)) p: α
-     | llmi m => li (HD ds1) (HD ds2) m v
+     | lLAM => lm (HD ds1) v (^term_ABS_t (HD ts1)) p: α
+     | lLAMi m => li (HD ds1) (HD ds2) m v
                     (^term_ABS_t (HD ts1))
                     (^term_ABS_t (HD ts2)) p”
 
@@ -464,4 +464,3 @@ val nti = NTI {
              (“labelledTerms$LAMi”, 1, ltpm_ALPHAi)]
 }
 val _ = binderLib.export_nomtype (“:lterm”, nti)
-

--- a/examples/lambda/basics/ctermScript.sml
+++ b/examples/lambda/basics/ctermScript.sml
@@ -4,23 +4,20 @@ Ancestors
 Libs
   boolSimps hurdUtils binderLib nomdatatype
 
-val tyname = "cterm"
+(* calling nominal_datatype *)
+val _ = (repcode := "ctrep");
+val _ = (rprefix := "ct");
 
-Datatype: ctrep = ctv | ctap | ctlm | ctc 'a
-End
+val {tynames, rep_t, lp} =
+    nominal_datatype
+      ‘cterm = VAR 'free | APP cterm cterm | LAM 'bound cterm | CONST 'a’;
+
+val tyname = hd tynames; (* "cterm" *)
 
 Definition is_ctc_def[simp]:
-  is_ctc (ctc _) = T ∧
+  is_ctc (ctCONST _) = T ∧
   is_ctc _ = F
 End
-
-(* GLAM corresponds to APP, LAM and CONST *)
-val lp =
-  “(λn lfvs (d:'a ctrep) tns uns.
-      n = 0 ∧ lfvs = 1 ∧ d = ctv ∧ tns = [] ∧ uns = [] ∨
-      n = 0 ∧ lfvs = 0 ∧ d = ctap ∧ tns = [] ∧ uns = [0;0] ∨
-      n = 0 ∧ lfvs = 0 ∧ d = ctlm ∧ tns = [0] ∧ uns = [] ∨
-      n = 0 ∧ lfvs = 0 ∧ is_ctc d ∧ tns = [] ∧ uns = [])”
 
 val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
      termP, absrep_id, repabs_pseudo_id, term_REP_t, term_ABS_t, newty, ...} =
@@ -31,7 +28,7 @@ val glam = genind_lam
 val LAM_t = mk_var("LAM", ``:string -> ^newty -> ^newty``)
 val LAM_def = new_definition(
   "LAM_def",
-  ``^LAM_t v t = ^term_ABS_t (GLAM v [] ctlm [^term_REP_t t] [])``)
+  ``^LAM_t v t = ^term_ABS_t (GLAM v [] ctLAM [^term_REP_t t] [])``)
 val LAM_termP = prove(
   mk_comb(termP, LAM_def |> SPEC_ALL |> concl |> rhs |> rand),
   match_mp_tac glam >> srw_tac [][genind_term_REP]);
@@ -41,29 +38,29 @@ val APP_t = mk_var("APP", ``:^newty -> ^newty -> ^newty``)
 val APP_def = new_definition(
   "APP_def",
   ``^APP_t t1 t2 =
-       ^term_ABS_t (GLAM ARB [] ctap [] [^term_REP_t t1; ^term_REP_t t2])``);
+       ^term_ABS_t (GLAM ARB [] ctAPP [] [^term_REP_t t1; ^term_REP_t t2])``);
 val APP_termP = prove(
-  ``^termP (GLAM x [] ctap [] [^term_REP_t t1; ^term_REP_t t2])``,
+  ``^termP (GLAM x [] ctAPP [] [^term_REP_t t1; ^term_REP_t t2])``,
   match_mp_tac glam >> srw_tac [][genind_term_REP])
 val APP_t = defined_const APP_def
 
 val APP_def' = prove(
-  ``^term_ABS_t (GLAM v [] ctap [] [^term_REP_t t1; ^term_REP_t t2]) =
+  ``^term_ABS_t (GLAM v [] ctAPP [] [^term_REP_t t1; ^term_REP_t t2]) =
     ^APP_t t1 t2``,
   srw_tac [][APP_def, GLAM_NIL_EQ, term_ABS_pseudo11, APP_termP]);
 
 val VAR_t = mk_var("VAR", ``:string -> ^newty``)
 val VAR_def = new_definition(
   "VAR_def",
-  ``^VAR_t s = ^term_ABS_t (GLAM ARB [s] ctv [][])``);
+  ``^VAR_t s = ^term_ABS_t (GLAM ARB [s] ctVAR [][])``);
 Theorem VAR_termP[local]:
-  ^termP (GLAM u [v] ctv [][])
+  ^termP (GLAM u [v] ctVAR [][])
 Proof
   srw_tac [][genind_rules]
 QED
 val VAR_t = defined_const VAR_def
 Theorem VAR_def':
-  ^term_ABS_t (GLAM u [v] ctv [][]) = VAR v
+  ^term_ABS_t (GLAM u [v] ctVAR [][]) = VAR v
 Proof
   srw_tac[][VAR_def, GLAM_NIL_EQ, term_ABS_pseudo11, VAR_termP]
 QED
@@ -71,14 +68,14 @@ QED
 val CONST_t = mk_var("CONST", “:'a -> ^newty”)
 val CONST_def = new_definition(
   "CONST_def",
-  “^CONST_t a = ^term_ABS_t (GLAM ARB [] (ctc a) [][])”);
+  “^CONST_t a = ^term_ABS_t (GLAM ARB [] (ctCONST a) [][])”);
 val CONST_termP = prove(
-  “^termP (GLAM v [] (ctc a) [][])”,
+  “^termP (GLAM v [] (ctCONST a) [][])”,
   srw_tac[][genind_rules]);
 val CONST_t = defined_const CONST_def
 
 val CONST_def' = prove(
-  “^term_ABS_t (GLAM v [] (ctc a) [] []) = ^CONST_t a”,
+  “^term_ABS_t (GLAM v [] (ctCONST a) [] []) = ^CONST_t a”,
   srw_tac[][CONST_def, GLAM_NIL_EQ, term_ABS_pseudo11, CONST_termP]);
 
 val cons_info =
@@ -160,14 +157,14 @@ val LIST_REL_CONS1 = listTheory.LIST_REL_CONS1
 val LIST_REL_NIL = listTheory.LIST_REL_NIL
 
 Theorem is_ctc_exists[local]:
-  is_ctc bv ⇔ ∃a. bv = ctc a
+  is_ctc bv ⇔ ∃a. bv = ctCONST a
 Proof
   Cases_on ‘bv’ >> simp[]
 QED
 
 Theorem cterm_bvc_induction =
     bvc_genind
-        |> INST_TYPE [alpha |-> ``:'a ctrep``]
+        |> INST_TYPE [alpha |-> rep_t]
         |> Q.INST [`lp` |-> `^lp`]
         |> SIMP_RULE std_ss [LIST_REL_CONS1, RIGHT_AND_OVER_OR,
                              LEFT_AND_OVER_OR, DISJ_IMP_THM, LIST_REL_NIL]
@@ -210,11 +207,11 @@ val tlf =
      (ds1:(ρ -> 'r) list) (ds2:(ρ -> 'r)  list)
      (ts1:^repty' list) (ts2:^repty' list) (p:ρ).
      case u of
-     | ctv => (tvf (HD fvs) p : 'r)
-     | ctap => taf (HD ds2) (HD (TL ds2)) (cterm_ABS (HD ts2))
+     | ctVAR => (tvf (HD fvs) p : 'r)
+     | ctAPP => taf (HD ds2) (HD (TL ds2)) (cterm_ABS (HD ts2))
                    (cterm_ABS (HD (TL ts2))) p
-     | ctlm => tlf (HD ds1) v (cterm_ABS (HD ts1)) p
-     | ctc a => tcf a p``
+     | ctLAM => tlf (HD ds1) v (cterm_ABS (HD ts1)) p
+     | ctCONST a => tcf a p``
 
 val termP_elim = prove(
   ``(∀g. ^termP g ⇒ P g) ⇔ (∀t. P (^term_REP_t t))``,
@@ -238,7 +235,7 @@ val termP0 = prove(
 
 Theorem parameter_tm_recursion =
   parameter_gtm_recursion
-      |> INST_TYPE [alpha |-> ``:'a ctrep``, gamma |-> “:'r”]
+      |> INST_TYPE [alpha |-> rep_t, gamma |-> “:'r”]
       |> Q.INST [`lf` |-> `^tlf`, `lp` |-> `^lp`, `n` |-> `0`]
       |> SIMP_RULE (srw_ss()) [sumTheory.FORALL_SUM, FORALL_AND_THM,
                                GSYM RIGHT_FORALL_IMP_THM, IMP_CONJ_THM,
@@ -1039,4 +1036,3 @@ val term_info =
        binders = [(``cterm$LAM``, 0, ctpm_ALPHA)]}
 
 val _ = binderLib.export_nomtype (“:α cterm”, term_info)
-

--- a/examples/lambda/basics/nomdatatype.sig
+++ b/examples/lambda/basics/nomdatatype.sig
@@ -47,4 +47,13 @@ sig
                            thm -> thm
   val defined_const : thm -> term
 
+  val free_tyname  : string ref
+  val bound_tyname : string ref
+  val repcode      : string ref
+  val rprefix      : string ref
+  val nominal_datatype : hol_type quotation ->
+                        {tynames : string list,
+                         rep_t   : hol_type,
+                         lp      : term}
+
 end

--- a/examples/lambda/basics/nomdatatype.sml
+++ b/examples/lambda/basics/nomdatatype.sml
@@ -626,7 +626,7 @@ val lp = “λn lfvs (d:lrep) tns uns.
   n is the index of (multiple) nominal types being defined
   lfvs is the number of 'free names in the constructor
   d is the repcode of the constructor
-  tns is the list of indexes of bounded arguments (at most one is allowed)
+  tns is the list of indexes of bounded arguments
   uns is the list of indexes of unbounded (free) arguments.
 *)
 
@@ -655,9 +655,17 @@ fun pretypeToName pty =
       | dTyop {Tyop = s, Thy, Args} => s
       | dAQ pty => type_to_string pty;
 
-(* NOTE: Currently the “tns” list is either empty or singleton list containing
-   the index of a normal type being defined. We check the presence of 'bound
-   and get the index of the followed nominal type.
+(* filter_this_next 2 [1,2,3,2,5] [] = [3,5] *)
+fun filter_this_next e l acc =
+    if l = [] then rev acc
+    else
+        if hd l = e then
+            filter_this_next e (tl (tl l)) (hd (tl l)::acc)
+        else
+            filter_this_next e (tl l) acc;
+
+(* NOTE: We assume there's always one bound nominal parameter after each 'bound
+   name. In the existing examples, at most one 'bound is present.
 
    val ptys = [dVartype "'free", dVartype "'bound",
                dTyop {Args = [], Thy = NONE, Tyop = "pi"}]
@@ -665,15 +673,10 @@ fun pretypeToName pty =
  *)
 fun build_tns ptys tynames = let
     val dv = dVartype (!bound_tyname);
-    val bound_names = List.filter (fn e => e = dv) ptys
+    val bound_args = filter_this_next dv ptys [];
+    val indexes = map (fn e => index_of (pretypeToName e) tynames) bound_args
 in
-    if bound_names = [] then
-        “tns = [] :num list”
-    else
-        let val i_tm = index_of (pretypeToName (find_next dv ptys)) tynames
-        in
-            mk_eq (“tns :num list”, mk_list ([i_tm], numSyntax.num))
-        end
+    mk_eq (“tns :num list”, mk_list (indexes, numSyntax.num)
 end;
 
 fun pretypeIsNominal pty =
@@ -682,20 +685,20 @@ fun pretypeIsNominal pty =
       | dTyop {Tyop, Thy = thy, Args} => (thy = NONE)
       | dAQ pty => false;
 
-(* filter_out2 2 [1,2,3,4,5] [] = [1,4,5] *)
-fun filter_out2 e l acc =
+(* filter_out_this_next 2 [1,2,3,4,5] [] = [1,4,5] *)
+fun filter_out_this_next e l acc =
     if l = [] then rev acc
     else
         if hd l = e then
-            filter_out2 e (tl (tl l)) acc
+            filter_out_this_next e (tl (tl l)) acc
         else
-            filter_out2 e (tl l) (hd l::acc);
+            filter_out_this_next e (tl l) (hd l::acc);
 
 (* The “uns” list contains indexes of all nominal types, excluding the one
    after 'bound (which is put into the “tns” list).
  *)
 fun build_uns ptys tynames = let
-    val l1 = filter_out2 (dVartype (!bound_tyname)) ptys [];
+    val l1 = filter_out_this_next (dVartype (!bound_tyname)) ptys [];
     val l2 = List.filter pretypeIsNominal l1;
     val uns = List.map (fn e => index_of (pretypeToName e) tynames) l2
 in
@@ -772,6 +775,7 @@ end;
 
 (* Step 1: parse datatype quotation
    Step 2: define repcode (intermediate datatype)
+   Step 3: generate lp term
  *)
 fun nominal_datatype q = let
   val asts = parse_datatype q;

--- a/examples/lambda/basics/nomdatatype.sml
+++ b/examples/lambda/basics/nomdatatype.sml
@@ -3,6 +3,7 @@
 (* TITLE   : Nominal datatype package                                         *)
 (*                                                                            *)
 (* AUTHORS : 2005-2011 Michael Norrish                                        *)
+(*           2026      Chun Tian                                              *)
 (* ========================================================================== *)
 
 structure nomdatatype :> nomdatatype =
@@ -336,5 +337,451 @@ in
   {term_REP_tpm = term_REP_tpm, tpm_thm = tpm_thm, t_pmact_t = t_pmact_t,
    tpm_t = tpm_t}
 end
+
+(* ----------------------------------------------------------------------
+    The "Nominal_datatype" API
+   ---------------------------------------------------------------------- *)
+
+open ParseDatatype numSyntax listSyntax;
+
+(*
+val q = ‘term = VAR 'free | APP term term | LAM 'bound term’;
+val asts = ParseDatatype.hparse (type_grammar()) q;
+   [("term",
+     Constructors
+      [("VAR", [dVartype "'free"]),
+       ("APP",
+        [dTyop {Args = [], Thy = NONE, Tyop = "term"},
+         dTyop {Args = [], Thy = NONE, Tyop = "term"}]),
+       ("LAM",
+        [dVartype "'bound", dTyop {Args = [], Thy = NONE, Tyop = "term"}])])]
+
+val q = ‘cterm = VAR 'free | APP cterm cterm | LAM 'bound cterm | CONST 'a’;
+val asts = ParseDatatype.hparse (type_grammar()) q;
+   [("cterm",
+     Constructors
+      [("VAR", [dVartype "'free"]),
+       ("APP",
+        [dTyop {Args = [], Thy = SOME "term", Tyop = "term"},
+         dTyop {Args = [], Thy = SOME "term", Tyop = "term"}]),
+       ("LAM",
+        [dVartype "'bound",
+         dTyop {Args = [], Thy = SOME "term", Tyop = "term"}]),
+       ("CONST", [dVartype "'a"])])]
+
+val q = ‘lterm = VAR 'free
+               | APP lterm lterm
+               | LAM 'bound lterm
+               | LAMi num 'bound lterm lterm’;
+val asts = ParseDatatype.hparse (type_grammar()) q;
+   [("lterm",
+     Constructors
+      [("VAR", [dVartype "'free"]),
+       ("APP",
+        [dTyop {Args = [], Thy = NONE, Tyop = "lterm"},
+         dTyop {Args = [], Thy = NONE, Tyop = "lterm"}]),
+       ("LAM",
+        [dVartype "'bound", dTyop {Args = [], Thy = NONE, Tyop = "lterm"}]),
+       ("LAMi",
+        [dTyop {Args = [], Thy = SOME "num", Tyop = "num"},
+         dVartype "'bound", dTyop {Args = [], Thy = NONE, Tyop = "lterm"},
+         dTyop {Args = [], Thy = NONE, Tyop = "lterm"}])])]
+
+val q =  ‘CCS = var 'free
+              | prefix ('a Action) CCS
+              | sum CCS CCS
+              | par CCS CCS
+              | restr ('a Label set) CCS
+              | relab CCS ('a Relabeling)
+              | rec 'bound CCS’;
+val asts = ParseDatatype.hparse (type_grammar()) q;
+   [("CCS",
+     Constructors
+      [("var", [dVartype "'free"]),
+       ("prefix",
+        [dTyop {Args = [dVartype "'a"], Thy = NONE, Tyop = "Action"},
+         dTyop {Args = [], Thy = NONE, Tyop = "CCS"}]),
+       ("sum",
+        [dTyop {Args = [], Thy = NONE, Tyop = "CCS"},
+         dTyop {Args = [], Thy = NONE, Tyop = "CCS"}]),
+       ("par",
+        [dTyop {Args = [], Thy = NONE, Tyop = "CCS"},
+         dTyop {Args = [], Thy = NONE, Tyop = "CCS"}]),
+       ("restr",
+        [dTyop
+          {Args =
+           [dTyop {Args = [dVartype "'a"], Thy = NONE, Tyop = "Label"},
+            dTyop {Args = [], Thy = SOME "min", Tyop = "bool"}], Thy =
+           SOME "min", Tyop = "fun"},
+         dTyop {Args = [], Thy = NONE, Tyop = "CCS"}]),
+       ("relab",
+        [dTyop {Args = [], Thy = NONE, Tyop = "CCS"},
+         dTyop {Args = [dVartype "'a"], Thy = NONE, Tyop = "Relabeling"}]),
+       ("rec",
+        [dVartype "'bound", dTyop {Args = [], Thy = NONE, Tyop = "CCS"}])])]
+
+  val q = ‘pi   = Nil                         (* 0 *)
+                | Tau pi                      (* tau.P *)
+                | Input 'free 'bound pi       (* a(x).P *)
+                | Output 'free 'free pi       (* {a}b.P *)
+                | Match 'free 'free pi        (* [a == b] P *)
+                | Mismatch 'free 'free pi     (* [a <> b] P *)
+                | Sum pi pi                   (* P + Q *)
+                | Par pi pi                   (* P | Q *)
+                | Res 'bound pi               (* nu x. P *)
+                ;
+       residual = TauR pi
+                | InputS 'free 'bound pi      (* Input *)
+                | BoundOutput 'free 'bound pi (* Bound output *)
+                | FreeOutput 'free 'free pi   (* Free output *)’;
+  val asts = ParseDatatype.hparse (type_grammar()) q;
+   [("pi",
+     Constructors
+      [("Nil", []), ("Tau", [dTyop {Args = [], Thy = NONE, Tyop = "pi"}]),
+       ("Input",
+        [dVartype "'free", dVartype "'bound",
+         dTyop {Args = [], Thy = NONE, Tyop = "pi"}]),
+       ("Output",
+        [dVartype "'free", dVartype "'free",
+         dTyop {Args = [], Thy = NONE, Tyop = "pi"}]),
+       ("Match",
+        [dVartype "'free", dVartype "'free",
+         dTyop {Args = [], Thy = NONE, Tyop = "pi"}]),
+       ("Mismatch",
+        [dVartype "'free", dVartype "'free",
+         dTyop {Args = [], Thy = NONE, Tyop = "pi"}]),
+       ("Sum",
+        [dTyop {Args = [], Thy = NONE, Tyop = "pi"},
+         dTyop {Args = [], Thy = NONE, Tyop = "pi"}]),
+       ("Par",
+        [dTyop {Args = [], Thy = NONE, Tyop = "pi"},
+         dTyop {Args = [], Thy = NONE, Tyop = "pi"}]),
+       ("Res",
+        [dVartype "'bound", dTyop {Args = [], Thy = NONE, Tyop = "pi"}])]),
+    ("residual",
+     Constructors
+      [("TauR", [dTyop {Args = [], Thy = NONE, Tyop = "pi"}]),
+       ("InputS",
+        [dVartype "'free", dVartype "'bound",
+         dTyop {Args = [], Thy = NONE, Tyop = "pi"}]),
+       ("BoundOutput",
+        [dVartype "'free", dVartype "'bound",
+         dTyop {Args = [], Thy = NONE, Tyop = "pi"}]),
+       ("FreeOutput",
+        [dVartype "'free", dVartype "'free",
+         dTyop {Args = [], Thy = NONE, Tyop = "pi"}])])]
+ *)
+
+fun parse_datatype q = hparse (type_grammar()) q;
+
+(* ["pi", "residual"] *)
+fun extract_tynames (asts :AST list) = List.map fst asts;
+
+(* ["Nil", "Tau", "Input", "Output", "Match", "Mismatch", "Sum", "Par",
+    "Res", "TauR", "InputS", "BoundOutput", "FreeOutput"] *)
+fun constructor_and_types (asts :AST list) =
+    List.concat (List.map (fn (_,df) =>
+                              case df of
+                                  Constructors cs => cs
+                                | Record _ => []) asts);
+
+fun constructors (asts :AST list) = List.map fst (constructor_and_types asts);
+
+(* The special type variables 'free and 'bound (by default) are free and bound
+   names occurred in the nominal types being defined.
+
+   NOTE: Due to Datatype syntax restriction, each constructor supports at most
+   one bound name argument, and if it has two (or more) recursive term arguments,
+   only one (the first) is considered bounded. For instance, in labelled lambda
+   terms (lterm), we have the constructor ‘LAMi num 'bound lterm lterm’, which
+   actually means an application ‘(LAMi num 'bound lterm) @@ lterm’, where the
+   first lterm is bounded (by the name in the position of 'bound), while the
+   second lterm is not bounded by that name.
+ *)
+val free_tyname  = ref "'free";
+val bound_tyname = ref "'bound";
+
+(* This variant of pretypeToType returns only external types *)
+fun pretypeToType1 pty =
+  case pty of
+    dVartype s => if s = !free_tyname orelse s = !bound_tyname then
+                      NONE
+                  else
+                      SOME (Type.mk_vartype s)
+  | dTyop {Tyop = s, Thy, Args} => let
+    in
+      case Thy of
+        NONE => NONE (* This is referring to nominal types being defined *)
+      | SOME t => SOME (Type.mk_thy_type{Tyop = s, Thy = t,
+                                         Args = map pretypeToType Args})
+    end
+  | dAQ pty => SOME pty;
+
+fun constructor_types (asts) =
+    List.concat (List.map snd (constructor_and_types asts));
+
+fun external_types (asts) =
+    List.map Option.valOf
+             (List.filter Option.isSome
+                          (List.map pretypeToType1 (constructor_types asts)));
+
+(* no leading ":" but with parenthesis, e.g. ('a Action) *)
+fun type_to_string1 ty =
+    let val s = type_to_string ty;
+        val n = String.size s;
+    in
+        "(" ^ substring (s,1,n-1) ^ ")"
+    end;
+
+val external_type_vars = type_varsl o external_types;
+
+val repcode = ref "";
+val rprefix = ref "r";
+
+(* e.g., ("cprefix", [``:'a Action``]) *)
+fun repcode_pair (n,df) =
+    (!rprefix ^ n,
+     List.map Option.valOf
+              (List.filter Option.isSome (List.map pretypeToType1 df)));
+
+fun repcode_line (n,types) =
+    [QUOTE n] @ (List.map (QUOTE o type_to_string1) types);
+
+(* This function generates the term quotation and call it by Datatype, e.g.
+Datatype:
+  repcode = rNil | rTau | rInput | rOutput | rMatch | rMismatch | rSum
+          | rPar | rRes | rTauR | rInputS | rBoundOutput | rFreeOutput
+End
+Datatype:
+  crep = cvar
+       | cprefix ('a Action) | csum | cpar
+       | crestr ('a Label set)
+       | crelab ('a Relabeling)
+       | crec
+End
+ *)
+fun define_repcode (asts :AST list) = let
+    val lines = List.map repcode_pair (constructor_and_types asts);
+    val tynames = extract_tynames asts;
+    val repname = if !repcode = "" then (hd tynames) ^ "_repcode"
+                  else !repcode;
+    val dtype0 = [QUOTE repname] @ ‘=’ @ repcode_line (hd lines);
+    val dtype1 = dtype0 @
+                 List.concat (List.map (fn s => ‘|’ @ repcode_line s) (tl lines));
+    val types = external_type_vars asts;
+in
+    (Datatype dtype1; mk_type (repname, types))
+end;
+
+(*
+Example 1 (multiple types; mixed free and bound names in the same constructor):
+
+  val q = ‘pi   = Nil                         (* 0 *)
+                | Tau pi                      (* tau.P *)
+                | Input 'free 'bound pi       (* a(x).P *)
+                | Output 'free 'free pi       (* {a}b.P *)
+                | Match 'free 'free pi        (* [a == b] P *)
+                | Mismatch 'free 'free pi     (* [a <> b] P *)
+                | Sum pi pi                   (* P + Q *)
+                | Par pi pi                   (* P | Q *)
+                | Res 'bound pi               (* nu x. P *)
+                ;
+       residual = TauR pi
+                | InputS 'free 'bound pi      (* Input *)
+                | BoundOutput 'free 'bound pi (* Bound output *)
+                | FreeOutput 'free 'free pi   (* Free output *)’;
+val asts = ParseDatatype.hparse (type_grammar()) q;
+val lp =
+  “(\n lfvs d tns uns.
+     n = 0 /\ lfvs = 0 /\ d = rNil /\ tns = [] /\ uns = [] \/
+     n = 0 /\ lfvs = 0 /\ d = rTau /\ tns = [] /\ uns = [0] \/
+     n = 0 /\ lfvs = 1 /\ d = rInput /\ tns = [0] /\ uns = [] \/
+     n = 0 /\ lfvs = 2 /\ d = rOutput /\ tns = [] /\ uns = [0] \/
+     n = 0 /\ lfvs = 2 /\ d = rMatch /\ tns = [] /\ uns = [0] \/
+     n = 0 /\ lfvs = 2 /\ d = rMismatch /\ tns = [] /\ uns = [0] \/
+     n = 0 /\ lfvs = 0 /\ d = rSum /\ tns = [] /\ uns = [0; 0] \/
+     n = 0 /\ lfvs = 0 /\ d = rPar /\ tns = [] /\ uns = [0; 0] \/
+     n = 0 /\ lfvs = 0 /\ d = rRes /\ tns = [1] /\ uns = [] \/
+
+     n = 1 /\ lfvs = 0 /\ d = rTauR /\ tns = [] /\ uns = [0] \/
+     n = 1 /\ lfvs = 1 /\ d = rInputS /\ tns = [0] /\ uns = [] \/
+     n = 1 /\ lfvs = 1 /\ d = rBoundOutput /\ tns = [0] /\ uns = [] \/
+     n = 1 /\ lfvs = 2 /\ d = rFreeOutput /\ tns = [] /\ uns = [0]
+    )”;
+
+Example 2 (mixed free and bound recursive terms; external data):
+
+val q = ‘lterm = VAR 'free
+               | APP lterm lterm
+               | LAM 'bound lterm
+               | LAMi num 'bound lterm lterm’;
+val asts = ParseDatatype.hparse (type_grammar()) q;
+
+val lp = “λn lfvs (d:lrep) tns uns.
+            n = 0 /\ lfvs = 1 /\ d = lvar /\ tns = [] /\ uns = [] \/
+            n = 0 /\ lfvs = 0 /\ d = lapp /\ tns = [] /\ uns = [0;0] \/
+            n = 0 /\ lfvs = 0 /\ d = llam /\ tns = [0] /\ uns = [] \/
+            ?m. n = 0 /\ lfvs = 0 /\ d = llmi m /\ tns = [0] /\ uns = [0]”;
+
+  n is the index of (multiple) nominal types being defined
+  lfvs is the number of 'free names in the constructor
+  d is the repcode of the constructor
+  tns is the list of indexes of bounded arguments (at most one is allowed)
+  uns is the list of indexes of unbounded (free) arguments.
+*)
+
+(* NOTE: index_of "b" ["a", "b", "c"] = “1 :num” *)
+local
+    open Arbnum
+    fun index_of_inner (n :num) e l =
+        if e = hd l orelse tl l = [] then n
+        else index_of_inner (n + one) e (tl l);
+in
+fun index_of e l = numSyntax.mk_numeral (index_of_inner Arbnum.zero e l)
+end;
+
+fun build_lfvs (ptys) = let
+    val i = List.length (List.filter (fn e => e = dVartype (!free_tyname)) ptys)
+in
+    mk_eq (“lfvs :num”, mk_numeral (Arbnum.fromInt i))
+end;
+
+(* find_prev 2 [1,2,3,4,5] = 3 *)
+fun find_next e l = if hd l = e then hd (tl l) else find_next e (tl l);
+
+fun pretypeToName pty =
+    case pty of
+        dVartype s => s
+      | dTyop {Tyop = s, Thy, Args} => s
+      | dAQ pty => type_to_string pty;
+
+(* NOTE: Currently the “tns” list is either empty or singleton list containing
+   the index of a normal type being defined. We check the presence of 'bound
+   and get the index of the followed nominal type.
+
+   val ptys = [dVartype "'free", dVartype "'bound",
+               dTyop {Args = [], Thy = NONE, Tyop = "pi"}]
+   ==> tns = [0]
+ *)
+fun build_tns ptys tynames = let
+    val dv = dVartype (!bound_tyname);
+    val bound_names = List.filter (fn e => e = dv) ptys
+in
+    if bound_names = [] then
+        “tns = [] :num list”
+    else
+        let val i_tm = index_of (pretypeToName (find_next dv ptys)) tynames
+        in
+            mk_eq (“tns :num list”, mk_list ([i_tm], numSyntax.num))
+        end
+end;
+
+fun pretypeIsNominal pty =
+    case pty of
+        dVartype s => false
+      | dTyop {Tyop, Thy = thy, Args} => (thy = NONE)
+      | dAQ pty => false;
+
+(* filter_out2 2 [1,2,3,4,5] [] = [1,4,5] *)
+fun filter_out2 e l acc =
+    if l = [] then rev acc
+    else
+        if hd l = e then
+            filter_out2 e (tl (tl l)) acc
+        else
+            filter_out2 e (tl l) (hd l::acc);
+
+(* The “uns” list contains indexes of all nominal types, excluding the one
+   after 'bound (which is put into the “tns” list).
+ *)
+fun build_uns ptys tynames = let
+    val l1 = filter_out2 (dVartype (!bound_tyname)) ptys [];
+    val l2 = List.filter pretypeIsNominal l1;
+    val uns = List.map (fn e => index_of (pretypeToName e) tynames) l2
+in
+    mk_eq (“uns :num list”, mk_list (uns, numSyntax.num))
+end;
+
+(* gen_names 3 [] = ["a0", "a1", "a2"] *)
+fun gen_names n acc =
+    if n = 0 then acc
+    else
+        gen_names (n - 1) (("a" ^ Int.toString (n - 1))::acc);
+
+fun build_args ptys = let
+    val tys = List.map Option.valOf
+                       (List.filter Option.isSome (List.map pretypeToType1 ptys));
+    val n = List.length tys; (* could be zero *)
+    val names = gen_names n []
+in
+    List.map mk_var (zip names tys)
+end;
+
+fun build_lp_inner cptys tyname tynames = let
+    val n_tm = index_of tyname tynames
+in
+    List.map (fn (c:string,ptys) =>
+                 (mk_eq (“n :num”, n_tm),
+                  build_lfvs ptys,
+                  c,
+                  build_args ptys,
+                  build_tns ptys tynames,
+                  build_uns ptys tynames)) cptys
+end;
+
+fun build_d_term cname args rep_t = let
+    val rcname = !rprefix ^ cname;
+    val argtypes = List.map type_of args;
+    val c_ty = list_mk_fun (argtypes, rep_t);
+    val c_tm = mk_const (rcname,c_ty);
+    val d_tm = list_mk_comb (c_tm, args)
+in
+    mk_eq (mk_var("d",rep_t), d_tm)
+end;
+
+(*
+val data =
+   [(``n = 0``, ``lfvs = 1``, "VAR", [], ``tns = []``, ``uns = []``),
+    (``n = 0``, ``lfvs = 0``, "APP", [], ``tns = []``, ``uns = [0; 0]``),
+    (``n = 0``, ``lfvs = 0``, "LAM", [], ``tns = [0]``, ``uns = []``),
+    (``n = 0``, ``lfvs = 0``, "LAMi", [``a0``], ``tns = [0]``, ``uns = [0]``)]:
+   (term * term * string * term list * term * term) list
+*)
+fun build_lp (asts :AST list) rep_t = let
+    val tynames = extract_tynames asts;
+    val data = List.concat (List.map (fn (tyname,df) =>
+                                         case df of
+                                             Constructors cs =>
+                                             build_lp_inner cs tyname tynames
+                                           | Record _ => []) asts);
+    val c_tms = List.map
+                    (fn (n_tm,lfvs_tm,cname,args,tns_tm,uns_tm) =>
+                        list_mk_exists
+                            (args,
+                             list_mk_conj [n_tm, lfvs_tm,
+                                           build_d_term cname args rep_t,
+                                           tns_tm, uns_tm])) data;
+    val n_tm    = “n :num”
+    and lfvs_tm = “lfvs :num”
+    and d_tm    = mk_var ("d", rep_t)
+    and tns_tm  = “tns :num list”
+    and uns_tm  = “uns :num list”
+in
+    list_mk_abs ([n_tm, lfvs_tm, d_tm, tns_tm, uns_tm], list_mk_disj c_tms)
+end;
+
+(* Step 1: parse datatype quotation
+   Step 2: define repcode (intermediate datatype)
+ *)
+fun nominal_datatype q = let
+  val asts = parse_datatype q;
+  val tynames = extract_tynames asts;
+  val rep_t = define_repcode asts;
+  val lp_tm = build_lp asts rep_t
+in
+    {tynames = tynames,
+     rep_t = rep_t,
+     lp = lp_tm}
+end;
 
 end (* struct *)

--- a/examples/lambda/basics/termScript.sml
+++ b/examples/lambda/basics/termScript.sml
@@ -5,6 +5,7 @@
 (* AUTHORS : 2005-2011 Michael Norrish                                        *)
 (*         : 2023-2024 Michael Norrish and Chun Tian                          *)
 (* ========================================================================== *)
+
 Theory term
 Ancestors
   arithmetic pred_set list finite_map relation pair rich_list
@@ -12,16 +13,13 @@ Ancestors
 Libs
   boolSimps hurdUtils binderLib nomdatatype
 
-
 val _ = set_fixity "=" (Infix(NONASSOC, 450))
 
-val tyname = "term"
+(* calling nominal_datatype *)
+val {tynames, rep_t, lp} =
+    nominal_datatype ‘term = VAR 'free | APP term term | LAM 'bound term’;
 
-(* d ≈ var + app + lam *)
-val lp = “(λn lfvs (d:unit + unit + unit) tns uns.
-             lfvs = 1 ∧ n = 0 ∧ ISL d ∧ tns = [] ∧ uns = [] ∨
-             lfvs = 0 ∧ n = 0 ∧ ISR d ∧ ISL (OUTR d) ∧ tns = [] ∧ uns = [0;0] ∨
-             lfvs = 0 ∧ n = 0 ∧ ISR d ∧ ISR (OUTR d) ∧ tns = [0] ∧ uns = [])”
+val tyname = hd tynames; (* "term" *)
 
 val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
      termP, absrep_id, repabs_pseudo_id, term_REP_t, term_ABS_t, newty, ...} =
@@ -32,7 +30,7 @@ val glam = genind_lam
 val LAM_t = mk_var("LAM", ``:string -> ^newty -> ^newty``)
 val LAM_def = new_definition(
   "LAM_def",
-  ``^LAM_t v t = ^term_ABS_t (GLAM v [] (INR $ INR ()) [^term_REP_t t] [])``);
+  ``^LAM_t v t = ^term_ABS_t (GLAM v [] rLAM [^term_REP_t t] [])``);
 
 val LAM_termP = prove(
   mk_comb(termP, LAM_def |> SPEC_ALL |> concl |> rhs |> rand),
@@ -43,15 +41,15 @@ val APP_t = mk_var("APP", ``:^newty -> ^newty -> ^newty``)
 val APP_def = new_definition(
   "APP_def",
   ``^APP_t t1 t2 =
-       ^term_ABS_t (GLAM ARB [] (INR $ INL ()) []
+       ^term_ABS_t (GLAM ARB [] rAPP []
                          [^term_REP_t t1; ^term_REP_t t2])``);
 val APP_termP = prove(
-  ``^termP (GLAM x [] (INR $ INL ()) [] [^term_REP_t t1; ^term_REP_t t2])``,
+  ``^termP (GLAM x [] rAPP [] [^term_REP_t t1; ^term_REP_t t2])``,
   match_mp_tac glam >> srw_tac [][genind_term_REP])
 val APP_t = defined_const APP_def
 
 Theorem APP_def':
-  ^term_ABS_t (GLAM v [] (INR $ INL ()) [] [^term_REP_t t1; ^term_REP_t t2]) =
+  ^term_ABS_t (GLAM v [] rAPP [] [^term_REP_t t1; ^term_REP_t t2]) =
   ^APP_t t1 t2
 Proof srw_tac [][APP_def, GLAM_NIL_EQ, term_ABS_pseudo11, APP_termP]
 QED
@@ -59,15 +57,15 @@ QED
 val VAR_t = mk_var("VAR", ``:string -> ^newty``)
 val VAR_def = new_definition(
   "VAR_def",
-  ``^VAR_t s = ^term_ABS_t (GLAM ARB [s] (INL ()) [] [])``);
+  ``^VAR_t s = ^term_ABS_t (GLAM ARB [s] rVAR [] [])``);
 Theorem VAR_termP[local]:
-  ^termP (GLAM u [v] (INL ()) [][])
+  ^termP (GLAM u [v] rVAR [][])
 Proof irule glam >> srw_tac[][genind_term_REP]
 QED
 val VAR_t = defined_const VAR_def
 
 Theorem VAR_def':
-  ^term_ABS_t (GLAM u [v] (INL ()) [] []) = ^VAR_t v
+  ^term_ABS_t (GLAM u [v] rVAR [] []) = ^VAR_t v
 Proof
   srw_tac[][VAR_def, GLAM_NIL_EQ, term_ABS_pseudo11, VAR_termP]
 QED
@@ -161,7 +159,7 @@ val LIST_REL_NIL = listTheory.LIST_REL_NIL
 
 val term_ind =
     bvc_genind
-        |> INST_TYPE [alpha |-> ``:unit+unit+unit``]
+        |> INST_TYPE [alpha |-> rep_t]
         |> Q.INST [`lp` |-> `^lp`]
         |> SIMP_RULE std_ss [LIST_REL_CONS1, RIGHT_AND_OVER_OR,
                              LEFT_AND_OVER_OR, DISJ_IMP_THM, LIST_REL_NIL]
@@ -215,17 +213,17 @@ val LAM_eq_thm = save_thm(
 val (_, repty) = dom_rng (type_of term_REP_t)
 val repty' = ty_antiq repty
 
+val u_tm = mk_var("u", rep_t);
+
 val tlf =
-   “λ(v:string) (fvs : string list) (u:unit + unit + unit)
+   “λ(v:string) (fvs : string list) ^u_tm
      (ds1:(ρ -> α) list) (ds2:(ρ -> α) list)
      (ts1:^repty' list) (ts2:^repty' list) (p :ρ).
-      if ISL u then
-        tvf (HD fvs) p
-      else if ISL (OUTR u) then
-        taf (HD ds2) (HD (TL ds2)) (^term_ABS_t (HD ts2))
-            (^term_ABS_t (HD (TL ts2))) p :α
-      else
-        tlf (HD ds1) v (^term_ABS_t (HD ts1)) p :α”
+     case u of
+       rVAR => tvf (HD fvs) p
+     | rAPP => taf (HD ds2) (HD (TL ds2)) (^term_ABS_t (HD ts2))
+                   (^term_ABS_t (HD (TL ts2))) p :α
+     | rLAM => tlf (HD ds1) v (^term_ABS_t (HD ts1)) p :α”
 
 val termP_elim = prove(
   ``(∀g. ^termP g ⇒ P g) ⇔ (∀t. P (^term_REP_t t))``,
@@ -249,7 +247,7 @@ val termP0 = prove(
 
 Theorem parameter_tm_recursion =
   parameter_gtm_recursion
-      |> INST_TYPE [alpha |-> ``:unit + unit + unit``,
+      |> INST_TYPE [alpha |-> rep_t,
                     gamma |-> alpha]
       |> Q.INST [`lf` |-> `^tlf`, `lp` |-> `^lp`]
       |> SIMP_RULE (srw_ss()) [sumTheory.FORALL_SUM, FORALL_AND_THM,
@@ -259,12 +257,12 @@ Theorem parameter_tm_recursion =
                                GSYM LEFT_FORALL_IMP_THM,
                                LIST_REL_CONS1, LENGTH_EQ_NUM_compute,
                                genind_GLAM_eqn, sidecond_def,
-                               NEWFCB_def, relsupp_def,
+                               NEWFCB_def,
                                LENGTH_NIL_SYM, LENGTH1, LENGTH2]
       |> ONCE_REWRITE_RULE [termP0]
       |> SIMP_RULE (srw_ss() ++ DNF_ss) [LENGTH1, LENGTH2, LENGTH_NIL]
       |> CONV_RULE (DEPTH_CONV termP_removal)
-      |> SIMP_RULE (srw_ss()) [GSYM supp_tpm, SYM term_REP_tpm]
+      |> SIMP_RULE (srw_ss()) [GSYM supp_tpm, SYM term_REP_tpm, relsupp_def]
       |> UNDISCH
       |> rpt_hyp_dest_conj
       |> lift_exfunction {repabs_pseudo_id = repabs_pseudo_id,


### PR DESCRIPTION
Hi,

This is a preliminary work (first step) of establishing a user-friendly API for creating nominal datatypes. Currently it's not easy to create them - a lot of boilerplate code must be written. Now I added a function `nominal_datatype` (in `nomdatatype`) to automate the initial part of this process. Let me first introduce the API.

For the type `term` (of λ-calculus), now user can use the following call to create a nominal type `term` representing λ-terms with constructors `VAR`, `APP` and `LAM`:
```
val {tynames, rep_t, lp} =
    nominal_datatype ‘term = VAR 'free | APP term term | LAM 'bound term’;
```
Note that the special type variables `'free` and `'bound` to denote free and bound names used in the related constructors. Other type variables and parameterized types are considered external types. The above call currently returns 3 values (and a `Datatype` call happens inside):
- `tynames` is a list of names of the nominal types being created. The value is `["term"]` in this case.
- `rep_t` is the intermediate representation type, whose value is `:term_repcode`, defined automatically by
```
Datatype :
   term_repcode = rVAR | rAPP | rLAM
End
```
- `lp` is a long term holding information about the number of free and bounded names and recursive arguments:
```
   ``\n lfvs d tns uns.
         n = 0 /\ lfvs = 1 /\ d = rVAR /\ tns = [] /\ uns = [] \/
         n = 0 /\ lfvs = 0 /\ d = rAPP /\ tns = [] /\ uns = [0; 0] \/
         n = 0 /\ lfvs = 0 /\ d = rLAM /\ tns = [0] /\ uns = []``: term
```
That's all it currently can do. Perhaps it's not very impressive for the type `term`. But for the two nominal terms of π-calculus, we can do the following now: (NOTE: setting `repcode` will forcely set the type name of the representation type, otherwise it's `pi_repcode` by default.)
```
val _ = (repcode := "repcode");

val {tynames, rep_t, lp} =
    nominal_datatype
          ‘pi   = Nil                         (* 0 *)
                | Tau pi                      (* tau.P *)
                | Input 'free 'bound pi       (* a(x).P *)
                | Output 'free 'free pi       (* {a}b.P *)
                | Match 'free 'free pi        (* [a == b] P *)
                | Mismatch 'free 'free pi     (* [a <> b] P *)
                | Sum pi pi                   (* P + Q *)
                | Par pi pi                   (* P | Q *)
                | Res 'bound pi               (* nu x. P *)
                ;
       residual = TauR pi                     (* tau.P *)
                | InputS 'free 'bound pi      (* a(x).P *)
                | BoundOutput 'free 'bound pi (* a{x}.P *)
                | FreeOutput 'free 'free pi   (* {a}b.P *)’;
```
And this will give us the following correct `lp` term, which previously must be written manually:
```
val lp =
  “(\n lfvs d tns uns.
     n = 0 /\ lfvs = 0 /\ d = rNil /\ tns = [] /\ uns = [] \/
     n = 0 /\ lfvs = 0 /\ d = rTau /\ tns = [] /\ uns = [0] \/
     n = 0 /\ lfvs = 1 /\ d = rInput /\ tns = [0] /\ uns = [] \/
     n = 0 /\ lfvs = 2 /\ d = rOutput /\ tns = [] /\ uns = [0] \/
     n = 0 /\ lfvs = 2 /\ d = rMatch /\ tns = [] /\ uns = [0] \/
     n = 0 /\ lfvs = 2 /\ d = rMismatch /\ tns = [] /\ uns = [0] \/
     n = 0 /\ lfvs = 0 /\ d = rSum /\ tns = [] /\ uns = [0; 0] \/
     n = 0 /\ lfvs = 0 /\ d = rPar /\ tns = [] /\ uns = [0; 0] \/
     n = 0 /\ lfvs = 0 /\ d = rRes /\ tns = [1] /\ uns = [] \/
     n = 1 /\ lfvs = 0 /\ d = rTauR /\ tns = [] /\ uns = [0] \/
     n = 1 /\ lfvs = 1 /\ d = rInputS /\ tns = [0] /\ uns = [] \/
     n = 1 /\ lfvs = 1 /\ d = rBoundOutput /\ tns = [0] /\ uns = [] \/
     n = 1 /\ lfvs = 2 /\ d = rFreeOutput /\ tns = [] /\ uns = [0])”;
```

Note that, I have reused the input syntax of the existing `Datatype` package, and for labelled term there's no way to distinguish between free and bound parameters:
```
val _ = (repcode := "lrep");
val _ = (rprefix := "l");

val {tynames, rep_t, lp} =
    nominal_datatype
      ‘lterm = VAR 'free
             | APP lterm lterm
             | LAM 'bound lterm
             | LAMi num 'bound lterm lterm’;
```
which gives the following `lp`:
```
val lp = “λn lfvs (d:lrep) tns uns.
            n = 0 /\ lfvs = 1 /\ d = lVAR /\ tns = [] /\ uns = [] \/
            n = 0 /\ lfvs = 0 /\ d = lAPP /\ tns = [] /\ uns = [0;0] \/
            n = 0 /\ lfvs = 0 /\ d = lLAM /\ tns = [0] /\ uns = [] \/
            ?m. n = 0 /\ lfvs = 0 /\ d = lLAMi m /\ tns = [0] /\ uns = [0]”;
```
Note that `LAMi num 'bound lterm lterm` actually means `(LAMi num 'bound lterm) lterm`, where the first `lterm` is bounded by the name, while the second is not.  And that's why the last line of `lp` has `tns = [0] /\ uns = [0]`, i.e. one parameter is free, the other is bound.

The current rule (to interprete the input quotation) is the following: **if the type variable`'bound` occurs in a constructor, then the immediately followed nominal type parameter is bounded, while other nominal parameters are considered free**. This avoids designing new syntax of the input quotation for now and works for all existing use cases.

--Chun
