### PR TITLE
Add a patch to asl-equiv download script

### DIFF
--- a/examples/l3-machine-code/arm8/asl-equiv/get-armv8.6-hol-snapshot
+++ b/examples/l3-machine-code/arm8/asl-equiv/get-armv8.6-hol-snapshot
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+set -e
 git clone https://github.com/HOL-Theorem-Prover/armv8.6-asl-snapshot.git
 cd armv8.6-asl-snapshot
 git checkout 9f9bb9a9e6a133876152124ce3c30993a61fa7c9
+
+# Disable the large pretty-printed doc comment in armv86aTheory.sig.
+# Without this the generated .sig is ~1.3 GB, which trips a 32-bit Int
+# overflow in the MLton-built Holmake during dependency analysis.
+script=A64_ISA_v86A/armv86aScript.sml
+if ! grep -q '"TheoryPP.include_docs"' "$script"; then
+    sed -i '/^val _ = export_theory()/i val _ = Feedback.set_trace "TheoryPP.include_docs" 0;\n' "$script"
+fi

--- a/tools/parsing/HOLSourceAST.sml
+++ b/tools/parsing/HOLSourceAST.sml
@@ -670,8 +670,31 @@ fun updateCursorSimple ({body, evts, file, pos, line, col, idx}: cursor, p) = le
   val (line, col) = firstLine pos
   in {body = body, evts = evts, file = file, pos = p, line = line, col = col, idx = idx} end
 
-fun updateCursor (cur: cursor as {body, evts, pos, ...}, p): cursor =
-  if p < pos then updateCursor (newCursor body evts, p) (* TODO walk backwards *)
+fun updateCursor (cur: cursor as {body, evts, pos, line, col, idx, ...}, p): cursor =
+  if p < pos then
+    (* Backward seek. Falls back to reset only when events (e.g. #line pragmas)
+       were applied in (p, pos] and would need to be undone. *)
+    let val eventsCrossed =
+          idx > 0 andalso
+          eventPos (DArray.sub (#evts evts, idx - 1)) > p
+    in if eventsCrossed then updateCursor (newCursor body evts, p)
+       else if p >= pos - col then
+         (* p is on the same line as pos: pos - col is the line start *)
+         {body = body, evts = evts, file = #file cur,
+          pos = p, line = line, col = col - (pos - p), idx = idx}
+       else
+         (* p is on an earlier line: one backward scan finds both the newline
+            count (for line) and the line start (for col) *)
+         let fun scan i nls =
+               if i < 0 then (nls, 0)
+               else if DString.sub (body, i) = #"\n" then
+                 if i >= p then scan (i-1) (nls+1) else (nls, i+1)
+               else scan (i-1) nls
+             val (nls, lineStart) = scan (pos-1) 0
+         in {body = body, evts = evts, file = #file cur,
+             pos = p, line = line - nls, col = p - lineStart, idx = idx}
+         end
+    end
   else let
     fun readEvts (cur as {evts, idx, ...}) =
       case SOME (DArray.sub (#evts evts, idx)) handle Subscript => NONE of


### PR DESCRIPTION
Prevents it from generating sig docs which, in turn, cause an Overflow in the parser (DArray / DString) when it tries to load the entire comment at once.