### PR TITLE
Add a patch to asl-equiv download script

### DIFF
--- a/examples/l3-machine-code/arm8/asl-equiv/get-armv8.6-hol-snapshot
+++ b/examples/l3-machine-code/arm8/asl-equiv/get-armv8.6-hol-snapshot
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+set -e
 git clone https://github.com/HOL-Theorem-Prover/armv8.6-asl-snapshot.git
 cd armv8.6-asl-snapshot
 git checkout 9f9bb9a9e6a133876152124ce3c30993a61fa7c9
+
+# Disable the large pretty-printed doc comment in armv86aTheory.sig.
+# Without this the generated .sig is ~1.3 GB, which trips a 32-bit Int
+# overflow in the MLton-built Holmake during dependency analysis.
+script=A64_ISA_v86A/armv86aScript.sml
+if ! grep -q '"TheoryPP.include_docs"' "$script"; then
+    sed -i '/^val _ = export_theory()/i val _ = Feedback.set_trace "TheoryPP.include_docs" 0;\n' "$script"
+fi


### PR DESCRIPTION
Prevents it from generating sig docs which, in turn, cause an Overflow in the parser (DArray / DString) when it tries to load the entire comment at once.