### PR TITLE
perf: avoid unnecessary uptodate checks

### DIFF
--- a/src/1/ThmSetData.sml
+++ b/src/1/ThmSetData.sml
@@ -173,7 +173,20 @@ fun new_exporter {settype = name, efns = efns as {add, remove}} = let
     | hook (DelBinding s) = neqbinding s
     | hook (NewBinding(s,_)) = neqbinding s
     | hook _ = fn _ => true
-  fun check_thydelta (arg as (sexp,td)) = revise_data (hook td) arg
+  (* For events that use uptodate_thmdelta (retire-state check on each
+     stored theorem), skip the scan when retire_epoch is unchanged since
+     our last scan.  Name-based events (NewBinding/DelBinding via
+     neqbinding) must still scan since they're unrelated to retires. *)
+  val last_scan_epoch = ref ~1
+  fun retire_memoable (DelConstant _) = true
+    | retire_memoable (DelTypeOp _) = true
+    | retire_memoable (NewConstant _) = true
+    | retire_memoable (NewTypeOp _) = true
+    | retire_memoable _ = false
+  fun check_thydelta (arg as (_, td)) =
+    case KernelSig.retire_epoch () of cur =>
+    if retire_memoable td andalso !last_scan_epoch = cur then NONE
+    else revise_data (hook td) arg before last_scan_epoch := cur
 
 
   val {export = export_deltasexp, segment_data, ...} =

--- a/src/parse/AncestryData.sml
+++ b/src/parse/AncestryData.sml
@@ -36,7 +36,7 @@ type ('d,'v) info =
       apply_delta : 'd -> 'v -> 'v, tag : string,
       parents : {thyname : string} -> string list}
 
-fun fpluck f [] = NONE
+fun fpluck _ [] = NONE
   | fpluck f (h::t) = case f h of
                           NONE => Option.map (fn (v,r) => (v,h::r)) (fpluck f t)
                         | SOME v => SOME ((h,v),t)
@@ -147,8 +147,8 @@ fun make {info : ('delta,'value)adata_info, get_deltas, delta_side_effects} =
           Symtab.lookup (Sref.value value_table) thyname
 
       (* calculates merged values in the "onload" hook *)
-      val apply_delta_hook = ref (fn ps => NONE)
-      fun side_effects thy = List.app delta_side_effects
+      val apply_delta_hook = ref (fn _ => NONE)
+      fun side_effects _ = List.app delta_side_effects
       val parent_extras =
           {tag = tag, apply_delta_hook = apply_delta_hook,
            delta_side_effects = side_effects,
@@ -158,7 +158,7 @@ fun make {info : ('delta,'value)adata_info, get_deltas, delta_side_effects} =
       val {export = parent_export,
            segment_data = parent_segment_data, ...} =
           ThyDataSexp.new {
-            thydataty = tag, merge = fn {old,new} => new,
+            thydataty = tag, merge = #new,
             load = parent_onload parent_extras, other_tds = fn (s,_) => SOME s
           }
       fun parents thyname =
@@ -191,7 +191,21 @@ fun make {info : ('delta,'value)adata_info, get_deltas, delta_side_effects} =
        parents = parents, set_parents = set_ancestry}
     end
 
-fun gen_other_tds {tag,dec,enc,P} (t, thyevent) =
+fun gen_other_tds {tag,dec,enc,P} = let
+  val last_scan_epoch = ref ~1
+  (* Memoize only retire-sensitive events.  The scan's predicate P
+     (via ThmSetData.export_with_ancestry) composes retire checks with
+     DB.lookup, so it can change on *any* event that mutates the binding
+     table — NewBinding, UpdBinding, DelBinding.
+     When retire_epoch is unchanged and the event is one that only fires
+     after a retire (NewConstant / NewTypeOp / DelConstant / DelTypeOp),
+     we know no entry's P result can have changed since the last scan. *)
+  fun memoable (TheoryDelta.NewConstant _) = true
+    | memoable (TheoryDelta.NewTypeOp _) = true
+    | memoable (TheoryDelta.DelConstant _) = true
+    | memoable (TheoryDelta.DelTypeOp _) = true
+    | memoable _ = false
+  fun scan t =
     case t of
         ThyDataSexp.List raw_ds =>
         let
@@ -209,6 +223,11 @@ fun gen_other_tds {tag,dec,enc,P} (t, thyevent) =
                             ("Bad encoding (1) for tag: "^tag)
         end
       | _ => raise ERR "gen_other_tds" ("Bad encoding (2) for tag: "^tag)
+  in fn (t, thyevent) =>
+    case KernelSig.retire_epoch () of cur =>
+    if memoable thyevent andalso !last_scan_epoch = cur then NONE
+    else scan t before last_scan_epoch := cur
+  end
 
 type ('delta,'value) fullresult =
      { merge : string list -> 'value option,
@@ -220,10 +239,9 @@ type ('delta,'value) fullresult =
        get_global_value : unit -> 'value,
        update_global_value : ('value -> 'value) -> unit }
 
-fun fullmake (arg as {adinfo:('delta,'value)adata_info,...}) =
+fun fullmake {adinfo:('delta,'value)adata_info, sexps, globinfo, uptodate_delta} =
     let
       open ThyDataSexp
-      val {adinfo, sexps, globinfo, uptodate_delta} = arg
       val {dec,enc} = sexps
       val {apply_to_global,initial_value,thy_finaliser} = globinfo
       val {initial_values, tag, apply_delta, ...} = adinfo
@@ -259,7 +277,7 @@ fun fullmake (arg as {adinfo:('delta,'value)adata_info,...}) =
             )
 
       (* store parentage *)
-      val apply_delta_hook = ref (fn ps => NONE)
+      val apply_delta_hook = ref (fn _ => NONE)
       fun delta_side_effects thyname ds =
           case thy_finaliser of
               NONE => List.app (update_global_value o apply_to_global) ds
@@ -269,10 +287,9 @@ fun fullmake (arg as {adinfo:('delta,'value)adata_info,...}) =
            delta_side_effects = delta_side_effects,
            apply_delta = apply_delta, get_deltas = get_deltas,
            value_table = value_table}
-      val {export = export_raw_parents, segment_data = get_raw_parents,
-           set = set_raw_parents} =
+      val {export = export_raw_parents, segment_data = get_raw_parents, ...} =
           ThyDataSexp.new {thydataty = tag ^ ".parents",
-                           merge = (fn {old,new} => new),
+                           merge = #new,
                            load = parent_onload parent_extras,
                            other_tds = (fn (t,_) => SOME t)}
       fun get_parents {thyname} =

--- a/src/parse/GrammarDeltas.sml
+++ b/src/parse/GrammarDeltas.sml
@@ -351,20 +351,30 @@ fun nopp s _ = HOLPP.add_string ("<" ^ s ^ ">")
 fun check_gdelta (TMD tmd) = check_delta tmd
   | check_gdelta (TYD tyd) = check_tydelta tyd
 
-fun other_tds (t, thyevent) =
-    case list_decode gdelta_decode t of
-        NONE => raise Fail ("GrammarDelta: encoding failure: t = \n  " ^
-                            HOLPP.pp_to_string 70
-                             (pp_sexp (nopp"ty") (nopp"tm") (nopp"thm"))
-                             t)
-      | SOME gds =>
-        let
-          val (goodgds, badgds) = Lib.partition check_gdelta gds
-        in
-          if null badgds then NONE
-          else
-            SOME (mk_list gdelta_encode goodgds)
-        end
+(* check_gdelta inspects only retire-state (uptodate_term / prim_mk_const /
+   uptodate_type).  If retire_epoch is unchanged since the last successful
+   scan, every stored grammar delta remains as valid as it was then. *)
+local
+  val last_scan_epoch = ref ~1
+  fun scan t =
+      case list_decode gdelta_decode t of
+          NONE => raise Fail ("GrammarDelta: encoding failure: t = \n  " ^
+                              HOLPP.pp_to_string 70
+                               (pp_sexp (nopp"ty") (nopp"tm") (nopp"thm"))
+                               t)
+        | SOME gds =>
+          let
+            val (goodgds, badgds) = Lib.partition check_gdelta gds
+          in
+            if null badgds then NONE
+            else SOME (mk_list gdelta_encode goodgds)
+          end
+in
+  fun other_tds (t, _) =
+    case KernelSig.retire_epoch () of cur =>
+    if !last_scan_epoch = cur then NONE
+    else scan t before last_scan_epoch := cur
+end
 
 val {export, segment_data, set} = ThyDataSexp.new {
       thydataty = "grammardelta",

--- a/src/prekernel/KernelSig.sig
+++ b/src/prekernel/KernelSig.sig
@@ -14,6 +14,7 @@ sig
   val new_id : kernelname -> kernelid
   val uptodate_id : kernelid -> bool
   val retire_id : kernelid -> unit
+  val retire_epoch : unit -> int
   val name_of : kernelid -> string
   val seg_of : kernelid -> string
 

--- a/src/prekernel/KernelSig.sml
+++ b/src/prekernel/KernelSig.sml
@@ -14,13 +14,23 @@ struct
 
   type kernelid = (kernelname * bool) ref (* bool is uptodate flag *)
 
-  fun name_of_id r = case !r of (n,utd) => n
-  fun uptodate_id r = case !r of (n,utd) => utd
+  (* Monotone counter bumped on every retire_id.  Lets downstream listeners
+     (ThmSetData, AncestryData, GrammarDeltas) skip their O(n) "scan all
+     stored deltas for staleness" work when no constant/type has been
+     retired since the last scan.  A constant's uptodate flag only flips
+     via retire_id, so the counter is a sound summary of "has any stored
+     delta potentially become stale?". *)
+  val retire_counter = ref 0
+  fun retire_epoch () = !retire_counter
+
+  fun name_of_id r = case !r of (n,_) => n
+  fun uptodate_id r = case !r of (_,utd) => utd
   fun new_id n = ref (n, true)
-  fun retire_id r = case !r of ({Thy,Name}, _) =>
-      r := ({Thy = Thy, Name = Globals.old Name}, false)
-  fun name_of r = case !r of  ({Name,Thy},_) => Name
-  fun seg_of r = case !r of ({Thy,Name},_) => Thy
+  fun retire_id r = case !r of ({Thy,Name}, _) => (
+    r := ({Thy = Thy, Name = Globals.old Name}, false);
+    retire_counter := !retire_counter + 1)
+  fun name_of r = case !r of  ({Thy=_,Name},_) => Name
+  fun seg_of r = case !r of ({Thy,Name=_},_) => Thy
   fun id_toString id = name_toString (name_of_id id)
   fun id_compare(i1, i2) =
     case (!i1, !i2) of ((n1,_), (n2,_)) =>
@@ -40,7 +50,6 @@ struct
   datatype 'a symtab_error = Success of 'a
                            | Failure of exn
   fun isSuccess (Success _) = true | isSuccess _ = false
-  fun destSuccess (Success a) = a | destSuccess (Failure e) = raise e
 
   fun new_table() = Sref.new (Symtab.empty, Symtab.empty, 0)
   fun peek(tab : 'a symboltable, knm as {Thy,Name}) =
@@ -93,7 +102,7 @@ struct
   fun retire_name (r, n) =
       case remove(r, n) of
         Failure e => raise e
-      | Success (kid, v) => retire_id kid
+      | Success (kid, _) => retire_id kid
 
   fun insert(tab : 'a symboltable, n as {Thy,Name}, v) = let
     val id = new_id n
@@ -134,7 +143,7 @@ struct
 
   fun listName tab nm =
       let
-        val (kmap, tmap, _) = Sref.value tab
+        val (_, tmap, _) = Sref.value tab
         val thys = case Symtab.lookup tmap nm of NONE => [] | SOME xs => xs
         val knms = map (fn thy => {Thy = thy, Name = nm}) thys
       in
@@ -142,8 +151,8 @@ struct
       end
 
   fun del_segment (r : 'a symboltable, thyname) = let
-    fun appthis (knm as {Name,Thy},(id,v)) =
-        if Thy = thyname then retire_name(r,knm)
+    fun appthis (knm, _) =
+        if #Thy knm = thyname then retire_name(r,knm)
         else ()
   in
     app appthis r


### PR DESCRIPTION
This came up while benchmarking some cakeml changes that will generate a lot of simple definitions. When there are a lot of registered constants, every definition becomes more expensive due to these outofdate checks, which are not needed most of the time. An easy way to detect whether it is needed is to use an epoch counter which is incremented every time you retire an id. If the counter hasn't changed since last time you looked, then nothing new could have been retired and therefore the outofdate check is redundant. This yields a 5% improvement in HOL src compile time on my machine, and about an 18% improvement on the definition-heavy code I was testing.

Also drive-by fixed a few warnings in touched files.