### PR TITLE
Fix nested suspense/resume proofs

### DIFF
--- a/src/basicProof/theory_tests/suspNestedScript.sml
+++ b/src/basicProof/theory_tests/suspNestedScript.sml
@@ -1,0 +1,21 @@
+Theory suspNested[bare]
+
+Libs HolKernel Parse boolLib markerLib
+
+Theorem nested:
+  p ∧ (p ⇒ r) ⇒ p ∧ r
+Proof
+  strip_tac >> suspend "goal"
+QED
+
+Resume nested[goal]:
+  conj_tac
+  >- suspend "p"
+  >> res_tac
+QED
+
+Resume nested[p]:
+  ASM_REWRITE_TAC[]
+QED
+
+Finalise nested

--- a/src/marker/markerLib.sig
+++ b/src/marker/markerLib.sig
@@ -127,7 +127,7 @@ sig
 
   val add_suspension_label : string -> thm -> thm
   val resumption_to_goal : (int * term) list -> (term list * term)
-  val extract_suspended_goal : thm -> string -> (int * term) list
+  val extract_suspended_goal : thm list -> string -> (int * term) list
   val RESUME_TAC : tactic
 
 end (* sig *)

--- a/src/marker/markerLib.sml
+++ b/src/marker/markerLib.sml
@@ -1229,9 +1229,9 @@ fun resume {suspension_name, label_name} tac =
           (case Lib.total (extract_suspended_goal (th::sths)) label_name of
                NONE =>
                (* No suspendlabel hypothesis for this label.  This is the
-		  --fast case (or the user is trying to resume a label of
-		  an already-finalised theorem, or making a typo);
-		  shortcut. *)
+                  --fast case (or the user is trying to resume a label of
+                  an already-finalised theorem, or making a typo);
+                  shortcut. *)
                fast_shortcut ()
              | SOME ncts =>
                let

--- a/src/marker/markerLib.sml
+++ b/src/marker/markerLib.sml
@@ -909,16 +909,18 @@ fun prove_suspended nm ncts th tgt =
 
 (* extract_suspended_goal: returns a list of (nclosure, term) pairs,
    one per hypothesis with the given label. *)
-fun extract_suspended_goal th label =
-    let fun myhyp t =
-            case total dest_slab t of
-                SOME (nm,nc,t0) => if nm = label then SOME (nc,t0) else NONE
-              | NONE => NONE
+fun extract_suspended_goal thms label =
+    let
+      fun myhyp t =
+          case total dest_slab t of
+              SOME (nm,nc,t0) => if nm = label then SOME (nc,t0) else NONE
+            | NONE => NONE
+      val to_ncts = List.mapPartial myhyp o hyp
     in
-      case List.mapPartial myhyp (hyp th) of
-          [] => raise ERR "extract_suspended_goal"
+      case List.find (not o null) (List.map to_ncts thms) of
+          NONE => raise ERR "extract_suspended_goal"
                         ("No such label in theorem: " ^ label)
-        | ncts => ncts
+        | SOME ncts => ncts
     end
 
 (* resumption_to_goal: given the (nclosure, term) list from
@@ -939,7 +941,7 @@ fun resumption_to_goal ncts =
 
 
 fun prim_resume (th,label,tac) =
-    let val ncts = extract_suspended_goal th label
+    let val ncts = extract_suspended_goal [th] label
         val goal = resumption_to_goal ncts
         val sub_th = prove_goal(goal, tac)
     in
@@ -1220,45 +1222,66 @@ fun resume {suspension_name, label_name} tac =
                   ("No suspended theorem named " ^ suspension_name ^
                    " in the current theory or its ancestors")
       | SOME (_, parent_thy, th) =>
-        (case Lib.total (extract_suspended_goal th) label_name of
-            NONE =>
-            (* No suspendlabel hypothesis for this label.  This is the
-               --fast case (or the user is trying to resume a label of
-               an already-finalised theorem, or making a typo);
-               shortcut. *)
-            fast_shortcut ()
-          | SOME ncts =>
-            let
-              val goal = resumption_to_goal ncts
-              val sub_th = prove_goal (goal, tac)
-              (* Build |- suspendlabel "lab" G_i for each hyp i and
-                 record each as its own resumption delta. *)
-              val susp_thms =
-                  build_suspendlabel_thms
-                    label_name (ncts, sub_th)
-              val _ =
-                  List.app
-                    (fn rth =>
-                        record_resumption_delta
-                          (AddResumption
-                             ((parent_thy, suspension_name, label_name),
-                              rth)))
-                    susp_thms
-            in
-              sub_th
-            end)
+        let val sths = lookup_resumption {parent_thy = parent_thy,
+                                          parent_name = suspension_name,
+                                          label = label_name}
+        in
+          (case Lib.total (extract_suspended_goal (th::sths)) label_name of
+               NONE =>
+               (* No suspendlabel hypothesis for this label.  This is the
+		  --fast case (or the user is trying to resume a label of
+		  an already-finalised theorem, or making a typo);
+		  shortcut. *)
+               fast_shortcut ()
+             | SOME ncts =>
+               let
+                 val goal = resumption_to_goal ncts
+                 val sub_th = prove_goal (goal, tac)
+                 (* Build |- suspendlabel "lab" G_i for each hyp i and
+                    record each as its own resumption delta. *)
+                 val susp_thms =
+                     build_suspendlabel_thms
+                         label_name (ncts, sub_th)
+                 fun record_suspend_resumptions rth =
+                     List.app (fn h =>
+                                  case total dest_slab h of
+                                      SOME (nm, _, _) =>
+                                      record_resumption_delta
+                                          (AddResumption
+                                               ((parent_thy, suspension_name, nm),
+                                                rth))
+                                    | NONE => ())
+                              (hyp rth)
+                 val _ =
+                     List.app
+                         (fn rth => (
+                              record_resumption_delta
+                                  (AddResumption
+                                       ((parent_thy, suspension_name, label_name),
+                                        rth));
+                              record_suspend_resumptions rth))
+                         susp_thms
+               in
+                   sub_th
+               end)
+        end
 
 fun prim_set_suspended_goal tacmod {suspension_name, label_name} =
     case find_parent suspension_name of
         NONE => raise ERR "set_suspended_goal"
                   ("No suspended theorem named " ^ suspension_name ^
                    " in the current theory or its ancestors")
-      | SOME (_, _, th) =>
+      | SOME (_, parent_thy, th) =>
+        let val sths = lookup_resumption {parent_thy = parent_thy,
+                                          parent_name = suspension_name,
+                                          label = label_name}
+        in
           proofManagerLib.new_goalstack (
-            resumption_to_goal (extract_suspended_goal th label_name)
+              resumption_to_goal (extract_suspended_goal (th::sths) label_name)
           )
           tacmod
           I
+        end
 
 val set_suspended_goal = prim_set_suspended_goal Manager.id_tacm
 
@@ -1305,11 +1328,18 @@ fun assemble_finalised parent_thy parent_nm parent_th =
                         ("No resumption proof found for label " ^ label ^
                          " of " ^ parent_thy ^ "$" ^ parent_nm)
               end
-      val founds = map find_res_for susp_hyps
-      val finalised = List.foldl (fn (rth, acc) => PROVE_HYP rth acc)
-                                 parent_th founds
+      fun aux current_th current_susp_hyps = let
+          val founds = map find_res_for current_susp_hyps
+          val finalised = List.foldl (fn (rth, acc) => PROVE_HYP rth acc)
+                                     current_th founds
+          val remaining_susp_hyps = List.filter (Option.isSome o total dest_slab)
+                                                (hyp finalised)
+      in
+          if null remaining_susp_hyps then finalised else
+          aux finalised remaining_susp_hyps
+      end
     in
-      finalised
+      aux parent_th susp_hyps
     end
 
 fun finalise_suspended_thm loc nm0 =

--- a/src/marker/selftest.sml
+++ b/src/marker/selftest.sml
@@ -153,7 +153,7 @@ val _ = tprint "extract_suspended_goal (1)"
 val _ = require_msg
           (check_result (goal_eq ([q, p], p)))
           goal_print
-          (fn th => resumption_to_goal (extract_suspended_goal th "p"))
+          (fn th => resumption_to_goal (extract_suspended_goal [th] "p"))
           pq_th1
 
 val _ = tprint "extract_suspended_goal (2)"
@@ -167,13 +167,13 @@ val _ = require_msg
             )
           )
           goal_print
-          (fn th => resumption_to_goal (extract_suspended_goal th "pq"))
+          (fn th => resumption_to_goal (extract_suspended_goal [th] "pq"))
           pq_th2
 
 val _ = shouldfail {checkexn = is_struct_HOL_ERR "markerLib",
                     printarg = K "extract_suspended_goal fails (1)",
                     printresult = goal_print,
-                    testfn = (fn th => resumption_to_goal (extract_suspended_goal th "pq"))}
+                    testfn = (fn th => resumption_to_goal (extract_suspended_goal [th] "pq"))}
                    pq_th1
 
 val _ = show_assums := true


### PR DESCRIPTION
This addresses #1922 by fixing nested suspense/resume proofs and adds a test.

The main things this PR does to fix this is:
- Changed `extract_suspended_goal` to take a list of theorems, so it can search the parent and any of its resume proofs for a label 
- When recording a resumption proof, also store it under the key of each nested suspendlabel hypothesis it carries, which lets us use `lookup_resumption` on a label during `resume` to find its respective suspend
- `assemble_finalised` now loops until no suspendlabel hypotheses are left, since `PROVE_HYP` can introduce new ones if nested suspends are present