### PR TITLE
Add build --nodoc option

### DIFF
--- a/tools/build/build.sml
+++ b/tools/build/build.sml
@@ -25,7 +25,7 @@ val _ = startup_check()
    ---------------------------------------------------------------------- *)
 
 val cline_record = process_cline ()
-val {cmdline,build_theory_graph,selftest_level,keepgoing,...} = cline_record
+val {cmdline,build_theory_graph,selftest_level,keepgoing,no_doc,...} = cline_record
 val {extra={SRCDIRS},jobcount,relocbuild,debug,thmsrc,...} = cline_record
 
 
@@ -127,7 +127,8 @@ in
     handle Interrupt => (finish_logging false; die "Interrupted");
   finish_logging true;
   make_buildstamp();
-  build_help build_theory_graph;
+  if no_doc then print "\nSkipping documentation/help generation (--nodoc).\n"
+  else build_help build_theory_graph;
   print "\nHol built successfully.\n"
 end
 

--- a/tools/build/buildcline.sml
+++ b/tools/build/buildcline.sml
@@ -9,12 +9,12 @@ type 'a cline_result = {
 
 local
   open FunctionalRecordUpdate
-  fun makeUpdateT z = makeUpdate12 z
+  fun makeUpdateT z = makeUpdate13 z
 in
 fun updateT z = let
   fun from build_theory_graph debug help jobcount keepgoing kernelspec
            multithread
-           relocbuild selftest
+           no_doc relocbuild selftest
            seqname thmsrc timelimit =
     {build_theory_graph = build_theory_graph,
      debug = debug,
@@ -23,12 +23,13 @@ fun updateT z = let
      keepgoing = keepgoing,
      kernelspec = kernelspec,
      multithread = multithread,
+     no_doc = no_doc,
      relocbuild = relocbuild,
      selftest = selftest,
      seqname = seqname,
      thmsrc = thmsrc,
      timelimit = timelimit}
-  fun from' timelimit thmsrc seqname selftest relocbuild multithread kernelspec
+  fun from' timelimit thmsrc seqname selftest relocbuild no_doc multithread kernelspec
             keepgoing
             jobcount help
             debug
@@ -40,6 +41,7 @@ fun updateT z = let
      keepgoing = keepgoing,
      kernelspec = kernelspec,
      multithread = multithread,
+     no_doc = no_doc,
      relocbuild = relocbuild,
      selftest = selftest,
      seqname = seqname,
@@ -47,10 +49,10 @@ fun updateT z = let
      timelimit = timelimit}
   fun to f {build_theory_graph, debug, help, jobcount, keepgoing, kernelspec,
             multithread,
-            relocbuild,
+            no_doc, relocbuild,
             selftest, seqname, thmsrc, timelimit} =
     f build_theory_graph debug help jobcount keepgoing kernelspec multithread
-      relocbuild
+      no_doc relocbuild
       selftest
       seqname thmsrc
       timelimit
@@ -158,6 +160,8 @@ val cline_opt_descrs = [
    desc = optInt "thread count" 0 #multithread},
   {help = "don't build a thy dep. graph", long = ["nograph"], short = "",
    desc = mkBoolOpt #build_theory_graph false},
+  {help = "don't build generated documentation/help files", long = ["nodoc"], short = "",
+   desc = mkBool #no_doc true},
   {help = "build with logging kernel", long = ["otknl"], short = "",
    desc = setKname "--otknl"},
   {help = "theorem source (dat or tr)", long = ["thmsrc"], short = "",

--- a/tools/build/buildcline_dtype.sml
+++ b/tools/build/buildcline_dtype.sml
@@ -12,13 +12,14 @@ type t = {kernelspec : string option,
           selftest : int option,
           relocbuild : bool,
           thmsrc : string option,
-          timelimit : int option}
+          timelimit : int option,
+          no_doc : bool}
 
 val initial : t =
     { kernelspec = NONE, jobcount = NONE, seqname = NONE, help = false,
       build_theory_graph = NONE, selftest = NONE, debug = false,
       relocbuild = false, multithread = NONE, keepgoing = false,
-      thmsrc = NONE, timelimit = NONE
+      thmsrc = NONE, timelimit = NONE, no_doc = false
     }
 
 type 'a final_options =
@@ -32,7 +33,8 @@ type 'a final_options =
       keepgoing : bool,
       relocbuild : bool,
       thmsrc : string option,
-      timelimit : int option}
+      timelimit : int option,
+      no_doc : bool}
 
 
 

--- a/tools/build/buildhelp.txt
+++ b/tools/build/buildhelp.txt
@@ -25,3 +25,6 @@ The clean* variations can be given in whatever mix of letter-cases
 desired (i.e., "cleanall" and "Cleanall" work as well as "cleanAll").
 
 Options:
+
+  --nodoc
+    skip generated documentation/help-file construction after the main build

--- a/tools/build/buildutils.sml
+++ b/tools/build/buildutils.sml
@@ -385,6 +385,7 @@ in
           extra = {seqname = seqspec, kernelspec = knlspec},
           jobcount = jcount,
           keepgoing = #keepgoing option_record,
+          no_doc = #no_doc option_record,
           multithread = #multithread option_record,
           relocbuild = #relocbuild option_record,
           thmsrc = #thmsrc option_record,
@@ -929,7 +930,7 @@ fun process_cline () =
       end
     | Normal {extra = {seqname,kernelspec}, cmdline, multithread,
               build_theory_graph, jobcount, relocbuild, debug, keepgoing,
-              selftest_level, thmsrc, timelimit} =>
+              no_doc, selftest_level, thmsrc, timelimit} =>
       let
         val SRCDIRS = read_buildsequence {kernelname = kernelspec} seqname
       in
@@ -944,6 +945,7 @@ fun process_cline () =
            jobcount = jobcount,
            keepgoing = keepgoing,
            multithread = multithread,
+           no_doc = no_doc,
            relocbuild = relocbuild,
            selftest_level = selftest_level,
            thmsrc = thmsrc,


### PR DESCRIPTION
Adds a `--nodoc` option to the HOL build command so the normal build can skip generated documentation/help-file construction.

This preserves the current default behavior:

- `build [options]` still builds documentation/help by default.
- `build --nodoc` skips the final `build_help` step after the main build.
- `build help` remains unchanged and still builds the help system explicitly.

This addresses issue #1834 by avoiding the documentation/help generation stage when a user wants to build without docfiles.