### PR TITLE
Add PFT replay module

### DIFF
--- a/src/postkernel/prooftrace/.gitignore
+++ b/src/postkernel/prooftrace/.gitignore
@@ -1,1 +1,2 @@
 replay-test
+pft-replay-test

--- a/src/postkernel/prooftrace/Holmakefile
+++ b/src/postkernel/prooftrace/Holmakefile
@@ -1,9 +1,15 @@
-ifdef HAVE_WORD64
-all: $(DEFAULT_TARGETS)
-else
-all:
-endif
 .PHONY: all
 
 replay-test: replay-test.mlb replay-test.sml
 	mlton -default-type intinf $<
+
+pft-replay-test: pft-replay-test.mlb pft-replay-test.sml
+	mlton -default-type intinf $<
+
+ifdef HAVE_WORD64
+all: pft-replay-test replay-test
+else
+all: pft-replay-test
+endif
+
+EXTRA_CLEANS = replay-test pft-replay-test

--- a/src/postkernel/prooftrace/PFTOpcodes.sig
+++ b/src/postkernel/prooftrace/PFTOpcodes.sig
@@ -1,0 +1,53 @@
+signature PFTOpcodes = sig
+
+  (* The wire / JSON shape of one argument of a ruleset command. *)
+  datatype arg_shape =
+      AId of string               (* varint ID in given namespace *)
+    | AVal                        (* varint, no namespace meaning *)
+    | AIdList of string           (* count-prefixed ID list *)
+    | AIdPairs of string * string (* count-prefixed ID pairs, rendered as
+                                     {"redex":..,"residue":..} in JSON *)
+    | AStrIdPairs of string       (* count-prefixed (string, id) pairs,
+                                     rendered as a named map in JSON *)
+    | AName                       (* single string argument *)
+    | ANameList                   (* count-prefixed list of strings *)
+
+  (* The merge-relevant semantic role of an argument. *)
+  datatype arg_role =
+      RNormal
+    | RNewType                    (* string that introduces a type op *)
+    | RNewConst                   (* string that introduces a constant *)
+    | RNewConsts                  (* strings that introduce constants *)
+
+  type arg_spec = {
+    label : string,               (* JSON key for this argument *)
+    shape : arg_shape,
+    role  : arg_role
+  }
+
+  type opcode_desc = {
+    tag     : string,             (* JSON "cmd" tag, e.g. "REFL" *)
+    results : string list,        (* namespaces of the result IDs
+                                     (all but COMPUTE_INIT have one;
+                                     Candle new_type_definition has two) *)
+    args    : arg_spec list
+  }
+
+  (* Decoded form of one argument, parallel to arg_shape. *)
+  datatype arg_val =
+      VId         of int
+    | VVal        of int
+    | VIdList     of int list
+    | VIdPairs    of (int * int) list
+    | VStrIdPairs of (string * int) list
+    | VName       of string
+    | VNameList   of string list
+
+  val hol4_descs : (int * opcode_desc) list
+  val candle_descs : (int * opcode_desc) list
+
+  val lookup_desc : (int * opcode_desc) list -> int -> opcode_desc
+
+  val descs_for_ruleset : string -> (int * opcode_desc) list
+
+end

--- a/src/postkernel/prooftrace/PFTOpcodes.sml
+++ b/src/postkernel/prooftrace/PFTOpcodes.sml
@@ -1,0 +1,194 @@
+structure PFTOpcodes :> PFTOpcodes = struct
+
+datatype arg_shape =
+    AId of string
+  | AVal
+  | AIdList of string
+  | AIdPairs of string * string
+  | AStrIdPairs of string
+  | AName
+  | ANameList
+
+datatype arg_role =
+    RNormal
+  | RNewType
+  | RNewConst
+  | RNewConsts
+
+type arg_spec = {
+  label : string,
+  shape : arg_shape,
+  role  : arg_role
+}
+
+type opcode_desc = {
+  tag     : string,
+  results : string list,
+  args    : arg_spec list
+}
+
+datatype arg_val =
+    VId         of int
+  | VVal        of int
+  | VIdList     of int list
+  | VIdPairs    of (int * int) list
+  | VStrIdPairs of (string * int) list
+  | VName       of string
+  | VNameList   of string list
+
+(* Convenience constructors for building descriptor tables. *)
+local
+  fun mk lbl sh = {label = lbl, shape = sh, role = RNormal}
+in
+  fun id lbl ns        = mk lbl (AId ns)
+  fun ids lbl ns       = mk lbl (AIdList ns)
+  fun pairs lbl (a, b) = mk lbl (AIdPairs (a, b))
+  fun strids lbl ns    = mk lbl (AStrIdPairs ns)
+  fun ty_name lbl      = {label = lbl, shape = AName, role = RNewType}
+  fun c_name lbl       = {label = lbl, shape = AName, role = RNewConst}
+  fun c_names lbl      = {label = lbl, shape = ANameList, role = RNewConsts}
+end
+
+val hol4_descs : (int * opcode_desc) list = [
+  (0x10, {tag="REFL",          results=["th"],
+          args=[id "tm" "tm"]}),
+  (0x11, {tag="ALPHA",         results=["th"],
+          args=[id "tm1" "tm", id "tm2" "tm"]}),
+  (0x12, {tag="ASSUME",        results=["th"],
+          args=[id "tm" "tm"]}),
+  (0x13, {tag="BETA_CONV",     results=["th"],
+          args=[id "tm" "tm"]}),
+  (0x14, {tag="EQ_MP",         results=["th"],
+          args=[id "eq" "th", id "th" "th"]}),
+  (0x15, {tag="MP",            results=["th"],
+          args=[id "imp" "th", id "ant" "th"]}),
+  (0x16, {tag="SYM",           results=["th"],
+          args=[id "th" "th"]}),
+  (0x17, {tag="TRANS",         results=["th"],
+          args=[id "th1" "th", id "th2" "th"]}),
+  (0x18, {tag="CONJ",          results=["th"],
+          args=[id "th1" "th", id "th2" "th"]}),
+  (0x19, {tag="CONJUNCT1",     results=["th"],
+          args=[id "th" "th"]}),
+  (0x1A, {tag="CONJUNCT2",     results=["th"],
+          args=[id "th" "th"]}),
+  (0x1B, {tag="DISCH",         results=["th"],
+          args=[id "tm" "tm", id "th" "th"]}),
+  (0x1C, {tag="DISJ1",         results=["th"],
+          args=[id "th" "th", id "tm" "tm"]}),
+  (0x1D, {tag="DISJ2",         results=["th"],
+          args=[id "tm" "tm", id "th" "th"]}),
+  (0x1E, {tag="DISJ_CASES",    results=["th"],
+          args=[id "disj" "th", id "left" "th", id "right" "th"]}),
+  (0x1F, {tag="NOT_ELIM",      results=["th"],
+          args=[id "th" "th"]}),
+  (0x20, {tag="NOT_INTRO",     results=["th"],
+          args=[id "th" "th"]}),
+  (0x21, {tag="CCONTR",        results=["th"],
+          args=[id "tm" "tm", id "th" "th"]}),
+  (0x22, {tag="EXISTS",        results=["th"],
+          args=[id "tm1" "tm", id "tm2" "tm", id "th" "th"]}),
+  (0x23, {tag="CHOOSE",        results=["th"],
+          args=[id "var" "tm", id "existence" "th", id "body" "th"]}),
+  (0x24, {tag="GEN",           results=["th"],
+          args=[id "tm" "tm", id "th" "th"]}),
+  (0x25, {tag="SPEC",          results=["th"],
+          args=[id "tm" "tm", id "th" "th"]}),
+  (0x26, {tag="Specialize",    results=["th"],
+          args=[id "tm" "tm", id "th" "th"]}),
+  (0x27, {tag="GENL",          results=["th"],
+          args=[id "th" "th", ids "tms" "tm"]}),
+  (0x28, {tag="ABSL",          results=["th"],
+          args=[id "th" "th", ids "tms" "tm"]}),
+  (0x29, {tag="GEN_ABS",       results=["th"],
+          args=[id "th" "th", id "tm" "tm", ids "tms" "tm"]}),
+  (0x30, {tag="ABS_THM",       results=["th"],
+          args=[id "tm" "tm", id "th" "th"]}),
+  (0x31, {tag="AP_TERM",       results=["th"],
+          args=[id "tm" "tm", id "th" "th"]}),
+  (0x32, {tag="AP_THM",        results=["th"],
+          args=[id "th" "th", id "tm" "tm"]}),
+  (0x33, {tag="MK_COMB",       results=["th"],
+          args=[id "th1" "th", id "th2" "th"]}),
+  (0x34, {tag="Beta",          results=["th"],
+          args=[id "th" "th"]}),
+  (0x35, {tag="Mk_abs",        results=["th"],
+          args=[id "eq" "th", id "body" "th"]}),
+  (0x36, {tag="Mk_comb",       results=["th"],
+          args=[id "eq" "th", id "rator" "th", id "rand" "th"]}),
+  (0x37, {tag="EQ_IMP_RULE1",  results=["th"],
+          args=[id "th" "th"]}),
+  (0x38, {tag="EQ_IMP_RULE2",  results=["th"],
+          args=[id "th" "th"]}),
+  (0x39, {tag="INST",          results=["th"],
+          args=[id "th" "th", pairs "subst" ("tm","tm")]}),
+  (0x3A, {tag="INST_TYPE",     results=["th"],
+          args=[id "th" "th", pairs "subst" ("ty","ty")]}),
+  (0x3B, {tag="SUBST",         results=["th"],
+          args=[id "template" "tm", id "th" "th",
+                pairs "subst" ("tm","th")]}),
+  (0x3C, {tag="deductAntisym", results=["th"],
+          args=[id "th1" "th", id "th2" "th"]}),
+  (0x40, {tag="DEF_TYOP",      results=["th"],
+          args=[id "th" "th", ty_name "name"]}),
+  (0x41, {tag="DEF_SPEC",      results=["th"],
+          args=[id "th" "th", c_names "names"]}),
+  (0x42, {tag="DEF_SPEC_GEN",  results=["th"],
+          args=[id "th" "th", c_names "names"]}),
+  (0x43, {tag="COMPUTE_INIT",  results=["ci"],
+          args=[id "num_ty" "ty", id "cval_ty" "ty",
+                strids "char_eqns" "th",
+                strids "cval_terms" "tm"]}),
+  (0x44, {tag="COMPUTE",       results=["th"],
+          args=[id "ci" "ci", id "tm" "tm", ids "ths" "th"]})
+]
+
+val candle_descs : (int * opcode_desc) list = [
+  (0x10, {tag="REFL",                results=["th"],
+          args=[id "tm" "tm"]}),
+  (0x11, {tag="TRANS",               results=["th"],
+          args=[id "th1" "th", id "th2" "th"]}),
+  (0x12, {tag="MK_COMB",             results=["th"],
+          args=[id "th1" "th", id "th2" "th"]}),
+  (0x13, {tag="ABS_THM",             results=["th"],
+          args=[id "tm" "tm", id "th" "th"]}),
+  (0x14, {tag="BETA",                results=["th"],
+          args=[id "tm" "tm"]}),
+  (0x15, {tag="ASSUME",              results=["th"],
+          args=[id "tm" "tm"]}),
+  (0x16, {tag="EQ_MP",               results=["th"],
+          args=[id "eq" "th", id "th" "th"]}),
+  (0x17, {tag="DEDUCT_ANTISYM_RULE", results=["th"],
+          args=[id "th1" "th", id "th2" "th"]}),
+  (0x18, {tag="INST",                results=["th"],
+          args=[id "th" "th", pairs "subst" ("tm","tm")]}),
+  (0x19, {tag="INST_TYPE",           results=["th"],
+          args=[id "th" "th", pairs "subst" ("ty","ty")]}),
+  (0x20, {tag="SYM",                 results=["th"],
+          args=[id "th" "th"]}),
+  (0x21, {tag="PROVE_HYP",           results=["th"],
+          args=[id "th1" "th", id "th2" "th"]}),
+  (0x30, {tag="new_specification",   results=["th"],
+          args=[id "th" "th", c_names "names"]}),
+  (0x31, {tag="new_type_definition", results=["th","th"],
+          args=[id "th" "th",
+                ty_name "tyname",
+                c_name "absname",
+                c_name "repname"]}),
+  (0x40, {tag="COMPUTE_INIT",        results=["ci"],
+          args=[ids "ths" "th"]}),
+  (0x41, {tag="COMPUTE",             results=["th"],
+          args=[id "ci" "ci", id "tm" "tm", ids "ths" "th"]})
+]
+
+fun lookup_desc descs opc =
+  case List.find (fn (o', _) => o' = opc) descs of
+    SOME (_, d) => d
+  | NONE => raise Fail ("PFTOpcodes: unknown opcode 0x" ^
+                         Int.fmt StringCvt.HEX opc)
+
+fun descs_for_ruleset "candle" = candle_descs
+  | descs_for_ruleset "hol4" = hol4_descs
+  | descs_for_ruleset r = raise Fail ("PFTOpcodes: unknown ruleset " ^ r)
+
+end

--- a/src/postkernel/prooftrace/PFTReader.sig
+++ b/src/postkernel/prooftrace/PFTReader.sig
@@ -1,0 +1,120 @@
+signature PFTReader = sig
+
+  (* Format-level handler: commands common to all rulesets *)
+  type format_handler = {
+    (* Type commands *)
+    tyvar     : int * string -> unit,
+    tyop      : int * string * int list -> unit,
+    (* Term commands *)
+    var       : int * string * int -> unit,
+    const     : int * string * int -> unit,
+    comb      : int * int * int -> unit,
+    abs       : int * int * int -> unit,
+    (* Kernel commands *)
+    new_const : string * int -> unit,
+    new_type  : string * int -> unit,
+    axiom     : int * int * string option -> unit,
+    (* Control commands *)
+    save      : string * int -> unit,
+    load      : int * string -> unit,
+    del       : string * int -> unit,
+    del_range : string * int * int -> unit
+  }
+
+  (* Ruleset-specific command dispatcher: called with (opcode, reader).
+     The reader functions allow the dispatcher to consume arguments
+     from the stream. *)
+  type stream_reader = {
+    readVarint : unit -> int,
+    readString : unit -> string,
+    readVarintList : unit -> int list,
+    readVarintPairs : unit -> (int * int) list,
+    readStringVarintPairs : unit -> (string * int) list,
+    readStringList : unit -> string list
+  }
+
+  type ruleset_handler = int -> stream_reader -> unit
+
+  (* Decode the arguments of a ruleset command whose opcode has
+     already been consumed and whose result-id varint has already
+     been consumed. Returns one arg_val per entry of desc.args in
+     the same order. *)
+  val read_raw_args : PFTOpcodes.opcode_desc -> stream_reader
+                      -> PFTOpcodes.arg_val list
+
+  (* Read a PFT file, calling handler functions for each command.
+     Format-level commands are dispatched via format_handler.
+     Ruleset-specific opcodes (0x10-0x4F) are dispatched via
+     ruleset_handler.
+     Returns the header info and footer (peak namespace counts). *)
+  val read : {file: string, binary: bool,
+              format_handler: format_handler,
+              ruleset_handler: ruleset_handler}
+             -> {version: int, ruleset: string,
+                 n_ty: int, n_tm: int, n_th: int, n_ci: int}
+
+  (* Read just the limits (peak namespace counts) from a PFT file
+     without processing commands. Useful for pre-allocating arrays
+     before a full read. Seeks to end of file to find the footer. *)
+  val read_limits : {file: string, binary: bool}
+                    -> {n_ty: int, n_tm: int, n_th: int, n_ci: int}
+
+  (* Read just the header (version and ruleset) from a PFT file
+     without processing commands. *)
+  val read_header : {file: string, binary: bool}
+                    -> {version: int, ruleset: string}
+
+  (* Construct a ruleset_handler for the HOL4 ruleset *)
+  structure HOL4 : sig
+    type handler = {
+      refl          : int * int -> unit,
+      alpha         : int * int * int -> unit,
+      beta_conv     : int * int -> unit,
+      sym           : int * int -> unit,
+      trans         : int * int * int -> unit,
+      eq_mp         : int * int * int -> unit,
+      mk_comb       : int * int * int -> unit,
+      abs_thm       : int * int * int -> unit,
+      ap_term       : int * int * int -> unit,
+      ap_thm        : int * int * int -> unit,
+      beta_thm      : int * int -> unit,
+      mk_comb_thm   : int * int * int * int -> unit,
+      mk_abs_thm    : int * int * int -> unit,
+      assume        : int * int -> unit,
+      mp            : int * int * int -> unit,
+      disch         : int * int * int -> unit,
+      not_intro     : int * int -> unit,
+      not_elim      : int * int -> unit,
+      ccontr        : int * int * int -> unit,
+      deductAntisym : int * int * int -> unit,
+      conj          : int * int * int -> unit,
+      conjunct1     : int * int -> unit,
+      conjunct2     : int * int -> unit,
+      disj1         : int * int * int -> unit,
+      disj2         : int * int * int -> unit,
+      disj_cases    : int * int * int * int -> unit,
+      gen           : int * int * int -> unit,
+      spec          : int * int * int -> unit,
+      specialize    : int * int * int -> unit,
+      genl          : int * int * int list -> unit,
+      exists        : int * int * int * int -> unit,
+      choose        : int * int * int * int -> unit,
+      absl          : int * int * int list -> unit,
+      gen_abs       : int * int * int * int list -> unit,
+      inst          : int * int * (int * int) list -> unit,
+      inst_type     : int * int * (int * int) list -> unit,
+      subst         : int * int * int * (int * int) list -> unit,
+      eq_imp_rule1  : int * int -> unit,
+      eq_imp_rule2  : int * int -> unit,
+      def_tyop      : int * int * string -> unit,
+      def_spec      : int * int * string list -> unit,
+      def_spec_gen  : int * int * string list -> unit,
+      compute_init  : int * int * int
+                      * (string * int) list * (string * int) list -> unit,
+      compute       : int * int * int * int list -> unit
+    }
+
+    val make_handler : handler -> ruleset_handler
+  end
+
+end

--- a/src/postkernel/prooftrace/PFTReader.sml
+++ b/src/postkernel/prooftrace/PFTReader.sml
@@ -1,0 +1,377 @@
+structure PFTReader :> PFTReader = struct
+
+type format_handler = {
+  tyvar: int * string -> unit, tyop: int * string * int list -> unit,
+  var: int * string * int -> unit, const: int * string * int -> unit,
+  comb: int * int * int -> unit, abs: int * int * int -> unit,
+  new_const: string * int -> unit, new_type: string * int -> unit,
+  axiom: int * int * string option -> unit,
+  save: string * int -> unit, load: int * string -> unit,
+  del: string * int -> unit, del_range: string * int * int -> unit
+}
+
+type stream_reader = {
+  readVarint : unit -> int,
+  readString : unit -> string,
+  readVarintList : unit -> int list,
+  readVarintPairs : unit -> (int * int) list,
+  readStringVarintPairs : unit -> (string * int) list,
+  readStringList : unit -> string list
+}
+
+type ruleset_handler = int -> stream_reader -> unit
+
+fun read_raw_args (desc: PFTOpcodes.opcode_desc) (sr: stream_reader) =
+  let
+    open PFTOpcodes
+    fun one (spec: arg_spec) =
+      case #shape spec of
+        AId _          => VId (#readVarint sr ())
+      | AVal           => VVal (#readVarint sr ())
+      | AIdList _      => VIdList (#readVarintList sr ())
+      | AIdPairs _     => VIdPairs (#readVarintPairs sr ())
+      | AStrIdPairs _  => VStrIdPairs (#readStringVarintPairs sr ())
+      | AName          => VName (#readString sr ())
+      | ANameList      => VNameList (#readStringList sr ())
+  in List.map one (#args desc) end
+
+(* ========================================================================= *)
+(* Binary I/O primitives with position tracking                              *)
+(* ========================================================================= *)
+
+type bin_reader = {
+  readByte: unit -> int,
+  readBytes: int -> Word8Vector.vector,
+  pos: unit -> int,
+  close: unit -> unit
+}
+
+fun open_bin_reader file : bin_reader = let
+  val inp = BinIO.openIn file
+  val p = ref 0
+  fun rb () = case BinIO.input1 inp of
+      SOME b => (p := !p + 1; Word8.toInt b)
+    | NONE => raise Fail "PFTReader: unexpected EOF"
+  fun rbs n = let val v = BinIO.inputN(inp, n) in
+    if Word8Vector.length v = n then (p := !p + n; v)
+    else raise Fail "PFTReader: unexpected EOF"
+  end
+in {readByte = rb, readBytes = rbs,
+    pos = fn () => !p, close = fn () => BinIO.closeIn inp} end
+
+fun skip_to (r: bin_reader) target = let
+  val n = target - #pos r ()
+in if n > 0 then (ignore (#readBytes r n)) else () end
+
+fun mk_readVarint (r: bin_reader) () = let
+  val rb = #readByte r
+  fun loop acc shift = let val b = rb ()
+  in if b < 128 then acc + b * shift
+     else loop (acc + (b - 128) * shift) (shift * 128) end
+in loop 0 1 end
+
+fun mk_readString (r: bin_reader) () = let
+  val len = mk_readVarint r ()
+  val bytes = #readBytes r len
+in Byte.bytesToString bytes end
+
+fun mk_readList (r: bin_reader) f () = let
+  val n = mk_readVarint r ()
+  fun loop 0 acc = List.rev acc
+    | loop k acc = loop (k - 1) (f () :: acc)
+in loop n [] end
+
+fun mk_readPairs (r: bin_reader) f g () = let
+  val n = mk_readVarint r ()
+  fun loop 0 acc = List.rev acc
+    | loop k acc = let val a = f () val b = g ()
+                   in loop (k - 1) ((a, b) :: acc) end
+in loop n [] end
+
+fun mk_stream_reader (r: bin_reader) : stream_reader = let
+  val vi = mk_readVarint r
+  val vs = mk_readString r
+in {
+  readVarint = vi,
+  readString = vs,
+  readVarintList = mk_readList r vi,
+  readVarintPairs = mk_readPairs r vi vi,
+  readStringVarintPairs = mk_readPairs r vs vi,
+  readStringList = mk_readList r vs
+} end
+
+(* ========================================================================= *)
+(* Binary footer reader                                                      *)
+(* ========================================================================= *)
+
+fun read_footer_raw file = let
+  val file_size = Position.toInt (OS.FileSys.fileSize file)
+  val r = open_bin_reader file
+  val () = skip_to r (file_size - 2)
+  val lo = #readByte r ()
+  val hi = #readByte r ()
+  val footer_len = hi * 256 + lo
+  val () = #close r ()
+  val r = open_bin_reader file
+  val () = skip_to r (file_size - footer_len - 2)
+  val opc = #readByte r ()
+  val () = if opc = 0xFF then ()
+           else raise Fail "PFTReader: bad footer opcode"
+  val vi = mk_readVarint r
+  val n_ty = vi () val n_tm = vi () val n_th = vi () val n_ci = vi ()
+  val () = #close r ()
+in {n_ty = n_ty, n_tm = n_tm, n_th = n_th, n_ci = n_ci,
+    footer_len = footer_len, file_size = file_size} end
+
+(* ========================================================================= *)
+(* JSONL limits reader: scan backwards from EOF for last line                *)
+(* ========================================================================= *)
+
+fun read_limits_jsonl file = let
+  val file_size = Position.toInt (OS.FileSys.fileSize file)
+  val inp = BinIO.openIn file
+  (* Read last 1KB — limits line is short *)
+  val chunk_size = Int.min(file_size, 1024)
+  val _ = BinIO.inputN(inp, file_size - chunk_size)
+  val chunk = Byte.bytesToString (BinIO.inputN(inp, chunk_size))
+  val () = BinIO.closeIn inp
+  (* Find last newline-delimited line *)
+  val len = String.size chunk
+  fun find_nl i =
+    if i < 0 then 0
+    else if String.sub(chunk, i) = #"\n" andalso i < len - 1 then i + 1
+    else find_nl (i - 1)
+  val last_line = String.extract(chunk, find_nl (len - 2), NONE)
+  (* Extract integer field from JSON object via Substring.position *)
+  fun getField s field = let
+    val key = "\"" ^ field ^ "\":"
+    val (_, rest) = Substring.position key (Substring.full s)
+  in if Substring.size rest = 0
+     then raise Fail ("PFTReader: no " ^ field ^ " in limits line")
+     else let
+       val after = Substring.dropl Char.isSpace
+                     (Substring.triml (String.size key) rest)
+       val digits = Substring.takel Char.isDigit after
+     in case Int.fromString (Substring.string digits) of
+          SOME n => n
+        | NONE => raise Fail ("PFTReader: bad " ^ field ^ " in limits line")
+     end
+  end
+in {n_ty = getField last_line "n_ty",
+    n_tm = getField last_line "n_tm",
+    n_th = getField last_line "n_th",
+    n_ci = getField last_line "n_ci"} end
+
+fun read_limits {file, binary} =
+  if binary then let
+    val {n_ty, n_tm, n_th, n_ci, ...} = read_footer_raw file
+  in {n_ty = n_ty, n_tm = n_tm, n_th = n_th, n_ci = n_ci} end
+  else read_limits_jsonl file
+
+fun read_header {file, binary} =
+  if not binary
+  then raise Fail "PFTReader: read_header not supported for JSONL"
+  else let
+    val r = open_bin_reader file
+    val _ = #readBytes r 4   (* magic "PFT\0" *)
+    val vi = mk_readVarint r
+    val vs = mk_readString r
+    val version = vi ()
+    val ruleset = vs ()
+    val () = #close r ()
+  in {version = version, ruleset = ruleset} end
+
+(* ========================================================================= *)
+(* Binary command reader                                                     *)
+(* ========================================================================= *)
+
+fun read_binary file (fh: format_handler) (rh: ruleset_handler) = let
+  val {n_ty, n_tm, n_th, n_ci, footer_len, file_size} =
+    read_footer_raw file
+  val cmd_end = file_size - footer_len - 2
+  val r = open_bin_reader file
+  val vi = mk_readVarint r
+  val vs = mk_readString r
+  val sr = mk_stream_reader r
+
+  (* Skip header, but capture version and ruleset *)
+  val _ = #readBytes r 4   (* magic "PFT\0" *)
+  val version = vi ()
+  val ruleset = vs ()
+
+  fun dispatch opc =
+    if opc >= 0x10 andalso opc <= 0x4F then
+      rh opc sr
+    else case opc of
+    (* Type commands *)
+      0x01 => let val id = vi() val name = vs()
+              in #tyvar fh (id, name) end
+    | 0x02 => let val id = vi() val name = vs()
+                  val args = mk_readList r vi ()
+              in #tyop fh (id, name, args) end
+    (* Term commands *)
+    | 0x03 => let val id = vi() val name = vs() val ty = vi()
+              in #var fh (id, name, ty) end
+    | 0x04 => let val id = vi() val name = vs() val ty = vi()
+              in #const fh (id, name, ty) end
+    | 0x05 => let val id = vi() val a = vi() val b = vi()
+              in #comb fh (id, a, b) end
+    | 0x06 => let val id = vi() val a = vi() val b = vi()
+              in #abs fh (id, a, b) end
+    (* Kernel commands *)
+    | 0x07 => let val name = vs() val ty = vi()
+              in #new_const fh (name, ty) end
+    | 0x08 => let val name = vs() val arity = vi()
+              in #new_type fh (name, arity) end
+    | 0x09 => let val id = vi() val tm = vi() val name = vs()
+              in #axiom fh (id, tm,
+                   if name = "" then NONE else SOME name) end
+    (* Control commands *)
+    | 0x50 => let val name = vs() val th = vi()
+              in #save fh (name, th) end
+    | 0x51 => let val id = vi() val name = vs()
+              in #load fh (id, name) end
+    (* DEL *)
+    | 0xE0 => #del fh ("ty", vi())
+    | 0xE1 => #del fh ("tm", vi())
+    | 0xE2 => #del fh ("th", vi())
+    | 0xE3 => #del fh ("ci", vi())
+    | 0xF0 => let val a = vi() val b = vi() in #del_range fh ("ty",a,b) end
+    | 0xF1 => let val a = vi() val b = vi() in #del_range fh ("tm",a,b) end
+    | 0xF2 => let val a = vi() val b = vi() in #del_range fh ("th",a,b) end
+    | 0xF3 => let val a = vi() val b = vi() in #del_range fh ("ci",a,b) end
+    | _ => raise Fail ("PFTReader: unknown opcode 0x" ^
+                        Int.fmt StringCvt.HEX opc)
+
+  fun cmd_loop () =
+    if #pos r () >= cmd_end then ()
+    else (dispatch (#readByte r ()); cmd_loop ())
+
+  val () = cmd_loop ()
+  val () = #close r ()
+in {version = version, ruleset = ruleset,
+    n_ty = n_ty, n_tm = n_tm, n_th = n_th, n_ci = n_ci} end
+
+(* ========================================================================= *)
+(* HOL4 ruleset handler                                                      *)
+(* ========================================================================= *)
+
+structure HOL4 = struct
+
+type handler = {
+  refl: int * int -> unit, alpha: int * int * int -> unit,
+  beta_conv: int * int -> unit, sym: int * int -> unit,
+  trans: int * int * int -> unit, eq_mp: int * int * int -> unit,
+  mk_comb: int * int * int -> unit, abs_thm: int * int * int -> unit,
+  ap_term: int * int * int -> unit, ap_thm: int * int * int -> unit,
+  beta_thm: int * int -> unit,
+  mk_comb_thm: int * int * int * int -> unit,
+  mk_abs_thm: int * int * int -> unit,
+  assume: int * int -> unit, mp: int * int * int -> unit,
+  disch: int * int * int -> unit, not_intro: int * int -> unit,
+  not_elim: int * int -> unit, ccontr: int * int * int -> unit,
+  deductAntisym: int * int * int -> unit,
+  conj: int * int * int -> unit, conjunct1: int * int -> unit,
+  conjunct2: int * int -> unit,
+  disj1: int * int * int -> unit, disj2: int * int * int -> unit,
+  disj_cases: int * int * int * int -> unit,
+  gen: int * int * int -> unit, spec: int * int * int -> unit,
+  specialize: int * int * int -> unit,
+  genl: int * int * int list -> unit,
+  exists: int * int * int * int -> unit,
+  choose: int * int * int * int -> unit,
+  absl: int * int * int list -> unit,
+  gen_abs: int * int * int * int list -> unit,
+  inst: int * int * (int * int) list -> unit,
+  inst_type: int * int * (int * int) list -> unit,
+  subst: int * int * int * (int * int) list -> unit,
+  eq_imp_rule1: int * int -> unit, eq_imp_rule2: int * int -> unit,
+  def_tyop: int * int * string -> unit,
+  def_spec: int * int * string list -> unit,
+  def_spec_gen: int * int * string list -> unit,
+  compute_init: int * int * int
+                * (string * int) list * (string * int) list -> unit,
+  compute: int * int * int * int list -> unit
+}
+
+fun make_handler (h: handler) : ruleset_handler = fn opc => fn sr => let
+  val vi = #readVarint sr
+  val vs = #readString sr
+in case opc of
+    0x10 => let val id = vi() in #refl h (id, vi()) end
+  | 0x11 => let val id = vi() val a = vi() in #alpha h (id, a, vi()) end
+  | 0x12 => let val id = vi() in #assume h (id, vi()) end
+  | 0x13 => let val id = vi() in #beta_conv h (id, vi()) end
+  | 0x14 => let val id = vi() val a = vi() in #eq_mp h (id, a, vi()) end
+  | 0x15 => let val id = vi() val a = vi() in #mp h (id, a, vi()) end
+  | 0x16 => let val id = vi() in #sym h (id, vi()) end
+  | 0x17 => let val id = vi() val a = vi() in #trans h (id, a, vi()) end
+  | 0x18 => let val id = vi() val a = vi() in #conj h (id, a, vi()) end
+  | 0x19 => let val id = vi() in #conjunct1 h (id, vi()) end
+  | 0x1A => let val id = vi() in #conjunct2 h (id, vi()) end
+  | 0x1B => let val id = vi() val a = vi() in #disch h (id, a, vi()) end
+  | 0x1C => let val id = vi() val a = vi() in #disj1 h (id, a, vi()) end
+  | 0x1D => let val id = vi() val a = vi() in #disj2 h (id, a, vi()) end
+  | 0x1E => let val id = vi() val a = vi() val b = vi()
+            in #disj_cases h (id, a, b, vi()) end
+  | 0x1F => let val id = vi() in #not_elim h (id, vi()) end
+  | 0x20 => let val id = vi() in #not_intro h (id, vi()) end
+  | 0x21 => let val id = vi() val a = vi() in #ccontr h (id, a, vi()) end
+  | 0x22 => let val id = vi() val a = vi() val b = vi()
+            in #exists h (id, a, b, vi()) end
+  | 0x23 => let val id = vi() val a = vi() val b = vi()
+            in #choose h (id, a, b, vi()) end
+  | 0x24 => let val id = vi() val a = vi() in #gen h (id, a, vi()) end
+  | 0x25 => let val id = vi() val a = vi() in #spec h (id, a, vi()) end
+  | 0x26 => let val id = vi() val a = vi() in #specialize h (id, a, vi()) end
+  | 0x27 => let val id = vi() val th = vi()
+            in #genl h (id, th, #readVarintList sr ()) end
+  | 0x28 => let val id = vi() val th = vi()
+            in #absl h (id, th, #readVarintList sr ()) end
+  | 0x29 => let val id = vi() val th = vi() val c = vi()
+            in #gen_abs h (id, th, c, #readVarintList sr ()) end
+  | 0x30 => let val id = vi() val a = vi() in #abs_thm h (id, a, vi()) end
+  | 0x31 => let val id = vi() val a = vi() in #ap_term h (id, a, vi()) end
+  | 0x32 => let val id = vi() val a = vi() in #ap_thm h (id, a, vi()) end
+  | 0x33 => let val id = vi() val a = vi() in #mk_comb h (id, a, vi()) end
+  | 0x34 => let val id = vi() in #beta_thm h (id, vi()) end
+  | 0x35 => let val id = vi() val a = vi() in #mk_abs_thm h (id, a, vi()) end
+  | 0x36 => let val id = vi() val a = vi() val b = vi()
+            in #mk_comb_thm h (id, a, b, vi()) end
+  | 0x37 => let val id = vi() in #eq_imp_rule1 h (id, vi()) end
+  | 0x38 => let val id = vi() in #eq_imp_rule2 h (id, vi()) end
+  | 0x39 => let val id = vi() val th = vi()
+            in #inst h (id, th, #readVarintPairs sr ()) end
+  | 0x3A => let val id = vi() val th = vi()
+            in #inst_type h (id, th, #readVarintPairs sr ()) end
+  | 0x3B => let val id = vi() val t = vi() val th = vi()
+            in #subst h (id, t, th, #readVarintPairs sr ()) end
+  | 0x3C => let val id = vi() val a = vi()
+            in #deductAntisym h (id, a, vi()) end
+  | 0x40 => let val id = vi() val th = vi()
+            in #def_tyop h (id, th, vs()) end
+  | 0x41 => let val id = vi() val th = vi()
+            in #def_spec h (id, th, #readStringList sr ()) end
+  | 0x42 => let val id = vi() val th = vi()
+            in #def_spec_gen h (id, th, #readStringList sr ()) end
+  | 0x43 => let val id = vi() val ty1 = vi() val ty2 = vi()
+                val eqns = #readStringVarintPairs sr ()
+                val terms = #readStringVarintPairs sr ()
+            in #compute_init h (id, ty1, ty2, eqns, terms) end
+  | 0x44 => let val id = vi() val ci = vi() val tm = vi()
+            in #compute h (id, ci, tm, #readVarintList sr ()) end
+  | _ => raise Fail ("PFTReader.HOL4: unknown opcode 0x" ^
+                      Int.fmt StringCvt.HEX opc)
+end
+
+end (* structure HOL4 *)
+
+(* ========================================================================= *)
+(* Public interface                                                          *)
+(* ========================================================================= *)
+
+fun read {file, binary, format_handler, ruleset_handler} =
+  if binary then read_binary file format_handler ruleset_handler
+  else raise Fail "PFTReader: JSON reader not yet implemented"
+
+end

--- a/src/postkernel/prooftrace/PFTReplay.sig
+++ b/src/postkernel/prooftrace/PFTReplay.sig
@@ -1,0 +1,28 @@
+signature PFTReplay = sig
+
+  (* Database of replayed theorems, shared across theories.
+     Keys are "Thy$name" for named theorems and "Thy#n" for
+     anonymous theorems. *)
+  type trDB
+
+  val empty_trDB : trDB
+
+  (* Replay a single .pft file. The theory name and format are
+     inferred from the filename:
+       foo.pft.bin   -> binary, thyname = "foo"
+       foo.pft.jsonl -> JSONL,  thyname = "foo"
+       foo.pft       -> binary, thyname = "foo"
+     Ancestor theories must already be in the trDB.
+     Replayed theorems are inserted into the trDB as they are saved. *)
+  val replay : trDB -> string -> trDB
+
+  (* Look up a theorem by key: "Thy$name" or "Thy#n" *)
+  val lookup : trDB -> string -> Thm.thm option
+
+  (* Number of theorems stored *)
+  val size : trDB -> int
+
+  (* All entries as (key, thm) pairs *)
+  val listItems : trDB -> (string * Thm.thm) list
+
+end

--- a/src/postkernel/prooftrace/PFTReplay.sml
+++ b/src/postkernel/prooftrace/PFTReplay.sml
@@ -1,0 +1,351 @@
+structure PFTReplay :> PFTReplay = struct
+
+open Feedback Lib Type Term Thm
+
+infix |->
+
+(* ========================================================================= *)
+(* trDB: theorem database keyed by "Thy$name" / "Thy#n"                      *)
+(* ========================================================================= *)
+
+type trDB = (string, thm) Redblackmap.dict
+
+val empty_trDB = Redblackmap.mkDict String.compare
+
+fun lookup (db: trDB) key = Redblackmap.peek(db, key)
+
+fun size (db: trDB) = Redblackmap.numItems db
+
+fun listItems (db: trDB) = Redblackmap.listItems db
+
+(* ========================================================================= *)
+(* Filename parsing                                                          *)
+(* ========================================================================= *)
+
+val known_extensions = [
+  (".pft.jsonl", false),
+  (".pft.bin",   true),
+  (".pft",       true)
+]
+
+fun parse_filename file = let
+  val base = OS.Path.file file
+  fun try [] = raise Fail ("PFTReplay: unrecognised extension: " ^ file)
+    | try ((ext, binary) :: rest) =
+        if String.isSuffix ext base
+        then (Substring.string
+                (Substring.trimr (String.size ext) (Substring.full base)),
+              binary)
+        else try rest
+in try known_extensions end
+
+(* ========================================================================= *)
+(* Name parsing: "thy$name" -> ("thy","name")                                *)
+(* ========================================================================= *)
+
+fun split_qualified s = let
+  fun find i =
+    if i >= String.size s then
+      raise Fail ("PFTReplay: unqualified name: " ^ s)
+    else if String.sub(s, i) = #"$" then
+      (String.substring(s, 0, i), String.extract(s, i+1, NONE))
+    else find (i + 1)
+in find 0 end
+
+(* ========================================================================= *)
+(* Replay                                                                    *)
+(* ========================================================================= *)
+
+fun replay (db: trDB) file = let
+  val db_ref = ref db
+  val (thyname, binary) = parse_filename file
+  val {n_ty, n_tm, n_th, n_ci} =
+    PFTReader.read_limits {file = file, binary = binary}
+
+  val tys : hol_type option array = Array.array(n_ty, NONE)
+  val tms : term option array     = Array.array(n_tm, NONE)
+  val ths : thm option array      = Array.array(n_th, NONE)
+  val cis : (thm list -> term -> thm) option array =
+    Array.array(n_ci, NONE)
+
+  fun get msg arr i = case Array.sub(arr, i) of
+      SOME x => x
+    | NONE => raise Fail ("PFTReplay: dead " ^ msg ^ " " ^ Int.toString i)
+  val get_ty = get "ty" tys
+  val get_tm = get "tm" tms
+  val get_th = get "th" ths
+  val get_ci = get "ci" cis
+
+  fun set_ty (i, v) = Array.update(tys, i, SOME v)
+  fun set_tm (i, v) = Array.update(tms, i, SOME v)
+  fun set_th (i, v) = Array.update(ths, i, SOME v)
+  fun set_ci (i, v) = Array.update(cis, i, SOME v)
+
+  fun del_ns ("ty", i) = Array.update(tys, i, NONE)
+    | del_ns ("tm", i) = Array.update(tms, i, NONE)
+    | del_ns ("th", i) = Array.update(ths, i, NONE)
+    | del_ns ("ci", i) = Array.update(cis, i, NONE)
+    | del_ns (ns, _) = raise Fail ("PFTReplay: unknown ns " ^ ns)
+
+  fun del_range_ns (ns, lo, hi) = let
+    fun loop i = if i > hi then ()
+                 else (del_ns (ns, i); loop (i + 1))
+  in loop lo end
+
+  (* Extract common theory prefix from qualified names ["thy$c1","thy$c2",...] *)
+  fun thy_of_names names = case names of
+      [] => raise Fail "PFTReplay: empty names list"
+    | (n :: rest) => let val (t, _) = split_qualified n in
+        List.app (fn n' =>
+          if #1 (split_qualified n') = t then ()
+          else raise Fail ("PFTReplay: inconsistent theory prefix: "
+                           ^ n ^ " vs " ^ n')) rest;
+        t end
+
+  (* ---- Format handler -------------------------------------------------- *)
+
+  val format_handler : PFTReader.format_handler = {
+    tyvar = fn (id, name) =>
+      set_ty (id, mk_vartype name),
+
+    tyop = fn (id, name, args) => let
+      val (Thy, Tyop) = split_qualified name
+      val Args = List.map get_ty args
+    in set_ty (id, mk_thy_type {Thy=Thy, Tyop=Tyop, Args=Args}) end,
+
+    var = fn (id, name, ty) =>
+      set_tm (id, mk_var(name, get_ty ty)),
+
+    const = fn (id, name, ty) => let
+      val (Thy, Name) = split_qualified name
+    in set_tm (id, mk_thy_const {Thy=Thy, Name=Name, Ty=get_ty ty}) end,
+
+    comb = fn (id, f, x) =>
+      set_tm (id, mk_comb(get_tm f, get_tm x)),
+
+    abs = fn (id, v, b) =>
+      set_tm (id, mk_abs(get_tm v, get_tm b)),
+
+    new_const = fn (name, ty) => let
+      val (Thy, Name) = split_qualified name
+    in ignore (
+         Term.prim_mk_const {Thy=Thy, Name=Name}
+         handle HOL_ERR _ =>
+           Term.prim_new_const {Thy=Thy, Name=Name} (get_ty ty))
+    end,
+
+    new_type = fn (name, arity) => let
+      val (Thy, Tyop) = split_qualified name
+    in case Type.op_arity {Thy=Thy, Tyop=Tyop} of
+         SOME n => if n = arity then ()
+                   else raise Fail ("PFTReplay: new_type arity mismatch: " ^
+                                    name)
+       | NONE => Type.prim_new_type {Thy=Thy, Tyop=Tyop} arity
+    end,
+
+    axiom = fn (id, tm, nameOpt) => let
+      val c = get_tm tm
+      val ax_name = case nameOpt of
+          SOME n => n
+        | NONE => (print "WARNING: PFTReplay: axiom without name\n";
+                   "UNNAMED_AXIOM")
+    in set_th (id, mk_axiom_thm(Nonce.mk ax_name, c)) end,
+
+    save = fn (name, th) =>
+      db_ref := Redblackmap.insert(!db_ref, name, get_th th),
+
+    load = fn (id, name) =>
+      (case Redblackmap.peek(!db_ref, name) of
+         SOME th => set_th (id, th)
+       | NONE => raise Fail ("PFTReplay: load: not found: " ^ name)),
+
+    del = del_ns,
+
+    del_range = del_range_ns
+  }
+
+  (* ---- Bool constant registration --------------------------------------- *)
+
+  fun register_bool_def name thm =
+    case name of
+      "T"               => register_T thm
+    | "!"               => register_forall thm
+    | "?"               => register_exists thm
+    | "F"               => register_F thm
+    | "~"               => register_neg thm
+    | "/\\"             => register_conj thm
+    | "\\/"             => register_disj thm
+    | "TYPE_DEFINITION" => register_type_definition thm
+    | _                 => ()
+
+  (* ---- HOL4 ruleset handler -------------------------------------------- *)
+
+  val hol4_handler : PFTReader.HOL4.handler = {
+    refl = fn (id, tm) =>
+      set_th (id, REFL (get_tm tm)),
+
+    alpha = fn (id, a, b) =>
+      set_th (id, ALPHA (get_tm a) (get_tm b)),
+
+    beta_conv = fn (id, tm) =>
+      set_th (id, BETA_CONV (get_tm tm)),
+
+    sym = fn (id, a) =>
+      set_th (id, SYM (get_th a)),
+
+    trans = fn (id, a, b) =>
+      set_th (id, TRANS (get_th a) (get_th b)),
+
+    eq_mp = fn (id, a, b) =>
+      set_th (id, EQ_MP (get_th a) (get_th b)),
+
+    mk_comb = fn (id, a, b) =>
+      set_th (id, MK_COMB (get_th a, get_th b)),
+
+    abs_thm = fn (id, v, th) =>
+      set_th (id, ABS (get_tm v) (get_th th)),
+
+    ap_term = fn (id, tm, th) =>
+      set_th (id, AP_TERM (get_tm tm) (get_th th)),
+
+    ap_thm = fn (id, th, tm) =>
+      set_th (id, AP_THM (get_th th) (get_tm tm)),
+
+    beta_thm = fn (id, th) =>
+      set_th (id, Beta (get_th th)),
+
+    mk_comb_thm = fn (id, th1, th2, th3) => let
+      val (_, _, mkc) = Mk_comb (get_th th1)
+    in set_th (id, mkc (get_th th2) (get_th th3)) end,
+
+    mk_abs_thm = fn (id, th1, th3) => let
+      val (_, _, mka) = Mk_abs (get_th th1)
+    in set_th (id, mka (get_th th3)) end,
+
+    assume = fn (id, tm) =>
+      set_th (id, ASSUME (get_tm tm)),
+
+    mp = fn (id, a, b) =>
+      set_th (id, MP (get_th a) (get_th b)),
+
+    disch = fn (id, tm, th) =>
+      set_th (id, DISCH (get_tm tm) (get_th th)),
+
+    not_intro = fn (id, th) =>
+      set_th (id, NOT_INTRO (get_th th)),
+
+    not_elim = fn (id, th) =>
+      set_th (id, NOT_ELIM (get_th th)),
+
+    ccontr = fn (id, tm, th) =>
+      set_th (id, CCONTR (get_tm tm) (get_th th)),
+
+    deductAntisym = fn _ =>
+      raise Fail "PFTReplay: deductAntisym not implemented",
+
+    conj = fn (id, a, b) =>
+      set_th (id, CONJ (get_th a) (get_th b)),
+
+    conjunct1 = fn (id, th) =>
+      set_th (id, CONJUNCT1 (get_th th)),
+
+    conjunct2 = fn (id, th) =>
+      set_th (id, CONJUNCT2 (get_th th)),
+
+    disj1 = fn (id, th, tm) =>
+      set_th (id, DISJ1 (get_th th) (get_tm tm)),
+
+    disj2 = fn (id, tm, th) =>
+      set_th (id, DISJ2 (get_tm tm) (get_th th)),
+
+    disj_cases = fn (id, th0, th1, th2) =>
+      set_th (id, DISJ_CASES (get_th th0) (get_th th1) (get_th th2)),
+
+    gen = fn (id, tm, th) =>
+      set_th (id, GEN (get_tm tm) (get_th th)),
+
+    spec = fn (id, tm, th) =>
+      set_th (id, SPEC (get_tm tm) (get_th th)),
+
+    specialize = fn (id, tm, th) =>
+      set_th (id, Specialize (get_tm tm) (get_th th)),
+
+    genl = fn (id, th, tms) =>
+      set_th (id, GENL (List.map get_tm tms) (get_th th)),
+
+    exists = fn (id, p, w, th) =>
+      set_th (id, EXISTS (get_tm p, get_tm w) (get_th th)),
+
+    choose = fn (id, v, th1, th2) =>
+      set_th (id, CHOOSE (get_tm v, get_th th1) (get_th th2)),
+
+    absl = fn (id, th, tms) => let
+      fun fold_abs (tm_id, acc) = ABS (get_tm tm_id) acc
+    in set_th (id, List.foldr fold_abs (get_th th) tms) end,
+
+    gen_abs = fn (id, th, c, tms) =>
+      set_th (id, GEN_ABS (SOME (get_tm c))
+                           (List.map get_tm tms) (get_th th)),
+
+    inst = fn (id, th, pairs) => let
+      val s = List.map (fn (a, b) => get_tm a |-> get_tm b) pairs
+    in set_th (id, INST s (get_th th)) end,
+
+    inst_type = fn (id, th, pairs) => let
+      val s = List.map (fn (a, b) => get_ty a |-> get_ty b) pairs
+    in set_th (id, INST_TYPE s (get_th th)) end,
+
+    subst = fn (id, template, th, pairs) => let
+      val s = List.map (fn (a, b) => get_tm a |-> get_th b) pairs
+    in set_th (id, SUBST s (get_tm template) (get_th th)) end,
+
+    eq_imp_rule1 = fn (id, th) =>
+      set_th (id, #1 (EQ_IMP_RULE (get_th th))),
+
+    eq_imp_rule2 = fn (id, th) =>
+      set_th (id, #2 (EQ_IMP_RULE (get_th th))),
+
+    def_tyop = fn (id, th, name) => let
+      val (Thy, Tyop) = split_qualified name
+    in set_th (id, prim_type_definition ({Thy=Thy, Tyop=Tyop},
+                                         get_th th)) end,
+
+    def_spec = fn (id, th, names) => let
+      val thy = thy_of_names names
+      val cnames = List.map (#2 o split_qualified) names
+    in set_th (id, prim_specification thy cnames (get_th th)) end,
+
+    def_spec_gen = fn (id, th, names) => let
+      val thy = thy_of_names names
+      val thm = #2 (gen_prim_specification thy (get_th th))
+      val () = if thy = "bool" then
+                 List.app (fn n => register_bool_def (#2 (split_qualified n)) thm)
+                   names
+               else ()
+    in set_th (id, thm) end,
+
+    compute_init = fn (id, ty1, ty2, eqns, terms) => let
+      val num_type = get_ty ty1
+      val cval_type = get_ty ty2
+      val char_eqns = List.map (fn (s, t) => (s, get_th t)) eqns
+      val cval_terms = List.map (fn (s, t) => (s, get_tm t)) terms
+    in set_ci (id, compute {num_type = num_type, char_eqns = char_eqns,
+                            cval_type = cval_type,
+                            cval_terms = cval_terms}) end,
+
+    compute = fn (id, ci, tm, ths) => let
+      val f = get_ci ci
+      val t = get_tm tm
+      val thms = List.map get_th ths
+    in set_th (id, f thms t) end
+  }
+
+  val _ = PFTReader.read {
+    file = file,
+    binary = binary,
+    format_handler = format_handler,
+    ruleset_handler = PFTReader.HOL4.make_handler hol4_handler
+  }
+in !db_ref end
+
+end

--- a/src/postkernel/prooftrace/pft-format.md
+++ b/src/postkernel/prooftrace/pft-format.md
@@ -1,0 +1,330 @@
+# HOL PFT Format Specification (Draft)
+
+## Overview
+
+A proof trace (PFT) is a linear stream of commands for a HOL theorem proving
+kernel to construct a set of theorems.
+
+Commands are topologically ordered — every object is constructed before it is
+used.
+
+## Object Namespaces
+
+There are four namespaces, each with independently numbered IDs:
+
+| Namespace        | Identifier |
+|------------------|------------|
+| Types            | `ty`       |
+| Terms            | `tm`       |
+| Theorems         | `th`       |
+| Compute contexts | `ci`       |
+
+IDs are reused: when an object is no longer needed, its ID may be assigned to
+a new object in the same namespace. Each command assigns an ID in the
+appropriate namespace (determined by the command type). A command may assign
+an ID that it also references as an argument; the replayer reads all arguments
+before writing the result.
+
+Since every command is typed, the assigned ID does not need a namespace
+qualifier — it is unambiguously in the namespace of the command's result type.
+DEL commands do require a namespace qualifier.
+
+A compute context is a cached collection of types/terms/theorems used by
+the fast computation mechanism of kernels that support such a mechanism.
+See the specific ruleset specifications for details on what they contain.
+
+## Encodings
+
+The format has two encodings: **binary** (primary, for production use) and
+**JSON Lines** (for human inspection and interoperability). Both encode the
+same abstract command stream. Producers and consumers SHOULD use the binary
+encoding; the JSON Lines encoding is provided for debugging, testing, and
+integration with tools that consume JSON.
+
+## Header and Footer
+
+Every trace begins with a header and ends with a footer.
+
+### Header
+
+The header specifies:
+
+- **version**: the format version number (currently `1`). Covers the encoding
+  and syntax of the format.
+- **ruleset**: the name of the ruleset that defines the theorem commands
+  available in the trace. The ruleset is specified separately (e.g.,
+  [pft-ruleset-hol4.md](pft-ruleset-hol4.md) for the `hol4` ruleset).
+
+### Footer
+
+The footer declares the peak number of simultaneously live objects per
+namespace: four counts for types, terms, theorems, and compute contexts
+respectively.
+
+A replayer can use these to pre-allocate fixed-size arrays. The footer is
+placed at the end so that a producer can emit commands in a single pass
+without needing to know the peak counts upfront. A reader can seek to the
+end of the file to read the footer before processing commands from the start.
+
+## Command Reference
+
+Commands are divided into **format-level** commands (defined here, common to
+all rulesets) and **theorem commands** (defined by the ruleset).
+
+### Type Commands
+
+| Command | Arguments | Description |
+|---------|-----------|-------------|
+| TYVAR   | id, name  | Construct a type variable |
+| TYOP    | id, name, args: type-id list | Construct a type operator application |
+
+### Term Commands
+
+| Command | Arguments | Description |
+|---------|-----------|-------------|
+| VAR     | id, name, ty: type-id | Construct a variable |
+| CONST   | id, name, ty: type-id | Construct a constant |
+| COMB    | id, rator: term-id, rand: term-id | Construct a function application |
+| ABS     | id, var: term-id, body: term-id | Construct a lambda abstraction |
+
+**Term equality.** Two terms are equal if and only if they are
+alpha-equivalent. In particular, theorem commands that require two terms to
+be equal (e.g., TRANS matching the middle term) succeed whenever the terms
+are alpha-equivalent, regardless of binder names.
+
+### Kernel Commands
+
+| Command | Arguments | Description |
+|---------|-----------|-------------|
+| NEW_CONST | name, ty: type-id | Declare a new constant |
+| NEW_TYPE | name, arity: int | Declare a new type operator |
+| AXIOM | id, tm, name (optional) | Assert an axiom (produces a theorem) |
+
+**NEW_CONST** declares a new constant with the given name and type. The
+constant can then be referenced by subsequent CONST commands. No ID is
+assigned. It is an error to declare two constants with the same name.
+
+**NEW_TYPE** declares a new type operator with the given name and arity. The
+type operator can then be referenced by subsequent TYOP commands. No ID is
+assigned. It is an error to declare two type operators with the same name.
+
+**AXIOM** asserts an axiom: the given term (which must have type `bool`)
+becomes the conclusion of a new theorem with no hypotheses. The theorem is
+assigned an ID. The optional name is purely informational. AXIOM is
+generative: each AXIOM command is a distinct axiom assertion, even if two
+commands have the same name and conclusion.
+
+### Control Commands
+
+| Command | Arguments |
+|---------|-----------|
+| DEL | ns, id, upto: id (optional) |
+| SAVE | name, th |
+| LOAD | id, name |
+
+**DEL** informs the replayer that the given object (or range of objects from
+`id` to `upto` inclusive, if `upto` is present) is no longer needed. The
+replayer MAY use this to free memory. A correct replayer MAY ignore all DEL
+commands. Since IDs are reused, a slot will eventually be overwritten
+regardless of whether DEL was issued; DEL allows the replayer to free the
+underlying object earlier.
+
+**SAVE** makes a theorem available by name. The replayer stores it in a
+name→theorem table. The theorem remains available for subsequent LOAD commands
+(including in concatenated traces).
+
+**LOAD** retrieves a previously saved theorem by name and assigns it to a
+theorem ID. The named theorem must have been saved by a prior SAVE command.
+
+These commands enable modularity: a trace can be split into separate files
+(e.g., one per theory), where each file LOADs its dependencies and SAVEs its
+exports. Concatenating traces works as long as LOADs come after the
+corresponding SAVEs.
+
+### Theorem Commands
+
+Theorem commands are defined by the ruleset. See the relevant ruleset
+specification for the full list of commands, their arguments, and their
+logical semantics.
+
+**Definition commands.** Some theorem commands introduce new constants or
+type operators as a side effect (e.g., constant definition, type definition).
+Such commands MUST include the names of all newly introduced constants and/or
+type operators among their arguments. This enables tools (e.g., trace mergers)
+to determine what a definition command defines without inspecting term
+structure.
+
+## Name Semantics
+
+Names in the trace are opaque strings. For systems with namespaced identifiers
+(e.g., HOL4's `thy$name`), the namespace is encoded as part of the string.
+The trace format does not interpret the structure of names.
+
+Names carry the following semantics depending on context:
+
+- **Type operator names** (in TYOP): Identify a type operator. Two TYOP
+  commands with the same name and arguments produce the same type, even if
+  assigned different IDs.
+- **Type variable names** (in TYVAR): Identify a type variable. Two TYVAR
+  commands with the same name produce the same type variable.
+- **Constant names** (in CONST): Identify a constant. Two CONST commands with
+  the same name and type produce the same constant.
+- **Variable names** (in VAR): Identify a variable. Two VAR commands with the
+  same name and type produce the same variable.
+- **New constant names** (in NEW_CONST): Identify the constant being declared.
+  Must match the name used in subsequent CONST commands.
+- **New type names** (in NEW_TYPE): Identify the type operator being declared.
+  Must match the name used in subsequent TYOP commands.
+- **Axiom names** (in AXIOM): Optional, purely informational.
+- **Save/Load names** (in SAVE, LOAD): Identify theorems in the name→theorem
+  table. These are chosen by the producer and have no kernel significance.
+
+Additional name semantics (e.g., for definition commands) are defined by the
+ruleset.
+
+A well-optimised producer SHOULD avoid creating duplicate IDs for the same
+logical entity (i.e., should hash-cons types, terms, and sub-terms). However,
+a valid trace MAY assign multiple IDs to equivalent objects — the replayer
+will produce correct results either way.
+
+## Binary Encoding
+
+The binary format is the primary encoding. A binary trace starts with the
+magic bytes `PFT\0` followed by the header, then a sequence of encoded
+commands, and ends with a footer.
+
+### Primitive encodings
+
+- **Varint**: Variable-length unsigned integer encoding (LEB128). Each byte
+  uses 7 data bits and 1 continuation bit (high bit). The last byte has its
+  high bit clear.
+- **String**: A varint length followed by that many bytes of UTF-8 text.
+
+### Header
+
+```
+PFT\0 <version:varint> <ruleset:string>
+```
+
+### Footer
+
+```
+<0xFF> <n_ty:varint> <n_tm:varint> <n_th:varint> <n_ci:varint> <footer_len:uint16le>
+```
+
+The footer begins with a single-byte opcode `0xFF` (LIMITS), followed by
+four varint counts, followed by a 2-byte little-endian unsigned integer
+giving the byte length of the footer excluding the 2-byte length field
+itself (i.e., the opcode byte plus the four varints). A reader seeks to
+the last 2 bytes of the file to read the length, then seeks back that
+many bytes to read the opcode and the four counts.
+
+### Command encoding
+
+Each command is encoded as a single-byte opcode, followed by its arguments.
+IDs and counts are encoded as varints. Names are encoded as strings.
+
+### Format-level opcodes
+
+| Opcode | Command       | Arguments                              |
+|--------|---------------|----------------------------------------|
+| 0x01   | TYVAR         | id name                                |
+| 0x02   | TYOP          | id name n_args arg...                  |
+| 0x03   | VAR           | id name type_id                        |
+| 0x04   | CONST         | id name type_id                        |
+| 0x05   | COMB          | id rator rand                          |
+| 0x06   | ABS           | id var body                            |
+| 0x07   | NEW_CONST     | name type_id                           |
+| 0x08   | NEW_TYPE      | name arity                             |
+| 0x09   | AXIOM         | id tm name                             |
+| 0x50   | SAVE          | name th                                |
+| 0x51   | LOAD          | id name                                |
+| 0xE0   | DEL ty        | id                                     |
+| 0xE1   | DEL tm        | id                                     |
+| 0xE2   | DEL th        | id                                     |
+| 0xE3   | DEL ci        | id                                     |
+| 0xF0   | DEL ty range  | id_lo id_upto                          |
+| 0xF1   | DEL tm range  | id_lo id_upto                          |
+| 0xF2   | DEL th range  | id_lo id_upto                          |
+| 0xF3   | DEL ci range  | id_lo id_upto                          |
+| 0xFF   | LIMITS        | n_ty n_tm n_th n_ci                    |
+
+Opcodes in the range 0x10–0x4F are reserved for theorem commands defined by
+the ruleset.
+
+Note: In the binary format, variable-length lists are preceded by a varint
+count, since there are no delimiters.
+
+## JSON Lines Encoding
+
+The JSON Lines encoding represents the same abstract command stream as the
+binary format. Each line of the file is a single JSON object. Empty lines
+are ignored.
+
+The file extension SHOULD be `.jsonl`.
+
+### Header and footer
+
+```json
+{"cmd":"PFT","version":1,"ruleset":"hol4"}
+```
+
+```json
+{"cmd":"LIMITS","n_ty":3,"n_tm":4,"n_th":2,"n_ci":0}
+```
+
+The footer is the last non-empty line. A reader can seek to the end of the
+file and scan backwards for the last newline to read the footer.
+
+### Type commands
+
+```json
+{"cmd":"TYVAR","id":0,"name":"'a"}
+{"cmd":"TYOP","id":1,"name":"min$fun","args":[0,0]}
+```
+
+For TYOP, `args` is an array of type IDs (empty array for nullary operators).
+
+### Term commands
+
+```json
+{"cmd":"VAR","id":0,"name":"x","ty":0}
+{"cmd":"CONST","id":1,"name":"bool$T","ty":0}
+{"cmd":"COMB","id":2,"rator":0,"rand":1}
+{"cmd":"ABS","id":3,"var":0,"body":1}
+```
+
+### Kernel commands
+
+```json
+{"cmd":"NEW_CONST","name":"bool$ARB","ty":3}
+{"cmd":"NEW_TYPE","name":"bool$ind","arity":0}
+{"cmd":"AXIOM","id":0,"tm":1,"name":"MY_AXIOM"}
+{"cmd":"AXIOM","id":0,"tm":1}
+```
+
+For AXIOM, the `name` key is omitted when no name is provided. In the binary
+encoding, the name is always present; an empty string indicates no name.
+
+### Control commands
+
+```json
+{"cmd":"DEL","ns":"tm","id":2}
+{"cmd":"DEL","ns":"tm","id":2,"upto":5}
+{"cmd":"SAVE","name":"bool$TRUTH","th":1}
+{"cmd":"LOAD","id":0,"name":"bool$TRUTH"}
+```
+
+For DEL, `ns` is one of `"ty"`, `"tm"`, `"th"`, `"ci"`. When `upto` is
+present, all IDs from `id` to `upto` inclusive are deleted.
+
+### Theorem commands
+
+The JSON encoding of theorem commands is defined by the ruleset. Each theorem
+command is a JSON object with a `"cmd"` key identifying the command and an
+`"id"` key for the assigned theorem ID (or other namespace ID as appropriate).
+
+### Example
+
+See the ruleset specification for a complete example including theorem
+commands.

--- a/src/postkernel/prooftrace/pft-replay-test.mlb
+++ b/src/postkernel/prooftrace/pft-replay-test.mlb
@@ -1,0 +1,2 @@
+pft-replay.mlb
+pft-replay-test.sml

--- a/src/postkernel/prooftrace/pft-replay-test.sml
+++ b/src/postkernel/prooftrace/pft-replay-test.sml
@@ -1,0 +1,14 @@
+(* PFT replay test: replays a .pft.bin file given as the first
+   command-line argument and reports the number of theorems produced. *)
+open Feedback
+
+val () = case CommandLine.arguments () of
+  [file] => let
+    val db = PFTReplay.replay PFTReplay.empty_trDB file
+      handle e as (HOL_ERR r) =>
+        (print ("Uncaught HOL_ERR: " ^ message_of r ^ "\n"); raise e)
+  in
+    print ("Replay produced " ^ Int.toString (PFTReplay.size db) ^
+           " theorems\n")
+  end
+| _ => print ("Usage: pft-replay-test <file.pft.bin>\n")

--- a/src/postkernel/prooftrace/pft-replay.mlb
+++ b/src/postkernel/prooftrace/pft-replay.mlb
@@ -1,0 +1,8 @@
+../../thm/mlton/thm-stdknl.mlb
+
+PFTOpcodes.sig
+PFTOpcodes.sml
+PFTReader.sig
+PFTReader.sml
+PFTReplay.sig
+PFTReplay.sml

--- a/src/postkernel/prooftrace/pft-ruleset-hol4.md
+++ b/src/postkernel/prooftrace/pft-ruleset-hol4.md
@@ -1,0 +1,657 @@
+# PFT Ruleset: `hol4` (Draft)
+
+This document defines the `hol4` ruleset for the
+[PFT format](pft-format.md). It specifies the theorem commands available
+in traces with `"ruleset":"hol4"`, their binary opcodes, JSON encodings,
+and logical semantics.
+
+## Primitive Constants and Types
+
+The `hol4` ruleset assumes three primitive types and constants provided by
+the `min` theory. These are not defined by the trace; they are built into
+the kernel.
+
+The primitive type operators are:
+
+| Type operator | Name | Arity |
+|---------------|------|-------|
+| Booleans | `min$bool` | 0 |
+| Functions | `min$fun` | 2 |
+| Individuals | `min$ind` | 0 |
+
+We write the first two as simply `bool` and `_ → _` henceforth; `min$ind`
+is the type of individuals assumed to be infinite (the `INFINITY_AX` axiom
+asserted in `boolTheory` is stated over it).  No `NEW_TYPE` command is
+emitted for any of the three — they are built into the kernel.
+
+The primitive constants are:
+
+| Constant | Name | Type |
+|----------|------|------|
+| Equality | `min$=` | `'a → 'a → bool` |
+| Implication | `min$==>` | `bool → bool → bool` |
+| Choice | `min$@` | `('a → bool) → 'a` |
+
+Here `'a` is the concrete type variable name (i.e., the string one would
+pass to TYVAR). When applied to arguments, we write `_ = _`, `_ ⇒ _`,
+and `@` without the `min$` prefix.
+
+## Required Constant Definitions
+
+Several kernel rules refer to logical connectives (¬, ∧, ∨, ∀, ∃, etc.)
+that are not primitive. Before these rules can be used, the corresponding
+constants must be defined via DEF_SPEC, producing a theorem
+`⊢ c = <expected RHS>` whose RHS exactly matches what the kernel expects
+(up to alpha-equivalence).
+
+The constants must be defined in the order listed below, because later
+definitions depend on earlier ones. Each definition introduces a constant
+in the `bool` theory.
+
+### 1. `bool$T` (truth)
+
+```
+bool$T = ((λx:bool. x) = (λx:bool. x))
+```
+
+No dependencies beyond the primitive `min$=`.
+
+**Required by**: no rules directly, but needed by `bool$!`.
+
+### 2. `bool$!` (universal quantification)
+
+```
+bool$! = (λP:'a→bool. P = (λx:'a. T))
+```
+
+The type variable `'a` is concrete. The constant has type
+`('a → bool) → bool`.
+
+Depends on: `bool$T`.
+
+**Required by**: SPEC, Specialize, GEN, GENL, EXISTS, CHOOSE, and
+indirectly by all rules that depend on constants defined using `!`.
+
+### 3. `bool$?` (existential quantification)
+
+```
+bool$? = (λP:'a→bool. P (@ P))
+```
+
+The type variable `'a` is concrete. The constant has type
+`('a → bool) → bool`.
+
+Depends on: `min$@` (primitive).
+
+**Required by**: EXISTS, CHOOSE, DEF_TYOP.
+
+### 4. `bool$F` (falsity)
+
+```
+bool$F = bool$!(λt:bool. t)
+```
+
+Depends on: `bool$!`.
+
+**Required by**: NOT_INTRO, NOT_ELIM, CCONTR (via `bool$~`).
+
+### 5. `bool$~` (negation)
+
+```
+bool$~ = (λt:bool. t ⇒ bool$F)
+```
+
+Depends on: `bool$F`, `min$==>`.
+
+**Required by**: NOT_INTRO, NOT_ELIM, CCONTR.
+
+### 6. `bool$/\` (conjunction)
+
+```
+bool$/\ = (λt1:bool. λt2:bool. bool$!(λt:bool. (t1 ⇒ t2 ⇒ t) ⇒ t))
+```
+
+Depends on: `bool$!`, `min$==>`.
+
+**Required by**: CONJ, CONJUNCT1, CONJUNCT2, DEF_TYOP (via
+`bool$TYPE_DEFINITION`).
+
+### 7. `bool$\/` (disjunction)
+
+```
+bool$\/ = (λt1:bool. λt2:bool. bool$!(λt:bool. (t1 ⇒ t) ⇒ (t2 ⇒ t) ⇒ t))
+```
+
+Depends on: `bool$!`, `min$==>`.
+
+**Required by**: DISJ1, DISJ2, DISJ_CASES.
+
+### 8. `bool$TYPE_DEFINITION`
+
+```
+bool$TYPE_DEFINITION =
+  (λP:'a→bool. λrep:'b→'a.
+    (∀x':'b. ∀x'':'b. (rep x' = rep x'') ⇒ (x' = x'')) ∧
+    (∀x:'a. P x = ∃x':'b. x = rep x'))
+```
+
+The type variables `'a` and `'b` are concrete. The constant has type
+`('a → bool) → ('b → 'a) → bool`.
+
+Depends on: `bool$!`, `bool$?`, `bool$/\`, `min$=`, `min$==>`.
+
+**Required by**: DEF_TYOP.
+
+### Summary of rule dependencies
+
+| Rules | Required constants |
+|-------|-------------------|
+| REFL, ALPHA, BETA_CONV, SYM, TRANS, EQ_MP, MK_COMB, ABS_THM, AP_TERM, AP_THM, Beta, Mk_comb, Mk_abs, ASSUME, MP, DISCH, deductAntisym, EQ_IMP_RULE1, EQ_IMP_RULE2, INST, INST_TYPE, SUBST, ABSL, GEN_ABS, DEF_SPEC | *(none)* |
+| GEN, GENL | `bool$!` |
+| SPEC, Specialize | `bool$!` |
+| EXISTS | `bool$?` |
+| CHOOSE | `bool$?` |
+| NOT_INTRO, NOT_ELIM | `bool$~`, `bool$F` |
+| CCONTR | `bool$~`, `bool$F` |
+| CONJ, CONJUNCT1, CONJUNCT2 | `bool$/\` |
+| DISJ1, DISJ2, DISJ_CASES | `bool$\/` |
+| DEF_TYOP | `bool$TYPE_DEFINITION` |
+
+## Command Reference
+
+### Equality and rewriting
+
+| Command | Arguments |
+|---------|-----------|
+| REFL | id, tm |
+| ALPHA | id, tm1, tm2 |
+| BETA_CONV | id, tm |
+| SYM | id, th |
+| TRANS | id, th1, th2 |
+| EQ_MP | id, eq: thm-id, th: thm-id |
+
+### Congruence
+
+| Command | Arguments |
+|---------|-----------|
+| MK_COMB | id, th1, th2 |
+| ABS_THM | id, tm, th |
+| AP_TERM | id, tm, th |
+| AP_THM | id, th, tm |
+| Beta | id, th |
+| Mk_comb | id, eq: thm-id, rator: thm-id, rand: thm-id |
+| Mk_abs | id, eq: thm-id, body: thm-id |
+
+### Implication and modus ponens
+
+| Command | Arguments |
+|---------|-----------|
+| ASSUME | id, tm |
+| MP | id, imp: thm-id, ant: thm-id |
+| DISCH | id, tm, th |
+| NOT_INTRO | id, th |
+| NOT_ELIM | id, th |
+| CCONTR | id, tm, th |
+| deductAntisym | id, th1, th2 |
+
+### Conjunction
+
+| Command | Arguments |
+|---------|-----------|
+| CONJ | id, th1, th2 |
+| CONJUNCT1 | id, th |
+| CONJUNCT2 | id, th |
+
+### Disjunction
+
+| Command | Arguments |
+|---------|-----------|
+| DISJ1 | id, th, tm |
+| DISJ2 | id, tm, th |
+| DISJ_CASES | id, disj: thm-id, left: thm-id, right: thm-id |
+
+### Quantifiers
+
+| Command | Arguments |
+|---------|-----------|
+| GEN | id, tm, th |
+| SPEC | id, tm, th |
+| Specialize | id, tm, th |
+| GENL | id, th, tms: term-id list |
+| EXISTS | id, tm1, tm2, th |
+| CHOOSE | id, var: term-id, existence: thm-id, body: thm-id |
+
+### Abstraction lists
+
+| Command | Arguments |
+|---------|-----------|
+| ABSL | id, th, tms: term-id list |
+| GEN_ABS | id, th, tm, tms: term-id list |
+
+### Instantiation and substitution
+
+| Command | Arguments |
+|---------|-----------|
+| INST | id, th, subst: {redex: term-id, residue: term-id} list |
+| INST_TYPE | id, th, subst: {redex: type-id, residue: type-id} list |
+| SUBST | id, template: term-id, th, subst: {redex: term-id, residue: thm-id} list |
+| EQ_IMP_RULE1 | id, th |
+| EQ_IMP_RULE2 | id, th |
+
+### Definitions
+
+| Command | Arguments |
+|---------|-----------|
+| DEF_TYOP | id, th, name |
+| DEF_SPEC | id, th, names: string list |
+| DEF_SPEC_GEN | id, th, names: string list |
+
+### Computation
+
+| Command | Arguments |
+|---------|-----------|
+| COMPUTE_INIT | id, num_ty: type-id, cval_ty: type-id, char_eqns: {name: thm-id}, cval_terms: {name: term-id} |
+| COMPUTE | id, ci: compute-id, tm, ths: thm-id list |
+
+## Binary Opcodes
+
+| Opcode | Command       | Arguments                              |
+|--------|---------------|----------------------------------------|
+| 0x10   | REFL          | id tm                                  |
+| 0x11   | ALPHA         | id tm1 tm2                             |
+| 0x12   | ASSUME        | id tm                                  |
+| 0x13   | BETA_CONV     | id tm                                  |
+| 0x14   | EQ_MP         | id eq th                               |
+| 0x15   | MP            | id imp ant                             |
+| 0x16   | SYM           | id th                                  |
+| 0x17   | TRANS         | id th1 th2                             |
+| 0x18   | CONJ          | id th1 th2                             |
+| 0x19   | CONJUNCT1     | id th                                  |
+| 0x1A   | CONJUNCT2     | id th                                  |
+| 0x1B   | DISCH         | id tm th                               |
+| 0x1C   | DISJ1         | id th tm                               |
+| 0x1D   | DISJ2         | id tm th                               |
+| 0x1E   | DISJ_CASES    | id disj left right                     |
+| 0x1F   | NOT_ELIM      | id th                                  |
+| 0x20   | NOT_INTRO     | id th                                  |
+| 0x21   | CCONTR        | id tm th                               |
+| 0x22   | EXISTS        | id tm1 tm2 th                          |
+| 0x23   | CHOOSE        | id var existence body                  |
+| 0x24   | GEN           | id tm th                               |
+| 0x25   | SPEC          | id tm th                               |
+| 0x26   | Specialize    | id tm th                               |
+| 0x27   | GENL          | id th n_tms tm...                      |
+| 0x28   | ABSL          | id th n_tms tm...                      |
+| 0x29   | GEN_ABS       | id th tm n_tms tm...                   |
+| 0x30   | ABS_THM       | id tm th                               |
+| 0x31   | AP_TERM       | id tm th                               |
+| 0x32   | AP_THM        | id th tm                               |
+| 0x33   | MK_COMB       | id th1 th2                             |
+| 0x34   | Beta          | id th                                  |
+| 0x35   | Mk_abs        | id eq body                             |
+| 0x36   | Mk_comb       | id eq rator rand                       |
+| 0x37   | EQ_IMP_RULE1  | id th                                  |
+| 0x38   | EQ_IMP_RULE2  | id th                                  |
+| 0x39   | INST          | id th n_subst (redex residue)...       |
+| 0x3A   | INST_TYPE     | id th n_subst (redex residue)...       |
+| 0x3B   | SUBST         | id template th n_subst (redex residue)...|
+| 0x3C   | deductAntisym | id th1 th2                             |
+| 0x40   | DEF_TYOP      | id th name                             |
+| 0x41   | DEF_SPEC      | id th n_names name...                  |
+| 0x42   | DEF_SPEC_GEN  | id th n_names name...                   |
+| 0x43   | COMPUTE_INIT  | id ty1 ty2 n_eqns (name th)... n_terms (name tm)... |
+| 0x44   | COMPUTE       | id ci tm n_ths th...                   |
+
+## JSON Lines Encoding
+
+### Simple commands
+
+```json
+{"cmd":"REFL","id":0,"tm":1}
+{"cmd":"ALPHA","id":0,"tm1":1,"tm2":2}
+{"cmd":"ASSUME","id":0,"tm":1}
+{"cmd":"BETA_CONV","id":0,"tm":1}
+{"cmd":"SYM","id":0,"th":1}
+{"cmd":"TRANS","id":0,"th1":1,"th2":2}
+{"cmd":"MK_COMB","id":0,"th1":1,"th2":2}
+{"cmd":"ABS_THM","id":0,"tm":1,"th":2}
+{"cmd":"AP_TERM","id":0,"tm":1,"th":2}
+{"cmd":"AP_THM","id":0,"th":1,"tm":2}
+{"cmd":"Beta","id":0,"th":1}
+{"cmd":"DISCH","id":0,"tm":1,"th":2}
+{"cmd":"NOT_INTRO","id":0,"th":1}
+{"cmd":"NOT_ELIM","id":0,"th":1}
+{"cmd":"CCONTR","id":0,"tm":1,"th":2}
+{"cmd":"deductAntisym","id":0,"th1":1,"th2":2}
+{"cmd":"CONJ","id":0,"th1":1,"th2":2}
+{"cmd":"CONJUNCT1","id":0,"th":1}
+{"cmd":"CONJUNCT2","id":0,"th":1}
+{"cmd":"DISJ1","id":0,"th":1,"tm":2}
+{"cmd":"DISJ2","id":0,"tm":1,"th":2}
+{"cmd":"GEN","id":0,"tm":1,"th":2}
+{"cmd":"SPEC","id":0,"tm":1,"th":2}
+{"cmd":"Specialize","id":0,"tm":1,"th":2}
+{"cmd":"EXISTS","id":0,"tm1":1,"tm2":2,"th":3}
+{"cmd":"EQ_IMP_RULE1","id":0,"th":1}
+{"cmd":"EQ_IMP_RULE2","id":0,"th":1}
+```
+
+### Commands with descriptive keys
+
+```json
+{"cmd":"EQ_MP","id":0,"eq":1,"th":2}
+{"cmd":"MP","id":0,"imp":1,"ant":2}
+{"cmd":"DISJ_CASES","id":0,"disj":1,"left":2,"right":3}
+{"cmd":"CHOOSE","id":0,"var":1,"existence":2,"body":3}
+{"cmd":"Mk_comb","id":0,"eq":1,"rator":2,"rand":3}
+{"cmd":"Mk_abs","id":0,"eq":1,"body":2}
+```
+
+### Commands with lists
+
+```json
+{"cmd":"GENL","id":0,"th":1,"tms":[2,3]}
+{"cmd":"ABSL","id":0,"th":1,"tms":[2,3]}
+{"cmd":"GEN_ABS","id":0,"th":1,"tm":2,"tms":[3,4]}
+```
+
+### Substitution commands
+
+Substitution lists use `redex` and `residue` keys:
+
+```json
+{"cmd":"INST","id":0,"th":1,"subst":[{"redex":2,"residue":3}]}
+{"cmd":"INST_TYPE","id":0,"th":1,"subst":[{"redex":2,"residue":3}]}
+{"cmd":"SUBST","id":0,"template":1,"th":2,"subst":[{"redex":3,"residue":4}]}
+```
+
+For INST and INST_TYPE, `redex` and `residue` are term IDs and type IDs
+respectively. For SUBST, `redex` is a term ID and `residue` is a theorem ID.
+
+### Definitions
+
+```json
+{"cmd":"DEF_SPEC","id":0,"th":1,"names":["foo$c1","foo$c2"]}
+{"cmd":"DEF_SPEC_GEN","id":0,"th":1,"names":["mytheory$c1","mytheory$c2"]}
+{"cmd":"DEF_TYOP","id":0,"th":1,"name":"mytype"}
+```
+
+### Computation
+
+```json
+{"cmd":"COMPUTE_INIT","id":0,"num_ty":1,"cval_ty":2,
+ "char_eqns":{"alt_zero":10,"cond_T":11,"cond_F":12},
+ "cval_terms":{"truth":20,"false":21}}
+{"cmd":"COMPUTE","id":0,"ci":1,"tm":2,"ths":[3,4,5]}
+```
+
+`char_eqns` is an object mapping equation names to theorem IDs.
+`cval_terms` is an object mapping operator names to term IDs.
+
+## Example
+
+```json
+{"cmd":"PFT","version":1,"ruleset":"hol4"}
+{"cmd":"TYOP","id":0,"name":"bool$bool","args":[]}
+{"cmd":"TYOP","id":1,"name":"min$fun","args":[0,0]}
+{"cmd":"CONST","id":0,"name":"bool$=","ty":1}
+{"cmd":"CONST","id":1,"name":"bool$T","ty":0}
+{"cmd":"COMB","id":2,"rator":0,"rand":1}
+{"cmd":"COMB","id":3,"rator":2,"rand":1}
+{"cmd":"DEL","ns":"tm","id":2}
+{"cmd":"REFL","id":0,"tm":1}
+{"cmd":"AP_TERM","id":1,"tm":3,"th":0}
+{"cmd":"DEL","ns":"th","id":0}
+{"cmd":"DEL","ns":"tm","id":0,"upto":1}
+{"cmd":"DEL","ns":"tm","id":3}
+{"cmd":"SAVE","name":"bool$TRUTH","th":1}
+{"cmd":"LIMITS","n_ty":3,"n_tm":4,"n_th":2,"n_ci":0}
+```
+
+## Specification of the Theorem Commands
+
+We write `A` for hypothesis sets and `⊢` for entailment. The following
+Unicode notation is used for readability:
+
+| Symbol | Meaning |
+|--------|---------|
+| `λ` | lambda abstraction (primitive) |
+| `⇒` | implication (`min$==>`) |
+| `∀` | universal quantification (`bool$!`) |
+| `∃` | existential quantification (`bool$?`) |
+| `¬` | negation (`bool$~`) |
+| `∧` | conjunction (`bool$/\`) |
+| `∨` | disjunction (`bool$\/`) |
+
+### Equality and rewriting
+
+| Rule | Inputs | Result | Side Conditions |
+|------|--------|--------|-----------------|
+| REFL | `t` | `⊢ t = t` | |
+| ALPHA | `t1` `t2` | `⊢ t1 = t2` | `t1` and `t2` are alpha-equivalent |
+| BETA_CONV | `(λx. t) u` | `⊢ (λx. t) u = t[u/x]` | |
+| SYM | `A ⊢ t1 = t2` | `A ⊢ t2 = t1` | |
+| TRANS | `A ⊢ t1 = t2`, `B ⊢ t2 = t3` | `A ∪ B ⊢ t1 = t3` | |
+| EQ_MP | `A ⊢ p = q`, `B ⊢ p` | `A ∪ B ⊢ q` | |
+
+### Congruence
+
+| Rule | Inputs | Result | Side Conditions |
+|------|--------|--------|-----------------|
+| MK_COMB | `A ⊢ f = g`, `B ⊢ x = y` | `A ∪ B ⊢ f x = g y` | types must be compatible |
+| ABS_THM | `x`, `A ⊢ t1 = t2` | `A ⊢ (λx. t1) = (λx. t2)` | `x` not free in `A` |
+| AP_TERM | `f`, `A ⊢ x = y` | `A ⊢ f x = f y` | `f` has compatible function type |
+| AP_THM | `A ⊢ f = g`, `x` | `A ⊢ f x = g x` | types must be compatible |
+| Beta | `A ⊢ t1 = (λx. b) u` | `A ⊢ t1 = b[u/x]` | RHS must be a beta-redex |
+
+### Implication and modus ponens
+
+| Rule | Inputs | Result | Side Conditions |
+|------|--------|--------|-----------------|
+| ASSUME | `p` | `{p} ⊢ p` | `p` has type `bool` |
+| MP | `A ⊢ p ⇒ q`, `B ⊢ p` | `A ∪ B ⊢ q` | |
+| DISCH | `p`, `A ⊢ q` | `A \ {p} ⊢ p ⇒ q` | |
+| NOT_INTRO | `A ⊢ p ⇒ F` | `A ⊢ ¬p` | Requires `bool$~` and `bool$F` |
+| NOT_ELIM | `A ⊢ ¬p` | `A ⊢ p ⇒ F` | Requires `bool$~` and `bool$F` |
+| CCONTR | `p`, `A ⊢ F` | `A \ {¬p} ⊢ p` | Requires `bool$~` and `bool$F` |
+| deductAntisym | `A ⊢ p`, `B ⊢ q` | `(A \ {q}) ∪ (B \ {p}) ⊢ p = q` | |
+
+### Conjunction
+
+| Rule | Inputs | Result | Side Conditions |
+|------|--------|--------|-----------------|
+| CONJ | `A ⊢ p`, `B ⊢ q` | `A ∪ B ⊢ p ∧ q` | Requires `bool$/\` |
+| CONJUNCT1 | `A ⊢ p ∧ q` | `A ⊢ p` | Requires `bool$/\` |
+| CONJUNCT2 | `A ⊢ p ∧ q` | `A ⊢ q` | Requires `bool$/\` |
+
+### Disjunction
+
+| Rule | Inputs | Result | Side Conditions |
+|------|--------|--------|-----------------|
+| DISJ1 | `A ⊢ p`, `q` | `A ⊢ p ∨ q` | Requires `bool$\/` |
+| DISJ2 | `q`, `A ⊢ p` | `A ⊢ q ∨ p` | Requires `bool$\/` |
+| DISJ_CASES | `A ⊢ p ∨ q`, `B ⊢ r`, `C ⊢ r` | `A ∪ (B \ {p}) ∪ (C \ {q}) ⊢ r` | Requires `bool$\/` |
+
+### Quantifiers
+
+| Rule | Inputs | Result | Side Conditions |
+|------|--------|--------|-----------------|
+| GEN | `x`, `A ⊢ p` | `A ⊢ ∀x. p` | `x` not free in `A`; requires `bool$!` |
+| SPEC | `t`, `A ⊢ ∀x. p` | `A ⊢ p[t/x]` | `t` has same type as `x`; requires `bool$!` |
+| Specialize | `t`, `A ⊢ ∀x. p` | `A ⊢ p[t/x]` | `t` has the same type as `x`; requires `bool$!` |
+| GENL | `A ⊢ p`, `[x1,...,xn]` | `A ⊢ ∀x1...xn. p` | each `xi` not free in `A`; requires `bool$!` |
+| EXISTS | `(∃x. p)`, `t`, `A ⊢ p[t/x]` | `A ⊢ ∃x. p` | Requires `bool$?` |
+| CHOOSE | `v`, `A ⊢ ∃x. P`, `B ⊢ q` | `A ∪ (B \ {P[v/x]}) ⊢ q` | `v` not free in `∃x. P`, `q`, or the remaining hypotheses; requires `bool$?` |
+
+Note: `Specialize` has the same logical semantics as `SPEC`, but indicates
+a request to delay the substitution in kernel implementations whose terms
+support doing that.
+
+### Abstraction lists
+
+| Rule | Inputs | Result | Side Conditions |
+|------|--------|--------|-----------------|
+| ABSL | `A ⊢ t1 = t2`, `[x1,...,xn]` | `A ⊢ (λx1...xn. t1) = (λx1...xn. t2)` | each `xi` not free in `A` |
+| GEN_ABS | `A ⊢ t1 = t2`, `c`, `[x1,...,xn]` | `A ⊢ (c (λx1. c (λx2. ... c (λxn. t1)...))) = (c (λx1. c (λx2. ... c (λxn. t2)...)))` | types are compatible; each `xi` not free in `A` |
+
+### Parallel congruence (Mk rules)
+
+| Rule | Inputs | Result | Side Conditions |
+|------|--------|--------|-----------------|
+| Mk_comb | `A ⊢ t = f x`, `B ⊢ f = f'`, `C ⊢ x = x'` | `A ∪ B ∪ C ⊢ t = f' x'` | RHS of first thm must be an application; LHS of second must be alpha-equivalent to the rator; LHS of third must be alpha-equivalent to the rand |
+| Mk_abs | `A ⊢ t = λv. b`, `B ⊢ b = b'` | `A ∪ B ⊢ t = λv. b'` | RHS of first thm must be an abstraction; LHS of second must be alpha-equivalent to the body; `v` not free in `B` |
+
+In the kernel API, `Mk_comb` and `Mk_abs` return continuations. In the trace,
+all arguments are provided directly.
+
+### Instantiation and substitution
+
+| Rule | Inputs | Result | Side Conditions |
+|------|--------|--------|-----------------|
+| INST | `A ⊢ p`, `[(x1,t1),...,(xn,tn)]` | `A[ti/xi] ⊢ p[ti/xi]` | each `ti` has same type as `xi` |
+| INST_TYPE | `A ⊢ p`, `[(a1,ty1),...,(an,tyn)]` | `A[tyi/ai] ⊢ p[tyi/ai]` | type variable substitution |
+| SUBST | `[(v1, A1 ⊢ t1 = t1'),...,(vn, An ⊢ tn = tn')]`, `template`, `B ⊢ p` | `A1 ∪...∪ An ∪ B ⊢ p'` | `p'` is `p` with each `vi` in template replaced by corresponding `ti'` |
+| EQ_IMP_RULE1 | `A ⊢ p = q` | `A ⊢ p ⇒ q` | |
+| EQ_IMP_RULE2 | `A ⊢ p = q` | `A ⊢ q ⇒ p` | |
+
+### Axioms and definitions
+
+| Rule | Inputs | Result | Side Conditions |
+|------|--------|--------|-----------------|
+| DEF_SPEC | `⊢ ∃v1...vn. P`, `[s1,...,sn]` | `⊢ P[c1/v1,...,cn/vn]` | The input theorem must have no hypotheses and no free variables; each `si` is the name of a fresh constant `ci` with the same type as `vi`. Corresponds to HOL4's `prim_specification`. |
+| DEF_SPEC_GEN | `{v1 = t1, ..., vn = tn} ⊢ P`, `[s1,...,sn]` | `⊢ P[c1/v1,...,cn/vn]` | Each hypothesis must be an equation `vi = ti` where `vi` is a variable. The `ti` must have no free variables other than those bound by other hypotheses. Each `si` must match `thy$vi` for some common theory prefix `thy`; each `ci` is a fresh constant named `si` with the same type as `vi`. Corresponds to HOL4's `gen_prim_specification`. |
+| DEF_TYOP | `⊢ ∃v. P v`, name | `⊢ ∃rep. TYPE_DEFINITION P rep` | Creates a new type operator with the given name; `P : dom → bool` must be a closed term; the input theorem must have no hypotheses; the new type has the type variables of `P` as parameters. Requires `bool$TYPE_DEFINITION` |
+
+### Computation
+
+| Rule | Inputs | Result | Side Conditions |
+|------|--------|--------|-----------------|
+| COMPUTE | ci, `[th1,...,thn]`, `t` | `⊢ t = v` | See below |
+
+#### COMPUTE_INIT
+
+Creates a compute context from four components:
+
+- **`num_ty`**: the type of natural numbers (`:num`)
+- **`cval_ty`**: the type of computed values (`:cv`)
+- **`cval_terms`**: an object mapping operator names to term IDs. The
+  following names must be present, each bound to a constant of the
+  appropriate type:
+
+  | Name | Description | Name | Description |
+  |------|-------------|------|-------------|
+  | `truth` | `T` | `false` | `F` |
+  | `cond` | conditional | `let` | let-binding |
+  | `zero` | `0 : num` | `alt_zero` | alternate zero |
+  | `suc` | successor | `numeral` | numeral wrapper |
+  | `bit1` | binary encoding | `bit2` | binary encoding |
+  | `add` | addition | `sub` | subtraction |
+  | `mul` | multiplication | `div` | division |
+  | `mod` | modulus | `lt` | less-than |
+  | `cv_pair` | cv pair constructor | `cv_num` | cv numeral constructor |
+  | `cv_fst` | cv first projection | `cv_snd` | cv second projection |
+  | `cv_ispair` | cv pair test | `cv_eq` | cv equality |
+  | `cv_add` | cv addition | `cv_sub` | cv subtraction |
+  | `cv_mul` | cv multiplication | `cv_div` | cv division |
+  | `cv_mod` | cv modulus | `cv_lt` | cv less-than |
+  | `cv_if` | cv conditional | | |
+
+- **`char_eqns`**: an object mapping equation names to theorem IDs. Each
+  theorem must have no hypotheses. The equations use the `cval_terms`
+  constants and operate at `num_ty` and `cval_ty` types. We write `0`,
+  `SUC`, `+`, `−`, `*`, `DIV`, `MOD`, `<` for the `zero`, `suc`, `add`,
+  `sub`, `mul`, `div`, `mod`, `lt` constants; `T`, `F`, `COND` for
+  `truth`, `false`, `cond`; `NUMERAL`, `ZERO`, `BIT1`, `BIT2` for
+  `numeral`, `alt_zero`, `bit1`, `bit2`; `LET` for `let`; and `cv_num`,
+  `cv_pair`, etc. for the cv constants. Variables `m`, `n` have type
+  `num_ty`; variables `p`, `q`, `r`, `s` have type `cval_ty`; variables
+  `f`, `a`, `b`, `x` are polymorphic as indicated.
+
+  The required equations are:
+
+  | Name | Equation |
+  |------|----------|
+  | `alt_zero` | `⊢ ZERO = 0` |
+  | `cond_T` | `⊢ COND T a b = a` |
+  | `cond_F` | `⊢ COND F a b = b` |
+  | `numeral` | `⊢ NUMERAL n = n` |
+  | `bit1` | `⊢ BIT1 n = n + (n + SUC 0)` |
+  | `bit2` | `⊢ BIT2 n = n + (n + SUC (SUC 0))` |
+  | `add1` | `⊢ 0 + n = n` |
+  | `add2` | `⊢ SUC m + n = SUC (m + n)` |
+  | `sub1` | `⊢ 0 − m = 0` |
+  | `sub2` | `⊢ SUC m − n = COND (m < n) 0 (SUC (m − n))` |
+  | `mul1` | `⊢ 0 * n = 0` |
+  | `mul2` | `⊢ SUC m * n = m * n + n` |
+  | `div` | `⊢ m DIV n = COND (n = 0) 0 (COND (m < n) 0 (SUC ((m − n) DIV n)))` |
+  | `mod` | `⊢ m MOD n = COND (n = 0) m (COND (m < n) m ((m − n) MOD n))` |
+  | `lt1` | `⊢ (m < 0) = F` |
+  | `lt2` | `⊢ (m < SUC n) = COND (m = n) T (m < n)` |
+  | `suc1` | `⊢ (SUC m = 0) = F` |
+  | `suc2` | `⊢ (SUC m = SUC n) = (m = n)` |
+  | `cval1` | `⊢ (cv_pair p q = cv_pair r s) = COND (p = r) (q = s) F` |
+  | `cval2` | `⊢ (cv_pair p q = cv_num n) = F` |
+  | `cval3` | `⊢ (cv_num m = cv_num n) = (m = n)` |
+  | `cv_add1` | `⊢ cv_add (cv_num m) (cv_num n) = cv_num (m + n)` |
+  | `cv_add2` | `⊢ cv_add (cv_num m) (cv_pair p q) = cv_num m` |
+  | `cv_add3` | `⊢ cv_add (cv_pair p q) (cv_num n) = cv_num n` |
+  | `cv_add4` | `⊢ cv_add (cv_pair p q) (cv_pair r s) = cv_num 0` |
+  | `cv_sub1` | `⊢ cv_sub (cv_num m) (cv_num n) = cv_num (m − n)` |
+  | `cv_sub2` | `⊢ cv_sub (cv_num m) (cv_pair p q) = cv_num m` |
+  | `cv_sub3` | `⊢ cv_sub (cv_pair p q) (cv_num n) = cv_num 0` |
+  | `cv_sub4` | `⊢ cv_sub (cv_pair p q) (cv_pair r s) = cv_num 0` |
+  | `cv_mul1` | `⊢ cv_mul (cv_num m) (cv_num n) = cv_num (m * n)` |
+  | `cv_mul2` | `⊢ cv_mul (cv_num m) (cv_pair p q) = cv_num 0` |
+  | `cv_mul3` | `⊢ cv_mul (cv_pair p q) (cv_num n) = cv_num 0` |
+  | `cv_mul4` | `⊢ cv_mul (cv_pair p q) (cv_pair r s) = cv_num 0` |
+  | `cv_div1` | `⊢ cv_div (cv_num m) (cv_num n) = cv_num (m DIV n)` |
+  | `cv_div2` | `⊢ cv_div (cv_num m) (cv_pair p q) = cv_num 0` |
+  | `cv_div3` | `⊢ cv_div (cv_pair p q) (cv_num n) = cv_num 0` |
+  | `cv_div4` | `⊢ cv_div (cv_pair p q) (cv_pair r s) = cv_num 0` |
+  | `cv_mod1` | `⊢ cv_mod (cv_num m) (cv_num n) = cv_num (m MOD n)` |
+  | `cv_mod2` | `⊢ cv_mod (cv_num m) (cv_pair p q) = cv_num m` |
+  | `cv_mod3` | `⊢ cv_mod (cv_pair p q) (cv_num n) = cv_num 0` |
+  | `cv_mod4` | `⊢ cv_mod (cv_pair p q) (cv_pair r s) = cv_num 0` |
+  | `cv_lt1` | `⊢ cv_lt (cv_num m) (cv_num n) = cv_num (COND (m < n) (SUC 0) 0)` |
+  | `cv_lt2` | `⊢ cv_lt (cv_num m) (cv_pair p q) = cv_num 0` |
+  | `cv_lt3` | `⊢ cv_lt (cv_pair p q) (cv_num n) = cv_num 0` |
+  | `cv_lt4` | `⊢ cv_lt (cv_pair p q) (cv_pair r s) = cv_num 0` |
+  | `cv_if1` | `⊢ cv_if (cv_num (SUC m)) p q = p` |
+  | `cv_if2` | `⊢ cv_if (cv_num 0) p q = q` |
+  | `cv_if3` | `⊢ cv_if (cv_pair r s) p q = q` |
+  | `cv_fst1` | `⊢ cv_fst (cv_pair p q) = p` |
+  | `cv_fst2` | `⊢ cv_fst (cv_num m) = cv_num 0` |
+  | `cv_snd1` | `⊢ cv_snd (cv_pair p q) = q` |
+  | `cv_snd2` | `⊢ cv_snd (cv_num m) = cv_num 0` |
+  | `cv_ispair1` | `⊢ cv_ispair (cv_pair p q) = cv_num (SUC 0)` |
+  | `cv_ispair2` | `⊢ cv_ispair (cv_num m) = cv_num 0` |
+  | `cv_eq` | `⊢ cv_eq p q = cv_num (COND (p = q) (SUC 0) 0)` |
+  | `let` | `⊢ LET f x = f x` |
+
+The context is created once and reused across multiple COMPUTE calls.
+
+#### COMPUTE
+
+Takes a compute context `ci`, a list of code equation theorems
+`[th1,...,thn]`, and a term `t`. Returns `⊢ t = v` (no hypotheses) where `v`
+is the normal form of `t` under evaluation.
+
+**Compute expressions**: A compute expression is a term `e` satisfying:
+- the type of `e` is `cval_ty`
+- `e` contains no abstractions except as the first argument to `LET`
+- all constants in `e` are among the LHS head constants of the code equations,
+  the `cval_terms` constants whose names begin with `cv_`, or `let`
+- all applications of `cv_num` are of the form `cv_num (NUMERAL n)` or `cv_num n`
+  where `n` contains no variables and all constants in `n` are among `0`, `ZERO`,
+  `BIT1`, and `BIT2`
+
+**Conditions on code equations**: Each `thi` must be a theorem with no
+hypotheses whose conclusion has the form `f x1 ... xk = r` where:
+- `f` is a constant
+- each `xi` is a variable of type `cval_ty`
+- the `xi` are all distinct
+- the RHS `r` is a compute expression
+- all free variables in `r` are among `x1,...,xk`
+
+**Conditions on the term**: The term `t` must be a
+compute expression with no free variables.


### PR DESCRIPTION
This commit introduces the PFT format for HOL proof traces and a standalone tool for replaying proofs in that format in HOL4.

In the future we intend to also integrate such replay in the system using the --thmsrc option of Holmake/build.