### PR TITLE
Fix Holmake parallel cross-directory dependencies

### DIFF
--- a/tools/Holmake/core/Holmake.sml
+++ b/tools/Holmake/core/Holmake.sml
@@ -407,6 +407,7 @@ type incmap = (hmdir.t, {incs:dirset,pres:dirset}) Binarymap.dict
 type dirinfo = {incdirmap : incmap, visited : hmdir.t Binaryset.set,
                 ancestors : hmdir.t list (* most recent hd of list *)}
 type 'a hmfold =
+     incmap ->
      {includes : string list, preincludes : string list} ->
      (string -> unit) ->
      hmdir.t ->
@@ -532,7 +533,8 @@ let
             val _ = if not (isSome dsopt) then
                       info_inline (verb ^ " " ^ bold (hmdir.pretty_dir dir))
                     else ()
-            val data' = hm {includes=f incs,preincludes=f pres} warn dir data
+            val data' = hm incdirmap {includes=f incs,preincludes=f pres}
+                           warn dir data
           in
             {incdirmap = incdirmap, visited = visited, data = data'}
           end
@@ -832,7 +834,7 @@ fun cdset_toString ((_,stk):cdset) =
 
 (* is run in a directory at a time *)
 type g = GraphExtra.t HM_DepGraph.t
-fun build_depgraph cdset incinfo (tgt:dep) g0:(g * node) =
+fun build_depgraph incinfo_for_dir cdset incinfo (tgt:dep) g0:(g * node) =
 let
   val dir = hm_target.dirpart tgt and target = hm_target.filepart tgt
   val {preincludes,includes} = incinfo
@@ -846,7 +848,8 @@ let
   fun addF tgt n = (n,tgt)
   fun nstatus g n = peeknode g n |> valOf |> #status
   fun build (tgt':dep) g =
-    build_depgraph (cdset_add cdset (dir, target_s)) incinfo tgt' g
+    build_depgraph incinfo_for_dir (cdset_add cdset (dir, target_s))
+                   incinfo tgt' g
 
   val fullpath = fp dir target_s
   val fullpath_s = fps fullpath
@@ -871,14 +874,31 @@ in
       if not (hmdir.eqdir dir actual_dir) andalso
          no_full_extra_rule (SOME tgt)
          (* path outside of current directory *)
-      then (
-        diag (fn _ => "Target "^pretty_tgt^" external to directory");
-        add_node {target = tgt, seqnum = 0, phony = false,
-                  status = if exists_readable fullpath_s then Succeeded
-                           else Failed{needed=false},
-                  dir = dir, extra = extra,
-                  command = NoCmd, dependencies = []} g0
-      )
+      then
+        if exists_readable fullpath_s then (
+          diag (fn _ => "Target "^pretty_tgt^" external to directory");
+          add_node {target = tgt, seqnum = 0, phony = false,
+                    status = Succeeded,
+                    dir = dir, extra = extra,
+                    command = NoCmd, dependencies = []} g0
+        )
+        else if FileSys.access (hmdir.toAbsPath dir,
+                                 [FileSys.A_READ, FileSys.A_EXEC]) then (
+          diag (fn _ => "Target "^pretty_tgt^
+                        " external to directory; building in place");
+          pushdir (hmdir.toAbsPath dir)
+                  (build_depgraph incinfo_for_dir cdset (incinfo_for_dir dir)
+                                  tgt)
+                  g0
+        )
+        else (
+          diag (fn _ => "Target "^pretty_tgt^
+                        " external to missing directory");
+          add_node {target = tgt, seqnum = 0, phony = false,
+                    status = Failed{needed=false},
+                    dir = dir, extra = extra,
+                    command = NoCmd, dependencies = []} g0
+        )
       else if isSome pdep andalso no_full_extra_rule (SOME tgt) then
         let
           val pdep = hm_target.mk(dir, valOf pdep)
@@ -1081,15 +1101,25 @@ fun get_targets dir =
                       rules
     end
 
-fun extend_graph_in_dir incinfo warn dir graph =
+fun include_info_from_map incdirmap dir =
+    let
+      val {pres, incs} = idm_lookup incdirmap dir
+      fun paths ds =
+          Binaryset.foldr (fn (d, acc) => hmdir.toAbsPath d :: acc) [] ds
+    in
+      {includes = paths incs, preincludes = paths pres}
+    end
+
+fun extend_graph_in_dir incdirmap incinfo warn dir graph =
     let
       open HM_DepGraph
+      val incinfo_for_dir = include_info_from_map incdirmap
       val _ = diag "builddepgraph" (fn _ =>
                        "Extending graph in directory " ^ hmdir.pretty_dir dir)
       val dir_targets = get_targets dir
     in
       Binaryset.foldl
-        (fn (t,g) => #1 (build_depgraph empty_cdset incinfo t g))
+        (fn (t,g) => #1 (build_depgraph incinfo_for_dir empty_cdset incinfo t g))
         graph
         dir_targets
     end
@@ -1247,7 +1277,7 @@ fun work() =
           else (
             recursively getnewincs (SOME cline_incs) {
               outputfns = outputfns, verb = "Cleaning",
-              hm = (fn _ => fn _ => fn _ => fn _ =>
+              hm = (fn _ => fn _ => fn _ => fn _ => fn _ =>
                        List.app (ignore o do_clean_target) cleanTargets),
               dirinfo = {incdirmap=idmap0, ancestors = [original_dir],
                          visited = Binaryset.empty hmdir.compare},

--- a/tools/Holmake/core/Holmake.sml
+++ b/tools/Holmake/core/Holmake.sml
@@ -882,13 +882,14 @@ in
                     dir = dir, extra = extra,
                     command = NoCmd, dependencies = []} g0
         )
-        else if FileSys.access (hmdir.toAbsPath dir,
-                                 [FileSys.A_READ, FileSys.A_EXEC]) then (
+        else if isSome (incinfo_for_dir dir) andalso
+                FileSys.access (hmdir.toAbsPath dir,
+                                [FileSys.A_READ, FileSys.A_EXEC]) then (
           diag (fn _ => "Target "^pretty_tgt^
                         " external to directory; building in place");
           pushdir (hmdir.toAbsPath dir)
-                  (build_depgraph incinfo_for_dir cdset (incinfo_for_dir dir)
-                                  tgt)
+                  (build_depgraph incinfo_for_dir cdset
+                                  (valOf (incinfo_for_dir dir)) tgt)
                   g0
         )
         else (
@@ -1102,13 +1103,15 @@ fun get_targets dir =
     end
 
 fun include_info_from_map incdirmap dir =
-    let
-      val {pres, incs} = idm_lookup incdirmap dir
-      fun paths ds =
-          Binaryset.foldr (fn (d, acc) => hmdir.toAbsPath d :: acc) [] ds
-    in
-      {includes = paths incs, preincludes = paths pres}
-    end
+    case Binarymap.peek(incdirmap, dir) of
+        NONE => NONE
+      | SOME {pres, incs} =>
+        let
+          fun paths ds =
+              Binaryset.foldr (fn (d, acc) => hmdir.toAbsPath d :: acc) [] ds
+        in
+          SOME {includes = paths incs, preincludes = paths pres}
+        end
 
 fun extend_graph_in_dir incdirmap incinfo warn dir graph =
     let

--- a/tools/Holmake/tests/parallel_deps/Holmakefile
+++ b/tools/Holmake/tests/parallel_deps/Holmakefile
@@ -1,0 +1,7 @@
+parallel-deps-selftest.log: selftest.exe
+	@$(tee ./$<, $@)
+
+selftest.exe: selftest.uo
+	$(HOLMOSMLC) -o $@ $<
+
+EXTRA_CLEANS = selftest.exe parallel-deps-selftest.log

--- a/tools/Holmake/tests/parallel_deps/selftest.sml
+++ b/tools/Holmake/tests/parallel_deps/selftest.sml
@@ -1,0 +1,45 @@
+open testutils
+
+infix ++
+val op++ = OS.Path.concat
+
+fun exists p = HOLFileSys.access(p, [OS.FileSys.A_READ])
+fun die_missing p = die ("Expected build product missing: " ^ p)
+
+val holmake = Globals.HOLDIR ++ "bin" ++ "Holmake"
+val depchain_dir = ".." ++ "depchain1" ++ "dir3"
+val holstate0 = Globals.HOLDIR ++ "bin" ++ "hol.state0"
+
+fun holmake_args args =
+    [holmake] @
+    (if Systeml.ML_SYSNAME = "poly" then ["--holstate", holstate0] else []) @
+    args
+
+fun run_holmake desc args =
+    let
+      val _ = tprint desc
+      val res = Systeml.systeml (holmake_args args)
+    in
+      if OS.Process.isSuccess res then OK()
+      else die ("Holmake failed while " ^ desc)
+    end
+
+val products =
+    [".." ++ "dir2" ++ "dir1" ++ "baseTheory.ui",
+     ".." ++ "dir2" ++ "dir1" ++ "baseTheory.uo",
+     ".." ++ "dir2" ++ "baseLib.ui",
+     ".." ++ "dir2" ++ "baseLib.uo",
+     "nextTheory.ui",
+     "nextTheory.uo",
+     "lastTheory.ui",
+     "lastTheory.uo"]
+
+val here = HOLFileSys.getDir()
+
+val _ = HOLFileSys.chDir depchain_dir
+val _ = run_holmake "cleaning cross-directory dependency chain"
+                    ["-r", "cleanAll"]
+val _ = run_holmake "building cross-directory dependency chain with -j2"
+                    ["--jobs=2", "lastTheory.uo"]
+val _ = app (fn p => if exists p then () else die_missing p) products
+val _ = HOLFileSys.chDir here

--- a/tools/sequences/kernel
+++ b/tools/sequences/kernel
@@ -39,5 +39,6 @@ src/proofman
 !src/proofman/tests
 !tools/Holmake/tests/preexec
 !tools/Holmake/tests/parallel_tests
+!tools/Holmake/tests/parallel_deps
 !tools/Holmake/tests/repl
 !src/1/theory_tests


### PR DESCRIPTION
_co-authored by OpenAI ChatGPT_

## Summary

This fixes parallel Holmake graph construction for clean cross-directory builds.

When a needed target is in an `INCLUDES` directory but has not been built yet, Holmake previously inserted a `Failed/NoCmd` placeholder for the external target. After `mkneeded`, that node remained unbuildable, so parallel builds could schedule dependent work before the external `.ui`/`.uo` products existed.

The fix expands missing external targets from scanned include directories in place:

- existing external targets remain `Succeeded/NoCmd` placeholders
- missing external targets in scanned directories are rebuilt as real graph nodes in their own directory
- missing external targets outside the recursive scan, such as standard `sigobj` entries, retain the old placeholder behavior

This keeps one global scheduler and avoids spawning nested Holmake processes.

## Validation

- compiled `bin/Holmake` from the patched sources
- checked `tools/Holmake/tests/depchain1/dir3` with `Holmake -n --jobs=2`
- confirmed the generated graph includes cross-directory dependency nodes and does not expand standard `sigobj` targets into a self-dependency loop
- added and ran `tools/Holmake/tests/parallel_deps`, which cleans and rebuilds the existing `depchain1/dir3` cross-directory dependency chain with `--jobs=2`


