### PR TITLE
Fix isOnlyComments

### DIFF
--- a/src/IndDef/selftest.sml
+++ b/src/IndDef/selftest.sml
@@ -240,5 +240,12 @@ val _ = shouldfail {
       printresult = with_flag (show_assums, true) thm_to_string o #1}
       ‘ ∀n. ((¬test (n : num)) ⇒ test n) ’;
 
+val _ = tprint "Github 1931: comment containing opening parenthesis before first label"
+Inductive cmt_paren_rel:
+(* ( *)
+[~refl:]
+  (!x. cmt_paren_rel R x x)
+End
+val _ = OK()
 
 val _ = exit_count0 failcount

--- a/tools/parsing/HOLSourceAST.sml
+++ b/tools/parsing/HOLSourceAST.sml
@@ -632,7 +632,8 @@ fun isOnlyComments s = let
   fun go cm p =
     case cur p of
       #"\000" => true
-    | #"(" => cur (p+1) = #"*" andalso go (cm + 1) (p+2)
+    | #"(" => if cur (p+1) = #"*" then go (cm + 1) (p+2)
+              else cm > 0 andalso go cm (p+1)
     | #"*" => cm > 0 andalso if cur (p+1) = #")" then go (cm - 1) (p+2) else go cm (p+1)
     | c => (cm > 0 orelse Char.isSpace c) andalso go cm (p+1)
   in go 0 start end


### PR DESCRIPTION
This issue seems to have lead the  HOLSource expander to inject an empty clause when the first label is preceded by a comment containing an open parenthesis, causing the `Vacuous clause trivialises whole definition` error in #1931.

Closes #1931

Assisted-by: Claude:claude-opus-4-7