### PR TITLE
Fix Proof[exclude_frags = ...] for simp[] and standalone tactics

### DIFF
--- a/Manual/Description/modern-syntax.smd
+++ b/Manual/Description/modern-syntax.smd
@@ -214,6 +214,8 @@ The following describes the attributes listed above:
 
 :   Used with `Proof` or `Resume`.
     The list of fragment names following is removed from the global simpset for the duration of the given proof, affecting all simplifier tactics that refer to the global simpset.
+    The exclusion is *sticky*: while it is in effect, attempts to add back a fragment with one of the named names via the `++` operator (including those performed implicitly by derived simpsets such as the one used by `simp[]`) are silent no-ops.
+    To opt back in for a specific simplification call, use the `SF` marker in its theorem-list argument (e.g. `simp[SF ARITH_ss]` inside a `Proof[exclude_frags = ARITH]` body re-enables `ARITH_ss` for that one call).
 
 `exclude_simps`=...
 

--- a/Manual/Description/simplifier.stex
+++ b/Manual/Description/simplifier.stex
@@ -544,6 +544,15 @@ pick up the default ``filter'' function for converting theorems to
 rewrite rules.  (This filtering process is described below in
 Section~\ref{sec:generating-rewrite-rules}.)
 
+A \simpset{} also carries a (usually empty) set of \emph{excluded}
+fragment names, set up by \ml{simpLib.exclude\_ssfrags} (which is
+what \ml{Proof[exclude\_frags = \ldots]} ultimately calls).  When the
+incoming fragment of \ml{ss\ ++\ frag} has a name in that set, the
+addition is a silent no-op and \ml{ss} is returned unchanged.  Use
+\ml{simpLib.force\_add}, or the \ml{SF} marker in a thm-list argument
+to a simplification tactic, to override that prohibition for a
+particular fragment.
+
 For major theories (or groups thereof), a collection of relevant
 \simpset{} fragments is usually found in the module \ml{<thy>Simps},
 with \ml{<thy>} the name of the theory.  For example, \simpset{}
@@ -687,6 +696,15 @@ Thus, one can use high-level tactics with the arithmetic decision procedure remo
 ##assert aconv (#2 (top_goal())) ``x < 10 ==> x < 13``
 \end{alltt}
 \end{session}
+The exclusion that \ml{ExclSF} effects is local to the \ml{simp} call
+in which it appears.  For an exclusion that persists across all the
+simplification tactics in a proof body, use the
+\ml{Proof[exclude\_frags\ =\ \ldots]} attribute (the
+\ml{simpLib.exclude\_ssfrags} function it relies on records the names
+in the \simpset{}'s excluded set, so subsequent uses of \ml{++} also
+respect it; see Section~\ref{sec:simpset-fragments}).  Inside such a
+proof body, the \ml{SF} marker can opt back in for an individual
+\ml{simp} call.
 \index{simplification!removing rewrites|)}
 
 \subsection{Rewriting with the simplifier}
@@ -1414,6 +1432,11 @@ For example, one can rewrite with conjunctions as assumptions using the \ml{CONJ
 ##assert aconv (#2 (top_goal())) ``x = 10``
 \end{alltt}
 \end{session}
+\ml{SF} also serves as the in-call escape hatch for fragments excluded
+by an enclosing \ml{Proof[exclude\_frags\ =\ \ldots]} attribute (see
+Section~\ref{sec:simpset-fragments}): writing \ml{simp[SF~X\_ss]}
+inside a body where the fragment named \ml{"X"} has been excluded
+re-enables it for that one \ml{simp} call.
 
 \paragraph{Simplifying at particular sub-terms}
 \index{simplification!at particular sub-terms}

--- a/help/Docfiles/simpLib..KAL.md
+++ b/help/Docfiles/simpLib..KAL.md
@@ -14,6 +14,15 @@ Infix operator for adding an `ssfrag` item into a simpset.
 
 `bossLib.++` is identical to `simpLib.++`.
 
+If the incoming fragment has a name and that name is currently in the
+simpset's *excluded* set (set up by an earlier `exclude_ssfrags` call —
+e.g. via the `Proof[exclude_frags = ...]` attribute), the addition is a
+silent no-op and `ss ++ frag` returns `ss` unchanged.  Use `force_add`
+(or, in the rewrite-list of a simplification tactic, the `SF` marker) to
+override that prohibition.
+
 ### See also
 
-[`bossLib.++`](#bossLib..KAL)
+[`bossLib.++`](#bossLib..KAL),
+[`simpLib.exclude_ssfrags`](#simpLib.exclude_ssfrags),
+[`simpLib.force_add`](#simpLib.force_add)

--- a/help/Docfiles/simpLib.exclude_ssfrags.md
+++ b/help/Docfiles/simpLib.exclude_ssfrags.md
@@ -1,0 +1,53 @@
+## `exclude_ssfrags`
+
+``` hol4
+simpLib.exclude_ssfrags : string list -> simpset -> simpset
+```
+
+------------------------------------------------------------------------
+
+Removes named simpset fragments and records the exclusion in the simpset.
+
+A call to `exclude_ssfrags fragnames simpset` returns a simpset that is
+the same as `simpset` except that
+1.  every fragment with a name in `fragnames` has been removed from the
+    simpset's history (as with `remove_ssfrags`); and
+2.  the names in `fragnames` are recorded in the simpset's *excluded*
+    set, so that any subsequent attempt to add a fragment with one of
+    those names via the `++` operator is a silent no-op.
+
+Use `force_add` (or, in user-facing thm-list arguments to simplification
+tactics, the `SF` marker) to opt back in: it adds a fragment and removes
+its name from the excluded set in one step.
+
+This is the function used to implement the `Proof[exclude_frags = ...]`
+attribute on theorem proofs.
+
+### Failure
+
+Never fails (unlike `remove_ssfrags`, no `Conv.UNCHANGED` is raised when
+none of the names match a fragment in the simpset).
+
+### Example
+
+``` hol4
+> val base = simpLib.exclude_ssfrags ["ARITH"] (srw_ss());
+val base = ... : simpset
+
+
+> List.exists (fn n => n = "ARITH")
+              (simpLib.ssfrag_names_of (base ++ numSimps.ARITH_ss));
+val it = false : bool   (* ++ was a silent no-op *)
+
+
+> List.exists (fn n => n = "ARITH")
+              (simpLib.ssfrag_names_of
+                 (simpLib.force_add base numSimps.ARITH_ss));
+val it = true : bool    (* force_add overrode the exclusion *)
+```
+
+### See also
+
+[`simpLib.remove_ssfrags`](#simpLib.remove_ssfrags),
+[`simpLib.force_add`](#simpLib.force_add),
+[`bossLib.SF`](#bossLib.SF)

--- a/help/Docfiles/simpLib.force_add.md
+++ b/help/Docfiles/simpLib.force_add.md
@@ -1,0 +1,34 @@
+## `force_add`
+
+``` hol4
+simpLib.force_add : simpset -> ssfrag -> simpset
+```
+
+------------------------------------------------------------------------
+
+Adds a simpset fragment, overriding any active exclusion of its name.
+
+A call to `force_add simpset frag` returns a simpset that is `simpset`
+augmented with `frag` (as if by `++`).  In addition, if `frag` has a name
+that is currently in the simpset's *excluded* set (because of an earlier
+`exclude_ssfrags` call), that name is removed from the excluded set so
+that subsequent `++` of a fragment with the same name will also succeed.
+
+This function is the override mechanism for `exclude_ssfrags`: while
+`++` is silent when the incoming fragment is currently excluded,
+`force_add` lifts the exclusion for that name and performs the addition.
+
+`force_add` is what underlies the behaviour of the `SF` marker in
+thm-list arguments to simplification tactics: writing `simp[SF FRAG_ss]`
+inside a `Proof[exclude_frags = FRAG]` body re-enables `FRAG_ss` for
+that simp call.
+
+### Failure
+
+Never fails.
+
+### See also
+
+[`simpLib.exclude_ssfrags`](#simpLib.exclude_ssfrags),
+[`simpLib.++`](#simpLib..KAL),
+[`bossLib.SF`](#bossLib.SF)

--- a/help/Docfiles/simpLib.remove_ssfrags.md
+++ b/help/Docfiles/simpLib.remove_ssfrags.md
@@ -1,14 +1,14 @@
 ## `remove_ssfrags`
 
 ``` hol4
-simpLib.remove_ssfrags : simpset -> string list -> simpset
+simpLib.remove_ssfrags : string list -> simpset -> simpset
 ```
 
 ------------------------------------------------------------------------
 
 Removes named simpset fragments from a simpset.
 
-A call to `remove_ssfrags simpset fragnames` returns a simpset that is
+A call to `remove_ssfrags fragnames simpset` returns a simpset that is
 the same as `simpset` except that the simpset fragments with names in
 the list `fragnames` are no longer included. As a special case, the
 empty name `""` matches all unnamed fragments within `simpset` and
@@ -16,23 +16,37 @@ causes them to be removed.
 
 ### Failure
 
-If no member of `fragnames` names a fragments in `simpset`, the
+If no member of `fragnames` names a fragment in `simpset`, the
 `Conv.UNCHANGED` exception is raised.
 
 ### Example
 
 ``` hol4
-- SIMP_CONV (srw_ss()) [] ``MAP ($+ 1) [3;4;5]``;
+> SIMP_CONV (srw_ss()) [] “MAP ($+ 1) [3;4;5]”;
 <<HOL message: Initialising SRW simpset ... done>>
-> val it = |- MAP ($+ 1) [3; 4; 5] = [4; 5; 6] : thm
+val it = ⊢ MAP ($+ 1) [3; 4; 5] = [4; 5; 6] : thm
 
-- val myss = simpLib.remove_ssfrags (srw_ss()) ["REDUCE"]
-> val myss = ...output elided...
 
-- SIMP_CONV myss [] ``MAP ($+ 1) [3;4;5]``
-> val it = |- MAP ($+ 1) [3; 4; 5] = [1 + 3; 1 + 4; 1 + 5] : thm
+> val myss = simpLib.remove_ssfrags ["REDUCE"] (srw_ss());
+val myss = ... : simpset
+
+
+> SIMP_CONV myss [] “MAP ($+ 1) [3;4;5]”;
+val it = ⊢ MAP ($+ 1) [3; 4; 5] = [1 + 3; 1 + 4; 1 + 5] : thm
 ```
+
+### Comparison with `exclude_ssfrags`
+
+`remove_ssfrags` only strips matching fragments from the simpset's
+history; a subsequent `ss ++ FRAG_ss` would re-add them.  By contrast,
+`exclude_ssfrags` also records the exclusion in the simpset itself, so
+that subsequent `++` of a fragment with one of the named names is a
+silent no-op (until cleared via `force_add` / `SF`).  `exclude_ssfrags`
+also never raises `Conv.UNCHANGED`.  The `Proof[exclude_frags = ...]`
+attribute uses `exclude_ssfrags`.
 
 ### See also
 
+[`simpLib.exclude_ssfrags`](#simpLib.exclude_ssfrags),
+[`simpLib.force_add`](#simpLib.force_add),
 [`BasicProvers.diminish_srw_ss`](#BasicProvers.diminish_srw_ss)

--- a/src/basicProof/BasicProvers.sml
+++ b/src/basicProof/BasicProvers.sml
@@ -1255,7 +1255,8 @@ fun with_simpset_updates f g x = (
   (* tell clients that their derived values are stale because we're about
      to update the base *)
   notify();
-  AncestryData.with_temp_value adresult (f (srw_ss()), true, []) g x
+  let val ss' = f (srw_ss()) handle Conv.UNCHANGED => srw_ss()
+  in AncestryData.with_temp_value adresult (ss', true, []) g x end
   (* clients may believe they're up-to-date but we've just flipped the
      base value back, so we need to notify again *)
   before notify()
@@ -1384,7 +1385,7 @@ fun mk_tacmod s =
       fun key_to_f k =
           case k of
               "exclude_simps" => simpLib.remove_simps
-            | "exclude_frags" => simpLib.remove_ssfrags
+            | "exclude_frags" => simpLib.exclude_ssfrags
             | _ => (fn vs => fn ss => ss)
       val f =
           gen_mktm { values = (fn vs => vs),

--- a/src/boss/theory_tests/exclArithBugScript.sml
+++ b/src/boss/theory_tests/exclArithBugScript.sml
@@ -1,0 +1,69 @@
+Theory exclArithBug
+Ancestors
+  hol
+
+open testutils
+
+(* The first three Theorem blocks exercise the Theorem ... Proof[...] ... QED
+   parser surface; the inline tests below exercise the underlying
+   exclude_ssfrags / SF / ++ semantics via mk_tacmod. *)
+
+Theorem works:
+  10n < x ==> 6 < x
+Proof
+  simp[]
+QED
+
+Theorem test = EQT_ELIM (numLib.ARITH_CONV “10n < x ==> 6 < x”)
+
+(* Original bug: the body's UNCHANGED leaked out, so this proof failed. *)
+Theorem should_work:
+  10n < x ==> 6 < x
+Proof[exclude_frags = ARITH]
+  numLib.ARITH_TAC
+QED
+
+local
+  val arith_goal : goal = ([], “10n < x ==> 6 < x”)
+  fun under_excl tac =
+      let val {tacm, ...} = BasicProvers.mk_tacmod "[exclude_frags = ARITH]"
+      in tacm tac end
+  (* turn "tactic returned a non-empty subgoal list" into an exception so
+     shouldfail can express "this proof attempt should not solve". *)
+  exception NotSolved
+  fun must_solve tac g =
+      case tac g of
+          ([], _) => ()
+        | _      => raise NotSolved
+  fun solved (Exn.Res (sgs, _)) = List.null sgs
+    | solved (Exn.Exn _)        = false
+  val printresult_solved = fn () => "(unexpectedly solved)"
+in
+
+val _ = shouldfail {
+          printarg   = fn _ => "exclude_frags = ARITH disables simp[]",
+          testfn     = must_solve (under_excl (bossLib.simp [])),
+          printresult = printresult_solved,
+          checkexn   = fn _ => true
+        } arith_goal
+
+val _ = tprint "simp[SF ARITH_ss] overrides exclude_frags = ARITH"
+val _ = require_msg
+          solved
+          (fn _ => "(failed to solve despite SF override)")
+          (under_excl (bossLib.simp [simpLib.SF numSimps.ARITH_ss]))
+          arith_goal
+
+val _ = let open simpLib in
+  shouldfail {
+    printarg = fn _ => "naked ++ ARITH_ss inside body is blocked by exclusion",
+    testfn = must_solve
+               (under_excl
+                  (fn g => SIMP_TAC
+                             (BasicProvers.srw_ss() ++ numSimps.ARITH_ss) [] g)),
+    printresult = printresult_solved,
+    checkexn = fn _ => true
+  } arith_goal
+end
+
+end

--- a/src/simp/src/simpLib.sig
+++ b/src/simp/src/simpLib.sig
@@ -131,6 +131,14 @@ sig
   val ssfrags_of      : simpset -> ssfrag list
   val mk_simpset      : ssfrag list -> simpset
   val remove_ssfrags  : string list -> simpset -> simpset
+
+  (* Like remove_ssfrags, but additionally records the names so that any
+     subsequent ++ of a named fragment with one of those names is silently
+     a no-op.  force_add is the override for that prohibition.
+     Never raises Conv.UNCHANGED. *)
+  val exclude_ssfrags : string list -> simpset -> simpset
+  val force_add       : simpset -> ssfrag -> simpset
+
   val ssfrag_names_of : simpset -> string list
   val ++              : simpset * ssfrag -> simpset  (* infix *)
   val -*              : simpset * string list -> simpset (* infix *)

--- a/src/simp/src/simpLib.sml
+++ b/src/simp/src/simpLib.sml
@@ -254,16 +254,24 @@ datatype simpset =
             initial_net : net,
             dprocs      : reducer list,
             travrules   : travrules,
-            limit       : int option}
+            limit       : int option,
+            (* Names of fragments that are forbidden from being added by ++.
+               Set by `exclude_ssfrags`; cleared per-name by `force_add`. *)
+            excluded    : string Binaryset.set}
 
-fun ssupd_net f (SS{mk_rewrs,history,initial_net,dprocs,travrules,limit}) =
+val empty_excluded : string Binaryset.set = Binaryset.empty String.compare
+
+fun ssupd_net f (SS{mk_rewrs,history,initial_net,dprocs,travrules,limit,
+                    excluded}) =
     SS{mk_rewrs = mk_rewrs, history = history, initial_net = f initial_net,
-       dprocs = dprocs, travrules = travrules, limit = limit}
+       dprocs = dprocs, travrules = travrules, limit = limit,
+       excluded = excluded}
 
  val empty_ss = SS {mk_rewrs=fn x => [x],
                     history = [], limit = NONE,
                     initial_net=empty,
-                    dprocs=[],travrules=EQ_tr};
+                    dprocs=[],travrules=EQ_tr,
+                    excluded = empty_excluded};
 
  fun ssfrags_of (SS x) =
      List.mapPartial (fn ADDFRAG sf => SOME sf | _ => NONE) (#history x)
@@ -308,7 +316,8 @@ fun dphas_name_from nms (REDUCER {name = SOME n,...}) = Lib.mem n nms
   | dphas_name_from _ _ = false
 fun filter_dprocs_by_names nms = List.filter (not o dphas_name_from nms)
 
-fun (ss as SS{mk_rewrs,history,initial_net,dprocs,travrules,limit}) -* nms =
+fun (ss as SS{mk_rewrs,history,initial_net,dprocs,travrules,limit,
+              excluded}) -* nms =
     if null nms then ss
     else
       SS{initial_net = filter_net_by_names nms initial_net,
@@ -316,7 +325,8 @@ fun (ss as SS{mk_rewrs,history,initial_net,dprocs,travrules,limit}) -* nms =
          mk_rewrs = mk_rewrs,
          dprocs = filter_dprocs_by_names nms dprocs,
          travrules = travrules,
-         limit = limit}
+         limit = limit,
+         excluded = excluded}
 fun remove_simps nms ss = ss -* nms
 
 
@@ -379,9 +389,11 @@ fun remove_simps nms ss = ss -* nms
           |> List.mapPartial ssfrag_name
           |> Lib.mk_set
 
- fun fupdlimit f (SS{mk_rewrs,history,travrules,initial_net,dprocs,limit}) =
+ fun fupdlimit f (SS{mk_rewrs,history,travrules,initial_net,dprocs,limit,
+                     excluded}) =
      SS{mk_rewrs = mk_rewrs, history = history, travrules = travrules,
-        initial_net = initial_net, dprocs = dprocs, limit = f limit}
+        initial_net = initial_net, dprocs = dprocs, limit = f limit,
+        excluded = excluded}
 
  fun limit n = fupdlimit (fn _ => SOME n)
 
@@ -408,11 +420,13 @@ fun getlimit (SS ss) = #limit ss
  end
 
  fun add_weakener (wd as (rels,congs,dp)) simpset = let
-   val SS {mk_rewrs,history,travrules,initial_net,dprocs,limit} = simpset
+   val SS {mk_rewrs,history,travrules,initial_net,dprocs,limit,excluded} =
+       simpset
  in
    SS {mk_rewrs = mk_rewrs, history = ADDWEAKENER wd :: history,
        travrules = merge_travrules [travrules, wk_mk_travrules(rels,congs)],
-       initial_net = initial_net, dprocs = dprocs @ [dp], limit = limit}
+       initial_net = initial_net, dprocs = dprocs @ [dp], limit = limit,
+       excluded = excluded}
  end
 
 (* ----------------------------------------------------------------------
@@ -614,9 +628,15 @@ fun getlimit (SS ss) = #limit ss
      end
 
 
- fun op++(SS sset, f as SSFRAG_CON ssf) = let
-   val {mk_rewrs=mk_rewrs',history,travrules,initial_net,dprocs=dprocs',limit}=
-       sset
+ fun is_excluded (SS{excluded,...}) f =
+     case frag_name f of
+         SOME n => Binaryset.member(excluded, n)
+       | NONE => false
+
+ fun op++(ss as SS sset, f as SSFRAG_CON ssf) = if is_excluded ss f then ss else
+   let
+   val {mk_rewrs=mk_rewrs',history,travrules,initial_net,dprocs=dprocs',limit,
+        excluded}= sset
    val {convs,rewrs,filter,ac,dprocs,congs,relsimps,...} = ssf
    val mk_rewrs = case filter of
                     SOME f => f oo mk_rewrs'
@@ -645,6 +665,7 @@ fun getlimit (SS ss) = #limit ss
        initial_net = net,
        limit       = limit,
        dprocs      = new_dprocs,
+       excluded    = excluded,
        travrules   = merge_travrules
                          (travrules::mk_travrules relations congs::reltravs)
    }
@@ -663,7 +684,12 @@ fun build_from_history h0 =
       List.foldl foldthis empty_ss (List.rev h0)
     end
 
-fun remove_ssfrags names (ss as SS{history,limit,...}) =
+fun setexcluded e (SS{mk_rewrs,history,initial_net,dprocs,travrules,limit,
+                       excluded=_}) =
+    SS{mk_rewrs=mk_rewrs, history=history, initial_net=initial_net,
+       dprocs=dprocs, travrules=travrules, limit=limit, excluded=e}
+
+fun remove_ssfrags names (ss as SS{history,limit,excluded,...}) =
     let
       val s = Set.addList (Binaryset.empty String.compare, names)
       val nil_included = Set.member(s, "")
@@ -676,6 +702,48 @@ fun remove_ssfrags names (ss as SS{history,limit,...}) =
               raise Conv.UNCHANGED
     in
       build_from_history history' |> fupdlimit (fn _ => limit)
+                                  |> setexcluded excluded
+    end
+
+(* Like `remove_ssfrags`, but additionally records the names so that any
+   subsequent `++` of a fragment with one of those names is silently
+   skipped.  `force_add` is the override that bypasses (and clears) this
+   prohibition for a given fragment.  Never raises Conv.UNCHANGED.
+
+   Desired invariant on every simpset:
+       no ADDFRAG in `history` has a name in `excluded`.
+   The other simpset operations (`++`, `-*`, `add_weakener`, `force_add`,
+   `remove_ssfrags`) all preserve this invariant, so in principle we
+   could filter `history` against `names` alone here.  We defensively
+   filter against `excluded ∪ names` instead so that this function stays
+   correct in isolation even if some future operation accidentally
+   introduces an ADDFRAG of an already-excluded name. *)
+fun exclude_ssfrags names (ss as SS{history,limit,excluded,...}) =
+    let
+      val excluded' = Binaryset.addList (excluded, names)
+      val nil_included = Binaryset.member(excluded', "")
+      fun isexcl (SSFRAG_CON{name = SOME n,...}) =
+            Binaryset.member(excluded',n)
+        | isexcl (SSFRAG_CON{name = NONE,...}) = nil_included
+      fun filterthis (hi as ADDFRAG f) = not(isexcl f)
+        | filterthis hi = true
+      val history' = List.filter filterthis history
+    in
+      build_from_history history' |> fupdlimit (fn _ => limit)
+                                  |> setexcluded excluded'
+    end
+
+(* Force-include a fragment, even if its name is in the simpset's
+   excluded set — and remove that name from the excluded set so that
+   subsequent `++` of the same fragment also succeeds. *)
+fun force_add (ss as SS sset) f =
+    let val excluded' =
+            case frag_name f of
+                SOME n => (Binaryset.delete(#excluded sset, n)
+                           handle NotFound => #excluded sset)
+              | NONE => #excluded sset
+    in
+      setexcluded excluded' ss ++ f
     end
 
 (*---------------------------------------------------------------------------*)
@@ -774,14 +842,17 @@ fun process_tags ss thl =
       then (ss,thl)
       else
         let val base = remove_ssfrags exclfrags ss handle Conv.UNCHANGED => ss
+            val cong_ac =
+                SSFRAG_CON{name=SOME"Cong and/or AC", relsimps = [],
+                           ac=map unAC ACs, congs=map (normCong o unCong) Congs,
+                           convs=[],rewrs=[],filter=NONE,dprocs=[]}
+            (* Cong/AC is named but never user-excludable; SF-derived frags
+               go through force_add so they override any active exclusion. *)
+            val withCongAc = base ++ cong_ac
+            val withFrags = List.foldl (fn (f,ss) => force_add ss f)
+                                       withCongAc frags
         in
-          (List.foldl (flip op++) base (
-            SSFRAG_CON{name=SOME"Cong and/or AC", relsimps = [],
-                       ac=map unAC ACs, congs=map (normCong o unCong) Congs,
-                       convs=[],rewrs=[],filter=NONE,dprocs=[]} ::
-            frags
-           ) -* excludes,
-           rst)
+          (withFrags -* excludes, rst)
         end
     end
 

--- a/tools/parsing/AttributeSyntax.sml
+++ b/tools/parsing/AttributeSyntax.sml
@@ -47,7 +47,7 @@ fun gen_mktm (r as {values,combine,null,perkey}) attrs =
 fun string_of_key k =
     case k of
         "exclude_simps" => "simpLib.remove_simps"
-      | "exclude_frags" => "simpLib.remove_ssfrags"
+      | "exclude_frags" => "simpLib.exclude_ssfrags"
       | _ => k
 fun mk_tacmodifier_string alist =
     case alist of

--- a/tools/parsing/HOLSourceExpand.sml
+++ b/tools/parsing/HOLSourceExpand.sml
@@ -62,7 +62,7 @@ fun doProofKvals _ [] tac = tac
     val args = case bind of NONE => [] | SOME {vals, eq_=_} => map mkString vals
     val key = case key of
       "exclude_simps" => "simpLib.remove_simps"
-    | "exclude_frags" => "simpLib.remove_ssfrags"
+    | "exclude_frags" => "simpLib.exclude_ssfrags"
     | _ => key
     in App (mkIdent (p, key), mkList (p, args)) end
   fun mktm (kv, e) = Infix {left = e, id = (p, "o"), right = mktm1 kv}

--- a/tools/parsing/HolParserOld.sml
+++ b/tools/parsing/HolParserOld.sml
@@ -74,7 +74,7 @@ fun destNameAttrs ss =
 fun stringOfKey k =
     case k of
         "exclude_simps" => "simpLib.remove_simps"
-      | "exclude_frags" => "simpLib.remove_ssfrags"
+      | "exclude_frags" => "simpLib.exclude_ssfrags"
       | _ => k
 
 fun destAttrs attrs =
@@ -366,7 +366,7 @@ structure ToSML = struct
       let
         val {aux,readAt,line,ss,countlines,...} = ddargs:doDecl_args
         fun ofKey "exclude_simps" = "simpLib.remove_simps"
-          | ofKey "exclude_frags" = "simpLib.remove_ssfrags"
+          | ofKey "exclude_frags" = "simpLib.exclude_ssfrags"
           | ofKey k = k
         fun mktm1 (k,vals) =
             ofKey (ss k) ^ " [" ^


### PR DESCRIPTION
Another Claude-mediated piece of coding.  I noticed the bug a little while ago, and the subsequent dialogue came up with a nice solution.  

Documentation fixes seem to tell the right story. 

Its PR text follows

---

Two bugs in the same area:

1. Proof[exclude_frags = ARITH] numLib.ARITH_TAC raised Conv.UNCHANGED out of the proof body. Cause: with_simpset_updates eagerly called simpLib.remove_ssfrags on srw_ss(), which raises UNCHANGED when no fragment matches -- and the bare srw_ss() has no fragment named "ARITH" (the merged "ARITH" frag lives in boss_ss(), added by boss_augment).

2. Proof[exclude_frags = ARITH] simp[] would still apply ARITH: even after stripping ARITH_ss from srw_ss(), boss_augment unconditionally re-added it to boss_ss() via ++.

Solution: encode the exclusion in the simpset itself.

* simpset gains an "excluded : string Binaryset.set" field.
* ++ is a silent no-op when the incoming fragment's name is in the excluded set.
* New simpLib.exclude_ssfrags : string list -> simpset -> simpset removes matching frags from the history *and* records the names in "excluded". Never raises UNCHANGED. The implementation defensively filters against the union of old "excluded" and new names, with a comment stating the simpset invariant ("no ADDFRAG in history has a name in excluded") and why filtering against just the new names would also be sufficient if the invariant is preserved everywhere.
* New simpLib.force_add : simpset -> ssfrag -> simpset is the override: clears the name from "excluded" then ++s.
* process_tags routes SF-derived frags through force_add, so simp[SF FRAG_ss] still works as the user-facing override -- for example, simp[SF ARITH_ss] inside Proof[exclude_frags = ARITH] re-enables ARITH for that simp call.
* The parser-side translators for exclude_frags = ... now emit simpLib.exclude_ssfrags. with_simpset_updates also gains a defensive "handle Conv.UNCHANGED" (covers other callers that may still pass remove_ssfrags-style functions).

Documentation:
* New docfiles for simpLib.exclude_ssfrags and simpLib.force_add.
* simpLib.remove_ssfrags docfile: corrected curried-arg-order in signature; example modernised to Poly/ML REPL style; added "Comparison with exclude_ssfrags" section.
* simpLib.++ docfile (simpLib..KAL.md): describes the new excluded-set behaviour.
* Manual/Description/modern-syntax.smd: the exclude_frags= attribute entry now describes the sticky semantics plus the SF override with a worked example.

Test (src/boss/theory_tests/exclArithBugScript.sml):
* Three Theorem blocks exercise the actual Theorem ... Proof[...] ... QED parser surface (including should_work, the original exception-leak regression).
* Three testutils assertions exercise the new semantics directly:
  - simp[] under exclude_frags = ARITH does not solve.
  - simp[SF ARITH_ss] under same does solve (override works).
  - SIMP_TAC (srw_ss() ++ ARITH_ss) [] (lazy in body) is blocked by the exclusion.