### PR TITLE
Drop duplicate MAX_LIST definitions

### DIFF
--- a/examples/logic/modal-tableaux/tableauKTScript.sml
+++ b/examples/logic/modal-tableaux/tableauKTScript.sml
@@ -7,7 +7,7 @@
 *)
 Theory tableauKT
 Ancestors
-  pair pred_set list relation modalBasics tableauBasics
+  pair pred_set list rich_list relation modalBasics tableauBasics
 
 
 Definition trule_def[simp]:
@@ -31,11 +31,6 @@ Definition modal_size_def[simp]:
   modal_size (NVar a) = 0 ∧
   modal_size (Conj a0 a1) = modal_size a0 + modal_size a1 ∧
   modal_size (Disj a0 a1) = modal_size a0 + modal_size a1
-End
-
-Definition max_list_def[simp]:
-  max_list []     = 0 ∧
-  max_list (h::t) = MAX h (max_list t)
 End
 
 Definition degree_def[simp]:
@@ -163,14 +158,14 @@ Proof
 QED
 
 Theorem max_2_lists[simp]:
-  ∀l1 l2. max_list (l1++l2) = MAX (max_list l1) (max_list l2)
+  ∀l1 l2. MAX_LIST (l1++l2) = MAX (MAX_LIST l1) (MAX_LIST l2)
 Proof
   Induct_on`l1` >> simp[] >> Induct_on`l2` >> simp[]
   >> rw[] >> simp[arithmeticTheory.MAX_ASSOC]
 QED
 
-Theorem max_list_diff[simp]:
-  ∀l1 l2 l3. max_list l2 < max_list l3 ⇒ max_list (l1++l2) <= max_list (l1++l3)
+Theorem MAX_LIST_diff[simp]:
+  ∀l1 l2 l3. MAX_LIST l2 < MAX_LIST l3 ⇒ MAX_LIST (l1++l2) <= MAX_LIST (l1++l3)
 Proof
   rw[]
 QED
@@ -182,8 +177,8 @@ Proof
   Induct_on`Σ` >> simp[AC arithmeticTheory.MAX_COMM arithmeticTheory.MAX_ASSOC]
 QED
 
-Theorem degree_max_list:
-∀Σ Γ.  degree (Σ, Γ) = max_list (MAP modal_size (Σ++Γ))
+Theorem degree_MAX_LIST:
+∀Σ Γ.  degree (Σ, Γ) = MAX_LIST (MAP modal_size (Σ++Γ))
 Proof
   Induct_on`Σ` >> Induct_on`Γ` >> simp[]
 QED
@@ -221,10 +216,10 @@ QED
 
 Theorem degree_inv[simp]:
   ∀Σ Γ Σ' Γ'.
-    Σ = Σ' ∧ ((max_list $ MAP modal_size Γ) < (max_list $ MAP modal_size Γ')) ⇒
+    Σ = Σ' ∧ ((MAX_LIST $ MAP modal_size Γ) < (MAX_LIST $ MAP modal_size Γ')) ⇒
     degree (Σ, Γ) <= degree (Σ', Γ')
 Proof
-  rw[degree_max_list]
+  rw[degree_MAX_LIST]
 QED
 
 Theorem conjsplit_degree:

--- a/examples/separationLogic/src/treeScript.sml
+++ b/examples/separationLogic/src/treeScript.sml
@@ -1,6 +1,6 @@
 Theory tree
 Ancestors
-  relation pred_set combin arithmetic list
+  relation pred_set combin arithmetic list rich_list
 Libs
   boolSimps ConseqConv
 
@@ -297,8 +297,6 @@ QED
 Definition MIN_LIST_def:   (MIN_LIST [] = 0) /\
                            (MIN_LIST (t::l) = FOLDR MIN t l)
 End
-Definition MAX_LIST_def:   MAX_LIST l = FOLDR MAX 0 l
-End
 
 Theorem MIN_MAX_LIST_THM:
   (MIN_LIST [] = 0) /\ (MAX_LIST [] = 0) /\
@@ -307,9 +305,10 @@ Theorem MIN_MAX_LIST_THM:
   (!n ns. (MAX_LIST (n::ns) = MAX n (MAX_LIST ns)))
 Proof
 
-SIMP_TAC list_ss [MIN_LIST_def, MAX_LIST_def] THEN
+SIMP_TAC list_ss [MIN_LIST_def, rich_listTheory.MAX_LIST_def] THEN
 Induct_on `ns` THEN
-ASM_SIMP_TAC list_ss [MIN_LIST_def, COND_RAND, COND_RATOR] THEN
+ASM_SIMP_TAC list_ss [MIN_LIST_def, COND_RAND, COND_RATOR,
+                      rich_listTheory.MAX_LIST_def] THEN
 PROVE_TAC[MIN_ASSOC, MIN_COMM]
 QED
 


### PR DESCRIPTION
## Summary
- Remove the local `max_list` in `examples/logic/modal-tableaux/tableauKTScript.sml` — it was just `rich_listTheory.MAX_LIST` under another name.
- Remove the local `MAX_LIST l = FOLDR MAX 0 l` in `examples/separationLogic/src/treeScript.sml`; reprove `MIN_MAX_LIST_THM` against `rich_listTheory.MAX_LIST_def`.

The local `MIN_LIST` in `treeScript.sml` is intentionally left alone: `rich_listTheory.MIN_LIST` is partial on the empty list (`MIN_LIST []` is unspecified), whereas tree's gives `MIN_LIST [] = 0`, and that clause is exposed via `MIN_MAX_LIST_THM` to holfoot's `tree_depth` example. Unifying these is a separate task — first make `rich_listTheory.MIN_LIST` total, then drop tree's local copy.

Closes #1486.

## Test plan
- [x] Core build (`bin/build -t --seq=tools/sequences/upto-parallel`) green.
- [x] `examples/logic/modal-tableaux` builds clean (all five theories).
- [x] `examples/separationLogic/src` builds clean from `Holmake cleanAll`.
- [x] `examples/separationLogic/src/holfoot` directory builds clean.
