### PR TITLE
Clearer error from UNABBREV_TAC for missing abbrev

### DIFF
--- a/src/marker/markerLib.sml
+++ b/src/marker/markerLib.sml
@@ -247,10 +247,13 @@ in
   CONV_TAC (K unbeta_goal) THEN MAP_EVERY ABB' (safe_inst_sort tminst)
 end gl;
 
-fun UNABBREV_TAC s =
+fun UNABBREV_TAC s gl =
  FIRST_X_ASSUM(SUBST_ALL_TAC o
                assert(equal s o fst o dest_var o lhs o concl) o
-               DeAbbrev);
+               DeAbbrev) gl
+ handle HOL_ERR _ =>
+   raise ERR "UNABBREV_TAC"
+         ("No assumption of the form `Abbrev (" ^ s ^ " = ...)`");
 
 val UNABBREV_ALL_TAC =
  let fun ttac th0 =

--- a/src/marker/selftest.sml
+++ b/src/marker/selftest.sml
@@ -242,3 +242,17 @@ val _ = require_msg
    a perfectly valid export (as a theorem with suspendlabel hypotheses);
    export_theory no longer fails on unfinalised suspensions. *)
 val incomplete_th = Feedback.quiet_messages save_thm("incomplete_th", pq_th1)
+
+(* UNABBREV_TAC on a name with no matching abbrev assumption used to fail
+   inside FIRST_ASSUM with an empty error message; it should now report a
+   clear UNABBREV_TAC error mentioning the missing abbreviation. (#1483) *)
+val _ = tprint "UNABBREV_TAC missing abbrev gives clear error"
+val _ = shouldfail {
+  checkexn = check_HOL_ERRexn
+               (fn (_, fnnm, msg) =>
+                   fnnm = "UNABBREV_TAC" andalso
+                   String.isSubstring "MISSING_ABBR" msg),
+  printarg = K "UNABBREV_TAC \"MISSING_ABBR\" with no such abbrev",
+  printresult = goals_print,
+  testfn = (fn g => testtac (UNABBREV_TAC "MISSING_ABBR") g)
+} ([“(P:'a -> bool) x”], “(Q:'a -> bool) x”)


### PR DESCRIPTION
## Summary
`UNABBREV_TAC "x"` (the implementation behind `fs[Abbr `x`]`, `simp[Abbr `x`]`, `rw[Abbr `x`]`, …) used to delegate to `FIRST_X_ASSUM` to find the matching `Abbrev (x = ...)` assumption. When no such assumption existed, the user saw an unhelpful

```
Exception- HOL_ERR {message = "", origin_function = "FIRST_ASSUM",
                    origin_structure = "Tactical", source_location = <??>} raised
```

with no hint that the problem was a typo in an abbreviation name.

This change wraps the `FIRST_X_ASSUM` call in a `handle HOL_ERR _ =>` that re-raises a `UNABBREV_TAC`-tagged error explicitly naming the missing abbreviation. The matching-abbrev path (overwhelmingly the common one) is otherwise untouched.

A regression test in `src/marker/selftest.sml` exercises `UNABBREV_TAC` on an unmatched name and asserts the new error structure via `check_HOL_ERRexn`.

Closes #1483.

## Test plan
- [x] Core build green (`bin/build -t --seq=tools/sequences/upto-parallel`).
- [x] `marker-selftest.log` reports `UNABBREV_TAC missing abbrev gives clear error … OK`.
- [x] Existing tactic uses of `Abbr` (anywhere in the source tree) continue to work — they exercise the unchanged success path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
