### PR TITLE
Phase 1 of Table.sml-based map migration (issue #1595)

### DIFF
--- a/src/1/DefnBaseCore.sml
+++ b/src/1/DefnBaseCore.sml
@@ -7,19 +7,25 @@ struct
 open HolKernel boolSyntax Drule
 
 type kname = KernelSig.kernelname
-type defnstore = (string * kname, string * thm) Binarymap.dict
+
+structure DStab = Table(struct
+  type key = string * kname
+  val ord = pair_compare(String.compare, KernelSig.name_compare)
+  fun pp (s,k) = HOLPP.add_string (s ^ "," ^ KernelSig.name_toString k)
+end)
+
 datatype defn_thm = STDEQNS of thm | OTHER of thm
 fun thm_of (STDEQNS th) = th | thm_of (OTHER th) = th
 type defn_presentation = {const: term, thmname: kname, thm : defn_thm}
+type defnstore = (kname * defn_thm) DStab.table
 
 
-val empty_dstore =
-    Binarymap.mkDict(pair_compare(String.compare, KernelSig.name_compare))
+val empty_dstore : defnstore = DStab.empty
 
 fun list_insert m k v =
-    case Binarymap.peek(m,k) of
-        NONE => Binarymap.insert(m,k,[v])
-      | SOME vs => Binarymap.insert(m,k,v::vs)
+    case KNametab.lookup m k of
+        NONE => KNametab.update (k,[v]) m
+      | SOME vs => KNametab.update (k,v::vs) m
 
 fun to_kid {Thy,Name,Ty} = {Thy = Thy, Name = Name}
 val prim_dest_const = to_kid o dest_thy_const
@@ -31,7 +37,7 @@ fun register_nonstd_p tag (thname as {Thy,...} :kname) thm dstore =
           let val cinfo as {Thy = tthy,...} = prim_dest_const t
           in
             tthy = Thy andalso (
-            case Binarymap.peek(dstore, (tag, cinfo)) of
+            case DStab.lookup dstore (tag, cinfo) of
                 NONE => true
               | SOME (_, defth) => not (uptodate_thm $ thm_of defth)
             )
@@ -41,7 +47,7 @@ fun register_nonstd_p tag (thname as {Thy,...} :kname) thm dstore =
                              (Binaryset.empty KernelSig.name_compare)
                              cs
       fun fold (cinfo, A) =
-          Binarymap.insert(A, (tag, cinfo), (thname, OTHER thm))
+          DStab.update ((tag, cinfo), (thname, OTHER thm)) A
     in
       Binaryset.foldl fold dstore cinfS
     end
@@ -63,14 +69,14 @@ val constants_of_defn = mk_set o map #1 o defn_eqns
 fun register_defn_p tag (thname, thm) dstore =
     let
       val m = List.foldr (fn ((t,th),A) => list_insert A t th)
-                         (Binarymap.mkDict KernelSig.name_compare)
+                         KNametab.empty
                          (defn_eqns thm)
-      open Binarymap
     in
-      foldl
-        (fn (k,cs,A) => insert(A,(tag,k),(thname, STDEQNS $ LIST_CONJ cs)))
-        dstore
+      KNametab.fold
+        (fn (k,cs) => fn A =>
+            DStab.update ((tag,k), (thname, STDEQNS $ LIST_CONJ cs)) A)
         m
+        dstore
     end handle nonstdform => register_nonstd_p tag thname thm dstore
 
 fun add_thy thyname dstore =
@@ -92,10 +98,10 @@ val initial_dstore =
 
 
 fun remove_def s dstore =
-    Binarymap.foldl (fn (k,v as (nm, th), A) =>
-                        if s <> nm then Binarymap.insert(A,k,v) else A)
-                    empty_dstore
-                    dstore
+    DStab.fold (fn (k, v as (nm, th)) => fn A =>
+                   if s <> nm then DStab.update (k,v) A else A)
+               dstore
+               empty_dstore
 
 fun udef_apply (ThmSetData.ADD v) dstore = register_defn_p "user" v dstore
   | udef_apply (ThmSetData.REMOVE s) dstore =
@@ -133,25 +139,25 @@ fun lookup_userdef_p dstore c =
                                     "lookup_userdef" "Not a constant"
       val k = ("user", {Name=Name,Thy=Thy})
     in
-      Option.map (presentation k) $ Binarymap.peek(dstore, k)
+      Option.map (presentation k) $ DStab.lookup dstore k
     end
 fun lookup_userdef c = lookup_userdef_p (get_userdefs_db()) c
 
 fun current_userdefs () =
-    let fun foldthis (k as (tag,kid), v, A) =
+    let fun foldthis (k as (tag,kid), v) A =
             if tag = "user" then presentation k v::A else A
     in
-      Binarymap.foldl foldthis [] $ get_userdefs_db()
+      DStab.fold foldthis (get_userdefs_db()) []
     end
 
 fun thy_userdefs {thyname} =
     let
-      fun foldthis (k as (tag, kid), v, A) =
+      fun foldthis (k as (tag, kid), v) A =
           if tag = "user" andalso #Thy kid = thyname then
             presentation k v :: A
           else A
     in
-      Binarymap.foldl foldthis [] $ get_userdefs_db()
+      DStab.fold foldthis (get_userdefs_db()) []
     end
 
 
@@ -167,8 +173,8 @@ fun thy_userdefs {thyname} =
    ---------------------------------------------------------------------- *)
 
 
-type indnstore = (KernelSig.kernelname, thm * kname list) Binarymap.dict
-val empty_istore = Binarymap.mkDict KernelSig.name_compare
+type indnstore = (thm * kname list) KNametab.table
+val empty_istore : indnstore = KNametab.empty
 
 (* the 'delta' is a thm * term list, with each term a constant *)
 local open ThyDataSexp
@@ -227,8 +233,8 @@ fun register_indn_p (ind, knms) istore =
       val _ = ListPair.all check (Ps, cs)
     in
       List.foldl (fn (c, A) =>
-                     Binarymap.insert(A, c |> dest_thy_const |> to_kid,
-                                      (ind,knms)))
+                     KNametab.update (c |> dest_thy_const |> to_kid,
+                                      (ind,knms)) A)
                  istore
                  cs
     end
@@ -257,7 +263,7 @@ fun lookup_indn_p istore c =
                 handle HOL_ERR _ => raise mk_HOL_ERR "DefnBase"
                                           "lookup_indn" "Not a constant"
     in
-      Binarymap.peek (istore, knm)
+      KNametab.lookup istore knm
     end
 fun lookup_indn c = lookup_indn_p (the_istore()) c
 

--- a/src/1/Drule.sml
+++ b/src/1/Drule.sml
@@ -491,22 +491,24 @@ fun CONJUNCTS_AC (t1, t2) =
    let
       fun conjuncts dict th =
          conjuncts (conjuncts dict (CONJUNCT1 th)) (CONJUNCT2 th)
-         handle HOL_ERR _ => Redblackmap.insert (dict, concl th, th)
+         handle HOL_ERR _ => Termtab.update (concl th, th) dict
       fun prove_conj dict t =
          let
             val (l, r) = dest_conj t
          in
             CONJ (prove_conj dict l) (prove_conj dict r)
          end
-         handle HOL_ERR _ => Redblackmap.find (dict, t)
-      val empty = Redblackmap.mkDict compare
+         handle HOL_ERR _ =>
+                (case Termtab.lookup dict t of
+                     SOME th => th
+                   | NONE => raise ERR "CONJUNCTS_AC" "")
+      val empty = Termtab.empty
       val t1_imp_t2 = prove_conj (conjuncts empty (ASSUME t1)) t2
       val t2_imp_t1 = prove_conj (conjuncts empty (ASSUME t2)) t1
    in
       IMP_ANTISYM_RULE (DISCH t1 t1_imp_t2) (DISCH t2 t2_imp_t1)
    end
    handle HOL_ERR _ => raise ERR "CONJUNCTS_AC" ""
-        | Redblackmap.NotFound => raise ERR "CONJUNCTS_AC" ""
 
 (*---------------------------------------------------------------------------*
  * |- t1 = t2  if t1 and t2 are equivalent using idempotence, symmetry and   *
@@ -547,7 +549,7 @@ fun DISJUNCTS_AC (t1, t2) =
          in
             disjuncts (disjuncts dict (l, l_th)) (r, r_th)
          end
-         handle HOL_ERR _ => Redblackmap.insert (dict, t, th)
+         handle HOL_ERR _ => Termtab.update (t, th) dict
       fun prove_from_disj dict t =
          let
             val (l, r) = dest_disj t
@@ -555,15 +557,17 @@ fun DISJUNCTS_AC (t1, t2) =
             DISJ_CASES (ASSUME t) (prove_from_disj dict l)
                                   (prove_from_disj dict r)
          end
-         handle HOL_ERR _ => Redblackmap.find (dict, t)
-      val empty = Redblackmap.mkDict compare
+         handle HOL_ERR _ =>
+                (case Termtab.lookup dict t of
+                     SOME th => th
+                   | NONE => raise ERR "DISJUNCTS_AC" "")
+      val empty = Termtab.empty
       val t1_imp_t2 = prove_from_disj (disjuncts empty (t2, ASSUME t2)) t1
       val t2_imp_t1 = prove_from_disj (disjuncts empty (t1, ASSUME t1)) t2
    in
       IMP_ANTISYM_RULE (DISCH t1 t1_imp_t2) (DISCH t2 t2_imp_t1)
    end
    handle HOL_ERR _ => raise ERR "DISJUNCTS_AC" ""
-        | Redblackmap.NotFound => raise ERR "DISJUNCTS_AC" ""
 
 (*---------------------------------------------------------------------------*
  *           A,t |- t1 = t2                                                  *
@@ -1732,7 +1736,6 @@ in
                          handle HOL_ERR _ => RAND_CONV (BETA_VAR v Rand)
                       end
 
-   structure Map = Redblackmap
 
    (* count from zero to indicate last argument, up to #args - 1 to indicate
       first argument *)
@@ -1753,7 +1756,7 @@ in
             case dest_term t of
                LAMB (bv, body) =>
                  let
-                   val newposnmap = Map.insert (bvarposns, bv, curposn)
+                   val newposnmap = Termtab.update (bv, curposn) bvarposns
                    val (newdonemap, restore) =
                       (HOLset.delete (donebvars, bv),
                        fn m => HOLset.add (m, bv))
@@ -1772,7 +1775,7 @@ in
                    fun argfold (n, arg, A) =
                       recurse (curposn o arg_CONV n) bvarposns A arg
                  in
-                    case Map.peek (absmap, f) of
+                    case Termtab.lookup absmap f of
                       NONE => foldri argfold (donebvars, acc) args
                     | SOME abs_t =>
                        let
@@ -1782,7 +1785,7 @@ in
                                 ((arg, absv), acc as (dbvars, actionlist)) =
                              if HOLset.member (dbvars, arg)
                                 then acc
-                             else case Map.peek (bvarposns, arg) of
+                             else case Termtab.lookup bvarposns arg of
                                     NONE => acc
                                   | SOME p =>
                                     (HOLset.add (dbvars, arg),
@@ -1795,7 +1798,7 @@ in
                  end
              | _ => (donebvars, acc)
       in
-         recurse I (Map.mkDict Term.compare) (empty_tmset, []) (concl th)
+         recurse I Termtab.empty (empty_tmset, []) (concl th)
       end
 
    (* Modified HO_PART_MATCH by PVH on Apr. 25, 2005: code was broken;
@@ -1879,9 +1882,9 @@ in
                         if is_abs residue
                            andalso all (fn v => HOLset.member (tmbvs, v))
                                        (fst (strip_abs residue))
-                          then Map.insert (acc, redex, residue) else acc
+                          then Termtab.update (redex, residue) acc else acc
                      val bound_to_abs =
-                        List.foldl foldthis (Map.mkDict Term.compare) tmin
+                        List.foldl foldthis Termtab.empty tmin
                      val sth0 = INST_TYPE tyin sth
                      val sth0c = concl sth0
                      val (sth1, tmin') =
@@ -1903,7 +1906,7 @@ in
                                  tmin')
                              end
                      val sth2 =
-                          if Map.numItems bound_to_abs = 0
+                          if Termtab.size bound_to_abs = 0
                              then sth1
                           else CONV_RULE
                                  (EVERY_CONV (#2 (munge_bvars bound_to_abs sth1)))

--- a/src/1/FullUnify.sig
+++ b/src/1/FullUnify.sig
@@ -13,8 +13,8 @@ sig
      val lookup_ty : t -> hol_type -> hol_type
      val lookup_tm : t -> term -> term
      val instE : t -> term -> term
-     val triTM : t -> (term,term)Binarymap.dict
-     val triTY : t -> (string,hol_type)Binarymap.dict
+     val triTM : t -> term Termtab.table
+     val triTY : t -> hol_type Symtab.table
      val fromEmpty : 'a EM -> 'a option
   end
 

--- a/src/1/FullUnify.sml
+++ b/src/1/FullUnify.sml
@@ -19,16 +19,15 @@ struct
 
      where sigma is the type instantiation given by the map
   *)
-  type t = (string, hol_type) Binarymap.dict * (term, term) Binarymap.dict
+  type t = hol_type Symtab.table * term Termtab.table
   fun triTY ((d,_):t) = d
   fun triTM ((_, d):t) = d
   type 'a EM = (t, 'a) optmonad.optmonad
-  val empty : t =
-        (Binarymap.mkDict String.compare, Binarymap.mkDict Term.compare)
+  val empty : t = (Symtab.empty, Termtab.empty)
 
   fun lookup_ty0 tym ty =
       if is_vartype ty then
-        case Binarymap.peek(tym, dest_vartype ty) of
+        case Symtab.lookup tym (dest_vartype ty) of
             NONE => ty
           | SOME ty' => lookup_ty0 tym ty'
       else ty
@@ -45,7 +44,7 @@ struct
         val tm = instE E tm0
       in
         case dest_term tm of
-          VAR _ => (case Binarymap.peek(#2 E, tm) of
+          VAR _ => (case Termtab.lookup (#2 E) tm of
                         NONE => tm
                       | SOME tm' => lookup_tm E tm')
         | _ => tm
@@ -54,13 +53,13 @@ struct
 
 
   fun add_tybind (s,ty) : unit EM = fn (tym,tmm)  =>
-      case Binarymap.peek(tym, s) of
-          NONE => SOME ((Binarymap.insert(tym,s,ty), tmm), ())
+      case Symtab.lookup tym s of
+          NONE => SOME ((Symtab.update (s, ty) tym, tmm), ())
         | SOME _ => NONE
 
   fun add_tmbind (v, tm) : unit EM = fn (tym,tmm) =>
-      case Binarymap.peek(tmm, v) of
-          NONE => SOME((tym, Binarymap.insert(tmm,v,tm)), ())
+      case Termtab.lookup tmm v of
+          NONE => SOME((tym, Termtab.update (v, tm) tmm), ())
         | SOME _ => NONE
 
   fun fromEmpty (m : 'a EM) = Option.map #2 (m empty)
@@ -188,20 +187,21 @@ fun collapse_map (freeset,empty,dosub) subst =
 fun collapse0 E =
     let
       val mk_vartype = trace ("Vartype Format Complaint", 0) mk_vartype
-      fun EtoSUBST i E =
-          Binarymap.foldl
-            (fn (k,v,A) => {redex = i k, residue = v} :: A)
-            []
-            E
       val tymap =
           collapse_map (HOLset.fromList Type.compare o Type.type_vars,
                       HOLset.empty Type.compare,
                       Type.type_subst)
-                     (EtoSUBST mk_vartype (Env.triTY E))
+                     (Symtab.fold
+                        (fn (k,v) => fn A =>
+                            {redex = mk_vartype k, residue = v} :: A)
+                        (Env.triTY E) [])
       val tmmap0 = map (fn {residue,redex} =>
                            {residue = Term.inst tymap residue,
                             redex = Term.inst tymap redex})
-                       (EtoSUBST (fn x => x) (Env.triTM E))
+                       (Termtab.fold
+                          (fn (k,v) => fn A =>
+                              {redex = k, residue = v} :: A)
+                          (Env.triTM E) [])
     in
       (tymap,
        collapse_map (fn t => FVL [t] empty_tmset, empty_tmset, Term.subst) tmmap0

--- a/src/1/Ho_Net.sml
+++ b/src/1/Ho_Net.sml
@@ -74,7 +74,12 @@ fun stored_label (fvars,tm) =
        | _ => fail()
     end;
 
-open Binarymap
+structure LabelTab = Table(struct
+  type key = term_label
+  val ord = label_cmp
+  fun pp _ = HOLPP.add_string "<term_label>"
+end)
+
 fun label_for_lookup tm =
   let val (oper,args) = strip_comb tm
   in case dest_term oper
@@ -90,7 +95,7 @@ fun label_for_lookup tm =
      val empty = NODE(mkDict label_cmp, [])
    then empty can't be fully polymorphic, thanks to the call to
    mkDict. *)
-datatype 'a net = NODE of (term_label,'a net) dict * 'a list
+datatype 'a net = NODE of 'a net LabelTab.table * 'a list
                 | EMPTY of 'a list
 
 val empty = EMPTY []
@@ -98,16 +103,17 @@ val empty = EMPTY []
 
 
 fun edges (NODE(es, _)) = es
-  | edges (EMPTY _) = mkDict label_cmp
+  | edges (EMPTY _) = LabelTab.empty
 fun tips (NODE(_, ts)) = ts
   | tips (EMPTY ts) = ts
 fun add_tip e (NODE(es, tips)) = NODE(es, e::tips)
   | add_tip e (EMPTY tips) = EMPTY (e::tips)
 
-fun check_edge(NODE(es, _), label) = peek(es, label)
+fun check_edge(NODE(es, _), label) = LabelTab.lookup es label
   | check_edge(EMPTY _, label) = NONE
-fun new_edge(NODE(es, ts), label, n) = NODE(insert(es, label, n), ts)
-  | new_edge(EMPTY ts, label, n) = NODE(insert(mkDict label_cmp, label, n), ts)
+fun new_edge(NODE(es, ts), label, n) = NODE(LabelTab.update (label, n) es, ts)
+  | new_edge(EMPTY ts, label, n) =
+      NODE(LabelTab.update (label, n) LabelTab.empty, ts)
 
 
 fun net_update (elem, tms:(term list * term) list, net) =
@@ -144,12 +150,12 @@ fun enter (fvars,tm,elem) net = net_update(elem,[(fvars,tm)],net);
 fun lookup tm net = follow([tm],net);
 
 fun merge_nets (n1, n2) = let
-  fun add_node (lab, net, m) =
-      case peek(m, lab) of
-        SOME net' => insert(m, lab, merge_nets(net, net'))
-      | NONE => insert(m, lab, net)
+  fun add_node (lab, net) m =
+      case LabelTab.lookup m lab of
+        SOME net' => LabelTab.update (lab, merge_nets(net, net')) m
+      | NONE => LabelTab.update (lab, net) m
 in
-  NODE (foldl add_node (edges n1) (edges n2), tips n1 @ tips n2)
+  NODE (LabelTab.fold add_node (edges n2) (edges n1), tips n1 @ tips n2)
 end
 
 fun fold' f n A =
@@ -157,7 +163,7 @@ fun fold' f n A =
         NODE (children, vals) =>
         let val A1 = Portable.foldl' f vals A
         in
-          Binarymap.foldl (fn (_, n, A) => fold' f n A) A1 children
+          LabelTab.fold (fn (_, n) => fn A => fold' f n A) children A1
         end
       | EMPTY vs => Portable.foldl' f vs A
 
@@ -165,10 +171,10 @@ fun vfilter P n =
     case n of
         NODE (children, vals) =>
         let
-          val children' = Binarymap.map (fn (_, a) => vfilter P a) children
+          val children' = LabelTab.map (fn _ => fn a => vfilter P a) children
           val vals' = List.filter P vals
         in
-          if Binarymap.numItems children' = 0 then EMPTY vals'
+          if LabelTab.size children' = 0 then EMPTY vals'
           else NODE (children', vals')
         end
       | EMPTY vs => EMPTY (List.filter P vs)

--- a/src/1/Holmakefile
+++ b/src/1/Holmakefile
@@ -13,10 +13,12 @@ LVTermNetFunctorApplied.uo: LVTermNetFunctorApplied.sml $(dprot $(SIGOBJ)/LVTerm
 # resolves them at compile time.
 
 DefnBaseCore.uo: DefnBaseCore.sml DefnBaseCore.ui $(TABLE_UID) ThmSetData.ui \
+                 $(dprot $(SIGOBJ)/HolKernel.ui) \
                  $(dprot $(SIGOBJ)/KNametab.ui)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
-Ho_Net.uo: Ho_Net.sml Ho_Net.ui $(TABLE_UID)
+Ho_Net.uo: Ho_Net.sml Ho_Net.ui $(TABLE_UID) \
+           $(dprot $(SIGOBJ)/HolKernel.ui)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
 

--- a/src/1/Holmakefile
+++ b/src/1/Holmakefile
@@ -12,7 +12,8 @@ LVTermNetFunctorApplied.uo: LVTermNetFunctorApplied.sml $(dprot $(SIGOBJ)/LVTerm
 # builds them before this rule fires; mosml's implicit -I . then
 # resolves them at compile time.
 
-DefnBaseCore.uo: DefnBaseCore.sml DefnBaseCore.ui $(TABLE_UID) ThmSetData.ui
+DefnBaseCore.uo: DefnBaseCore.sml DefnBaseCore.ui $(TABLE_UID) ThmSetData.ui \
+                 $(dprot $(SIGOBJ)/KNametab.ui)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
 Ho_Net.uo: Ho_Net.sml Ho_Net.ui $(TABLE_UID)

--- a/src/1/Holmakefile
+++ b/src/1/Holmakefile
@@ -1,8 +1,23 @@
 all: $(DEFAULT_TARGETS) selftest.exe
 .PHONY: all
 
+TABLE_UID = $(dprot $(SIGOBJ)/Table.ui)
+
 LVTermNetFunctorApplied.uo: LVTermNetFunctorApplied.sml $(dprot $(SIGOBJ)/LVTermNetFunctor.ui) $(dprot $(SIGOBJ)/HOLset.ui)
 	$(HOLMOSMLC) -c $(protect $(SIGOBJ)/LVTermNetFunctor.ui) $<
+
+# Files instantiating the Table functor locally need an explicit
+# Table.ui argument; mosml's auto-detection doesn't pick up functor
+# applications.  Sibling .ui files are listed as prereqs so Holmake
+# builds them before this rule fires; mosml's implicit -I . then
+# resolves them at compile time.
+
+DefnBaseCore.uo: DefnBaseCore.sml DefnBaseCore.ui $(TABLE_UID) ThmSetData.ui
+	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
+
+Ho_Net.uo: Ho_Net.sml Ho_Net.ui $(TABLE_UID)
+	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
+
 
 selftest.exe: selftest.uo simpfrag.uo $(dprot $(SIGOBJ)/term_pp.uo) \
               $(dprot $(SIGOBJ)/testutils.uo) $(dprot $(SIGOBJ)/TermParse.uo) \

--- a/src/1/Pmatch.sml
+++ b/src/1/Pmatch.sml
@@ -484,8 +484,9 @@ end
      Repeated variable occurrences in a pattern are not allowed.
  ---------------------------------------------------------------------------*)
 
-fun inc d k = case Binarymap.peek(d,k) of NONE => Binarymap.insert(d,k,1)
-                                        | SOME n => Binarymap.insert(d,k,n+1);
+fun inc d k = case Termtab.lookup d k of
+                  NONE => Termtab.update (k,1) d
+                | SOME n => Termtab.update (k,n+1) d;
 
 fun FV_multiset tm =
   let
@@ -500,15 +501,15 @@ fun FV_multiset tm =
              | COMB(Rator,Rand) => recurse d (TM Rator :: TM Rand :: rest)
              | LAMB(Bvar,Body) =>
                let
-                 val c0 = case Binarymap.peek(d,Bvar) of
+                 val c0 = case Termtab.lookup d Bvar of
                               NONE => 0
                             | SOME i => i
                in
                  recurse d (TM Body :: RESET(Bvar,c0) :: rest)
                end)
-        | RESET (v,c) :: rest => recurse (Binarymap.insert(d,v,c)) rest
+        | RESET (v,c) :: rest => recurse (Termtab.update (v,c) d) rest
   in
-    recurse (Binarymap.mkDict Term.compare) [TM tm]
+    recurse Termtab.empty [TM tm]
   end
 
 fun no_repeat_vars pat =
@@ -516,7 +517,8 @@ fun no_repeat_vars pat =
     fun check d =
       let
         val repeats =
-            Binarymap.foldl (fn (k,v,acc) => if v > 1 then k::acc else acc) [] d
+            Termtab.fold (fn (k,v) => fn acc =>
+                             if v > 1 then k::acc else acc) d []
       in
         if null repeats then true
         else

--- a/src/1/Prim_rec.sml
+++ b/src/1/Prim_rec.sml
@@ -140,11 +140,13 @@ fun prove_raw_recursive_functions_exist ax tm = let
   val raxs0 = rev_itlist gax (map (repeat rator o hd o snd) lpats) ([],table)
   val raxs = List.rev (fst raxs0)
   val axfns = map (repeat rator o lhand o snd o strip_forall) raxs
-  val dict = ListPair.foldl (fn (a,(b,_),d) => Binarymap.insert(d,a,b))
-                            (Binarymap.mkDict Term.compare)
+  val dict = ListPair.foldl (fn (a,(b,_),d) => Termtab.update (a,b) d)
+                            Termtab.empty
                             (axfns, lpats)
   val urfns =
-      map (fn v => Binarymap.find(dict,v) handle Binarymap.NotFound => v) exvs
+      map (fn v => case Termtab.lookup dict v of
+                       SOME b => b
+                     | NONE => v) exvs
   val axtm = list_mk_exists(exvs,list_mk_conj raxs)
   and urtm = list_mk_exists(urfns,tm)
   val ixth = mymatch_and_instantiate axth axtm urtm

--- a/src/1/ThmSetData.sig
+++ b/src/1/ThmSetData.sig
@@ -32,7 +32,7 @@ sig
       {settype : string, delta_ops : 'value ops} ->
       (setdelta,'value) AncestryData.fullresult
 
-  type simple_dictionary = (string,thm) Binarymap.dict
+  type simple_dictionary = thm Symtab.table
   val simple_dictionary_ops : simple_dictionary -> simple_dictionary ops
   val export_simple_dictionary :
       {settype : string, initial : (string * thm) list} ->

--- a/src/1/ThmSetData.sml
+++ b/src/1/ThmSetData.sml
@@ -300,19 +300,19 @@ fun export_with_ancestry
     Some simple instances
    ---------------------------------------------------------------------- *)
 
-type simple_dictionary = (string,thm) Binarymap.dict
+type simple_dictionary = thm Symtab.table
 fun sdict_apply_delta delta (d : simple_dictionary) =
     case delta of
-        ADD({Thy,Name}, th) => Binarymap.insert(d, Thy ^ "." ^ Name, th)
-      | REMOVE n => #1 (Binarymap.remove(d, n)) handle NotFound => d
+        ADD({Thy,Name}, th) => Symtab.update (Thy ^ "." ^ Name, th) d
+      | REMOVE n => Symtab.delete_safe n d
 fun simple_dictionary_ops i =
     {apply_to_global = sdict_apply_delta, apply_delta = sdict_apply_delta,
      thy_finaliser = NONE, uptodate_delta = K true, initial_value = i}
 fun export_simple_dictionary {settype,initial} =
     let
       val i =
-          List.foldl (fn ((n,th), d) => Binarymap.insert(d, n, th))
-                     (Binarymap.mkDict String.compare) initial
+          List.foldl (fn ((n,th), d) => Symtab.update (n, th) d)
+                     Symtab.empty initial
       val ops as {apply_delta,...} = simple_dictionary_ops i
       val res = export_with_ancestry {settype = settype, delta_ops = ops}
       val updgv = #update_global_value res
@@ -326,17 +326,18 @@ fun export_simple_dictionary {settype,initial} =
        temp_export = temp_export,
        export = (fn s => (temp_export s; #record_delta res (mk_add s))),
        getDB = getDB,
-       get_thms = Binarymap.foldl (fn (n,th,A) => th::A) [] o getDB,
+       get_thms = (fn db => Symtab.fold (fn (_,th) => fn A => th::A) db []) o
+                  getDB,
        temp_setDB = updgv o K}
     end
 
 fun sdict_withflag_thms({getDB,temp_setDB}, thms) f x =
     let
-      open Binarymap
       val (_, tdb) =
-          List.foldl (fn (th,(n,db)) => (n + 1, insert(db, Int.toString n, th)))
-                     (0, mkDict String.compare)
-                     thms
+          List.foldl
+            (fn (th,(n,db)) => (n + 1, Symtab.update (Int.toString n, th) db))
+            (0, Symtab.empty)
+            thms
     in
       Portable.genwith_flag({get=getDB,set=temp_setDB}, tdb) f x
     end
@@ -374,7 +375,6 @@ fun export_alist {settype,initial} =
 
 fun alist_withflag_thms({getDB,temp_setDB}, thms) f x =
     let
-      open Binarymap
       val (_, tdb) =
           List.foldr (fn (th,(n,db)) => (n + 1, (Int.toString n, th)::db))
                      (0, []) thms

--- a/src/1/TypeBase.sml
+++ b/src/1/TypeBase.sml
@@ -197,11 +197,11 @@ fun tyi_from_name s =
         let
           val tyg = Parse.type_grammar()
         in
-          case Redblackmap.peek(privileged_abbrevs tyg, nm) of
+          case Symtab.lookup (privileged_abbrevs tyg) nm of
               NONE => raise ERR "tyi_from_name"
                             ("Ty-grammar doesn't know name: "^nm)
             | SOME thy =>
-              (case Redblackmap.peek(parse_map tyg, {Thy = thy, Name = nm}) of
+              (case KNametab.lookup (parse_map tyg) {Thy = thy, Name = nm} of
                    NONE => raise ERR "tyi_from_name"
                                  ("Ty-grammar has bad abbrev-map for name: "^nm)
                  | SOME (TYOP {Thy,Tyop,...}) => tyi_from_kid Thy Tyop

--- a/src/1/TypeBase.sml
+++ b/src/1/TypeBase.sml
@@ -197,11 +197,11 @@ fun tyi_from_name s =
         let
           val tyg = Parse.type_grammar()
         in
-          case HOLdict.peek(privileged_abbrevs tyg, nm) of
+          case Redblackmap.peek(privileged_abbrevs tyg, nm) of
               NONE => raise ERR "tyi_from_name"
                             ("Ty-grammar doesn't know name: "^nm)
             | SOME thy =>
-              (case HOLdict.peek(parse_map tyg, {Thy = thy, Name = nm}) of
+              (case Redblackmap.peek(parse_map tyg, {Thy = thy, Name = nm}) of
                    NONE => raise ERR "tyi_from_name"
                                  ("Ty-grammar has bad abbrev-map for name: "^nm)
                  | SOME (TYOP {Thy,Tyop,...}) => tyi_from_kid Thy Tyop

--- a/src/1/TypeBasePure.sml
+++ b/src/1/TypeBasePure.sml
@@ -632,6 +632,13 @@ fun next_ty ty = mk_vartype(Lexis.tyvar_vary (dest_vartype ty))
 (*                                                                           *)
 (*---------------------------------------------------------------------------*)
 
+local
+  structure Typetab = Table(struct
+    type key = Type.hol_type
+    val ord = Type.compare
+    fun pp _ = HOLPP.add_string "<type>"
+  end)
+in
 fun normalise_ty ty = let
   fun recurse (acc as (dict,usethis)) tylist =
       case tylist of
@@ -639,8 +646,8 @@ fun normalise_ty ty = let
       | ty :: rest => let
         in
           if is_vartype ty then
-            case Binarymap.peek(dict,ty) of
-                NONE => recurse (Binarymap.insert(dict,ty,usethis),
+            case Typetab.lookup dict ty of
+                NONE => recurse (Typetab.update (ty,usethis) dict,
                                  next_ty usethis)
                                 rest
               | SOME _ => recurse acc rest
@@ -650,13 +657,14 @@ fun normalise_ty ty = let
               recurse acc (Args @ rest)
             end
         end
-  val (inst0, _) = recurse (Binarymap.mkDict Type.compare, Type.alpha) [ty]
-  val inst = Binarymap.foldl (fn (tyk,tyv,acc) => (tyk |-> tyv)::acc)
-                             []
-                             inst0
+  val (inst0, _) = recurse (Typetab.empty, Type.alpha) [ty]
+  val inst = Typetab.fold (fn (tyk,tyv) => fn acc => (tyk |-> tyv)::acc)
+                          inst0
+                          []
 in
   Type.type_subst inst ty
 end
+end (* local *)
 
 fun prim_get (db:typeBase) (thy,tyop) =
     case Type.op_arity {Thy = thy, Tyop = tyop} of

--- a/src/1/TypeBasePure.sml
+++ b/src/1/TypeBasePure.sml
@@ -632,13 +632,6 @@ fun next_ty ty = mk_vartype(Lexis.tyvar_vary (dest_vartype ty))
 (*                                                                           *)
 (*---------------------------------------------------------------------------*)
 
-local
-  structure Typetab = Table(struct
-    type key = Type.hol_type
-    val ord = Type.compare
-    fun pp _ = HOLPP.add_string "<type>"
-  end)
-in
 fun normalise_ty ty = let
   fun recurse (acc as (dict,usethis)) tylist =
       case tylist of
@@ -664,7 +657,6 @@ fun normalise_ty ty = let
 in
   Type.type_subst inst ty
 end
-end (* local *)
 
 fun prim_get (db:typeBase) (thy,tyop) =
     case Type.op_arity {Thy = thy, Tyop = tyop} of

--- a/src/1/match_goal.sml
+++ b/src/1/match_goal.sml
@@ -3,12 +3,7 @@ struct
 
 open HolKernel boolLib Streams
 
-fun Redblackmap_contains (m,v) =
-  let
-    exception found
-    val _ = Redblackmap.app (fn (_,v') => if v = v' then raise found else ()) m
-  in false end
-  handle found => true
+fun Symtab_contains (m,v) = Symtab.exists (fn (_,v') => v = v') m
 
 val ERR = Feedback.mk_HOL_ERR"match_goal";
 
@@ -21,8 +16,8 @@ type pattern = term quotation
 type matcher = name * pattern * bool
 
                (* (name, assumption number) *)
-type named_thms = (string, int) Redblackmap.dict
-val (empty_named_thms:named_thms) = Redblackmap.mkDict String.compare;
+type named_thms = int Symtab.table
+val (empty_named_thms:named_thms) = Symtab.empty;
 
 (* If you want to be able to treat certain type variables as constants (e.g.,
    if they are in the goal) then you need to keep track of the avoid_tys/tyIds
@@ -76,11 +71,11 @@ fun match_single fvs ((asl,w):goal)
   let
     fun add_nth NONE _ = SOME nths
       | add_nth (SOME l) i =
-        (case Redblackmap.peek(nths,l) of
+        (case Symtab.lookup nths l of
            NONE =>
-             if Redblackmap_contains(nths,i)
+             if Symtab_contains(nths,i)
              then NONE
-             else SOME (Redblackmap.insert(nths,l,i))
+             else SOME (Symtab.update (l,i) nths)
          | SOME j => if i = j then SOME nths else NONE)
 
     fun protect f NONE = K empty_stream
@@ -127,7 +122,7 @@ fun match_tac (ms:matcher list,mtac:mg_tactic) (g as (asl,w):goal) : goal list *
       let
         fun lookup_assum s =
           let
-            val i = Redblackmap.find(thms,s)
+            val i = valOf (Symtab.lookup thms s)
             val tm = List.nth(#1 g,i)
           in ASSUME tm end
         val s =

--- a/src/1/simpfrag.sml
+++ b/src/1/simpfrag.sml
@@ -16,12 +16,12 @@ fun add_rwts {convs, rewrs} newrwts = {convs = convs, rewrs = rewrs @ newrwts};
 
 fun add_convs cds {convs, rewrs} = {convs = convs@cds, rewrs = rewrs}
 
-val sconv_db = ref (Binarymap.mkDict String.compare : (string,thm -> convdata) Binarymap.dict)
+val sconv_db : (thm -> convdata) Symtab.table ref = ref Symtab.empty
 
 fun register_simpfrag_conv {name,code} =
-  sconv_db := Binarymap.insert(!sconv_db, name, code)
+  sconv_db := Symtab.update (name, code) (!sconv_db)
 
-fun lookup_simpfrag_conv k = Binarymap.peek(!sconv_db, k)
+fun lookup_simpfrag_conv k = Symtab.lookup (!sconv_db) k
 
 val simpfrag_conv_tag = "ssfrag_CONV"
 

--- a/src/1/theory_tests/gh168aScript.sml
+++ b/src/1/theory_tests/gh168aScript.sml
@@ -5,7 +5,7 @@ Libs
   HolKernel Parse boolLib
 
 val thy =
-    Redblackmap.find(type_grammar.privileged_abbrevs (type_grammar()), "foo")
+    valOf (Symtab.lookup (type_grammar.privileged_abbrevs (type_grammar())) "foo")
 
 val _ = disable_tyabbrev_printing (thy^"$foo")
 

--- a/src/1/theory_tests/gh168aScript.sml
+++ b/src/1/theory_tests/gh168aScript.sml
@@ -5,7 +5,7 @@ Libs
   HolKernel Parse boolLib
 
 val thy =
-    HOLdict.find(type_grammar.privileged_abbrevs (type_grammar()), "foo")
+    Redblackmap.find(type_grammar.privileged_abbrevs (type_grammar()), "foo")
 
 val _ = disable_tyabbrev_printing (thy^"$foo")
 

--- a/src/1/theory_tests/gh168bScript.sml
+++ b/src/1/theory_tests/gh168bScript.sml
@@ -22,6 +22,6 @@ fun typrinttest s =
 val _ = typrinttest ":bool -> bool"
 val _ = typrinttest ":bool -> bool -> bool"
 val _ = tprint "type_grammar abbrevs map is empty"
-val _ = if Redblackmap.numItems (type_grammar.parse_map tyg) = 4 then OK()
+val _ = if KNametab.size (type_grammar.parse_map tyg) = 4 then OK()
         else die "FAILED!"
 

--- a/src/1/theory_tests/gh168bScript.sml
+++ b/src/1/theory_tests/gh168bScript.sml
@@ -22,6 +22,6 @@ fun typrinttest s =
 val _ = typrinttest ":bool -> bool"
 val _ = typrinttest ":bool -> bool -> bool"
 val _ = tprint "type_grammar abbrevs map is empty"
-val _ = if HOLdict.numItems (type_grammar.parse_map tyg) = 4 then OK()
+val _ = if Redblackmap.numItems (type_grammar.parse_map tyg) = 4 then OK()
         else die "FAILED!"
 

--- a/src/1/theory_tests/gh168cScript.sml
+++ b/src/1/theory_tests/gh168cScript.sml
@@ -5,7 +5,7 @@ Libs
   HolKernel Parse boolLib testutils
 
 val tyg0 = type_grammar()
-val privthy = Redblackmap.find(type_grammar.privileged_abbrevs tyg0, "foo")
+val privthy = valOf (Symtab.lookup (type_grammar.privileged_abbrevs tyg0) "foo")
 val unprivthy = if privthy = "gh294a" then "gh294b" else "gh294a"
 
 val _ = remove_type_abbrev (privthy ^ "$foo")

--- a/src/1/theory_tests/gh168cScript.sml
+++ b/src/1/theory_tests/gh168cScript.sml
@@ -5,7 +5,7 @@ Libs
   HolKernel Parse boolLib testutils
 
 val tyg0 = type_grammar()
-val privthy = HOLdict.find(type_grammar.privileged_abbrevs tyg0, "foo")
+val privthy = Redblackmap.find(type_grammar.privileged_abbrevs tyg0, "foo")
 val unprivthy = if privthy = "gh294a" then "gh294b" else "gh294a"
 
 val _ = remove_type_abbrev (privthy ^ "$foo")

--- a/src/1/theory_tests/gh168eScript.sml
+++ b/src/1/theory_tests/gh168eScript.sml
@@ -8,7 +8,7 @@ val b2b = bool --> bool
 val b2b2b = bool --> b2b
 
 val tyg0 = type_grammar()
-val privthy = Redblackmap.find(type_grammar.privileged_abbrevs tyg0, "foo")
+val privthy = valOf (Symtab.lookup (type_grammar.privileged_abbrevs tyg0) "foo")
 val unprivthy = if privthy = "gh294a" then "gh294b" else "gh294a"
 
 val (privty, unprivty) = if privthy = "gh294a" then (b2b, b2b2b)

--- a/src/1/theory_tests/gh168eScript.sml
+++ b/src/1/theory_tests/gh168eScript.sml
@@ -8,7 +8,7 @@ val b2b = bool --> bool
 val b2b2b = bool --> b2b
 
 val tyg0 = type_grammar()
-val privthy = HOLdict.find(type_grammar.privileged_abbrevs tyg0, "foo")
+val privthy = Redblackmap.find(type_grammar.privileged_abbrevs tyg0, "foo")
 val unprivthy = if privthy = "gh294a" then "gh294b" else "gh294a"
 
 val (privty, unprivty) = if privthy = "gh294a" then (b2b, b2b2b)

--- a/src/HolQbf/QDimacs.sml
+++ b/src/HolQbf/QDimacs.sml
@@ -42,19 +42,19 @@ struct
     (* "global" state references (could instead be passed as arguments to the
        following functions to obtain a purely functional implementation) *)
     val freshvar = ref 1
-    val dict = ref (HOLdict.mkDict Term.compare)
+    val dict = ref (Redblackmap.mkDict Term.compare)
     (* the following functions essentially implement the production rules of
        the QDIMACS grammar *)
     (* term -> string *)
     fun variable_to_qdimacs tm =
       if Term.is_var tm then
-        Int.toString (HOLdict.find (!dict, tm)
-          handle HOLdict.NotFound =>
+        Int.toString (Redblackmap.find (!dict, tm)
+          handle Redblackmap.NotFound =>
             let
               val fresh = !freshvar
             in
               freshvar := fresh + 1;
-              dict := HOLdict.insert (!dict, tm, fresh);
+              dict := Redblackmap.insert (!dict, tm, fresh);
               fresh
             end)
       else
@@ -148,11 +148,11 @@ struct
 
   fun dict_to_varfn dict : int -> Term.term =
   let
-    val inverted_dict = HOLdict.foldl (fn (t, i, dict) =>
-      HOLdict.insert (dict, i, t)) (HOLdict.mkDict Int.compare) dict
+    val inverted_dict = Redblackmap.foldl (fn (t, i, dict) =>
+      Redblackmap.insert (dict, i, t)) (Redblackmap.mkDict Int.compare) dict
   in
-    fn i => HOLdict.find (inverted_dict, i)
-      handle HOLdict.NotFound =>
+    fn i => Redblackmap.find (inverted_dict, i)
+      handle Redblackmap.NotFound =>
         raise Feedback.mk_HOL_ERR "QDimacs" "dict_to_varfn"
           ("unknown index " ^ Int.toString i)
   end

--- a/src/HolQbf/QDimacs.sml
+++ b/src/HolQbf/QDimacs.sml
@@ -42,21 +42,23 @@ struct
     (* "global" state references (could instead be passed as arguments to the
        following functions to obtain a purely functional implementation) *)
     val freshvar = ref 1
-    val dict = ref (Redblackmap.mkDict Term.compare)
+    val dict : int Termtab.table ref = ref Termtab.empty
     (* the following functions essentially implement the production rules of
        the QDIMACS grammar *)
     (* term -> string *)
     fun variable_to_qdimacs tm =
       if Term.is_var tm then
-        Int.toString (Redblackmap.find (!dict, tm)
-          handle Redblackmap.NotFound =>
-            let
-              val fresh = !freshvar
-            in
-              freshvar := fresh + 1;
-              dict := Redblackmap.insert (!dict, tm, fresh);
-              fresh
-            end)
+        Int.toString
+          (case Termtab.lookup (!dict) tm of
+               SOME i => i
+             | NONE =>
+               let
+                 val fresh = !freshvar
+               in
+                 freshvar := fresh + 1;
+                 dict := Termtab.update (tm, fresh) (!dict);
+                 fresh
+               end)
       else
         raise ERR "write_qdimacs_file"
           ("term is not a QBF (variable expected, subterm '" ^
@@ -148,13 +150,14 @@ struct
 
   fun dict_to_varfn dict : int -> Term.term =
   let
-    val inverted_dict = Redblackmap.foldl (fn (t, i, dict) =>
-      Redblackmap.insert (dict, i, t)) (Redblackmap.mkDict Int.compare) dict
+    val inverted_dict = Termtab.fold (fn (t, i) => fn d =>
+      Inttab.update (i, t) d) dict Inttab.empty
   in
-    fn i => Redblackmap.find (inverted_dict, i)
-      handle Redblackmap.NotFound =>
-        raise Feedback.mk_HOL_ERR "QDimacs" "dict_to_varfn"
-          ("unknown index " ^ Int.toString i)
+    fn i => case Inttab.lookup inverted_dict i of
+                SOME t => t
+              | NONE =>
+                raise Feedback.mk_HOL_ERR "QDimacs" "dict_to_varfn"
+                  ("unknown index " ^ Int.toString i)
   end
 
 (* ------------------------------------------------------------------------- *)

--- a/src/HolQbf/QbfCertificate.sml
+++ b/src/HolQbf/QbfCertificate.sml
@@ -34,9 +34,9 @@ struct
   type resolution = literal list * cindex list
 
   datatype certificate =
-      VALID of (vindex, extension) HOLdict.dict
-        * (vindex, literal) HOLdict.dict
-    | INVALID of (cindex, resolution) HOLdict.dict * cindex
+      VALID of (vindex, extension) Redblackmap.dict
+        * (vindex, literal) Redblackmap.dict
+    | INVALID of (cindex, resolution) Redblackmap.dict * cindex
 
 (* ------------------------------------------------------------------------- *)
 (* read_certificate_file: reads a QBF certificate from a file                *)
@@ -73,10 +73,10 @@ struct
       extension_lits (int_from_string literal :: lits) xs
     (* (vindex, extension) dict -> string list -> (vindex, extension) dict *)
     fun extension ext [vindex, "I", lit1, lit2, lit3] =
-      HOLdict.insert (ext, int_from_string vindex,
+      Redblackmap.insert (ext, int_from_string vindex,
         ITE (int_from_string lit1, int_from_string lit2, int_from_string lit3))
       | extension ext (vindex :: "A" :: lits) =
-      HOLdict.insert (ext, int_from_string vindex,
+      Redblackmap.insert (ext, int_from_string vindex,
         AND (extension_lits [] lits))
       | extension _ _ =
       raise ERR "read_certificate_file" "extension: invalid format"
@@ -106,14 +106,14 @@ struct
           "resolution: missing '*' or '0' terminator"
     (* (cindex, resolution) dict -> string list -> (cindex, resolution) dict *)
     fun resolution res (cindex :: xs) =
-      HOLdict.insert (res, int_from_string cindex, resolution_args [] xs)
+      Redblackmap.insert (res, int_from_string cindex, resolution_args [] xs)
       | resolution _ _ =
       raise ERR "read_certificate_file" "resolution: clause index expected"
     (* (vindex, literal) dict -> string list -> (vindex, literal) dict *)
     fun valid_conclusion dict [] =
       dict
       | valid_conclusion dict (vindex :: literal :: xs) =
-      valid_conclusion (HOLdict.insert
+      valid_conclusion (Redblackmap.insert
         (dict, int_from_string vindex, int_from_string literal)) xs
       | valid_conclusion _ _ =
       raise ERR "read_certificate_file"
@@ -122,15 +122,15 @@ struct
          conclusion *)
     fun conclusion (ext, res) ("VALID" :: xs) =
       let
-        val _ = HOLdict.isEmpty res orelse
+        val _ = Redblackmap.isEmpty res orelse
           raise ERR "read_certificate_file"
             "conclusion is 'VALID', but there are resolutions"
       in
-        VALID (ext, valid_conclusion (HOLdict.mkDict Int.compare) xs)
+        VALID (ext, valid_conclusion (Redblackmap.mkDict Int.compare) xs)
       end
       | conclusion (ext, res) ["INVALID", cindex] =
       let
-        val _ = HOLdict.isEmpty ext orelse
+        val _ = Redblackmap.isEmpty ext orelse
           raise ERR "read_certificate_file"
             "conclusion is 'INVALID', but there are extensions"
       in
@@ -152,7 +152,7 @@ struct
         raise ERR "read_certificate_file" "missing conclusion"
   in
     (certificate
-       (HOLdict.mkDict Int.compare, HOLdict.mkDict Int.compare)
+       (Redblackmap.mkDict Int.compare, Redblackmap.mkDict Int.compare)
     o (map (String.tokens (Lib.C Lib.mem [#" ", #"\t", #"\n"])))
     o filter_header
     o List.filter (fn l => l <> "\n")
@@ -177,7 +177,7 @@ struct
 
   fun check t dict (VALID (exts,lits)) = let
     open Lib Thm Drule Term Type boolSyntax
-    open HOLset HOLdict
+    open HOLset Redblackmap
 
     val (var_to_index, index_to_var) = let
       open String Int Option
@@ -372,10 +372,10 @@ struct
          variable's index and a Boolean that is true if the variable is
          universally quantified, and false if it is existentially quantified *)
       val var_dict = List.foldl (fn ((i, var, is_forall), var_dict) =>
-        HOLdict.insert (var_dict, var, (i, is_forall)))
-        (HOLdict.mkDict Term.var_compare) vars
+        Redblackmap.insert (var_dict, var, (i, is_forall)))
+        (Redblackmap.mkDict Term.var_compare) vars
       fun index_fn var =
-        HOLdict.find (var_dict, var)
+        Redblackmap.find (var_dict, var)
 
       val vars = List.rev vars
       fun foldthis (clause, (i, clause_dict)) =
@@ -383,7 +383,7 @@ struct
           val clause = QbfLibrary.CLAUSE_TO_SEQUENT clause
           val lits = QbfLibrary.literals_in_clause index_fn clause
         in
-          (i + 1, HOLdict.insert (clause_dict, i,
+          (i + 1, Redblackmap.insert (clause_dict, i,
             QbfLibrary.forall_reduce (clause, vars, matrix, lits)))
         end
 
@@ -394,19 +394,19 @@ struct
          this is 'matrix'), and 4. the list of literals in the clause (cf.
          'QbfLibrary.literals_in_clause' *)
       val clause_dict = Lib.snd (List.foldl foldthis
-        (1, HOLdict.mkDict Int.compare)
+        (1, Redblackmap.mkDict Int.compare)
         (Drule.CONJUNCTS (Thm.ASSUME matrix)))
 
       (* depth-first recursion over the certificate (which represents a DAG),
          using QRESOLVE_CLAUSES to derive new clauses from existing ones *)
       fun derive (c_dict, index) =
-        case HOLdict.peek (c_dict, index) of
+        case Redblackmap.peek (c_dict, index) of
           SOME clause =>
           (c_dict, clause)
         | NONE =>
           let
-            val (_, indices) = HOLdict.find (dict, index)
-              handle HOLdict.NotFound =>
+            val (_, indices) = Redblackmap.find (dict, index)
+              handle Redblackmap.NotFound =>
                 raise ERR "check"
                   ("invalid certificate: no definition for clause ID " ^
                    Int.toString index)
@@ -419,7 +419,7 @@ struct
             val clause = List.foldl (QbfLibrary.QRESOLVE_CLAUSES)
               (List.hd clauses) (List.tl clauses)
           in
-            (HOLdict.insert (c_dict, index, clause), clause)
+            (Redblackmap.insert (c_dict, index, clause), clause)
           end
 
       (* derive "t |- F", using the certificate *)

--- a/src/HolQbf/QbfCertificate.sml
+++ b/src/HolQbf/QbfCertificate.sml
@@ -34,9 +34,8 @@ struct
   type resolution = literal list * cindex list
 
   datatype certificate =
-      VALID of (vindex, extension) Redblackmap.dict
-        * (vindex, literal) Redblackmap.dict
-    | INVALID of (cindex, resolution) Redblackmap.dict * cindex
+      VALID of extension Inttab.table * literal Inttab.table
+    | INVALID of resolution Inttab.table * cindex
 
 (* ------------------------------------------------------------------------- *)
 (* read_certificate_file: reads a QBF certificate from a file                *)
@@ -71,13 +70,14 @@ struct
         "missing '0' terminator after extension literals"
       | extension_lits lits (literal :: xs) =
       extension_lits (int_from_string literal :: lits) xs
-    (* (vindex, extension) dict -> string list -> (vindex, extension) dict *)
+    (* extension Inttab.table -> string list -> extension Inttab.table *)
     fun extension ext [vindex, "I", lit1, lit2, lit3] =
-      Redblackmap.insert (ext, int_from_string vindex,
+      Inttab.update (int_from_string vindex,
         ITE (int_from_string lit1, int_from_string lit2, int_from_string lit3))
+        ext
       | extension ext (vindex :: "A" :: lits) =
-      Redblackmap.insert (ext, int_from_string vindex,
-        AND (extension_lits [] lits))
+      Inttab.update (int_from_string vindex,
+        AND (extension_lits [] lits)) ext
       | extension _ _ =
       raise ERR "read_certificate_file" "extension: invalid format"
     (* cindex list -> string list -> cindex list *)
@@ -104,33 +104,34 @@ struct
       | resolution_args _ [] =
         raise ERR "read_certificate_file"
           "resolution: missing '*' or '0' terminator"
-    (* (cindex, resolution) dict -> string list -> (cindex, resolution) dict *)
+    (* resolution Inttab.table -> string list -> resolution Inttab.table *)
     fun resolution res (cindex :: xs) =
-      Redblackmap.insert (res, int_from_string cindex, resolution_args [] xs)
+      Inttab.update (int_from_string cindex, resolution_args [] xs) res
       | resolution _ _ =
       raise ERR "read_certificate_file" "resolution: clause index expected"
-    (* (vindex, literal) dict -> string list -> (vindex, literal) dict *)
+    (* literal Inttab.table -> string list -> literal Inttab.table *)
     fun valid_conclusion dict [] =
       dict
       | valid_conclusion dict (vindex :: literal :: xs) =
-      valid_conclusion (Redblackmap.insert
-        (dict, int_from_string vindex, int_from_string literal)) xs
+      valid_conclusion
+        (Inttab.update (int_from_string vindex, int_from_string literal) dict)
+        xs
       | valid_conclusion _ _ =
       raise ERR "read_certificate_file"
         "vindex/literal pair expected in conclusion"
-    (* (vindex, extension) dict * (cindex, resolution) dict -> string list ->
+    (* extension Inttab.table * resolution Inttab.table -> string list ->
          conclusion *)
     fun conclusion (ext, res) ("VALID" :: xs) =
       let
-        val _ = Redblackmap.isEmpty res orelse
+        val _ = Inttab.is_empty res orelse
           raise ERR "read_certificate_file"
             "conclusion is 'VALID', but there are resolutions"
       in
-        VALID (ext, valid_conclusion (Redblackmap.mkDict Int.compare) xs)
+        VALID (ext, valid_conclusion Inttab.empty xs)
       end
       | conclusion (ext, res) ["INVALID", cindex] =
       let
-        val _ = Redblackmap.isEmpty ext orelse
+        val _ = Inttab.is_empty ext orelse
           raise ERR "read_certificate_file"
             "conclusion is 'INVALID', but there are extensions"
       in
@@ -152,7 +153,7 @@ struct
         raise ERR "read_certificate_file" "missing conclusion"
   in
     (certificate
-       (Redblackmap.mkDict Int.compare, Redblackmap.mkDict Int.compare)
+       (Inttab.empty, Inttab.empty)
     o (map (String.tokens (Lib.C Lib.mem [#" ", #"\t", #"\n"])))
     o filter_header
     o List.filter (fn l => l <> "\n")
@@ -177,7 +178,6 @@ struct
 
   fun check t dict (VALID (exts,lits)) = let
     open Lib Thm Drule Term Type boolSyntax
-    open HOLset Redblackmap
 
     val (var_to_index, index_to_var) = let
       open String Int Option
@@ -189,13 +189,14 @@ struct
          on indexes of extension variables as necessary,
          (using num_to_var for extensions) *)
       fun invert_dict d =
-        foldl (fn(v,n,d)=>insert(d,n,v)) (mkDict compare) d
+        Termtab.fold (fn (v,n) => fn d => Inttab.update (n, v) d) d Inttab.empty
       val tcid = ref (invert_dict dict)
-      fun update (n,v) = (tcid := insert(!tcid,n,v); v)
+      fun update (n,v) = (tcid := Inttab.update (n, v) (!tcid); v)
     in
-      (curry find dict,
-       fn n => find (!tcid,n)
-         handle NotFound => update (n,num_to_var n))
+      ((fn v => valOf (Termtab.lookup dict v)),
+       fn n => case Inttab.lookup (!tcid) n of
+                   SOME v => v
+                 | NONE => update (n, num_to_var n))
     end
 
     (* Strip quantifiers from t and return the matrix mat.
@@ -212,34 +213,44 @@ struct
        It will also map existential and universal variables to singleton
        lists containing the next bound variable (empty list for innermost) *)
     val (vars,mat,lits,deps,lvi) = let
-      val cmp = Int.compare
       fun enum vars t lits' deps lvi = let
         val ((v,t), is_forall) = (dest_forall t, true)
           handle Feedback.HOL_ERR _ => (dest_exists t, false)
         val vi = var_to_index v
         val (var,lits',deps) =
-          if is_forall then (Forall v,lits',deps) else let
-            val (tm,lits',deps) = let
-              val ext_lit = find(lits,vi)
-              val ext_index = Int.abs ext_lit
-              val tm = index_to_var ext_index
-              val tm = if ext_lit < 0 then mk_neg tm else tm
-            in (tm,lits',insert(deps,ext_index,[vi])) end
-            handle NotFound => (T,insert(lits',vi,0),deps)
-          in (Exists (v,tm),lits',deps) end
-        val deps = case lvi of NONE => deps | SOME lvi => insert(deps,lvi,[vi])
-      in enum (insert(vars,vi,var)) t lits' deps (SOME vi) end
+          if is_forall then (Forall v,lits',deps) else
+            (case Inttab.lookup lits vi of
+                 SOME ext_lit =>
+                 let
+                   val ext_index = Int.abs ext_lit
+                   val tm = index_to_var ext_index
+                   val tm = if ext_lit < 0 then mk_neg tm else tm
+                 in
+                   (Exists (v, tm), lits',
+                    Inttab.update (ext_index, [vi]) deps)
+                 end
+               | NONE => (Exists (v, T),
+                          Inttab.update (vi, 0) lits',
+                          deps))
+        val deps =
+            case lvi of
+                NONE => deps
+              | SOME lvi => Inttab.update (lvi, [vi]) deps
+      in enum (Inttab.update (vi, var) vars) t lits' deps (SOME vi) end
       handle Feedback.HOL_ERR _ => (vars,t,lits',deps,lvi)
-    in enum (mkDict Int.compare) t lits (mkDict Int.compare) NONE end
-    val deps = case lvi of NONE => deps | SOME lvi => insert(deps,lvi,[])
+    in enum Inttab.empty t lits Inttab.empty NONE end
+    val deps =
+        case lvi of
+            NONE => deps
+          | SOME lvi => Inttab.update (lvi, []) deps
 
     (* add all the hypotheses for the original existential variables
        onto the front of the matrix, so we end up with
        (v1 = e1) ==> (v2 = e2) ==> ... ==> mat *)
-    fun foldthis (_,Forall _,t) = t
-      | foldthis (_,Ext    _,t) = t
-      | foldthis (_,Exists (v,tm),t) = mk_imp(mk_eq(v,tm),t)
-    val mat = (foldl foldthis mat) vars
+    fun foldthis (_, Forall _) t = t
+      | foldthis (_, Ext _) t = t
+      | foldthis (_, Exists (v,tm)) t = mk_imp(mk_eq(v,tm),t)
+    val mat = Inttab.fold foldthis vars mat
 
     (* extension_to_term calculates a term corresponding
          to the definition of an extension variable,
@@ -254,7 +265,7 @@ struct
          if v is the test in an ITE, replace the ITE by its consequent
          etc. *)
     local
-      val empty = empty Int.compare
+      val empty = HOLset.empty Int.compare
       (* lit processes a literal l, accumulating dependencies in s.
          TFk is the continuation for when l has no witness.
            TFk is passed whether l was not negated
@@ -264,20 +275,21 @@ struct
              and s with the index of the witness added *)
       fun lit (l,s) TFk vk = let
         val index = Int.abs l
-      in let
-        val el = find(lits,index)
-      in if el = 0 then TFk (l > 0) else let
-        val ext_index = Int.abs el
-        val s = add(s,ext_index)
-        val v = index_to_var ext_index
-        val neg = if l < 0 then el > 0 else el < 0
-        val v = if neg then mk_neg v else v
-      in vk (v,s) end end
-      handle NotFound => let
-        val s = add(s,index)
-        val v = index_to_var index
-        val v = if l < 0 then mk_neg v else v
-      in vk (v,s) end end
+      in case Inttab.lookup lits index of
+             SOME el =>
+             if el = 0 then TFk (l > 0) else let
+               val ext_index = Int.abs el
+               val s = HOLset.add(s,ext_index)
+               val v = index_to_var ext_index
+               val neg = if l < 0 then el > 0 else el < 0
+               val v = if neg then mk_neg v else v
+             in vk (v,s) end
+           | NONE => let
+               val s = HOLset.add(s,index)
+               val v = index_to_var index
+               val v = if l < 0 then mk_neg v else v
+             in vk (v,s) end
+      end
       exception False
       fun afold (l,(t,s)) = lit (l,s)
         (fn true=>(t,s)|false=>raise False)
@@ -315,15 +327,19 @@ struct
        Fill in the rest of the vars map.
        Fill in the deps map by adding each extension variable
        to the list belonging to each variable appearing in its definition term. *)
-    fun foldthis (i,ext,(t,vars,deps)) = let
+    fun foldthis (i,ext) (t,vars,deps) = let
       val v = index_to_var i
       val (tm,ds) = extension_to_term ext
-      val vars = insert(vars,i,Ext(v,tm))
+      val vars = Inttab.update (i, Ext(v,tm)) vars
       val h = mk_eq(v,tm)
-      fun foldthis (n,d) = update (d,n,fn NONE => [i] | SOME ls => i::ls)
+      fun foldthis (n,d) =
+          Inttab.update
+            (n, case Inttab.lookup d n of
+                    NONE => [i]
+                  | SOME ls => i :: ls) d
       val deps = HOLset.foldl foldthis deps ds
     in (mk_imp(h,t),vars,deps) end
-    val (mat,vars,deps) = (foldl foldthis (mat,vars,deps)) exts
+    val (mat,vars,deps) = Inttab.fold foldthis exts (mat,vars,deps)
 
     val thm = (!sat_prove) mat
 
@@ -332,7 +348,7 @@ struct
     (* now deps is the list of variable indexes in the order
        they should be eliminated (quantified and have hypothesis discharged) *)
 
-    fun foldthis (i,th) = case find(vars,i) of
+    fun foldthis (i,th) = case valOf (Inttab.lookup vars i) of
       Forall v => (fn() => GEN v th) ()
     | Exists (v,w) => (fn () => let
         val th = EXISTS (mk_exists(v,concl th),v) th
@@ -372,10 +388,10 @@ struct
          variable's index and a Boolean that is true if the variable is
          universally quantified, and false if it is existentially quantified *)
       val var_dict = List.foldl (fn ((i, var, is_forall), var_dict) =>
-        Redblackmap.insert (var_dict, var, (i, is_forall)))
-        (Redblackmap.mkDict Term.var_compare) vars
+        Termtab.update (var, (i, is_forall)) var_dict)
+        Termtab.empty vars
       fun index_fn var =
-        Redblackmap.find (var_dict, var)
+        valOf (Termtab.lookup var_dict var)
 
       val vars = List.rev vars
       fun foldthis (clause, (i, clause_dict)) =
@@ -383,8 +399,8 @@ struct
           val clause = QbfLibrary.CLAUSE_TO_SEQUENT clause
           val lits = QbfLibrary.literals_in_clause index_fn clause
         in
-          (i + 1, Redblackmap.insert (clause_dict, i,
-            QbfLibrary.forall_reduce (clause, vars, matrix, lits)))
+          (i + 1, Inttab.update (i,
+            QbfLibrary.forall_reduce (clause, vars, matrix, lits)) clause_dict)
         end
 
       (* a dictionary that maps each clause identifier to a 4-tuple, which
@@ -394,22 +410,23 @@ struct
          this is 'matrix'), and 4. the list of literals in the clause (cf.
          'QbfLibrary.literals_in_clause' *)
       val clause_dict = Lib.snd (List.foldl foldthis
-        (1, Redblackmap.mkDict Int.compare)
+        (1, Inttab.empty)
         (Drule.CONJUNCTS (Thm.ASSUME matrix)))
 
       (* depth-first recursion over the certificate (which represents a DAG),
          using QRESOLVE_CLAUSES to derive new clauses from existing ones *)
       fun derive (c_dict, index) =
-        case Redblackmap.peek (c_dict, index) of
+        case Inttab.lookup c_dict index of
           SOME clause =>
           (c_dict, clause)
         | NONE =>
           let
-            val (_, indices) = Redblackmap.find (dict, index)
-              handle Redblackmap.NotFound =>
-                raise ERR "check"
-                  ("invalid certificate: no definition for clause ID " ^
-                   Int.toString index)
+            val (_, indices) =
+                case Inttab.lookup dict index of
+                    SOME r => r
+                  | NONE => raise ERR "check"
+                              ("invalid certificate: no definition for clause ID "
+                               ^ Int.toString index)
             val _ = if List.null indices then
                 raise ERR "check"
                   ("invalid certificate: empty definition for clause ID " ^
@@ -419,7 +436,7 @@ struct
             val clause = List.foldl (QbfLibrary.QRESOLVE_CLAUSES)
               (List.hd clauses) (List.tl clauses)
           in
-            (Redblackmap.insert (c_dict, index, clause), clause)
+            (Inttab.update (index, clause) c_dict, clause)
           end
 
       (* derive "t |- F", using the certificate *)

--- a/src/HolSat/dpll.sml
+++ b/src/HolSat/dpll.sml
@@ -17,16 +17,16 @@ fun count_vars ds acc =
     | lit::lits => let
         val v = dest_neg lit handle HOL_ERR _ => lit
       in
-        case Binarymap.peek (acc, v) of
-          NONE => count_vars lits (Binarymap.insert(acc,v,1))
-        | SOME n => count_vars lits (Binarymap.insert(acc,v,n + 1))
+        case Termtab.lookup acc v of
+          NONE => count_vars lits (Termtab.update (v,1) acc)
+        | SOME n => count_vars lits (Termtab.update (v,n + 1) acc)
       end
 
 fun getBiggest acc =
-    #1 (Binarymap.foldl(fn (v,cnt,a as (bestv,bestcnt)) =>
-                           if cnt > bestcnt then (v,cnt) else a)
-                       (boolSyntax.T, 0)
-                       acc)
+    #1 (Termtab.fold (fn (v,cnt) => fn (a as (bestv,bestcnt)) =>
+                         if cnt > bestcnt then (v,cnt) else a)
+                     acc
+                     (boolSyntax.T, 0))
 
 (* The first unit we see, or the var that occurs most often *)
 fun find_splitting_var phi = let
@@ -39,7 +39,7 @@ fun find_splitting_var phi = let
         | _ => recurse (count_vars ds acc) cs
       end
 in
-  recurse (Binarymap.mkDict Term.compare) (strip_conj phi)
+  recurse Termtab.empty (strip_conj phi)
 end
 
 fun casesplit v th = let (*th is [assignments, cnf] |- current *)
@@ -55,12 +55,13 @@ fun mk_satmap th = let
   fun foldthis (t,acc) = let
     val (l,r) = dest_eq t
   in
-    Binarymap.insert(acc,l,r)
+    Termtab.update (l,r) acc
   end handle HOL_ERR _ => acc
-  val fmap = HOLset.foldl foldthis (Binarymap.mkDict Term.compare) hyps
+  val fmap = HOLset.foldl foldthis Termtab.empty hyps
 in
-  Sat (fn v => Binarymap.find(fmap,v)
-          handle Binarymap.NotFound => boolSyntax.T)
+  Sat (fn v => case Termtab.lookup fmap v of
+                   SOME t => t
+                 | NONE => boolSyntax.T)
 end
 
 fun CoreDPLL initial_th = let (* [ci] |- cnf *)

--- a/src/IndDef/IndDefLib.sig
+++ b/src/IndDef/IndDefLib.sig
@@ -21,7 +21,7 @@ sig
   val export_mono   : string -> unit
   val thy_monos     : string -> thm list
 
-  type rule_induction_map = ({Thy:string,Name:string},thm list) Binarymap.dict
+  type rule_induction_map = thm list KNametab.table
   val thy_rule_inductions : string -> thm list
   val rule_induction_map : unit -> rule_induction_map
   val rule_induction_map_by_theory : {thyname : string} ->

--- a/src/IndDef/IndDefLib.sml
+++ b/src/IndDef/IndDefLib.sml
@@ -58,12 +58,12 @@ end;
     Store all rule inductions
    ---------------------------------------------------------------------- *)
 
-type rule_induction_map = ({Thy:string,Name:string},thm list) Binarymap.dict
+type rule_induction_map = thm list KNametab.table
 
 fun listdict_add (d, k, e) =
-    case Binarymap.peek(d, k) of
-      NONE => Binarymap.insert(d,k,[e])
-    | SOME l => Binarymap.insert(d,k,e::l)
+    case KNametab.lookup d k of
+      NONE => KNametab.update (k,[e]) d
+    | SOME l => KNametab.update (k,e::l) d
 
 fun ind_thm_to_consts thm = let
   open boolSyntax
@@ -98,7 +98,7 @@ val {update_global_value = rule_ind_apply_global_update,
       delta_ops = {apply_to_global = apply_delta,
                    uptodate_delta = K true,
                    thy_finaliser = NONE,
-                   initial_value = Binarymap.mkDict KernelSig.name_compare,
+                   initial_value = KNametab.empty,
                    apply_delta = apply_delta}
     }
 

--- a/src/TeX/EmitTeX.sml
+++ b/src/TeX/EmitTeX.sml
@@ -264,7 +264,7 @@ local
      | c     => c
 
   fun string_map (s,sz) =
-      case Binarymap.peek(TexTokenMap.the_map(), s) of
+      case Symtab.lookup (TexTokenMap.the_map()) s of
         SOME {info = result, ...} => result
       | NONE => (UTF8.translate char_map s,
                  case sz of NONE => String.size s | SOME sz => sz)

--- a/src/TeX/holindex.lex
+++ b/src/TeX/holindex.lex
@@ -25,8 +25,8 @@ fun lexError msg text pos line =
 (* The table of keywords *)
 
 val keyword_table =
-List.foldl (fn ((str, tok), t) => Binarymap.insert (t, str, tok))
-(Binarymap.mkDict String.compare)
+List.foldl (fn ((str, tok), t) => Symtab.update (str, tok) t)
+Symtab.empty
 [
   ("TERM",         TERM),
   ("@TERM",        TERM),
@@ -64,8 +64,9 @@ fun toUpperString s =
    String.translate (fn c => Char.toString(Char.toUpper c)) s
 
 fun mkKeyword text pos line =
-  (Binarymap.find (keyword_table, toUpperString text)) (mkMtTok text pos line)
-  handle Binarymap.NotFound => IDENT (mkTok I text pos line);
+  case Symtab.lookup keyword_table (toUpperString text) of
+      SOME tok => tok (mkMtTok text pos line)
+    | NONE => IDENT (mkTok I text pos line);
 
 
 %%

--- a/src/TeX/holindex.sml
+++ b/src/TeX/holindex.sml
@@ -137,7 +137,7 @@ fun cleanup_data_store (sds_thm, sds_term, sds_type) =
 let
     fun cleanup_subdata_store sds =
     let
-        val sdsL = Redblackmap.listItems sds
+        val sdsL = Symtab.dest sds
         val sdsL' = List.filter (data_entry_is_used o snd) sdsL;
     in
         sdsL'
@@ -277,11 +277,7 @@ let
    val thmDefL = process_thm_defs os thmL;
 
    fun list2map l =
-   let
-      val emptyMap = Redblackmap.mkDict String.compare;
-   in
-      List.foldr (fn ((id,d),m) => Redblackmap.insert(m,id,d)) emptyMap l
-   end
+      List.foldr (fn ((id,d),m) => Symtab.update (id, d) m) Symtab.empty l
 in
    (list2map thmDefL,list2map termDefL,list2map typeDefL)
 end;
@@ -427,7 +423,7 @@ let
    val _ = Portable.output (os, if isSome comment_opt then valOf comment_opt
                                 else "")
    val _ = Portable.output (os, "}{");
-   val _ = Portable.output (os, Redblackmap.find (d,id));
+   val _ = Portable.output (os, valOf (Symtab.lookup d id));
    val _ = Portable.output (os, "}\n");
 in
   ()

--- a/src/TeX/holindexData.sig
+++ b/src/TeX/holindexData.sig
@@ -16,13 +16,13 @@ sig
    type data_entry_transform = data_entry -> data_entry
 
    type data_store_ty =
-        (string, data_entry) Redblackmap.dict *
-        (string, data_entry) Redblackmap.dict *
-        (string, data_entry) Redblackmap.dict
+        data_entry Symtab.table *
+        data_entry Symtab.table *
+        data_entry Symtab.table
 
    val default_data_entry : data_entry
    val new_data_store     : data_store_ty;
-   val new_data_substore  : (string, data_entry) Redblackmap.dict
+   val new_data_substore  : data_entry Symtab.table
 
    val data_entry___update_in_index   : bool          -> data_entry_transform
    val data_entry___update_printed    : bool          -> data_entry_transform

--- a/src/TeX/holindexData.sml
+++ b/src/TeX/holindexData.sml
@@ -253,8 +253,7 @@ fun data_entry_is_used
    (in_index orelse isSome pos_opt);
 
 
-val new_data_substore =
-    (Redblackmap.mkDict scomp):(string, data_entry) Redblackmap.dict
+val new_data_substore : data_entry Symtab.table = Symtab.empty
 
 val new_data_store  =  (*Thms, Terms, Types*)
    (new_data_substore, new_data_substore, new_data_substore);
@@ -265,17 +264,19 @@ val new_data_store  =  (*Thms, Terms, Types*)
    val key2 = "Term_ID_1"
    fun upf e = data_entry___add_page e "1";
 *)
-type data_store_ty = (string, data_entry) Redblackmap.dict *
-                     (string, data_entry) Redblackmap.dict *
-                     (string, data_entry) Redblackmap.dict
+type data_store_ty = data_entry Symtab.table *
+                     data_entry Symtab.table *
+                     data_entry Symtab.table
 
 local
    fun update_data_substore (allow_new,error_fun) sds (key:string) upf =
    let
-      open Redblackmap
-      val (ent,ok) = (find (sds, key),true)
-          handle NotFound => (default_data_entry, allow_new);
-      val sds' = if ok then (insert(sds,key,upf ent)) else (error_fun key;sds)
+      val (ent,ok) =
+          case Symtab.lookup sds key of
+              SOME e => (e, true)
+            | NONE => (default_data_entry, allow_new)
+      val sds' = if ok then Symtab.update (key, upf ent) sds
+                 else (error_fun key; sds)
    in
       sds'
    end;

--- a/src/TeX/mungeTools.sig
+++ b/src/TeX/mungeTools.sig
@@ -4,7 +4,7 @@ sig
   datatype command = Theorem | Term | Type
   type optionset
   type posn = int * int (* linenum, charnum *)
-  type override_map = (string,(string * int))Binarymap.dict
+  type override_map = (string * int) Symtab.table
 
   val parseOpts : posn -> string -> optionset
   val usage : unit -> 'a

--- a/src/TeX/mungeTools.sml
+++ b/src/TeX/mungeTools.sml
@@ -154,7 +154,7 @@ fun stringOpt pos s =
 
 
 
-type override_map = (string,(string * int))Binarymap.dict
+type override_map = (string * int) Symtab.table
 fun read_overrides fname = let
   val istrm = TextIO.openIn fname
               handle _ => usage()
@@ -183,11 +183,11 @@ fun read_overrides fname = let
                            acc)
                 | SOME n => let
                   in
-                    case Binarymap.peek(acc, word1) of
-                      NONE => Binarymap.insert(acc, word1, (word2, n))
+                    case Symtab.lookup acc word1 of
+                      NONE => Symtab.update (word1, (word2, n)) acc
                     | SOME _ => (warn ((count,0),
                                        fname ^ " rebinds " ^ word1);
-                                 Binarymap.insert(acc, word1, (word2, n)))
+                                 Symtab.update (word1, (word2, n)) acc)
                   end
               end
           end
@@ -195,7 +195,7 @@ fun read_overrides fname = let
           recurse (count + 1) acc'
         end
 in
-  recurse 1 (Binarymap.mkDict String.compare) before
+  recurse 1 Symtab.empty before
   TextIO.closeIn istrm
 end
 
@@ -247,11 +247,11 @@ fun optset_traces opts f =
     OptSet.fold (fn (e, f) => case e of TraceSet p => trace p f | _ => f) f opts
 
 val HOL = !EmitTeX.texPrefix
-val user_overrides = ref (Binarymap.mkDict String.compare)
+val user_overrides : (string * int) Symtab.table ref = ref Symtab.empty
 
 fun diag s = (TextIO.output(TextIO.stdErr, s ^ "\n");
               TextIO.flushOut TextIO.stdErr)
-fun overrides s = Binarymap.peek (!user_overrides, s)
+fun overrides s = Symtab.lookup (!user_overrides) s
 
 fun isChar x y = x = y
 
@@ -276,30 +276,28 @@ fun mkinst loc opts tm = let
   fun foldthis (v, acc) = let
     val (n,ty) = dest_var v
   in
-    Binarymap.insert(acc,n,ty)
+    Symtab.update (n, ty) acc
   end
-  val vtypemap = HOLset.foldl foldthis (Binarymap.mkDict String.compare) vs
-  fun foldthis ((nm1,nm2),acc) = let
-    val ty = Binarymap.find(vtypemap, nm2)
-  in
-    (mk_var(nm2,ty) |-> mk_var(nm1,ty)) :: acc
-  end handle Binarymap.NotFound => acc
+  val vtypemap = HOLset.foldl foldthis Symtab.empty vs
+  fun foldthis ((nm1,nm2),acc) =
+      case Symtab.lookup vtypemap nm2 of
+          NONE => acc
+        | SOME ty => (mk_var(nm2,ty) |-> mk_var(nm1,ty)) :: acc
 in
   (insts, tytheta, foldr foldthis [] insts)
 end
 
 fun mk_s2smap pairs = let
-  fun foldthis ((nm1,nm2), acc) = Binarymap.insert(acc, nm2, nm1)
-  val m = Binarymap.mkDict String.compare
+  fun foldthis ((nm1,nm2), acc) = Symtab.update (nm2, nm1) acc
 in
-   List.foldl foldthis m pairs
+   List.foldl foldthis Symtab.empty pairs
 end
 
 fun rename m t = let
   val (v0, _) = dest_abs t
   val (vnm, vty) = dest_var v0
 in
-  case Binarymap.peek (m, vnm) of
+  case Symtab.lookup m vnm of
     NONE => NO_CONV t
   | SOME newname => ALPHA_CONV (mk_var(newname,vty)) t
 end

--- a/src/basicProof/BasicProvers.sml
+++ b/src/basicProof/BasicProvers.sml
@@ -748,11 +748,11 @@ fun TRIV_LET_CONV tm =
 (* This calculation has to use multisets.                                    *)
 (*---------------------------------------------------------------------------*)
 
-val empty_mset = HOLdict.mkDict Term.compare : (term,int) HOLdict.dict
-fun mset_insert t mset = HOLdict.insertWith (op+) (mset,t,1)
+val empty_mset = Redblackmap.mkDict Term.compare : (term,int) Redblackmap.dict
+fun mset_insert t mset = Redblackmap.insertWith (op+) (mset,t,1)
 fun mset_of list = itlist mset_insert list empty_mset
 fun mset_diff l2 l1 =  (* important to maintain the order of elements in l2 *)
-  let open HOLdict
+  let open Redblackmap
       val mset1 = mset_of l1
       val mset2 = mset_of l2
       fun winnow [] acc = rev acc

--- a/src/basicProof/BasicProvers.sml
+++ b/src/basicProof/BasicProvers.sml
@@ -748,17 +748,17 @@ fun TRIV_LET_CONV tm =
 (* This calculation has to use multisets.                                    *)
 (*---------------------------------------------------------------------------*)
 
-val empty_mset = Redblackmap.mkDict Term.compare : (term,int) Redblackmap.dict
-fun mset_insert t mset = Redblackmap.insertWith (op+) (mset,t,1)
+val empty_mset : int Termtab.table = Termtab.empty
+fun mset_insert t mset =
+    Termtab.update (t, Option.getOpt (Termtab.lookup mset t, 0) + 1) mset
 fun mset_of list = itlist mset_insert list empty_mset
 fun mset_diff l2 l1 =  (* important to maintain the order of elements in l2 *)
-  let open Redblackmap
-      val mset1 = mset_of l1
+  let val mset1 = mset_of l1
       val mset2 = mset_of l2
       fun winnow [] acc = rev acc
         | winnow (h::t) acc =
-          let val i = find (mset1,h) handle NotFound => 0
-              val j = find (mset2,h)  (* at least 1 *)
+          let val i = Option.getOpt (Termtab.lookup mset1 h, 0)
+              val j = valOf (Termtab.lookup mset2 h)  (* at least 1 *)
           in winnow t (if i < j then h::acc else acc) end
   in
     winnow l2 []

--- a/src/basicProof/BasicProvers.sml
+++ b/src/basicProof/BasicProvers.sml
@@ -470,8 +470,9 @@ fun Induct_on qtm g =
           SOME {Thy,Name,...} =>
           let
             fun indths() =
-                Binarymap.find (rule_induction_map(), {Thy=Thy,Name=Name})
-                handle NotFound => []
+                Option.getOpt (KNametab.lookup (rule_induction_map())
+                                               {Thy=Thy,Name=Name},
+                               [])
             fun numSchematics th =
                 let
                   val (_,base) = th |> concl |> strip_forall |> #2 |> dest_imp

--- a/src/bool/TexTokenMap.sig
+++ b/src/bool/TexTokenMap.sig
@@ -4,7 +4,6 @@ sig
   val TeX_notation : {hol: string, TeX : string * int} -> unit
   val temp_TeX_notation : {hol: string, TeX : string * int} -> unit
 
-  val the_map : unit ->
-                (string,{thy : string, info : string * int})Binarymap.dict
+  val the_map : unit -> {thy : string, info : string * int} Symtab.table
 
 end

--- a/src/bool/TexTokenMap.sml
+++ b/src/bool/TexTokenMap.sml
@@ -41,12 +41,12 @@ struct
       }
 
 
-  val tokmap = ref (Binarymap.mkDict String.compare)
+  val tokmap = ref Symtab.empty
   fun the_map() = !tokmap
 
   fun temp_TeX_notation0 src thy {hol,TeX} =
-      case Binarymap.peek (!tokmap, hol) of
-        NONE => tokmap := Binarymap.insert(!tokmap,hol,{thy = thy,info = TeX})
+      case Symtab.lookup (!tokmap) hol of
+        NONE => tokmap := Symtab.update (hol,{thy = thy,info = TeX}) (!tokmap)
       | SOME {thy = oldthy, info = oldt} => let
           fun ttoString (t,i) = "(\"" ^ String.toString t ^ "\", "^
                                 Int.toString i ^ ")"
@@ -58,7 +58,7 @@ struct
                          ttoString oldt^", from "^oldthy^"); now \""^
                          ttoString TeX^"\"")
           else ();
-          tokmap := Binarymap.insert(!tokmap,hol,{thy = thy,info = TeX})
+          tokmap := Symtab.update (hol,{thy = thy,info = TeX}) (!tokmap)
         end
 
   val temp_TeX_notation =

--- a/src/compute/src/Holmakefile
+++ b/src/compute/src/Holmakefile
@@ -6,7 +6,8 @@ TABLE_UID = $(dprot $(SIGOBJ)/Table.ui)
 # clauses.sml instantiates the Table functor locally; mosml needs
 # Table.ui passed explicitly because its dep auto-detection misses
 # functor applications.
-clauses.uo: clauses.sml clauses.ui $(TABLE_UID) compute_rules.uo
+clauses.uo: clauses.sml clauses.ui $(TABLE_UID) compute_rules.uo \
+            $(dprot $(SIGOBJ)/HolKernel.ui)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
 selftest.exe: selftest.uo

--- a/src/compute/src/Holmakefile
+++ b/src/compute/src/Holmakefile
@@ -1,6 +1,14 @@
 all: $(DEFAULT_TARGETS) selftest.exe
 .PHONY: all
 
+TABLE_UID = $(dprot $(SIGOBJ)/Table.ui)
+
+# clauses.sml instantiates the Table functor locally; mosml needs
+# Table.ui passed explicitly because its dep auto-detection misses
+# functor applications.
+clauses.uo: clauses.sml clauses.ui $(TABLE_UID) compute_rules.uo
+	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
+
 selftest.exe: selftest.uo
 	$(HOLMOSMLC) -o $@ $<
 

--- a/src/compute/src/clauses.sml
+++ b/src/compute/src/clauses.sml
@@ -142,7 +142,7 @@ datatype action =
    Database of actions for a single constant. There is a linked list through the
    argument of `NeedArg` and `Tail` of `Try`. The linked-to `db` is for the same
    constant with arity greater by 1. The `db` that appears as a value in the
-   `Redblackmap.dict` in the `compset` is the `db` for arity 0 for that
+   table in the `compset` is the `db` for arity 0 for that
    constant.
 
    TO-DO: Which type instance of the constant is `Hcst`?
@@ -202,17 +202,22 @@ fun partition_skip (SOME n) Args =
    Adding rules for EXISTING constants in a sealed compset raises an exception.
    Use `copy` to create an unsealed copy if you need to extend existing constants.
 *)
-datatype compset
-   = Compset of { sealed: bool,
-                  dict: (string * string, (db * int option) ref) Redblackmap.dict };
-
 fun lex_string_comp ((s1, s2), (s3, s4)) =
   case String.compare (s1, s3) of
     EQUAL => String.compare (s2, s4)
   | x => x
 
-val empty_rws = Compset { sealed = true,
-                          dict = Redblackmap.mkDict lex_string_comp };
+structure SSPairTab = Table(struct
+  type key = string * string
+  val ord = lex_string_comp
+  fun pp (s1,s2) = HOLPP.add_string (s1 ^ "$" ^ s2)
+end)
+
+datatype compset
+   = Compset of { sealed: bool,
+                  dict: (db * int option) ref SSPairTab.table };
+
+val empty_rws = Compset { sealed = true, dict = SSPairTab.empty };
 
 (* Seal a compset, preventing mutation of existing constant entries. *)
 fun seal (Compset {dict, ...}) = Compset {sealed = true, dict = dict}
@@ -221,7 +226,7 @@ fun seal (Compset {dict, ...}) = Compset {sealed = true, dict = dict}
    Use this when you need to extend rules for existing constants. *)
 fun copy (Compset {dict, ...}) =
   Compset { sealed = false,
-            dict = Redblackmap.transform (fn r => ref (!r)) dict }
+            dict = SSPairTab.map (fn _ => fn r => ref (!r)) dict }
 
 (*
    Look up the per-constant database of `cst` in the given compset. If it does
@@ -230,10 +235,11 @@ fun copy (Compset {dict, ...}) =
    and the ref to the per-constant database.
 *)
 fun assoc_clause (Compset {sealed, dict}) cst =
-  case Redblackmap.peek (dict, cst)
+  case SSPairTab.lookup dict cst
    of SOME rl => (Compset {sealed=sealed, dict=dict}, rl)
     | NONE => let val mt = ref (EndDb, NONE)
-              in (Compset {sealed=false, dict=Redblackmap.insert (dict,cst,mt)}, mt)
+              in (Compset {sealed=false,
+                           dict=SSPairTab.update (cst,mt) dict}, mt)
               end;
 
 (* Check if modifying this constant would violate sealing.
@@ -241,7 +247,7 @@ fun assoc_clause (Compset {sealed, dict}) cst =
    Empty entries (created by from_term for RHS constants) don't count. *)
 fun is_sealed_existing (Compset {sealed, dict}) cst =
   sealed andalso
-  (case Redblackmap.peek (dict, cst) of
+  (case SSPairTab.lookup dict cst of
      SOME r => (case !r of (EndDb, _) => false | _ => true)
    | NONE => false)
 
@@ -284,7 +290,7 @@ fun set_skip compset p sk =
 
 fun scrub_const (Compset {sealed, dict}) c =
   let val {Thy,Name,Ty} = dest_thy_const c
-  in Compset {sealed=false, dict = #1 (Redblackmap.remove (dict,(Name,Thy)))}
+  in Compset {sealed=false, dict = SSPairTab.delete_safe (Name,Thy) dict}
   end;
 
 (*
@@ -475,7 +481,7 @@ fun scrub_thms lthm compset =
 (*---------------------------------------------------------------------------*)
 
 fun rws_of (Compset {dict, ...}) =
- let val thinglist = Redblackmap.listItems dict
+ let val thinglist = SSPairTab.dest dict
      fun db_of_entry (ss, r) = let val (db,opt) = !r in db end
      val dblist = List.map db_of_entry thinglist
      fun get_actions db =
@@ -504,7 +510,7 @@ datatype transform
 (* to make all the dependencies explicit.                                    *)
 (*---------------------------------------------------------------------------*)
 fun deplist (Compset {dict, ...}) =
- let val thinglist = Redblackmap.listItems dict
+ let val thinglist = SSPairTab.dest dict
      fun db_of_entry (ss, r) = let val (db,opt) = !r in (ss,db) end
      val dblist = List.map db_of_entry thinglist
      fun get_actions db =

--- a/src/datatype/Datatype.sml
+++ b/src/datatype/Datatype.sml
@@ -151,16 +151,15 @@ fun check_constrs_unique_in_theory asts = let
         handle HOL_ERR _ => []
     fun foldthis (c,fm) =
         if uptodate_term c then
-          Binarymap.insert(fm, #Name (dest_thy_const c), tyname)
+          Symtab.update (#Name (dest_thy_const c), tyname) fm
         else fm
   in
     foldl foldthis fm tys_cons
   end
   val current_constructors =
-      List.foldl current_constructors (Binarymap.mkDict String.compare)
-                 current_types
+      List.foldl current_constructors Symtab.empty current_types
   fun calculate_intersection ((tyname, conname), acc) =
-      case Binarymap.peek(current_constructors, conname) of
+      case Symtab.lookup current_constructors conname of
         NONE => acc
       | SOME ty' => (tyname, conname, ty') :: acc
   val common = List.rev (foldl calculate_intersection [] constrs)

--- a/src/datatype/record/RecordType.sml
+++ b/src/datatype/record/RecordType.sml
@@ -24,12 +24,6 @@ open Parse
 
 val K_tm = combinSyntax.K_tm
 
-structure Typetab = Table(struct
-  type key = hol_type
-  val ord = Type.compare
-  fun pp _ = HOLPP.add_string "<type>"
-end)
-
 val debugp = ref false
 fun DIAG s = if !debugp then print ("RecordType: " ^ s ^ "\n") else ()
 val ERR = mk_HOL_ERR "RecordType";

--- a/src/datatype/record/RecordType.sml
+++ b/src/datatype/record/RecordType.sml
@@ -24,6 +24,12 @@ open Parse
 
 val K_tm = combinSyntax.K_tm
 
+structure Typetab = Table(struct
+  type key = hol_type
+  val ord = Type.compare
+  fun pp _ = HOLPP.add_string "<type>"
+end)
+
 val debugp = ref false
 fun DIAG s = if !debugp then print ("RecordType: " ^ s ^ "\n") else ()
 val ERR = mk_HOL_ERR "RecordType";
@@ -187,7 +193,7 @@ fun prove_recordtype_thms (tyinfo, fields) = let
     domtys [] (type_of constructor)
   end
   val varying_tyvs = let
-    val tymap = Binarymap.mkDict Type.compare : (hol_type,int) Binarymap.dict
+    val tymap : int Typetab.table = Typetab.empty
     fun recurse m tys =
       case tys of
           [] => m
@@ -195,16 +201,16 @@ fun prove_recordtype_thms (tyinfo, fields) = let
           let
             val tyvs = HOLset.fromList Type.compare (Type.type_vars ty)
             fun foldthis (tyv,m) =
-                case Binarymap.peek(m, tyv) of
-                    NONE => Binarymap.insert(m,tyv,1)
-                  | SOME i => Binarymap.insert(m,tyv,i+1)
+                case Typetab.lookup m tyv of
+                    NONE => Typetab.update (tyv,1) m
+                  | SOME i => Typetab.update (tyv,i+1) m
           in
             recurse (HOLset.foldl foldthis m tyvs) tyrest
           end
   in
-    Binarymap.foldl (fn (tyv,c,acc) => if c = 1 then tyv::acc else acc)
-                    []
-                    (recurse tymap types)
+    Typetab.fold (fn (tyv,c) => fn acc => if c = 1 then tyv::acc else acc)
+                 (recurse tymap types)
+                 []
   end
 
   val tysigma = let

--- a/src/emit/ConstMapML.sml
+++ b/src/emit/ConstMapML.sml
@@ -33,22 +33,21 @@ structure CMap :> sig
   val listItems : 'a dict -> ({Name:string,Thy:string} * (hol_type * 'a) list) list
 end =
 struct
-  structure RBM = Redblackmap
   fun tstamp () = Time.toReal (Time.now())
-  type 'a dict = ({Name:string,Thy:string}, ('a * real) TypeNet.typenet)RBM.dict
+  type 'a dict = ('a * real) TypeNet.typenet KNametab.table
   fun listItems d =
-      RBM.listItems d |> map (fn (k,v) => (k, map (apsnd #1) (TypeNet.listItems v)))
+      KNametab.dest d |> map (fn (k,v) => (k, map (apsnd #1) (TypeNet.listItems v)))
   fun insert (d,k,v) = let
     val v = (v,tstamp())
     val {Name,Thy,Ty} = dest_thy_const k
     val rbk = {Name = Name, Thy = Thy}
   in
-    case RBM.peek(d, rbk) of
-      NONE => RBM.insert(d,rbk,TypeNet.insert(TypeNet.empty,Ty,v))
+    case KNametab.lookup d rbk of
+      NONE => KNametab.update (rbk, TypeNet.insert(TypeNet.empty,Ty,v)) d
     | SOME tynet => let
         val tynet' = TypeNet.insert(tynet,Ty,v)
       in
-        RBM.insert(d,rbk,tynet')
+        KNametab.update (rbk, tynet') d
       end
   end
 
@@ -56,7 +55,7 @@ struct
     val {Name,Thy,Ty} = dest_thy_const k
     val rbk = {Name = Name, Thy = Thy}
   in
-    case RBM.peek(d,rbk) of
+    case KNametab.lookup d rbk of
       NONE => NONE
     | SOME tynet => let
       in
@@ -84,15 +83,13 @@ struct
           end
       end
   end
-  fun cmp ({Name=n1,Thy=t1},{Name=n2,Thy=t2}) =
-      pair_compare(String.compare,String.compare) ((n1,t1),(n2,t2))
-  fun empty() = RBM.mkDict cmp
+  fun empty() = KNametab.empty
 
   fun exact_peek (d : 'a dict,k) = let
     val {Name,Thy,Ty} = dest_thy_const k
     val rbk = {Name = Name, Thy = Thy}
   in
-    case RBM.peek(d,rbk) of
+    case KNametab.lookup d rbk of
       NONE => NONE
     | SOME tynet => Option.map #1 (TypeNet.peek(tynet,Ty))
   end

--- a/src/finite_maps/alist_treeLib.sml
+++ b/src/finite_maps/alist_treeLib.sml
@@ -28,16 +28,16 @@ val err = mk_HOL_ERR "alist_treeLib"
 (* the repr set object *)
 datatype 'a alist_reprs = AList_Reprs of {R_thm: thm, conv: conv,
     dest: term -> 'a, cmp: ('a * 'a) -> order,
-    dict: (term, thm) Redblackmap.dict ref}
+    dict: thm Termtab.table ref}
 
 fun mk_alist_reprs R_thm conv dest cmp
     = AList_Reprs {R_thm = R_thm, conv = conv, cmp = cmp,
-        dest = dest, dict = ref (Redblackmap.mkDict Term.compare)}
+        dest = dest, dict = ref Termtab.empty}
 
 fun peek_functions_in_rs (AList_Reprs inn_rs)
-    = Redblackmap.listItems (! (#dict inn_rs)) |> map fst
+    = Termtab.dest (! (#dict inn_rs)) |> map fst
 
-fun peek_repr (AList_Reprs inn_rs) tm = Redblackmap.peek (! (#dict inn_rs), tm)
+fun peek_repr (AList_Reprs inn_rs) tm = Termtab.lookup (! (#dict inn_rs)) tm
 
 (* constructing is_insert thms *)
 
@@ -244,7 +244,7 @@ fun add_alist_repr rs thm = let
       | NONE => (mk_repr rs rhs
         |> CONV_RULE (RAND_CONV (REWR_CONV (SYM thm))))
   in
-    #dict inn_rs := Redblackmap.insert (! (#dict inn_rs), f, repr_thm)
+    #dict inn_rs := Termtab.update (f, repr_thm) (! (#dict inn_rs))
   end
 
 fun timeit msg f v = let

--- a/src/finite_maps/flookupLib.sml
+++ b/src/finite_maps/flookupLib.sml
@@ -7,14 +7,20 @@ val ERR = mk_HOL_ERR "flookupLib"
 
 (* ------------------------------------------------------------------------- *)
 
-fun memoize size cmp f =
+structure Typetab = Table(struct
+  type key = hol_type
+  val ord = Type.compare
+  fun pp _ = HOLPP.add_string "<type>"
+end)
+
+fun memoize size f =
    let
-      val d = ref (Redblackmap.mkDict cmp)
+      val d : 'b Typetab.table ref = ref Typetab.empty
       val k = ref []
       val finite = 0 < size
    in
       fn v =>
-         case Redblackmap.peek (!d, v) of
+         case Typetab.lookup (!d) v of
             SOME r => r
           | NONE =>
                let
@@ -22,15 +28,15 @@ fun memoize size cmp f =
                in
                   if finite
                      then (k := !k @ [v]
-                           ; if size < Redblackmap.numItems (!d)
+                           ; if size < Typetab.size (!d)
                                 then case List.getItem (!k) of
                                         SOME (h, t) =>
-                                          (d := fst (Redblackmap.remove (!d, h))
+                                          (d := Typetab.delete h (!d)
                                            ; k := t)
                                       | NONE => raise ERR "memoize" "empty"
                               else ())
                   else ()
-                  ; d := Redblackmap.insert (!d, v, r)
+                  ; d := Typetab.update (v, r) (!d)
                   ; r
                end
    end
@@ -41,7 +47,7 @@ local
    val eqf_into = List.map (EQF_INTRO o SPEC_ALL) o CONJUNCTS
 in
    val datatype_eq_conv =
-      memoize 20 Type.compare
+      memoize 20
         (fn ty =>
             case Lib.total TypeBase.distinct_of ty of
                SOME th =>
@@ -131,20 +137,20 @@ in
             List.foldl
                (fn (t, (d, th)) =>
                  (case Lib.total (rule o id_rule o Thm.INST [x |-> t]) th of
-                     SOME r => Redblackmap.insert (d, t, r)
+                     SOME r => Termtab.update (t, r) d
                    | NONE => d,
                   Conv.RIGHT_CONV_RULE
                      (Conv.REWR_CONV (Thm.INST [a |-> t] flookup_rest)) th))
-               (Redblackmap.mkDict Term.compare, th) tms
+               (Termtab.empty, th) tms
          val dict'' =
             List.foldl
                (fn (t, d) =>
-                  case Redblackmap.peek (dict, t) of
-                     SOME r => Redblackmap.insert
-                                 (d, t,
+                  case Termtab.lookup dict t of
+                     SOME r => Termtab.update
+                                 (t,
                                   (rule o
                                    Conv.RIGHT_CONV_RULE (Conv.REWR_CONV r))
-                                      (Thm.INST [x |-> t] rest'))
+                                      (Thm.INST [x |-> t] rest')) d
                    | NONE => raise err) dict' old_tms
          val rest'' = if is_refl rest
                          then rest'
@@ -175,11 +181,9 @@ val new_const_size = ref 100
    -------------------------------------------------------------------------- *)
 
 local
-   val completed_fmap_convs =
-      ref (Redblackmap.mkDict Term.compare: (term, conv) Redblackmap.dict)
-   val head_fmaps =
-      ref (Redblackmap.mkDict Term.compare:
-             (term, (term, thm) Redblackmap.dict * thm) Redblackmap.dict)
+   val completed_fmap_convs : conv Termtab.table ref = ref Termtab.empty
+   val head_fmaps : (thm Termtab.table * thm) Termtab.table ref =
+      ref Termtab.empty
    fun introduce_fmap_consts _ = ALL_CONV
    val const_number = ref 0
    val flookup_fallback_conv =
@@ -192,7 +196,7 @@ local
       let
          val i = snd (finite_mapSyntax.dest_flookup tm)
       in
-         case Redblackmap.peek (dict, i) of
+         case Termtab.lookup dict i of
             SOME thm => Conv.REWR_CONV thm tm
           | NONE => let
                        val x = Term.rand (boolSyntax.rhs (Thm.concl rest))
@@ -217,18 +221,17 @@ local
                val sym_def = SYM def
                val (c', tm) = boolSyntax.dest_eq (Thm.concl def)
                val (dict, rest) =
-                  extend_flookup_thms
-                    (Redblackmap.mkDict Term.compare, Thm.REFL c) tm
+                  extend_flookup_thms (Termtab.empty, Thm.REFL c) tm
                val cnv = Conv.REWR_CONV sym_def
                val rule =
                   Conv.CONV_RULE
                      (Conv.LAND_CONV (Conv.RATOR_CONV (Conv.RAND_CONV cnv)))
-               val dict = Redblackmap.transform rule dict
+               val dict = Termtab.map (fn _ => rule) dict
                val rest = rule rest
                val () =
                   completed_fmap_convs :=
-                  Redblackmap.insert
-                    (!completed_fmap_convs, c', DICT_REST_CONV (dict, rest))
+                  Termtab.update
+                    (c', DICT_REST_CONV (dict, rest)) (!completed_fmap_convs)
             in
                iter (sym_def :: a) (c', List.drop (l, !new_const_size))
             end
@@ -247,21 +250,20 @@ in
          if not (List.null (Term.free_vars tm))
             then flookup_fallback_conv tm
          else if List.null ups
-            then case Redblackmap.peek (!completed_fmap_convs, base) of
+            then case Termtab.lookup (!completed_fmap_convs) base of
                     SOME cnv => cnv tm
                   | NONE => flookup_fallback_conv tm
          else if n < !new_const_size
             then let
                     val dr =
-                       case Redblackmap.peek (!head_fmaps, base) of
+                       case Termtab.lookup (!head_fmaps) base of
                           SOME dr => dr
-                        | NONE =>
-                            (Redblackmap.mkDict Term.compare, Thm.REFL base)
+                        | NONE => (Termtab.empty, Thm.REFL base)
                  in
                     case Lib.total (extend_flookup_thms dr) fm of
                        SOME dr' =>
                           ( head_fmaps :=
-                               Redblackmap.insert (!head_fmaps, base, dr')
+                               Termtab.update (base, dr') (!head_fmaps)
                           ; DICT_REST_CONV dr' tm
                           )
                      | NONE => flookup_fallback_conv tm

--- a/src/floating-point/binary_ieeeLib.sml
+++ b/src/floating-point/binary_ieeeLib.sml
@@ -332,14 +332,17 @@ local
             (Conv.FORK_CONV (Conv.REWR_CONV rx2_thm, Conv.REWR_CONV u_thm))
           THENC EVAL)
       |> Drule.EQT_ELIM
-   val twm_map =
-      ref (Redblackmap.mkDict
-            (Lib.pair_compare (Lib.pair_compare (Type.compare, Type.compare),
-                               Term.compare))
-           : ((hol_type * hol_type) * term,
-              (term -> float) * conv) Redblackmap.dict)
+   structure TwmTab = Table(struct
+     type key = (hol_type * hol_type) * term
+     val ord = Lib.pair_compare
+                 (Lib.pair_compare (Type.compare, Type.compare),
+                  Term.compare)
+     fun pp _ = HOLPP.add_string "<twm-key>"
+   end)
+   val twm_map : ((term -> float) * conv) TwmTab.table ref =
+       ref TwmTab.empty
    fun lookup (x as (tw as (t, w), mode)) =
-      case Redblackmap.peek (!twm_map, x) of
+      case TwmTab.lookup (!twm_map) x of
          SOME y => y
        | NONE =>
            let
@@ -350,7 +353,7 @@ local
                            then threshold_CONV (mk_threshold tw)
                         else largest_CONV (mk_large tw)
               val y = (f, Conv.REWR_CONV thm)
-              val () = twm_map := Redblackmap.insert (!twm_map, x, y)
+              val () = twm_map := TwmTab.update (x, y) (!twm_map)
            in
               y
            end

--- a/src/integer/CooperShell.sml
+++ b/src/integer/CooperShell.sml
@@ -376,27 +376,28 @@ fun best_var vars tm = let
         fun foldthis (v, map) = let
           open Arbint
           val (a,b) = assess_leaf v negp t
-          val (a0,b0) = Binarymap.find(map, v)
-              handle Binarymap.NotFound => (zero,zero)
+          val (a0,b0) =
+              Option.getOpt (Termtab.lookup map v, (zero,zero))
         in
-          Binarymap.insert(map, v, (a + a0, b + b0))
+          Termtab.update (v, (a + a0, b + b0)) map
         end
       in
         List.foldl foldthis map vars
       end
   end
-  val initial_map = Binarymap.mkDict Term.compare
+  val initial_map = Termtab.empty
 in
   case vars of
     [] => NONE
   | [x] => SOME x
   | (v::vs) => let
       val final_map = assess false initial_map tm
-      val start = (v, Arbint.min(Binarymap.find(final_map, v))
-                      handle Binarymap.NotFound => Arbint.zero)
+      fun min_of v = case Termtab.lookup final_map v of
+                         SOME pair => Arbint.min pair
+                       | NONE => Arbint.zero
+      val start = (v, min_of v)
       fun findmin (v, acc as (minvar, minc)) = let
-        val vc = Arbint.min(Binarymap.find(final_map, v))
-                            handle Binarymap.NotFound => Arbint.zero
+        val vc = min_of v
       in
         if Arbint.<=(vc, minc) then (v, vc) else acc
       end

--- a/src/integer/CooperSyntax.sml
+++ b/src/integer/CooperSyntax.sml
@@ -289,20 +289,19 @@ in
 end
 
 fun count_vars tm = let
-  open Binarymap
   fun recurse (tm,dict) =
     case strip_comb tm of
       (f, []) => let
       in let
         val n = #1 (dest_var f)
       in
-        case peek(dict,n) of
-          NONE => insert(dict, n, 1)
-        | SOME i => insert(dict, n, i+1)
+        case Symtab.lookup dict n of
+          NONE => Symtab.update (n, 1) dict
+        | SOME i => Symtab.update (n, i+1) dict
       end handle HOL_ERR _ => dict end
     | (_, args) => List.foldl recurse dict args
 in
-  listItems (recurse (tm, mkDict String.compare))
+  Symtab.dest (recurse (tm, Symtab.empty))
 end
 
 (* dealing with constraints of the form lo < x /\ x <= hi *)

--- a/src/integer/OmegaMath.sml
+++ b/src/integer/OmegaMath.sml
@@ -699,16 +699,15 @@ val normalise_guards = TOP_SWEEP_ONCE_CONV normalise_guard
    ---------------------------------------------------------------------- *)
 
 fun cond_removal0 t = let
-  open Binarymap
   val condexps = List.map (hd o #2 o strip_comb) (find_terms is_cond t)
-  val empty_map = mkDict Term.compare
+  val empty_map = Termtab.empty
   fun my_insert(g, m) =
-      case peek(m,g) of
-        NONE => insert(m, g, 1)
-      | SOME n => insert(m, g, n + 1)
+      case Termtab.lookup m g of
+        NONE => Termtab.update (g, 1) m
+      | SOME n => Termtab.update (g, n + 1) m
   val final_map = List.foldl my_insert empty_map condexps
-  fun find_gt2 (t,n,l) = if n >= 2 then t::l else l
-  val gt2_guards = foldl find_gt2 [] final_map
+  fun find_gt2 (t,n) l = if n >= 2 then t::l else l
+  val gt2_guards = Termtab.fold find_gt2 final_map []
   val n = assert (curry op < 0) (length gt2_guards)
   val case_split = generate_nway_casesplit n
 in

--- a/src/integer/OmegaSymbolic.sml
+++ b/src/integer/OmegaSymbolic.sml
@@ -478,15 +478,15 @@ fun new_varinfo () : varinfo =
 exception NotFound
 
 fun variable_information vs t = let
-  val table = ref (Redblackmap.mkDict Term.compare)
+  val table : varinfo Termtab.table ref = ref Termtab.empty
   fun ins_initial_recs v =
-    table := Redblackmap.insert (!table, v, new_varinfo())
+    table := Termtab.update (v, new_varinfo()) (!table)
   val _ = app ins_initial_recs vs
   fun examine_cv t = let
     val (c, v) = dest_mult t
     val c_i = int_of_term c
   in
-    case Redblackmap.peek (!table, v) of
+    case Termtab.lookup (!table) v of
       NONE => ()
     | SOME {maxupc, maxloc, numups, numlos} =>
       if Arbint.<(c_i, Arbint.zero) then (* upper bound *)
@@ -519,7 +519,7 @@ fun findleast gt f l =
 
 fun best_variable_to_eliminate vs t = let
   val table = variable_information vs t
-  val items = Redblackmap.listItems (!table)
+  val items = Termtab.dest (!table)
   fun is_vacuous (_, {numups, numlos,...}) = !numups = 0 orelse !numlos = 0
   fun is_exact (_, {maxloc, maxupc,...}) = !maxloc = Arbint.one orelse
                                            !maxupc = Arbint.one

--- a/src/marker/Holmakefile
+++ b/src/marker/Holmakefile
@@ -12,7 +12,8 @@ endif
 # Table.ui passed explicitly because its dep auto-detection misses
 # functor applications.
 markerLib.uo: markerLib.sml markerLib.ui $(TABLE_UID) markerSyntax.uo \
-              markerTheory.uo $(dprot $(SIGOBJ)/KNametab.ui)
+              markerTheory.uo $(dprot $(SIGOBJ)/HolKernel.ui) \
+              $(dprot $(SIGOBJ)/KNametab.ui)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
 selftest.exe: selftest.uo

--- a/src/marker/Holmakefile
+++ b/src/marker/Holmakefile
@@ -1,10 +1,19 @@
 all: $(DEFAULT_TARGETS) selftest.exe
 .PHONY: all
 
+TABLE_UID = $(dprot $(SIGOBJ)/Table.ui)
+
 ifeq ($(KERNELID),otknl)
 all: $(patsubst %Script.sml,%.ot.art,$(wildcard *Script.sml))
 
 endif
+
+# markerLib.sml instantiates the Table functor locally; mosml needs
+# Table.ui passed explicitly because its dep auto-detection misses
+# functor applications.
+markerLib.uo: markerLib.sml markerLib.ui $(TABLE_UID) markerSyntax.uo \
+              markerTheory.uo
+	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
 selftest.exe: selftest.uo
 	$(HOLMOSMLC) -o $@ $<

--- a/src/marker/Holmakefile
+++ b/src/marker/Holmakefile
@@ -12,7 +12,7 @@ endif
 # Table.ui passed explicitly because its dep auto-detection misses
 # functor applications.
 markerLib.uo: markerLib.sml markerLib.ui $(TABLE_UID) markerSyntax.uo \
-              markerTheory.uo
+              markerTheory.uo $(dprot $(SIGOBJ)/KNametab.ui)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
 selftest.exe: selftest.uo

--- a/src/marker/markerLib.sml
+++ b/src/marker/markerLib.sml
@@ -974,34 +974,33 @@ open ThyDataSexp
 
 (* --- suspension.theorems store --- *)
 
-(* Key: (thy, name).  Theory qualification allows distinct theorems
-   with the same name in different theories. *)
-type susp_key = string * string
-
-val susp_key_compare = Portable.pair_compare (String.compare, String.compare)
-
-structure SuspTab = Table(struct
-  type key = susp_key
-  val ord = susp_key_compare
-  fun pp (s1,s2) = HOLPP.add_string (s1 ^ "$" ^ s2)
-end)
+(* Key: kernelname {Thy, Name}.  Theory qualification allows distinct
+   theorems with the same name in different theories.  Strictly a
+   slight bending of the semantics -- kernelnames are usually
+   logical entities like constants and type-operators -- but
+   reusing the existing top-level KNametab avoids defining a
+   parallel structure. *)
+type susp_key = KernelSig.kernelname
 
 datatype susp_delta =
     AddSuspended of susp_key * thm
   | RemoveSuspended of susp_key
 
-type susp_table = thm SuspTab.table
+type susp_table = thm KNametab.table
 
-val empty_susp_table : susp_table = SuspTab.empty
+val empty_susp_table : susp_table = KNametab.empty
 
 fun apply_susp_delta d (tab : susp_table) : susp_table =
     case d of
-        AddSuspended (k, th) => SuspTab.update (k, th) tab
-      | RemoveSuspended k => SuspTab.delete_safe k tab
+        AddSuspended (k, th) => KNametab.update (k, th) tab
+      | RemoveSuspended k => KNametab.delete_safe k tab
 
 val (susp_enc, susp_dec) = bij_ed (
-      (fn AddSuspended p => inl p | RemoveSuspended k => inr k),
-      (fn inl p => AddSuspended p | inr k => RemoveSuspended k)
+      (fn AddSuspended ({Thy,Name}, th) => inl ((Thy,Name), th)
+        | RemoveSuspended {Thy,Name} => inr (Thy,Name)),
+      (fn inl ((Thy,Name), th) =>
+              AddSuspended ({Thy=Thy,Name=Name}, th)
+        | inr (Thy,Name) => RemoveSuspended {Thy=Thy,Name=Name})
     ) (tagged_sum ("add", pair_ed (pair_ed (string_ed, string_ed), thm_ed))
                   ("rm", pair_ed (string_ed, string_ed)))
 
@@ -1110,15 +1109,15 @@ fun record_resumption_delta d =
    For unqualified lookup, scans the dictionary keys for any match.
    Returns (thy, thm) on success so caller knows which theory. *)
 fun lookup_suspension_qualified (thy, nm) =
-    case SuspTab.lookup (get_susp_global ()) (thy, nm) of
+    case KNametab.lookup (get_susp_global ()) {Thy = thy, Name = nm} of
         NONE => NONE
       | SOME th => SOME (thy, th)
 
 fun lookup_suspension_unqualified nm =
     let
       val tab = get_susp_global ()
-      val matches = SuspTab.fold
-            (fn ((t, n), th) => fn acc =>
+      val matches = KNametab.fold
+            (fn ({Thy = t, Name = n}, th) => fn acc =>
                 if n = nm then (t, th) :: acc else acc)
             tab []
     in
@@ -1149,7 +1148,8 @@ fun lookup_resumption {parent_thy, parent_name, label} =
    theorem DB. *)
 val _ = boolLib.suspended_theorem_recorder :=
     (fn (n, th) => record_suspension_delta
-                     (AddSuspended ((Theory.current_theory(), n), th)))
+                     (AddSuspended
+                        ({Thy = Theory.current_theory(), Name = n}, th)))
 
 (* ----------------------------------------------------------------------
     Finding the parent theorem for a Resume / Finalise.
@@ -1384,7 +1384,8 @@ fun finalise_suspended_thm loc nm0 =
             (* Drop this name from the suspension store so it's no
                longer considered pending.  (For FromDB there was no
                entry to drop anyway; the delta is harmless.) *)
-            val _ = record_suspension_delta (RemoveSuspended (parent_thy, name))
+            val _ = record_suspension_delta
+                      (RemoveSuspended {Thy = parent_thy, Name = name})
             (* Also clean up the resumption proofs for this theorem. *)
             val _ = record_resumption_delta (RemoveResumptions (parent_thy, name))
           in

--- a/src/marker/markerLib.sml
+++ b/src/marker/markerLib.sml
@@ -980,19 +980,24 @@ type susp_key = string * string
 
 val susp_key_compare = Portable.pair_compare (String.compare, String.compare)
 
+structure SuspTab = Table(struct
+  type key = susp_key
+  val ord = susp_key_compare
+  fun pp (s1,s2) = HOLPP.add_string (s1 ^ "$" ^ s2)
+end)
+
 datatype susp_delta =
     AddSuspended of susp_key * thm
   | RemoveSuspended of susp_key
 
-type susp_table = (susp_key, thm) Binarymap.dict
+type susp_table = thm SuspTab.table
 
-val empty_susp_table : susp_table = Binarymap.mkDict susp_key_compare
+val empty_susp_table : susp_table = SuspTab.empty
 
 fun apply_susp_delta d (tab : susp_table) : susp_table =
     case d of
-        AddSuspended (k, th) => Binarymap.insert (tab, k, th)
-      | RemoveSuspended k =>
-          (fst (Binarymap.remove (tab, k)) handle Binarymap.NotFound => tab)
+        AddSuspended (k, th) => SuspTab.update (k, th) tab
+      | RemoveSuspended k => SuspTab.delete_safe k tab
 
 val (susp_enc, susp_dec) = bij_ed (
       (fn AddSuspended p => inl p | RemoveSuspended k => inr k),
@@ -1037,31 +1042,37 @@ fun triple_compare (c1, c2, c3) ((a1,a2,a3), (b1,b2,b3)) =
 val res_key_compare =
     triple_compare (String.compare, String.compare, String.compare)
 
+structure ResTab = Table(struct
+  type key = res_key
+  val ord = res_key_compare
+  fun pp (s1,s2,s3) = HOLPP.add_string (s1 ^ "$" ^ s2 ^ "$" ^ s3)
+end)
+
 datatype res_delta =
     AddResumption of res_key * thm
   | RemoveResumptions of string * string  (* parent_thy, parent_name *)
 
-type res_dict = (res_key, thm list) Binarymap.dict
+type res_dict = thm list ResTab.table
 
-val empty_res_dict : res_dict = Binarymap.mkDict res_key_compare
+val empty_res_dict : res_dict = ResTab.empty
 
 fun apply_res_delta d (dict : res_dict) : res_dict =
     case d of
         AddResumption (k, th) =>
           let val existing =
-                  case Binarymap.peek (dict, k) of
+                  case ResTab.lookup dict k of
                       NONE => []
                     | SOME ths => ths
           in
-            Binarymap.insert (dict, k, th :: existing)
+            ResTab.update (k, th :: existing) dict
           end
       | RemoveResumptions (thy, nm) =>
-          Binarymap.foldl
-            (fn (k as (t,n,_), v, acc) =>
+          ResTab.fold
+            (fn (k as (t,n,_), v) => fn acc =>
                 if t = thy andalso n = nm then acc
-                else Binarymap.insert (acc, k, v))
-            empty_res_dict
+                else ResTab.update (k, v) acc)
             dict
+            empty_res_dict
 
 val reskey_ed : res_key ed = pair3_ed (string_ed, string_ed, string_ed)
 
@@ -1099,16 +1110,17 @@ fun record_resumption_delta d =
    For unqualified lookup, scans the dictionary keys for any match.
    Returns (thy, thm) on success so caller knows which theory. *)
 fun lookup_suspension_qualified (thy, nm) =
-    case Binarymap.peek (get_susp_global (), (thy, nm)) of
+    case SuspTab.lookup (get_susp_global ()) (thy, nm) of
         NONE => NONE
       | SOME th => SOME (thy, th)
 
 fun lookup_suspension_unqualified nm =
     let
       val tab = get_susp_global ()
-      val matches = Binarymap.foldl
-            (fn ((t, n), th, acc) => if n = nm then (t, th) :: acc else acc)
-            [] tab
+      val matches = SuspTab.fold
+            (fn ((t, n), th) => fn acc =>
+                if n = nm then (t, th) :: acc else acc)
+            tab []
     in
       case matches of
           [] => NONE
@@ -1127,8 +1139,8 @@ fun lookup_suspension nm =
       | _ => lookup_suspension_unqualified nm
 
 fun lookup_resumption {parent_thy, parent_name, label} =
-    case Binarymap.peek (get_res_global (),
-                        (parent_thy, parent_name, label)) of
+    case ResTab.lookup (get_res_global ())
+                       (parent_thy, parent_name, label) of
         NONE => []
       | SOME ths => ths
 
@@ -1309,7 +1321,7 @@ fun assemble_finalised parent_thy parent_nm parent_th =
               let
                 val key = (parent_thy, parent_nm, label)
                 val candidates =
-                    case Binarymap.peek (get_res_global (), key) of
+                    case ResTab.lookup (get_res_global ()) key of
                         NONE => []
                       | SOME ths => ths
                 (* Pick the candidate whose conclusion aconv-matches

--- a/src/metis/metisTools.sml
+++ b/src/metis/metisTools.sml
@@ -365,9 +365,9 @@ local
   fun mk_set ts = Binaryset.addList (Binaryset.empty compare, ts);
   fun member x s = Binaryset.member (s,x);
 
-  val empty : (term, bool * int) Binarymap.dict = Binarymap.mkDict compare;
-  fun update ts x n = Binarymap.insert (ts,x,n);
-  fun lookup ts x = Binarymap.peek (ts,x);
+  val empty : (bool * int) Termtab.table = Termtab.empty;
+  fun update ts x n = Termtab.update (x,n) ts;
+  fun lookup ts x = Termtab.lookup ts x;
 
   fun bump Full _ = Full
     | bump Higher Full = Full

--- a/src/monad/monadsyntax.sml
+++ b/src/monad/monadsyntax.sml
@@ -45,8 +45,7 @@ struct
                    "bad format - not an appropriately shaped list of 6 elements"
 end
 
-val monadDB =
-    ref (Binarymap.mkDict String.compare : (string,MonadInfo.t) Binarymap.dict);
+val monadDB : MonadInfo.t Symtab.table ref = ref Symtab.empty;
 
 fun write_keyval (nm, mi) =
   let
@@ -70,7 +69,7 @@ fun load_from_disk {thyname, data} =
   in
     case data of
         SOME (List keyvals) =>
-          monadDB := List.foldl (fn ((k,v), acc) => Binarymap.insert(acc,k,v))
+          monadDB := List.foldl (fn ((k,v), acc) => Symtab.update (k,v) acc)
                                 (!monadDB)
                                 (map dest_keyval keyvals)
       | NONE => ()
@@ -125,10 +124,10 @@ val {export = export_minfo, ...} = ThyDataSexp.new{
       merge = ThyDataSexp.alist_merge
     }
 
-fun predeclare (nm, t) = monadDB := Binarymap.insert(!monadDB, nm, t)
+fun predeclare (nm, t) = monadDB := Symtab.update (nm, t) (!monadDB)
 fun declare_monad p = (predeclare p; export_minfo (write_keyval p))
 
-fun all_monads () = Binarymap.listItems (!monadDB)
+fun all_monads () = Symtab.dest (!monadDB)
 
 
 fun to_vstruct a = let
@@ -408,7 +407,7 @@ fun mk_unitbind mbind =
   end
 
 fun getMI fname s =
-  case Binarymap.peek(!monadDB, s) of
+  case Symtab.lookup (!monadDB) s of
       NONE => raise ERR fname ("No such monad defined: "^s)
     | SOME mi => mi
 

--- a/src/n-bit/bitstringLib.sml
+++ b/src/n-bit/bitstringLib.sml
@@ -553,7 +553,7 @@ local
               (fn (s, _) =>
                  not (Lib.mem s ["bitstring$modify", "bitstring$bitwise",
                                  "words$word_modify", "words$word_reduce"]))
-         |> Redblackmap.fromList String.compare
+         |> List.foldl (fn ((k,v),m) => Symtab.update (k,v) m) Symtab.empty
   fun is_ground_arg tm =
     Lib.can bitstringSyntax.bitlist_of_term tm orelse
     Lib.can (bitstringSyntax.bitlist_of_term o fst o
@@ -567,7 +567,7 @@ local
   fun is_ground tm =
     case Lib.total boolSyntax.dest_strip_comb tm of
        SOME (name, l) =>
-         (case Redblackmap.peek (s, name) of
+         (case Symtab.lookup s name of
              SOME i => List.length l = i andalso List.all is_ground_arg l
            | NONE => false)
      | NONE => false

--- a/src/n-bit/blastLib.sml
+++ b/src/n-bit/blastLib.sml
@@ -467,13 +467,18 @@ local
 
    val FCP_EQ_CONV = Conv.REWR_CONV FCP_EQ_EVERY THENC EVAL_CONV
 
-   val fcp_map = ref (Redblackmap.mkDict Arbnum.compare)
-                   : (Arbnum.num, Thm.thm) Redblackmap.dict ref
+   structure Numtab = Table(struct
+     type key = Arbnum.num
+     val ord = Arbnum.compare
+     val pp = HOLPP.add_string o Arbnum.toString
+   end)
+
+   val fcp_map : Thm.thm Numtab.table ref = ref Numtab.empty
 in
    fun fcp_eq_thm ty =
       case Lib.total (fcpLib.index_to_num o wordsSyntax.dest_word_type) ty of
          SOME n =>
-             (case Redblackmap.peek (!fcp_map, n) of
+             (case Numtab.lookup (!fcp_map) n of
                  SOME thm => thm
                | _ =>
                   let
@@ -481,7 +486,7 @@ in
                      val b = Term.mk_var ("b", ty)
                      val thm = FCP_EQ_CONV (boolSyntax.mk_eq (a,b))
                      val thm = Thm.GEN a (Thm.GEN b thm)
-                     val () = fcp_map := Redblackmap.insert (!fcp_map, n, thm)
+                     val () = fcp_map := Numtab.update (n, thm) (!fcp_map)
                   in
                      thm
                   end)

--- a/src/n-bit/wordsLib.sml
+++ b/src/n-bit/wordsLib.sml
@@ -590,19 +590,23 @@ end
 val SYM_WORD_NEG_1 = SYM WORD_NEG_1
 
 local
-  val d = ref (Redblackmap.mkDict Arbnum.compare:
-               (Arbnum.num, thm) Redblackmap.dict)
+  structure Numtab = Table(struct
+    type key = Arbnum.num
+    val ord = Arbnum.compare
+    val pp = HOLPP.add_string o Arbnum.toString
+  end)
+  val d : thm Numtab.table ref = ref Numtab.empty
   val mk_th = Conv.RIGHT_CONV_RULE (Conv.REWR_CONV SYM_WORD_NEG_1) o GSYM o
               (Conv.REWR_CONV word_T_def THENC Conv.RAND_CONV SIZES_CONV) o
               wordsSyntax.mk_word_T o fcpSyntax.mk_numeric_type
   fun PRIM_UINT_MAX_CONV n =
-    case Redblackmap.peek (!d, n) of
+    case Numtab.lookup (!d) n of
        SOME th => Conv.REWR_CONV th
      | NONE =>
         let
           val th = mk_th n
         in
-          d := Redblackmap.insert (!d, n, th)
+          d := Numtab.update (n, th) (!d)
         ; Conv.REWR_CONV th
         end
   val err = ERR "UINT_MAX_CONV" ""

--- a/src/num/arith/src/GenRelNorm.sml
+++ b/src/num/arith/src/GenRelNorm.sml
@@ -38,13 +38,13 @@ fun gen_relnorm t = let
     fun base bmap t = let
       val (c,t0) = destf t
     in
-      case Binarymap.peek(bmap,t0) of
-        NONE => Binarymap.insert(bmap,t0, if left then (c,c,zero)
-                                          else (~c,zero,c))
+      case Termtab.lookup bmap t0 of
+        NONE => Termtab.update (t0, if left then (c,c,zero)
+                                    else (~c,zero,c)) bmap
       | SOME(tot,l,r) => if left then
-                           Binarymap.insert(bmap,t0,(tot + c, l + c, r))
+                           Termtab.update (t0,(tot + c, l + c, r)) bmap
                          else
-                           Binarymap.insert(bmap,t0,(tot - c, l, r + c))
+                           Termtab.update (t0,(tot - c, l, r + c)) bmap
     end
     fun recurse bmap t = let
       val (l,r) = dest t
@@ -54,17 +54,16 @@ fun gen_relnorm t = let
   in
     recurse bmap t
   end
-  val bmap = coeff_count (coeff_count (Binarymap.mkDict Term.compare) true l)
-                         false r
+  val bmap = coeff_count (coeff_count Termtab.empty true l) false r
   fun cons_mkf' (i,r) acc = if i = one then r::acc
                             else if i = zero then acc
                             else  mkf(i,r)::acc
-  fun foldthis (k,(tot,l,r),(common,ls,rs)) =
+  fun foldthis (k,(tot,l,r)) (common,ls,rs) =
       if l = zero then (common, ls, cons_mkf'(r,k) rs)
       else if r = zero then (common, cons_mkf'(l,k) ls, rs)
       else if tot < zero then (cons_mkf'(l,k) common, ls, cons_mkf'(r-l,k) rs)
       else (cons_mkf'(r,k) common, cons_mkf'(l-r,k) ls, rs)
-  val (common, ls, rs) = Binarymap.foldr foldthis ([],[],[]) bmap
+  val (common, ls, rs) = Termtab.fold_rev foldthis bmap ([],[],[])
   val _ = not (null common) orelse raise Conv.UNCHANGED
   val common_t = listmk common
   val left_thm = if null ls then addid common_t

--- a/src/num/termination/TotalDefn.sig
+++ b/src/num/termination/TotalDefn.sig
@@ -18,7 +18,7 @@ sig
    val WF_TAC        : tactic
 
    val termination_simps : unit -> thm list
-   val termination_simpdb : unit -> (string,thm) Binarymap.dict
+   val termination_simpdb : unit -> thm Symtab.table
    val temp_exclude_termsimp  : string -> unit
    val exclude_termsimp  : string -> unit
    val with_termsimps : thm list -> ('a -> 'b) -> ('a -> 'b)

--- a/src/parse/FCNet.sml
+++ b/src/parse/FCNet.sml
@@ -278,28 +278,27 @@ fun lookup tm net =
           (follow tm net)  [];
 
 (* term match *)
-structure Map = Redblackmap
 fun bvar_free (bvmap, tm) = let
   (* return true if none of the free variables occur as keys in bvmap *)
   fun recurse bs t =
       case dest_term t of
         v as VAR _ => HOLset.member(bs, t) orelse
-                      not (isSome (Map.peek(bvmap, t)))
+                      not (isSome (Termtab.lookup bvmap t))
       | CONST _ => true
       | COMB(f,x) => recurse bs f andalso recurse bs x
       | LAMB(v, body) => recurse (HOLset.add(bs, v)) body
 in
-  Map.numItems bvmap = 0 orelse recurse empty_varset tm
+  Termtab.size bvmap = 0 orelse recurse empty_varset tm
 end
 
 type tminfo = {ids : term HOLset.set, n : int,
-               patbvars : (term,int)Map.dict,
-               obbvars :  (term,int)Map.dict,
+               patbvars : int Termtab.table,
+               obbvars :  int Termtab.table,
                theta : (term,term) Lib.subst}
 
 datatype tmpair = TMP of term * term
-                | BVrestore of {patbvars : (term,int)Map.dict,
-                                obbvars : (term,int)Map.dict,
+                | BVrestore of {patbvars : int Termtab.table,
+                                obbvars : int Termtab.table,
                                 n : int}
 fun add_id v {ids, patbvars, obbvars, theta, n} =
     {ids = HOLset.add(ids, v), patbvars = patbvars, obbvars = obbvars, n = n,
@@ -325,7 +324,7 @@ fun RM patobs (theta0 as (tminfo, tyS)) =
         case (dest_term t1, dest_term t2) of
           (VAR(_, ty), _) => let
           in
-            case Map.peek(#patbvars tminfo, t1) of
+            case Termtab.lookup (#patbvars tminfo) t1 of
               NONE => (* var on left not bound *) let
               in
                 if bvar_free (#obbvars tminfo, t2) then
@@ -340,7 +339,7 @@ fun RM patobs (theta0 as (tminfo, tyS)) =
                   MERR "Attempt to capture bound variable"
               end
             | SOME i => if is_var t2 andalso
-                           Map.peek(#obbvars tminfo, t2) = SOME i
+                           Termtab.lookup (#obbvars tminfo) t2 = SOME i
                         then
                           RM rest theta0
                         else false
@@ -368,8 +367,8 @@ fun RM patobs (theta0 as (tminfo, tyS)) =
                 BVrestore {patbvars = patbvars, obbvars = obbvars, n = n} ::
                 rest)
                ({ids = #ids tminfo, n = n + 1, theta = theta,
-                 patbvars = Map.insert(patbvars, x1, n),
-                 obbvars = Map.insert(obbvars, x2, n)}, tyS')
+                 patbvars = Termtab.update (x1, n) patbvars,
+                 obbvars = Termtab.update (x2, n) obbvars}, tyS')
           end
         | _ => false
       end
@@ -380,7 +379,7 @@ fun RM patobs (theta0 as (tminfo, tyS)) =
                   obbvars = obbvars, n = n}, tyS)
       end
 
-val empty_subst = Map.mkDict Term.compare
+val empty_subst : int Termtab.table = Termtab.empty
 fun can_match_term pat t =
   RM [TMP (pat,t)] ({ids = empty_tmset, n = 0, theta = [],
                      patbvars = empty_subst, obbvars = empty_subst},

--- a/src/parse/FCNet.sml
+++ b/src/parse/FCNet.sml
@@ -278,7 +278,7 @@ fun lookup tm net =
           (follow tm net)  [];
 
 (* term match *)
-structure Map = HOLdict
+structure Map = Redblackmap
 fun bvar_free (bvmap, tm) = let
   (* return true if none of the free variables occur as keys in bvmap *)
   fun recurse bs t =

--- a/src/parse/Holmakefile
+++ b/src/parse/Holmakefile
@@ -28,18 +28,19 @@ LVTermNetFunctor.ui LVTermNetFunctor.uo: LVTermNetFunctor.sml $(dprot $(SIGOBJ)/
 LVTermNet.uo: LVTermNet.sml LVTermNet.ui $(TABLE_UID)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
-TypeNet.uo: TypeNet.sml TypeNet.ui $(TABLE_UID)
+TypeNet.uo: TypeNet.sml TypeNet.ui $(TABLE_UID) \
+            $(dprot $(SIGOBJ)/Typetab.ui)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
 term_grammar.uo: term_grammar.sml term_grammar.ui $(TABLE_UID) \
                  HOLgrammars.uo GrammarSpecials.uo term_grammar_dtype.uo \
-                 Absyn.ui
+                 Absyn.ui $(dprot $(SIGOBJ)/Symtab.ui)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
 parse_term.uo: parse_term.sml parse_term.ui $(TABLE_UID) \
                term_tokens.uo term_grammar.ui HOLgrammars.uo \
                GrammarSpecials.uo PrecAnalysis.ui parse_term_dtype.uo \
-               Absyn.ui
+               Absyn.ui $(dprot $(SIGOBJ)/Symtab.ui)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
 Overload.ui: Overload.sig LVTermNetFunctor.ui

--- a/src/parse/Holmakefile
+++ b/src/parse/Holmakefile
@@ -25,22 +25,25 @@ base_lexer.uo: base_tokens.uo MLstring.uo
 LVTermNetFunctor.ui LVTermNetFunctor.uo: LVTermNetFunctor.sml $(dprot $(SIGOBJ)/HolKernel.ui) $(TABLE_UID)
 	$(HOLMOSMLC) Overlay.ui Table.ui -toplevel -c $<
 
-LVTermNet.uo: LVTermNet.sml LVTermNet.ui $(TABLE_UID)
+LVTermNet.uo: LVTermNet.sml LVTermNet.ui $(TABLE_UID) \
+              $(dprot $(SIGOBJ)/HolKernel.ui)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
 TypeNet.uo: TypeNet.sml TypeNet.ui $(TABLE_UID) \
-            $(dprot $(SIGOBJ)/Typetab.ui)
+            $(dprot $(SIGOBJ)/HolKernel.ui) $(dprot $(SIGOBJ)/Typetab.ui)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
 term_grammar.uo: term_grammar.sml term_grammar.ui $(TABLE_UID) \
                  HOLgrammars.uo GrammarSpecials.uo term_grammar_dtype.uo \
-                 Absyn.ui $(dprot $(SIGOBJ)/Symtab.ui)
+                 Absyn.ui $(dprot $(SIGOBJ)/HolKernel.ui) \
+                 $(dprot $(SIGOBJ)/Symtab.ui)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
 parse_term.uo: parse_term.sml parse_term.ui $(TABLE_UID) \
                term_tokens.uo term_grammar.ui HOLgrammars.uo \
                GrammarSpecials.uo PrecAnalysis.ui parse_term_dtype.uo \
-               Absyn.ui $(dprot $(SIGOBJ)/Symtab.ui)
+               Absyn.ui $(dprot $(SIGOBJ)/HolKernel.ui) \
+               $(dprot $(SIGOBJ)/Symtab.ui)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
 Overload.ui: Overload.sig LVTermNetFunctor.ui

--- a/src/parse/Holmakefile
+++ b/src/parse/Holmakefile
@@ -6,6 +6,8 @@ SELFTEST_DEPS = $(dprot $(SIGOBJ)/Lib.uo) $(dprot $(SIGOBJ)/Type.uo) \
 
 UOFILES = $(patsubst %.sml,%.uo,$(wildcard *.sml))
 
+TABLE_UID = $(dprot $(SIGOBJ)/Table.ui)
+
 all: base_lexer.sml selftest.exe $(UOFILES)
 
 .PHONY: all
@@ -15,8 +17,30 @@ base_lexer.sml: base_lexer
 
 base_lexer.uo: base_tokens.uo MLstring.uo
 
-LVTermNetFunctor.ui LVTermNetFunctor.uo: LVTermNetFunctor.sml $(dprot $(SIGOBJ)/HolKernel.ui)
-	$(HOLMOSMLC) $(protect $(SIGOBJ)/Overlay.ui) -toplevel -c $<
+# Files instantiating the Table functor locally need explicit
+# Table.ui passed on the command line for mosml -- its dep
+# auto-detection misses functor applications.  Sibling .ui files
+# are listed as prereqs so Holmake builds them first.
+
+LVTermNetFunctor.ui LVTermNetFunctor.uo: LVTermNetFunctor.sml $(dprot $(SIGOBJ)/HolKernel.ui) $(TABLE_UID)
+	$(HOLMOSMLC) Overlay.ui Table.ui -toplevel -c $<
+
+LVTermNet.uo: LVTermNet.sml LVTermNet.ui $(TABLE_UID)
+	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
+
+TypeNet.uo: TypeNet.sml TypeNet.ui $(TABLE_UID)
+	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
+
+term_grammar.uo: term_grammar.sml term_grammar.ui $(TABLE_UID) \
+                 HOLgrammars.uo GrammarSpecials.uo term_grammar_dtype.uo \
+                 Absyn.ui
+	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
+
+parse_term.uo: parse_term.sml parse_term.ui $(TABLE_UID) \
+               term_tokens.uo term_grammar.ui HOLgrammars.uo \
+               GrammarSpecials.uo PrecAnalysis.ui parse_term_dtype.uo \
+               Absyn.ui
+	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
 Overload.ui: Overload.sig LVTermNetFunctor.ui
 	$(HOLMOSMLC) $(protect $(SIGOBJ)/Overlay.ui) LVTermNetFunctor.ui -c $<

--- a/src/parse/LVTermNet.sig
+++ b/src/parse/LVTermNet.sig
@@ -5,6 +5,7 @@ sig
   type 'a lvtermnet
   type term = Term.term
   type key = Term.term list * Term.term
+  exception NotFound
 
   val empty : 'a lvtermnet
   val insert : ('a lvtermnet * key * 'a) -> 'a lvtermnet
@@ -12,7 +13,7 @@ sig
   val peek : 'a lvtermnet * key -> 'a list
   val match : 'a lvtermnet * term -> (key * 'a) list
 
-  val delete : 'a lvtermnet * key -> 'a lvtermnet * 'a list
+  val delete : 'a lvtermnet * key -> 'a lvtermnet * 'a list  (* raises NotFound *)
   val numItems : 'a lvtermnet -> int
   val listItems : 'a lvtermnet -> (key * 'a) list
   val app : (key * 'a list -> unit) -> 'a lvtermnet -> unit

--- a/src/parse/LVTermNet.sig
+++ b/src/parse/LVTermNet.sig
@@ -1,7 +1,7 @@
 signature LVTermNet =
 sig
 
-  (* signature names modelled on HOLdict's *)
+  (* signature names modelled on Redblackmap's *)
   type 'a lvtermnet
   type term = Term.term
   type key = Term.term list * Term.term

--- a/src/parse/LVTermNet.sml
+++ b/src/parse/LVTermNet.sml
@@ -3,6 +3,8 @@ struct
 
 open HolKernel
 
+exception NotFound
+
 datatype label = V of int
                | C of {Name : string, Thy : string} * int
                | Lam of int
@@ -27,8 +29,20 @@ fun labcmp (p as (l1, l2)) =
     | (_, Lam _) => GREATER
     | (LV p1, LV p2) => pair_compare (String.compare, Int.compare) (p1, p2)
 
-datatype 'a N = LF of (key,'a list) Redblackmap.dict
-              | ND of (label,'a N) Redblackmap.dict
+structure KeyTab = Table(struct
+  type key = term list * term
+  val ord = tlt_compare
+  fun pp _ = HOLPP.add_string "<lvtm-key>"
+end)
+
+structure LabelTab = Table(struct
+  type key = label
+  val ord = labcmp
+  fun pp _ = HOLPP.add_string "<lvtm-label>"
+end)
+
+datatype 'a N = LF of 'a list KeyTab.table
+              | ND of 'a N LabelTab.table
               | EMPTY
 (* redundant EMPTY constructor is used to get around value polymorphism problem
    when creating a single value for empty below *)
@@ -37,7 +51,7 @@ type 'a lvtermnet = 'a N * int
 
 val empty = (EMPTY, 0)
 
-fun mkempty () = ND (Redblackmap.mkDict labcmp)
+fun mkempty () = ND LabelTab.empty
 
 fun ndest_term (fvs, tm) = let
   val (f, args) = strip_comb tm
@@ -53,14 +67,14 @@ in
 end
 
 fun cons_insert (bmap, k, i) =
-    case Redblackmap.peek(bmap,k) of
-      NONE => Redblackmap.insert(bmap,k,[i])
-    | SOME items => Redblackmap.insert(bmap,k,i::items)
+    case KeyTab.lookup bmap k of
+      NONE => KeyTab.update (k, [i]) bmap
+    | SOME items => KeyTab.update (k, i::items) bmap
 
 fun insert ((net,sz), k, item) = let
   fun newnode labs =
       case labs of
-        [] => LF (Redblackmap.mkDict tlt_compare)
+        [] => LF KeyTab.empty
       | _ => mkempty()
   fun trav (net, tms) =
       case (net, tms) of
@@ -69,11 +83,11 @@ fun insert ((net,sz), k, item) = let
           val (lab, rest) = ndest_term k
           val ks = rest @ ks0
           val n' =
-              case Redblackmap.peek(d,lab) of
+              case LabelTab.lookup d lab of
                 NONE => trav(newnode ks, ks)
               | SOME n => trav(n, ks)
         in
-          ND (Redblackmap.insert(d, lab, n'))
+          ND (LabelTab.update (lab, n') d)
         end
       | (EMPTY, ks) => trav(mkempty(), ks)
       | _ => raise Fail "LVTermNet.insert: catastrophic invariant failure"
@@ -82,15 +96,11 @@ in
 end
 
 fun listItems (net, sz) = let
-  fun cons'(k,vs,acc) = List.foldl (fn (v,acc) => (k,v)::acc) acc vs
+  fun cons' (k,vs) acc = List.foldl (fn (v,acc) => (k,v)::acc) acc vs
   fun trav (net, acc) =
       case net of
-        LF d => Redblackmap.foldl cons' acc d
-      | ND d => let
-          fun foldthis (k,v,acc) = trav(v,acc)
-        in
-          Redblackmap.foldl foldthis acc d
-        end
+        LF d => KeyTab.fold cons' d acc
+      | ND d => LabelTab.fold (fn (_,v) => fn acc => trav(v,acc)) d acc
       | EMPTY => []
 in
   trav(net, [])
@@ -101,11 +111,13 @@ fun numItems (net, sz) = sz
 fun peek ((net,sz), k) = let
   fun trav (net, tms) =
       case (net, tms) of
-        (LF d, []) => (valOf (Redblackmap.peek(d, k)) handle Option => [])
+        (LF d, []) => (case KeyTab.lookup d k of
+                           NONE => []
+                         | SOME items => items)
       | (ND d, k::ks) => let
           val (lab, rest) = ndest_term k
         in
-          case Redblackmap.peek(d, lab) of
+          case LabelTab.lookup d lab of
             NONE => []
           | SOME n => trav(n, rest @ ks)
         end
@@ -129,9 +141,9 @@ end
 
 fun conslistItems (d, acc) = let
   fun listfold k (v,acc) = (k,v)::acc
-  fun mapfold (k,vs,acc) = List.foldl (listfold k) acc vs
+  fun mapfold (k,vs) acc = List.foldl (listfold k) acc vs
 in
-  Redblackmap.foldl mapfold acc d
+  KeyTab.fold mapfold d acc
 end
 
 fun match ((net,sz), tm) = let
@@ -140,7 +152,7 @@ fun match ((net,sz), tm) = let
         (EMPTY, _) => []
       | (LF d, []) => conslistItems (d, acc)
       | (ND d, k::ks0) => let
-          val varresult = case Redblackmap.peek(d, V 0) of
+          val varresult = case LabelTab.lookup d (V 0) of
                             NONE => acc
                           | SOME n => trav acc (n, ks0)
           val (lab, rest) = lookup_label k
@@ -149,7 +161,7 @@ fun match ((net,sz), tm) = let
             fun recurse acc n =
               if n = 0 then acc
               else
-                case Redblackmap.peek (d, V n) of
+                case LabelTab.lookup d (V n) of
                     NONE => recurse acc (n - 1)
                   | SOME m => recurse
                                 (trav acc (m, List.drop(rest, restn - n) @ ks0))
@@ -158,7 +170,7 @@ fun match ((net,sz), tm) = let
             recurse varresult (length (#2 (strip_comb k)))
           end
         in
-          case Redblackmap.peek (d, lab) of
+          case LabelTab.lookup d lab of
             NONE => varhead_results
           | SOME n => trav varhead_results (n, rest @ ks0)
         end
@@ -170,28 +182,30 @@ end
 fun delete ((net,sz), k) = let
   fun trav (p as (net, ks)) =
       case p of
-        (EMPTY, _) => raise Redblackmap.NotFound
-      | (LF d, []) => let
-          val (d',removed) = Redblackmap.remove(d, k)
-        in
-          if Redblackmap.numItems d' = 0 then (NONE, removed)
-          else (SOME (LF d'), removed)
-        end
+        (EMPTY, _) => raise NotFound
+      | (LF d, []) =>
+        (case KeyTab.lookup d k of
+             NONE => raise NotFound
+           | SOME removed =>
+             let val d' = KeyTab.delete k d
+             in if KeyTab.size d' = 0 then (NONE, removed)
+                else (SOME (LF d'), removed)
+             end)
       | (ND d, k::ks) => let
           val (lab, rest) = ndest_term k
         in
-          case Redblackmap.peek(d, lab) of
-            NONE => raise Redblackmap.NotFound
+          case LabelTab.lookup d lab of
+            NONE => raise NotFound
           | SOME n => let
             in
               case trav (n, rest @ ks) of
                 (NONE, removed) => let
-                  val (d',_) = Redblackmap.remove(d, lab)
+                  val d' = LabelTab.delete lab d
                 in
-                  if Redblackmap.numItems d' = 0 then (NONE, removed)
+                  if LabelTab.size d' = 0 then (NONE, removed)
                   else (SOME (ND d'), removed)
                 end
-              | (SOME n', removed) => (SOME (ND (Redblackmap.insert(d,lab,n'))),
+              | (SOME n', removed) => (SOME (ND (LabelTab.update (lab, n') d)),
                                        removed)
             end
         end
@@ -205,8 +219,8 @@ end
 fun app f (net, sz) = let
   fun trav n =
       case n of
-        LF d => Redblackmap.app f d
-      | ND d => Redblackmap.app (fn (lab, n) => trav n) d
+        LF d => List.app f (KeyTab.dest d)
+      | ND d => List.app (fn (_, n) => trav n) (LabelTab.dest d)
       | EMPTY => ()
 in
   trav net
@@ -214,36 +228,36 @@ end
 
 fun consfoldl f acc d = let
   fun listfold k (d, acc) = f (k, d, acc)
-  fun mapfold (k,vs,acc) = List.foldl (listfold k) acc vs
+  fun mapfold (k,vs) acc = List.foldl (listfold k) acc vs
 in
-  Redblackmap.foldl mapfold acc d
+  KeyTab.fold mapfold d acc
 end
 
 fun fold f acc (net, sz) = let
   fun trav acc n =
       case n of
         LF d => consfoldl f acc d
-      | ND d => Redblackmap.foldl (fn (lab,n',acc) => trav acc n') acc d
+      | ND d => LabelTab.fold (fn (_,n') => fn acc => trav acc n') d acc
       | EMPTY => acc
 in
   trav acc net
 end
 
 fun consmap f d = let
-  fun foldthis (k,vs,acc) = let
+  fun foldthis (k,vs) acc = let
     val bs = map (fn v => f(k,v)) vs
   in
-    Redblackmap.insert(acc,k,bs)
+    KeyTab.update (k, bs) acc
   end
 in
-  Redblackmap.foldl foldthis (Redblackmap.mkDict tlt_compare) d
+  KeyTab.fold foldthis d KeyTab.empty
 end
 
 fun map f (net, sz) = let
   fun trav n =
       case n of
         LF d => LF (consmap f d)
-      | ND d => ND (Redblackmap.transform trav d)
+      | ND d => ND (LabelTab.map (fn _ => fn n => trav n) d)
       | EMPTY => EMPTY
 in
   (trav net, sz)

--- a/src/parse/LVTermNet.sml
+++ b/src/parse/LVTermNet.sml
@@ -27,8 +27,8 @@ fun labcmp (p as (l1, l2)) =
     | (_, Lam _) => GREATER
     | (LV p1, LV p2) => pair_compare (String.compare, Int.compare) (p1, p2)
 
-datatype 'a N = LF of (key,'a list) HOLdict.dict
-              | ND of (label,'a N) HOLdict.dict
+datatype 'a N = LF of (key,'a list) Redblackmap.dict
+              | ND of (label,'a N) Redblackmap.dict
               | EMPTY
 (* redundant EMPTY constructor is used to get around value polymorphism problem
    when creating a single value for empty below *)
@@ -37,7 +37,7 @@ type 'a lvtermnet = 'a N * int
 
 val empty = (EMPTY, 0)
 
-fun mkempty () = ND (HOLdict.mkDict labcmp)
+fun mkempty () = ND (Redblackmap.mkDict labcmp)
 
 fun ndest_term (fvs, tm) = let
   val (f, args) = strip_comb tm
@@ -53,14 +53,14 @@ in
 end
 
 fun cons_insert (bmap, k, i) =
-    case HOLdict.peek(bmap,k) of
-      NONE => HOLdict.insert(bmap,k,[i])
-    | SOME items => HOLdict.insert(bmap,k,i::items)
+    case Redblackmap.peek(bmap,k) of
+      NONE => Redblackmap.insert(bmap,k,[i])
+    | SOME items => Redblackmap.insert(bmap,k,i::items)
 
 fun insert ((net,sz), k, item) = let
   fun newnode labs =
       case labs of
-        [] => LF (HOLdict.mkDict tlt_compare)
+        [] => LF (Redblackmap.mkDict tlt_compare)
       | _ => mkempty()
   fun trav (net, tms) =
       case (net, tms) of
@@ -69,11 +69,11 @@ fun insert ((net,sz), k, item) = let
           val (lab, rest) = ndest_term k
           val ks = rest @ ks0
           val n' =
-              case HOLdict.peek(d,lab) of
+              case Redblackmap.peek(d,lab) of
                 NONE => trav(newnode ks, ks)
               | SOME n => trav(n, ks)
         in
-          ND (HOLdict.insert(d, lab, n'))
+          ND (Redblackmap.insert(d, lab, n'))
         end
       | (EMPTY, ks) => trav(mkempty(), ks)
       | _ => raise Fail "LVTermNet.insert: catastrophic invariant failure"
@@ -85,11 +85,11 @@ fun listItems (net, sz) = let
   fun cons'(k,vs,acc) = List.foldl (fn (v,acc) => (k,v)::acc) acc vs
   fun trav (net, acc) =
       case net of
-        LF d => HOLdict.foldl cons' acc d
+        LF d => Redblackmap.foldl cons' acc d
       | ND d => let
           fun foldthis (k,v,acc) = trav(v,acc)
         in
-          HOLdict.foldl foldthis acc d
+          Redblackmap.foldl foldthis acc d
         end
       | EMPTY => []
 in
@@ -101,11 +101,11 @@ fun numItems (net, sz) = sz
 fun peek ((net,sz), k) = let
   fun trav (net, tms) =
       case (net, tms) of
-        (LF d, []) => (valOf (HOLdict.peek(d, k)) handle Option => [])
+        (LF d, []) => (valOf (Redblackmap.peek(d, k)) handle Option => [])
       | (ND d, k::ks) => let
           val (lab, rest) = ndest_term k
         in
-          case HOLdict.peek(d, lab) of
+          case Redblackmap.peek(d, lab) of
             NONE => []
           | SOME n => trav(n, rest @ ks)
         end
@@ -131,7 +131,7 @@ fun conslistItems (d, acc) = let
   fun listfold k (v,acc) = (k,v)::acc
   fun mapfold (k,vs,acc) = List.foldl (listfold k) acc vs
 in
-  HOLdict.foldl mapfold acc d
+  Redblackmap.foldl mapfold acc d
 end
 
 fun match ((net,sz), tm) = let
@@ -140,7 +140,7 @@ fun match ((net,sz), tm) = let
         (EMPTY, _) => []
       | (LF d, []) => conslistItems (d, acc)
       | (ND d, k::ks0) => let
-          val varresult = case HOLdict.peek(d, V 0) of
+          val varresult = case Redblackmap.peek(d, V 0) of
                             NONE => acc
                           | SOME n => trav acc (n, ks0)
           val (lab, rest) = lookup_label k
@@ -149,7 +149,7 @@ fun match ((net,sz), tm) = let
             fun recurse acc n =
               if n = 0 then acc
               else
-                case HOLdict.peek (d, V n) of
+                case Redblackmap.peek (d, V n) of
                     NONE => recurse acc (n - 1)
                   | SOME m => recurse
                                 (trav acc (m, List.drop(rest, restn - n) @ ks0))
@@ -158,7 +158,7 @@ fun match ((net,sz), tm) = let
             recurse varresult (length (#2 (strip_comb k)))
           end
         in
-          case HOLdict.peek (d, lab) of
+          case Redblackmap.peek (d, lab) of
             NONE => varhead_results
           | SOME n => trav varhead_results (n, rest @ ks0)
         end
@@ -170,28 +170,28 @@ end
 fun delete ((net,sz), k) = let
   fun trav (p as (net, ks)) =
       case p of
-        (EMPTY, _) => raise HOLdict.NotFound
+        (EMPTY, _) => raise Redblackmap.NotFound
       | (LF d, []) => let
-          val (d',removed) = HOLdict.remove(d, k)
+          val (d',removed) = Redblackmap.remove(d, k)
         in
-          if HOLdict.numItems d' = 0 then (NONE, removed)
+          if Redblackmap.numItems d' = 0 then (NONE, removed)
           else (SOME (LF d'), removed)
         end
       | (ND d, k::ks) => let
           val (lab, rest) = ndest_term k
         in
-          case HOLdict.peek(d, lab) of
-            NONE => raise HOLdict.NotFound
+          case Redblackmap.peek(d, lab) of
+            NONE => raise Redblackmap.NotFound
           | SOME n => let
             in
               case trav (n, rest @ ks) of
                 (NONE, removed) => let
-                  val (d',_) = HOLdict.remove(d, lab)
+                  val (d',_) = Redblackmap.remove(d, lab)
                 in
-                  if HOLdict.numItems d' = 0 then (NONE, removed)
+                  if Redblackmap.numItems d' = 0 then (NONE, removed)
                   else (SOME (ND d'), removed)
                 end
-              | (SOME n', removed) => (SOME (ND (HOLdict.insert(d,lab,n'))),
+              | (SOME n', removed) => (SOME (ND (Redblackmap.insert(d,lab,n'))),
                                        removed)
             end
         end
@@ -205,8 +205,8 @@ end
 fun app f (net, sz) = let
   fun trav n =
       case n of
-        LF d => HOLdict.app f d
-      | ND d => HOLdict.app (fn (lab, n) => trav n) d
+        LF d => Redblackmap.app f d
+      | ND d => Redblackmap.app (fn (lab, n) => trav n) d
       | EMPTY => ()
 in
   trav net
@@ -216,14 +216,14 @@ fun consfoldl f acc d = let
   fun listfold k (d, acc) = f (k, d, acc)
   fun mapfold (k,vs,acc) = List.foldl (listfold k) acc vs
 in
-  HOLdict.foldl mapfold acc d
+  Redblackmap.foldl mapfold acc d
 end
 
 fun fold f acc (net, sz) = let
   fun trav acc n =
       case n of
         LF d => consfoldl f acc d
-      | ND d => HOLdict.foldl (fn (lab,n',acc) => trav acc n') acc d
+      | ND d => Redblackmap.foldl (fn (lab,n',acc) => trav acc n') acc d
       | EMPTY => acc
 in
   trav acc net
@@ -233,17 +233,17 @@ fun consmap f d = let
   fun foldthis (k,vs,acc) = let
     val bs = map (fn v => f(k,v)) vs
   in
-    HOLdict.insert(acc,k,bs)
+    Redblackmap.insert(acc,k,bs)
   end
 in
-  HOLdict.foldl foldthis (HOLdict.mkDict tlt_compare) d
+  Redblackmap.foldl foldthis (Redblackmap.mkDict tlt_compare) d
 end
 
 fun map f (net, sz) = let
   fun trav n =
       case n of
         LF d => LF (consmap f d)
-      | ND d => ND (HOLdict.transform trav d)
+      | ND d => ND (Redblackmap.transform trav d)
       | EMPTY => EMPTY
 in
   (trav net, sz)

--- a/src/parse/LVTermNetFunctor.sml
+++ b/src/parse/LVTermNetFunctor.sml
@@ -17,6 +17,7 @@ sig
   type key = Term.term list * Term.term
   type value
   structure Set : LVSET where type value = value
+  exception NotFound
 
   val empty : lvtermnet
   val insert : (lvtermnet * key * value) -> lvtermnet
@@ -24,7 +25,7 @@ sig
   val peek : lvtermnet * key -> Set.t
   val match : lvtermnet * term -> (key * value) list
 
-  val delete : lvtermnet * key -> lvtermnet * Set.t
+  val delete : lvtermnet * key -> lvtermnet * Set.t  (* raises NotFound *)
   val numItems : lvtermnet -> int
   val listItems : lvtermnet -> (key * value) list
   val app : (key * Set.t -> unit) -> lvtermnet -> unit
@@ -36,6 +37,8 @@ functor LVTermNetFunctor(S : LVSET) : LV_TERM_NET =
 struct
 
 open HolKernel
+
+exception NotFound
 
 datatype label = V of int
                | C of {Name : string, Thy : string} * int
@@ -63,12 +66,24 @@ fun labcmp (p as (l1, l2)) =
     | (_, Lam _) => GREATER
     | (LV p1, LV p2) => pair_compare (String.compare, Int.compare) (p1, p2)
 
-datatype N = LF of (key,S.t) Redblackmap.dict
-           | ND of (label,N) Redblackmap.dict
+structure KeyTab = Table(struct
+  type key = term list * term
+  val ord = tlt_compare
+  fun pp _ = HOLPP.add_string "<lvtm-key>"
+end)
+
+structure LabelTab = Table(struct
+  type key = label
+  val ord = labcmp
+  fun pp _ = HOLPP.add_string "<lvtm-label>"
+end)
+
+datatype N = LF of S.t KeyTab.table
+           | ND of N LabelTab.table
 
 type lvtermnet = N * int
 
-val empty_node = ND (Redblackmap.mkDict labcmp)
+val empty_node = ND LabelTab.empty
 val empty = (empty_node, 0)
 
 fun ndest_term (fvs, tm) = let
@@ -85,14 +100,14 @@ in
 end
 
 fun cons_insert (bmap, k, i) =
-    case Redblackmap.peek(bmap,k) of
-      NONE => Redblackmap.insert(bmap,k,S.insert(S.empty,i))
-    | SOME items => Redblackmap.insert(bmap,k,S.insert(items, i))
+    case KeyTab.lookup bmap k of
+      NONE => KeyTab.update (k, S.insert(S.empty,i)) bmap
+    | SOME items => KeyTab.update (k, S.insert(items, i)) bmap
 
 fun insert ((net,sz), k, item) = let
   fun newnode labs =
       case labs of
-        [] => LF (Redblackmap.mkDict tlt_compare)
+        [] => LF KeyTab.empty
       | _ => empty_node
   fun trav (net, tms) =
       case (net, tms) of
@@ -101,11 +116,11 @@ fun insert ((net,sz), k, item) = let
           val (lab, rest) = ndest_term k
           val ks = rest @ ks0
           val n' =
-              case Redblackmap.peek(d,lab) of
+              case LabelTab.lookup d lab of
                 NONE => trav(newnode ks, ks)
               | SOME n => trav(n, ks)
         in
-          ND (Redblackmap.insert(d, lab, n'))
+          ND (LabelTab.update (lab, n') d)
         end
       | _ => raise Fail "LVTermNet.insert: catastrophic invariant failure"
 in
@@ -113,15 +128,11 @@ in
 end
 
 fun listItems (net, sz) = let
-  fun cons'(k,vs,acc) = S.fold (fn (v,acc) => (k,v)::acc) acc vs
+  fun cons' (k,vs) acc = S.fold (fn (v,acc) => (k,v)::acc) acc vs
   fun trav (net, acc) =
       case net of
-        LF d => Redblackmap.foldl cons' acc d
-      | ND d => let
-          fun foldthis (k,v,acc) = trav(v,acc)
-        in
-          Redblackmap.foldl foldthis acc d
-        end
+        LF d => KeyTab.fold cons' d acc
+      | ND d => LabelTab.fold (fn (_,v) => fn acc => trav(v,acc)) d acc
 in
   trav(net, [])
 end
@@ -131,11 +142,13 @@ fun numItems (net, sz) = sz
 fun peek ((net,sz), k) = let
   fun trav (net, tms) =
       case (net, tms) of
-        (LF d, []) => (valOf (Redblackmap.peek(d, k)) handle Option => S.empty)
+        (LF d, []) => (case KeyTab.lookup d k of
+                           NONE => S.empty
+                         | SOME items => items)
       | (ND d, k::ks) => let
           val (lab, rest) = ndest_term k
         in
-          case Redblackmap.peek(d, lab) of
+          case LabelTab.lookup d lab of
             NONE => S.empty
           | SOME n => trav(n, rest @ ks)
         end
@@ -158,9 +171,9 @@ end
 
 fun conslistItems (d, acc) = let
   fun listfold k (v,acc) = (k,v)::acc
-  fun mapfold (k,vs,acc) = S.fold (listfold k) acc vs
+  fun mapfold (k,vs) acc = S.fold (listfold k) acc vs
 in
-  Redblackmap.foldl mapfold acc d
+  KeyTab.fold mapfold d acc
 end
 
 fun match ((net,sz), tm) = let
@@ -168,7 +181,7 @@ fun match ((net,sz), tm) = let
       case (net, ks) of
         (LF d, []) => conslistItems (d, acc)
       | (ND d, k::ks0) => let
-          val varresult = case Redblackmap.peek(d, V 0) of
+          val varresult = case LabelTab.lookup d (V 0) of
                             NONE => acc
                           | SOME n => trav acc (n, ks0)
           val (lab, rest) = lookup_label k
@@ -177,7 +190,7 @@ fun match ((net,sz), tm) = let
             fun recurse acc n =
               if n = 0 then acc
               else
-                case Redblackmap.peek (d, V n) of
+                case LabelTab.lookup d (V n) of
                     NONE => recurse acc (n - 1)
                   | SOME m => recurse
                                 (trav acc (m, List.drop(rest, restn - n) @ ks0))
@@ -186,7 +199,7 @@ fun match ((net,sz), tm) = let
             recurse varresult (length (#2 (strip_comb k)))
           end
         in
-          case Redblackmap.peek (d, lab) of
+          case LabelTab.lookup d lab of
             NONE => varhead_results
           | SOME n => trav varhead_results (n, rest @ ks0)
         end
@@ -198,27 +211,29 @@ end
 fun delete ((net,sz), k) = let
   fun trav (p as (net, ks)) =
       case p of
-        (LF d, []) => let
-          val (d',removed) = Redblackmap.remove(d, k)
-        in
-          if Redblackmap.numItems d' = 0 then (NONE, removed)
-          else (SOME (LF d'), removed)
-        end
+        (LF d, []) =>
+        (case KeyTab.lookup d k of
+             NONE => raise NotFound
+           | SOME removed =>
+             let val d' = KeyTab.delete k d
+             in if KeyTab.size d' = 0 then (NONE, removed)
+                else (SOME (LF d'), removed)
+             end)
       | (ND d, k::ks) => let
           val (lab, rest) = ndest_term k
         in
-          case Redblackmap.peek(d, lab) of
-            NONE => raise Redblackmap.NotFound
+          case LabelTab.lookup d lab of
+            NONE => raise NotFound
           | SOME n => let
             in
               case trav (n, rest @ ks) of
                 (NONE, removed) => let
-                  val (d',_) = Redblackmap.remove(d, lab)
+                  val d' = LabelTab.delete lab d
                 in
-                  if Redblackmap.numItems d' = 0 then (NONE, removed)
+                  if LabelTab.size d' = 0 then (NONE, removed)
                   else (SOME (ND d'), removed)
                 end
-              | (SOME n', removed) => (SOME (ND (Redblackmap.insert(d,lab,n'))),
+              | (SOME n', removed) => (SOME (ND (LabelTab.update (lab, n') d)),
                                        removed)
             end
         end
@@ -232,24 +247,24 @@ end
 fun app f (net, sz) = let
   fun trav n =
       case n of
-        LF d => Redblackmap.app f d
-      | ND d => Redblackmap.app (fn (lab, n) => trav n) d
+        LF d => List.app f (KeyTab.dest d)
+      | ND d => List.app (fn (_, n) => trav n) (LabelTab.dest d)
 in
   trav net
 end
 
 fun consfoldl f acc d = let
   fun setfold k (d, acc) = f (k, d, acc)
-  fun mapfold (k,vs,acc) = S.fold (setfold k) acc vs
+  fun mapfold (k,vs) acc = S.fold (setfold k) acc vs
 in
-  Redblackmap.foldl mapfold acc d
+  KeyTab.fold mapfold d acc
 end
 
 fun fold f acc (net, sz) = let
   fun trav acc n =
       case n of
         LF d => consfoldl f acc d
-      | ND d => Redblackmap.foldl (fn (lab,n',acc) => trav acc n') acc d
+      | ND d => LabelTab.fold (fn (_,n') => fn acc => trav acc n') d acc
 in
   trav acc net
 end

--- a/src/parse/LVTermNetFunctor.sml
+++ b/src/parse/LVTermNetFunctor.sml
@@ -11,7 +11,7 @@ end
 signature LV_TERM_NET =
 sig
 
-  (* signature names modelled on HOLdict's *)
+  (* signature names modelled on Redblackmap's *)
   type lvtermnet
   type term = Term.term
   type key = Term.term list * Term.term
@@ -63,12 +63,12 @@ fun labcmp (p as (l1, l2)) =
     | (_, Lam _) => GREATER
     | (LV p1, LV p2) => pair_compare (String.compare, Int.compare) (p1, p2)
 
-datatype N = LF of (key,S.t) HOLdict.dict
-           | ND of (label,N) HOLdict.dict
+datatype N = LF of (key,S.t) Redblackmap.dict
+           | ND of (label,N) Redblackmap.dict
 
 type lvtermnet = N * int
 
-val empty_node = ND (HOLdict.mkDict labcmp)
+val empty_node = ND (Redblackmap.mkDict labcmp)
 val empty = (empty_node, 0)
 
 fun ndest_term (fvs, tm) = let
@@ -85,14 +85,14 @@ in
 end
 
 fun cons_insert (bmap, k, i) =
-    case HOLdict.peek(bmap,k) of
-      NONE => HOLdict.insert(bmap,k,S.insert(S.empty,i))
-    | SOME items => HOLdict.insert(bmap,k,S.insert(items, i))
+    case Redblackmap.peek(bmap,k) of
+      NONE => Redblackmap.insert(bmap,k,S.insert(S.empty,i))
+    | SOME items => Redblackmap.insert(bmap,k,S.insert(items, i))
 
 fun insert ((net,sz), k, item) = let
   fun newnode labs =
       case labs of
-        [] => LF (HOLdict.mkDict tlt_compare)
+        [] => LF (Redblackmap.mkDict tlt_compare)
       | _ => empty_node
   fun trav (net, tms) =
       case (net, tms) of
@@ -101,11 +101,11 @@ fun insert ((net,sz), k, item) = let
           val (lab, rest) = ndest_term k
           val ks = rest @ ks0
           val n' =
-              case HOLdict.peek(d,lab) of
+              case Redblackmap.peek(d,lab) of
                 NONE => trav(newnode ks, ks)
               | SOME n => trav(n, ks)
         in
-          ND (HOLdict.insert(d, lab, n'))
+          ND (Redblackmap.insert(d, lab, n'))
         end
       | _ => raise Fail "LVTermNet.insert: catastrophic invariant failure"
 in
@@ -116,11 +116,11 @@ fun listItems (net, sz) = let
   fun cons'(k,vs,acc) = S.fold (fn (v,acc) => (k,v)::acc) acc vs
   fun trav (net, acc) =
       case net of
-        LF d => HOLdict.foldl cons' acc d
+        LF d => Redblackmap.foldl cons' acc d
       | ND d => let
           fun foldthis (k,v,acc) = trav(v,acc)
         in
-          HOLdict.foldl foldthis acc d
+          Redblackmap.foldl foldthis acc d
         end
 in
   trav(net, [])
@@ -131,11 +131,11 @@ fun numItems (net, sz) = sz
 fun peek ((net,sz), k) = let
   fun trav (net, tms) =
       case (net, tms) of
-        (LF d, []) => (valOf (HOLdict.peek(d, k)) handle Option => S.empty)
+        (LF d, []) => (valOf (Redblackmap.peek(d, k)) handle Option => S.empty)
       | (ND d, k::ks) => let
           val (lab, rest) = ndest_term k
         in
-          case HOLdict.peek(d, lab) of
+          case Redblackmap.peek(d, lab) of
             NONE => S.empty
           | SOME n => trav(n, rest @ ks)
         end
@@ -160,7 +160,7 @@ fun conslistItems (d, acc) = let
   fun listfold k (v,acc) = (k,v)::acc
   fun mapfold (k,vs,acc) = S.fold (listfold k) acc vs
 in
-  HOLdict.foldl mapfold acc d
+  Redblackmap.foldl mapfold acc d
 end
 
 fun match ((net,sz), tm) = let
@@ -168,7 +168,7 @@ fun match ((net,sz), tm) = let
       case (net, ks) of
         (LF d, []) => conslistItems (d, acc)
       | (ND d, k::ks0) => let
-          val varresult = case HOLdict.peek(d, V 0) of
+          val varresult = case Redblackmap.peek(d, V 0) of
                             NONE => acc
                           | SOME n => trav acc (n, ks0)
           val (lab, rest) = lookup_label k
@@ -177,7 +177,7 @@ fun match ((net,sz), tm) = let
             fun recurse acc n =
               if n = 0 then acc
               else
-                case HOLdict.peek (d, V n) of
+                case Redblackmap.peek (d, V n) of
                     NONE => recurse acc (n - 1)
                   | SOME m => recurse
                                 (trav acc (m, List.drop(rest, restn - n) @ ks0))
@@ -186,7 +186,7 @@ fun match ((net,sz), tm) = let
             recurse varresult (length (#2 (strip_comb k)))
           end
         in
-          case HOLdict.peek (d, lab) of
+          case Redblackmap.peek (d, lab) of
             NONE => varhead_results
           | SOME n => trav varhead_results (n, rest @ ks0)
         end
@@ -199,26 +199,26 @@ fun delete ((net,sz), k) = let
   fun trav (p as (net, ks)) =
       case p of
         (LF d, []) => let
-          val (d',removed) = HOLdict.remove(d, k)
+          val (d',removed) = Redblackmap.remove(d, k)
         in
-          if HOLdict.numItems d' = 0 then (NONE, removed)
+          if Redblackmap.numItems d' = 0 then (NONE, removed)
           else (SOME (LF d'), removed)
         end
       | (ND d, k::ks) => let
           val (lab, rest) = ndest_term k
         in
-          case HOLdict.peek(d, lab) of
-            NONE => raise HOLdict.NotFound
+          case Redblackmap.peek(d, lab) of
+            NONE => raise Redblackmap.NotFound
           | SOME n => let
             in
               case trav (n, rest @ ks) of
                 (NONE, removed) => let
-                  val (d',_) = HOLdict.remove(d, lab)
+                  val (d',_) = Redblackmap.remove(d, lab)
                 in
-                  if HOLdict.numItems d' = 0 then (NONE, removed)
+                  if Redblackmap.numItems d' = 0 then (NONE, removed)
                   else (SOME (ND d'), removed)
                 end
-              | (SOME n', removed) => (SOME (ND (HOLdict.insert(d,lab,n'))),
+              | (SOME n', removed) => (SOME (ND (Redblackmap.insert(d,lab,n'))),
                                        removed)
             end
         end
@@ -232,8 +232,8 @@ end
 fun app f (net, sz) = let
   fun trav n =
       case n of
-        LF d => HOLdict.app f d
-      | ND d => HOLdict.app (fn (lab, n) => trav n) d
+        LF d => Redblackmap.app f d
+      | ND d => Redblackmap.app (fn (lab, n) => trav n) d
 in
   trav net
 end
@@ -242,14 +242,14 @@ fun consfoldl f acc d = let
   fun setfold k (d, acc) = f (k, d, acc)
   fun mapfold (k,vs,acc) = S.fold (setfold k) acc vs
 in
-  HOLdict.foldl mapfold acc d
+  Redblackmap.foldl mapfold acc d
 end
 
 fun fold f acc (net, sz) = let
   fun trav acc n =
       case n of
         LF d => consfoldl f acc d
-      | ND d => HOLdict.foldl (fn (lab,n',acc) => trav acc n') acc d
+      | ND d => Redblackmap.foldl (fn (lab,n',acc) => trav acc n') acc d
 in
   trav acc net
 end

--- a/src/parse/Overload.sml
+++ b/src/parse/Overload.sml
@@ -62,17 +62,16 @@ end
 structure PrintMap = LVTermNetFunctor(PMDataSet)
 
 type overload_info =
-     ((string,overloaded_op_info) Redblackmap.dict * PrintMap.lvtermnet)
+     (overloaded_op_info Symtab.table * PrintMap.lvtermnet)
 
 fun raw_print_map ((x,y):overload_info) = y
 
 fun nthy_rec_cmp ({Name = n1, Thy = thy1}, {Name = n2, Thy = thy2}) =
     pair_compare (String.compare, String.compare) ((thy1, n1), (thy2, n2))
 
-val null_oinfo : overload_info =
-  (Redblackmap.mkDict String.compare, PrintMap.empty)
+val null_oinfo : overload_info = (Symtab.empty, PrintMap.empty)
 
-fun oinfo_ops (oi,_) = Redblackmap.listItems oi
+fun oinfo_ops (oi,_) = Symtab.dest oi
 fun print_map (_, pm) = let
   fun foldthis (_,(t,nm,_),acc) =
       if Theory.uptodate_term t then
@@ -188,14 +187,13 @@ fun fupd_base_type f {base_type, actual_ops, tyavoids} =
 fun fupd_tyavoids f {base_type, actual_ops, tyavoids} =
     {base_type = base_type, actual_ops = actual_ops, tyavoids = f tyavoids}
 
-fun fupd_dict_at_key k f dict = let
-  val (newdict, kitem) = Redblackmap.remove(dict,k)
-in
-  Redblackmap.insert(newdict,k,f kitem)
-end
+fun fupd_dict_at_key k f dict =
+    case Symtab.lookup dict k of
+        SOME kitem => Symtab.update (k, f kitem) dict
+      | NONE => raise Option
 
 fun info_for_name (overloads:overload_info) s =
-  Redblackmap.peek (#1 overloads, s)
+  Symtab.lookup (#1 overloads) s
 fun is_overloaded (overloads:overload_info) s =
   isSome (info_for_name overloads s)
 
@@ -212,8 +210,10 @@ end
 
 fun remove_overloaded_form s (oinfo:overload_info) = let
   val (op2cnst, cnst2op) = oinfo
-  val (okopc, badopc0) = (I ## #actual_ops) (Redblackmap.remove(op2cnst, s))
-    handle Redblackmap.NotFound => (op2cnst, [])
+  val (okopc, badopc0) =
+      case Symtab.lookup op2cnst s of
+          NONE => (op2cnst, [])
+        | SOME info => (Symtab.delete s op2cnst, #actual_ops info)
   val badopc = List.filter Theory.uptodate_term badopc0
   (* will keep okopc, but should now remove from cnst2op all pairs of the form
        (c, s)
@@ -248,11 +248,11 @@ in
   | (r::rs) => let
       val au = foldl (fn (r1, t) => anti_unify (type_of r1) t) (type_of r) rs
     in
-      (Redblackmap.insert
-         (op2c_map, s,
-          {base_type = au, actual_ops = withtypes,
-           tyavoids = tmlist_tyvs (HOLset.listItems
-                                     (FVL withtypes empty_tmset))}),
+      (Symtab.update
+         (s, {base_type = au, actual_ops = withtypes,
+              tyavoids = tmlist_tyvs (HOLset.listItems
+                                        (FVL withtypes empty_tmset))})
+         op2c_map,
        new_c2op_map)
     end
 end
@@ -298,10 +298,10 @@ fun add_overloading_with_inserter {inserter_opt, tstamp_opt} (opname, term) oinf
                       (tmlist_tyvs (free_varsl actual_ops), au_tml actual_ops)
                     else (tyavoids, base_type)
               in
-                Redblackmap.insert(opc0, opname,
-                                 {actual_ops = inserter(term,rest),
-                                  base_type = base_type,
-                                  tyavoids = avoids})
+                Symtab.update
+                  (opname, {actual_ops = inserter(term,rest),
+                            base_type = base_type,
+                            tyavoids = avoids}) opc0
               end
             | NONE => let
                 (* Wasn't in the map, so can just cons its record in *)
@@ -313,17 +313,17 @@ fun add_overloading_with_inserter {inserter_opt, tstamp_opt} (opname, term) oinf
                       (anti_unify base_type (type_of term),
                        Lib.union (tmlist_tyvs (free_vars term)) tyavoids)
               in
-                Redblackmap.insert(opc0, opname,
-                                 {actual_ops = inserter(term,actual_ops),
-                                  base_type = newbase,
-                                  tyavoids = new_avoids})
+                Symtab.update
+                  (opname, {actual_ops = inserter(term,actual_ops),
+                            base_type = newbase,
+                            tyavoids = new_avoids}) opc0
               end
           end
         | (SOME _, NONE) =>
           (* this name not overloaded at all *)
-          Redblackmap.insert(opc0, opname,
-                           {actual_ops = [term], base_type = type_of term,
-                            tyavoids = tmlist_tyvs (free_vars term)})
+          Symtab.update
+            (opname, {actual_ops = [term], base_type = type_of term,
+                      tyavoids = tmlist_tyvs (free_vars term)}) opc0
   val cop =
       case tstamp_opt of
           NONE => cop0
@@ -373,10 +373,10 @@ local
           in
             case List.find (aconv cnst) actual_ops of
               SOME x => (* the constant is in the map *)
-                Redblackmap.insert(opc0, opname,
-                  {actual_ops = f (aconv cnst) actual_ops,
-                   base_type = base_type,
-                   tyavoids = tyavoids})
+                Symtab.update
+                  (opname, {actual_ops = f (aconv cnst) actual_ops,
+                            base_type = base_type,
+                            tyavoids = tyavoids}) opc0
             | NONE => raise OVERLOAD_ERR
                         ("Constant not overloaded: "^realthy^"$"^realname)
           end
@@ -502,8 +502,8 @@ val _ = Feedback.register_btrace ("show_alias_printing_choices",
                                   show_alias_resolution)
 
 fun merge_oinfos (O1:overload_info) (O2:overload_info) : overload_info = let
-  val O1ops_sorted = Redblackmap.listItems (#1 O1)
-  val O2ops_sorted = Redblackmap.listItems (#1 O2)
+  val O1ops_sorted = Symtab.dest (#1 O1)
+  val O2ops_sorted = Symtab.dest (#1 O2)
   fun merge acc op1s op2s =
     case (op1s, op2s) of
       ([], x) => rev_append acc x
@@ -534,24 +534,26 @@ fun merge_oinfos (O1:overload_info) (O2:overload_info) : overload_info = let
         else acc
     val new_prmap = PrintMap.fold foldthis (#2 O2) (#2 O1)
 in
-  (List.foldr (fn ((k,v),dict) => Redblackmap.insert(dict,k,v))
-              (Redblackmap.mkDict String.compare)
+  (List.foldr (fn ((k,v),dict) => Symtab.update (k,v) dict)
+              Symtab.empty
               (merge [] O1ops_sorted O2ops_sorted),
    new_prmap)
 end
 
-fun keys dict = Redblackmap.foldr (fn (k,v,l) => k::l) [] dict
+fun known_constants (oi:overload_info) = Symtab.keys (#1 oi)
 
-fun known_constants (oi:overload_info) = keys (#1 oi)
-
-fun remove_omapping t str opdict = let
-  val (dictlessk, kitem) = Redblackmap.remove(opdict, str)
-  fun ok_actual t' = not (aconv t' t)
-  val new_rec = fupd_actual_ops (List.filter ok_actual) kitem
-in
-  if (null (#actual_ops new_rec)) then dictlessk
-  else Redblackmap.insert(dictlessk, str, new_rec)
-end handle Redblackmap.NotFound => opdict
+fun remove_omapping t str opdict =
+    case Symtab.lookup opdict str of
+        NONE => opdict
+      | SOME kitem =>
+        let
+          fun ok_actual t' = not (aconv t' t)
+          val new_rec = fupd_actual_ops (List.filter ok_actual) kitem
+          val dictlessk = Symtab.delete str opdict
+        in
+          if (null (#actual_ops new_rec)) then dictlessk
+          else Symtab.update (str, new_rec) dictlessk
+        end
 
 fun gen_remove_mapping str t ((opc, cop) : overload_info) = let
   val cop' = let

--- a/src/parse/Overload.sml
+++ b/src/parse/Overload.sml
@@ -62,7 +62,7 @@ end
 structure PrintMap = LVTermNetFunctor(PMDataSet)
 
 type overload_info =
-     ((string,overloaded_op_info) HOLdict.dict * PrintMap.lvtermnet)
+     ((string,overloaded_op_info) Redblackmap.dict * PrintMap.lvtermnet)
 
 fun raw_print_map ((x,y):overload_info) = y
 
@@ -70,9 +70,9 @@ fun nthy_rec_cmp ({Name = n1, Thy = thy1}, {Name = n2, Thy = thy2}) =
     pair_compare (String.compare, String.compare) ((thy1, n1), (thy2, n2))
 
 val null_oinfo : overload_info =
-  (HOLdict.mkDict String.compare, PrintMap.empty)
+  (Redblackmap.mkDict String.compare, PrintMap.empty)
 
-fun oinfo_ops (oi,_) = HOLdict.listItems oi
+fun oinfo_ops (oi,_) = Redblackmap.listItems oi
 fun print_map (_, pm) = let
   fun foldthis (_,(t,nm,_),acc) =
       if Theory.uptodate_term t then
@@ -189,13 +189,13 @@ fun fupd_tyavoids f {base_type, actual_ops, tyavoids} =
     {base_type = base_type, actual_ops = actual_ops, tyavoids = f tyavoids}
 
 fun fupd_dict_at_key k f dict = let
-  val (newdict, kitem) = HOLdict.remove(dict,k)
+  val (newdict, kitem) = Redblackmap.remove(dict,k)
 in
-  HOLdict.insert(newdict,k,f kitem)
+  Redblackmap.insert(newdict,k,f kitem)
 end
 
 fun info_for_name (overloads:overload_info) s =
-  HOLdict.peek (#1 overloads, s)
+  Redblackmap.peek (#1 overloads, s)
 fun is_overloaded (overloads:overload_info) s =
   isSome (info_for_name overloads s)
 
@@ -212,8 +212,8 @@ end
 
 fun remove_overloaded_form s (oinfo:overload_info) = let
   val (op2cnst, cnst2op) = oinfo
-  val (okopc, badopc0) = (I ## #actual_ops) (HOLdict.remove(op2cnst, s))
-    handle HOLdict.NotFound => (op2cnst, [])
+  val (okopc, badopc0) = (I ## #actual_ops) (Redblackmap.remove(op2cnst, s))
+    handle Redblackmap.NotFound => (op2cnst, [])
   val badopc = List.filter Theory.uptodate_term badopc0
   (* will keep okopc, but should now remove from cnst2op all pairs of the form
        (c, s)
@@ -248,7 +248,7 @@ in
   | (r::rs) => let
       val au = foldl (fn (r1, t) => anti_unify (type_of r1) t) (type_of r) rs
     in
-      (HOLdict.insert
+      (Redblackmap.insert
          (op2c_map, s,
           {base_type = au, actual_ops = withtypes,
            tyavoids = tmlist_tyvs (HOLset.listItems
@@ -298,7 +298,7 @@ fun add_overloading_with_inserter {inserter_opt, tstamp_opt} (opname, term) oinf
                       (tmlist_tyvs (free_varsl actual_ops), au_tml actual_ops)
                     else (tyavoids, base_type)
               in
-                HOLdict.insert(opc0, opname,
+                Redblackmap.insert(opc0, opname,
                                  {actual_ops = inserter(term,rest),
                                   base_type = base_type,
                                   tyavoids = avoids})
@@ -313,7 +313,7 @@ fun add_overloading_with_inserter {inserter_opt, tstamp_opt} (opname, term) oinf
                       (anti_unify base_type (type_of term),
                        Lib.union (tmlist_tyvs (free_vars term)) tyavoids)
               in
-                HOLdict.insert(opc0, opname,
+                Redblackmap.insert(opc0, opname,
                                  {actual_ops = inserter(term,actual_ops),
                                   base_type = newbase,
                                   tyavoids = new_avoids})
@@ -321,7 +321,7 @@ fun add_overloading_with_inserter {inserter_opt, tstamp_opt} (opname, term) oinf
           end
         | (SOME _, NONE) =>
           (* this name not overloaded at all *)
-          HOLdict.insert(opc0, opname,
+          Redblackmap.insert(opc0, opname,
                            {actual_ops = [term], base_type = type_of term,
                             tyavoids = tmlist_tyvs (free_vars term)})
   val cop =
@@ -373,7 +373,7 @@ local
           in
             case List.find (aconv cnst) actual_ops of
               SOME x => (* the constant is in the map *)
-                HOLdict.insert(opc0, opname,
+                Redblackmap.insert(opc0, opname,
                   {actual_ops = f (aconv cnst) actual_ops,
                    base_type = base_type,
                    tyavoids = tyavoids})
@@ -502,8 +502,8 @@ val _ = Feedback.register_btrace ("show_alias_printing_choices",
                                   show_alias_resolution)
 
 fun merge_oinfos (O1:overload_info) (O2:overload_info) : overload_info = let
-  val O1ops_sorted = HOLdict.listItems (#1 O1)
-  val O2ops_sorted = HOLdict.listItems (#1 O2)
+  val O1ops_sorted = Redblackmap.listItems (#1 O1)
+  val O2ops_sorted = Redblackmap.listItems (#1 O2)
   fun merge acc op1s op2s =
     case (op1s, op2s) of
       ([], x) => rev_append acc x
@@ -534,24 +534,24 @@ fun merge_oinfos (O1:overload_info) (O2:overload_info) : overload_info = let
         else acc
     val new_prmap = PrintMap.fold foldthis (#2 O2) (#2 O1)
 in
-  (List.foldr (fn ((k,v),dict) => HOLdict.insert(dict,k,v))
-              (HOLdict.mkDict String.compare)
+  (List.foldr (fn ((k,v),dict) => Redblackmap.insert(dict,k,v))
+              (Redblackmap.mkDict String.compare)
               (merge [] O1ops_sorted O2ops_sorted),
    new_prmap)
 end
 
-fun keys dict = HOLdict.foldr (fn (k,v,l) => k::l) [] dict
+fun keys dict = Redblackmap.foldr (fn (k,v,l) => k::l) [] dict
 
 fun known_constants (oi:overload_info) = keys (#1 oi)
 
 fun remove_omapping t str opdict = let
-  val (dictlessk, kitem) = HOLdict.remove(opdict, str)
+  val (dictlessk, kitem) = Redblackmap.remove(opdict, str)
   fun ok_actual t' = not (aconv t' t)
   val new_rec = fupd_actual_ops (List.filter ok_actual) kitem
 in
   if (null (#actual_ops new_rec)) then dictlessk
-  else HOLdict.insert(dictlessk, str, new_rec)
-end handle HOLdict.NotFound => opdict
+  else Redblackmap.insert(dictlessk, str, new_rec)
+end handle Redblackmap.NotFound => opdict
 
 fun gen_remove_mapping str t ((opc, cop) : overload_info) = let
   val cop' = let

--- a/src/parse/PPBackEnd.sml
+++ b/src/parse/PPBackEnd.sml
@@ -28,14 +28,16 @@ type output_colors = {
 (* Full styles                      *)
 (* -------------------------------- *)
 
-val UserStyle_dict = ref
-   (Redblackmap.mkDict String.compare:
-     (string, pp_style list * (string * pp_style list) list) Redblackmap.dict)
+val UserStyle_dict :
+    (pp_style list * (string * pp_style list) list) Symtab.table ref =
+    ref Symtab.empty
 
 fun register_UserStyle backendOpt sty stL =
 let
    val (default_stL, bstL) =
-       Redblackmap.find (!UserStyle_dict, sty) handle NotFound => (stL,[])
+       case Symtab.lookup (!UserStyle_dict) sty of
+           SOME entry => entry
+         | NONE => (stL, [])
 
    val default_stL = if isSome(backendOpt) then default_stL else stL
    val bstL = if isSome(backendOpt) then
@@ -44,23 +46,24 @@ let
 
    val _ =
        UserStyle_dict :=
-       Redblackmap.insert (!UserStyle_dict, sty, (default_stL, bstL))
+       Symtab.update (sty, (default_stL, bstL)) (!UserStyle_dict)
 in
    ()
 end;
 
 fun lookup_UserStyle backend sty =
 let
-   val (default_stL, bstL) = Redblackmap.find (!UserStyle_dict, sty)
-       handle NotFound =>
-       (register_UserStyle NONE sty []; ([],[]))
+   val (default_stL, bstL) =
+       case Symtab.lookup (!UserStyle_dict) sty of
+           SOME entry => entry
+         | NONE => (register_UserStyle NONE sty []; ([],[]))
    val styL = Lib.assoc backend bstL handle Feedback.HOL_ERR _ => default_stL
 in
    styL
 end
 
 fun known_UserStyles () =
-   map Lib.fst (Redblackmap.listItems (!UserStyle_dict))
+   map Lib.fst (Symtab.dest (!UserStyle_dict))
 
 
 (* fullstyle:

--- a/src/parse/Pretype.sml
+++ b/src/parse/Pretype.sml
@@ -9,12 +9,12 @@ val TCERR = mk_HOL_ERR "Pretype";
 
 structure Env =
 struct
-  type t = ((int,pretype) Binarymap.dict * int)
-  fun lookup (d,c) i = Binarymap.peek(d,i)
-  fun update (i,pty) (d,c) = (Binarymap.insert(d,i,pty), c)
-  val empty : t = (Binarymap.mkDict Int.compare, 0)
+  type t = (pretype Inttab.table * int)
+  fun lookup (d,c) i = Inttab.lookup d i
+  fun update (i,pty) (d,c) = (Inttab.update (i,pty) d, c)
+  val empty : t = (Inttab.empty, 0)
   fun new (d,c) = ((d,c+1), c)
-  fun toList (d,c) = List.tabulate(c, fn i => (i, Binarymap.peek(d,i)))
+  fun toList (d,c) = List.tabulate(c, fn i => (i, Inttab.lookup d i))
 end
 
 open typecheck_error

--- a/src/parse/TypeNet.sig
+++ b/src/parse/TypeNet.sig
@@ -4,14 +4,15 @@ sig
   (* signature names modelled on Redblackmap's *)
   type 'a typenet
   type hol_type = Type.hol_type
+  exception NotFound
 
   val empty : 'a typenet
   val insert : ('a typenet * hol_type * 'a) -> 'a typenet
-  val find : 'a typenet * hol_type -> 'a
+  val find : 'a typenet * hol_type -> 'a   (* raises NotFound *)
   val peek : 'a typenet * hol_type -> 'a option
   val match : 'a typenet * hol_type -> (hol_type * 'a) list
 
-  val delete : 'a typenet * hol_type -> 'a typenet * 'a
+  val delete : 'a typenet * hol_type -> 'a typenet * 'a   (* raises NotFound *)
   val numItems : 'a typenet -> int
   val listItems : 'a typenet -> (hol_type * 'a) list
   val app : (hol_type * 'a -> unit) -> 'a typenet -> unit

--- a/src/parse/TypeNet.sig
+++ b/src/parse/TypeNet.sig
@@ -1,7 +1,7 @@
 signature TypeNet =
 sig
 
-  (* signature names modelled on HOLdict's *)
+  (* signature names modelled on Redblackmap's *)
   type 'a typenet
   type hol_type = Type.hol_type
 

--- a/src/parse/TypeNet.sml
+++ b/src/parse/TypeNet.sml
@@ -3,6 +3,8 @@ struct
 
 open HolKernel
 
+exception NotFound
+
 datatype label = TV
                | TOP of {Thy : string, Tyop : string} * int
   (* The integer records arity of operator - this is necessary when
@@ -36,8 +38,14 @@ fun labcmp p =
          pair_compare(reccmp, Int.compare) (opdata1, opdata2)
     | (TOP _, TV) => GREATER
 
-datatype 'a N = LF of (hol_type,'a) Redblackmap.dict
-              | ND of (label,'a N) Redblackmap.dict
+structure LabelTab = Table(struct
+  type key = label
+  val ord = labcmp
+  fun pp _ = HOLPP.add_string "<typenet-label>"
+end)
+
+datatype 'a N = LF of 'a Typetab.table
+              | ND of 'a N LabelTab.table
               | EMPTY
 (* redundant EMPTY constructor is used to get around value polymorphism problem
    when creating a single value for empty below *)
@@ -46,7 +54,7 @@ type 'a typenet = 'a N * int
 
 val empty = (EMPTY, 0)
 
-fun mkempty () = ND (Redblackmap.mkDict labcmp)
+fun mkempty () = ND LabelTab.empty
 
 fun ndest_type ty =
     if is_vartype ty then (TV, [])
@@ -59,19 +67,19 @@ fun ndest_type ty =
 fun insert ((net,sz), ty, item) = let
   fun newnode labs =
       case labs of
-        [] => LF (Redblackmap.mkDict Type.compare)
+        [] => LF Typetab.empty
       | _ => mkempty()
   fun trav (net, tys) =
       case (net, tys) of
-        (LF d, []) => LF (Redblackmap.insert(d,ty,item))
+        (LF d, []) => LF (Typetab.update (ty, item) d)
       | (ND d, ty::tys0) => let
           val (lab, rest) = ndest_type ty
           val tys = rest @ tys0
           val n' =
-              case Redblackmap.peek(d,lab) of
+              case LabelTab.lookup d lab of
                 NONE => trav(newnode tys, tys)
               | SOME n => trav(n, tys)
-          val d' = Redblackmap.insert(d, lab, n')
+          val d' = LabelTab.update (lab, n') d
         in
           ND d'
         end
@@ -82,15 +90,10 @@ in
 end
 
 fun listItems (net, sz) = let
-  fun cons'(k,v,acc) = (k,v)::acc
   fun trav (net, acc) =
       case net of
-        LF d => Redblackmap.foldl cons' acc d
-      | ND d => let
-          fun foldthis (k,v,acc) = trav(v,acc)
-        in
-          Redblackmap.foldl foldthis acc d
-        end
+        LF d => Typetab.fold_rev (fn kv => fn acc => kv :: acc) d acc
+      | ND d => LabelTab.fold (fn (_,v) => fn acc => trav(v,acc)) d acc
       | EMPTY => []
 in
   trav(net, [])
@@ -101,11 +104,11 @@ fun numItems (net, sz) = sz
 fun peek ((net,sz), ty) = let
   fun trav (net, tys) =
       case (net, tys) of
-        (LF d, []) => Redblackmap.peek(d, ty)
+        (LF d, []) => Typetab.lookup d ty
       | (ND d, ty::tys) => let
           val (lab, rest) = ndest_type ty
         in
-          case Redblackmap.peek(d, lab) of
+          case LabelTab.lookup d lab of
             NONE => NONE
           | SOME n => trav(n, rest @ tys)
         end
@@ -116,15 +119,15 @@ in
 end
 
 fun find (n, ty) =
-    valOf (peek (n, ty)) handle Option => raise Redblackmap.NotFound
+    valOf (peek (n, ty)) handle Option => raise NotFound
 
 fun match ((net,sz), ty) = let
   fun trav acc (net, tyl) =
       case (net, tyl) of
         (EMPTY, _) => []
-      | (LF d, []) => Redblackmap.listItems d @ acc
+      | (LF d, []) => Typetab.dest d @ acc
       | (ND d, ty::tys) => let
-          val varresult = case Redblackmap.peek(d, TV) of
+          val varresult = case LabelTab.lookup d TV of
                             NONE => acc
                           | SOME n => trav acc (n, tys)
           val (lab, rest) = ndest_type ty
@@ -133,7 +136,7 @@ fun match ((net,sz), ty) = let
             TV => varresult
           | TOP _ => let
             in
-              case Redblackmap.peek (d, lab) of
+              case LabelTab.lookup d lab of
                 NONE => varresult
               | SOME n => trav varresult (n, rest @ tys)
             end
@@ -146,28 +149,30 @@ end
 fun delete ((net,sz), ty) = let
   fun trav (p as (net, tyl)) =
       case p of
-        (EMPTY, _) => raise Redblackmap.NotFound
-      | (LF d, []) => let
-          val (d',removed) = Redblackmap.remove(d, ty)
-        in
-          if Redblackmap.numItems d' = 0 then (NONE, removed)
-          else (SOME (LF d'), removed)
-        end
+        (EMPTY, _) => raise NotFound
+      | (LF d, []) =>
+        (case Typetab.lookup d ty of
+             NONE => raise NotFound
+           | SOME removed =>
+             let val d' = Typetab.delete ty d
+             in if Typetab.size d' = 0 then (NONE, removed)
+                else (SOME (LF d'), removed)
+             end)
       | (ND d, ty::tys) => let
           val (lab, rest) = ndest_type ty
         in
-          case Redblackmap.peek(d, lab) of
-            NONE => raise Redblackmap.NotFound
+          case LabelTab.lookup d lab of
+            NONE => raise NotFound
           | SOME n => let
             in
               case trav (n, rest @ tys) of
                 (NONE, removed) => let
-                  val (d',_) = Redblackmap.remove(d, lab)
+                  val d' = LabelTab.delete lab d
                 in
-                  if Redblackmap.numItems d' = 0 then (NONE, removed)
+                  if LabelTab.size d' = 0 then (NONE, removed)
                   else (SOME (ND d'), removed)
                 end
-              | (SOME n', removed) => (SOME (ND (Redblackmap.insert(d,lab,n'))),
+              | (SOME n', removed) => (SOME (ND (LabelTab.update (lab, n') d)),
                                        removed)
             end
         end
@@ -181,8 +186,8 @@ end
 fun app f (net, sz) = let
   fun trav n =
       case n of
-        LF d => Redblackmap.app f d
-      | ND d => Redblackmap.app (fn (lab, n) => trav n) d
+        LF d => List.app f (Typetab.dest d)
+      | ND d => List.app (fn (_, n) => trav n) (LabelTab.dest d)
       | EMPTY => ()
 in
   trav net
@@ -191,8 +196,8 @@ end
 fun fold f acc (net, sz) = let
   fun trav acc n =
       case n of
-        LF d => Redblackmap.foldl f acc d
-      | ND d => Redblackmap.foldl (fn (lab,n',acc) => trav acc n') acc d
+        LF d => Typetab.fold (fn (k,v) => fn a => f (k,v,a)) d acc
+      | ND d => LabelTab.fold (fn (_,n') => fn acc => trav acc n') d acc
       | EMPTY => acc
 in
   trav acc net
@@ -201,8 +206,8 @@ end
 fun map f (net, sz) = let
   fun trav n =
       case n of
-        LF d => LF (Redblackmap.map f d)
-      | ND d => ND (Redblackmap.transform trav d)
+        LF d => LF (Typetab.map (fn k => fn v => f (k, v)) d)
+      | ND d => ND (LabelTab.map (fn _ => fn n => trav n) d)
       | EMPTY => EMPTY
 in
   (trav net, sz)

--- a/src/parse/TypeNet.sml
+++ b/src/parse/TypeNet.sml
@@ -19,9 +19,9 @@ datatype label = TV
      If the user does a lot of this, the data structure will slowly fill
      up with garbage.  If a type gets replaced with a new one of the same
      arity, the data for the old type will be returned as part of a
-     HOLdict.listItems when "match" is called, but the user will eliminate
+     Redblackmap.listItems when "match" is called, but the user will eliminate
      the junk with the usual sort of call to match_type.  With "peek", the
-     old data won't be called because the lookup at the leaf's HOLdict
+     old data won't be called because the lookup at the leaf's Redblackmap
      will just find whatever's supposed to be associated with the new type.
   *)
 
@@ -36,8 +36,8 @@ fun labcmp p =
          pair_compare(reccmp, Int.compare) (opdata1, opdata2)
     | (TOP _, TV) => GREATER
 
-datatype 'a N = LF of (hol_type,'a) HOLdict.dict
-              | ND of (label,'a N) HOLdict.dict
+datatype 'a N = LF of (hol_type,'a) Redblackmap.dict
+              | ND of (label,'a N) Redblackmap.dict
               | EMPTY
 (* redundant EMPTY constructor is used to get around value polymorphism problem
    when creating a single value for empty below *)
@@ -46,7 +46,7 @@ type 'a typenet = 'a N * int
 
 val empty = (EMPTY, 0)
 
-fun mkempty () = ND (HOLdict.mkDict labcmp)
+fun mkempty () = ND (Redblackmap.mkDict labcmp)
 
 fun ndest_type ty =
     if is_vartype ty then (TV, [])
@@ -59,19 +59,19 @@ fun ndest_type ty =
 fun insert ((net,sz), ty, item) = let
   fun newnode labs =
       case labs of
-        [] => LF (HOLdict.mkDict Type.compare)
+        [] => LF (Redblackmap.mkDict Type.compare)
       | _ => mkempty()
   fun trav (net, tys) =
       case (net, tys) of
-        (LF d, []) => LF (HOLdict.insert(d,ty,item))
+        (LF d, []) => LF (Redblackmap.insert(d,ty,item))
       | (ND d, ty::tys0) => let
           val (lab, rest) = ndest_type ty
           val tys = rest @ tys0
           val n' =
-              case HOLdict.peek(d,lab) of
+              case Redblackmap.peek(d,lab) of
                 NONE => trav(newnode tys, tys)
               | SOME n => trav(n, tys)
-          val d' = HOLdict.insert(d, lab, n')
+          val d' = Redblackmap.insert(d, lab, n')
         in
           ND d'
         end
@@ -85,11 +85,11 @@ fun listItems (net, sz) = let
   fun cons'(k,v,acc) = (k,v)::acc
   fun trav (net, acc) =
       case net of
-        LF d => HOLdict.foldl cons' acc d
+        LF d => Redblackmap.foldl cons' acc d
       | ND d => let
           fun foldthis (k,v,acc) = trav(v,acc)
         in
-          HOLdict.foldl foldthis acc d
+          Redblackmap.foldl foldthis acc d
         end
       | EMPTY => []
 in
@@ -101,11 +101,11 @@ fun numItems (net, sz) = sz
 fun peek ((net,sz), ty) = let
   fun trav (net, tys) =
       case (net, tys) of
-        (LF d, []) => HOLdict.peek(d, ty)
+        (LF d, []) => Redblackmap.peek(d, ty)
       | (ND d, ty::tys) => let
           val (lab, rest) = ndest_type ty
         in
-          case HOLdict.peek(d, lab) of
+          case Redblackmap.peek(d, lab) of
             NONE => NONE
           | SOME n => trav(n, rest @ tys)
         end
@@ -116,15 +116,15 @@ in
 end
 
 fun find (n, ty) =
-    valOf (peek (n, ty)) handle Option => raise HOLdict.NotFound
+    valOf (peek (n, ty)) handle Option => raise Redblackmap.NotFound
 
 fun match ((net,sz), ty) = let
   fun trav acc (net, tyl) =
       case (net, tyl) of
         (EMPTY, _) => []
-      | (LF d, []) => HOLdict.listItems d @ acc
+      | (LF d, []) => Redblackmap.listItems d @ acc
       | (ND d, ty::tys) => let
-          val varresult = case HOLdict.peek(d, TV) of
+          val varresult = case Redblackmap.peek(d, TV) of
                             NONE => acc
                           | SOME n => trav acc (n, tys)
           val (lab, rest) = ndest_type ty
@@ -133,7 +133,7 @@ fun match ((net,sz), ty) = let
             TV => varresult
           | TOP _ => let
             in
-              case HOLdict.peek (d, lab) of
+              case Redblackmap.peek (d, lab) of
                 NONE => varresult
               | SOME n => trav varresult (n, rest @ tys)
             end
@@ -146,28 +146,28 @@ end
 fun delete ((net,sz), ty) = let
   fun trav (p as (net, tyl)) =
       case p of
-        (EMPTY, _) => raise HOLdict.NotFound
+        (EMPTY, _) => raise Redblackmap.NotFound
       | (LF d, []) => let
-          val (d',removed) = HOLdict.remove(d, ty)
+          val (d',removed) = Redblackmap.remove(d, ty)
         in
-          if HOLdict.numItems d' = 0 then (NONE, removed)
+          if Redblackmap.numItems d' = 0 then (NONE, removed)
           else (SOME (LF d'), removed)
         end
       | (ND d, ty::tys) => let
           val (lab, rest) = ndest_type ty
         in
-          case HOLdict.peek(d, lab) of
-            NONE => raise HOLdict.NotFound
+          case Redblackmap.peek(d, lab) of
+            NONE => raise Redblackmap.NotFound
           | SOME n => let
             in
               case trav (n, rest @ tys) of
                 (NONE, removed) => let
-                  val (d',_) = HOLdict.remove(d, lab)
+                  val (d',_) = Redblackmap.remove(d, lab)
                 in
-                  if HOLdict.numItems d' = 0 then (NONE, removed)
+                  if Redblackmap.numItems d' = 0 then (NONE, removed)
                   else (SOME (ND d'), removed)
                 end
-              | (SOME n', removed) => (SOME (ND (HOLdict.insert(d,lab,n'))),
+              | (SOME n', removed) => (SOME (ND (Redblackmap.insert(d,lab,n'))),
                                        removed)
             end
         end
@@ -181,8 +181,8 @@ end
 fun app f (net, sz) = let
   fun trav n =
       case n of
-        LF d => HOLdict.app f d
-      | ND d => HOLdict.app (fn (lab, n) => trav n) d
+        LF d => Redblackmap.app f d
+      | ND d => Redblackmap.app (fn (lab, n) => trav n) d
       | EMPTY => ()
 in
   trav net
@@ -191,8 +191,8 @@ end
 fun fold f acc (net, sz) = let
   fun trav acc n =
       case n of
-        LF d => HOLdict.foldl f acc d
-      | ND d => HOLdict.foldl (fn (lab,n',acc) => trav acc n') acc d
+        LF d => Redblackmap.foldl f acc d
+      | ND d => Redblackmap.foldl (fn (lab,n',acc) => trav acc n') acc d
       | EMPTY => acc
 in
   trav acc net
@@ -201,8 +201,8 @@ end
 fun map f (net, sz) = let
   fun trav n =
       case n of
-        LF d => LF (HOLdict.map f d)
-      | ND d => ND (HOLdict.transform trav d)
+        LF d => LF (Redblackmap.map f d)
+      | ND d => ND (Redblackmap.transform trav d)
       | EMPTY => EMPTY
 in
   (trav net, sz)

--- a/src/parse/parse_term.sig
+++ b/src/parse/parse_term.sig
@@ -19,8 +19,9 @@ sig
       (term qbuf * term PStack, unit, string locn.located) errormonad.t
 
   datatype mx_order = datatype parse_term_dtype.mx_order
+  structure STBSTab : TABLE
+    where type Key.key = (stack_terminal * bool) * stack_terminal
   val mk_prec_matrix :
-      term_grammar.grammar ->
-      ((stack_terminal * bool) * stack_terminal, mx_order) Redblackmap.dict Uref.t
+      term_grammar.grammar -> mx_order STBSTab.table Uref.t
 
 end

--- a/src/parse/parse_term.sig
+++ b/src/parse/parse_term.sig
@@ -21,6 +21,6 @@ sig
   datatype mx_order = datatype parse_term_dtype.mx_order
   val mk_prec_matrix :
       term_grammar.grammar ->
-      ((stack_terminal * bool) * stack_terminal, mx_order) HOLdict.dict Uref.t
+      ((stack_terminal * bool) * stack_terminal, mx_order) Redblackmap.dict Uref.t
 
 end

--- a/src/parse/parse_term.sig
+++ b/src/parse/parse_term.sig
@@ -19,9 +19,12 @@ sig
       (term qbuf * term PStack, unit, string locn.located) errormonad.t
 
   datatype mx_order = datatype parse_term_dtype.mx_order
-  structure STBSTab : TABLE
-    where type Key.key = (stack_terminal * bool) * stack_terminal
+  type 'a stbstab  (* abstract; backed by a local Table instantiation
+                      keyed on (stack_terminal * bool) * stack_terminal --
+                      not exposed as a structure to avoid leaking the
+                      TABLE signature, which trips mosml on
+                      case-insensitive filesystems *)
   val mk_prec_matrix :
-      term_grammar.grammar -> mx_order STBSTab.table Uref.t
+      term_grammar.grammar -> mx_order stbstab Uref.t
 
 end

--- a/src/parse/parse_term.sml
+++ b/src/parse/parse_term.sml
@@ -87,18 +87,18 @@ val complained_already = ref false;
 structure Polyhash =
 struct
    open Uref
-   fun peek (dict) k = HOLdict.peek(!dict,k)
+   fun peek (dict) k = Redblackmap.peek(!dict,k)
    fun peekInsert r (k,v) =
        let val dict = !r in
-         case HOLdict.peek(dict,k) of
-           NONE => (r := HOLdict.insert(dict,k,v); NONE)
+         case Redblackmap.peek(dict,k) of
+           NONE => (r := Redblackmap.insert(dict,k,v); NONE)
          | x => x
        end
    fun insert r (k,v) =
-       r := HOLdict.insert(!r,k,v)
-   fun listItems dict = HOLdict.listItems (!dict)
+       r := Redblackmap.insert(!r,k,v)
+   fun listItems dict = Redblackmap.listItems (!dict)
    fun mkDict cmp = let
-     val newref = Uref.new (HOLdict.mkDict cmp)
+     val newref = Uref.new (Redblackmap.mkDict cmp)
    in
      newref
    end
@@ -191,10 +191,10 @@ fun STtoString (G:grammar) x =
   | ResquanOpTok => #res_quanop (specials G)^" (res quan operator)"
 
 fun mk_prec_matrix G = let
-  exception NotFound = HOLdict.NotFound
+  exception NotFound = Redblackmap.NotFound
   exception BadTokList
   type dict = ((stack_terminal * bool) * stack_terminal,
-               mx_order) HOLdict.dict Uref.t
+               mx_order) Redblackmap.dict Uref.t
   val {lambda, endbinding, type_intro, restr_binders, ...} = specials G
   val specs = grammar_tokens G
   val Grules = term_grammar.grammar_rules G
@@ -557,7 +557,7 @@ fun suffix_rule (rels,nm) =
 
 fun mk_ruledb (G:grammar) = let
   val Grules = term_grammar.grammar_rules G
-  val table:(rule_element list, rule_summary)HOLdict.dict Uref.t =
+  val table:(rule_element list, rule_summary)Redblackmap.dict Uref.t =
        Polyhash.mkDict (Lib.list_compare RE_compare)
   fun insert_rule mkfix (rr:rule_record) =
     let
@@ -685,17 +685,17 @@ fun get_case_info (G : grammar) = let
   fun extract_toks ppels = List.rev (List.foldl extract_tok [] ppels)
   fun rr_foldthis ({term_name,elements,...}, acc) =
     if GrammarSpecials.is_case_special term_name then
-      case HOLdict.peek(acc, term_name) of
-          NONE => HOLdict.insert(acc, term_name, [extract_toks elements])
+      case Redblackmap.peek(acc, term_name) of
+          NONE => Redblackmap.insert(acc, term_name, [extract_toks elements])
         | SOME els =>
-            HOLdict.insert(acc, term_name, extract_toks elements :: els)
+            Redblackmap.insert(acc, term_name, extract_toks elements :: els)
     else acc
   fun foldthis (gr, acc) =
       case gr of
         PREFIX (STD_prefix rrs) => List.foldl rr_foldthis acc rrs
       | _ => acc
   val candidates =
-      List.foldl foldthis (HOLdict.mkDict String.compare) (grammar_rules G)
+      List.foldl foldthis (Redblackmap.mkDict String.compare) (grammar_rules G)
   val error_case = {casebar = NONE, casecase = NONE, caseof = NONE}
   fun mapthis (cspecial, candidates) =
     case Listsort.sort (flip_cmp (measure_cmp length)) candidates of
@@ -708,20 +708,20 @@ fun get_case_info (G : grammar) = let
           else {casebar = SOME (last toks), casecase = SOME (hd toks),
                 caseof = SOME (hd (tl toks))}
         end
-  val specials_to_toks = HOLdict.map mapthis candidates
+  val specials_to_toks = Redblackmap.map mapthis candidates
   val toks_to_specials = let
     fun foldthis (k,r,acc) =
       case #casecase r of
           NONE => acc
         | SOME tok =>
-          (case HOLdict.peek(acc,tok) of
-               NONE => HOLdict.insert(acc,tok,k)
+          (case Redblackmap.peek(acc,tok) of
+               NONE => Redblackmap.insert(acc,tok,k)
              | SOME k' => raise Fail ("Tok \"" ^ tok ^
                                       "\" maps to case specials " ^
                                       valOf (dest_case_special k) ^ " and " ^
                                       valOf (dest_case_special k')))
   in
-    HOLdict.foldl foldthis (HOLdict.mkDict String.compare) specials_to_toks
+    Redblackmap.foldl foldthis (Redblackmap.mkDict String.compare) specials_to_toks
   end
 in
   (specials_to_toks, toks_to_specials)
@@ -751,15 +751,15 @@ fun parse_term (G : grammar) (typeparser : term qbuf -> Pretype.pretype) = let
                 case b of
                   LAMBDA => acc
                 | BinderString {term_name, tok, ...} =>
-                    HOLdict.insert(acc,tok,term_name)
+                    Redblackmap.insert(acc,tok,term_name)
           in
             List.foldl irec acc blist
           end
         | _ => acc
   in
-    List.foldl recurse (HOLdict.mkDict String.compare) Grules
+    List.foldl recurse (Redblackmap.mkDict String.compare) Grules
   end
-  fun term_name_for_binder s = HOLdict.find(binder_table,s)
+  fun term_name_for_binder s = Redblackmap.find(binder_table,s)
   val grammar_tokens = term_grammar.grammar_tokens G
   val lex  = let
     val specials = endbinding::grammar_tokens @ term_grammar.known_constants G
@@ -889,11 +889,11 @@ fun parse_term (G : grammar) (typeparser : term qbuf -> Pretype.pretype) = let
       fun tokstring x = case x of TOK s => SOME s | _ => NONE
       val poss_left = case hd pattern of TOK x => x | _ => fail()
     in
-      case HOLdict.peek(casetok_to_spec, poss_left) of
+      case Redblackmap.peek(casetok_to_spec, poss_left) of
           SOME cspec =>
           let
             val {casecase,casebar,caseof} =
-                HOLdict.find(casespec_to_tok,cspec)
+                Redblackmap.find(casespec_to_tok,cspec)
             fun bars_ok l =
               case l of
                   [TM] => true

--- a/src/parse/parse_term.sml
+++ b/src/parse/parse_term.sml
@@ -89,6 +89,7 @@ structure STBSTab = Table(struct
   val ord = pair_compare(pair_compare(ST_compare, bool_compare), ST_compare)
   fun pp _ = HOLPP.add_string "<stbs-key>"
 end)
+type 'a stbstab = 'a STBSTab.table
 
 structure RElist_Tab = Table(struct
   type key = rule_element list

--- a/src/parse/parse_term.sml
+++ b/src/parse/parse_term.sml
@@ -84,25 +84,32 @@ exception PrecConflict of stack_terminal * stack_terminal
 
 val complained_already = ref false;
 
-structure Polyhash =
-struct
-   open Uref
-   fun peek (dict) k = Redblackmap.peek(!dict,k)
-   fun peekInsert r (k,v) =
-       let val dict = !r in
-         case Redblackmap.peek(dict,k) of
-           NONE => (r := Redblackmap.insert(dict,k,v); NONE)
-         | x => x
-       end
-   fun insert r (k,v) =
-       r := Redblackmap.insert(!r,k,v)
-   fun listItems dict = Redblackmap.listItems (!dict)
-   fun mkDict cmp = let
-     val newref = Uref.new (Redblackmap.mkDict cmp)
-   in
-     newref
-   end
-end
+structure STBSTab = Table(struct
+  type key = (stack_terminal * bool) * stack_terminal
+  val ord = pair_compare(pair_compare(ST_compare, bool_compare), ST_compare)
+  fun pp _ = HOLPP.add_string "<stbs-key>"
+end)
+
+structure RElist_Tab = Table(struct
+  type key = rule_element list
+  val ord = Lib.list_compare RE_compare
+  fun pp _ = HOLPP.add_string "<rel-list>"
+end)
+
+(* Tiny ref wrappers — preserve the original Polyhash idiom (a refcell
+   containing a dict updated in place by the building code). *)
+fun stbs_peek (r : 'a STBSTab.table Uref.t) k = STBSTab.lookup (Uref.!r) k
+fun stbs_peekInsert r (k, v) =
+    case STBSTab.lookup (Uref.!r) k of
+        NONE => (Uref.:= (r, STBSTab.update (k, v) (Uref.!r)); NONE)
+      | x => x
+fun stbs_insert r (k, v) = Uref.:= (r, STBSTab.update (k, v) (Uref.!r))
+fun stbs_listItems r = STBSTab.dest (Uref.!r)
+fun stbs_mkRef () = Uref.new STBSTab.empty
+
+fun rel_peek (r : 'a RElist_Tab.table Uref.t) k = RElist_Tab.lookup (Uref.!r) k
+fun rel_insert r (k, v) = Uref.:= (r, RElist_Tab.update (k, v) (Uref.!r))
+fun rel_mkRef () = Uref.new RElist_Tab.empty
 
 local
   val rule_elements = term_grammar.rule_elements o #elements
@@ -191,18 +198,14 @@ fun STtoString (G:grammar) x =
   | ResquanOpTok => #res_quanop (specials G)^" (res quan operator)"
 
 fun mk_prec_matrix G = let
-  exception NotFound = Redblackmap.NotFound
   exception BadTokList
-  type dict = ((stack_terminal * bool) * stack_terminal,
-               mx_order) Redblackmap.dict Uref.t
+  type dict = mx_order STBSTab.table Uref.t
   val {lambda, endbinding, type_intro, restr_binders, ...} = specials G
   val specs = grammar_tokens G
   val Grules = term_grammar.grammar_rules G
   val alltoks =
     ResquanOpTok :: VS_cons :: STD_HOL_TOK fnapp_special :: all_tokens specs
-  val matrix: dict =
-      Polyhash.mkDict (pair_compare(pair_compare(ST_compare,bool_compare),
-                                    ST_compare))
+  val matrix: dict = stbs_mkRef ()
       (* the bool is true if there is a non-terminal between the two
          terminal tokens.  E.g.,
            x + -y
@@ -214,7 +217,7 @@ fun mk_prec_matrix G = let
   val rule_elements = term_grammar.rule_elements o #elements
   val complained_this_iteration = Uref.new false
   fun insert_bail k =
-      (Polyhash.insert matrix (k, PM_LESS MS_Multi);
+      (stbs_insert matrix (k, PM_LESS MS_Multi);
        let open Uref in complained_this_iteration := true end;
        if not (!complained_already) andalso
           (!Globals.interactive orelse !ambigrm = 2)
@@ -234,8 +237,8 @@ fun mk_prec_matrix G = let
        else
          ())
   fun insert k v = let
-    val insert_result = Polyhash.peekInsert matrix (k, v)
-    val raw_insert = Polyhash.insert matrix
+    val insert_result = stbs_peekInsert matrix (k, v)
+    val raw_insert = stbs_insert matrix
   in
     case (insert_result, v) of
       (SOME PM_EQUAL, _) => ()  (* ignore this *)
@@ -343,7 +346,7 @@ fun mk_prec_matrix G = let
   fun calc_eqpairs() =
     List.mapPartial
         (fn (((t1,_),t2), v) => if v = PM_EQUAL then SOME (t1,t2) else NONE)
-        (Polyhash.listItems matrix)
+        (stbs_listItems matrix)
   fun terms_between_equals (k1, k2) = let
   in
     app (fn lhs => bi_insert (k1, lhs) (PM_LESS MS_Other)) all_lhs;
@@ -557,15 +560,14 @@ fun suffix_rule (rels,nm) =
 
 fun mk_ruledb (G:grammar) = let
   val Grules = term_grammar.grammar_rules G
-  val table:(rule_element list, rule_summary)Redblackmap.dict Uref.t =
-       Polyhash.mkDict (Lib.list_compare RE_compare)
+  val table : rule_summary RElist_Tab.table Uref.t = rel_mkRef ()
   fun insert_rule mkfix (rr:rule_record) =
     let
       val rels = term_grammar.rule_elements (#elements rr)
       val nm = #term_name rr
     in
-      (Polyhash.insert table (mkfix (rels,nm));
-       List.app (Polyhash.insert table) (listTM_delimiters rels))
+      (rel_insert table (mkfix (rels,nm));
+       List.app (rel_insert table) (listTM_delimiters rels))
     end
   fun addrule rule =
     case rule of
@@ -574,8 +576,8 @@ fun mk_ruledb (G:grammar) = let
     | INFIX VSCONS => ()
     | INFIX (FNAPP rules) => let
       in
-        Polyhash.insert table (mkrels_infix [TOK fnapp_special],
-                               RealRule(rsInfix, fnapp_special));
+        rel_insert table (mkrels_infix [TOK fnapp_special],
+                          RealRule(rsInfix, fnapp_special));
         app (insert_rule infix_rule) rules
       end
     | PREFIX (STD_prefix rules) =>
@@ -685,17 +687,17 @@ fun get_case_info (G : grammar) = let
   fun extract_toks ppels = List.rev (List.foldl extract_tok [] ppels)
   fun rr_foldthis ({term_name,elements,...}, acc) =
     if GrammarSpecials.is_case_special term_name then
-      case Redblackmap.peek(acc, term_name) of
-          NONE => Redblackmap.insert(acc, term_name, [extract_toks elements])
+      case Symtab.lookup acc term_name of
+          NONE => Symtab.update (term_name, [extract_toks elements]) acc
         | SOME els =>
-            Redblackmap.insert(acc, term_name, extract_toks elements :: els)
+            Symtab.update (term_name, extract_toks elements :: els) acc
     else acc
   fun foldthis (gr, acc) =
       case gr of
         PREFIX (STD_prefix rrs) => List.foldl rr_foldthis acc rrs
       | _ => acc
   val candidates =
-      List.foldl foldthis (Redblackmap.mkDict String.compare) (grammar_rules G)
+      List.foldl foldthis Symtab.empty (grammar_rules G)
   val error_case = {casebar = NONE, casecase = NONE, caseof = NONE}
   fun mapthis (cspecial, candidates) =
     case Listsort.sort (flip_cmp (measure_cmp length)) candidates of
@@ -708,20 +710,20 @@ fun get_case_info (G : grammar) = let
           else {casebar = SOME (last toks), casecase = SOME (hd toks),
                 caseof = SOME (hd (tl toks))}
         end
-  val specials_to_toks = Redblackmap.map mapthis candidates
+  val specials_to_toks = Symtab.map (fn k => fn v => mapthis (k, v)) candidates
   val toks_to_specials = let
-    fun foldthis (k,r,acc) =
+    fun foldthis (k,r) acc =
       case #casecase r of
           NONE => acc
         | SOME tok =>
-          (case Redblackmap.peek(acc,tok) of
-               NONE => Redblackmap.insert(acc,tok,k)
+          (case Symtab.lookup acc tok of
+               NONE => Symtab.update (tok, k) acc
              | SOME k' => raise Fail ("Tok \"" ^ tok ^
                                       "\" maps to case specials " ^
                                       valOf (dest_case_special k) ^ " and " ^
                                       valOf (dest_case_special k')))
   in
-    Redblackmap.foldl foldthis (Redblackmap.mkDict String.compare) specials_to_toks
+    Symtab.fold foldthis specials_to_toks Symtab.empty
   end
 in
   (specials_to_toks, toks_to_specials)
@@ -751,15 +753,15 @@ fun parse_term (G : grammar) (typeparser : term qbuf -> Pretype.pretype) = let
                 case b of
                   LAMBDA => acc
                 | BinderString {term_name, tok, ...} =>
-                    Redblackmap.insert(acc,tok,term_name)
+                    Symtab.update (tok, term_name) acc
           in
             List.foldl irec acc blist
           end
         | _ => acc
   in
-    List.foldl recurse (Redblackmap.mkDict String.compare) Grules
+    List.foldl recurse Symtab.empty Grules
   end
-  fun term_name_for_binder s = Redblackmap.find(binder_table,s)
+  fun term_name_for_binder s = valOf (Symtab.lookup binder_table s)
   val grammar_tokens = term_grammar.grammar_tokens G
   val lex  = let
     val specials = endbinding::grammar_tokens @ term_grammar.known_constants G
@@ -828,7 +830,7 @@ fun parse_term (G : grammar) (typeparser : term qbuf -> Pretype.pretype) = let
         case rest of
           [] => FAILloc x1locn "find_reduction : impossible"
         | (((Terminal x2,x2locn), _)::_) => let
-            val res = valOf (Polyhash.peek prec_matrix ((x2,false),x1))
+            val res = valOf (stbs_peek prec_matrix ((x2,false),x1))
               handle Option =>
                 FAILloc (locn.between x2locn x1locn)
                         ("No relation between "^STtoString G x2^" and "^
@@ -848,7 +850,7 @@ fun parse_term (G : grammar) (typeparser : term qbuf -> Pretype.pretype) = let
             case rest2 of
               [] => FAILloc t2locn "find_reduction : nonterminal at stack base!"
             | (((Terminal x2,x2locn), _)::_) => let
-                val res = valOf (Polyhash.peek prec_matrix ((x2,true), x1))
+                val res = valOf (stbs_peek prec_matrix ((x2,true), x1))
                   handle Option =>
                     FAILloc (locn.between x2locn t2locn)
                             ("No relation between "^STtoString G x2^" and "^
@@ -889,11 +891,11 @@ fun parse_term (G : grammar) (typeparser : term qbuf -> Pretype.pretype) = let
       fun tokstring x = case x of TOK s => SOME s | _ => NONE
       val poss_left = case hd pattern of TOK x => x | _ => fail()
     in
-      case Redblackmap.peek(casetok_to_spec, poss_left) of
+      case Symtab.lookup casetok_to_spec poss_left of
           SOME cspec =>
           let
             val {casecase,casebar,caseof} =
-                Redblackmap.find(casespec_to_tok,cspec)
+                valOf (Symtab.lookup casespec_to_tok cspec)
             fun bars_ok l =
               case l of
                   [TM] => true
@@ -948,20 +950,20 @@ fun parse_term (G : grammar) (typeparser : term qbuf -> Pretype.pretype) = let
         val lrlocn = locn.between llocn rlocn
         val top_was_tm = hd translated_rhs = TM
         fun lrcheck (s1,s2) =
-          case Polyhash.peek rule_db [TOK s1, TOK s2] of
+          case rel_peek rule_db [TOK s1, TOK s2] of
               SOME (ListOnly lsp) => SOME lsp
             | _ => NONE
         val listredns = check_for_listreductions lrcheck translated_rhs
         val (listfixed_rhs, lspinfo) =
             remove_listrels listredns translated_rhs
         val rule =
-            case Polyhash.peek rule_db listfixed_rhs of
+            case rel_peek rule_db listfixed_rhs of
                 NONE =>
                   if top_was_tm then
                     let
                       val drop1 = tl listfixed_rhs
                     in
-                      case Polyhash.peek rule_db drop1 of
+                      case rel_peek rule_db drop1 of
                           NONE => handle_case_reduction lrlocn drop1
                         | SOME r => checkcase r
                     end
@@ -1489,7 +1491,7 @@ fun parse_term (G : grammar) (typeparser : term qbuf -> Pretype.pretype) = let
           | ((Terminal _,_), _) :: _ => return (false,stk)
           | _ => return (true,stk)
       fun check_order (topntp,stk) =
-          case Polyhash.peek prec_matrix ((top,topntp), input_term) of
+          case stbs_peek prec_matrix ((top,topntp), input_term) of
             NONE => let
               val msg = "Don't expect to find a "^STtoString G input_term^
                         " in this position after a "^STtoString G top^"\n"^

--- a/src/parse/parse_type.sml
+++ b/src/parse/parse_type.sml
@@ -122,18 +122,18 @@ fun parse_type_fns tyfns allow_unknown_suffixes G = let
       in
         if is_numeric s then generate_fcpbit((s,locn), args)
         else
-          case HOLdict.peek(privabbs, s) of
+          case Redblackmap.peek(privabbs, s) of
             NONE => pType((s,locn), args)
           | SOME thy => let
             in
-              case HOLdict.peek(abbrevs, {Name = s, Thy = thy}) of
+              case Redblackmap.peek(abbrevs, {Name = s, Thy = thy}) of
                   NONE => raise Fail
                             "parse_tyop.apply_tyop: probably shouldn't happen"
                 | SOME st => structure_to_value (s,locn) args st
             end
       end
     | QTypeIdent(thy,ty) =>
-        (case HOLdict.peek(abbrevs, {Name = ty, Thy = thy}) of
+        (case Redblackmap.peek(abbrevs, {Name = ty, Thy = thy}) of
              NONE => qtyop{Thy=thy,Tyop=ty,Locn=locn,Args=args}
          |   SOME st => structure_to_value (ty,locn) args st)
     | _ => raise Fail "parse_type.apply_tyop: can't happen"

--- a/src/parse/parse_type.sml
+++ b/src/parse/parse_type.sml
@@ -122,18 +122,18 @@ fun parse_type_fns tyfns allow_unknown_suffixes G = let
       in
         if is_numeric s then generate_fcpbit((s,locn), args)
         else
-          case Redblackmap.peek(privabbs, s) of
+          case Symtab.lookup privabbs s of
             NONE => pType((s,locn), args)
           | SOME thy => let
             in
-              case Redblackmap.peek(abbrevs, {Name = s, Thy = thy}) of
+              case KNametab.lookup abbrevs {Name = s, Thy = thy} of
                   NONE => raise Fail
                             "parse_tyop.apply_tyop: probably shouldn't happen"
                 | SOME st => structure_to_value (s,locn) args st
             end
       end
     | QTypeIdent(thy,ty) =>
-        (case Redblackmap.peek(abbrevs, {Name = ty, Thy = thy}) of
+        (case KNametab.lookup abbrevs {Name = ty, Thy = thy} of
              NONE => qtyop{Thy=thy,Tyop=ty,Locn=locn,Args=args}
          |   SOME st => structure_to_value (ty,locn) args st)
     | _ => raise Fail "parse_type.apply_tyop: can't happen"

--- a/src/parse/term_grammar.sml
+++ b/src/parse/term_grammar.sml
@@ -114,6 +114,12 @@ fun fupd_lambda f {type_intro,lambda,endbinding,restr_binders,res_quanop} =
 
 type prmP0 = Absyn.absyn -> Parse_supportENV.preterm_in_env
 
+structure SI_Tab = Table(struct
+  type key = string * int
+  val ord = pair_compare(String.compare, Int.compare)
+  fun pp (s,i) = HOLPP.add_string (s ^ "/" ^ Int.toString i)
+end)
+
 datatype grammar = GCONS of
   {rules : (int option * grammar_rule) list,
    specials : special_info,
@@ -122,7 +128,7 @@ datatype grammar = GCONS of
    overload_info : overload_info,
    user_printers : (type_grammar.grammar * grammar, grammar) printer_info,
    absyn_postprocessors : (string * postprocessor) list,
-   preterm_processors : (string*int,ptmprocessor) Redblackmap.dict,
+   preterm_processors : ptmprocessor SI_Tab.table,
    next_timestamp : int
    }
 and postprocessor = AbPP of grammar -> Absyn.absyn -> Absyn.absyn
@@ -153,7 +159,7 @@ fun absyn_postprocessors g = map (apsnd destAbPP) (absyn_postprocessors0 g)
 fun gnext_timestamp (GCONS g) = #next_timestamp g
 
 fun preterm_processor (GCONS g) k =
-  Option.map destPtmP (Redblackmap.peek(#preterm_processors g, k))
+  Option.map destPtmP (SI_Tab.lookup (#preterm_processors g) k)
 
 
 (* fupdates *)
@@ -289,15 +295,16 @@ fun new_preterm_processor k f (GCONS g) = let
   val old = #preterm_processors g
 in
   GCONS (update_G g
-                  (U #preterm_processors (Redblackmap.insert(old,k,PtmP f))) $$)
+                  (U #preterm_processors (SI_Tab.update (k, PtmP f) old)) $$)
 end
 
 fun remove_preterm_processor k (G as GCONS g) = let
   val old = #preterm_processors g
 in
-  case Lib.total Redblackmap.remove (old,k) of
-      SOME(new, v) => (GCONS (update_G g (U #preterm_processors new) $$),
-                       SOME (destPtmP v))
+  case SI_Tab.lookup old k of
+      SOME v => (GCONS (update_G g
+                          (U #preterm_processors (SI_Tab.delete k old)) $$),
+                 SOME (destPtmP v))
     | NONE => (G, NONE)
 end
 
@@ -491,8 +498,7 @@ val stdhol : grammar =
    overload_info = Overload.null_oinfo,
    user_printers = (FCNet.empty, HOLset.empty String.compare),
    absyn_postprocessors = [],
-   preterm_processors =
-     Redblackmap.mkDict (pair_compare(String.compare, Int.compare)),
+   preterm_processors = SI_Tab.empty,
    next_timestamp = 1
    }
 
@@ -1028,10 +1034,10 @@ structure userSyntaxFns = struct
   type 'a t = 'a getter * 'a setter
   fun mk_table () =
     let
-      val tab = ref (Redblackmap.mkDict String.compare)
+      val tab = ref Symtab.empty
     in
-      ((fn s => Redblackmap.find(!tab, s)),
-       (fn {name,code} => tab := Redblackmap.insert(!tab, name, code)))
+      ((fn s => valOf (Symtab.lookup (!tab) s)),
+       (fn {name,code} => tab := Symtab.update (name, code) (!tab)))
     end
   val (get_userPP, register_userPP) = mk_table() : userprinter t
   val (get_absynPostProcessor, register_absynPostProcessor) =
@@ -1068,7 +1074,7 @@ fun add_delta ud G =
       else
         let
           val code = userSyntaxFns.get_userPP s
-                     handle Redblackmap.NotFound =>
+                     handle Option =>
                             raise ERROR "add_delta"
                                   ("No code named "^s^
                                    " registered for add user-printer")
@@ -1078,7 +1084,7 @@ fun add_delta ud G =
     | ADD_ABSYN_POSTP {codename} =>
       let
         val code = userSyntaxFns.get_absynPostProcessor codename
-          handle Redblackmap.NotFound =>
+          handle Option =>
                  raise ERROR "add_delta"
                        ("No code named "^codename^
                         " registered for add absyn-postprocessor")
@@ -1122,15 +1128,15 @@ end
 
 fun merge_bmaps typestring keyprinter m1 m2 = let
   (* m1 takes precedence - arbitrarily *)
-  fun foldfn (k,v,newmap) =
-    (if isSome (Redblackmap.peek(newmap, k)) then
+  fun foldfn (k,v) newmap =
+    (if isSome (SI_Tab.lookup newmap k) then
        Feedback.HOL_WARNING "term_grammar" "merge_grammars"
        ("Merging "^typestring^" has produced a clash on key "^keyprinter k)
      else
        ();
-     Redblackmap.insert(newmap,k,v))
+     SI_Tab.update (k, v) newmap)
 in
-  Redblackmap.foldl foldfn m2 m1
+  SI_Tab.fold foldfn m2 m1
 end
 
 fun merge_user_printers (n1,ks1) (n2,_) = let
@@ -1152,7 +1158,7 @@ in
 end
 
 fun bmap_merge m1 m2 =
-  Redblackmap.foldl (fn (k,v,acc) => Redblackmap.insert(acc,k,v)) m1 m2
+  SI_Tab.fold (fn (k,v) => fn acc => SI_Tab.update (k, v) acc) m1 m2
 
 fun merge_grammars (G1 as GCONS g1, G2 as GCONS g2) :grammar = let
   val g0_rules =

--- a/src/parse/term_grammar.sml
+++ b/src/parse/term_grammar.sml
@@ -122,7 +122,7 @@ datatype grammar = GCONS of
    overload_info : overload_info,
    user_printers : (type_grammar.grammar * grammar, grammar) printer_info,
    absyn_postprocessors : (string * postprocessor) list,
-   preterm_processors : (string*int,ptmprocessor) HOLdict.dict,
+   preterm_processors : (string*int,ptmprocessor) Redblackmap.dict,
    next_timestamp : int
    }
 and postprocessor = AbPP of grammar -> Absyn.absyn -> Absyn.absyn
@@ -153,7 +153,7 @@ fun absyn_postprocessors g = map (apsnd destAbPP) (absyn_postprocessors0 g)
 fun gnext_timestamp (GCONS g) = #next_timestamp g
 
 fun preterm_processor (GCONS g) k =
-  Option.map destPtmP (HOLdict.peek(#preterm_processors g, k))
+  Option.map destPtmP (Redblackmap.peek(#preterm_processors g, k))
 
 
 (* fupdates *)
@@ -289,13 +289,13 @@ fun new_preterm_processor k f (GCONS g) = let
   val old = #preterm_processors g
 in
   GCONS (update_G g
-                  (U #preterm_processors (HOLdict.insert(old,k,PtmP f))) $$)
+                  (U #preterm_processors (Redblackmap.insert(old,k,PtmP f))) $$)
 end
 
 fun remove_preterm_processor k (G as GCONS g) = let
   val old = #preterm_processors g
 in
-  case Lib.total HOLdict.remove (old,k) of
+  case Lib.total Redblackmap.remove (old,k) of
       SOME(new, v) => (GCONS (update_G g (U #preterm_processors new) $$),
                        SOME (destPtmP v))
     | NONE => (G, NONE)
@@ -492,7 +492,7 @@ val stdhol : grammar =
    user_printers = (FCNet.empty, HOLset.empty String.compare),
    absyn_postprocessors = [],
    preterm_processors =
-     HOLdict.mkDict (pair_compare(String.compare, Int.compare)),
+     Redblackmap.mkDict (pair_compare(String.compare, Int.compare)),
    next_timestamp = 1
    }
 
@@ -1028,10 +1028,10 @@ structure userSyntaxFns = struct
   type 'a t = 'a getter * 'a setter
   fun mk_table () =
     let
-      val tab = ref (HOLdict.mkDict String.compare)
+      val tab = ref (Redblackmap.mkDict String.compare)
     in
-      ((fn s => HOLdict.find(!tab, s)),
-       (fn {name,code} => tab := HOLdict.insert(!tab, name, code)))
+      ((fn s => Redblackmap.find(!tab, s)),
+       (fn {name,code} => tab := Redblackmap.insert(!tab, name, code)))
     end
   val (get_userPP, register_userPP) = mk_table() : userprinter t
   val (get_absynPostProcessor, register_absynPostProcessor) =
@@ -1068,7 +1068,7 @@ fun add_delta ud G =
       else
         let
           val code = userSyntaxFns.get_userPP s
-                     handle HOLdict.NotFound =>
+                     handle Redblackmap.NotFound =>
                             raise ERROR "add_delta"
                                   ("No code named "^s^
                                    " registered for add user-printer")
@@ -1078,7 +1078,7 @@ fun add_delta ud G =
     | ADD_ABSYN_POSTP {codename} =>
       let
         val code = userSyntaxFns.get_absynPostProcessor codename
-          handle HOLdict.NotFound =>
+          handle Redblackmap.NotFound =>
                  raise ERROR "add_delta"
                        ("No code named "^codename^
                         " registered for add absyn-postprocessor")
@@ -1123,14 +1123,14 @@ end
 fun merge_bmaps typestring keyprinter m1 m2 = let
   (* m1 takes precedence - arbitrarily *)
   fun foldfn (k,v,newmap) =
-    (if isSome (HOLdict.peek(newmap, k)) then
+    (if isSome (Redblackmap.peek(newmap, k)) then
        Feedback.HOL_WARNING "term_grammar" "merge_grammars"
        ("Merging "^typestring^" has produced a clash on key "^keyprinter k)
      else
        ();
-     HOLdict.insert(newmap,k,v))
+     Redblackmap.insert(newmap,k,v))
 in
-  HOLdict.foldl foldfn m2 m1
+  Redblackmap.foldl foldfn m2 m1
 end
 
 fun merge_user_printers (n1,ks1) (n2,_) = let
@@ -1152,7 +1152,7 @@ in
 end
 
 fun bmap_merge m1 m2 =
-  HOLdict.foldl (fn (k,v,acc) => HOLdict.insert(acc,k,v)) m1 m2
+  Redblackmap.foldl (fn (k,v,acc) => Redblackmap.insert(acc,k,v)) m1 m2
 
 fun merge_grammars (G1 as GCONS g1, G2 as GCONS g2) :grammar = let
   val g0_rules =

--- a/src/parse/term_pp.sml
+++ b/src/parse/term_pp.sml
@@ -527,7 +527,7 @@ fun pp_term (G : grammar) TyG backend = let
     fun val_insert (tstamp,r) NONE = [(n,tstamp,r)]
       | val_insert (tstamp,r) (SOME l) = sortinsert (tstamp,r) l
     fun myinsert ((k, (tstamp, r)), acc) = let
-      val existing = Redblackmap.peek(acc, k)
+      val existing = Symtab.lookup acc k
       val newvalue =
         case existing of
           NONE => [(n,tstamp,r)]
@@ -536,15 +536,13 @@ fun pp_term (G : grammar) TyG backend = let
           if tstamp > t' then (n,tstamp,r)::old::rest
           else old::(n,tstamp,r)::rest
     in
-      Redblackmap.insert(acc, k, newvalue)
+      Symtab.update (k, newvalue) acc
     end
   in
     (List.foldl myinsert acc keys_n_rules)
   end
-  val rule_table = List.foldl insert
-                              (Redblackmap.mkDict String.compare)
-                              (term_grammar.rules G)
-  fun lookup_term s = Redblackmap.peek(rule_table, s)
+  val rule_table = List.foldl insert Symtab.empty (term_grammar.rules G)
+  fun lookup_term s = Symtab.lookup rule_table s
   val comb_prec = #1 (hd (valOf (lookup_term fnapp_special)))
     handle Option =>
       raise PP_ERR "pp_term" "Grammar has no function application"

--- a/src/parse/term_pp.sml
+++ b/src/parse/term_pp.sml
@@ -527,7 +527,7 @@ fun pp_term (G : grammar) TyG backend = let
     fun val_insert (tstamp,r) NONE = [(n,tstamp,r)]
       | val_insert (tstamp,r) (SOME l) = sortinsert (tstamp,r) l
     fun myinsert ((k, (tstamp, r)), acc) = let
-      val existing = HOLdict.peek(acc, k)
+      val existing = Redblackmap.peek(acc, k)
       val newvalue =
         case existing of
           NONE => [(n,tstamp,r)]
@@ -536,15 +536,15 @@ fun pp_term (G : grammar) TyG backend = let
           if tstamp > t' then (n,tstamp,r)::old::rest
           else old::(n,tstamp,r)::rest
     in
-      HOLdict.insert(acc, k, newvalue)
+      Redblackmap.insert(acc, k, newvalue)
     end
   in
     (List.foldl myinsert acc keys_n_rules)
   end
   val rule_table = List.foldl insert
-                              (HOLdict.mkDict String.compare)
+                              (Redblackmap.mkDict String.compare)
                               (term_grammar.rules G)
-  fun lookup_term s = HOLdict.peek(rule_table, s)
+  fun lookup_term s = Redblackmap.peek(rule_table, s)
   val comb_prec = #1 (hd (valOf (lookup_term fnapp_special)))
     handle Option =>
       raise PP_ERR "pp_term" "Grammar has no function application"

--- a/src/parse/type_grammar.sig
+++ b/src/parse/type_grammar.sig
@@ -15,9 +15,9 @@ sig
   val min_grammar      : grammar
   val rules            : grammar -> {infixes: (int * grammar_rule) list,
                                      suffixes : string list}
-  val parse_map    : grammar -> (kernelname,type_structure) HOLdict.dict
+  val parse_map    : grammar -> (kernelname,type_structure) Redblackmap.dict
   val print_map    : grammar -> (int * kernelname) TypeNet.typenet
-  val privileged_abbrevs : grammar -> (string,string) HOLdict.dict
+  val privileged_abbrevs : grammar -> (string,string) Redblackmap.dict
 
   val abb_dest_type : grammar -> Type.hol_type ->
                       {Thy : string option, Tyop : string,

--- a/src/parse/type_grammar.sig
+++ b/src/parse/type_grammar.sig
@@ -15,9 +15,9 @@ sig
   val min_grammar      : grammar
   val rules            : grammar -> {infixes: (int * grammar_rule) list,
                                      suffixes : string list}
-  val parse_map    : grammar -> (kernelname,type_structure) Redblackmap.dict
+  val parse_map    : grammar -> type_structure KNametab.table
   val print_map    : grammar -> (int * kernelname) TypeNet.typenet
-  val privileged_abbrevs : grammar -> (string,string) Redblackmap.dict
+  val privileged_abbrevs : grammar -> string Symtab.table
 
   val abb_dest_type : grammar -> Type.hol_type ->
                       {Thy : string option, Tyop : string,

--- a/src/parse/type_grammar.sml
+++ b/src/parse/type_grammar.sml
@@ -26,9 +26,9 @@ fun break_qident s =
 
 datatype grammar = TYG of {
   rules : (int * grammar_rule) list,
-  parse_str : (kernelname, type_structure) HOLdict.dict,
+  parse_str : (kernelname, type_structure) Redblackmap.dict,
   str_print : (int * kernelname) TypeNet.typenet,
-  bare_names : (string, string) HOLdict.dict,
+  bare_names : (string, string) Redblackmap.dict,
   tstamp   : int
 }
 
@@ -116,12 +116,12 @@ val params = params0 (HOLset.empty Int.compare)
 val num_params = HOLset.numItems o params
 
 fun suffix_arity (abbrevs, privs) s =
-  case HOLdict.peek (privs, s) of
+  case Redblackmap.peek (privs, s) of
       NONE => NONE
     | SOME thy =>
       let
       in
-        case HOLdict.peek(abbrevs, {Thy = thy, Name = s}) of
+        case Redblackmap.peek(abbrevs, {Thy = thy, Name = s}) of
             NONE => NONE (* shouldn't happen *)
           | SOME st => if typstruct_uptodate st then SOME (s, num_params st)
                        else NONE
@@ -191,23 +191,23 @@ fun new_qtyop (kid as {Name = name, Thy = thy}) g =
         in
           g |> fupdate_str_print
                  (fn tynet => TypeNet.insert(tynet,ty,(tstamp,kid)))
-            |> fupdate_parse_str (fn m => HOLdict.insert(m, kid, opstructure))
+            |> fupdate_parse_str (fn m => Redblackmap.insert(m, kid, opstructure))
             |> fupdate_tstamp (fn i => i + 1)
-            |> fupdate_bare_names (fn m => HOLdict.insert(m, name, thy))
+            |> fupdate_bare_names (fn m => Redblackmap.insert(m, name, thy))
         end
   end
 
 fun hide_tyop s =
   fupdate_bare_names
-    (fn m => #1 (HOLdict.remove(m,s)) handle HOLdict.NotFound => m)
+    (fn m => #1 (Redblackmap.remove(m,s)) handle Redblackmap.NotFound => m)
 
 val empty_grammar = TYG { rules = [],
-                          parse_str = HOLdict.mkDict KernelSig.name_compare,
-                          bare_names = HOLdict.mkDict String.compare,
+                          parse_str = Redblackmap.mkDict KernelSig.name_compare,
+                          bare_names = Redblackmap.mkDict String.compare,
                           str_print = TypeNet.empty,
                           tstamp = 0 }
 
-fun keys m = HOLdict.foldr (fn (k,v,acc) => k :: acc) [] m
+fun keys m = Redblackmap.foldr (fn (k,v,acc) => k :: acc) [] m
 
 fun rules (TYG gr) = {infixes = #rules gr, suffixes = keys (#bare_names gr)}
 fun parse_map (TYG gr) = #parse_str gr
@@ -234,13 +234,13 @@ in
 end
 
 fun remove_knm_abbreviation g knm = let
-  val (dict, st) = HOLdict.remove(parse_map g, knm)
+  val (dict, st) = Redblackmap.remove(parse_map g, knm)
   fun doprint pmap0 = #1 (TypeNet.delete(pmap0, structure_to_type st))
-                     handle HOLdict.NotFound => pmap0
+                     handle Redblackmap.NotFound => pmap0
   fun maybe_rmpriv d =
-    case HOLdict.peek (d, #Name knm) of
+    case Redblackmap.peek (d, #Name knm) of
         NONE => d
-      | SOME thy' => if thy' = #Thy knm then #1 (HOLdict.remove(d, #Name knm))
+      | SOME thy' => if thy' = #Thy knm then #1 (Redblackmap.remove(d, #Name knm))
                      else d
 in
   g |> fupdate_parse_str (K dict)
@@ -252,26 +252,26 @@ fun remove_abbreviation g s =
   let
     val (thyopt, nm) = break_qident s
     fun parsemap nmcheck (knm,st,acc) =
-      if nmcheck knm then acc else HOLdict.insert(acc,knm,st)
+      if nmcheck knm then acc else Redblackmap.insert(acc,knm,st)
     fun printmap nmcheck (ty,i as (_, knm),acc) =
         if nmcheck knm then acc else TypeNet.insert(acc,ty,i)
     fun thyprivrm thy m =
-      case HOLdict.peek (m, nm) of
+      case Redblackmap.peek (m, nm) of
           NONE => m
-        | SOME thy' => if thy' = thy then #1 (HOLdict.remove(m,nm))
+        | SOME thy' => if thy' = thy then #1 (Redblackmap.remove(m,nm))
                        else m
     val (check,privrm) =
         case thyopt of
             NONE => ((fn knm => #Name knm = nm),
-                     (fn m => #1 (HOLdict.remove (m, nm))
-                              handle HOLdict.NotFound => m))
+                     (fn m => #1 (Redblackmap.remove (m, nm))
+                              handle Redblackmap.NotFound => m))
           | SOME thy => (equal {Name = nm, Thy = thy}, thyprivrm thy)
   in
     g |> fupdate_bare_names privrm
       |> fupdate_str_print (TypeNet.fold (printmap check) TypeNet.empty)
       |> fupdate_parse_str
-           (HOLdict.foldl (parsemap check)
-                            (HOLdict.mkDict KernelSig.name_compare))
+           (Redblackmap.foldl (parsemap check)
+                            (Redblackmap.mkDict KernelSig.name_compare))
   end
 
 fun type_to_structure ty =
@@ -279,10 +279,10 @@ fun type_to_structure ty =
     open Type
     val params = Listsort.sort Type.compare (type_vars ty)
     val (num_vars, pset) =
-        List.foldl (fn (ty,(i,pset)) => (i + 1, HOLdict.insert(pset,ty,i)))
-                   (0, HOLdict.mkDict Type.compare) params
+        List.foldl (fn (ty,(i,pset)) => (i + 1, Redblackmap.insert(pset,ty,i)))
+                   (0, Redblackmap.mkDict Type.compare) params
     fun mk_structure pset ty =
-      if is_vartype ty then PARAM (HOLdict.find(pset, ty))
+      if is_vartype ty then PARAM (Redblackmap.find(pset, ty))
       else let
         val {Thy,Tyop,Args} = dest_thy_type ty
       in
@@ -297,7 +297,7 @@ fun new_abbreviation {knm,print,ty} tyg = let
   open Portable
   val st = type_to_structure ty
   val {Name = s, Thy = thy} = knm
-  val tyg = case HOLdict.peek(parse_map tyg, knm) of
+  val tyg = case Redblackmap.peek(parse_map tyg, knm) of
                 NONE => tyg
               | SOME st' =>
                 if st = st' then tyg
@@ -320,13 +320,13 @@ fun new_abbreviation {knm,print,ty} tyg = let
                    | _ => ()
   val (tstamp, tyg) = bump_tstamp tyg
   val result =
-    tyg |> fupdate_parse_str (fn d => HOLdict.insert(d,knm,st))
+    tyg |> fupdate_parse_str (fn d => Redblackmap.insert(d,knm,st))
         |> (print ?
             fupdate_str_print
              (fn pmap => TypeNet.insert(pmap,
                                         structure_to_type st,
                                         (tstamp, knm))))
-        |> fupdate_bare_names(fn d => HOLdict.insert(d,s,thy))
+        |> fupdate_bare_names(fn d => Redblackmap.insert(d,s,thy))
 in
   result
 end
@@ -337,8 +337,8 @@ fun rev_append [] acc = acc
 
 fun merge_abbrevs G (d1, d2) = let
   fun merge_dictinsert (k,v,newdict) =
-      case HOLdict.peek(newdict,k) of
-        NONE => HOLdict.insert(newdict,k,v)
+      case Redblackmap.peek(newdict,k) of
+        NONE => Redblackmap.insert(newdict,k,v)
       | SOME v0 =>
         if v0 <> v then
           (Feedback.HOL_WARNING "parse_type" "merge_grammars"
@@ -352,14 +352,14 @@ fun merge_abbrevs G (d1, d2) = let
         else
           newdict
 in
-    HOLdict.foldr merge_dictinsert d1 d2
+    Redblackmap.foldr merge_dictinsert d1 d2
 end
 
 fun merge_pmaps (p1, p2) =
     TypeNet.fold (fn (ty,v,acc) => TypeNet.insert(acc,ty,v)) p1 p2
 
 fun merge_privs (p1, p2) =
-  HOLdict.foldl (fn (nm,thy,acc) => HOLdict.insert(acc,nm,thy)) p1 p2
+  Redblackmap.foldl (fn (nm,thy,acc) => Redblackmap.insert(acc,nm,thy)) p1 p2
 
 fun merge_grammars (G1, G2) = let
   (* both grammars are sorted, with no adjacent suffixes *)
@@ -434,7 +434,7 @@ fun prettyprint_grammar G = let
 
   fun kid_string kid st =
     let
-      val ispriv = case HOLdict.peek (bare_names, #Name kid) of
+      val ispriv = case Redblackmap.peek (bare_names, #Name kid) of
                        SOME thy => thy = #Thy kid
                      | NONE => false
       val kns = if ispriv then #Name kid else KernelSig.name_toString kid
@@ -456,7 +456,7 @@ fun prettyprint_grammar G = let
             (Int.max(mx,size kstr), (k,kstr,st)::kstrs)
           end
         else acc
-    val (lwidth, okabbrevs) = HOLdict.foldl foldthis (0, []) abbrevs
+    val (lwidth, okabbrevs) = Redblackmap.foldl foldthis (0, []) abbrevs
   in
     if length okabbrevs > 0 then [
       NL, add_string "Type abbreviations:",
@@ -568,7 +568,7 @@ in
       val inst' = Listsort.sort instcmp inst
       val args = map #residue inst'
     in
-      case HOLdict.peek (bare_names, Name) of
+      case Redblackmap.peek (bare_names, Name) of
           NONE => {Thy = SOME Thy, Tyop = Name, Args = args}
         | SOME thy' => if Thy = thy' then {Thy = NONE, Tyop = Name, Args = args}
                        else {Thy = SOME Thy, Tyop = Name, Args = args}
@@ -610,9 +610,9 @@ fun insert_minop (s,arity,ty) g =
   let
     val kid = {Thy = "min", Name = s}
   in
-    g |> fupdate_parse_str (fn m => HOLdict.insert(m,kid, nparams s arity))
+    g |> fupdate_parse_str (fn m => Redblackmap.insert(m,kid, nparams s arity))
       |> fupdate_str_print (fn n => TypeNet.insert(n,ty,(tstamp g, kid)))
-      |> fupdate_bare_names (fn m => HOLdict.insert(m,s,"min"))
+      |> fupdate_bare_names (fn m => Redblackmap.insert(m,s,"min"))
       |> fupdate_tstamp (fn i => i + 1)
   end
 

--- a/src/parse/type_grammar.sml
+++ b/src/parse/type_grammar.sml
@@ -26,9 +26,9 @@ fun break_qident s =
 
 datatype grammar = TYG of {
   rules : (int * grammar_rule) list,
-  parse_str : (kernelname, type_structure) Redblackmap.dict,
+  parse_str : type_structure KNametab.table,
   str_print : (int * kernelname) TypeNet.typenet,
-  bare_names : (string, string) Redblackmap.dict,
+  bare_names : string Symtab.table,
   tstamp   : int
 }
 
@@ -116,12 +116,12 @@ val params = params0 (HOLset.empty Int.compare)
 val num_params = HOLset.numItems o params
 
 fun suffix_arity (abbrevs, privs) s =
-  case Redblackmap.peek (privs, s) of
+  case Symtab.lookup privs s of
       NONE => NONE
     | SOME thy =>
       let
       in
-        case Redblackmap.peek(abbrevs, {Thy = thy, Name = s}) of
+        case KNametab.lookup abbrevs {Thy = thy, Name = s} of
             NONE => NONE (* shouldn't happen *)
           | SOME st => if typstruct_uptodate st then SOME (s, num_params st)
                        else NONE
@@ -191,25 +191,22 @@ fun new_qtyop (kid as {Name = name, Thy = thy}) g =
         in
           g |> fupdate_str_print
                  (fn tynet => TypeNet.insert(tynet,ty,(tstamp,kid)))
-            |> fupdate_parse_str (fn m => Redblackmap.insert(m, kid, opstructure))
+            |> fupdate_parse_str (fn m => KNametab.update (kid, opstructure) m)
             |> fupdate_tstamp (fn i => i + 1)
-            |> fupdate_bare_names (fn m => Redblackmap.insert(m, name, thy))
+            |> fupdate_bare_names (fn m => Symtab.update (name, thy) m)
         end
   end
 
-fun hide_tyop s =
-  fupdate_bare_names
-    (fn m => #1 (Redblackmap.remove(m,s)) handle Redblackmap.NotFound => m)
+fun hide_tyop s = fupdate_bare_names (Symtab.delete_safe s)
 
 val empty_grammar = TYG { rules = [],
-                          parse_str = Redblackmap.mkDict KernelSig.name_compare,
-                          bare_names = Redblackmap.mkDict String.compare,
+                          parse_str = KNametab.empty,
+                          bare_names = Symtab.empty,
                           str_print = TypeNet.empty,
                           tstamp = 0 }
 
-fun keys m = Redblackmap.foldr (fn (k,v,acc) => k :: acc) [] m
-
-fun rules (TYG gr) = {infixes = #rules gr, suffixes = keys (#bare_names gr)}
+fun rules (TYG gr) =
+    {infixes = #rules gr, suffixes = Symtab.keys (#bare_names gr)}
 fun parse_map (TYG gr) = #parse_str gr
 fun print_map (TYG gr) = #str_print gr
 fun privabbs (TYG gr) = #bare_names gr
@@ -234,13 +231,14 @@ in
 end
 
 fun remove_knm_abbreviation g knm = let
-  val (dict, st) = Redblackmap.remove(parse_map g, knm)
-  fun doprint pmap0 = #1 (TypeNet.delete(pmap0, structure_to_type st))
-                     handle Redblackmap.NotFound => pmap0
+  val st = valOf (KNametab.lookup (parse_map g) knm)
+  val dict = KNametab.delete knm (parse_map g)
+  fun doprint pmap0 = #1 (TypeNet.delete (pmap0, structure_to_type st))
+                      handle TypeNet.NotFound => pmap0
   fun maybe_rmpriv d =
-    case Redblackmap.peek (d, #Name knm) of
+    case Symtab.lookup d (#Name knm) of
         NONE => d
-      | SOME thy' => if thy' = #Thy knm then #1 (Redblackmap.remove(d, #Name knm))
+      | SOME thy' => if thy' = #Thy knm then Symtab.delete (#Name knm) d
                      else d
 in
   g |> fupdate_parse_str (K dict)
@@ -251,27 +249,25 @@ end
 fun remove_abbreviation g s =
   let
     val (thyopt, nm) = break_qident s
-    fun parsemap nmcheck (knm,st,acc) =
-      if nmcheck knm then acc else Redblackmap.insert(acc,knm,st)
+    fun parsemap nmcheck (knm,st) acc =
+      if nmcheck knm then acc else KNametab.update (knm,st) acc
     fun printmap nmcheck (ty,i as (_, knm),acc) =
         if nmcheck knm then acc else TypeNet.insert(acc,ty,i)
     fun thyprivrm thy m =
-      case Redblackmap.peek (m, nm) of
+      case Symtab.lookup m nm of
           NONE => m
-        | SOME thy' => if thy' = thy then #1 (Redblackmap.remove(m,nm))
+        | SOME thy' => if thy' = thy then Symtab.delete nm m
                        else m
     val (check,privrm) =
         case thyopt of
             NONE => ((fn knm => #Name knm = nm),
-                     (fn m => #1 (Redblackmap.remove (m, nm))
-                              handle Redblackmap.NotFound => m))
+                     (fn m => Symtab.delete_safe nm m))
           | SOME thy => (equal {Name = nm, Thy = thy}, thyprivrm thy)
   in
     g |> fupdate_bare_names privrm
       |> fupdate_str_print (TypeNet.fold (printmap check) TypeNet.empty)
       |> fupdate_parse_str
-           (Redblackmap.foldl (parsemap check)
-                            (Redblackmap.mkDict KernelSig.name_compare))
+           (fn d => KNametab.fold (parsemap check) d KNametab.empty)
   end
 
 fun type_to_structure ty =
@@ -279,10 +275,10 @@ fun type_to_structure ty =
     open Type
     val params = Listsort.sort Type.compare (type_vars ty)
     val (num_vars, pset) =
-        List.foldl (fn (ty,(i,pset)) => (i + 1, Redblackmap.insert(pset,ty,i)))
-                   (0, Redblackmap.mkDict Type.compare) params
+        List.foldl (fn (ty,(i,pset)) => (i + 1, Typetab.update (ty,i) pset))
+                   (0, Typetab.empty) params
     fun mk_structure pset ty =
-      if is_vartype ty then PARAM (Redblackmap.find(pset, ty))
+      if is_vartype ty then PARAM (valOf (Typetab.lookup pset ty))
       else let
         val {Thy,Tyop,Args} = dest_thy_type ty
       in
@@ -297,7 +293,7 @@ fun new_abbreviation {knm,print,ty} tyg = let
   open Portable
   val st = type_to_structure ty
   val {Name = s, Thy = thy} = knm
-  val tyg = case Redblackmap.peek(parse_map tyg, knm) of
+  val tyg = case KNametab.lookup (parse_map tyg) knm of
                 NONE => tyg
               | SOME st' =>
                 if st = st' then tyg
@@ -320,13 +316,13 @@ fun new_abbreviation {knm,print,ty} tyg = let
                    | _ => ()
   val (tstamp, tyg) = bump_tstamp tyg
   val result =
-    tyg |> fupdate_parse_str (fn d => Redblackmap.insert(d,knm,st))
+    tyg |> fupdate_parse_str (fn d => KNametab.update (knm, st) d)
         |> (print ?
             fupdate_str_print
              (fn pmap => TypeNet.insert(pmap,
                                         structure_to_type st,
                                         (tstamp, knm))))
-        |> fupdate_bare_names(fn d => Redblackmap.insert(d,s,thy))
+        |> fupdate_bare_names(fn d => Symtab.update (s, thy) d)
 in
   result
 end
@@ -336,9 +332,9 @@ fun rev_append [] acc = acc
   | rev_append (x::xs) acc = rev_append xs (x::acc)
 
 fun merge_abbrevs G (d1, d2) = let
-  fun merge_dictinsert (k,v,newdict) =
-      case Redblackmap.peek(newdict,k) of
-        NONE => Redblackmap.insert(newdict,k,v)
+  fun merge_dictinsert (k,v) newdict =
+      case KNametab.lookup newdict k of
+        NONE => KNametab.update (k, v) newdict
       | SOME v0 =>
         if v0 <> v then
           (Feedback.HOL_WARNING "parse_type" "merge_grammars"
@@ -352,14 +348,14 @@ fun merge_abbrevs G (d1, d2) = let
         else
           newdict
 in
-    Redblackmap.foldr merge_dictinsert d1 d2
+    KNametab.fold_rev merge_dictinsert d1 d2
 end
 
 fun merge_pmaps (p1, p2) =
     TypeNet.fold (fn (ty,v,acc) => TypeNet.insert(acc,ty,v)) p1 p2
 
 fun merge_privs (p1, p2) =
-  Redblackmap.foldl (fn (nm,thy,acc) => Redblackmap.insert(acc,nm,thy)) p1 p2
+  Symtab.fold (fn (nm,thy) => fn acc => Symtab.update (nm, thy) acc) p1 p2
 
 fun merge_grammars (G1, G2) = let
   (* both grammars are sorted, with no adjacent suffixes *)
@@ -434,7 +430,7 @@ fun prettyprint_grammar G = let
 
   fun kid_string kid st =
     let
-      val ispriv = case Redblackmap.peek (bare_names, #Name kid) of
+      val ispriv = case Symtab.lookup bare_names (#Name kid) of
                        SOME thy => thy = #Thy kid
                      | NONE => false
       val kns = if ispriv then #Name kid else KernelSig.name_toString kid
@@ -448,7 +444,7 @@ fun prettyprint_grammar G = let
     end
 
   val print_abbrevs = let
-    fun foldthis (k,st,acc as (mx,kstrs)) =
+    fun foldthis (k,st) (acc as (mx,kstrs)) =
         if typstruct_uptodate st then
           let
             val kstr = kid_string k st
@@ -456,7 +452,7 @@ fun prettyprint_grammar G = let
             (Int.max(mx,size kstr), (k,kstr,st)::kstrs)
           end
         else acc
-    val (lwidth, okabbrevs) = Redblackmap.foldl foldthis (0, []) abbrevs
+    val (lwidth, okabbrevs) = KNametab.fold foldthis abbrevs (0, [])
   in
     if length okabbrevs > 0 then [
       NL, add_string "Type abbreviations:",
@@ -517,7 +513,7 @@ in
       add_break (1,2),
       block CONSISTENT 0 (
         pr_list print_rule [NL] g @ [add_break(1,0)] @
-        print_suffixes (keys bare_names) @
+        print_suffixes (Symtab.keys bare_names) @
         [add_break(1,0), add_string "       TY  ::=  TY[TY] (array type)"]
       )
     ] :: print_abbrevs
@@ -568,7 +564,7 @@ in
       val inst' = Listsort.sort instcmp inst
       val args = map #residue inst'
     in
-      case Redblackmap.peek (bare_names, Name) of
+      case Symtab.lookup bare_names Name of
           NONE => {Thy = SOME Thy, Tyop = Name, Args = args}
         | SOME thy' => if Thy = thy' then {Thy = NONE, Tyop = Name, Args = args}
                        else {Thy = SOME Thy, Tyop = Name, Args = args}
@@ -610,9 +606,9 @@ fun insert_minop (s,arity,ty) g =
   let
     val kid = {Thy = "min", Name = s}
   in
-    g |> fupdate_parse_str (fn m => Redblackmap.insert(m,kid, nparams s arity))
+    g |> fupdate_parse_str (fn m => KNametab.update (kid, nparams s arity) m)
       |> fupdate_str_print (fn n => TypeNet.insert(n,ty,(tstamp g, kid)))
-      |> fupdate_bare_names (fn m => Redblackmap.insert(m,s,"min"))
+      |> fupdate_bare_names (fn m => Symtab.update (s, "min") m)
       |> fupdate_tstamp (fn i => i + 1)
   end
 

--- a/src/parse/type_pp.sml
+++ b/src/parse/type_pp.sml
@@ -187,7 +187,7 @@ fun pp_type0 (G:grammar) (backend: PPBackEnd.t) = let
                 let
                   val knm = {Thy = thy, Name = abop}
                 in
-                  case Redblackmap.peek (abbs, knm) of
+                  case KNametab.lookup abbs knm of
                       NONE => realtype ty (* probably shouldn't happen *)
                     | SOME st => doabbrev st
                 end
@@ -195,13 +195,13 @@ fun pp_type0 (G:grammar) (backend: PPBackEnd.t) = let
                 let
                   val privabbs = type_grammar.privileged_abbrevs G
                 in
-                  case Redblackmap.peek (privabbs, abop) of
+                  case Symtab.lookup privabbs abop of
                       NONE => realtype ty
                     | SOME thy =>
                       let
                         val knm = {Thy = thy, Name = abop}
                       in
-                        case Redblackmap.peek (abbs, knm) of
+                        case KNametab.lookup abbs knm of
                             NONE => raise Fail "Very confused tyabbrev"
                           | SOME st => doabbrev st
                       end

--- a/src/parse/type_pp.sml
+++ b/src/parse/type_pp.sml
@@ -187,7 +187,7 @@ fun pp_type0 (G:grammar) (backend: PPBackEnd.t) = let
                 let
                   val knm = {Thy = thy, Name = abop}
                 in
-                  case HOLdict.peek (abbs, knm) of
+                  case Redblackmap.peek (abbs, knm) of
                       NONE => realtype ty (* probably shouldn't happen *)
                     | SOME st => doabbrev st
                 end
@@ -195,13 +195,13 @@ fun pp_type0 (G:grammar) (backend: PPBackEnd.t) = let
                 let
                   val privabbs = type_grammar.privileged_abbrevs G
                 in
-                  case HOLdict.peek (privabbs, abop) of
+                  case Redblackmap.peek (privabbs, abop) of
                       NONE => realtype ty
                     | SOME thy =>
                       let
                         val knm = {Thy = thy, Name = abop}
                       in
-                        case HOLdict.peek (abbs, knm) of
+                        case Redblackmap.peek (abbs, knm) of
                             NONE => raise Fail "Very confused tyabbrev"
                           | SOME st => doabbrev st
                       end

--- a/src/pattern_matches/constrFamiliesLib.sml
+++ b/src/pattern_matches/constrFamiliesLib.sml
@@ -575,15 +575,17 @@ val thePmatchCompileDB = ref empty
 fun lookup_typeBase_constructorFamily ty = let
   val b_ty = base_ty ty
 in
-  SOME (b_ty, TypeNet.find (!typeConstrFamsDB, b_ty)) handle
-     NotFound => let
-       val cf = constructorFamily_of_typebase b_ty
-       val net = !typeConstrFamsDB
-       val net'= TypeNet.insert (net, b_ty, cf)
-       val _ = typeConstrFamsDB := net'
-     in
-       SOME (b_ty, cf)
-     end
+  case TypeNet.peek (!typeConstrFamsDB, b_ty) of
+      SOME cf => SOME (b_ty, cf)
+    | NONE =>
+      let
+        val cf = constructorFamily_of_typebase b_ty
+        val net = !typeConstrFamsDB
+        val net'= TypeNet.insert (net, b_ty, cf)
+        val _ = typeConstrFamsDB := net'
+      in
+        SOME (b_ty, cf)
+      end
 end handle HOL_ERR _ => NONE
 
 
@@ -792,7 +794,7 @@ fun pmatch_compile_db_add_constrFam (db : pmatch_compile_db) cf = {
     val cl = (#constructors cf)
     val ty = normalise_ty (#cl_type cl)
     val net = #pcdb_constrFams db
-    val cfs = TypeNet.find (net, ty) handle NotFound => []
+    val cfs = case TypeNet.peek (net, ty) of SOME l => l | NONE => []
     val net' = TypeNet.insert (net, ty, cf::cfs)
   in
     net'

--- a/src/pattern_matches/constrFamiliesLib.sml
+++ b/src/pattern_matches/constrFamiliesLib.sml
@@ -55,13 +55,6 @@ fun list_mk_comb_subst (c, args) = (case args of
 
 fun next_ty ty = mk_vartype(Lexis.tyvar_vary (dest_vartype ty));
 
-local
-  structure Typetab = Table(struct
-    type key = hol_type
-    val ord = Type.compare
-    fun pp _ = HOLPP.add_string "<type>"
-  end)
-in
 fun normalise_ty ty = let
   fun recurse (acc as (dict,usethis)) tylist =
       case tylist of
@@ -87,7 +80,6 @@ fun normalise_ty ty = let
 in
   Type.type_subst inst ty
 end
-end (* local *)
 
 
 fun base_ty ty = let

--- a/src/pattern_matches/constrFamiliesLib.sml
+++ b/src/pattern_matches/constrFamiliesLib.sml
@@ -55,6 +55,13 @@ fun list_mk_comb_subst (c, args) = (case args of
 
 fun next_ty ty = mk_vartype(Lexis.tyvar_vary (dest_vartype ty));
 
+local
+  structure Typetab = Table(struct
+    type key = hol_type
+    val ord = Type.compare
+    fun pp _ = HOLPP.add_string "<type>"
+  end)
+in
 fun normalise_ty ty = let
   fun recurse (acc as (dict,usethis)) tylist =
       case tylist of
@@ -62,8 +69,8 @@ fun normalise_ty ty = let
       | ty :: rest => let
         in
           if is_vartype ty then
-            case Binarymap.peek(dict,ty) of
-                NONE => recurse (Binarymap.insert(dict,ty,usethis),
+            case Typetab.lookup dict ty of
+                NONE => recurse (Typetab.update (ty, usethis) dict,
                                  next_ty usethis)
                                 rest
               | SOME _ => recurse acc rest
@@ -73,13 +80,14 @@ fun normalise_ty ty = let
               recurse acc (Args @ rest)
             end
         end
-  val (inst0, _) = recurse (Binarymap.mkDict Type.compare, Type.alpha) [ty]
-  val inst = Binarymap.foldl (fn (tyk,tyv,acc) => (tyk |-> tyv)::acc)
-                             []
-                             inst0
+  val (inst0, _) = recurse (Typetab.empty, Type.alpha) [ty]
+  val inst = Typetab.fold (fn (tyk,tyv) => fn acc => (tyk |-> tyv)::acc)
+                          inst0
+                          []
 in
   Type.type_subst inst ty
 end
+end (* local *)
 
 
 fun base_ty ty = let

--- a/src/portableML/Chartab.sml
+++ b/src/portableML/Chartab.sml
@@ -1,0 +1,5 @@
+structure Chartab = Table(
+  type key = char
+  val ord = Char.compare
+  val pp = HOLPP.add_string o Char.toString
+);

--- a/src/portableML/HOLdict.sig
+++ b/src/portableML/HOLdict.sig
@@ -1,4 +1,0 @@
-signature HOLdict =
-sig
-  include Redblackmap
-end

--- a/src/portableML/HOLdict.sml
+++ b/src/portableML/HOLdict.sml
@@ -1,5 +1,0 @@
-structure HOLdict :> HOLdict =
-struct
-  exception NotFound = Redblackmap.NotFound
-  open Redblackmap
-end

--- a/src/portableML/Holmakefile
+++ b/src/portableML/Holmakefile
@@ -26,6 +26,9 @@ Inttab.uo: Inttab.sml Table.ui
 Symtab.uo: Symtab.sml Table.ui
 	$(MOSMLC) Table.ui -c $<
 
+Chartab.uo: Chartab.sml Table.ui
+	$(MOSMLC) Table.ui -c $<
+
 SymGraph.uo: SymGraph.sml Graph.ui
 	$(MOSMLC) Graph.ui -c $<
 

--- a/src/portableML/LSPExtension.sml
+++ b/src/portableML/LSPExtension.sml
@@ -37,14 +37,21 @@ fun getLineCol lines index = let
 fun fromLineCol lines (line, col) =
   if line = 0 then col else Vector.sub (lines, line - 1) + col
 
+(* Binarymap (rather than Symtab/Table) here because LSPExtension is
+   `use`d directly by tools-poly/poly/poly-init2.ML at bootstrap, before
+   any of src/portableML's Holmake-built modules (Symtab, Table, ...)
+   are available. *)
 type plugin_data = (string, UniversalType.t) Binarymap.dict
 val emptyPluginData = Binarymap.mkDict String.compare
 
 type 'a tag = string * ('a -> UniversalType.t) * (UniversalType.t -> 'a)
 
-fun getPluginData (map, (name, _, proj)) = Option.map proj (Binarymap.peek (map, name))
-fun setPluginData (map, (name, inj, _), SOME v) = Binarymap.insert (map, name, inj v)
-  | setPluginData (map, (name, _, _), NONE) = #1 (Binarymap.remove (map, name))
+fun getPluginData (map, (name, _, proj)) =
+    Option.map proj (Binarymap.peek (map, name))
+fun setPluginData (map, (name, inj, _), SOME v) =
+    Binarymap.insert (map, name, inj v)
+  | setPluginData (map, (name, _, _), NONE) =
+    #1 (Binarymap.remove (map, name)) handle NotFound => map
 
 type 'a plugin = {
   name: string,

--- a/src/portableML/Profile.sml
+++ b/src/portableML/Profile.sml
@@ -1,12 +1,10 @@
 structure Profile :> Profile =
 struct
 
-open Binarymap
-
 type time = Time.time
 type call_info = {real: time, gc: time, sys: time, usr: time, n: int}
 
-val ptable = ref (Binarymap.mkDict String.compare : (string, call_info) dict)
+val ptable : call_info Symtab.table ref = ref Symtab.empty
 
 datatype 'a result = OK of 'a | Ex of exn
 
@@ -29,7 +27,7 @@ type timedata = {nongc: {usr: Time.time, sys: Time.time},
                  gc: {usr: Time.time, sys: Time.time}}
 
 fun add_profile nm timefx =
-   case peek (!ptable, nm) of
+   case Symtab.lookup (!ptable) nm of
       NONE =>
          let
             val ({nongc, gc}: timedata, real) = timefx
@@ -40,7 +38,7 @@ fun add_profile nm timefx =
                 n = 1,
                 real = real}
          in
-            ptable := insert (!ptable, nm, data)
+            ptable := Symtab.update (nm, data) (!ptable)
          end
     | SOME {usr = usr0, sys = sys0, gc = gc0, n = n0, real = real0} =>
          let
@@ -53,7 +51,7 @@ fun add_profile nm timefx =
                 n = Int.+ (n0, 1),
                 real = real0 + real1}
          in
-            ptable := insert (!ptable, nm, data)
+            ptable := Symtab.update (nm, data) (!ptable)
          end
 
 fun profile_exn_opt do_exn do_ok do_both nm f x =
@@ -76,13 +74,12 @@ fun profile_with_exn nm = profile_exn_opt (SOME false) true true nm
 fun profile_with_exn_name nm = profile_exn_opt (SOME true) true true nm
 fun profile_no_exn nm = profile_exn_opt NONE true false nm
 
-fun reset1 nm =
-   ptable := #1 (remove (!ptable, nm)) handle Binarymap.NotFound => ()
+fun reset1 nm = ptable := Symtab.delete_safe nm (!ptable)
 
-fun reset_all () = ptable := Binarymap.mkDict String.compare
+fun reset_all () = ptable := Symtab.empty
 
 fun results () = Listsort.sort (fn (i1, i2) => String.compare (#1 i1, #1 i2))
-                               (listItems (!ptable))
+                               (Symtab.dest (!ptable))
 
 fun foldl_map _ (acc, []) = (acc, [])
   | foldl_map f (acc, x :: xs) =

--- a/src/portableML/UTF8Set.sml
+++ b/src/portableML/UTF8Set.sml
@@ -1,33 +1,33 @@
 structure UTF8Set :> UTF8Set =
 struct
 
-datatype t = N of bool * (int,t)Binarymap.dict
+datatype t = N of bool * t Inttab.table
 
 open UTF8
 
-val empty = N(false, Binarymap.mkDict Int.compare)
+val empty = N(false, Inttab.empty)
 
 fun add(N (b,m), s) =
     case getChar s of
       NONE => N(true, m)
     | SOME ((c,i), rest) => let
       in
-        case Binarymap.peek (m, i) of
-          NONE => N(b, Binarymap.insert(m, i, add(empty, rest)))
-        | SOME t => N(b, Binarymap.insert(m, i, add(t, rest)))
+        case Inttab.lookup m i of
+          NONE => N(b, Inttab.update (i, add(empty, rest)) m)
+        | SOME t => N(b, Inttab.update (i, add(t, rest)) m)
       end
 
 fun addList (t, slist) = List.foldl (fn (s,t) => add(t,s)) t slist
 
-fun isEmpty (N(b,m)) = not b andalso Binarymap.numItems m = 0
+fun isEmpty (N(b,m)) = not b andalso Inttab.size m = 0
 
 fun listItems set = let
   fun listItems' pfx acc (N(b,m)) = let
-    fun foldthis (i,set,acc) =
+    fun foldthis (i,set) acc =
         listItems' (pfx ^ chr i) acc set
     val acc' = if b then pfx :: acc else acc
   in
-    Binarymap.foldl foldthis acc' m
+    Inttab.fold foldthis m acc'
   end
 in
   listItems' "" [] set
@@ -38,7 +38,7 @@ fun member(N(b,m),s) =
       NONE => b
     | SOME((_,i), rest) => let
       in
-        case Binarymap.peek(m,i) of
+        case Inttab.lookup m i of
           NONE => false
         | SOME s' => member (s', rest)
       end
@@ -51,7 +51,7 @@ fun longest_pfx_member(set, s) = let
       NONE => best
     | SOME ((_, i), rest) => let
       in
-        case Binarymap.peek (m,i) of
+        case Inttab.lookup m i of
           NONE => best
         | SOME set => recurse best (curpfx ^ chr i) rest set
       end

--- a/src/portableML/UnicodeChars.sml
+++ b/src/portableML/UnicodeChars.sml
@@ -219,18 +219,16 @@ fun foldthis (s, (sm,im,i)) =
     let
       val ((_, k), _) = valOf (UTF8.getChar s)
     in
-      (Binarymap.insert(sm,s,i), Binarymap.insert(im,k,i), i + 1)
+      (Symtab.update (s,i) sm, Inttab.update (k,i) im, i + 1)
     end
 val (supdigits_smap, supdigits_imap, _) =
-    List.foldl foldthis (Binarymap.mkDict String.compare,
-                         Binarymap.mkDict Int.compare,
-                         0)
+    List.foldl foldthis (Symtab.empty, Inttab.empty, 0)
                [sup_0, sup_1, sup_2, sup_3, sup_4, sup_5, sup_6, sup_7,
                 sup_8, sup_9]
-fun supDigitVal s = Binarymap.peek(supdigits_smap, s)
-fun supDigitVal_i i = Binarymap.peek(supdigits_imap, i)
+fun supDigitVal s = Symtab.lookup supdigits_smap s
+fun supDigitVal_i i = Inttab.lookup supdigits_imap i
 
-fun isSupDigit_i i = isSome (Binarymap.peek(supdigits_imap, i))
+fun isSupDigit_i i = isSome (Inttab.lookup supdigits_imap i)
 fun isSupDigit s = isSome (supDigitVal s)
 
 

--- a/src/portableML/mlton/portableML.mlb
+++ b/src/portableML/mlton/portableML.mlb
@@ -37,6 +37,10 @@ Interrupt.sml
 ../../../tools-poly/poly/Binarymap.sml
 ../../../tools-poly/poly/Binaryset.sig
 ../../../tools-poly/poly/Binaryset.sml
+Unsynchronized.sml
+../Table.sml
+../Symtab.sml
+../Inttab.sml
 ../UnicodeChars.sig
 ../UnicodeChars.sml
 ../Redblackmap.sig
@@ -45,12 +49,6 @@ Interrupt.sml
 ../Redblackset.sml
 ../HOLset.sig
 ../HOLset.sml
-../HOLdict.sig
-../HOLdict.sml
-Unsynchronized.sml
-../Table.sml
-../Symtab.sml
-../Inttab.sml
 ../mosml/concurrent/Sref.sig
 ../mosml/concurrent/Sref.sml
 ../seq.sig

--- a/src/portableML/mlton/portableML.mlb
+++ b/src/portableML/mlton/portableML.mlb
@@ -41,6 +41,7 @@ Unsynchronized.sml
 ../Table.sml
 ../Symtab.sml
 ../Inttab.sml
+../Chartab.sml
 ../UnicodeChars.sig
 ../UnicodeChars.sml
 ../Redblackmap.sig

--- a/src/postkernel/DB.sml
+++ b/src/postkernel/DB.sml
@@ -48,24 +48,23 @@ val toLower = CharVector.map Char.toLower
      is loaded.
  ---------------------------------------------------------------------------*)
 
-structure Map = Redblackmap
 (* the keys are lower-cased, but the data also stores the keys, and there
    the key information is kept in its original case *)
 
 fun updexisting key f m =
-    case Map.peek(m,key) of
+    case Symtab.lookup m key of
         NONE => m
-      | SOME v => Map.insert(m,key,f v)
+      | SOME v => Symtab.update (key, f v) m
 
 (* the submap is a map from lowercased item-name to those items with the
    same name.  There is a list of them because item-names are really
    case-sensitive *)
-type submap = (string, data list) Map.dict
-val empty_sdata_map = Map.mkDict String.compare
+type submap = data list Symtab.table
+val empty_sdata_map : submap = Symtab.empty
 (* the dbmap contains:
     - a map from theory-name to a submap (as above)
 *)
-datatype dbmap = DB of { namemap : (string, submap) Map.dict,
+datatype dbmap = DB of { namemap : submap Symtab.table,
                          revmap : location list Termtab.table,
                          localmap : (thm * thminfo) Symtab.table
                        }
@@ -82,30 +81,30 @@ fun updlocalmap f (DB{namemap,revmap,localmap}) =
 
 fun add_to_submap m (newdata as ((s1, s2), x)) =
     let val s2key = toLower s2
-        val oldvalue = case Map.peek(m, s2key) of
+        val oldvalue = case Symtab.lookup m s2key of
                            NONE => []
                          | SOME items => items
     in
-      Map.insert(m, s2key,
-                 newdata :: List.filter (not o dataNameEq s2) oldvalue)
+      Symtab.update
+        (s2key, newdata :: List.filter (not o dataNameEq s2) oldvalue) m
     end
 
 fun insert_localmap_into_namemap thyname ltab nmap =
     let
-      val sm0 = case Map.peek(nmap, thyname) of
+      val sm0 = case Symtab.lookup nmap thyname of
                     NONE => empty_sdata_map
                   | SOME sm0 => sm0
       fun foldthis (thname, th_thi) sm0 =
           add_to_submap sm0 ((thyname,thname), th_thi)
       val sm = Symtab.fold foldthis ltab sm0
     in
-      Map.insert(nmap, thyname, sm)
+      Symtab.update (thyname, sm) nmap
     end
 
 fun allnamemap cthy d =
     insert_localmap_into_namemap cthy (localmap d) (namemap d)
 
-val empty_dbmap = DB {namemap = Map.mkDict String.compare,
+val empty_dbmap = DB {namemap = Symtab.empty,
                       localmap = Symtab.empty, revmap = Termtab.empty}
 
 local val DBref = ref empty_dbmap
@@ -113,14 +112,14 @@ local val DBref = ref empty_dbmap
       fun functional_bindl_names thy blist namemap =
           (* used when a theory is loaded from disk *)
           let val submap =
-                  case Map.peek(namemap, thy) of
+                  case Symtab.lookup namemap thy of
                     NONE => empty_sdata_map
                   | SOME m => m
               fun foldthis ((n,th,info), m) =
                   add_to_submap m ((thy,n), (th,info))
               val submap' = List.foldl foldthis submap blist
           in
-            Map.insert(namemap, thy, submap')
+            Symtab.update (thy, submap') namemap
           end
       fun functional_bindl_revmap thy blist revmap =
           List.foldl
@@ -134,40 +133,37 @@ local val DBref = ref empty_dbmap
 
       fun purge_stale_bindings thyname =
           let
-            open Map
-            fun foldthis (n, datas : data list, m) =
+            fun foldthis (n, datas : data list) m =
                 let
                   val data' = List.filter(fn (_, (th, _)) => uptodate_thm th)
                                          datas
                 in
-                  insert(m,n,data')
+                  Symtab.update (n, data') m
                 end
             fun purge_stale ttab =
-                let open Termtab
-                in
-                  fold (fn (t,d) => fn A =>
-                           if uptodate_term t then update (t,d) A else A)
-                       ttab
-                       empty
-                end
+                Termtab.fold
+                  (fn (t,d) => fn A =>
+                      if uptodate_term t then Termtab.update (t,d) A else A)
+                  ttab Termtab.empty
           in
             DBref :=
             ((!DBref)
                |> updnamemap
-                    (updexisting thyname (foldl foldthis empty_sdata_map))
+                    (updexisting thyname
+                       (fn sm => Symtab.fold foldthis sm empty_sdata_map))
                |> updrevmap purge_stale)
           end
 
       fun delete_binding bnm =
           let
-            open Map
             val ct = current_theory()
             fun smdelbinding bnm sm =
-                case peek (sm, toLower bnm) of
+                case Symtab.lookup sm (toLower bnm) of
                     NONE => sm
                   | SOME datas =>
-                    insert(sm,toLower bnm,
-                           List.filter(not o dataNameEq bnm) datas)
+                    Symtab.update
+                      (toLower bnm,
+                       List.filter(not o dataNameEq bnm) datas) sm
           in
             DBref := updnamemap (updexisting ct (smdelbinding bnm)) (!DBref)
           end
@@ -235,9 +231,9 @@ fun thy s =
     let
       val DB{namemap,...} = CT()
     in
-      case Map.peek(namemap, norm_thyname s) of
+      case Symtab.lookup namemap (norm_thyname s) of
           NONE => []
-        | SOME m => Map.foldl (fn (lcnm, datas, A) => datas @ A) [] m
+        | SOME m => Symtab.fold (fn (_, datas) => fn A => datas @ A) m []
     end
 
 fun findpred pat =
@@ -252,15 +248,15 @@ fun find0 incprivatep s =
     let
       val DB{namemap,...} = CT()
       val check = findpred s (* pre-compiles regexp *)
-      fun subfold (k, vs, acc) =
+      fun subfold (k, vs) acc =
           if check k then
             (if incprivatep then vs
              else List.filter (fn (_, (_, {private=p,...})) => not p) vs) @
             acc
           else acc
-      fun fold (thy, m, acc) = Map.foldr subfold acc m
+      fun fold (_, m) acc = Symtab.fold_rev subfold m acc
     in
-      Map.foldr fold [] namemap
+      Symtab.fold_rev fold namemap []
     end
 
 fun find s = List.map drop_private (find0 false s)
@@ -273,19 +269,19 @@ val find_all = find0 true
 fun matchp0 incprivate P thylist =
     let fun data_P (_, (th, {private,...})) =
             (incprivate orelse not private) andalso P th
-        fun subfold (k, v, acc) = List.filter data_P v @ acc
+        fun subfold (k, v) acc = List.filter data_P v @ acc
         val curr = current_theory()
     in
       case thylist of
-        [] => let fun fold (k, m, acc) = Map.foldr subfold acc m
+        [] => let fun fold (_, m) acc = Symtab.fold_rev subfold m acc
               in
-                Map.foldr fold [] (allnamemap curr (CT()))
+                Symtab.fold_rev fold (allnamemap curr (CT())) []
               end
       | _ => let val db = allnamemap curr (CT())
                  fun fold (thyn, acc) =
-                     case Map.peek(db, norm_thyname thyn) of
+                     case Symtab.lookup db (norm_thyname thyn) of
                        NONE => acc
-                     | SOME m => Map.foldr subfold acc m
+                     | SOME m => Symtab.fold_rev subfold m acc
              in
                List.foldr fold [] thylist
              end
@@ -475,15 +471,15 @@ in List.filter (check o dataName)
 end
 
 fun listDB () =
-    let fun subfold (k,v,acc) = v @ acc
-        fun fold (_, m, acc) = Map.foldr subfold acc m
+    let fun subfold (_,v) acc = v @ acc
+        fun fold (_, m) acc = Symtab.fold_rev subfold m acc
     in
-      Map.foldr fold [] (namemap (CT()))
+      Symtab.fold_rev fold (namemap (CT())) []
     end
 
 fun listPublicDB() =
     let
-      fun subfold (_,dvs,acc) =
+      fun subfold (_,dvs) acc =
           let
             val dvs' =
                 List.mapPartial (fn d => if data_isprivate d then NONE
@@ -492,9 +488,9 @@ fun listPublicDB() =
           in
             dvs' :: acc
           end
-      fun fold (_, m, acc) = Map.foldr subfold acc m
+      fun fold (_, m) acc = Symtab.fold_rev subfold m acc
     in
-      List.concat (Map.foldr fold [] (namemap (CT())))
+      List.concat (Symtab.fold_rev fold (namemap (CT())) [])
     end
 
 fun selectDB sels =
@@ -519,10 +515,12 @@ fun thm_class origf thy name = let
   val db = namemap (CT())
   val thy = norm_thyname thy
   val nosuchthm = ("theorem "^thy^"$"^name^" not found")
-  val thymap = Map.find(db, thy)
-               handle Map.NotFound => raise ERR origf ("no such theory: "^thy)
-  val result = Map.find(thymap, toLower name)
-               handle Map.NotFound => raise ERR origf nosuchthm
+  val thymap = case Symtab.lookup db thy of
+                   SOME m => m
+                 | NONE => raise ERR origf ("no such theory: "^thy)
+  val result = case Symtab.lookup thymap (toLower name) of
+                   SOME r => r
+                 | NONE => raise ERR origf nosuchthm
 in
   case filter (equal (norm_thyname thy,name) o fst) result of
     [(_,p)] => p

--- a/src/postkernel/DB.sml
+++ b/src/postkernel/DB.sml
@@ -48,7 +48,7 @@ val toLower = CharVector.map Char.toLower
      is loaded.
  ---------------------------------------------------------------------------*)
 
-structure Map = HOLdict
+structure Map = Redblackmap
 (* the keys are lower-cased, but the data also stores the keys, and there
    the key information is kept in its original case *)
 

--- a/src/postkernel/Holmakefile
+++ b/src/postkernel/Holmakefile
@@ -3,3 +3,6 @@ all: $(DEFAULT_TARGETS)
 
 Termtab.uo Termtab.ui: Termtab.sml $(dprot $(SIGOBJ)/Table.ui)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
+
+Typetab.uo Typetab.ui: Typetab.sml $(dprot $(SIGOBJ)/Table.ui)
+	$(HOLMOSMLC) Overlay.ui Table.ui -c $<

--- a/src/postkernel/Holmakefile
+++ b/src/postkernel/Holmakefile
@@ -1,8 +1,22 @@
 all: $(DEFAULT_TARGETS)
 .PHONY: all
 
-Termtab.uo Termtab.ui: Termtab.sml $(dprot $(SIGOBJ)/Table.ui)
+TABLE_UID = $(dprot $(SIGOBJ)/Table.ui)
+
+# Termtab/Typetab: pre-existing rules from develop; safe under both
+# poly and mosml.
+Termtab.uo Termtab.ui: Termtab.sml $(TABLE_UID)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
-Typetab.uo Typetab.ui: Typetab.sml $(dprot $(SIGOBJ)/Table.ui)
+Typetab.uo Typetab.ui: Typetab.sml $(TABLE_UID)
+	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
+
+# Files instantiating the Table functor locally need explicit
+# Table.ui passed on the command line for mosml -- its dep
+# auto-detection misses functor applications.
+
+SharingTables.uo: SharingTables.sml SharingTables.ui $(TABLE_UID)
+	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
+
+TheoryGraph.uo: TheoryGraph.sml TheoryGraph.ui $(TABLE_UID)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<

--- a/src/postkernel/Holmakefile
+++ b/src/postkernel/Holmakefile
@@ -13,10 +13,17 @@ Typetab.uo Typetab.ui: Typetab.sml $(TABLE_UID)
 
 # Files instantiating the Table functor locally need explicit
 # Table.ui passed on the command line for mosml -- its dep
-# auto-detection misses functor applications.
+# auto-detection misses functor applications.  Sibling/sigobj .ui
+# deps are listed explicitly so they end up in the .uo metadata
+# (poly's poly_compile bypasses Holdep's include-path search when
+# the recipe is custom).
 
-SharingTables.uo: SharingTables.sml SharingTables.ui $(TABLE_UID)
+SharingTables.uo: SharingTables.sml SharingTables.ui $(TABLE_UID) \
+                  DB_dtype.uo \
+                  $(dprot $(SIGOBJ)/Term.ui) $(dprot $(SIGOBJ)/Type.ui) \
+                  $(dprot $(SIGOBJ)/RawTheoryReader.ui)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
-TheoryGraph.uo: TheoryGraph.sml TheoryGraph.ui $(TABLE_UID)
+TheoryGraph.uo: TheoryGraph.sml TheoryGraph.ui $(TABLE_UID) Theory.uo \
+                $(dprot $(SIGOBJ)/Portable.ui)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<

--- a/src/postkernel/SharingTables.sig
+++ b/src/postkernel/SharingTables.sig
@@ -8,12 +8,15 @@ sig
   type thminfo = DB_dtype.thminfo
   datatype raw_term = datatype RawTheory_dtype.raw_term
 
-  structure Idtab : TABLE where type Key.key = id
+  type 'a idtab  (* abstract; backed by a local Table instantiation
+                    keyed on `id` -- not exposed as a structure to
+                    avoid leaking the TABLE signature, which trips
+                    mosml on case-insensitive filesystems *)
 
   type stringtable =
        {size : int, map : int Symtab.table, list : string list}
   type idtable = {idsize : int,
-                  idmap : int Idtab.table,
+                  idmap : int idtab,
                   idlist : (int * int) list}
   type typetable = {tysize : int,
                     tymap : int Typetab.table,

--- a/src/postkernel/SharingTables.sig
+++ b/src/postkernel/SharingTables.sig
@@ -1,7 +1,6 @@
 signature SharingTables =
 sig
 
-  structure Map : Binarymap
   exception SharingTables of string
 
   type id = {Thy : string, Other : string}
@@ -9,16 +8,18 @@ sig
   type thminfo = DB_dtype.thminfo
   datatype raw_term = datatype RawTheory_dtype.raw_term
 
+  structure Idtab : TABLE where type Key.key = id
+
   type stringtable =
-       {size : int, map : (string,int) Map.dict, list : string list}
+       {size : int, map : int Symtab.table, list : string list}
   type idtable = {idsize : int,
-                  idmap : (id, int) Map.dict,
+                  idmap : int Idtab.table,
                   idlist : (int * int) list}
   type typetable = {tysize : int,
-                    tymap : (Type.hol_type, int)Map.dict,
+                    tymap : int Typetab.table,
                     tylist : raw_type list}
   type termtable = {termsize : int,
-                    termmap : (Term.term, int)Map.dict,
+                    termmap : int Termtab.table,
                     termlist : raw_term list}
 
   val empty_strtable : stringtable

--- a/src/postkernel/SharingTables.sml
+++ b/src/postkernel/SharingTables.sml
@@ -5,8 +5,19 @@ open Term Type DB_dtype RawTheoryReader
 infix |>
 fun x |> f = f x
 
-structure Map = Binarymap
 exception SharingTables of string
+
+type id = {Thy : string, Other : string}
+fun id_compare ({Other = id1, Thy = thy1}, {Other = id2, Thy = thy2}) =
+    case String.compare(id1, id2) of
+      EQUAL => String.compare(thy1, thy2)
+    | x => x
+
+structure Idtab = Table(
+  type key = id
+  val ord = id_compare
+  fun pp ({Thy, Other} : id) = HOLPP.add_string (Thy ^ "$" ^ Other)
+)
 
 type 'a sexppr = 'a -> HOLsexp.t
 
@@ -15,14 +26,13 @@ type 'a sexppr = 'a -> HOLsexp.t
    ---------------------------------------------------------------------- *)
 
 type stringtable =
-     {size : int, map : (string,int) Map.dict, list : string list}
-type id = {Thy : string, Other : string}
+     {size : int, map : int Symtab.table, list : string list}
 type idtable = {idsize : int,
-                idmap : (id, int) Map.dict,
+                idmap : int Idtab.table,
                 idlist : (int * int) list}
 
 val empty_strtable : stringtable =
-    {size = 0, map = Map.mkDict String.compare, list = []}
+    {size = 0, map = Symtab.empty, list = []}
 
 local
   open HOLsexp
@@ -43,11 +53,11 @@ end (* local *)
 
 
 fun new_string s (strtable as {size,list,map}:stringtable) =
-    case Map.peek(map, s) of
+    case Symtab.lookup map s of
         SOME i => (i, strtable)
       | NONE => (size, {size = size + 1,
                         list = s :: list,
-                        map = Map.insert(map,s,size)})
+                        map = Symtab.update (s, size) map})
 
 (* ----------------------------------------------------------------------
     IDs (also known as Theory-X pairs, where X is a Name for a constant,
@@ -56,7 +66,7 @@ fun new_string s (strtable as {size,list,map}:stringtable) =
 
 
 fun make_shared_id (id as {Thy,Other} : id) (strtable, idtable) =
-    case Map.peek(#idmap idtable, id) of
+    case Idtab.lookup (#idmap idtable) id of
       SOME i => (i, strtable, idtable)
     | NONE => let
         val {idsize, idmap, idlist} = idtable
@@ -64,16 +74,12 @@ fun make_shared_id (id as {Thy,Other} : id) (strtable, idtable) =
         val (otheri, strtable) = new_string Other strtable
       in
         (idsize, strtable,
-         {idsize = idsize + 1, idmap = Map.insert(idmap, id, idsize),
+         {idsize = idsize + 1, idmap = Idtab.update (id, idsize) idmap,
           idlist = (thyi,otheri) :: idlist})
       end
-fun id_compare ({Other = id1, Thy = thy1}, {Other = id2, Thy = thy2}) =
-    case String.compare(id1, id2) of
-      EQUAL => String.compare(thy1, thy2)
-    | x => x
 
 val empty_idtable : idtable = {idsize = 0,
-                               idmap = Map.mkDict id_compare,
+                               idmap = Idtab.empty,
                                idlist = []}
 
 
@@ -91,7 +97,7 @@ fun build_id_vector strings intpairs =
 open RawTheory_dtype
 
 type typetable = {tysize : int,
-                  tymap : (hol_type, int)Map.dict,
+                  tymap : int Typetab.table,
                   tylist : raw_type list}
 
 local
@@ -105,7 +111,7 @@ val enc_tytable : typetable encoder =
 end (* local *)
 
 fun make_raw_type ty strtable idtable table =
-    case Map.peek(#tymap table, ty) of
+    case Typetab.lookup (#tymap table) ty of
       SOME i => (i, strtable, idtable, table)
     | NONE => let
       in
@@ -114,7 +120,7 @@ fun make_raw_type ty strtable idtable table =
           in
             (tysize, strtable, idtable,
              {tysize = tysize + 1,
-              tymap = Map.insert(tymap, ty, tysize),
+              tymap = Typetab.update (ty, tysize) tymap,
               tylist = TYV (dest_vartype ty) :: tylist})
           end
         else let
@@ -133,38 +139,38 @@ fun make_raw_type ty strtable idtable table =
           in
             (tysize, strtable', idtable',
              {tysize = tysize + 1,
-              tymap = Map.insert(tymap, ty, tysize),
+              tymap = Typetab.update (ty, tysize) tymap,
               tylist = TYOP {opn = id, args = newargs} :: tylist})
           end
       end
 
 val empty_tytable : typetable =
-    {tysize = 0, tymap = Map.mkDict Type.compare, tylist = [] }
+    {tysize = 0, tymap = Typetab.empty, tylist = [] }
 
 fun build_type_vector idv shtylist = let
   fun build1 (shty, (n, tymap)) =
       case shty of
-        TYV s => (n + 1, Map.insert(tymap, n, Type.mk_vartype s))
+        TYV s => (n + 1, Inttab.update (n, Type.mk_vartype s) tymap)
       | TYOP {opn,args} => let
           fun mapthis i =
-              Map.find(tymap, i)
-              handle Map.NotFound =>
-                     raise SharingTables ("build_type_vector: (" ^
-                                          String.concatWith " "
-                                                (map Int.toString args) ^
-                                          "), " ^ Int.toString i ^
-                                          " not found")
+              case Inttab.lookup tymap i of
+                  SOME t => t
+                | NONE =>
+                  raise SharingTables ("build_type_vector: (" ^
+                                       String.concatWith " "
+                                             (map Int.toString args) ^
+                                       "), " ^ Int.toString i ^
+                                       " not found")
           val args = map mapthis args
           val {Thy,Other} = Vector.sub(idv, opn)
         in
           (n + 1,
-           Map.insert(tymap, n,
-                      Type.mk_thy_type {Thy = Thy, Tyop = Other, Args = args}))
+           Inttab.update
+             (n, Type.mk_thy_type {Thy = Thy, Tyop = Other, Args = args}) tymap)
         end
-  val (_, tymap) =
-      List.foldl build1 (0, Map.mkDict Int.compare) shtylist
+  val (_, tymap) = List.foldl build1 (0, Inttab.empty) shtylist
 in
-  Vector.fromList (map #2 (Map.listItems tymap))
+  Vector.fromList (map #2 (Inttab.dest tymap))
 end
 
 (* ----------------------------------------------------------------------
@@ -172,7 +178,7 @@ end
    ---------------------------------------------------------------------- *)
 
 type termtable = {termsize : int,
-                  termmap : (term, int)Map.dict,
+                  termmap : int Termtab.table,
                   termlist : raw_term list}
 
 local
@@ -185,10 +191,10 @@ val enc_tmtable : termtable encoder =
 end (* local *)
 
 val empty_termtable : termtable =
-    {termsize = 0, termmap = Map.mkDict Term.compare, termlist = [] }
+    {termsize = 0, termmap = Termtab.empty, termlist = [] }
 
 fun make_raw_term tm (tables as (strtable,idtable,tytable,tmtable)) =
-    case Map.peek(#termmap tmtable, tm) of
+    case Termtab.lookup (#termmap tmtable) tm of
       SOME i => (i, tables)
     | NONE => let
       in
@@ -201,7 +207,7 @@ fun make_raw_term tm (tables as (strtable,idtable,tytable,tmtable)) =
             (termsize,
              (strtable, idtable, tytable,
               {termsize = termsize + 1,
-               termmap = Map.insert(termmap, tm, termsize),
+               termmap = Termtab.update (tm, termsize) termmap,
                termlist = TMV (s, ty_i) :: termlist}))
           end
         else if is_const tm then let
@@ -215,7 +221,7 @@ fun make_raw_term tm (tables as (strtable,idtable,tytable,tmtable)) =
             (termsize,
              (strtable, idtable, tytable,
               {termsize = termsize + 1,
-               termmap = Map.insert(termmap, tm, termsize),
+               termmap = Termtab.update (tm, termsize) termmap,
                termlist = TMC (id_i, ty_i) :: termlist}))
           end
         else if is_comb tm then let
@@ -228,7 +234,7 @@ fun make_raw_term tm (tables as (strtable,idtable,tytable,tmtable)) =
             (termsize,
              (strtable, idtable, tytable,
               {termsize = termsize + 1,
-               termmap = Map.insert(termmap, tm, termsize),
+               termmap = Termtab.update (tm, termsize) termmap,
                termlist = TMAp(f_i, x_i) :: termlist}))
           end
         else  (* must be an abstraction *) let
@@ -241,32 +247,39 @@ fun make_raw_term tm (tables as (strtable,idtable,tytable,tmtable)) =
             (termsize,
              (strtable, idtable, tytable,
               {termsize = termsize + 1,
-               termmap = Map.insert(termmap, tm, termsize),
+               termmap = Termtab.update (tm, termsize) termmap,
                termlist = TMAbs(v_i, body_i) :: termlist}))
           end
       end
 
 fun build_term_vector idv tyv shtmlist = let
+  fun lookup tmmap i =
+      case Inttab.lookup tmmap i of
+          SOME t => t
+        | NONE => raise SharingTables ("build_term_vector: " ^
+                                       Int.toString i ^ " not found")
   fun build1 (shtm, (n, tmmap)) =
       case shtm of
         TMV (s, tyn) => (n + 1,
-                         Map.insert(tmmap, n, mk_var(s, Vector.sub(tyv, tyn))))
+                         Inttab.update
+                            (n, mk_var(s, Vector.sub(tyv, tyn))) tmmap)
       | TMC (idn, tyn) => let
           val {Thy, Other} = Vector.sub(idv, idn)
           val ty = Vector.sub(tyv, tyn)
         in
-          (n + 1, Map.insert(tmmap, n, mk_thy_const {Name = Other, Thy = Thy,
-                                                     Ty = ty}))
+          (n + 1, Inttab.update
+                    (n, mk_thy_const {Name = Other, Thy = Thy,
+                                      Ty = ty}) tmmap)
         end
       | TMAp (f_n, xn) =>
-        (n + 1, Map.insert(tmmap, n, mk_comb(Map.find(tmmap, f_n),
-                                             Map.find(tmmap, xn))))
+        (n + 1, Inttab.update
+                  (n, mk_comb(lookup tmmap f_n, lookup tmmap xn)) tmmap)
       | TMAbs (vn, bodyn) =>
-        (n + 1, Map.insert(tmmap, n, mk_abs(Map.find(tmmap, vn),
-                                            Map.find(tmmap, bodyn))))
-  val (_, tmmap) = List.foldl build1 (0, Map.mkDict Int.compare) shtmlist
+        (n + 1, Inttab.update
+                  (n, mk_abs(lookup tmmap vn, lookup tmmap bodyn)) tmmap)
+  val (_, tmmap) = List.foldl build1 (0, Inttab.empty) shtmlist
 in
-  Vector.fromList (map #2 (Map.listItems tmmap))
+  Vector.fromList (map #2 (Inttab.dest tmmap))
 end
 
 (* ----------------------------------------------------------------------
@@ -388,14 +401,19 @@ fun build_sharing_data (ed : extract_data) =
     end
 
 fun write_string (SDI{strtable,...}) s =
-    Map.find(#map strtable,s)
-    handle Map.NotFound =>
-           raise SharingTables ("write_string: can't find \"" ^ s ^ "\"")
+    case Symtab.lookup (#map strtable) s of
+        SOME i => i
+      | NONE => raise SharingTables
+                        ("write_string: can't find \"" ^ s ^ "\"")
 fun write_type (SDI{tytable,...}) ty =
-    Map.find(#tymap tytable,ty)
+    case Typetab.lookup (#tymap tytable) ty of
+        SOME i => i
+      | NONE => raise SharingTables "write_type: can't find type"
 fun write_term (SDI{tmtable,...}) =
-    Term.write_raw (fn t => Map.find(#termmap tmtable,t))
-    handle Map.NotFound => raise SharingTables "write_term: can't find term"
+    Term.write_raw
+      (fn t => case Termtab.lookup (#termmap tmtable) t of
+                   SOME i => i
+                 | NONE => raise SharingTables "write_term: can't find term")
 
 fun enc_thminfo findstr {private,loc,class} =
     let open HOLsexp
@@ -424,7 +442,10 @@ fun enc_sdata (sd as SDI{strtable,idtable,tytable,tmtable,exp}) =
       fun enc_thm(s,th,info) =
           let
             val (tag, asl, w) = (Thm.tag th, Thm.hyp th, Thm.concl th)
-            val i = Map.find(#map strtable, s)
+            val i = case Symtab.lookup (#map strtable) s of
+                        SOME i => i
+                      | NONE => raise SharingTables
+                                        ("enc_thm: can't find \"" ^ s ^ "\"")
           in
             pair4_encode
               (Integer,

--- a/src/postkernel/SharingTables.sml
+++ b/src/postkernel/SharingTables.sml
@@ -18,6 +18,7 @@ structure Idtab = Table(
   val ord = id_compare
   fun pp ({Thy, Other} : id) = HOLPP.add_string (Thy ^ "$" ^ Other)
 )
+type 'a idtab = 'a Idtab.table
 
 type 'a sexppr = 'a -> HOLsexp.t
 
@@ -28,7 +29,7 @@ type 'a sexppr = 'a -> HOLsexp.t
 type stringtable =
      {size : int, map : int Symtab.table, list : string list}
 type idtable = {idsize : int,
-                idmap : int Idtab.table,
+                idmap : int idtab,
                 idlist : (int * int) list}
 
 val empty_strtable : stringtable =

--- a/src/postkernel/Theory.sml
+++ b/src/postkernel/Theory.sml
@@ -204,11 +204,11 @@ type shared_readmaps = {strings : int -> string, terms : string -> term}
 
 datatype thydata = Loaded of UniversalType.t
                  | Pending of (HOLsexp.t * shared_readmaps) list
-type ThyDataMap = (string,thydata)Binarymap.dict
+type ThyDataMap = thydata Symtab.table
                   (* map from string identifying the "type" of the data,
                      e.g., "simp", "mono", "cong", "grammar_update",
                      "LaTeX map", to the data itself. *)
-val empty_datamap : ThyDataMap = Binarymap.mkDict String.compare
+val empty_datamap : ThyDataMap = Symtab.empty
 
 fun fact_thm (s, (th, _)) = th
 
@@ -240,11 +240,10 @@ in
 end (* local *)
 
 type metadata = {path: string, timestamp: Time.time}
-val metadata = ref ((Binarymap.mkDict String.compare):
-                    (string,metadata)Binarymap.dict)
+val metadata : metadata Symtab.table ref = ref Symtab.empty
 fun record_metadata thy md =
-  metadata := Binarymap.insert(!metadata, thy, md)
-fun thy_timestamp thy = #timestamp (Binarymap.find(!metadata, thy))
+  metadata := Symtab.update (thy, md) (!metadata)
+fun thy_timestamp thy = #timestamp (valOf (Symtab.lookup (!metadata) thy))
 
 
 (*---------------------------------------------------------------------------*
@@ -707,15 +706,13 @@ struct
                   read : shared_readmaps -> HOLsexp.t -> t option,
                   write : shared_writemaps -> t -> HOLsexp.t,
                   terms : t -> term list, strings : t -> string list}
-  val allthydata = ref (Binarymap.mkDict String.compare :
-                        (string, ThyDataMap) Binarymap.dict)
-  val dataops = ref (Binarymap.mkDict String.compare :
-                     (string, DataOps) Binarymap.dict)
+  val allthydata : ThyDataMap Symtab.table ref = ref Symtab.empty
+  val dataops : DataOps Symtab.table ref = ref Symtab.empty
 
   fun segment_data {thy,thydataty} = let
     val {thydata,name,...} = theCT()
     fun check_map m =
-        case Binarymap.peek(m, thydataty) of
+        case Symtab.lookup m thydataty of
           NONE => NONE
         | SOME (Loaded value) => SOME value
         | SOME (Pending _) => raise ERR "segment_data"
@@ -727,27 +724,26 @@ struct
                   " coming from current_theory\n");
        check_map thydata)
     else
-      case Binarymap.peek(!allthydata, thy) of
+      case Symtab.lookup (!allthydata) thy of
         NONE => NONE
       | SOME dmap => check_map dmap
   end
 
   fun segment_data_string (arg as {thy,thydataty}) =
-      case Binarymap.peek (!dataops, thydataty) of
+      case Symtab.lookup (!dataops) thydataty of
           SOME {pp,...} => Option.map pp (segment_data arg)
         | NONE => raise Fail ("No pp-fn for "^thydataty)
   val sexp_string_dbg = HOLPP.pp_to_string 75 HOLsexp.printer
 
   fun write_data_update {thydataty,data} =
-      case Binarymap.peek(!dataops, thydataty) of
+      case Symtab.lookup (!dataops) thydataty of
         NONE => raise ERR "write_data_update"
                           ("No operations defined for "^thydataty)
       | SOME {merge,pp,...} => let
           val (s as {thydata,...}) = theCT()
-          open Binarymap
           fun updatemap inmap = let
             val newdata =
-                case peek(inmap, thydataty) of
+                case Symtab.lookup inmap thydataty of
                   NONE => Loaded data
                 | SOME (Loaded t) => Loaded (merge(t, data))
                 | SOME (Pending ds) =>
@@ -768,38 +764,38 @@ struct
                             newdata_s ^ "\n"
                           end)
           in
-            insert(inmap,thydataty,newdata)
+            Symtab.update (thydataty, newdata) inmap
           end
         in
           makeCT (update_seg s (U #thydata (updatemap thydata)) $$)
         end
 
   fun set_theory_data {thydataty,data} =
-      case Binarymap.peek(!dataops, thydataty) of
+      case Symtab.lookup (!dataops) thydataty of
         NONE => raise ERR "set_theory_data"
                           ("No operations defined for "^thydataty)
       | SOME{pp,...} => let
           val (s as {thydata,...}) = theCT()
-          open Binarymap
         in
           DPRINT (fn _ => "Updating "^thydataty^" in segment with value " ^
                           pp data ^ "\n");
           makeCT
             (update_seg s
-                        (U #thydata (insert(thydata, thydataty, Loaded data)))
+                        (U #thydata
+                           (Symtab.update (thydataty, Loaded data) thydata))
                         $$)
         end
 
   fun temp_encoded_update (r as {thy,thydataty,data,shared_readmaps}) =
       let
         val (s as {thydata, name, ...}) = theCT()
-        open Binarymap
         fun updatemap inmap = let
           val baddecode = ERR "temp_encoded_update"
                           ("Bad decode for "^thydataty^" (" ^
                            sexp_string_dbg data ^ ")" )
           val newdata =
-              case (peek(inmap, thydataty), peek(!dataops,thydataty)) of
+              case (Symtab.lookup inmap thydataty,
+                    Symtab.lookup (!dataops) thydataty) of
                   (NONE, NONE) => Pending [(data,shared_readmaps)]
                 | (NONE, SOME {read,...}) =>
                   Loaded (valOf (read shared_readmaps data)
@@ -814,25 +810,24 @@ struct
                 | (SOME (Pending _), SOME _) =>
                   raise Fail "temp_encoded_update invariant failure 2"
         in
-          insert(inmap, thydataty, newdata)
+          Symtab.update (thydataty, newdata) inmap
         end
   in
     if thy = name then
       makeCT (update_seg s (U #thydata (updatemap thydata)) $$)
     else let
       val newsubmap =
-          case peek (!allthydata, thy) of
+          case Symtab.lookup (!allthydata) thy of
               NONE => updatemap empty_datamap
             | SOME dm => updatemap dm
     in
-      allthydata := insert(!allthydata, thy, newsubmap)
+      allthydata := Symtab.update (thy, newsubmap) (!allthydata)
     end
   end
 
 fun update_pending (m,r) thydataty = let
-  open Binarymap
   fun update1 inmap =
-      case peek(inmap, thydataty) of
+      case Symtab.lookup inmap thydataty of
         NONE => inmap
       | SOME (Loaded t) =>
           raise ERR "LoadableThyData.new"
@@ -844,13 +839,12 @@ fun update_pending (m,r) thydataty = let
           val ds' = List.rev ds
           val (d1,tmrd1) = hd ds'
         in
-          insert(inmap,thydataty,
-                 Loaded (List.foldl foldthis (valOf (r tmrd1 d1)) (tl ds')))
+          Symtab.update (thydataty,
+                         Loaded (List.foldl foldthis
+                                   (valOf (r tmrd1 d1)) (tl ds'))) inmap
         end
-  fun foldthis (k,v,acc) = insert(acc,k,update1 v)
-  val _ = allthydata := Binarymap.foldl foldthis
-                                        (Binarymap.mkDict String.compare)
-                                        (!allthydata)
+  fun foldthis (k,v) acc = Symtab.update (k, update1 v) acc
+  val _ = allthydata := Symtab.fold foldthis (!allthydata) Symtab.empty
   val (seg as {thydata,...}) = theCT()
 in
   makeCT (update_seg seg (U #thydata (update1 thydata)) $$)
@@ -867,9 +861,10 @@ fun 'a new {thydataty, merge, read, write, terms, strings, pp} = let
   fun pp' t = pp (vdest t)
 in
   update_pending (merge',read') thydataty;
-  dataops := Binarymap.insert(!dataops, thydataty,
-                              {merge=merge', read=read', write=write',
-                               terms=terms', pp=pp', strings=strings'});
+  dataops := Symtab.update
+                (thydataty,
+                 {merge=merge', read=read', write=write',
+                  terms=terms', pp=pp', strings=strings'}) (!dataops);
   (mk,dest)
 end
 
@@ -946,22 +941,23 @@ fun export_theory_return_hash () = let
                  parents = map thyid_name (Graph.fringe()),
                  all_thms = all_thms}
   fun mungethydata dmap = let
-    fun foldthis (k,v,acc as (strlist,tmlist,dict)) =
+    fun foldthis (k,v) (acc as (strlist,tmlist,dict)) =
         case v of
           Loaded t =>
           let
             val {write,terms,strings,...} =
-              Binarymap.find(!LoadableThyData.dataops, k)
-              handle Binarymap.NotFound =>
-                raise ERR "export_theory" ("Couldn't find thydata ops for "^k)
+                case Symtab.lookup (!LoadableThyData.dataops) k of
+                    SOME ops => ops
+                  | NONE => raise ERR "export_theory"
+                              ("Couldn't find thydata ops for "^k)
           in
             (strings t @ strlist,
              terms t @ tmlist,
-             Binarymap.insert(dict,k,(fn wrtm => write wrtm t)))
+             Symtab.update (k, fn wrtm => write wrtm t) dict)
           end
         | _ => acc
   in
-    Binarymap.foldl foldthis ([], [], Binarymap.mkDict String.compare) dmap
+    Symtab.fold foldthis dmap ([], [], Symtab.empty)
   end
   val structthry =
       {theory = thyname,

--- a/src/postkernel/TheoryGraph.sml
+++ b/src/postkernel/TheoryGraph.sml
@@ -9,6 +9,12 @@ exception NotFound of thy
 val thy_compare : thy * thy -> order =
     inv_img_cmp #thyname String.compare
 
+structure Thytab = Table(struct
+  type key = thy
+  val ord = thy_compare
+  val pp = HOLPP.add_string o #thyname
+end)
+
 type thyset = thy HOLset.set
 
 fun toThy s : thy = {thyname = s}
@@ -16,16 +22,19 @@ val slist_to_thyset =
   List.foldl (fn (s,acc) => HOLset.add(acc,{thyname = s}))
              (HOLset.empty thy_compare)
 
-type t = (thy,thyset) Binarymap.dict
+type t = thyset Thytab.table
 
-val empty : t = Binarymap.mkDict thy_compare
+val empty : t = Thytab.empty
 
 fun member G thy =
-  case Binarymap.peek(G, thy) of
+  case Thytab.lookup G thy of
       NONE => false
     | SOME _ => true
 
-fun parents G thy = Binarymap.find (G, thy)
+fun parents G thy =
+  case Thytab.lookup G thy of
+      NONE => raise NotFound thy
+    | SOME ps => ps
 
 fun ancestors G thy =
   let
@@ -92,7 +101,7 @@ fun insert (newthy, parents) G =
       let
         val ps' = eliminate_redundant_ancestors G parents
       in
-        Binarymap.insert(G, newthy, HOLset.fromList thy_compare ps')
+        Thytab.update (newthy, HOLset.fromList thy_compare ps') G
       end
 
 fun current () =

--- a/src/postkernel/TheoryPP.sig
+++ b/src/postkernel/TheoryPP.sig
@@ -20,7 +20,7 @@ sig
    all_thms    : (string * thm * thminfo) list,
    mldeps      : string list,
    thydata     : string list * Term.term list *
-                 (string,shared_writemaps -> HOLsexp.t)Binarymap.dict
+                 (shared_writemaps -> HOLsexp.t) Symtab.table
  }
  type sig_info_record = {
    name        : string,

--- a/src/postkernel/TheoryPP.sml
+++ b/src/postkernel/TheoryPP.sml
@@ -26,7 +26,7 @@ type struct_info_record = {
    all_thms    : (string * thm * thminfo) list,
    mldeps      : string list,
    thydata     : string list * Term.term list *
-                 (string,shared_writemaps -> HOLsexp.t)Binarymap.dict
+                 (shared_writemaps -> HOLsexp.t) Symtab.table
  }
 
 open Feedback Lib Portable Dep;
@@ -408,10 +408,10 @@ fun pp_thydata (info_record : struct_info_record) = let
   val enc_cpl = HOLsexp.pair_encode(HOLsexp.String, fn x => x)
 
   fun list_loadable shared_writers thydata_map =
-    Binarymap.foldl
-      (fn (k, data, rest) => (k, data shared_writers) :: rest)
-      []
+    Symtab.fold
+      (fn (k, data) => fn rest => (k, data shared_writers) :: rest)
       thydata_map
+      []
   fun enc_loadable shared_writers thydata_map =
       let open HOLsexp in
         tagged_encode "loadable-thydata" (list_encode enc_cpl)

--- a/src/postkernel/Typetab.sml
+++ b/src/postkernel/Typetab.sml
@@ -1,0 +1,25 @@
+structure Typetab = Table(
+  type key = Type.hol_type
+  val ord = Type.compare
+  fun simple_print ty =
+      let open HOLPP Type
+      in
+        if is_vartype ty then add_string (dest_vartype ty)
+        else
+          let val {Thy, Tyop, Args} = dest_thy_type ty
+              val opname = Thy ^ "$" ^ Tyop
+          in
+            case Args of
+                [] => add_string opname
+              | _ =>
+                block CONSISTENT 0 [
+                  add_string "(",
+                  block INCONSISTENT 1 (
+                    pr_list simple_print [add_break(1,0)] Args
+                  ),
+                  add_string (")" ^ opname)
+                ]
+          end
+      end
+  val pp = simple_print
+)

--- a/src/postkernel/prooftrace/PFTReplay.sml
+++ b/src/postkernel/prooftrace/PFTReplay.sml
@@ -8,15 +8,15 @@ infix |->
 (* trDB: theorem database keyed by "Thy$name" / "Thy#n"                      *)
 (* ========================================================================= *)
 
-type trDB = (string, thm) Redblackmap.dict
+type trDB = thm Symtab.table
 
-val empty_trDB = Redblackmap.mkDict String.compare
+val empty_trDB : trDB = Symtab.empty
 
-fun lookup (db: trDB) key = Redblackmap.peek(db, key)
+fun lookup (db: trDB) key = Symtab.lookup db key
 
-fun size (db: trDB) = Redblackmap.numItems db
+fun size (db: trDB) = Symtab.size db
 
-fun listItems (db: trDB) = Redblackmap.listItems db
+fun listItems (db: trDB) = Symtab.dest db
 
 (* ========================================================================= *)
 (* Filename parsing                                                          *)
@@ -152,10 +152,10 @@ fun replay (db: trDB) file = let
     in set_th (id, mk_axiom_thm(Nonce.mk ax_name, c)) end,
 
     save = fn (name, th) =>
-      db_ref := Redblackmap.insert(!db_ref, name, get_th th),
+      db_ref := Symtab.update (name, get_th th) (!db_ref),
 
     load = fn (id, name) =>
-      (case Redblackmap.peek(!db_ref, name) of
+      (case Symtab.lookup (!db_ref) name of
          SOME th => set_th (id, th)
        | NONE => raise Fail ("PFTReplay: load: not found: " ^ name)),
 

--- a/src/postkernel/prooftrace/ProofTraceReplay.sig
+++ b/src/postkernel/prooftrace/ProofTraceReplay.sig
@@ -6,5 +6,5 @@ signature ProofTraceReplay = sig
   val replay: string -> unit  (* takes a path to a .tr.gz or .tr file *)
   val replay_sequence: string list -> unit  (* takes thynames, looks in cwd *)
   val skip_standard_axiom: unit -> string
-  val replayed_thms: string -> (string, Thm.thm) Redblackmap.dict * Thm.thm list
+  val replayed_thms: string -> Thm.thm Symtab.table * Thm.thm list
 end

--- a/src/postkernel/prooftrace/ProofTraceReplay.sml
+++ b/src/postkernel/prooftrace/ProofTraceReplay.sml
@@ -7,14 +7,14 @@ qload "ProofTraceParser";
 qload "PIntMap";
 *)
 
-open Feedback Lib Type Term Thm Redblackmap ProofTraceParser
+open Feedback Lib Type Term Thm ProofTraceParser
 
 infix |->
 
 fun mk_eq(l,r) = list_mk_comb(inst[alpha |-> type_of l]equality, [l,r])
 
-val trDB : (string, (string, thm) dict * thm list) dict ref
-  = ref (mkDict String.compare)
+val trDB : (thm Symtab.table * thm list) Symtab.table ref
+  = ref Symtab.empty
 
 datatype hol_obj = Ty of hol_type | Tm of term | Th of thm | Unknown
 fun destTy (Ty ty) = ty | destTy _ = raise Fail "destTy"
@@ -122,7 +122,7 @@ let
   fun get_thm_id (id_ptr: thm_id ptr) = thmId heap id_ptr
 
   fun check_def map Thy nm =
-    if Thy = thyname then case peek (map, nm)
+    if Thy = thyname then case Symtab.lookup map nm
     of SOME thps => List.app (ignore o replay_thm) thps
      | _ => () else ()
 
@@ -242,14 +242,14 @@ let
       in prim_type_definition ({Thy=Thy, Tyop=Tyop}, thm) end
     | Disk_prf (thy, b) => let
         val id = get_thm_id b
-      in case peek(!trDB, thy) of
+      in case Symtab.lookup (!trDB) thy of
           NONE => raise NeedsAncestor thy
         | SOME (named,anons) => (case id of
             SavedAnon i => (
               List.nth(anons, i) handle Subscript =>
                 raise Fail ("Disk thy "^thy^":"^(Int.toString i)))
           | SavedName s => (
-              case peek(named, s) of
+              case Symtab.lookup named s of
                 NONE => raise Fail ("Disk thy "^thy^"$"^s)
               | SOME th => th))
       end
@@ -323,7 +323,9 @@ let
     val () = dbg_print " done\n"
   in (nm, th) end
 
-  val named = fromList String.compare (list heap export all_thms)
+  val named = List.foldl (fn ((k,v),m) => Symtab.update (k,v) m)
+                         Symtab.empty
+                         (list heap export all_thms)
   val anons = list heap replay_thm anon_thms
 
   fun ensure_const p = let
@@ -364,17 +366,17 @@ let
                Int.toString live_th, "th",
     "  pinned: ", Int.toString pinned_count,
     "  sat: ", Int.toString saturated,
-    "  named: ", Int.toString (numItems named),
+    "  named: ", Int.toString (Symtab.size named),
     "  anons: ", Int.toString (length anons), "\n"])
   in () end else ()
 
-in trDB := insert(!trDB, thyname, (named, anons)) end
+in trDB := Symtab.update (thyname, (named, anons)) (!trDB) end
 handle e as (NeedsAncestor s) => (print("Ancestor missing: "^s^"\n"); raise e)
      | e as (HOL_ERR m) => (print("HOL_ERR: "^(Feedback.message_of m)^"\n"); raise e)
 end (* let val thyname *)
 
-fun trDB_size () = foldl (fn (_,(n,a), acc) =>
-  acc + numItems n + length a) 0 (!trDB)
+fun trDB_size () = Symtab.fold (fn (_,(n,a)) => fn acc =>
+  acc + Symtab.size n + length a) (!trDB) 0
 
 fun replay_sequence [] = ()
   | replay_sequence (thy::thys) =
@@ -385,7 +387,7 @@ fun replay_sequence [] = ()
      (if !print_statistics then time else I) replay (thy ^ "Theory.tr.gz");
      replay_sequence thys)
 
-fun replayed_thms s = find(!trDB, s)
+fun replayed_thms s = valOf (Symtab.lookup (!trDB) s)
 
 (*
 

--- a/src/postkernel/prooftrace/ProofTraceReplay.sml
+++ b/src/postkernel/prooftrace/ProofTraceReplay.sml
@@ -67,7 +67,7 @@ fun thyname_from_path path =
 
 fun replay path =
   let val thyname = thyname_from_path path in
-  if inDomain(!trDB, thyname)
+  if Symtab.defined (!trDB) thyname
   then msg_print("skip ")
   else
 let

--- a/src/postkernel/prooftrace/ProofTraceWalk.sig
+++ b/src/postkernel/prooftrace/ProofTraceWalk.sig
@@ -8,8 +8,8 @@ signature ProofTraceWalk = sig
       anon_thms : Thm.thm list ptr,
       incr : unit ptr -> unit,
       on_def_thm : Thm.thm ptr -> unit } ->
-    { tm_defs : (string, Thm.thm ptr list) Redblackmap.dict,
-      ty_defs : (string, Thm.thm ptr list) Redblackmap.dict,
+    { tm_defs : Thm.thm ptr list Symtab.table,
+      ty_defs : Thm.thm ptr list Symtab.table,
       is_closed : Term.term ptr -> bool,
       get_const_id : Term.term ptr -> string * string,
       get_type_id : Type.hol_type ptr -> string * string }

--- a/src/postkernel/prooftrace/ProofTraceWalk.sml
+++ b/src/postkernel/prooftrace/ProofTraceWalk.sml
@@ -1,6 +1,9 @@
 structure ProofTraceWalk :> ProofTraceWalk = struct
 
-open Lib Redblackmap ProofTraceParser
+open Lib ProofTraceParser
+
+fun update_at (tab, k, f) =
+    Symtab.update (k, f (Symtab.lookup tab k)) tab
 
 fun walk {heap, thyname, named_thms, anon_thms,
           incr, on_def_thm} = let
@@ -66,8 +69,8 @@ fun walk {heap, thyname, named_thms, anon_thms,
   fun is_closed tm_ptr = isPtr tm_ptr andalso compute_closedness tm_ptr < 0
 
   (* Walk state *)
-  val tm_defs : (string, thm ptr list) dict ref = ref (mkDict String.compare)
-  val ty_defs : (string, thm ptr list) dict ref = ref (mkDict String.compare)
+  val tm_defs : thm ptr list Symtab.table ref = ref Symtab.empty
+  val ty_defs : thm ptr list Symtab.table ref = ref Symtab.empty
   val seen = BoolArray.array(heapSize heap, false)
 
   fun first_seen p =
@@ -114,7 +117,7 @@ fun walk {heap, thyname, named_thms, anon_thms,
                              thm_ptr::ls))
       fun check_thy defthy =
         if defthy = thyname then () else raise Fail "add_def thy"
-      fun add_const nm = tm_defs := update(!tm_defs, nm, add_thm_ptr nm)
+      fun add_const nm = tm_defs := update_at (!tm_defs, nm, add_thm_ptr nm)
       fun add_def_const p = let
         val (thy,nm) = get_const_id p
         val () = check_thy thy
@@ -151,7 +154,7 @@ fun walk {heap, thyname, named_thms, anon_thms,
           val () = th b
           val (thy,tyop) = get_type_id c
           val () = check_thy thy
-        in ty_defs := update(!ty_defs, tyop, add_thm_ptr tyop) end
+        in ty_defs := update_at (!ty_defs, tyop, add_thm_ptr tyop) end
       | Disk_prf _ => ()
       | EQ_IMP_RULE1_prf a => th a
       | EQ_IMP_RULE2_prf a => th a

--- a/src/postkernel/prooftrace/ThmSrc_tr.sml
+++ b/src/postkernel/prooftrace/ThmSrc_tr.sml
@@ -46,7 +46,7 @@ fun load_thydata {thyname, path, hash} =
           List.mapPartial
             (fn raw =>
                 let val nm = #name raw
-                in case Redblackmap.peek(named_dict, nm) of
+                in case Symtab.lookup named_dict nm of
                        SOME th => SOME (nm, th, get_thminfo raw)
                      | NONE => NONE
                 end)

--- a/src/prekernel/Feedback.sml
+++ b/src/prekernel/Feedback.sml
@@ -243,11 +243,10 @@ type trace_record = {
 
 datatype TI = TR of trace_record | ALIAS of string
 
-val trace_map =
-    ref (Binarymap.mkDict String.compare : (string,TI)Binarymap.dict)
+val trace_map : TI Symtab.table ref = ref Symtab.empty
 
 fun find_record n =
-  case Binarymap.peek (!trace_map, n) of
+  case Symtab.lookup (!trace_map) n of
       NONE => NONE
     | SOME (TR tr) => SOME tr
     | SOME (ALIAS a) => find_record a
@@ -281,13 +280,13 @@ fun register_trace0 fnm (nm, r, max) =
      let
        val trfns as TRFP recd = ref2trfp r
      in
-       case Binarymap.peek (!trace_map, nm) of
+       case Symtab.lookup (!trace_map) nm of
            NONE => ()
          | SOME _ =>
            WARN fnm ("Replacing a trace with name " ^ quote nm);
-       trace_map := Binarymap.insert
-                      (!trace_map, nm, TR {value = trfns, default = !r,
-                                           aliases = [], maximum = max});
+       trace_map := Symtab.update
+                      (nm, TR {value = trfns, default = !r,
+                               aliases = [], maximum = max}) (!trace_map);
        recd
      end
 val register_trace = ignore o register_trace0 "register_trace"
@@ -312,10 +311,10 @@ fun register_alias_trace {original, alias} =
               else alias::aliases
           val recd = {aliases = aliases', maximum = maximum, default = default,
                      value = value}
-          val record_alias = Binarymap.insert(!trace_map, original, TR recd)
-          val mk_alias = Binarymap.insert(record_alias, alias, ALIAS original)
+          val record_alias = Symtab.update (original, TR recd) (!trace_map)
+          val mk_alias = Symtab.update (alias, ALIAS original) record_alias
         in
-          case Binarymap.peek (record_alias, alias) of
+          case Symtab.lookup record_alias alias of
               NONE => ()
             | SOME (ALIAS a) =>
                 if a = original then ()
@@ -336,15 +335,15 @@ fun register_ftrace (nm, (get, set), max) =
       if default < 0 orelse max < 0
          then raise ERR "register_ftrace"
                         "Can't have trace values less than zero."
-      else (case Binarymap.peek (!trace_map, nm) of
+      else (case Symtab.lookup (!trace_map) nm of
                NONE => ()
              | SOME _ => WARN "register_ftrace"
                               ("Replacing a trace with name " ^ quote nm)
             ; trace_map :=
-                  Binarymap.insert
-                     (!trace_map, nm, TR {value = TRFP {get = get, set = set},
-                                          default = default, aliases = [],
-                                          maximum = max}))
+                  Symtab.update
+                     (nm, TR {value = TRFP {get = get, set = set},
+                              default = default, aliases = [],
+                              maximum = max}) (!trace_map))
    end
 
 fun register_btrace0 fnm (nm, bref) =
@@ -352,16 +351,16 @@ fun register_btrace0 fnm (nm, bref) =
       fun get() = !bref
       fun set b = bref := b
     in
-      case Binarymap.peek (!trace_map, nm) of
+      case Symtab.lookup (!trace_map) nm of
           NONE => ()
         | SOME _ => WARN fnm ("Replacing a trace with name "^ quote nm);
       trace_map :=
-      Binarymap.insert
-        (!trace_map, nm,
+      Symtab.update
+        (nm,
          TR {value = TRFP {get = (fn () => if !bref then 1 else 0),
                            set = (fn i => bref := (i > 0))},
              default = if !bref then 1 else 0, aliases = [],
-             maximum = 1});
+             maximum = 1}) (!trace_map);
       {set = set, get = get}
     end
 val register_btrace = ignore o register_btrace0 "register_btrace0"
@@ -397,7 +396,7 @@ fun pp_trace_elt (TraceElt{name,aliases,trace_level,default,max}) =
 
 fun traces () =
    let
-      fun foldthis (n, ti, acc) =
+      fun foldthis (n, ti) acc =
         case ti of
             ALIAS _ => acc
           | TR {value, default = d, maximum, aliases} =>
@@ -407,7 +406,7 @@ fun traces () =
              max = maximum} :: acc
    in
      List.map TraceElt
-        (Binarymap.foldr foldthis [] (!trace_map))
+        (Symtab.fold_rev foldthis (!trace_map) [])
    end
 
 fun set_trace nm newvalue =
@@ -426,7 +425,7 @@ fun reset_traces () =
     fun reset (TR{value,default,...}) = trfp_set value default
       | reset (ALIAS _) = ()
   in
-    Binarymap.app (reset o #2) (!trace_map)
+    List.app (reset o #2) (Symtab.dest (!trace_map))
   end
 
 fun current_trace nm =

--- a/src/prekernel/Lib.sig
+++ b/src/prekernel/Lib.sig
@@ -8,7 +8,7 @@ sig
    type ('a, 'b) istream
    type ('a, 'b) subst = {redex: 'a, residue: 'b} list
    type 'a set = 'a HOLset.set
-   type ('a, 'b) dict = ('a, 'b) HOLdict.dict
+   type ('a, 'b) dict = ('a, 'b) Redblackmap.dict
    val $  : ('a -> 'b) * 'a -> 'b
    val ## : ('a -> 'b) * ('c -> 'd) -> 'a * 'c -> 'b * 'd
    val ?> : ('a, 'c)verdict * ('a -> ('b, 'c)verdict) -> ('b, 'c)verdict

--- a/src/prekernel/Lib.sml
+++ b/src/prekernel/Lib.sml
@@ -306,7 +306,7 @@ fun topsort R =
 (* O(n*log(n)) time version
    deps = map from nodes to adjacency lists *)
 
-local open HOLdict in
+local open Redblackmap in
 type ('a, 'b) dict = ('a, 'b) dict
 
 fun dict_topsort deps =

--- a/src/prekernel/stringfindreplace.sml
+++ b/src/prekernel/stringfindreplace.sml
@@ -1,12 +1,6 @@
 structure stringfindreplace :> stringfindreplace =
 struct
 
-structure Chartab = Table(struct
-  type key = char
-  val ord = Char.compare
-  val pp = HOLPP.add_string o Char.toString
-end)
-
 datatype 'a trie = Nd of 'a option * 'a trie Chartab.table
 
 fun dictOf (Nd(_, d)) = d

--- a/src/prekernel/stringfindreplace.sml
+++ b/src/prekernel/stringfindreplace.sml
@@ -1,12 +1,18 @@
 structure stringfindreplace :> stringfindreplace =
 struct
 
-datatype 'a trie = Nd of 'a option * (char, 'a trie) Binarymap.dict
+structure Chartab = Table(struct
+  type key = char
+  val ord = Char.compare
+  val pp = HOLPP.add_string o Char.toString
+end)
+
+datatype 'a trie = Nd of 'a option * 'a trie Chartab.table
 
 fun dictOf (Nd(_, d)) = d
 fun valueOf (Nd(v,_)) = v
 
-fun empty() = Nd (NONE, Binarymap.mkDict Char.compare)
+fun empty() = Nd (NONE, Chartab.empty)
 
 fun insert (t, s, v) =
   let
@@ -18,11 +24,11 @@ fun insert (t, s, v) =
             NONE => Nd(SOME v, dict)
           | SOME (c, ss') =>
             let
-              val subt = case Binarymap.peek(dict, c) of
+              val subt = case Chartab.lookup dict c of
                              NONE => empty()
                            | SOME t => t
             in
-              Nd(val0, Binarymap.insert(dict,c,recurse subt ss'))
+              Nd(val0, Chartab.update (c, recurse subt ss') dict)
             end
       end
   in
@@ -37,7 +43,7 @@ fun foldl f acc t =
                       NONE => acc0
                     | SOME v => f(k,v,acc0)
       in
-        Binarymap.foldl (fn (c,t,a) => recurse (k ^ str c) a t) acc (dictOf t)
+        Chartab.fold (fn (c,t) => fn a => recurse (k ^ str c) a t) (dictOf t) acc
       end
   in
     recurse "" acc t
@@ -78,7 +84,7 @@ fun foldcheck trie0 s =
           fun newcellf inv old =
             if inv then old
             else
-              case Binarymap.peek(dictOf trie0, c) of
+              case Chartab.lookup (dictOf trie0) c of
                   NONE => old
                 | SOME t =>
                     (i, (t, Option.map (fn v => (v,1)) (valueOf t)))::old
@@ -88,7 +94,7 @@ fun foldcheck trie0 s =
               | ((cell as (starti, (t, bestopt)))::rest) =>
                 let
                 in
-                  case Binarymap.peek(dictOf t, c) of
+                  case Chartab.lookup (dictOf t) c of
                       NONE =>
                         (case bestopt of
                              NONE => updcells doneA continuingA

--- a/src/proofman/goalStack.sml
+++ b/src/proofman/goalStack.sml
@@ -235,16 +235,16 @@ fun check_vars (g as (asl,w)) =
           let
             val (nm,ty_s) = (I ## ty2s) (dest_var v)
           in
-            case Binarymap.peek(acc, nm) of
-                NONE => Binarymap.insert(acc, nm, [ty_s])
-              | SOME vs => Binarymap.insert(acc, nm, ty_s::vs)
+            case Symtab.lookup acc nm of
+                NONE => Symtab.update (nm, [ty_s]) acc
+              | SOME vs => Symtab.update (nm, ty_s::vs) acc
           end
-      val m = HOLset.foldl foldthis (Binarymap.mkDict String.compare) fvs
-      fun foldthis (nm,vtys,msg) =
+      val m = HOLset.foldl foldthis Symtab.empty fvs
+      fun foldthis (nm,vtys) msg =
           if length vtys > 1 then
             ("  " ^ nm ^ " : " ^ String.concatWith ", " vtys) :: msg
           else msg
-      val msg = Binarymap.foldl foldthis [] m
+      val msg = Symtab.fold foldthis m []
     in
       if null msg then nothing
       else (

--- a/src/quantHeuristics/ConseqConv.sml
+++ b/src/quantHeuristics/ConseqConv.sml
@@ -1063,9 +1063,9 @@ let
        if (same_const t T) orelse (same_const t F) then
           SOME (0, NONE)
        else if dir = CONSEQ_CONV_STRENGTHEN_direction then
-            Redblackmap.peek (cache_str, t)
+            Termtab.lookup cache_str t
        else
-            Redblackmap.peek (cache_weak, t);
+            Termtab.lookup cache_weak t;
    val cached_result' = if isSome cached_result then
        let
           val (n, thm_opt) = valOf cached_result;
@@ -1098,9 +1098,9 @@ in
       val (cache_str, cache_weak) = !cache_ref;
       val _ = cache_ref := (
             if dir = CONSEQ_CONV_STRENGTHEN_direction then
-               (Redblackmap.insert (cache_str, t, result'), cache_weak)
+               (Termtab.update (t, result') cache_str, cache_weak)
             else
-               (cache_str, Redblackmap.insert (cache_weak, t, result')))
+               (cache_str, Termtab.update (t, result') cache_weak))
    in
       ()
    end
@@ -1198,7 +1198,7 @@ fun DEPTH_CONSEQ_CONV_num step_conv cache_opt
   end handle UNCHANGED => (n, NONE);
 
 type depth_conseq_conv_cache =
-    ((term, (int * thm option)) Redblackmap.dict * (term, (int * thm option)) Redblackmap.dict) ref
+    ((int * thm option) Termtab.table * (int * thm option) Termtab.table) ref
 type depth_conseq_conv_cache_opt =
    ((unit -> depth_conseq_conv_cache) * ((term * (int * thm option)) -> bool)) option
 
@@ -1208,14 +1208,13 @@ fun dest_cache NONE = ([], [])
  let
     val (str, weak) = !(cf ())
  in
-    (Redblackmap.listItems str,
-     Redblackmap.listItems weak)
+    (Termtab.dest str,
+     Termtab.dest weak)
  end;
 *)
 
 
-fun mk_DEPTH_CONSEQ_CONV_CACHE_dict () =
-   (Redblackmap.mkDict (Term.compare), Redblackmap.mkDict (Term.compare))
+fun mk_DEPTH_CONSEQ_CONV_CACHE_dict () = (Termtab.empty, Termtab.empty)
 
 fun mk_DEPTH_CONSEQ_CONV_CACHE () =
    (ref (mk_DEPTH_CONSEQ_CONV_CACHE_dict ())):depth_conseq_conv_cache

--- a/src/quantHeuristics/quantHeuristicsLibAbbrev.sml
+++ b/src/quantHeuristics/quantHeuristicsLibAbbrev.sml
@@ -29,9 +29,9 @@ fun no_var_const_filter t =
   not ((is_var t) orelse (is_const t))
 
 local
-   fun find_tms (d:(term, int) Redblackmap.dict) tm =
+   fun find_tms (d : int Termtab.table) tm =
    let
-      val d = Redblackmap.update (d, tm, (fn vo => (getOpt (vo, 0)) + 1))
+      val d = Termtab.update (tm, getOpt (Termtab.lookup d tm, 0) + 1) d
    in
       find_tms d (body tm)
       handle HOL_ERR _ =>
@@ -40,7 +40,7 @@ local
           | NONE => d
    end
 
-   val empty_tm_dict:(term, int) Redblackmap.dict = Redblackmap.mkDict Term.compare
+   val empty_tm_dict : int Termtab.table = Termtab.empty
 
 in
    (* Returns a list of all the subterms of t that satisfy P ordered by the number of appearences in t.
@@ -48,9 +48,9 @@ in
    fun find_terms_count P t =
    let
       val d = find_tms empty_tm_dict t;
-      fun d_fun t = getOpt(Redblackmap.peek (d, t), 0)
+      fun d_fun t = getOpt (Termtab.lookup d t, 0)
 
-      val tL = Redblackmap.listItems d;
+      val tL = Termtab.dest d;
       val ftL = filter (fn (t, _) => P t) tL
       val stL = Lib.sort (fn (_, i) => fn (_, j:int) => (i > j)) ftL
       val ftL = map fst stL

--- a/src/quantHeuristics/quantHeuristicsLibBase.sml
+++ b/src/quantHeuristics/quantHeuristicsLibBase.sml
@@ -2390,8 +2390,8 @@ fun inst_filter_qp fL =
    val t = ``x:num = 9``
 *)
 
-type quant_heuristic_cache = (Term.term, (Term.term, guess_collection) Redblackmap.dict) Redblackmap.dict
-fun mk_quant_heuristic_cache () = (Redblackmap.mkDict Term.compare):quant_heuristic_cache
+type quant_heuristic_cache = guess_collection Termtab.table Termtab.table
+fun mk_quant_heuristic_cache () : quant_heuristic_cache = Termtab.empty
 
 (*
 val cache = mk_quant_heuristic_cache ()
@@ -2403,12 +2403,9 @@ val gc = SOME empty_guess_collection
 
 fun quant_heuristic_cache___insert (cache:quant_heuristic_cache) (v:term) (t:term) (gc:guess_collection) =
 let
-   val t_cache_opt = Redblackmap.peek (cache,t)
-   val t_cache = if isSome t_cache_opt then valOf t_cache_opt else
-                 (Redblackmap.mkDict Term.compare);
-
-   val t_cache' = Redblackmap.insert (t_cache, v, gc)
-   val cache' = Redblackmap.insert (cache, t, t_cache')
+   val t_cache = Option.getOpt (Termtab.lookup cache t, Termtab.empty)
+   val t_cache' = Termtab.update (v, gc) t_cache
+   val cache' = Termtab.update (t, t_cache') cache
 in
    cache':quant_heuristic_cache
 end;
@@ -2416,12 +2413,9 @@ end;
 
 
 fun quant_heuristic_cache___peek (cache:quant_heuristic_cache) (v:term) (t:term) =
-let
-   val t_cache = Redblackmap.find (cache,t)
-   val gc = Redblackmap.find (t_cache,v);
-in
-   SOME gc
-end handle Redblackmap.NotFound => NONE;
+   case Termtab.lookup cache t of
+       NONE => NONE
+     | SOME t_cache => Termtab.lookup t_cache v;
 
 
 

--- a/src/quotient/src/quotient.sml
+++ b/src/quotient/src/quotient.sml
@@ -130,27 +130,29 @@ val _ = register_btrace("quotient", chatting);
 val caching = ref true; (* should be pure efficiency gain *)
 
 
-structure Map = Redblackmap
+structure Typetab = Table(struct
+  type key = hol_type
+  val ord = Type.compare
+  fun pp _ = HOLPP.add_string "<type>"
+end)
 
-(* Redblackmap has the same signature as Binarymap. *)
-
-val quotient_cache = ref ((Map.mkDict Type.compare) :(hol_type, thm) Map.dict);
+val quotient_cache : thm Typetab.table ref = ref Typetab.empty;
 
 val hits = ref 0;
 val misses = ref 0;
 
 fun reset_cache () =
-      (quotient_cache := (Map.mkDict Type.compare : (hol_type, thm)Map.dict);
+      (quotient_cache := Typetab.empty;
        hits := 0; misses := 0)
 
 fun list_cache () = (if !chatting andalso !caching then (
                      print (    "Hits = " ^ Int.toString (!hits) ^
                             ", Misses = " ^ Int.toString (!misses) ^
                             ", Cache size = " ^
-                             Int.toString (Map.numItems (!quotient_cache))
+                             Int.toString (Typetab.size (!quotient_cache))
                               ^ "\n"))
                      else ();
-                     Map.listItems (!quotient_cache))
+                     Typetab.dest (!quotient_cache))
 
 fun del_imps tm = if is_imp tm then (del_imps o #conseq o dest_imp) tm
                                else tm;
@@ -2382,7 +2384,7 @@ would include
                     tyop_ty_ths
 
         fun insert_cache ty qth =
-            (quotient_cache := Map.insert(!quotient_cache, ty, qth); qth)
+            (quotient_cache := Typetab.update (ty, qth) (!quotient_cache); qth)
 
 (* The function get_quotient produces the quotient theorem for type ty. *)
 
@@ -2412,7 +2414,7 @@ would include
 
         fun get_quotient1 ty =
            if !caching then
-              case Map.peek(!quotient_cache, ty) of
+              case Typetab.lookup (!quotient_cache) ty of
                  SOME th => (hits := !hits + 1; th)
                | NONE    => (misses := !misses + 1;
                              insert_cache ty (get_quotient ty))

--- a/src/quotient/src/quotient.sml
+++ b/src/quotient/src/quotient.sml
@@ -130,12 +130,6 @@ val _ = register_btrace("quotient", chatting);
 val caching = ref true; (* should be pure efficiency gain *)
 
 
-structure Typetab = Table(struct
-  type key = hol_type
-  val ord = Type.compare
-  fun pp _ = HOLPP.add_string "<type>"
-end)
-
 val quotient_cache : thm Typetab.table ref = ref Typetab.empty;
 
 val hits = ref 0;

--- a/src/real/RealArith0.sml
+++ b/src/real/RealArith0.sml
@@ -420,7 +420,7 @@ end
    the form “a * x + b * y + c”, represented by a finite map from terms to
    rationals such as [x |=> a, y |=> b, 1 |=> c].
  *)
-local open HOLdict Arbrat in
+local open Redblackmap Arbrat in
 type linear_type = (term,rat)dict
 
 val is_undefined :linear_type -> bool = isEmpty

--- a/src/real/RealArith0.sml
+++ b/src/real/RealArith0.sml
@@ -420,44 +420,42 @@ end
    the form “a * x + b * y + c”, represented by a finite map from terms to
    rationals such as [x |=> a, y |=> b, 1 |=> c].
  *)
-local open Redblackmap Arbrat in
-type linear_type = (term,rat)dict
+local open Arbrat in
+type linear_type = rat Termtab.table
 
-val is_undefined :linear_type -> bool = isEmpty
-val undefined :linear_type = mkDict Term.compare
-fun is_single (m :linear_type) = (numItems m = 1)
-fun defined (m :linear_type) (k :term) = inDomain (m,k)
-fun dom (m :linear_type) :term list = listKeys m
+val is_undefined :linear_type -> bool = Termtab.is_empty
+val undefined :linear_type = Termtab.empty
+fun is_single (m :linear_type) = (Termtab.size m = 1)
+fun defined (m :linear_type) (k :term) = Termtab.defined m k
+fun dom (m :linear_type) :term list = Termtab.keys m
 
-fun tryapply (m :linear_type) k d = find (m,k) handle NotFound => d
+fun tryapply (m :linear_type) k d =
+    case Termtab.lookup m k of SOME r => r | NONE => d
 fun apply (m :linear_type) k = tryapply m k zero
 
 infix |=>
-fun (k :term) |=> (v :rat) :linear_type = singleton Term.compare (k,v)
+fun (k :term) |=> (v :rat) :linear_type = Termtab.update (k,v) Termtab.empty
 
-fun undefine (k :term) (m :linear_type) :linear_type =
-    (fst(remove(m,k))) handle NotFound => m
+fun undefine (k :term) (m :linear_type) :linear_type = Termtab.delete_safe k m
 
 fun choose (m :linear_type) =
-    case firsti m of
+    case Termtab.min m of
        SOME kx => kx
      | NONE    => failwith "empty dict"
 
-val listItems = listItems
-val mapWith = transform
+val listItems = Termtab.dest
+fun mapWith f m = Termtab.map (fn _ => f) m
 
 fun mergeWithoutZero f (m1 :linear_type) (m2 :linear_type) :linear_type =
-let
-    fun add (SOME x, SOME y) = let val z = Arbrat.+ (x,y) in
-                                   if z = Arbrat.zero then NONE
-                                   else SOME z
-                               end
-      | add (SOME x, NONE  ) = SOME x
-      | add (NONE,   SOME y) = SOME y
-      | add (NONE,   NONE  ) = NONE
-in
-    mergeWith add (m1,m2)
-end
+    Termtab.fold
+      (fn (k, x) => fn acc =>
+          case Termtab.lookup acc k of
+              NONE => Termtab.update (k, x) acc
+            | SOME y => let val z = f (x, y)
+                        in if z = Arbrat.zero then Termtab.delete k acc
+                           else Termtab.update (k, z) acc
+                        end)
+      m2 m1
 end (* local *)
 
 (* NOTE: this function is only used in verbose mode *)

--- a/src/real/SOSLib.sml
+++ b/src/real/SOSLib.sml
@@ -58,19 +58,19 @@ fun lcm_num (a:Arbnum.num) (b:Arbnum.num) : Arbnum.num =
 
 (* ===================================================================== *)
 (* Sparse finite maps for monomials and polynomials                      *)
-(* We use (term, int) Redblackmap for monomials (var -> power)           *)
-(* and (monomial, rat) for polynomials                                   *)
+(* Monomials are int Termtab.tables (var -> power); polynomials are     *)
+(* rat MonoTab.tables (monomial -> coefficient).                        *)
 (* ===================================================================== *)
 
 (* A monomial is a map from variables (terms) to positive integer powers *)
-type monomial = (term, int) Redblackmap.dict;
+type monomial = int Termtab.table;
 
-val mono_empty : monomial = Redblackmap.mkDict Term.compare;
+val mono_empty : monomial = Termtab.empty;
 
 (* Canonical monomial comparison for use as map keys *)
 fun mono_compare (m1:monomial, m2:monomial) =
-    let val l1 = Redblackmap.listItems m1
-        val l2 = Redblackmap.listItems m2
+    let val l1 = Termtab.dest m1
+        val l2 = Termtab.dest m2
         fun cmp ([], []) = EQUAL
           | cmp ([], _)  = LESS
           | cmp (_, [])  = GREATER
@@ -83,93 +83,99 @@ fun mono_compare (m1:monomial, m2:monomial) =
     in cmp(l1, l2)
     end;
 
+structure MonoTab = Table(
+  type key = monomial
+  val ord = mono_compare
+  fun pp _ = HOLPP.add_string "<monomial>"
+)
+
 val mono_1 : monomial = mono_empty;
 
-fun mono_var x : monomial = Redblackmap.insert(mono_empty, x, 1);
+fun mono_var x : monomial = Termtab.update (x, 1) mono_empty;
 
 fun mono_mul (m1:monomial) (m2:monomial) : monomial =
-    Redblackmap.foldl
-      (fn (v, p, acc) =>
-          case Redblackmap.peek(acc, v) of
-              NONE => Redblackmap.insert(acc, v, p)
+    Termtab.fold
+      (fn (v, p) => fn acc =>
+          case Termtab.lookup acc v of
+              NONE => Termtab.update (v, p) acc
             | SOME q => let val s = p + q in
-                          if s = 0 then #1(Redblackmap.remove(acc, v))
-                          else Redblackmap.insert(acc, v, s)
+                          if s = 0 then Termtab.delete v acc
+                          else Termtab.update (v, s) acc
                         end)
-      m1 m2;
+      m2 m1;
 
 fun mono_pow (m:monomial) 0 = mono_1
-  | mono_pow m k = Redblackmap.map (fn (_, p) => k * p) m;
+  | mono_pow m k = Termtab.map (fn _ => fn p => k * p) m;
 
 fun mono_degree (m:monomial) =
-    Redblackmap.foldl (fn (_, p, acc) => acc + p) 0 m;
+    Termtab.fold (fn (_, p) => fn acc => acc + p) m 0;
 
 fun mono_var_degree x (m:monomial) =
-    case Redblackmap.peek(m, x) of NONE => 0 | SOME p => p;
+    case Termtab.lookup m x of NONE => 0 | SOME p => p;
 
 fun mono_variables (m:monomial) : term list =
-    map #1 (Redblackmap.listItems m);
+    map #1 (Termtab.dest m);
 
-fun mono_is1 (m:monomial) = Redblackmap.numItems m = 0;
+fun mono_is1 (m:monomial) = Termtab.size m = 0;
 
 (* A polynomial is a map from monomials to rational coefficients *)
-type poly = (monomial, rat) Redblackmap.dict;
+type poly = rat MonoTab.table;
 
-val poly_empty : poly = Redblackmap.mkDict mono_compare;
+val poly_empty : poly = MonoTab.empty;
 
 val poly_0 : poly = poly_empty;
 
 fun poly_isconst (p:poly) =
-    Redblackmap.foldl (fn (m, _, acc) => acc andalso mono_is1 m) true p;
+    MonoTab.fold (fn (m, _) => fn acc => acc andalso mono_is1 m) p true;
 
 fun poly_const (c:rat) : poly =
     if c = rat0 then poly_0
-    else Redblackmap.insert(poly_empty, mono_1, c);
+    else MonoTab.update (mono_1, c) poly_empty;
 
 fun poly_var x : poly =
-    Redblackmap.insert(poly_empty, mono_var x, rat1);
+    MonoTab.update (mono_var x, rat1) poly_empty;
 
 fun poly_neg (p:poly) : poly =
-    Redblackmap.map (fn (_, c) => rat_neg c) p;
+    MonoTab.map (fn _ => fn c => rat_neg c) p;
 
 fun poly_cmul (c:rat) (p:poly) : poly =
     if c = rat0 then poly_0
-    else Redblackmap.map (fn (_, d) => rat_mul(c, d)) p;
+    else MonoTab.map (fn _ => fn d => rat_mul(c, d)) p;
 
 fun poly_add (p1:poly) (p2:poly) : poly =
-    Redblackmap.foldl
-      (fn (m, c, acc) =>
-          case Redblackmap.peek(acc, m) of
-              NONE => Redblackmap.insert(acc, m, c)
+    MonoTab.fold
+      (fn (m, c) => fn acc =>
+          case MonoTab.lookup acc m of
+              NONE => MonoTab.update (m, c) acc
             | SOME d => let val s = rat_add(c, d) in
-                          if s = rat0 then #1(Redblackmap.remove(acc, m))
-                          else Redblackmap.insert(acc, m, s)
+                          if s = rat0 then MonoTab.delete m acc
+                          else MonoTab.update (m, s) acc
                         end)
-      p1 p2;
+      p2 p1;
 
 fun poly_sub p1 p2 = poly_add p1 (poly_neg p2);
 
 fun poly_cmmul (c:rat, m:monomial) (p:poly) : poly =
     if c = rat0 then poly_0
     else
-      Redblackmap.foldl
-        (fn (m', d, acc) =>
+      MonoTab.fold
+        (fn (m', d) => fn acc =>
             let val m'' = mono_mul m m'
                 val cd = rat_mul(c, d)
-            in case Redblackmap.peek(acc, m'') of
-                   NONE => Redblackmap.insert(acc, m'', cd)
+            in case MonoTab.lookup acc m'' of
+                   NONE => MonoTab.update (m'', cd) acc
                  | SOME e => let val s = rat_add(cd, e) in
                                if s = rat0
-                               then #1(Redblackmap.remove(acc, m''))
-                               else Redblackmap.insert(acc, m'', s)
+                               then MonoTab.delete m'' acc
+                               else MonoTab.update (m'', s) acc
                              end
             end)
-        poly_0 p;
+        p poly_0;
 
 fun poly_mul (p1:poly) (p2:poly) : poly =
-    Redblackmap.foldl
-      (fn (m, c, acc) => poly_add (poly_cmmul (c, m) p2) acc)
-      poly_0 p1;
+    MonoTab.fold
+      (fn (m, c) => fn acc => poly_add (poly_cmmul (c, m) p2) acc)
+      p1 poly_0;
 
 fun poly_square p = poly_mul p p;
 
@@ -181,24 +187,24 @@ fun poly_pow p 0 = poly_const rat1
     end;
 
 fun poly_eval (p:poly) = (* evaluate at an empty assignment = constant term *)
-    Redblackmap.foldl
-      (fn (m, c, acc) =>
+    MonoTab.fold
+      (fn (m, c) => fn acc =>
           if mono_is1 m then rat_add(acc, c) else acc)
-      rat0 p;
+      p rat0;
 
 fun degree x (p:poly) =
-    Redblackmap.foldl (fn (m,_,acc) => Int.max(mono_var_degree x m, acc)) 0 p;
+    MonoTab.fold (fn (m,_) => fn acc => Int.max(mono_var_degree x m, acc)) p 0;
 
 fun multidegree (p:poly) =
-    Redblackmap.foldl (fn (m,_,acc) => Int.max(mono_degree m, acc)) 0 p;
+    MonoTab.fold (fn (m,_) => fn acc => Int.max(mono_degree m, acc)) p 0;
 
 fun poly_variables (p:poly) : term list =
-    let val vs = Redblackmap.foldl
-                   (fn (m,_,acc) => mono_variables m @ acc) [] p
+    let val vs = MonoTab.fold
+                   (fn (m,_) => fn acc => mono_variables m @ acc) p []
     in HOLset.listItems (HOLset.addList(empty_tmset, vs))
     end;
 
-fun poly_is0 (p:poly) = Redblackmap.numItems p = 0;
+fun poly_is0 (p:poly) = MonoTab.size p = 0;
 
 (* ===================================================================== *)
 (* Conversion between HOL terms and polynomials                          *)
@@ -267,7 +273,7 @@ fun term_of_varpow x 1 = x
     mk_comb(mk_comb(pow_tm, x), numSyntax.mk_numeral(Arbnum.fromInt k));
 
 fun term_of_monomial (m:monomial) =
-    let val items = Redblackmap.listItems m in
+    let val items = Termtab.dest m in
       case items of
           [] => realSyntax.one_tm
         | _ =>
@@ -291,7 +297,7 @@ fun term_of_poly (p:poly) =
     else
       let
         (* Sort monomials: higher degree first, then lexicographic *)
-        val items = Redblackmap.listItems p
+        val items = MonoTab.dest p
         fun cmp ((m1,_),(m2,_)) =
             case Int.compare(mono_degree m2, mono_degree m1) of
                 EQUAL => mono_compare(m1, m2)
@@ -312,18 +318,24 @@ fun term_of_poly (p:poly) =
 (* Matrices are ((rows,cols), ((int*int),rat) map)                       *)
 (* ===================================================================== *)
 
-(* We use IntRedBlackMap for vectors and a custom comparison for matrices *)
-structure IMap = Redblackmap;
+(* Vectors use Inttab (int keys); matrices use a local IntPairTab. *)
 
 fun int_compare (i:int, j:int) = Int.compare(i,j);
 fun intpair_compare ((i1,j1):int*int, (i2,j2):int*int) =
     case Int.compare(i1,i2) of EQUAL => Int.compare(j1,j2) | ord => ord;
 
-type vector = int * (int, rat) IMap.dict;
-type matrix = (int * int) * ((int * int), rat) IMap.dict;
+structure IntPairTab = Table(
+  type key = int * int
+  val ord = intpair_compare
+  fun pp (i,j) =
+      HOLPP.add_string ("(" ^ Int.toString i ^ "," ^ Int.toString j ^ ")")
+)
 
-val imap_empty = IMap.mkDict int_compare;
-val mmap_empty = IMap.mkDict intpair_compare;
+type vector = int * rat Inttab.table;
+type matrix = (int * int) * rat IntPairTab.table;
+
+val imap_empty = Inttab.empty;
+val mmap_empty = IntPairTab.empty;
 
 (* HOL Light's list-set union is "itlist insert", which preserves the left
    list's order. Variable order feeds directly into SOS basis construction
@@ -334,19 +346,19 @@ fun hl_union eq xs ys =
 fun vec_dim ((n, _):vector) = n;
 
 fun vec_el ((_, m):vector) i =
-    case IMap.peek(m, i) of NONE => rat0 | SOME c => c;
+    case Inttab.lookup m i of NONE => rat0 | SOME c => c;
 
 fun vec_0 n : vector = (n, imap_empty);
 
 fun vec_cmul c ((n, m):vector) : vector =
     if c = rat0 then vec_0 n
-    else (n, IMap.map (fn (_, x) => rat_mul(c, x)) m);
+    else (n, Inttab.map (fn _ => fn x => rat_mul(c, x)) m);
 
 fun vec_of_list l : vector =
     let val n = length l
     in (n, #2 (List.foldl (fn (c, (i, m)) =>
                               if c = rat0 then (i+1, m)
-                              else (i+1, IMap.insert(m, i, c)))
+                              else (i+1, Inttab.update (i, c) m))
                           (1, imap_empty) l))
     end;
 
@@ -354,38 +366,39 @@ fun vec_of_list l : vector =
 fun mat_dims ((d, _):matrix) = d;
 
 fun mat_el ((_, m):matrix) (i,j) =
-    case IMap.peek(m, (i,j)) of NONE => rat0 | SOME c => c;
+    case IntPairTab.lookup m (i,j) of NONE => rat0 | SOME c => c;
 
 fun mat_0 (r,c) : matrix = ((r,c), mmap_empty);
 
 fun mat_neg (((r,c), m):matrix) : matrix =
-    ((r,c), IMap.map (fn (_, x) => rat_neg x) m);
+    ((r,c), IntPairTab.map (fn _ => fn x => rat_neg x) m);
 
 fun mat_cmul k (((r,c), m):matrix) : matrix =
     if k = rat0 then mat_0 (r,c)
-    else ((r,c), IMap.map (fn (_, x) => rat_mul(k, x)) m);
+    else ((r,c), IntPairTab.map (fn _ => fn x => rat_mul(k, x)) m);
 
 fun mat_add (((r1,c1), m1):matrix) (((r2,c2), m2):matrix) : matrix =
     if r1 <> r2 orelse c1 <> c2
     then raise ERR "mat_add" "incompatible dimensions"
     else ((r1,c1),
-          IMap.foldl
-            (fn (ij, c, acc) =>
-                case IMap.peek(acc, ij) of
-                    NONE => IMap.insert(acc, ij, c)
+          IntPairTab.fold
+            (fn (ij, c) => fn acc =>
+                case IntPairTab.lookup acc ij of
+                    NONE => IntPairTab.update (ij, c) acc
                   | SOME d => let val s = rat_add(c,d) in
-                                if s = rat0 then #1(IMap.remove(acc, ij))
-                                else IMap.insert(acc, ij, s)
+                                if s = rat0
+                                then IntPairTab.delete ij acc
+                                else IntPairTab.update (ij, s) acc
                               end)
-            m1 m2);
+            m2 m1);
 
 fun mat_row k (((r,c), m):matrix) : vector =
-    (c, IMap.foldl
-          (fn ((i,j), v, acc) =>
-              if i = k then IMap.insert(acc, j, v) else acc)
-          imap_empty m);
+    (c, IntPairTab.fold
+          (fn ((i,j), v) => fn acc =>
+              if i = k then Inttab.update (j, v) acc else acc)
+          m imap_empty);
 
-fun mat_is0 (((_, _), m):matrix) = IMap.numItems m = 0;
+fun mat_is0 (((_, _), m):matrix) = IntPairTab.size m = 0;
 
 (* ===================================================================== *)
 (* Equation elimination (Gaussian elimination for parametric equations)   *)
@@ -400,45 +413,44 @@ type eqvar = int * int;
 fun eqvar_compare ((a1,b1):eqvar, (a2,b2):eqvar) =
     case Int.compare(a1,a2) of EQUAL => Int.compare(b1,b2) | ord => ord;
 
-type equation = (eqvar, rat) Redblackmap.dict;
-val eq_empty : equation = Redblackmap.mkDict eqvar_compare;
+type equation = rat IntPairTab.table;
+val eq_empty : equation = IntPairTab.empty;
 
 fun eq_cmul (c:rat) (eq:equation) : equation =
     if c = rat0 then eq_empty
-    else Redblackmap.map (fn (_, d) => rat_mul(c, d)) eq;
+    else IntPairTab.map (fn _ => fn d => rat_mul(c, d)) eq;
 
 fun eq_add (eq1:equation) (eq2:equation) : equation =
-    Redblackmap.foldl
-      (fn (v, c, acc) =>
-          case Redblackmap.peek(acc, v) of
-              NONE => Redblackmap.insert(acc, v, c)
+    IntPairTab.fold
+      (fn (v, c) => fn acc =>
+          case IntPairTab.lookup acc v of
+              NONE => IntPairTab.update (v, c) acc
             | SOME d => let val s = rat_add(c, d) in
-                          if s = rat0 then #1(Redblackmap.remove(acc, v))
-                          else Redblackmap.insert(acc, v, s)
+                          if s = rat0 then IntPairTab.delete v acc
+                          else IntPairTab.update (v, s) acc
                         end)
-      eq1 eq2;
+      eq2 eq1;
 
 fun eq_eval (assig: eqvar -> rat) (eq:equation) : rat =
-    Redblackmap.foldl (fn (v, c, acc) => rat_add(acc, rat_mul(assig v, c)))
-      rat0 eq;
+    IntPairTab.fold
+      (fn (v, c) => fn acc => rat_add(acc, rat_mul(assig v, c))) eq rat0;
 
-fun eq_is0 (eq:equation) = Redblackmap.numItems eq = 0;
+fun eq_is0 (eq:equation) = IntPairTab.size eq = 0;
 
-fun eq_peek (eq:equation) v = Redblackmap.peek(eq, v);
+fun eq_peek (eq:equation) v = IntPairTab.lookup eq v;
 
-fun eq_remove v (eq:equation) =
-    #1(Redblackmap.remove(eq, v)) handle NotFound => eq;
+fun eq_remove v (eq:equation) = IntPairTab.delete_safe v eq;
 
-fun eq_vars (eq:equation) = map #1 (Redblackmap.listItems eq);
+fun eq_vars (eq:equation) = map #1 (IntPairTab.dest eq);
 
 (* Eliminate all variables from a system of equations.
    Returns (free_vars, assignment) where assignment maps
    eliminated vars to equations in terms of free vars. *)
 fun eliminate_all_equations (one:eqvar) (eqs: equation list)
-    : eqvar list * (eqvar, equation) Redblackmap.dict =
+    : eqvar list * equation IntPairTab.table =
     let
       fun choose_variable (eq:equation) =
-          let val items = Redblackmap.listItems eq in
+          let val items = IntPairTab.dest eq in
             case items of
                 [] => raise ERR "choose_variable" "empty equation"
               | [(v,_)] => if eqvar_compare(v, one) = EQUAL
@@ -457,7 +469,7 @@ fun eliminate_all_equations (one:eqvar) (eqs: equation list)
                   else v
                 end
           end
-      val assig_empty = Redblackmap.mkDict eqvar_compare
+      val assig_empty = IntPairTab.empty
       fun elim dun [] = dun
         | elim dun (eq::oeqs) =
           if eq_is0 eq then elim dun oeqs
@@ -474,21 +486,21 @@ fun eliminate_all_equations (one:eqvar) (eqs: equation list)
                     | SOME b =>
                       eq_add (eq_remove v e)
                              (eq_cmul (rat_div(rat_neg b, a)) (eq_remove v eq))
-              val dun' = Redblackmap.insert(
-                           Redblackmap.map (fn (_, f) => subst_in f) dun,
-                           v, eq')
+              val dun' = IntPairTab.update
+                           (v, eq')
+                           (IntPairTab.map (fn _ => fn f => subst_in f) dun)
             in
               elim dun' (map subst_in oeqs)
             end
       val assig = elim assig_empty eqs
-      val vs = Redblackmap.foldl
-                 (fn (_, f, acc) =>
+      val vs = IntPairTab.fold
+                 (fn (_, f) => fn acc =>
                      let val fvs = List.filter
                                      (fn v => eqvar_compare(v, one) <> EQUAL)
                                      (eq_vars f)
                      in fvs @ acc
                      end)
-                 [] assig
+                 assig []
       val vs' = Lib.mk_set (Listsort.sort eqvar_compare vs)
     in (vs', assig)
     end;
@@ -500,13 +512,13 @@ fun solve_equations (one:eqvar) (eqs: equation list) =
       (* Map: free vars -> 0, 'one' -> -1 *)
       val vfn = fn v => if eqvar_compare(v, one) = EQUAL then rat_neg rat1
                         else rat0
-      val result = Redblackmap.map (fn (_, eq) => eq_eval vfn eq) assig
+      val result = IntPairTab.map (fn _ => fn eq => eq_eval vfn eq) assig
       (* Also add free vars -> 0 *)
       val result' = List.foldl
-                      (fn (v, acc) => Redblackmap.insert(acc, v, rat0))
+                      (fn (v, acc) => IntPairTab.update (v, rat0) acc)
                       result free_vars
       (* Verify *)
-      val lookup = fn v => case Redblackmap.peek(result', v) of
+      val lookup = fn v => case IntPairTab.lookup result' v of
                                NONE => if eqvar_compare(v, one) = EQUAL
                                        then rat_neg rat1 else rat0
                              | SOME c => c
@@ -535,7 +547,7 @@ fun diag (mat : matrix) =
               else if a_ii = rat0 then
                 (* Check row is zero *)
                 let val row_i = mat_row i m in
-                  if IMap.numItems (#2 row_i) = 0 then go (i+1) m
+                  if Inttab.size (#2 row_i) = 0 then go (i+1) m
                   else raise ERR "diag" "matrix not PSD (zero pivot, nonzero row)"
                 end
               else
@@ -553,7 +565,7 @@ fun diag (mat : matrix) =
                                       rat_mul(vec_el row_i j,
                                               vec_el v' k))
                         in if v <> rat0
-                           then acc := IMap.insert(!acc, (j,k), v)
+                           then acc := IntPairTab.update ((j,k), v) (!acc)
                            else ()
                         end)
                       (List.tabulate(n - i, fn x => x + i + 1)))
@@ -574,18 +586,18 @@ fun deration (d : (rat * vector) list) =
         fun adj (c, (n, m) : vector) =
             let
               (* Find LCM of denominators and GCD of numerators *)
-              val lcd = IMap.foldl
-                          (fn (_, v, acc) => lcm_num acc (rat_denom v))
-                          (Arbnum.fromInt 1) m
-              val gcn = IMap.foldl
-                          (fn (_, v, acc) =>
+              val lcd = Inttab.fold
+                          (fn (_, v) => fn acc => lcm_num acc (rat_denom v))
+                          m (Arbnum.fromInt 1)
+              val gcn = Inttab.fold
+                          (fn (_, v) => fn acc =>
                               gcd_num acc (Arbint.toNat(Arbint.abs(rat_numer v))))
-                          Arbnum.zero m
+                          m Arbnum.zero
               val gcn' = if gcn = Arbnum.zero then Arbnum.fromInt 1 else gcn
               val a = Arbrat.fromNat(Arbnum.div(lcd, gcn'))
               val a_sq = rat_mul(a, a)
             in (rat_div(c, a_sq),
-                (n, IMap.map (fn (_, x) => rat_mul(a, x)) m))
+                (n, Inttab.map (fn _ => fn x => rat_mul(a, x)) m))
             end
         val d' = map adj d
         (* Now find overall scaling *)
@@ -673,10 +685,10 @@ fun sdpa_of_problem (obj:vector) (mats : matrix list) =
       val m = length mats - 1
       val (n, _) = mat_dims (hd mats)
       fun fmt_entry matno ((_, mm):matrix) =
-          let val ents = IMap.foldl
-                (fn ((i,j), c, acc) =>
+          let val ents = IntPairTab.fold
+                (fn ((i,j), c) => fn acc =>
                     if i > j then acc else (i,j,c)::acc)
-                [] mm
+                mm []
               val sorted = Listsort.sort
                 (fn ((i1,j1,_),(i2,j2,_)) =>
                     case Int.compare(i1,i2) of
@@ -828,7 +840,7 @@ fun nice_rational n (x:rat) =
     end;
 
 fun nice_vector n ((dim, vm):vector) : vector =
-    (dim, IMap.map (fn (_, x) => nice_rational n x) vm);
+    (dim, Inttab.map (fn _ => fn x => nice_rational n x) vm);
 
 (* Run CSDP on an SDP problem, returning the raw exit code and dual vector.
    CSDP syntax: csdp <input.dat-s> <output.sol>
@@ -906,20 +918,20 @@ fun vec_const c n : vector =
     if c = rat0 then vec_0 n
     else
       (n, List.foldl
-            (fn (i, m) => IMap.insert(m, i, c))
+            (fn (i, m) => Inttab.update (i, c) m)
             imap_empty
             (List.tabulate(n, fn i => i + 1)));
 
 fun mat_column j (((rows, _), m):matrix) : vector =
-    (rows, IMap.foldl
-             (fn ((i, j'), c, acc) =>
-                 if j = j' then IMap.insert(acc, i, c) else acc)
-             imap_empty m);
+    (rows, IntPairTab.fold
+             (fn ((i, j'), c) => fn acc =>
+                 if j = j' then Inttab.update (i, c) acc else acc)
+             m imap_empty);
 
 fun diagonal ((n, vm):vector) : matrix =
-    ((n, n), IMap.foldl
-               (fn (i, c, acc) => IMap.insert(acc, (i, i), c))
-               mmap_empty vm);
+    ((n, n), Inttab.fold
+               (fn (i, c) => fn acc => IntPairTab.update ((i, i), c) acc)
+               vm mmap_empty);
 
 fun linear_program_basic (a:matrix) =
     let
@@ -973,7 +985,7 @@ fun in_convex_hull pts pt =
       val m = v + n - 1
       val base =
         List.foldl
-          (fn (i, acc) => IMap.insert(acc, (v + i, i + 1), rat1))
+          (fn (i, acc) => IntPairTab.update ((v + i, i + 1), rat1) acc)
           mmap_empty
           (List.tabulate(n, fn i => i + 1))
       val entries =
@@ -983,7 +995,8 @@ fun in_convex_hull pts pt =
                     val acc' =
                       #2 (List.foldl
                             (fn (x, (i, a)) =>
-                                (i + 1, IMap.insert(a, (i, j), Arbrat.fromInt x)))
+                                (i + 1,
+                                 IntPairTab.update ((i, j), Arbrat.fromInt x) a))
                             (1, acc) col)
                   in
                     (j + 1, acc')
@@ -1018,7 +1031,7 @@ fun all_monomials_upto vars ds =
         List.concat
           (List.tabulate(d+1, fn k =>
              map (fn m => if k = 0 then m
-                          else Redblackmap.insert(m, v, k))
+                          else Termtab.update (v, k) m)
                  (all_monomials_upto vs dds)));
 
 fun newton_polytope (pol:poly) =
@@ -1026,8 +1039,8 @@ fun newton_polytope (pol:poly) =
       val vars = poly_variables pol
       val mons =
         map (fn (m, _) => map (fn x =>
-              case Redblackmap.peek(m, x) of SOME k => k | NONE => 0) vars)
-            (Redblackmap.listItems pol)
+              case Termtab.lookup m x of SOME k => k | NONE => 0) vars)
+            (MonoTab.dest pol)
       val ds = map (fn x => (degree x pol + 1) div 2) vars
       val all = all_monomials_upto vars ds
       (* The HOL Light SOS search filters the half-degree basis through the
@@ -1038,7 +1051,7 @@ fun newton_polytope (pol:poly) =
         List.filter (fn m =>
           let
             val exps = map (fn x =>
-              2 * (case Redblackmap.peek(m, x) of SOME k => k | NONE => 0)) vars
+              2 * (case Termtab.lookup m x of SOME k => k | NONE => 0)) vars
           in
             in_convex_hull mons' exps
           end) all
@@ -1058,11 +1071,10 @@ fun gram_equations (pol:poly) (mons:monomial list) =
       val indexed_mons = ListPair.zip(mons, List.tabulate(n, fn i => i+1))
       (* For each pair (i,j) with i<=j, the Gram entry G[i,j] contributes
          to monomial mons[i]*mons[j] with coefficient 1 (if i=j) or 2 *)
-      val eqs_map = ref (Redblackmap.mkDict mono_compare
-                         : (monomial, equation) Redblackmap.dict)
-      fun get_eq m = case Redblackmap.peek(!eqs_map, m) of
+      val eqs_map : equation MonoTab.table ref = ref MonoTab.empty
+      fun get_eq m = case MonoTab.lookup (!eqs_map) m of
                          SOME eq => eq | NONE => eq_empty
-      fun set_eq m eq = eqs_map := Redblackmap.insert(!eqs_map, m, eq)
+      fun set_eq m eq = eqs_map := MonoTab.update (m, eq) (!eqs_map)
       val _ =
         List.app (fn (m1, i) =>
           List.app (fn (m2, j) =>
@@ -1071,7 +1083,7 @@ fun gram_equations (pol:poly) (mons:monomial list) =
               let val m = mono_mul m1 m2
                   val c = if i = j then rat1 else Arbrat.fromInt 2
                   val eq = get_eq m
-                  val eq' = Redblackmap.insert(eq, (i,j), c)
+                  val eq' = IntPairTab.update ((i,j), c) eq
               in set_eq m eq'
               end)
           indexed_mons)
@@ -1085,27 +1097,27 @@ fun gram_equations (pol:poly) (mons:monomial list) =
          But wait: c*(-1) = -c, so sum(...) + (-c) = 0 ⟹ sum(...) = c. YES.
          So we add (0,0) |-> c (the positive coefficient). *)
       val _ =
-        Redblackmap.app
+        List.app
           (fn (m, c) =>
               let val eq = get_eq m
-                  val eq' = Redblackmap.insert(eq, (0,0), c)
+                  val eq' = IntPairTab.update ((0,0), c) eq
               in set_eq m eq'
               end)
-          pol
+          (MonoTab.dest pol)
 
-      val eqs = map #2 (Redblackmap.listItems (!eqs_map))
+      val eqs = map #2 (MonoTab.dest (!eqs_map))
     in eqs
     end;
 
 (* Build polynomial from vector: sum_i vec[i] * mons[i-1] *)
 fun poly_of_lin (mons:monomial list) ((_, vm):vector) : poly =
-    IMap.foldl
-      (fn (i, c, acc) =>
+    Inttab.fold
+      (fn (i, c) => fn acc =>
           if c = rat0 then acc
           else let val m = List.nth(mons, i-1)
-               in poly_add acc (Redblackmap.insert(poly_empty, m, c))
+               in poly_add acc (MonoTab.update (m, c) poly_empty)
                end)
-      poly_0 vm;
+      vm poly_0;
 
 (* The main pure SOS function: try to decompose pol as a sum of squares
    using exact rational arithmetic only. *)
@@ -1124,15 +1136,15 @@ fun sumofsquares_pure (pol:poly) : rat * (rat * poly) list =
           let val entries = ref mmap_empty
               fun set (i,j) v =
                   if v <> rat0 then
-                    (entries := IMap.insert(!entries, (i,j), v);
-                     entries := IMap.insert(!entries, (j,i), v))
+                    (entries := IntPairTab.update ((i,j), v) (!entries);
+                     entries := IntPairTab.update ((j,i), v) (!entries))
                   else ()
           in
             List.app (fn i =>
               List.app (fn j =>
                 if i > j then ()
                 else
-                  let val v = case Redblackmap.peek(solution, (i,j)) of
+                  let val v = case IntPairTab.lookup solution (i,j) of
                                   SOME c => c | NONE => rat0
                   in set (i,j) v
                   end)
@@ -1183,20 +1195,20 @@ fun sumofsquares_csdp (pol:poly) : rat * (rat * poly) list =
           val allassig = assig
           fun mk_matrix v : matrix =
               let val entries = ref mmap_empty
-              in Redblackmap.app
+              in List.app
                    (fn (ij as (i,j), eq) =>
                        if i < 1 orelse j < 1 then ()
                        else
-                         let val c = case Redblackmap.peek(eq, v) of
+                         let val c = case IntPairTab.lookup eq v of
                                          SOME r => r | NONE => rat0
                          in if c <> rat0 then
-                              (entries := IMap.insert(!entries, (i,j), c);
+                              (entries := IntPairTab.update ((i,j), c) (!entries);
                                if i <> j then
-                                 entries := IMap.insert(!entries, (j,i), c)
+                                 entries := IntPairTab.update ((j,i), c) (!entries)
                                else ())
                             else ()
                          end)
-                   allassig;
+                   (IntPairTab.dest allassig);
                  ((n,n), !entries)
               end
           val mat = mat_neg (mk_matrix (0,0))
@@ -1212,28 +1224,28 @@ fun sumofsquares_csdp (pol:poly) : rat * (rat * poly) list =
           val allassig =
               List.foldl
                 (fn (v, acc) =>
-                    Redblackmap.insert(acc, v,
-                      Redblackmap.insert(eq_empty, v, rat1)))
+                    IntPairTab.update
+                      (v, IntPairTab.update (v, rat1) eq_empty) acc)
                 assig pvs
 
           (* For each variable v, build the matrix M_v where
              M_v[i,j] = coefficient of v in allassig[(i,j)] *)
           fun mk_matrix v : matrix =
               let val entries = ref mmap_empty
-              in Redblackmap.app
+              in List.app
                    (fn ((i,j), eq) =>
                        if i < 1 orelse j < 1 then ()
                        else
-                         let val c = case Redblackmap.peek(eq, v) of
+                         let val c = case IntPairTab.lookup eq v of
                                          SOME r => r | NONE => rat0
                          in if c <> rat0 then
-                              (entries := IMap.insert(!entries, (i,j), c);
+                              (entries := IntPairTab.update ((i,j), c) (!entries);
                                if i <> j then
-                                 entries := IMap.insert(!entries, (j,i), c)
+                                 entries := IntPairTab.update ((j,i), c) (!entries)
                                else ())
                             else ()
                          end)
-                   allassig;
+                   (IntPairTab.dest allassig);
                  ((n,n), !entries)
               end
 
@@ -1243,7 +1255,7 @@ fun sumofsquares_csdp (pol:poly) : rat * (rat * poly) list =
           val diagents =
               List.foldl
                 (fn (i, acc) =>
-                    case Redblackmap.peek(allassig, (i,i)) of
+                    case IntPairTab.lookup allassig (i,i) of
                         SOME e => eq_add acc e
                       | NONE => acc)
                 eq_empty (List.tabulate(n, fn i => i+1))
@@ -1255,7 +1267,7 @@ fun sumofsquares_csdp (pol:poly) : rat * (rat * poly) list =
           val mats = map mk_matrix qvars
           val obj_coeffs =
               map (fn v =>
-                      case Redblackmap.peek(diagents, v) of
+                      case IntPairTab.lookup diagents v of
                           SOME c => c | NONE => rat0)
                   pvs
           val obj = vec_of_list obj_coeffs
@@ -1358,43 +1370,50 @@ fun eqvar3_compare ((a1,b1,c1):eqvar3, (a2,b2,c2):eqvar3) =
                     | ord => ord)
       | ord => ord;
 
-type equation3 = (eqvar3, rat) Redblackmap.dict;
-val eq3_empty : equation3 = Redblackmap.mkDict eqvar3_compare;
+structure IntTripleTab = Table(
+  type key = eqvar3
+  val ord = eqvar3_compare
+  fun pp (i,j,k) =
+      HOLPP.add_string ("(" ^ Int.toString i ^ "," ^ Int.toString j ^ "," ^
+                        Int.toString k ^ ")")
+)
+
+type equation3 = rat IntTripleTab.table;
+val eq3_empty : equation3 = IntTripleTab.empty;
 
 fun eq3_cmul (c:rat) (eq:equation3) : equation3 =
     if c = rat0 then eq3_empty
-    else Redblackmap.map (fn (_, d) => rat_mul(c, d)) eq;
+    else IntTripleTab.map (fn _ => fn d => rat_mul(c, d)) eq;
 
 fun eq3_add (eq1:equation3) (eq2:equation3) : equation3 =
-    Redblackmap.foldl
-      (fn (v, c, acc) =>
-          case Redblackmap.peek(acc, v) of
-              NONE => Redblackmap.insert(acc, v, c)
+    IntTripleTab.fold
+      (fn (v, c) => fn acc =>
+          case IntTripleTab.lookup acc v of
+              NONE => IntTripleTab.update (v, c) acc
             | SOME d => let val s = rat_add(c, d) in
-                          if s = rat0 then #1(Redblackmap.remove(acc, v))
-                          else Redblackmap.insert(acc, v, s)
+                          if s = rat0 then IntTripleTab.delete v acc
+                          else IntTripleTab.update (v, s) acc
                         end)
-      eq1 eq2;
+      eq2 eq1;
 
 fun eq3_eval (assig: eqvar3 -> rat) (eq:equation3) : rat =
-    Redblackmap.foldl (fn (v, c, acc) => rat_add(acc, rat_mul(assig v, c)))
-      rat0 eq;
+    IntTripleTab.fold
+      (fn (v, c) => fn acc => rat_add(acc, rat_mul(assig v, c))) eq rat0;
 
-fun eq3_is0 (eq:equation3) = Redblackmap.numItems eq = 0;
+fun eq3_is0 (eq:equation3) = IntTripleTab.size eq = 0;
 
-fun eq3_peek (eq:equation3) v = Redblackmap.peek(eq, v);
+fun eq3_peek (eq:equation3) v = IntTripleTab.lookup eq v;
 
-fun eq3_remove v (eq:equation3) =
-    #1(Redblackmap.remove(eq, v)) handle NotFound => eq;
+fun eq3_remove v (eq:equation3) = IntTripleTab.delete_safe v eq;
 
-fun eq3_vars (eq:equation3) = map #1 (Redblackmap.listItems eq);
+fun eq3_vars (eq:equation3) = map #1 (IntTripleTab.dest eq);
 
 (* Eliminate all variables from a system of equations (3-tuple version) *)
 fun eliminate_all_equations3 (one:eqvar3) (eqs: equation3 list)
-    : eqvar3 list * (eqvar3, equation3) Redblackmap.dict =
+    : eqvar3 list * equation3 IntTripleTab.table =
     let
       fun choose_variable (eq:equation3) =
-          let val items = Redblackmap.listItems eq in
+          let val items = IntTripleTab.dest eq in
             case items of
                 [] => raise ERR "choose_variable3" "empty equation"
               | [(v,_)] => if eqvar3_compare(v, one) = EQUAL
@@ -1412,7 +1431,7 @@ fun eliminate_all_equations3 (one:eqvar3) (eqs: equation3 list)
                   else v
                 end
           end
-      val assig_empty = Redblackmap.mkDict eqvar3_compare
+      val assig_empty = IntTripleTab.empty
       fun elim dun [] = dun
         | elim dun (eq::oeqs) =
           if eq3_is0 eq then elim dun oeqs
@@ -1429,21 +1448,21 @@ fun eliminate_all_equations3 (one:eqvar3) (eqs: equation3 list)
                     | SOME b =>
                       eq3_add (eq3_remove v e)
                              (eq3_cmul (rat_div(rat_neg b, a)) (eq3_remove v eq))
-              val dun' = Redblackmap.insert(
-                           Redblackmap.map (fn (_, f) => subst_in f) dun,
-                           v, eq')
+              val dun' = IntTripleTab.update
+                           (v, eq')
+                           (IntTripleTab.map (fn _ => fn f => subst_in f) dun)
             in
               elim dun' (map subst_in oeqs)
             end
       val assig = elim assig_empty eqs
-      val vs = Redblackmap.foldl
-                 (fn (_, f, acc) =>
+      val vs = IntTripleTab.fold
+                 (fn (_, f) => fn acc =>
                      let val fvs = List.filter
                                      (fn v => eqvar3_compare(v, one) <> EQUAL)
                                      (eq3_vars f)
                      in fvs @ acc
                      end)
-                 [] assig
+                 assig []
       val vs' = Lib.mk_set (Listsort.sort eqvar3_compare vs)
     in (vs', assig)
     end;
@@ -1453,33 +1472,33 @@ fun eliminate_all_equations3 (one:eqvar3) (eqs: equation3 list)
 (* ===================================================================== *)
 
 (* 3D matrix type: (block, row, col) -> rat *)
-type bmatrix = (eqvar3, rat) Redblackmap.dict;
-val bmat_empty : bmatrix = Redblackmap.mkDict eqvar3_compare;
+type bmatrix = rat IntTripleTab.table;
+val bmat_empty : bmatrix = IntTripleTab.empty;
 
 fun bmatrix_add (m1:bmatrix) (m2:bmatrix) : bmatrix =
-    Redblackmap.foldl
-      (fn (k, c, acc) =>
-          case Redblackmap.peek(acc, k) of
-              NONE => Redblackmap.insert(acc, k, c)
+    IntTripleTab.fold
+      (fn (k, c) => fn acc =>
+          case IntTripleTab.lookup acc k of
+              NONE => IntTripleTab.update (k, c) acc
             | SOME d => let val s = rat_add(c, d) in
-                          if s = rat0 then #1(Redblackmap.remove(acc, k))
-                          else Redblackmap.insert(acc, k, s)
+                          if s = rat0 then IntTripleTab.delete k acc
+                          else IntTripleTab.update (k, s) acc
                         end)
-      m1 m2;
+      m2 m1;
 
 fun bmatrix_cmul (c:rat) (bm:bmatrix) : bmatrix =
     if c = rat0 then bmat_empty
-    else Redblackmap.map (fn (_, x) => rat_mul(c, x)) bm;
+    else IntTripleTab.map (fn _ => fn x => rat_mul(c, x)) bm;
 
 fun bmatrix_neg bm = bmatrix_cmul (rat_neg rat1) bm;
 
 (* SDPA-sparse for block diagonal matrix *)
 fun sdpa_of_blockdiagonal matno (bm:bmatrix) =
     let val pfx = Int.toString matno ^ " "
-        val ents = Redblackmap.foldl
-          (fn ((b,i,j), c, acc) =>
+        val ents = IntTripleTab.fold
+          (fn ((b,i,j), c) => fn acc =>
               if i > j then acc else ((b,i,j),c)::acc)
-          [] bm
+          bm []
         val sorted = Listsort.sort
           (fn (((b1,i1,j1),_),((b2,i2,j2),_)) =>
               case Int.compare(b1,b2) of
@@ -1514,10 +1533,10 @@ fun blocks (blocksizes:int list) (bm:bmatrix) : matrix list =
     let val indexed = ListPair.zip(blocksizes,
                                    List.tabulate(length blocksizes, fn i => i+1))
     in map (fn (bs, b0) =>
-         let val m = Redblackmap.foldl
-               (fn ((b,i,j), c, acc) =>
-                   if b = b0 then IMap.insert(acc, (i,j), c) else acc)
-               mmap_empty bm
+         let val m = IntTripleTab.fold
+               (fn ((b,i,j), c) => fn acc =>
+                   if b = b0 then IntPairTab.update ((i,j), c) acc else acc)
+               bm mmap_empty
          in ((bs,bs), m) : matrix
          end)
        indexed
@@ -1579,27 +1598,30 @@ fun run_csdp_blocks nblocks blocksizes (obj:vector) (mats:bmatrix list)
 fun scale_then solver (obj:vector) (mats:bmatrix list) : vector =
     let
       fun common_denom (bm:bmatrix) acc =
-          Redblackmap.foldl (fn (_, c, a) => lcm_num (rat_denom c) a) acc bm
+          IntTripleTab.fold
+            (fn (_, c) => fn a => lcm_num (rat_denom c) a) bm acc
       fun common_denom_vec ((_, vm):vector) acc =
-          IMap.foldl (fn (_, c, a) => lcm_num (rat_denom c) a) acc vm
+          Inttab.fold (fn (_, c) => fn a => lcm_num (rat_denom c) a) vm acc
       fun max_elt (bm:bmatrix) acc =
-          Redblackmap.foldl (fn (_, c, a) =>
-              let val ac = rat_abs c in if rat_gt(ac, a) then ac else a end)
-            acc bm
+          IntTripleTab.fold
+            (fn (_, c) => fn a =>
+                let val ac = rat_abs c
+                in if rat_gt(ac, a) then ac else a end)
+            bm acc
       fun pow2_scale e =
           if e >= 0 then rat_pow (Arbrat.fromInt 2) e
           else rat_div(rat1, rat_pow (Arbrat.fromInt 2) (~e))
       val cd1 = List.foldl (fn (m, a) => common_denom m a)
                   (Arbnum.fromInt 1) mats
       val cd2 = common_denom_vec obj (Arbnum.fromInt 1)
-      val mats' = map (Redblackmap.map (fn (_, x) =>
+      val mats' = map (IntTripleTab.map (fn _ => fn x =>
                          rat_mul(Arbrat.fromNat cd1, x))) mats
       val obj' = vec_cmul (Arbrat.fromNat cd2) obj
       (* Scale to reasonable magnitudes *)
       val max1 = List.foldl (fn (m, a) => max_elt m a) rat0 mats'
-      val max2 = IMap.foldl (fn (_, c, a) =>
+      val max2 = Inttab.fold (fn (_, c) => fn a =>
                      let val ac = rat_abs c in
-                       if rat_gt(ac, a) then ac else a end) rat0 (#2 obj')
+                       if rat_gt(ac, a) then ac else a end) (#2 obj') rat0
       fun log2_scale mx =
           if mx = rat0 then rat1
           else let val f = Real.fromLargeInt
@@ -1612,7 +1634,7 @@ fun scale_then solver (obj:vector) (mats:bmatrix list) : vector =
                end handle _ => rat1
       val scal1 = log2_scale max1
       val scal2 = log2_scale max2
-      val mats'' = map (Redblackmap.map (fn (_, x) => rat_mul(scal1, x))) mats'
+      val mats'' = map (IntTripleTab.map (fn _ => fn x => rat_mul(scal1, x))) mats'
       val obj'' = vec_cmul scal2 obj'
     in solver obj'' mats''
     end;
@@ -1623,35 +1645,35 @@ fun scale_then solver (obj:vector) (mats:bmatrix list) : vector =
 (* matrix variables). Each coefficient of the poly is a linear expr.    *)
 (* ===================================================================== *)
 
-type epoly = (monomial, equation3) Redblackmap.dict;
-val epoly_empty : epoly = Redblackmap.mkDict mono_compare;
+type epoly = equation3 MonoTab.table;
+val epoly_empty : epoly = MonoTab.empty;
 
 (* Multiply regular poly p by epoly q, accumulate into acc *)
 fun epoly_pmul (p:poly) (q:epoly) (acc:epoly) : epoly =
-    Redblackmap.foldl
-      (fn (m1, c, a) =>
-          Redblackmap.foldl
-            (fn (m2, e, b) =>
+    MonoTab.fold
+      (fn (m1, c) => fn a =>
+          MonoTab.fold
+            (fn (m2, e) => fn b =>
                 let val m = mono_mul m1 m2
-                    val es = case Redblackmap.peek(b, m) of
+                    val es = case MonoTab.lookup b m of
                                  SOME e0 => e0 | NONE => eq3_empty
-                in Redblackmap.insert(b, m, eq3_add (eq3_cmul c e) es)
+                in MonoTab.update (m, eq3_add (eq3_cmul c e) es) b
                 end)
-            a q)
-      acc p;
+            q a)
+      p acc;
 
 fun epoly_cmul (c:rat) (l:epoly) : epoly =
     if c = rat0 then epoly_empty
-    else Redblackmap.map (fn (_, e) => eq3_cmul c e) l;
+    else MonoTab.map (fn _ => fn e => eq3_cmul c e) l;
 
 (* Convert poly to epoly: each coefficient c at monomial m becomes
    (0,0,0) |=> -c  (convention: (0,0,0) evaluates to -1) *)
 fun epoly_of_poly (p:poly) : epoly =
-    Redblackmap.foldl
-      (fn (m, c, a) =>
-          Redblackmap.insert(a, m,
-            Redblackmap.insert(eq3_empty, (0,0,0), rat_neg c)))
-      epoly_empty p;
+    MonoTab.fold
+      (fn (m, c) => fn a =>
+          MonoTab.update
+            (m, IntTripleTab.update ((0,0,0), rat_neg c) eq3_empty) a)
+      p epoly_empty;
 
 (* ===================================================================== *)
 (* Positivstellensatz certificate search                                 *)
@@ -1669,7 +1691,7 @@ fun enumerate_monomials d (vars : term list) : monomial list =
         List.concat
           (List.tabulate(d+1, fn k =>
             map (fn m => if k = 0 then m
-                         else Redblackmap.insert(m, v, k))
+                         else Termtab.update (v, k) m)
                 (enumerate_monomials (d - k) vs)));
 
 (* Enumerate products of distinct input polys with degree <= d.
@@ -1711,8 +1733,8 @@ fun real_positivnullstellensatz_general linf d
           val nons = ListPair.zip(mons, List.tabulate(length mons, fn i => i+1))
       in (mons,
           List.foldl (fn ((m,n), acc) =>
-            Redblackmap.insert(acc, m,
-              Redblackmap.insert(eq3_empty, (~k, ~n, n), rat1)))
+            MonoTab.update
+              (m, IntTripleTab.update ((~k, ~n, n), rat1) eq3_empty) acc)
           epoly_empty nons)
       end
 
@@ -1729,10 +1751,12 @@ fun real_positivnullstellensatz_general linf d
               else
                 let val m = mono_mul m1 m2
                     val c = if n1 = n2 then rat1 else Arbrat.fromInt 2
-                    val es = case Redblackmap.peek(acc2, m) of
+                    val es = case MonoTab.lookup acc2 m of
                                  SOME e => e | NONE => eq3_empty
-                in Redblackmap.insert(acc2, m,
-                     eq3_add (Redblackmap.insert(eq3_empty, (k,n1,n2), c)) es)
+                in MonoTab.update
+                     (m, eq3_add
+                           (IntTripleTab.update ((k,n1,n2), c) eq3_empty) es)
+                     acc2
                 end)
             acc1 nons)
           epoly_empty nons)
@@ -1760,41 +1784,41 @@ fun real_positivnullstellensatz_general linf d
       end
 
     (* Extract equations (one per monomial in bigsum) *)
-    val eqns = Redblackmap.foldl (fn (_, e, acc) => e :: acc) [] bigsum
+    val eqns = MonoTab.fold (fn (_, e) => fn acc => e :: acc) bigsum []
 
     (* Eliminate to get free variables *)
     val (pvs, assig) = eliminate_all_equations3 (0,0,0) eqns
     val qvars = (0,0,0) :: pvs
     val allassig =
       List.foldl (fn (v, acc) =>
-                     Redblackmap.insert(acc, v,
-                       Redblackmap.insert(eq3_empty, v, rat1)))
+                     IntTripleTab.update
+                       (v, IntTripleTab.update (v, rat1) eq3_empty) acc)
                  assig pvs
 
     (* Build block-diagonal matrices for each variable *)
     fun mk_matrix v : bmatrix =
-      Redblackmap.foldl
-        (fn ((b,i,j), ass, m) =>
+      IntTripleTab.fold
+        (fn ((b,i,j), ass) => fn m =>
             if b < 0 then m (* skip ideal multiplier entries *)
-            else let val c = case Redblackmap.peek(ass, v) of
+            else let val c = case IntTripleTab.lookup ass v of
                                  SOME r => r | NONE => rat0
                  in if c = rat0 then m
-                    else let val m' = Redblackmap.insert(m, (b,j,i), c)
-                         in Redblackmap.insert(m', (b,i,j), c)
+                    else let val m' = IntTripleTab.update ((b,j,i), c) m
+                         in IntTripleTab.update ((b,i,j), c) m'
                          end
                  end)
-        bmat_empty allassig
+        allassig bmat_empty
 
     (* Objective: sum of diagonal entries *)
     val diagents =
-      Redblackmap.foldl
-        (fn ((b,i,j), e, a) =>
+      IntTripleTab.fold
+        (fn ((b,i,j), e) => fn a =>
             if b > 0 andalso i = j then eq3_add e a else a)
-        eq3_empty allassig
+        allassig eq3_empty
 
     val mats = map mk_matrix qvars
     val obj_coeffs =
-      map (fn v => case Redblackmap.peek(diagents, v) of
+      map (fn v => case IntTripleTab.lookup diagents v of
                        SOME c => c | NONE => rat0) pvs
     val obj = vec_of_list obj_coeffs
 
@@ -1843,40 +1867,40 @@ fun real_positivnullstellensatz_general linf d
 
     (* Reconstruct certificates *)
     val newassigs =
-      let val base = Redblackmap.insert(eq3_empty, (0,0,0), rat_neg rat1)
+      let val base = IntTripleTab.update ((0,0,0), rat_neg rat1) eq3_empty
       in List.foldl (fn (k, acc) =>
-           Redblackmap.insert(acc, List.nth(pvs, k-1), vec_el vec k))
+           IntTripleTab.update (List.nth(pvs, k-1), vec_el vec k) acc)
          base (List.tabulate(vec_dim vec, fn i => i+1))
       end
 
     val finalassigs =
-      Redblackmap.foldl
-        (fn (v, e, a) =>
-            Redblackmap.insert(a, v, eq3_eval (fn w =>
-              case Redblackmap.peek(newassigs, w) of
-                  SOME c => c | NONE => rat0) e))
-        newassigs allassig
+      IntTripleTab.fold
+        (fn (v, e) => fn a =>
+            IntTripleTab.update
+              (v, eq3_eval (fn w =>
+                    case IntTripleTab.lookup newassigs w of
+                        SOME c => c | NONE => rat0) e) a)
+        allassig newassigs
 
     fun poly_of_epoly (ep:epoly) : poly =
-      Redblackmap.foldl
-        (fn (m, e, a) =>
+      MonoTab.fold
+        (fn (m, e) => fn a =>
             let val c = eq3_eval (fn w =>
-                  case Redblackmap.peek(finalassigs, w) of
+                  case IntTripleTab.lookup finalassigs w of
                       SOME r => r | NONE => rat0) e
             in if c = rat0 then a
-               else poly_add a (Redblackmap.insert(poly_empty, m, c))
+               else poly_add a (MonoTab.update (m, c) poly_empty)
             end)
-        poly_0 ep
+        ep poly_0
 
     fun mk_sos mons dia =
       map (fn (c, (_, vm)) =>
-        (c, IMap.foldl
-              (fn (k, v, acc) =>
+        (c, Inttab.fold
+              (fn (k, v) => fn acc =>
                   if v = rat0 then acc
                   else poly_add acc
-                    (Redblackmap.insert(poly_empty,
-                       List.nth(mons, k-1), v)))
-              poly_0 vm))
+                    (MonoTab.update (List.nth(mons, k-1), v) poly_empty))
+              vm poly_0))
       dia
 
     val sqs_out = ListPair.map (fn (m, d) => mk_sos m d) (sqmonlist, ratdias)

--- a/src/refute/Canon.sml
+++ b/src/refute/Canon.sml
@@ -743,10 +743,8 @@ val _ = Parse.temp_set_grammars ambient_grammars;
 (*            (Ported from HOL-Light by Chun Tian, June 1, 2022)             *)
 (* ------------------------------------------------------------------------- *)
 
-local open Redblackmap in
-
-type func = (term,thm)dict;
-val undefined :func = mkDict Term.compare;
+type func = thm Termtab.table;
+val undefined :func = Termtab.empty;
 
 val CONJ_ACI_RULE = let
   fun mk_fun th (f :func) :func =
@@ -755,14 +753,14 @@ val CONJ_ACI_RULE = let
             let val (th1,th2) = CONJ_PAIR th in
                 mk_fun th1 (mk_fun th2 f)
             end
-        else insert (f,tm,th)
+        else Termtab.update (tm, th) f
     end
   and use_fun (f :func) tm :thm =
     if is_conj tm then
         let val (l,r) = dest_conj tm in
             CONJ (use_fun f l) (use_fun f r)
         end
-    else find (f,tm)
+    else valOf (Termtab.lookup f tm)
 in
   fn tm => let val (p,p') = dest_eq tm in
                if p ~~ p' then REFL p else
@@ -802,14 +800,14 @@ val DISJ_ACI_RULE = let
             let val (th1,th2) = NOT_DISJ_PAIR th in
                 mk_fun th1 (mk_fun th2 f)
             end
-        else insert (f,tm,th)
+        else Termtab.update (tm, th) f
     end
   and use_fun (f :func) tm :thm =
     if is_disj tm then
         let val (l,r) = dest_disj tm in
             NOT_DISJ (use_fun f l) (use_fun f r)
         end
-    else find (f,tm)
+    else valOf (Termtab.lookup f tm)
 in
   fn tm => let val (p,p') = dest_eq tm in
                if p ~~ p' then REFL p else
@@ -821,8 +819,6 @@ in
                end
            end
 end; (* DISJ_ACI_RULE *)
-
-end; (* local *)
 
 (* ------------------------------------------------------------------------- *)
 (* Order canonically, right-associate and remove duplicates.                 *)

--- a/src/simp/src/Cache.sml
+++ b/src/simp/src/Cache.sml
@@ -8,11 +8,11 @@ type key = term
 type hypinfo = {hyps : term HOLset.set, thms : term HOLset.set}
 type data = (hypinfo * thm option) list
 
-type table = (key, data) Redblackmap.dict
-val empty_table = Redblackmap.mkDict Term.compare : table
+type table = data Termtab.table
+val empty_table : table = Termtab.empty
 
 type cache = table Sref.t
-fun c_insert c (k,v) = Sref.update c (fn t => Redblackmap.insert(t,k,v))
+fun c_insert c (k,v) = Sref.update c (fn t => Termtab.update (k,v) t)
 fun cvalue (c:cache) = Sref.value c
 fun new_cache() : cache = Sref.new empty_table
 
@@ -39,8 +39,7 @@ fun CACHE (filt,conv) = let
   fun cache_proc thms tm = let
     val _ = if (filt tm) then ()
             else failwith "CACHE_CCONV: not applicable"
-    val prevs = Redblackmap.find (cvalue cache, tm)
-                handle Redblackmap.NotFound => []
+    val prevs = Option.getOpt (Termtab.lookup (cvalue cache) tm, [])
     val curr = all_hyps thms
     fun ok (prev,SOME thm) = prev << curr
       | ok (prev,NONE) = curr << prev
@@ -72,7 +71,7 @@ end
 fun clear_cache cache = (Sref.update cache (fn c => empty_table))
 
 fun cache_values (cache : cache) = let
-  val items = Redblackmap.listItems (cvalue cache)
+  val items = Termtab.dest (cvalue cache)
   fun tolist (set, thmopt) = (hypinfo_list set, thmopt)
   fun ToList (k, stlist) = (k, map tolist stlist)
 in
@@ -115,14 +114,13 @@ end
    ---------------------------------------------------------------------- *)
 
 fun ccs G vs = let
-  (* G is a Binarymap from terms to term sets, with the set representing
+  (* G is a Termtab from terms to term sets, with the set representing
      the adjacent nodes in the graph.  The graph is undirected so
      there will be two entries for each link.
      vs is a list of all the terms in G. *)
   fun recurse acc visited v = let
     (* v is already in acc and visited *)
-    val neighbours = Binarymap.find (G, v)
-        handle Binarymap.NotFound => empty_tmset
+    val neighbours = Option.getOpt (Termtab.lookup G v, empty_tmset)
     fun visit_neighbour(n, (acc, visited)) =
         if HOLset.member(visited, n) then (acc, visited)
         else recurse (n::acc) (HOLset.add(visited, n)) n
@@ -146,19 +144,19 @@ fun make_links fvs_of (t, G) = let
   val fvs = fvs_of t
   fun mk_link1 t1 t2 G = let
     val newset =
-        case Binarymap.peek(G, t1) of
+        case Termtab.lookup G t1 of
           NONE => HOLset.singleton Term.compare t2
         | SOME s => HOLset.add(s, t2)
   in
-    Binarymap.insert(G, t1, newset)
+    Termtab.update (t1, newset) G
   end
   fun mk_link t1 t2 G = mk_link1 t1 t2 (mk_link1 t2 t1 G)
   fun mk_links [] G = G
     | mk_links [_] G = G
     | mk_links (x::y::rest) G = mk_link x y (mk_links (y::rest) G)
   fun enter_domain x G =
-      case Binarymap.peek (G, x) of
-        NONE => Binarymap.insert(G, x, HOLset.empty Term.compare)
+      case Termtab.lookup G x of
+        NONE => Termtab.update (x, HOLset.empty Term.compare) G
       | SOME _ => G
 in
   case fvs of
@@ -183,7 +181,7 @@ end
    same component anyway.
 *)
 fun build_graph fvs_of tmlist =
-    List.foldl (make_links fvs_of) (Binarymap.mkDict Term.compare) tmlist
+    List.foldl (make_links fvs_of) Termtab.empty tmlist
 
 (* given a list of list of variables; build a map where all the variables
    in the same list point to the same updatable reference cell *)
@@ -191,10 +189,10 @@ val build_var_to_group_map = let
   fun foldthis (tlist, acc) = let
     val r = Uref.new (empty_hypinfo, [] : thm list)
   in
-    List.foldl (fn (t, acc) => Binarymap.insert(acc, t, r)) acc tlist
+    List.foldl (fn (t, acc) => Termtab.update (t, r) acc) acc tlist
   end
 in
-  List.foldl foldthis (Binarymap.mkDict Term.compare)
+  List.foldl foldthis Termtab.empty
 end
 
 
@@ -214,8 +212,7 @@ end
 
 fun consider_false_context_cache table original_goal (ctxtlist:context list) =
     let
-      val cache_F = Redblackmap.find (table, boolSyntax.F)
-                    handle Redblackmap.NotFound => []
+      val cache_F = Option.getOpt (Termtab.lookup table boolSyntax.F, [])
       fun recurse acc ctxts =
           case ctxts of
             [] => possible_ctxts acc
@@ -241,8 +238,7 @@ fun prove_false_context (conv:thm list -> conv) (cache:cache) (ctxtlist:context 
         [] => raise mk_HOL_ERR "Cache" "RCACHE"
                                "No (more) possibly false contexts"
       | (hyps,thms)::cs => let
-          val oldval = Redblackmap.find (cvalue cache, F)
-                       handle Redblackmap.NotFound => []
+          val oldval = Option.getOpt (Termtab.lookup (cvalue cache) F, [])
           val conjs = list_mk_conj (map concl thms)
         in
           case Lib.total (conv thms) boolSyntax.F of
@@ -272,7 +268,7 @@ fun RCACHE (dpfvs, check, conv) = let
     case dpfvs c of
       [] => ()
     | (v::_) => let
-        val r = Binarymap.find(mp,v)
+        val r = valOf (Termtab.lookup mp v)
         val (oldhyps, oldthms) = !r
       in
         r := (hypinfo_addth(th, oldhyps), th::oldthms)
@@ -281,7 +277,7 @@ fun RCACHE (dpfvs, check, conv) = let
   fun decider ctxt t = let
     val _ = if check t then ()
             else raise mk_HOL_ERR "Cache" "RCACHE" "not applicable"
-    val prevs = Redblackmap.find (cvalue cache, t) handle NotFound => []
+    val prevs = Option.getOpt (Termtab.lookup (cvalue cache) t, [])
     val curr = all_hyps ctxt
     fun oksome (prev, SOME thm) = prev << curr
       | oksome (_, NONE) = false
@@ -301,7 +297,7 @@ fun RCACHE (dpfvs, check, conv) = let
             List.foldl foldthis ([], []) ctxt
         val G = build_graph dpfvs (t::ctxt_ts)
                 (* G a map from v to v's neighbours *)
-        val vs = Binarymap.foldl (fn (k,v,acc) => k::acc) [] G
+        val vs = Termtab.fold (fn (k,_) => fn acc => k::acc) G []
         val (comps, _) = ccs G vs
                 (* a list of lists of variables *)
         val group_map = build_var_to_group_map comps
@@ -313,15 +309,17 @@ fun RCACHE (dpfvs, check, conv) = let
         val (group_map', glstmtref) =
           case dpfvs t of
             [] => (group_map, Uref.new (empty_hypinfo, []))
-          | (glvar::_) => Binarymap.remove(group_map, glvar)
+          | (glvar::_) =>
+              let val r = valOf (Termtab.lookup group_map glvar)
+              in (Termtab.delete glvar group_map, r) end
 
         (* and the remaining contexts, ensuring there are no
            duplicate copies *)
-        fun foldthis (k, v, acc as (setlist, seenreflist)) =
+        fun foldthis (k, v) (acc as (setlist, seenreflist)) =
             if mem v seenreflist then acc
             else (!v::setlist, v::seenreflist)
         val (divided_clist0, _) =
-            Binarymap.foldl foldthis ([], [glstmtref]) group_map'
+            Termtab.fold foldthis group_map' ([], [glstmtref])
 
         (* fold in every ground hypothesis as a separate context, entire
            unto itself *)

--- a/src/simp/src/Cond_rewr.sml
+++ b/src/simp/src/Cond_rewr.sml
@@ -42,7 +42,7 @@ fun dest_hd env t =
     case dest_term t of
       VAR (s, ty) => let
       in
-        case Binarymap.peek(env, t) of
+        case Termtab.lookup env t of
           NONE => (((s, ""), 0), ty)
         | SOME n => ((("", ""), ~n), Type.alpha)
       end
@@ -68,8 +68,8 @@ in
           in
             case Type.compare(type_of bv1, type_of bv2) of
               EQUAL => let
-                val env1' = Binarymap.insert(env1, bv1, n)
-                val env2' = Binarymap.insert(env2, bv2, n)
+                val env1' = Termtab.update (bv1, n) env1
+                val env2' = Termtab.update (bv2, n) env2
               in
                 ac_term_ord0 (n + 1) (env1', env2') (bdy1, bdy2)
               end
@@ -87,7 +87,7 @@ in
     end
   | x => x
 end
-val empty_dict = Binarymap.mkDict Term.compare
+val empty_dict = Termtab.empty
 val ac_term_ord = ac_term_ord0 0 (empty_dict, empty_dict)
 
 (* bad old implementation, has a loop between

--- a/src/sort/permLib.sml
+++ b/src/sort/permLib.sml
@@ -340,8 +340,11 @@ fun ASSUM_BY_CONV conv thm = let
   in MP thm TRUTH handle HOL_ERR e => (print ("ASSUM_BY_CONV: conv-ed thm: "
     ^ Parse.thm_to_string thm ^ "\n"); raise (HOL_ERR e)) end
 
-fun add_count d k n = Redblackmap.update (d, k, fn NONE => n | SOME m => m + n)
-fun look_count d k = case Redblackmap.peek (d, k) of NONE => 0 | SOME n => n
+fun add_count d k n =
+    Termtab.update (k, case Termtab.lookup d k of
+                           NONE => n
+                         | SOME m => m + n) d
+fun look_count d k = case Termtab.lookup d k of NONE => 0 | SOME n => n
 
 local
    fun strip_build_opers t ops =
@@ -374,8 +377,7 @@ end
    order they appear in l1/l2, and l1rem and l2rem are the
    remainders. Fast: O(n) proof steps, O(nlogn) calculation. *)
 fun PERM_ELIM_COMMON_IMP common l1 l2 = let
-    val comm_tab = foldl (fn (x, d) => add_count d x 1)
-        (Redblackmap.mkDict Term.compare) common
+    val comm_tab = foldl (fn (x, d) => add_count d x 1) Termtab.empty common
     val (l1_comm, l1_rem) = strip_perm_list_div comm_tab l1
     val (l2_comm, l2_rem) = strip_perm_list_div comm_tab l2
     val thm = ISPECL [l1, l1_comm, l1_rem, l2, l2_comm, l2_rem]

--- a/src/taut/tautLib.sml
+++ b/src/taut/tautLib.sml
@@ -52,12 +52,13 @@ fun TAUT_CHECK_CONV tm =
     let val (vars,tm') = strip_forall tm
         val g = list_mk_exists(vars,mk_neg tm')
         val cxm = List.foldl (fn (v, cxm) =>
-          if is_neg v then Redblackmap.insert (cxm, dest_neg v, F)
-          else Redblackmap.insert (cxm, v, T))
-            (Redblackmap.mkDict Term.compare)
+          if is_neg v then Termtab.update (dest_neg v, F) cxm
+          else Termtab.update (v, T) cxm)
+            Termtab.empty
             (strip_conj (fst (dest_imp (concl th))))
-        val cex = List.map (fn v => Redblackmap.find (cxm, v)
-          handle NotFound => T) vars
+        val cex = List.map (fn v => case Termtab.lookup cxm v of
+                                        SOME t => t
+                                      | NONE => T) vars
         val th1 = prove(g, MAP_EVERY EXISTS_TAC cex THEN REWRITE_TAC [])
         val th2 = CONV_RULE (REPEATC (LAST_EXISTS_CONV EXISTS_NOT_CONV)) th1
     in EQF_INTRO th2 end

--- a/src/tfl/src/Defn.sml
+++ b/src/tfl/src/Defn.sml
@@ -1738,8 +1738,8 @@ fun defn_absyn_to_term a = let
   fun foldthis (pv as Preterm.Var{Name,Ty,Locn}, env) =
     if String.sub(Name,0) = #"_" then return env
     else
-      (case Binarymap.peek(env,Name) of
-           NONE => return (Binarymap.insert(env,Name,pv))
+      (case Symtab.lookup env Name of
+           NONE => return (Symtab.update (Name,pv) env)
          | SOME pv' =>
              Preterm.ptype_of pv' >- (fn pty' => Pretype.unify Ty pty') >>
              return env)
@@ -1763,7 +1763,7 @@ fun defn_absyn_to_term a = let
       let
         val all_frees = op_U Preterm.veq (map ptdefn_freevars pts)
       in
-        foldlM foldthis (Binarymap.mkDict String.compare) all_frees >>
+        foldlM foldthis Symtab.empty all_frees >>
         construct_final_term pts
       end)
 in

--- a/src/transfer/transferLib.sml
+++ b/src/transfer/transferLib.sml
@@ -156,24 +156,24 @@ infix >* >>-
 val op>>- =  op >-
 fun (m1 >* m2) = lift2 (fn x => fn y => (x,y)) m1 m2
 type preterm = Preterm.preterm
-type env = (term, preterm) Binarymap.dict * int
+type env = preterm Termtab.table * int
 type 'a t = env -> env * 'a
 fun getmap E = (E, #1 E)
 val newconst : Preterm.preterm t = fn (vmap, i) =>
     ((vmap, i + 1), pmk_var("UC" ^ Int.toString i, i))
 fun newvar bv (m:'a t) : (preterm * 'a) t = fn (vmap,i) =>
     let val pv = pmk_var(#1 (dest_var bv) (* ^ Int.toString i *), i)
-        val vmap' = Binarymap.insert(vmap, bv, pv)
+        val vmap' = Termtab.update (bv, pv) vmap
         val ((vmap'',i'), result) = m (vmap', i + 1)
     in
       ((vmap, i'), (pv, result))
     end
 in
-val env0:env = (Binarymap.mkDict Term.compare, 0)
+val env0:env = (Termtab.empty, 0)
 fun build_preterm rdb ct : Preterm.preterm t =
     let
       fun varmap ct e =
-          case Binarymap.peek(e,ct) of
+          case Termtab.lookup e ct of
               NONE => raise Fail ("Free variable: "^term_to_string ct)
             | SOME pt => return pt
       fun recurse ct =


### PR DESCRIPTION
## Summary

Phase 1 of the consolidation requested in #1595: replace the
overlapping `Binarymap`/`Redblackmap`/`HOLdict` map libraries with
structures derived from `src/portableML/Table.sml` (the Isabelle-style
2-3 tree functor already vendored in tree).  Existing instantiations
are reused where possible -- `Symtab` (string), `Inttab` (int),
`Termtab` (term), `KNametab` (kname), `Typetab` (hol_type, promoted to
top-level as part of the SharingTables work here), `Symreltab` -- with
local Tab structures for the handful of maps whose key types don't
already have a top-level instantiation.

This PR is the dictionary half of the consolidation only; sets and
the polymorphic comparator-passing abstractions are deferred (see
"What's not in this PR" below).

## Why Table over SML/NJ ORD_MAP

The issue proposes SML/NJ Library's `ORD_SET`/`ORD_MAP` functors as
the destination.  This PR uses `Table` instead because it is already
in tree (no new dependency), the API is richer (`update_new`,
`default`, `map_default`, `cons_list`, `insert_list`, `join`,
`merge`, ...), and the "bonus points" task in #1595 -- pre-instantiated
maps for term/type/etc. -- is partly already done in tree (`Termtab`,
`KNametab`).

Happy to switch direction if there's a strong reason to prefer the
SML/NJ functors instead.

## Commit structure

Six commits, each independently buildable with `bin/build -F`:

1. **Migrate src/ map users to Table-derived structures** -- the bulk
   of the work: a per-directory walk through src/ (~33 directories,
   originally landed one commit each before being squashed for review).
2. **Switch SharingTables to Symtab/Idtab/Typetab/Termtab** -- a
   public-API surface that needed coordinated changes across consumers.
3. **Switch src/real/SOSLib to Termtab/MonoTab/IntPairTab/IntTripleTab**
   -- ~100 sites in one large internal file, no signature leak.
4. **Remove HOLdict and switch FullUnify Env to Symtab/Termtab** --
   delete a redundant Redblackmap wrapper after mass-renaming its
   28 consumers; rebuild FullUnify.Env on Symtab/Termtab.
5. **Migrate post-HOLdict consumers to specific Tabs** -- per-consumer
   migration of those 28 sites to the right Tab for their key type,
   plus follow-up exception-interface cleanup in TypeNet/LVTermNet/
   LVTermNetFunctor (each now has a local `exception NotFound`).
6. **Switch ThmSetData.simple_dictionary to Symtab** -- the last
   public-API dict surface in src/.

## What's *not* in this PR

Explicitly deferred from phase 1:

- **Sets** (Binaryset/Redblackset).  Table lacks union/intersection/
  difference/subset; adding them is its own change.
- **Polymorphic comparator-passing abstractions**: `Conv.memoize`
  (gates one site in `wordsLib`), `aiLib`, `mlib*` (Multiset, Subst,
  Termnet, Termorder, Thm), `HolSat` RBM/SVM.  These need
  restructuring rather than a straight migration since `Table` is a
  functor over a fixed key type.
- **Cross-directory** `OpenTheoryMap` (consumed by relation,
  coretypes, num/theories, datatype, many *Script.sml).
- **Internal-heavy** `src/HolSmt` (~12 files, dozens of sites).
- **`tools/`** -- blocked on having Table.sml available early enough
  in the build sequence (would need `tools/sequences/` futzing).
- **`examples/`** -- next phase, not started.

`Lib.dict` and `Lib.dict_topsort` intentionally stay polymorphic.

## Test plan

- [x] `bin/build -F` passes after each commit (verified during the
      original per-directory work; full build green on the regrouped
      branch as well)
- [x] No content drift vs. the pre-regroup commit history (empty diff
      between the regrouped tip and the original 44-commit tip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
