### PR TITLE
Fix SAT_ORACLE bogus theorems from dropped F conjuncts in to_cnf

### DIFF
--- a/src/HolSat/Holmakefile
+++ b/src/HolSat/Holmakefile
@@ -1,6 +1,18 @@
 .PHONY: all
-all: $(DEFAULT_TARGETS)
+all: $(DEFAULT_TARGETS) selftest.exe
 
 ifeq ($(KERNELID),otknl)
 all: $(patsubst %Script.sml,%.ot.art,$(wildcard *Script.sml))
 endif
+
+selftest.exe: selftest.uo
+	$(HOLMOSMLC) -o $@ $<
+
+ifdef HOLSELFTESTLEVEL
+all: holsat-selftest.log
+
+holsat-selftest.log: selftest.exe
+	$(tee ./selftest.exe 2>&1,$@)
+endif
+
+EXTRA_CLEANS = selftest.exe holsat-selftest.log

--- a/src/HolSat/def_cnf.sig
+++ b/src/HolSat/def_cnf.sig
@@ -3,6 +3,7 @@ sig
 
   include Abbrev
   val presimp_conv : conv
+  exception to_cnf_unsat of thm
   val to_cnf : bool -> term ->
                (string option * int *
                 (term,term)satCommonTools.RBM.dict *

--- a/src/HolSat/def_cnf.sml
+++ b/src/HolSat/def_cnf.sml
@@ -17,6 +17,12 @@ val presimp_conv =
             [NOT_CLAUSES, AND_CLAUSES, OR_CLAUSES, IMP_CLAUSES, EQ_CLAUSES,
              COND_EXPAND, COND_CLAUSES])
 
+(* Raised by to_cnf when boolean simplification of one of the top-level
+   conjuncts of the input term reduces to F: the input is unsatisfiable
+   without help from the SAT solver. The carried theorem is |- ~tm where
+   tm is the term passed to to_cnf. *)
+exception to_cnf_unsat of thm
+
 (* ------------------------------------------------------------------------- *)
 (* Split up a theorem according to conjuncts, in a general sense.            *)
 (* ------------------------------------------------------------------------- *)
@@ -236,7 +242,11 @@ fun to_cnf is_cnf tm =
                     itlist (fn (ic,th) =>
                             fn (m,tops,defs,lfn) =>
                                let val t = concl th
-                               in if is_T t orelse is_F t then (m,tops,defs,lfn)
+                               in if is_T t then (m,tops,defs,lfn)
+                                  else if is_F t then
+                                    (* th : tm |- F, so |- ~tm *)
+                                    raise to_cnf_unsat
+                                            (NOT_INTRO (DISCH tm th))
                                   else
                                   let val (n,v,defs',lfn') =
                                           if ic then

--- a/src/HolSat/minisatProve.sml
+++ b/src/HolSat/minisatProve.sml
@@ -111,16 +111,20 @@ fun finalise solver infile is_cnf th tmpname in_name =
 exception initexp of thm;
 fun initialise infile is_cnf tm =
     let val (cnfv,vc,svm,sva,tmpname,in_name,ntm,lfn,clauseth) =
-            if isSome infile
-            then let val fname = valOf infile
-                     val (tm,svm,sva) = genReadDimacs fname
-                     val (cnfv,vc,lfn,clauseth) = to_cnf is_cnf (mk_neg tm)
-                 in (cnfv,vc,svm,sva,"",fname,mk_neg tm,lfn,clauseth) end
-            else let val (cnfv,vc,lfn,clauseth) = to_cnf is_cnf (mk_neg tm)
-                     val (tmpname,cnfname,sva,svm) =
-                         generateDimacs (SOME vc) tm (SOME clauseth)
-                                        (SOME (Array.length clauseth))
-                 in (cnfv,vc,svm,sva,tmpname,cnfname,mk_neg tm,lfn,clauseth) end
+            (if isSome infile
+             then let val fname = valOf infile
+                      val (tm,svm,sva) = genReadDimacs fname
+                      val (cnfv,vc,lfn,clauseth) = to_cnf is_cnf (mk_neg tm)
+                  in (cnfv,vc,svm,sva,"",fname,mk_neg tm,lfn,clauseth) end
+             else let val (cnfv,vc,lfn,clauseth) = to_cnf is_cnf (mk_neg tm)
+                      val (tmpname,cnfname,sva,svm) =
+                          generateDimacs (SOME vc) tm (SOME clauseth)
+                                         (SOME (Array.length clauseth))
+                  in (cnfv,vc,svm,sva,tmpname,cnfname,mk_neg tm,lfn,clauseth)
+                  end)
+            handle to_cnf_unsat nottm_thm =>
+              (* nottm_thm : |- ~(~tm), peel double-negation to get |- tm *)
+              raise initexp (CONV_RULE NOT_NOT_CONV nottm_thm)
     in if vc=0 then
          (* no vars: all 'presimp'-ified conjuncts were either T or F *)
            let val th0 = presimp_conv (dest_neg ntm)

--- a/src/HolSat/selftest.sml
+++ b/src/HolSat/selftest.sml
@@ -1,0 +1,19 @@
+open HolKernel Parse boolLib testutils HolSatLib
+
+val _ = set_trace "Unicode" 0
+
+(* #1170: SAT_ORACLE used to fabricate a bogus theorem on inputs whose
+   negated form has a top-level conjunct that boolean-simplifies to F.
+   For ``b ==> T`` the negation is ``b /\ ~T``; presimp turns ``~T`` into
+   ``F``, but the F conjunct was silently dropped from the CNF passed to
+   MiniSAT, which then declared satisfiability. SAT_ORACLE skipped the
+   model-check that SAT_PROVE relies on and returned a bogus
+   |- b ==> ~(b ==> T). The fix short-circuits in to_cnf when a conjunct
+   reduces to F, so MiniSAT is never invoked for this case (and so the
+   test does not depend on a working MiniSAT installation). *)
+val _ = tprint "SAT_ORACLE proves `b ==> T` (#1170)"
+val _ = require_msg
+          (check_result (fn th => concl th ~~ ``b ==> T``))
+          thm_to_string
+          SAT_ORACLE
+          ``b ==> T``


### PR DESCRIPTION
## Summary

`SAT_ORACLE  “b ==> T”` previously produced

```
Exception- SAT_cex [oracles: HolSatLib] [] ⊢ b ⇒ ¬(b ⇒ T) raised
```

— a bogus oracle theorem from which `|- F` is derivable.

The root cause was in `to_cnf` (`src/HolSat/def_cnf.sml`). For `tm = b ⇒ T` the negated goal `~tm = b ∧ ¬T` is split by `GCONJUNCTS` into `[b, ¬T]`; `presimp_conv` collapses `¬T` to `F`. The dispatch loop then read

```sml
if is_T t orelse is_F t then (m,tops,defs,lfn)   (* skip *)
else …build clause…
```

Skipping a `T` conjunct is sound (`p ∧ T = p`); skipping an `F` conjunct is not (`p ∧ F = F`, not `p`). With the `F` clause gone, the CNF passed to MiniSAT was just `[b]`, MiniSAT correctly reported satisfiability, and `SAT_ORACLE` (which by design skips the post-hoc `satCheck` that `SAT_PROVE` runs) fabricated the bogus implication and raised `SAT_cex`.

This PR fixes the root cause: when `to_cnf` detects an `F` conjunct it raises a new `to_cnf_unsat` exception carrying `|- ¬tm`; `initialise` translates that into the existing `initexp` channel via `NOT_NOT_CONV` and `GEN_SAT` returns `|- tm`. Both `SAT_PROVE` and `SAT_ORACLE` benefit, and MiniSAT is no longer invoked for trivially-unsat preprocessing cases.

A regression test under `src/HolSat/selftest.sml` asserts `SAT_ORACLE \`b ==> T\`` returns `|- b ==> T`. The test runs without needing a working MiniSAT (the short-circuit is hit before any solver invocation).

### Follow-up not addressed here

Issue #1170's discussion also flags a deeper soundness concern: `SAT_ORACLE`'s "SAT verdict" branch fabricates an oracle theorem from the model without verifying it, so a buggy verdict from MiniSAT on any *other* input could still leak a bogus theorem. binghe (in the issue thread) eventually concluded that "perhaps the whole idea of SAT_ORACLE is wrong — without calling satCheck the intended oracle theorem cannot be determined." Hardening that path (e.g. always running `satCheck`, even on the oracle path) is left as a separate follow-up; this PR closes the specific reported reproducer.

Closes #1170.

## Test plan
- [x] Core build (`bin/build -t --seq=tools/sequences/upto-parallel`) green.
- [x] New regression test passes: `SAT_ORACLE proves `b ==> T` (#1170) … OK`.
- [x] Existing HolSat behaviour for genuinely-SAT inputs is unaffected — only the `is_F` branch in `to_cnf`'s dispatch loop changes; the `is_T` skip and the clause-building branch are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
