### PR TITLE
Stop case-printer's strip_case orphaning bound variables

### DIFF
--- a/src/1/Pmatch.sml
+++ b/src/1/Pmatch.sml
@@ -699,7 +699,7 @@ local fun dest tybase (pat,rhs) =
            in
              if null (op_set_diff aconv fvs patvars) andalso null (free_vars e)
                 andalso is_var v
-                (* andalso null_intersection fvs (free_vars (hd rhsides)) *)
+                andalso tm_null_intersection fvs (free_vars (hd rhsides))
              then flatten
                     (map (dest tybase) (zip [subst [v |-> e] pat, pat] rhsides))
              else [(pat,rhs)]

--- a/src/datatype/selftest.sml
+++ b/src/datatype/selftest.sml
@@ -526,6 +526,27 @@ val _ = TypeBase.export [
 val _ = Hol_datatype `t1 = T1 of (((num, num) list_syn # t2) list)
     ;  t2 = T2 of t1`;
 
+(* #1086: the case-printer's strip_case used to merge clauses by
+   substituting [v |-> e] into a pattern when the inner case scrutinised
+   `v = e`, but it didn't check whether v still occurred in the
+   corresponding rhs. For a closed input like
+       case x of MCons y ys => if y = T then y else F | MNil => F
+   the merge produced
+       case x of MCons T ys => y | MCons y ys => F | MNil => F
+   with `y` orphaned in the first clause, so the printer rendered the
+   closed term as a string that fails to round-trip through the parser. *)
+val _ = Hol_datatype `boollist = MNil | MCons of bool => boollist`
+local
+  val orig =
+      Parse.Term`(\x. case x of MCons y ys => if y = T then y else F
+                              | MNil => F) z`
+  fun roundtrip t = Parse.Term [QUOTE (Parse.term_to_string t)]
+in
+val _ = tprint "case-printer keeps bound vars bound (#1086)"
+val _ = require_msg (check_result (aconv orig)) term_to_string
+                    roundtrip orig
+end
+
 val _ = OK ()
 
 val _ = Process.exit Process.success;


### PR DESCRIPTION
## Summary

`Pmatch.strip_case` (used by the case-expression pretty-printer through `TypeBase`) flattens a nested case where the outer pattern binds some variable `v` and the inner case scrutinises `v = e` for a closed `e`. The merge substitutes `[v |-> e]` into the *first* (true-branch) pattern so that the two clauses can be inlined into the outer case. The check guarding the merge already required `v` to be a variable, the free-vars of `v` to be among the outer pat-vars, and `e` to be closed — but it failed to require `v` to be absent from the true-branch rhs.

So for

```
case x of MCons y ys => if y = T then y else F | MNil => F
```

`dest` produced the clause pair `(MCons T ys, y)` together with `(MCons y ys, F)`. The `y` in the first rhs was bound by the outer `MCons y ys` pattern, but after the substitution the binder is gone — `y` is orphaned. The closed term then printed as

```
\x. case x of MNil => F | MCons T ys => y | MCons y ys => F
```

which doesn't round-trip through the parser (the printed `y` reads as a free variable). Reported in #1086.

The fix is one line: re-enable the safety check that was already there as a `(* ... *)` comment at the merge site, with the helper name brought up to date. We require `v` not to occur free in the rhs being paired with the substituted pattern. When the check fails, `strip_case` keeps the inner case visible rather than producing a broken merge. The non-eq branch right below already does the analogous check via `tm_null_intersection` over `free_varsl rhsides`; this PR just reinstates it for the eq branch.

A regression test in `src/datatype/selftest.sml` (using a small local `boollist` datatype, since lists themselves aren't built yet at that point in the sequence) builds the closed term above, prints it, re-parses, and asserts the result is alpha-equivalent to the original. Without this fix the test fails with the reparsed term having a stray free `y`; with the fix it passes.

Closes #1086.

## Test plan
- [x] Core build (`bin/build -t --seq=tools/sequences/upto-parallel`) green.
- [x] New regression test passes: `case-printer keeps bound vars bound (#1086) … OK`.
- [x] Existing parsing/case tests under `src/1/selftest.sml` and `src/datatype/selftest.sml` continue to pass — only the eq-branch merge path's guard changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
