### PR TITLE
Surface real error after parallel-build kill teardown (#1903)

### DIFF
--- a/tools/Holmake/poly/MB_Monitor.sig
+++ b/tools/Holmake/poly/MB_Monitor.sig
@@ -3,11 +3,13 @@ sig
 
   val new : {info : string -> unit, warn : string -> unit,
              multidir : bool,
+             keep_going : bool,
              genLogFile : {tag:string,dir:string} -> string,
              time_limit : Time.time option} ->
             ProcessMultiplexor.monitor *
             {coloured_info : string * string -> unit,
              red : string -> string, green : string -> string,
-             bold : string -> string}
+             bold : string -> string,
+             final_report : unit -> unit}
 
 end

--- a/tools/Holmake/poly/MB_Monitor.sml
+++ b/tools/Holmake/poly/MB_Monitor.sml
@@ -172,10 +172,14 @@ fun rlsquash_to wdth s =
 
 val rlsquash_to = nstr_subhandler rlsquash_to "rlsquash_to"
 
-fun new {info,warn,genLogFile,time_limit,multidir} =
+fun new {info,warn,genLogFile,time_limit,multidir,keep_going} =
   let
     val monitor_map =
         ref (Binarymap.mkDict jobkey_compare : (jobkey,procinfo)Binarymap.dict)
+    val failures :
+        {tag:string, dir:string, status:string, log:string,
+         fulllines:string list, lastpartial:string} list ref
+        = ref []
     val last_width_check = ref (Time.now())
     val width = ref (getWidth())
     val last_child_cputime = let
@@ -375,16 +379,22 @@ fun new {info,warn,genLogFile,time_limit,multidir} =
                       tinfo ((if seen oracle_string then boldyellow else green),
                              "OK")
                   else
-                    (tinfo (red, "FAIL<" ^ status_string ^ ">");
-                     List.app (fn s => info (" " ^ dim s)) fulllines;
-                     if lastpartial <> "" then info (" " ^ dim lastpartial)
-                     else ();
-                     info (
-                       bold (
-                         " Full log: "^ fullPath [dir,LOGDIR,delsml_sfx tag]
-                       )
-                     )
-                    );
+                    let
+                      val log = fullPath [dir,LOGDIR,delsml_sfx tag]
+                    in
+                      tinfo (red, "FAIL<" ^ status_string ^ ">");
+                      if keep_going then
+                        (List.app (fn s => info (" " ^ dim s)) fulllines;
+                         if lastpartial <> "" then
+                           info (" " ^ dim lastpartial)
+                         else ();
+                         info (bold (" Full log: " ^ log)))
+                      else ();
+                      failures := !failures @
+                        [{tag = tag, dir = dir, status = status_string,
+                          log = log, fulllines = fulllines,
+                          lastpartial = lastpartial}]
+                    end;
                   TextIO.closeOut strm;
                   monitor_map := #1 (Binarymap.remove(!monitor_map, jk));
                   display_map();
@@ -400,18 +410,45 @@ fun new {info,warn,genLogFile,time_limit,multidir} =
           in
             stdhandle jk
                (fn {os = strm,tb, status = stat,...} =>
-                   (taginfo td dirstr utstr (red, "MKILLED");
+                   (taginfo td dirstr utstr (dim, "killed");
                     TextIO.closeOut strm;
                     monitor_map := #1 (Binarymap.remove(!monitor_map, jk));
                     display_map();
                     NONE))
           end
         | _ => NONE
+    fun final_report () =
+        case !failures of
+            [] => ()
+          | fs =>
+            let
+              val n = length fs
+              val tgt = if n = 1 then "target" else "targets"
+            in
+              info "";
+              info (red ("*** Holmake aborted - " ^ Int.toString n ^
+                         " " ^ tgt ^ " failed:"));
+              List.app
+                (fn {tag,dir,status,log,fulllines,lastpartial} =>
+                    let
+                      val dirpfx =
+                          if multidir then " in " ^ prettydir dir else ""
+                    in
+                      info (red "*** " ^ bold (delsml_sfx tag) ^ dirpfx ^
+                            " (status " ^ status ^ ")");
+                      List.app (fn s => info (" " ^ dim s)) fulllines;
+                      if lastpartial <> "" then info (" " ^ dim lastpartial)
+                      else ();
+                      info (bold (" Full log: " ^ log))
+                    end)
+                fs
+            end
   in
     (monitor,
      {coloured_info =
       (fn (s1,s2) => info (lrpad (infopfx ^ s1, s2 ^ " " ^ CLR_EOL))),
-      red = red, green = green, bold = bold})
+      red = red, green = green, bold = bold,
+      final_report = final_report})
   end
 
 

--- a/tools/Holmake/poly/multibuild.sml
+++ b/tools/Holmake/poly/multibuild.sml
@@ -126,9 +126,10 @@ fun graphbuild optinfo g =
           ldir ++ safetag dir tag
         end
 
-    val (monitor, {bold,green,red,coloured_info = info}) =
+    val (monitor, {bold,green,red,coloured_info = info,final_report}) =
         MB_Monitor.new {info = info, warn = warn, genLogFile = genLF,
                         time_limit = time_limit,
+                        keep_going = keep_going,
                         multidir = is_multidir dirmap}
 
     fun dircomplete dir (good, bad) t =
@@ -390,7 +391,7 @@ fun graphbuild optinfo g =
                       provider = { initial = (g,true), genjob = genjob }}
   in
     do_work(worklist, monitor)
-    before release_all_locks()
+    before (release_all_locks(); final_report())
   end
 
 end

--- a/tools/Holmake/tests/issue1903/Holmakefile
+++ b/tools/Holmake/tests/issue1903/Holmakefile
@@ -1,0 +1,11 @@
+ifdef POLY
+HOLHEAP = $(HOLDIR)/bin/hol.state0
+endif
+
+issue1903-selftest.log: selftest.exe
+	@$(tee ./$<, $@)
+
+selftest.exe: selftest.uo
+	$(HOLMOSMLC) -o $@ $<
+
+EXTRA_CLEANS = selftest.exe issue1903-selftest.log

--- a/tools/Holmake/tests/issue1903/selftest.sml
+++ b/tools/Holmake/tests/issue1903/selftest.sml
@@ -1,0 +1,89 @@
+(* Test for github issue 1903: parallel-build error reporting.
+
+   When a parallel build is aborted by a job failure, the output should:
+     1. Use a low-key "killed" notice for collateral kills (not the loud
+        red "MKILLED" the issue complains about).
+     2. End with a "*** Holmake aborted - N target(s) failed" summary
+        whose closing lines point at the actual failure, so users do not
+        have to scroll past collateral notices to find the real error. *)
+
+open testutils
+
+val op++ = OS.Path.concat
+val Holmake = Globals.HOLDIR ++ "bin" ++ "Holmake"
+val testdir = OS.FileSys.getDir() ++ "testdir"
+
+fun read_file f =
+    let val s = TextIO.openIn f
+    in TextIO.inputAll s before TextIO.closeIn s end
+
+fun run_holmake_in dir args =
+    let
+      val saved = OS.FileSys.getDir()
+      val _ = OS.FileSys.chDir dir
+      val cmd = String.concatWith " "
+                  (Holmake :: args @ [">", "output", "2>&1"])
+      val res = OS.Process.system cmd
+    in
+      OS.FileSys.chDir saved;
+      (res, read_file (dir ++ "output"))
+    end
+
+fun has s out = String.isSubstring s out
+fun missing s out = not (String.isSubstring s out)
+
+fun show_output_on_failure out =
+    (print "\n--- captured Holmake output ---\n";
+     print out;
+     print "--- end captured output ---\n")
+
+fun clean_testdir () =
+    OS.Process.system
+      ("cd " ^ testdir ^ " && " ^ Holmake ^ " cleanAll > /dev/null 2>&1")
+
+fun expect_failure (label, args, checks) =
+    let
+      val _ = tprint label
+      val _ = ignore (clean_testdir ())
+      val (res, output) = run_holmake_in testdir args
+      fun fail msg =
+          (show_output_on_failure output; die ("FAILED: " ^ msg))
+    in
+      if OS.Process.isSuccess res then
+        fail "sub-Holmake unexpectedly succeeded"
+      else
+        case List.find (fn (_, p) => not (p output)) checks of
+            SOME (msg, _) => fail msg
+          | NONE => OK()
+    end
+
+(* Default mode: first failure aborts the build.  The slow theories are
+   killed mid-flight; only one FAIL is reported. *)
+val _ = expect_failure (
+  "Default mode: collateral 'killed' (not MKILLED) and final summary",
+  ["-j", "4"],
+  [("output should NOT contain 'MKILLED'", missing "MKILLED"),
+   ("output should contain 'killed' for collateral",  has "killed"),
+   ("output should contain a final '*** Holmake aborted'",
+    has "*** Holmake aborted"),
+   ("output should contain '*** badboyTheory'", has "*** badboyTheory"),
+   ("output should contain final 'Full log:' line", has "Full log:"),
+   ("output should mention the deliberate failure",
+    has "deliberate failure for issue 1903 test")])
+
+(* keep-going mode: every failing job reports its full block inline AND
+   in the closing summary; non-failing jobs still complete OK, so no job
+   gets killed and "killed" should not appear in the output. *)
+val _ = expect_failure (
+  "Keep-going mode: failures appear inline AND in final summary",
+  ["-k", "-j", "4"],
+  [("output should NOT contain 'MKILLED'", missing "MKILLED"),
+   ("output should NOT contain 'killed' (slow jobs all finish)",
+    missing "killed"),
+   ("output should contain a final '*** Holmake aborted'",
+    has "*** Holmake aborted"),
+   ("output should contain '*** badboyTheory'", has "*** badboyTheory"),
+   ("output should mention the deliberate failure",
+    has "deliberate failure for issue 1903 test")])
+
+val _ = ignore (clean_testdir ())

--- a/tools/Holmake/tests/issue1903/testdir/Holmakefile
+++ b/tools/Holmake/tests/issue1903/testdir/Holmakefile
@@ -1,0 +1,5 @@
+ifdef POLY
+CLINE_OPTIONS = --holstate=$(HOLDIR)/bin/hol.state0
+endif
+
+EXTRA_CLEANS = output slowATheory.txt slowBTheory.txt slowCTheory.txt

--- a/tools/Holmake/tests/issue1903/testdir/badboyScript.sml
+++ b/tools/Holmake/tests/issue1903/testdir/badboyScript.sml
@@ -1,0 +1,3 @@
+Theory badboy[bare]
+
+val _ = raise Fail "deliberate failure for issue 1903 test"

--- a/tools/Holmake/tests/issue1903/testdir/slowAScript.sml
+++ b/tools/Holmake/tests/issue1903/testdir/slowAScript.sml
@@ -1,0 +1,3 @@
+Theory slowA[bare]
+
+val _ = OS.Process.sleep (Time.fromSeconds 4)

--- a/tools/Holmake/tests/issue1903/testdir/slowBScript.sml
+++ b/tools/Holmake/tests/issue1903/testdir/slowBScript.sml
@@ -1,0 +1,3 @@
+Theory slowB[bare]
+
+val _ = OS.Process.sleep (Time.fromSeconds 4)

--- a/tools/Holmake/tests/issue1903/testdir/slowCScript.sml
+++ b/tools/Holmake/tests/issue1903/testdir/slowCScript.sml
@@ -1,0 +1,3 @@
+Theory slowC[bare]
+
+val _ = OS.Process.sleep (Time.fromSeconds 4)

--- a/tools/Holmake/tests/parallel_tests/Holmakefile
+++ b/tools/Holmake/tests/parallel_tests/Holmakefile
@@ -40,7 +40,8 @@ DIRNAMES += cachefetch \
             dirlock \
             heap-size \
             ignore_errors/j4 \
-            hollogs
+            hollogs \
+            issue1903
 endif
 
 


### PR DESCRIPTION
## Summary

- When `-j N` Holmake aborts because of a job failure, the killed-mid-flight collateral notices used to be printed *after* the actual `FAIL` block in loud red `MKILLED` lines, burying the real error. This PR demotes those notices to a dim `killed` verdict and defers each failure's verbose tail-of-output + `Full log:` path into a single closing `*** Holmake aborted - N target(s) failed:` block, so the very last lines on screen now point at the real cause.
- Under `--keep-going` the verbose per-failure block is still printed inline at the moment of failure (live builds still surface errors promptly) and is *also* repeated in the final summary.
- Adds a regression test at `tools/Holmake/tests/issue1903/` (wired in via `tools/Holmake/tests/parallel_tests/Holmakefile`) that runs a parallel sub-Holmake with three slow `Theory[bare]` scripts plus a deliberately-failing one and asserts on the captured output in both default and `-k` modes.

Closes #1903.

## Test plan

- [x] `poly < tools/smart-configure.sml` — both poly- and mlton-built Holmakes compile cleanly with the changes.
- [x] `bin/build -t --seq=tools/sequences/upto-parallel` — core build still passes (exit 0).
- [x] New selftest passes from inside `tools/Holmake/tests/issue1903/` — both subtests (`default mode` and `-k`) report OK in `issue1903-selftest.log`.
- [x] Manual run of a failing `-j 4` build shows the new shape: brief `FAIL<n>` inline, dim `killed` for the kills, and the closing `*** Holmake aborted` block with the real error as the last lines on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
