### PR TITLE
Show the actual numeric literal in inject_number error messages

### DIFF
--- a/src/integer/selftest.sml
+++ b/src/integer/selftest.sml
@@ -96,4 +96,35 @@ val _ = List.app (rule_test INTEGER_RULE) [
        “d int_divides m ==> d int_divides (m * n:int)”)
       ];
 
+(* #1747: when overload-resolution fails for a numeric literal, the error
+   should name the literal itself (and read as English about a numeric
+   literal), not show the internal `_ inject_number` placeholder.
+   This requires multiple `_ inject_number` overloads to be active so
+   that resolution actually filters them all out — which is why this
+   test lives in src/integer rather than src/num/theories. *)
+local
+  fun parse_msg q =
+      (Parse.Term q; "<unexpected success>")
+      handle Feedback.HOL_ERR err => Feedback.message_of err
+  fun contains needle hay = String.isSubstring needle hay
+in
+val _ = tprint "#1747 numeric-literal error names the literal (0)"
+val _ = require_msg
+          (check_result
+             (fn m => contains "numeric literal" m
+                      andalso contains "`0`" m
+                      andalso not (contains "_ inject_number" m)))
+          (fn m => "got: " ^ m)
+          parse_msg `0 = T`
+
+val _ = tprint "#1747 numeric-literal error names the literal (42)"
+val _ = require_msg
+          (check_result
+             (fn m => contains "numeric literal" m
+                      andalso contains "`42`" m
+                      andalso not (contains "_ inject_number" m)))
+          (fn m => "got: " ^ m)
+          parse_msg `42 = T`
+end
+
 val _ = Process.exit Process.success;

--- a/src/parse/GrammarSpecials.sig
+++ b/src/parse/GrammarSpecials.sig
@@ -33,6 +33,7 @@ sig
   val term_name_is_lform : string -> bool
   val recd_lform_name : string
 
+  val stringinjn_base : string
   val mk_stringinjn_name : string -> string
   val std_stringinjn_name : string (* above applied to "\"" *)
   val string_elim_term : string

--- a/src/parse/Preterm.sml
+++ b/src/parse/Preterm.sml
@@ -4,7 +4,7 @@ struct
 open Feedback Lib GrammarSpecials;
 open errormonad typecheck_error
 
-infix >> >-
+infix >> >- ++?
 
 val ERR = mk_HOL_ERR "Preterm"
 val ERRloc = mk_HOL_ERRloc "Preterm"
@@ -389,12 +389,53 @@ fun filterM PM l =
     | h::t => PM h >- (fn b => if b then lift (cons h) (filterM PM t)
                                else filterM PM t)
 
+(* Decode the BIT1/BIT2/ZERO preterm tree representing a numeric literal
+   back to its Arbnum value, for use in error reporting. Returns NONE if
+   the tree doesn't have the expected structure (e.g. partially elaborated
+   or non-standard injection). *)
+fun decode_numeral_preterm pt =
+    let
+      open Arbnum
+      val a1 = one
+      val a2 = two
+      fun go pt =
+          case pt of
+            Const{Name = "0", Thy = "num", ...} => SOME zero
+          | Const{Name = "ZERO", Thy = "arithmetic", ...} => SOME zero
+          | Comb{Rator = Const{Name = "NUMERAL", Thy = "arithmetic", ...},
+                 Rand, ...} => go Rand
+          | Comb{Rator = Const{Name = "BIT1", Thy = "arithmetic", ...},
+                 Rand, ...} => Option.map (fn n => a2 * n + a1) (go Rand)
+          | Comb{Rator = Const{Name = "BIT2", Thy = "arithmetic", ...},
+                 Rand, ...} => Option.map (fn n => a2 * n + a2) (go Rand)
+          | _ => NONE
+    in go pt end
+
 fun remove_overloading_phase1 ptm =
   case ptm of
     Comb{Rator, Rand, Locn} =>
-      lift2 (fn t1 => fn t2 => Comb{Rator = t1, Rand = t2, Locn = Locn})
-            (remove_overloading_phase1 Rator)
-            (remove_overloading_phase1 Rand)
+      let
+        (* If elaborating Rator fails specifically because the
+           `_ inject_number` overload couldn't be resolved at the
+           required type, try to surface the actual numeric literal
+           in the error so the user isn't shown the internal
+           placeholder name. (#1747) *)
+        fun handler (OvlNoType(s, ty), errLoc) =
+              if s = fromNum_str then
+                case decode_numeral_preterm Rand of
+                    SOME n =>
+                      error (Misc ("Couldn't infer a type for the \
+                                   \numeric literal `" ^
+                                   Arbnum.toString n ^ "`"),
+                             Locn)
+                  | NONE => error (OvlNoType(s, ty), errLoc)
+              else error (OvlNoType(s, ty), errLoc)
+          | handler other = error other
+      in
+        lift2 (fn t1 => fn t2 => Comb{Rator = t1, Rand = t2, Locn = Locn})
+              (remove_overloading_phase1 Rator ++? handler)
+              (remove_overloading_phase1 Rand)
+      end
   | Abs{Bvar, Body, Locn} =>
       lift2 (fn t1 => fn t2 => Abs{Bvar = t1, Body = t2, Locn = Locn})
             (remove_overloading_phase1 Bvar)

--- a/src/parse/typecheck_error.sml
+++ b/src/parse/typecheck_error.sml
@@ -9,12 +9,29 @@ struct
          | Misc of string
 
   type error = tcheck_error * locn.locn
+  (* Some overloaded names are internal placeholders that the parser
+     wraps around literals before type elaboration (e.g. the numeric
+     literal injection `_ inject_number`, the various `_ inject_string…`
+     entries for character/string literals).  Showing these raw to the
+     user is unhelpful — they don't appear in any source they wrote.
+     Map a recognised internal name to a description of what kind of
+     literal it represents; return NONE for ordinary overloads. *)
+  fun pretty_internal_overload s =
+      if s = GrammarSpecials.fromNum_str then
+        SOME "the numeric literal"
+      else if String.isPrefix GrammarSpecials.stringinjn_base s then
+        SOME "the string/character literal"
+      else
+        NONE
+
   fun errorMsg tc =
     case tc of
         ConstrainFail (_,_,msg) => msg
       | AppFail (_,_,msg) => msg
       | OvlNoType(s,_) =>
-        ("Couldn't infer type for overloaded name "^s)
+        (case pretty_internal_overload s of
+             SOME desc => "Couldn't infer a type for " ^ desc
+           | NONE => "Couldn't infer type for overloaded name "^s)
       | OvlFail => "Overloading constraints were unsatisfiable"
       | OvlTooMany =>
           "There was more than one resolution of overloaded constants"


### PR DESCRIPTION
## Summary

For a term like `0 = []` or `(42 : 'a list)`, type elaboration has to resolve the parser-internal overload `_ inject_number` (the wrapper the parser puts around every numeric literal that needs to be injected into a target type). If no candidate type unifies with the demanded one, Preterm raised `OvlNoType("_ inject_number", _)` and `typecheck_error.errorMsg` rendered that as

```
Couldn't infer type for overloaded name _ inject_number
```

That placeholder doesn't appear anywhere in the user's source. The reporter's request was simple: "I just want the text `0` a.k.a. the numeral which overloading failed."

This PR does that, on two layers:

1. **Surface the actual digits.** `Preterm.remove_overloading_phase1`'s `Comb` case now wraps the recursion into `Rator` with `++?` and, when the failure is `OvlNoType(fromNum_str, _)`, decodes the `Rand` (a `NUMERAL/BIT1/BIT2/ZERO` preterm tree) back to an `Arbnum` and re-raises a `Misc` error reading

   ```
   Couldn't infer a type for the numeric literal `42`
   ```

   The decoder is a small recursive function on preterms; if the tree isn't in the expected shape (e.g. partially elaborated) it returns `NONE` and falls through.

2. **Prettify the magic name as a fallback.** `typecheck_error.errorMsg`'s `OvlNoType(s, _)` arm now dispatches on `s`: for `GrammarSpecials.fromNum_str` (numerals) and any name prefixed with `GrammarSpecials.stringinjn_base` (character/string literals), it emits "Couldn't infer a type for the numeric literal" / "Couldn't infer a type for the string/character literal" instead of the raw internal name. `stringinjn_base` is added to `GrammarSpecials.sig` since `typecheck_error.sml` now references it.

### Tests

Two new tests in `src/integer/selftest.sml` (where `:num` and `:int` overloads of `_ inject_number` both exist, so the `OvlNoType` path actually fires — in single-overload contexts like `src/num/theories` the parser short-circuits via `AppFail` and never exposes the bug):

- `\`0 = T\`` errors with a message containing `numeric literal` and the literal ``\`0\````, and not `_ inject_number`.
- `\`42 = T\`` likewise for ``\`42\````.

### Follow-up

[Issue #517](https://github.com/HOL-Theorem-Prover/HOL/issues/517) ("Error messages when type-checking case expressions are disgusting") is the same kind of bug for the case-expression magic constants (`mk_case_special` family). The dispatch added in this PR is the natural place to plug case-magic recognisers into; that's earmarked as the next step rather than expanded here.

Closes #1747.

## Test plan
- [x] Core build green (`bin/build -t --seq=tools/sequences/upto-parallel`).
- [x] `src/integer` builds clean from `Holmake cleanAll`; selftest reports both `#1747 numeric-literal error names the literal (0)` and `(42)` as `OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
