### PR TITLE
fix vim interrupt kills hol process

### DIFF
--- a/tools/editor-modes/vim/vimhol.src
+++ b/tools/editor-modes/vim/vimhol.src
@@ -81,7 +81,12 @@ local
       NONE => (warn "Vimhol's tail gave eof\n"; restartTail())
     | SOME line =>
       case String.tokens Char.isSpace line of
-          ["Interrupt"] => (warn "Vim interrupt\n"; Thread.broadcastInterrupt ())
+          ["Interrupt"] => (
+            warn "Vim interrupt\n";
+            if Thread.isActive (!rpid) then
+              Thread.interrupt (!rpid)
+            else
+              warn "No proof thread to interrupt\n")
         | ["ReadFile",tmp] => let open Thread Mutex ConditionVar in
             warn ("Vim input "^tmp^"\n");
             lock m;
@@ -95,7 +100,6 @@ local
           end
         | [] => ()
         | _ => warn ("Got this rubbish from Vim: "^line);
-    Thread.testInterrupt () handle Interrupt => (removeQueue(); Thread.exit());
     poller ()
   end
   val () = OS.Process.atExit stopTail

--- a/tools/editor-modes/vim/vimhol.src
+++ b/tools/editor-modes/vim/vimhol.src
@@ -100,6 +100,7 @@ local
           end
         | [] => ()
         | _ => warn ("Got this rubbish from Vim: "^line);
+    Thread.testInterrupt () handle Interrupt => (removeQueue(); Thread.exit());
     poller ()
   end
   val () = OS.Process.atExit stopTail


### PR DESCRIPTION
Currently, vim interrupt (h-c) kills the whole terminal process instead of interrupting the executing thread. Now, instead of the interrupt broadcasting to all threads, we check if the executing thread is alive and interrupt it directly, else we do nothing.

Minimal reproduction: `echo Interrupt >>"$HOLDIR/tools/editor-modes/vim/fifo"` while a hol process is running kills the terminal.