### PR TITLE
Gate mlton-only Holmakefile rules on $(which mlton) and NO_MLTON

### DIFF
--- a/src/portableML/rawtheory/Holmakefile
+++ b/src/portableML/rawtheory/Holmakefile
@@ -8,7 +8,8 @@ theorystats.ui: theorystats.sig $(dprot $(SIGOBJ)/Graph.ui) $(dprot $(SIGOBJ)/Ta
 theorystats.uo: theorystats.sml theorystats.ui $(dprot $(SIGOBJ)/Graph.ui) $(dprot $(SIGOBJ)/SHA1.uo)
 	$(HOLMOSMLC) -c Graph.ui $<
 
-ifneq ($(which mlton),)
+HAVE_MLTON = $(if $(NO_MLTON),,$(which mlton))
+ifneq ($(HAVE_MLTON),)
 all: dat-printer theorytool
 
 dat-printer: dat-printer.mlb RawTermPP.sml RawTheoryReader.sig RawTheoryReader.sml mlton-datprinter.ML DatPrinterTool.ML

--- a/src/postkernel/prooftrace/Holmakefile
+++ b/src/postkernel/prooftrace/Holmakefile
@@ -1,5 +1,7 @@
 .PHONY: all
 
+HAVE_MLTON = $(if $(NO_MLTON),,$(which mlton))
+ifneq ($(HAVE_MLTON),)
 replay-test: replay-test.mlb replay-test.sml
 	mlton -default-type intinf $<
 
@@ -10,6 +12,7 @@ ifdef HAVE_WORD64
 all: pft-replay-test replay-test
 else
 all: pft-replay-test
+endif
 endif
 
 EXTRA_CLEANS = replay-test pft-replay-test


### PR DESCRIPTION
## Summary

- `src/portableML/rawtheory` already gated its mlton-only rules with `$(which mlton)` (and falls back to `$(POLYC)`); `src/postkernel/prooftrace` was unguarded and would fail the core build on a host without mlton.
- Both Holmakefiles now share the pattern
  ```
  HAVE_MLTON = $(if $(NO_MLTON),,$(which mlton))
  ifneq ($(HAVE_MLTON),)
  ...
  endif
  ```
  so an additional `NO_MLTON=1` env var simulates "mlton not installed" without PATH gymnastics.
- The variable indirection works around `tools/Holmake/hmf/ReadHMF.sml`'s `ifneq` arg splitter, which splits on the first comma without paren-awareness — a nested `$(if …,…,…)` would mis-parse.

## Test plan

- [x] `bin/build -t --seq=tools/sequences/upto-parallel` with mlton on PATH — green; `replay-test` and `dat-printer` built via mlton as before.
- [x] Same build with `/opt/homebrew/bin` (mlton's location) stripped from PATH — green; `dat-printer` built via the Poly/ML fallback, prooftrace's mlton-only targets correctly skipped.
- [x] `NO_MLTON=1 Holmake` in each gated dir takes the no-mlton branch; plain `Holmake` (mlton present) still picks `replay-test` / `dat-printer` as before.

## Follow-up (not in this PR)

`HAVE_MLTON` could be promoted to a Holmake base-env variable alongside `HAVE_WORD64` (`tools/Holmake/hmf/Holmake_types.sml:384`), removing the duplication and letting other mlton-using Holmakefiles (e.g. `src/thm/mlton`, `examples/arm/v4/mlton`) opt in trivially. Two call sites doesn't feel like enough to justify the plumbing yet.
