### PR TITLE
markerLib: reject cyclic Resume proofs at recording time

### DIFF
--- a/src/basicProof/theory_tests/suspCrossThmScript.sml
+++ b/src/basicProof/theory_tests/suspCrossThmScript.sml
@@ -1,0 +1,53 @@
+Theory suspCrossThm[bare]
+
+(* Demonstrates the cross-theorem Resume-dependency limitation
+   tracked at GitHub issue #1963.
+
+   A Resume proof for th1 is allowed to depend on another, still
+   suspended theorem th2: the cycle check from #1960 is scoped
+   to the current parent's slabs, so th2's slab does not match.
+   Finalise th1, however, cannot resolve the foreign slab because
+   find_res_for keys lookups on the current parent's name.
+
+   This test pins down the current behaviour: Resume th1[l1]
+   succeeds, Finalise th2 succeeds, and Finalise th1 then raises
+   a HOL_ERR "No resumption proof found ..." rather than looping
+   (the failure mode #1960 used to exhibit). *)
+
+Libs HolKernel Parse boolLib markerLib testutils
+
+Theorem th1:
+  p ==> T
+Proof
+  suspend "l1"
+QED
+
+Theorem th2:
+  q ==> T
+Proof
+  suspend "l2"
+QED
+
+(* th2 is still suspended at this point; the resume-time check
+   accepts this proof because slab_th2_l2 differs from any of
+   th1's slabs. *)
+Resume th1[l1]:
+  MATCH_ACCEPT_TAC th2
+QED
+
+Resume th2[l2]:
+  strip_tac >> ACCEPT_TAC TRUTH
+QED
+
+Finalise th2
+
+val _ = shouldfail {
+  testfn = (fn () =>
+              finalise_suspended_thm (DB_dtype.mkloc(#(FILE),#(LINE),true))
+                                     "th1"),
+  printarg = (fn _ => "Finalise th1 (cross-theorem dependency on th2)"),
+  printresult = (fn _ => "<unexpected success>"),
+  checkexn =
+    check_HOL_ERRexn (fn (_, fnm, msg) =>
+        fnm = "Finalise" andalso String.isSubstring "No resumption" msg)
+} ()

--- a/src/basicProof/theory_tests/suspCycleScript.sml
+++ b/src/basicProof/theory_tests/suspCycleScript.sml
@@ -1,0 +1,51 @@
+Theory suspCycle[bare]
+
+(* Regression test for GitHub issue #1960.
+
+   If a Resume proof depends on the parent theorem's own
+   suspendlabel hypotheses (e.g. via `cj 1 useful` where `useful`
+   is the still-suspended parent), the resulting resumption
+   theorem re-introduces those hypotheses every time PROVE_HYP
+   discharges them, so Finalise's assembly loop never converges.
+
+   Reproduced from the issue:
+
+     Theorem useful:
+       (x ==> T) /\ (F ==> T)
+     Proof
+       conj_tac >- suspend "x" >> suspend "F"
+     QED
+     Resume useful[x]:
+       strip_tac >> ACCEPT_TAC TRUTH
+     QED
+     Resume useful[F]:
+       MATCH_ACCEPT_TAC (cj 1 useful)
+     QED
+     Finalise useful
+
+   Used to spin forever inside finalise_suspended_thm; now
+   `resume` rejects the cyclic proof up-front. *)
+
+Libs HolKernel Parse boolLib markerLib testutils
+
+Theorem useful:
+  (x ==> T) /\ (F ==> T)
+Proof
+  conj_tac >- suspend "x" >> suspend "F"
+QED
+
+Resume useful[x]:
+  strip_tac >> ACCEPT_TAC TRUTH
+QED
+
+val _ = shouldfail {
+  testfn = (fn () =>
+              resume {suspension_name = "useful", label_name = "F"}
+                     (MATCH_ACCEPT_TAC (cj 1 useful))),
+  printarg = (fn _ =>
+              "resume useful[F] with MATCH_ACCEPT_TAC (cj 1 useful)"),
+  printresult = (fn _ => "<unexpected success>"),
+  checkexn =
+    check_HOL_ERRexn (fn (_, fnm, msg) =>
+        fnm = "resume" andalso String.isSubstring "cycle" msg)
+} ()

--- a/src/marker/markerLib.sml
+++ b/src/marker/markerLib.sml
@@ -1252,6 +1252,23 @@ fun resume {suspension_name, label_name} tac =
                let
                  val goal = resumption_to_goal ncts
                  val sub_th = prove_goal (goal, tac)
+                 (* Reject resumption proofs that depend on the parent
+                    theorem's own suspendlabel hypotheses: those hyps
+                    will be re-introduced every time PROVE_HYP discharges
+                    them at Finalise, so assembly never converges. *)
+                 val parent_slabs = HOLset.filter (can dest_slab) (hypset th)
+                 val _ =
+                     List.app
+                       (fn h =>
+                         if HOLset.member (parent_slabs, h) then
+                           raise ERR "resume"
+                             ("Resumption proof for " ^ suspension_name ^
+                              "[" ^ label_name ^ "] depends on a \
+                              \suspendlabel hypothesis of " ^
+                              suspension_name ^ " itself; this would \
+                              \create a cycle at Finalise.")
+                         else ())
+                       (List.filter (can dest_slab) (hyp sub_th))
                  (* Build |- suspendlabel "lab" G_i for each hyp i and
                     record each as its own resumption delta. *)
                  val susp_thms =
@@ -1349,9 +1366,25 @@ fun assemble_finalised parent_thy parent_nm parent_th =
                                      current_th founds
           val remaining_susp_hyps = List.filter (Option.isSome o total dest_slab)
                                                 (hyp finalised)
+          (* Progress check: every slab from current_susp_hyps must
+             actually disappear in this iteration.  PROVE_HYP only
+             drops the targeted slab, so if any current slab reappears
+             in `remaining_susp_hyps` then some resumption proof
+             reintroduced the slab we were trying to discharge -- a
+             cycle.  New (unrelated) slabs appearing are fine; that's
+             how nested Resume works. *)
+          val any_reintroduced =
+              List.exists (fn h => tmem h remaining_susp_hyps)
+                          current_susp_hyps
       in
-          if null remaining_susp_hyps then finalised else
-          aux finalised remaining_susp_hyps
+          if null remaining_susp_hyps then finalised
+          else if any_reintroduced then
+            raise ERR "Finalise"
+              ("Assembly stalled for " ^ parent_thy ^ "$" ^ parent_nm ^
+               ": resumption proofs reintroduce the suspendlabel \
+               \hypotheses they are meant to discharge (likely a \
+               \circular dependency among Resume proofs).")
+          else aux finalised remaining_susp_hyps
       end
     in
       aux parent_th susp_hyps


### PR DESCRIPTION
## Summary
- Detect resumption proofs whose hypotheses include any suspendlabel of the parent theorem (the exact pattern in #1960: `MATCH_ACCEPT_TAC (cj 1 useful)`) and reject them in `markerLib.resume` before they reach the resumption store.
- Add a defence-in-depth progress check in `assemble_finalised`: bail out if any slab targeted in an iteration reappears in the result.

## Test plan
- [x] New regression test `src/basicProof/theory_tests/suspCycleScript.sml` reproduces the issue and asserts the cyclic resume call now raises `HOL_ERR` with `"cycle"` in the message.
- [x] `bin/build -t --seq=tools/sequences/upto-parallel` passes cleanly; existing `suspTest`, `suspNested`, `suspFast`, `suspRerun`, `suspCross{A,B}`, `suspSib{A,B,C,D}` are unaffected.

Closes #1960

🤖 Generated with [Claude Code](https://claude.com/claude-code)
