### PR TITLE
listLib: short-circuit ALL_EL_CONV (#423)

### DIFF
--- a/src/list/src/ListConv1.sml
+++ b/src/list/src/ListConv1.sml
@@ -801,28 +801,26 @@ fun thm_eq th1 th2 =
                (dest_thm th1, dest_thm th2) = EQUAL
 
 val ALL_EL_CONV =
-    let val (bth,ith) = CONJ_PAIR (rich_listTheory.ALL_EL)
-        val AND_THM = op_mk_set thm_eq (flatten(map (CONJ_LIST 5)
-            [(SPEC (“T”) AND_CLAUSES),(SPEC (“F”) AND_CLAUSES)]))
+    let val (bth,ith) = CONJ_PAIR rich_listTheory.ALL_EL
+        val and_cls = CONJ_LIST 5 (SPEC_ALL AND_CLAUSES)
+        val T_and = List.nth(and_cls, 0)  (* |- T /\ t = t *)
+        val F_and = List.nth(and_cls, 2)  (* |- F /\ t = F *)
     in
-  fn conv => fn tm =>
-    (let val (P,l) = listSyntax.dest_every tm
-         val bth' = ISPEC P bth and ith' = ISPEC P ith
-         val lis = #1(dest_list l)
-         fun ffn x th =
-             let val {lhs=left,rhs=right} = dest_eq(concl th)
-                 val (p,ls) = case strip_comb left
-                              of (_,[p,ls]) => (p,ls)
-                               | _ => raise ERR "ALL_EL_CONV" ""
-                 val fthm = SPECL [x,ls] ith'
-                 and cthm = conv (mk_comb{Rator=P,Rand=x})
-             in
-                 SUBS AND_THM (SUBS[cthm,th]fthm)
-             end
-     in
-         (itlist ffn lis bth')
-     end)
-         handle e => raise wrap_exn "List_conv" "ALL_EL_CONV" e
+      fn conv =>
+        let
+          fun walk tm =
+            let val (_,l) = listSyntax.dest_every tm
+            in
+              if listSyntax.is_nil l then REWR_CONV bth tm
+              else (REWR_CONV ith THENC
+                    LAND_CONV conv THENC
+                    (REWR_CONV F_and ORELSEC
+                     (REWR_CONV T_and THENC walk))) tm
+            end
+        in
+          fn tm => walk tm
+                   handle e => raise wrap_exn "List_conv" "ALL_EL_CONV" e
+        end
     end;
 
 (* --------------------------------------------------------------------- *)

--- a/src/list/src/selftest.sml
+++ b/src/list/src/selftest.sml
@@ -295,3 +295,22 @@ val _ = List.app tpp [
       "l❲i❳", "l❲2 ↦ T; 3 ↦ F❳",
       "l❲2 ↦ T; 3 ↦ F❳❲i❳"
     ]
+
+val _ = app(test "ALL_EL_CONV" Term.compare term_to_string
+                 (ALL_EL_CONV BETA_CONV))
+           [(``EVERY (\x:bool. x) ([]:bool list)``, ``T``),
+            (``EVERY (\x:bool. x) [T; T; T]``, ``T``),
+            (``EVERY (\x:bool. x) [F; T; T]``, ``F``),
+            (``EVERY (\x:bool. x) [T; F; T]``, ``F``),
+            (``EVERY (\x:bool. x) [T; T; F]``, ``F``)]
+
+val _ = let
+  val tm = ``EVERY (\x:bool. x) [F; T; T]``
+  val calls = ref 0
+  fun strict_beta t = (calls := !calls + 1; BETA_CONV t)
+  val _ = ALL_EL_CONV strict_beta tm
+in
+  tprint "ALL_EL_CONV short-circuits on first F";
+  if !calls = 1 then OK()
+  else die ("FAILED (calls=" ^ Int.toString (!calls) ^ ")")
+end


### PR DESCRIPTION
`ALL_EL_CONV` previously walked the entire list eagerly via `itlist` and rebuilt the LHS via `SPECL`, so on a list whose head element already determined the answer it was slower than `EVAL`. Rewritten to walk the term directly with `REWR_CONV`/`THENC`/`ORELSEC` and stop the moment the element conv returns `F`.

Selftest in `src/list/src/selftest.sml` uses `convtest` for empty / all-T / early-F / mid-F / late-F cases, plus a strict element conv that asserts exactly one call when the head element is `F`.

Closes #423