### PR TITLE
32-bit recoder for trace files

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -5,6 +5,7 @@ Holmake
 build
 hol
 unquote
+recode32
 hol.builder
 hol.builder0
 *.bat

--- a/src/postkernel/prooftrace/ProofTraceParser.sig
+++ b/src/postkernel/prooftrace/ProofTraceParser.sig
@@ -16,6 +16,11 @@ val parse: string -> root ptr * heap
 
 val heapSize: heap -> int
 
+(* Scan every tagptr in every Regular object and return the maximum observed
+   pointer index and the maximum absolute integer value. Used to verify that
+   the 32-bit recoder's 31-bit range is sufficient for a given trace. *)
+val scan_widths: heap -> {max_ptr: int, max_int: int, max_obj_len: int}
+
 datatype 'a any = Int of int | Bytes of Word8VectorSlice.slice | Obj of 'a list | Other
 val any: heap -> (unit, 'A) gparser -> ('b, 'A any) gparser
 

--- a/src/postkernel/prooftrace/ProofTraceParser.sml
+++ b/src/postkernel/prooftrace/ProofTraceParser.sml
@@ -17,8 +17,18 @@ type 'a ptr = Word64.word
 type ('a,'A) gparser = 'a ptr -> 'A
 type 'a parser = ('a, 'a) gparser
 type root = unit
-type heap = Word8Vector.vector * int vector
-fun heapSize (_, ptrs) = Vector.length ptrs
+
+(* Heap is a two-variant datatype so the parser can read either the legacy
+   64-bit PolyML heap dump or the 32-bit narrow format produced by the
+   recoder in Tracing.sml directly, without inflating the 32-bit form into
+   a 64-bit byte vector. Each variant carries the raw decompressed bytes
+   plus a vector of object-start byte offsets. *)
+type heap_data = Word8Vector.vector * int vector
+datatype heap = Heap64 of heap_data | Heap32 of heap_data
+
+fun heapSize (Heap64 (_, ptrs)) = Vector.length ptrs
+  | heapSize (Heap32 (_, ptrs)) = Vector.length ptrs
+
 val castPtr = I
 fun isPtr w = Word64.andb(w, 0w1) = 0w0
 
@@ -35,56 +45,187 @@ fun get56 vec start = let
     (b 4 << 0w32) orb (b 5 << 0w40) orb (b 6 << 0w48)
   in Word.toInt w end
 
+(* Read a 32-bit little-endian word, sign-extended to 64 bits. Tag-bit
+   preservation and negative int decoding both rely on sign extension. *)
+fun get32 vec start = let
+  fun b i = Word64.fromInt (Word8.toInt (Word8Vector.sub (vec, start + i)))
+  open Word64 infix orb << ~>>
+  in (b 0 orb (b 1 << 0w8) orb (b 2 << 0w16) orb (b 3 << 0w24) << 0w32) ~>> 0w32
+end
+
+fun get24 vec start = let
+  fun b i = Word.fromInt (Word8.toInt (Word8Vector.sub (vec, start + i)))
+  open Word infix orb <<
+  val w = b 0 orb (b 1 << 0w8) orb (b 2 << 0w16)
+  in Word.toInt w end
+
+fun is_32bit_magic raw =
+  Word8Vector.length raw >= 8 andalso
+  get64 raw 0 = 0wxFF00000032335254 (* "TR32\0\0\0\xFF" *)
+
+(* Parse: detects the magic byte, builds a ptrs vector with the right word
+   size, and returns the appropriate heap variant. Both variants share the
+   same public API — sh* functions dispatch internally. *)
 fun parse filename = let
-  val vec = decompressGzip filename
-  val root = Word8Vector.length vec - 8
-  val out = DArray.new (64, 0)
-  fun process start = if start >= root then () else
-    (DArray.push (out, start); process (start + 8 * (get56 vec start + 1)))
-  in process 0; (get64 vec root, (vec, DArray.vector out)) end
+  val raw = decompressGzip filename
+in
+  if is_32bit_magic raw then let
+    val vec = raw
+    val root = Word8Vector.length vec - 4   (* last 4 bytes = root tagptr *)
+    val out = DArray.new (64, 0)
+    fun process start =
+      if start >= root then ()
+      else (DArray.push (out, start);
+            process (start + 4 * (get24 vec start + 1)))
+    val () = process 8   (* skip 8-byte magic at start *)
+    val rootPtr = get32 vec root
+  in (rootPtr, Heap32 (vec, DArray.vector out)) end
+  else let
+    val vec = raw
+    val root = Word8Vector.length vec - 8
+    val out = DArray.new (64, 0)
+    fun process start =
+      if start >= root then ()
+      else (DArray.push (out, start);
+            process (start + 8 * (get56 vec start + 1)))
+    val () = process 0
+    val rootPtr = get64 vec root
+  in (rootPtr, Heap64 (vec, DArray.vector out)) end
+end
 
 datatype flags = FBytes of int | FObj of int | FOther
-fun flags vec start =
-  case Word8.andb(Word8Vector.sub (vec, start + 7), 0w3) of
-    0w0 => FObj (get56 vec start)
-  | 0w1 => FBytes (get56 vec start)
-  | _ => FOther
+
+(* Variant-aware flags reader. For 64-bit headers flags are byte 7, length
+   is bytes 0..6. For 32-bit headers flags are byte 3, length bytes 0..2.
+   The int returned is in the variant's own word unit (8-byte words for
+   Heap64, 4-byte words for Heap32). *)
+fun flags_of h start = case h of
+    Heap64 (vec, _) =>
+      (case Word8.andb(Word8Vector.sub (vec, start + 7), 0w3) of
+         0w0 => FObj (get56 vec start)
+       | 0w1 => FBytes (get56 vec start)
+       | _ => FOther)
+  | Heap32 (vec, _) =>
+      (case Word8.andb(Word8Vector.sub (vec, start + 3), 0w3) of
+         0w0 => FObj (get24 vec start)
+       | 0w1 => FBytes (get24 vec start)
+       | _ => FOther)
 
 fun int w = Int.fromLarge (Word64.toLargeIntX w div 2)
 fun ptr w = Word64.toInt (Word64.>>(w, 0w1)) - 1
 
+(* any returns a tagged view of a word. For pointers it dereferences to a
+   list of child words. The list walk uses variant-specific word sizes. *)
 datatype 'a any = Int of int | Bytes of Word8VectorSlice.slice | Obj of 'a list | Other
-fun any (vec, ptrs) p w =
-  if Word64.andb (w, 0w1) = 0w1 then Int (int w) else
-  case Vector.sub (ptrs, ptr w) of start =>
-  case flags vec start of
-    FBytes n => Bytes (Word8VectorSlice.slice (vec, start, SOME (8*n)))
-  | FOther => Other
-  | FObj n => let
-    fun build (i, acc) = if i = start then acc else case i - 8 of i =>
-      build (i, p (get64 vec i) :: acc)
-    in Obj (build (start + 8 * n, [])) end
+fun any h p w =
+  if Word64.andb (w, 0w1) = 0w1 then Int (int w)
+  else case h of
+    Heap64 (vec, ptrs) => let
+      val start = Vector.sub (ptrs, ptr w)
+    in case flags_of h start of
+         FBytes n => Bytes (Word8VectorSlice.slice (vec, start + 8, SOME (8*n)))
+       | FOther => Other
+       | FObj n =>
+           let fun build (i, acc) = if i = start + 8 then acc
+                 else case i - 8 of j => build (j, p (get64 vec j) :: acc)
+           in Obj (build (start + 8 * (n+1), [])) end
+    end
+  | Heap32 (vec, ptrs) => let
+      val start = Vector.sub (ptrs, ptr w)
+    in case flags_of h start of
+         FBytes n => Bytes (Word8VectorSlice.slice (vec, start + 4, SOME (4*n)))
+       | FOther => Other
+       | FObj n =>
+           let fun build (i, acc) = if i = start + 4 then acc
+                 else case i - 4 of j => build (j, p (get32 vec j) :: acc)
+           in Obj (build (start + 4 * (n+1), [])) end
+    end
 
-fun obj' (vec, ptrs) p =
-  case Vector.sub (ptrs, p) of start =>
-  case flags vec start of
-    FObj n => (start + 8, n)
-  | _ => raise Fail "parse error"
-fun obj c w = obj' c (ptr w)
-fun arg' (c as (vec, _)) w = case #1 (obj c w) of start => fn n => get64 vec (start + n)
-fun arg c n w = arg' c w (8*n)
+(* obj': given an object pointer index, check the object is a Regular, and
+   return (data_start, n_words) where data_start is the byte offset just
+   past the header. *)
+fun obj' h p = case h of
+    Heap64 (vec, ptrs) =>
+      (case Vector.sub (ptrs, p) of start =>
+       case flags_of h start of
+         FObj n => (start + 8, n)
+       | _ => raise Fail "parse error")
+  | Heap32 (vec, ptrs) =>
+      (case Vector.sub (ptrs, p) of start =>
+       case flags_of h start of
+         FObj n => (start + 4, n)
+       | _ => raise Fail "parse error")
+fun obj h w = obj' h (ptr w)
 
-fun shVariant (c as (vec, _)) w = let
-  val (start, n) = obj c w
-  fun build (i, acc) = if i = start then (int (get64 vec i), acc) else
-    build (i - 8, get64 vec i :: acc)
-  in build (start + 8 * (n - 1), []) end
+(* arg h w n reads the n-th word of the object pointed to by w (8 bytes
+   per word for Heap64, 4 for Heap32). The partial application `arg h w`
+   returns a word-indexed reader for repeated access to the same object. *)
+fun arg h w =
+  let val (start, _) = obj h w in
+  case h of
+    Heap64 (vec, _) => (fn n => get64 vec (start + 8*n))
+  | Heap32 (vec, _) => (fn n => get32 vec (start + 4*n))
+  end
+
+fun scan_widths h = let
+  val max_ptr = ref 0
+  val max_int = ref 0
+  val max_obj_len = ref 0
+  val (vec, ptrs, word_bytes, read_word_at, read_len_at, flags_byte) =
+    case h of
+      Heap64 (v, p) => (v, p, 8, get64 v, get56 v, 7)
+    | Heap32 (v, p) => (v, p, 4, get32 v, get24 v, 3)
+  val sz = Vector.length ptrs
+  fun loop k =
+    if k >= sz then () else let
+      val start = Vector.sub (ptrs, k)
+      val len = read_len_at start
+      val flags = Word8.andb (Word8Vector.sub (vec, start + flags_byte), 0w3)
+    in
+      if len > !max_obj_len then max_obj_len := len else ();
+      (* Regular (flags=0): data is tagptr array; Bytes (flags=1): skip; others empty *)
+      if flags = 0w0 then let
+        fun visit i =
+          if i >= len then () else let
+            val w = read_word_at (start + word_bytes * (i + 1))
+          in
+            (if Word64.andb (w, 0w1) = 0w1 then
+               let val n = int w
+                   val a = if n < 0 then ~n else n
+               in if a > !max_int then max_int := a else () end
+             else
+               let val p = ptr w
+               in if p > !max_ptr then max_ptr := p else () end);
+            visit (i + 1)
+          end
+      in visit 0 end
+      else ();
+      loop (k + 1)
+    end
+in loop 0;
+   {max_ptr = !max_ptr, max_int = !max_int, max_obj_len = !max_obj_len}
+end
+
+fun shVariant h w = let
+  val (start, n) = obj h w
+  val (word_bytes, read) = case h of
+      Heap64 (vec, _) => (8, get64 vec)
+    | Heap32 (vec, _) => (4, get32 vec)
+  fun build (i, acc) =
+    if i = start then (int (read i), acc)
+    else build (i - word_bytes, read i :: acc)
+in build (start + word_bytes * (n - 1), []) end
 
 local
-  fun tuple c p w = p (#1 c, #1 (obj c w))
   infixr 9 <>
-  fun (p <> q) (vec, i) = (p (get64 vec i), q (vec, i + 8))
-  fun t1 p (vec, i) = p (get64 vec i)
+  fun tuple h p w =
+    let val (start, _) = obj h w in
+    case h of
+      Heap64 (vec, _) => p (start, 8, get64 vec)
+    | Heap32 (vec, _) => p (start, 4, get32 vec)
+    end
+  fun (p <> q) (i, wb, rd) = (p (rd i), q (i + wb, wb, rd))
+  fun t1 p (i, wb, rd) = p (rd i)
 in
   fun tuple2 c (p1,p2) = tuple c (p1 <> t1 p2)
   fun tuple3 c (p1,p2,p3) = tuple c (p1 <> p2 <> t1 p3)
@@ -92,7 +233,7 @@ in
 end
 
 fun option _ _ 0w0 = NONE
-  | option c p w = SOME (p (arg' c w 0))
+  | option c p w = SOME (p (arg c w 0))
 
 fun list c go w = let
   fun build (0w1, acc) = rev acc
@@ -103,34 +244,42 @@ fun appList _ _ 0w1 = ()
   | appList c go w = case tuple2 c (I, I) w of (a, b) => (go a; appList c go b)
 
 fun appSet c go w = let
-  fun go' w = case arg' c w of f =>
-    case f 0 of 0w3 => () | _ => (go' (f 16); go (f 8); go' (f 24))
-  in go' (arg' c w 8) end
+  fun go' w = case arg c w of f =>
+    case f 0 of 0w3 => () | _ => (go' (f 2); go (f 1); go' (f 3))
+  in go' (arg c w 1) end
 
-fun str (vec, ptrs) w = let
-  val start = Vector.sub (ptrs, ptr w)
-  val _ = case flags vec start of FBytes _ => () | _ => raise Fail "str: parse error"
-  val n = Word64.toInt (get64 vec (start + 8))
+(* Read a PolyML string object: the object data starts with an 8-byte
+   length word followed by that many raw bytes. The length word is always
+   stored as 8 bytes in both variants (the recoder preserves bytes
+   verbatim for Bytes-kind objects), so we can use get64 on both sides —
+   the only difference is the header size. *)
+fun str h w = let
+  val pidx = ptr w
+  val (vec, start, data_off) = case h of
+      Heap64 (v, p) => (v, Vector.sub (p, pidx), 8)
+    | Heap32 (v, p) => (v, Vector.sub (p, pidx), 4)
+  val _ = case flags_of h start of FBytes _ => () | _ => raise Fail "str: parse error"
+  val n = Word64.toInt (get64 vec (start + data_off))
   open Word8VectorSlice
-  in Byte.bytesToString (vector (slice (vec, start + 16, SOME n))) end
+  in Byte.bytesToString (vector (slice (vec, start + data_off + 8, SOME n))) end
 
 type ident = string * string
-fun ident c w = tuple2 c (str c, str c) (arg c 0 (arg c 0 w))
+fun ident c w = tuple2 c (str c, str c) (arg c (arg c w 0) 0)
 
-fun thmId c w = case arg' c w of f =>
+fun thmId c w = case arg c w of f =>
   case f 0 of
-    0w1 => SavedAnon (int (f 8))
-  | 0w3 => SavedName (str c (f 8))
+    0w1 => SavedAnon (int (f 1))
+  | 0w3 => SavedName (str c (f 1))
   | _ => raise Fail "thmId: parse error"
 
 datatype sh_type =
   Tyapp of ident ptr * hol_type list ptr
 | Tyv of string
 
-fun shType c w = case arg' c w of f =>
+fun shType c w = case arg c w of f =>
   case f 0 of
-    0w1 => Tyapp (arg c 0 (f 8), f 16)
-  | 0w3 => Tyv (str c (f 8))
+    0w1 => Tyapp (arg c (f 1) 0, f 2)
+  | 0w3 => Tyv (str c (f 1))
   | _ => raise Fail "shType: parse error"
 
 datatype sh_term =
@@ -141,14 +290,14 @@ datatype sh_term =
 | Const of ident ptr * hol_type ptr
 | Fv of string * hol_type ptr
 
-fun shTerm c w = case arg' c w of f =>
+fun shTerm c w = case arg c w of f =>
   case f 0 of
-    0w1 => Abs (f 8, f 16)
-  | 0w3 => Bv (int (f 8))
-  | 0w5 => Clos (f 8, f 16)
-  | 0w7 => Comb (f 8, f 16)
-  | 0w9 => Const (f 8, arg c 1 (f 16))
-  | 0w11 => Fv (str c (f 8), f 16)
+    0w1 => Abs (f 1, f 2)
+  | 0w3 => Bv (int (f 1))
+  | 0w5 => Clos (f 1, f 2)
+  | 0w7 => Comb (f 1, f 2)
+  | 0w9 => Const (f 1, arg c (f 2) 1)
+  | 0w11 => Fv (str c (f 1), f 2)
   | _ => raise Fail "shTerm: parse error"
 
 datatype 'a sh_subs =
@@ -157,27 +306,27 @@ datatype 'a sh_subs =
 | Lift of int * 'a Subst.subs ptr
 | Shift of int * 'a Subst.subs ptr
 
-fun shSubs c w = case arg' c w of f =>
+fun shSubs c w = case arg c w of f =>
   case f 0 of
-    0w1 => Cons (f 8, f 16)
+    0w1 => Cons (f 1, f 2)
   | 0w3 => Id
-  | 0w5 => Lift (int (f 8), f 16)
-  | 0w7 => Shift (int (f 8), f 16)
+  | 0w5 => Lift (int (f 1), f 2)
+  | 0w7 => Shift (int (f 1), f 2)
   | _ => raise Fail "shSubs: parse error"
 
 type proof = unit
-fun shThm c w = case arg' c w of f => (f 8, f 16, arg c 0 (f 24))
+fun shThm c w = case arg c w of f => (f 1, f 2, arg c (f 3) 0)
 
-fun shRoot c w = case arg' c w of f =>
+fun shRoot c w = case arg c w of f =>
   { types = f 0,
-    mldeps = f 8,
-    theory = str c (f 16),
-    parents = f 24,
-    all_thms = f 32,
-    anon_thms = f 40,
-    constants = f 48 }
+    mldeps = f 1,
+    theory = str c (f 2),
+    parents = f 3,
+    all_thms = f 4,
+    anon_thms = f 5,
+    constants = f 6 }
 
-fun shThmInfo c w = {private = arg c 2 w = 0w3}
+fun shThmInfo c w = {private = arg c w 2 = 0w3}
 
 datatype sh_proof =
   ABS_prf of term ptr * thm ptr
@@ -230,63 +379,63 @@ datatype sh_proof =
 | deleted_prf
 | save_dep_prf of thm ptr
 
-fun shProof c w = case arg' c w of f =>
+fun shProof c w = case arg c w of f =>
   case f 0 of
-    0w01 => ABS_prf            (f 8, f 16)
-  | 0w03 => ALPHA_prf          (f 8, f 16)
-  | 0w05 => AP_TERM_prf        (f 8, f 16)
-  | 0w07 => AP_THM_prf         (f 8, f 16)
-  | 0w09 => ASSUME_prf         (f 8)
+    0w01 => ABS_prf            (f 1, f 2)
+  | 0w03 => ALPHA_prf          (f 1, f 2)
+  | 0w05 => AP_TERM_prf        (f 1, f 2)
+  | 0w07 => AP_THM_prf         (f 1, f 2)
+  | 0w09 => ASSUME_prf         (f 1)
   | 0w11 => Axiom_prf
-  | 0w13 => BETA_CONV_prf      (f 8)
-  | 0w15 => Beta_prf           (f 8)
-  | 0w17 => CCONTR_prf         (f 8, f 16)
-  | 0w19 => CHOOSE_prf         (f 8, f 16, f 24)
-  | 0w21 => CONJUNCT1_prf      (f 8)
-  | 0w23 => CONJUNCT2_prf      (f 8)
-  | 0w25 => CONJ_prf           (f 8, f 16)
-  | 0w27 => DISCH_prf          (f 8, f 16)
-  | 0w29 => DISJ1_prf          (f 8, f 16)
-  | 0w31 => DISJ2_prf          (f 8, f 16)
-  | 0w33 => DISJ_CASES_prf     (f 8, f 16, f 24)
-  | 0w35 => Def_const_list_prf (f 8, f 16)
-  | 0w37 => Def_const_prf      (f 8, f 16)
-  | 0w39 => Def_spec_prf       (f 8, f 16)
-  | 0w41 => Def_tyop_prf       (f 8, f 16, f 24)
-  | 0w43 => Disk_prf           (str c (f 8), f 16)
-  | 0w45 => EQ_IMP_RULE1_prf   (f 8)
-  | 0w47 => EQ_IMP_RULE2_prf   (f 8)
-  | 0w49 => EQ_MP_prf          (f 8, f 16)
-  | 0w51 => EXISTS_prf         (f 8, f 16, f 24)
-  | 0w53 => Exported_prf       (str c (f 8), f 16)
-  | 0w55 => GENL_prf           (f 8, f 16)
-  | 0w57 => GEN_ABS_prf        (f 8, f 16, f 24)
-  | 0w59 => GEN_prf            (f 8, f 16)
-  | 0w61 => INST_TYPE_prf      (f 8, f 16)
-  | 0w63 => INST_prf           (f 8, f 16)
-  | 0w65 => MK_COMB_prf        (f 8, f 16)
-  | 0w67 => MP_prf             (f 8, f 16)
-  | 0w69 => Mark_prf           (str c (f 8), f 16)
-  | 0w71 => Mk_abs_prf         (f 8, f 16, f 24)
-  | 0w73 => Mk_comb_prf        (f 8, f 16, f 24)
-  | 0w75 => NOT_ELIM_prf       (f 8)
-  | 0w77 => NOT_INTRO_prf      (f 8)
-  | 0w79 => REFL_prf           (f 8)
-  | 0w81 => SPEC_prf           (f 8, f 16)
-  | 0w83 => SUBST_prf          (f 8, f 16, f 24)
-  | 0w85 => SYM_prf            (f 8)
-  | 0w87 => Specialize_prf     (f 8, f 16)
-  | 0w89 => TRANS_prf          (f 8, f 16)
-  | 0w91 => compute_prf        (f 8, f 16)
-  | 0w93 => deductAntisym_prf  (f 8, f 16)
+  | 0w13 => BETA_CONV_prf      (f 1)
+  | 0w15 => Beta_prf           (f 1)
+  | 0w17 => CCONTR_prf         (f 1, f 2)
+  | 0w19 => CHOOSE_prf         (f 1, f 2, f 3)
+  | 0w21 => CONJUNCT1_prf      (f 1)
+  | 0w23 => CONJUNCT2_prf      (f 1)
+  | 0w25 => CONJ_prf           (f 1, f 2)
+  | 0w27 => DISCH_prf          (f 1, f 2)
+  | 0w29 => DISJ1_prf          (f 1, f 2)
+  | 0w31 => DISJ2_prf          (f 1, f 2)
+  | 0w33 => DISJ_CASES_prf     (f 1, f 2, f 3)
+  | 0w35 => Def_const_list_prf (f 1, f 2)
+  | 0w37 => Def_const_prf      (f 1, f 2)
+  | 0w39 => Def_spec_prf       (f 1, f 2)
+  | 0w41 => Def_tyop_prf       (f 1, f 2, f 3)
+  | 0w43 => Disk_prf           (str c (f 1), f 2)
+  | 0w45 => EQ_IMP_RULE1_prf   (f 1)
+  | 0w47 => EQ_IMP_RULE2_prf   (f 1)
+  | 0w49 => EQ_MP_prf          (f 1, f 2)
+  | 0w51 => EXISTS_prf         (f 1, f 2, f 3)
+  | 0w53 => Exported_prf       (str c (f 1), f 2)
+  | 0w55 => GENL_prf           (f 1, f 2)
+  | 0w57 => GEN_ABS_prf        (f 1, f 2, f 3)
+  | 0w59 => GEN_prf            (f 1, f 2)
+  | 0w61 => INST_TYPE_prf      (f 1, f 2)
+  | 0w63 => INST_prf           (f 1, f 2)
+  | 0w65 => MK_COMB_prf        (f 1, f 2)
+  | 0w67 => MP_prf             (f 1, f 2)
+  | 0w69 => Mark_prf           (str c (f 1), f 2)
+  | 0w71 => Mk_abs_prf         (f 1, f 2, f 3)
+  | 0w73 => Mk_comb_prf        (f 1, f 2, f 3)
+  | 0w75 => NOT_ELIM_prf       (f 1)
+  | 0w77 => NOT_INTRO_prf      (f 1)
+  | 0w79 => REFL_prf           (f 1)
+  | 0w81 => SPEC_prf           (f 1, f 2)
+  | 0w83 => SUBST_prf          (f 1, f 2, f 3)
+  | 0w85 => SYM_prf            (f 1)
+  | 0w87 => Specialize_prf     (f 1, f 2)
+  | 0w89 => TRANS_prf          (f 1, f 2)
+  | 0w91 => compute_prf        (f 1, f 2)
+  | 0w93 => deductAntisym_prf  (f 1, f 2)
   | 0w95 => deleted_prf
-  | 0w97 => save_dep_prf       (f 8)
+  | 0w97 => save_dep_prf       (f 1)
   | _ => raise Fail "shProof: parse error"
 
-fun shComputeArgs c w = case arg' c w of f =>
+fun shComputeArgs c w = case arg c w of f =>
   { num_type = f 0,
-    char_eqns = f 8,
-    cval_type = f 16,
-    cval_terms = f 24 }
+    char_eqns = f 1,
+    cval_type = f 2,
+    cval_terms = f 3 }
 
 end

--- a/src/postkernel/prooftrace/tr-format.md
+++ b/src/postkernel/prooftrace/tr-format.md
@@ -4,31 +4,39 @@ The output of the `--trknl` proof tracer ([#1309](https://github.com/HOL-Theorem
 is a compressed proof trace for each theory, e.g. `src/bool/.hol/objs/boolTheory.tr.gz`.
 If you uncompress it with `gzip`, the resulting data file is in the `.tr` file format.
 
-This is a PolyML memory dump, but it can still be decoded to get to the proof matter.
+There are two variants of the format: a **64-bit** variant (the original, produced
+by PolyML's `exportSmallToFD` directly) and a **32-bit** narrow variant (produced
+by the `recode32` pipeline stage). The 32-bit variant starts with an 8-byte magic
+`54 52 33 32 00 00 00 FF` (`"TR32\0\0\0\xFF"`); the 64-bit variant has no magic.
+The formats cannot collide because byte 7 of the magic is `FF`, which is not a valid
+flags byte (the flags byte of a 64-bit header occupies byte 7 and is always `00`–`03`).
 
-## File structure: bit level
+The 64-bit variant is a PolyML memory dump; the 32-bit variant recodes each word
+from 8 bytes to 4 bytes but preserves the same logical structure.
+
+## 64-bit file structure: bit level
 
 The outer structure of the dump is a sequence of objects, followed by a root pointer:
 
 ```c
-file ::= object* tagptr
+file64 ::= object64* tagptr64
 ```
 
-A tagged pointer `tagptr` is a little-endian 64 bit value which can be either an integer or a pointer.
+A tagged pointer `tagptr64` is a little-endian 64 bit value which can be either an integer or a pointer.
 If the low bit is `0`, then the remaining 63 bits are an index into the object list
 (1-based, with 0 denoting the null pointer), and if the low bit is `1` then the
 remaining bits denote a signed 63 bit integer.
 ```c
-tagptr ::= 0 ptr63 | 1 int63
+tagptr64 ::= 0 ptr63 | 1 int63
 ```
 
 An object begins with a 64 bit header word, with the top 8 bits reserved for flags:
 ```c
-header ::= len56 flags8
+header64 ::= len56 flags8
 ```
 In all cases, an object will have exactly `len56` 64-bit words following it:
 ```c
-object ::= header data64[len56]
+object64 ::= header64 data64[len56]
 ```
 The contents of those bytes depends on the object kind.
 
@@ -41,24 +49,70 @@ flags8 ::= 00xxxxxx  // 0: Regular
 ```
 * For the `Code` and `Closure` kinds, the exporter does not export the contents, and `len56` will be 0.
 
-* For `Bytes`, the data is a packed byte-array. The first word is the byte length of the array,
-  and it is followed by that many bytes. It is then padded to a multiple of 8 bytes.
-
-  ```c
-  bytes_data ::= blen64 data8[blen64] pad
-  ```
+* For `Bytes`, the data is an opaque byte region occupying `len56 * 8` bytes.
+  Some byte objects (notably strings) begin with an 8-byte word giving the logical
+  byte length of the array, followed by that many bytes of content and then padding
+  to an 8-byte boundary. Other byte-array-like objects (used internally by PolyML)
+  do **not** have a length prefix — the entire `len56 * 8` bytes are content.
+  Since the two cases cannot be distinguished from the header alone, consumers
+  that need to handle arbitrary byte objects should treat the whole region as opaque.
 
 * For `Regular`, the data is a sequence of tagged pointers:
   ```c
-  regular_data ::= tagptr[len56]
+  regular_data ::= tagptr64[len56]
   ```
+
+## 32-bit file structure
+
+The 32-bit variant has the same logical structure but every word is 4 bytes instead
+of 8. It is produced by the standalone `recode32` binary
+(`src/tracing/recode32.sml`) which reads a 64-bit dump from stdin and writes the
+32-bit form to stdout, streaming with constant memory.
+
+```c
+file32 ::= magic32 object32* tagptr32
+
+magic32 ::= 54 52 33 32 00 00 00 FF   // 8 bytes: "TR32\0\0\0\xFF"
+
+tagptr32 ::= 0 ptr31 | 1 int31   // 4-byte little-endian
+                                  // ptr: 31-bit object index (1-based)
+                                  // int: signed 31-bit integer
+
+header32 ::= len24 flags8        // 4-byte little-endian
+                                  // low 24 bits = word count, high 8 bits = flags
+object32 ::= header32 data32[len24]
+```
+
+**Regular** objects: each data slot is a `tagptr32` (4 bytes). Word count `len24`
+equals the 64-bit `len56` — same number of slots, each half as wide.
+
+**Bytes** objects: the recoder copies the original `len56 * 8` raw bytes verbatim.
+The 32-bit word count is `len24 = len56 * 2` (double the word count, half the word
+width, same byte count). The raw content is byte-identical to the 64-bit form,
+including any internal length prefix and padding. This means bytes objects have
+**no size reduction** in the 32-bit format; savings come only from Regular objects
+and headers.
+
+**Code/Closure** objects: `len24 = 0`, same as 64-bit.
+
+### Width assumptions
+
+The 32-bit format requires that all pointer indices fit in 31 bits and all integer
+values fit in 31 signed bits. Empirical verification across 279 CakeML theory files
+confirmed:
+* max pointer index: ~250M (~28 bits)
+* max absolute integer: ~15K (~14 bits)
+* max object word count: 10
+
+There is ample headroom. If a future file exceeds these limits, the recoder
+raises `Fail` rather than emitting truncated output.
 
 ## File structure: encoding types
 
 We can summarize the file structure more abstractly like so:
 
 ```c
-tagptr ::= int63 | ptr63
+tagptr ::= int | ptr
 bytes ::= int8*
 regular ::= tagptr*
 code ::= ()
@@ -69,7 +123,7 @@ file ::= object* tagptr
 
 If we ignore the indirection in `Ptr`, this can be represented as an ADT:
 ```sml
-datatype tagptr = Int of int63 | Ptr of object
+datatype tagptr = Int of int | Ptr of object
 and object = Bytes of word8 array | Regular of tagptr array | Code | Closure
 ```
 
@@ -193,7 +247,7 @@ datatype proof
   | compute_prf of (compute_args * thm list) * term
   | deductAntisym_prf of thm * thm
   | deleted_prf
-  | saved_prf of thm
+  | save_dep_prf of thm
 
 type compute_args =
   { num_type   : hol_type,

--- a/src/tracing/yes/Holmakefile
+++ b/src/tracing/yes/Holmakefile
@@ -1,0 +1,10 @@
+ifdef POLY
+
+all: $(DEFAULT_TARGETS) $(HOLDIR)/bin/recode32
+
+$(HOLDIR)/bin/recode32: recode32.ML
+	$(POLYC) $< -o $@
+
+EXTRA_CLEANS = $(HOLDIR)/bin/recode32
+
+endif

--- a/src/tracing/yes/Tracing.sml
+++ b/src/tracing/yes/Tracing.sml
@@ -2,21 +2,40 @@ structure Tracing :> Tracing =
 struct
 open TheoryPP
 
+(* When true, trace_theory recodes the PolyML heap dump from 64-bit to 32-bit
+   before gzipping. Produces a backward-incompatible format marked by an
+   8-byte magic "TR32\0\0\0\xFF". *)
+val recode_32bit = ref true
+
+val recode32_path = ref (
+  (case OS.Process.getEnv "HOLDIR" of SOME d => d | NONE => ".") ^ "/bin/recode32")
+
 fun export (file, x: 'a) = let
   val () = PolyML.shareCommonData x
   open Posix
   val {infd = pipeRead, outfd = pipeWrite} = IO.pipe ()
-  val pid = case Process.fork () of SOME pid => pid | NONE => let
-    val () = IO.dup2 {old = pipeRead, new = FileSys.stdin}
+  fun gzip read = case Process.fork () of SOME pid => pid | NONE => let
+    val () = IO.dup2 {old = read, new = FileSys.stdin}
     val fd = FileSys.createf (file, FileSys.O_WRONLY, FileSys.O.trunc,
       let open FileSys.S in flags [irusr, iwusr, irgrp, iwgrp, iroth] end)
     val () = IO.dup2 {old = fd, new = FileSys.stdout}
     val () = app IO.close [pipeRead, pipeWrite, fd]
     in Process.exec ("/usr/bin/gzip", []) end
+  val pids = if !recode_32bit then let
+    val {infd = recRead, outfd = recWrite} = IO.pipe ()
+    val gzipPid = gzip recRead
+    val recPid = case Process.fork () of SOME pid => pid | NONE => let
+      val () = IO.dup2 {old = pipeRead, new = FileSys.stdin}
+      val () = IO.dup2 {old = recWrite, new = FileSys.stdout}
+      val () = app IO.close [pipeRead, pipeWrite, recRead, recWrite]
+      in Process.exec (!recode32_path, []) end
+    val () = app IO.close [recRead, recWrite]
+    in [recPid, gzipPid] end
+  else [gzip pipeRead]
+  val () = IO.close pipeRead
   val () = PolyML.exportSmallToFD (pipeWrite, x)
-  val () = app IO.close [pipeRead, pipeWrite]
-  val _ = Process.waitpid (Process.W_CHILD pid, [])
-  in () end
+  val () = IO.close pipeWrite
+in app (fn pid => ignore (Process.waitpid (Process.W_CHILD pid, []))) pids end
 
 fun trace_theory name args = export(concat[".hol/objs/",name,".tr.gz"], args)
 

--- a/src/tracing/yes/recode32.ML
+++ b/src/tracing/yes/recode32.ML
@@ -1,0 +1,180 @@
+(* recode32.ML — Standalone streaming 64-bit → 32-bit PolyML heap recoder.
+   Reads a 64-bit heap dump from stdin, writes a 32-bit narrow format to
+   stdout, with constant memory usage (two small buffers).
+
+   Built by Holmake (see Holmakefile in this directory) into
+   $HOLDIR/bin/recode32. Invoked by Tracing.export as a pipe stage:
+     poly-export | recode32 | gzip > file.tr.gz
+*)
+
+val BUF_SIZE = 65536
+
+(* ----- Buffered stdin reader ----- *)
+
+val rBuf = Word8Array.array (BUF_SIZE, 0w0)
+val rSize = ref 0
+val rPos = ref 0
+val rEof = ref false
+
+fun rFill () =
+  if !rEof then () else
+  let
+    val keep = !rSize - !rPos
+    val () = if !rPos > 0 andalso keep > 0 then
+               Word8ArraySlice.copy
+                 {src = Word8ArraySlice.slice (rBuf, !rPos, SOME keep),
+                  dst = rBuf, di = 0}
+             else ()
+    val () = rPos := 0
+    val () = rSize := keep
+    fun loop () =
+      if !rSize >= BUF_SIZE then () else
+      let val got = Posix.IO.readArr (Posix.FileSys.stdin,
+                      Word8ArraySlice.slice (rBuf, !rSize, SOME (BUF_SIZE - !rSize)))
+      in if got = 0 then rEof := true
+         else (rSize := !rSize + got; loop ()) end
+  in loop () end
+
+fun rEnsure n =
+  if !rSize - !rPos >= n then true
+  else (rFill (); !rSize - !rPos >= n)
+
+fun rReadW64 () =
+  if not (rEnsure 8) then NONE
+  else let
+    val p = !rPos
+    fun b i = Word64.fromInt (Word8.toInt (Word8Array.sub (rBuf, p + i)))
+    val w = let open Word64 infix orb <<
+            in b 0 orb (b 1 << 0w8) orb (b 2 << 0w16) orb (b 3 << 0w24) orb
+               (b 4 << 0w32) orb (b 5 << 0w40) orb (b 6 << 0w48) orb (b 7 << 0w56)
+            end
+    val () = rPos := p + 8
+  in SOME w end
+
+fun rReadW64' () = case rReadW64 () of SOME w => w
+  | NONE => raise Fail "recode32: unexpected EOF"
+
+(* Pump n raw bytes from stdin to the writer function `sink`. *)
+fun rPump n sink = let
+  fun loop rem =
+    if rem = 0 then () else
+    let val avail = !rSize - !rPos
+        val chunk = Int.min (avail, rem)
+    in
+      if chunk > 0 then (
+        sink (rBuf, !rPos, chunk);
+        rPos := !rPos + chunk;
+        loop (rem - chunk))
+      else if rEnsure 1 then loop rem
+      else raise Fail "recode32: EOF in byte pump"
+    end
+in loop n end
+
+(* ----- Buffered stdout writer ----- *)
+
+val wBuf = Word8Array.array (BUF_SIZE, 0w0)
+val wPos = ref 0
+
+fun wFlush () =
+  if !wPos = 0 then ()
+  else let
+    val n = !wPos
+    fun loop p =
+      if p >= n then ()
+      else let val s = Word8ArraySlice.slice (wBuf, p, SOME (n - p))
+               val k = Posix.IO.writeArr (Posix.FileSys.stdout, s)
+           in loop (p + k) end
+  in loop 0; wPos := 0 end
+
+fun wReserve n = if !wPos + n > BUF_SIZE then wFlush () else ()
+
+fun wU32 v = let
+  val () = wReserve 4
+  val p = !wPos
+  fun bite i = Word8.fromLargeWord
+    (Word64.toLargeWord (Word64.andb (Word64.>> (v, Word.fromInt (i*8)), 0wxFF)))
+in
+  Word8Array.update (wBuf, p,   bite 0);
+  Word8Array.update (wBuf, p+1, bite 1);
+  Word8Array.update (wBuf, p+2, bite 2);
+  Word8Array.update (wBuf, p+3, bite 3);
+  wPos := p + 4
+end
+
+fun wHeader32 (len, flags) =
+  if len >= 0x1000000 then
+    raise Fail ("recode32: object length " ^ Int.toString len ^ " >= 2^24")
+  else wU32 (Word64.orb (Word64.fromInt len,
+                         Word64.<< (Word64.fromInt flags, 0w24)))
+
+(* Write a tagged pointer, verifying it sign-extends from 32 to 64 bits
+   (i.e. parses back identically via get32). One shift-shift-compare per
+   write; the not-overflow branch is taken on every valid input. *)
+fun wTagptr32 v =
+  if Word64.~>> (Word64.<< (v, 0w32), 0w32) = v then wU32 v
+  else raise Fail ("recode32: tagptr 0x" ^ Word64.toString v ^
+                   " does not fit in 32 bits")
+
+fun wBytes4 (b0, b1, b2, b3) = (
+  wReserve 4;
+  let val p = !wPos in
+    Word8Array.update (wBuf, p,   b0);
+    Word8Array.update (wBuf, p+1, b1);
+    Word8Array.update (wBuf, p+2, b2);
+    Word8Array.update (wBuf, p+3, b3);
+    wPos := p + 4
+  end)
+
+fun wSlice (src, off, n) = let
+  fun loop i =
+    if i >= n then () else (
+      wReserve 1;
+      Word8Array.update (wBuf, !wPos, Word8Array.sub (src, off + i));
+      wPos := !wPos + 1;
+      loop (i + 1))
+in loop 0 end
+
+(* ----- Main recoder loop ----- *)
+
+val LEN_MASK = Word64.- (Word64.<< (0w1, 0w56), 0w1)
+
+fun processHeader buf peek = let
+  val flags = Word64.toInt (Word64.>> (buf, 0w56))
+  val len = Word64.toInt (Word64.andb (buf, LEN_MASK))
+  val kind = flags mod 4
+in case kind of
+     0 => ( (* Regular *)
+       wHeader32 (len, flags);
+       if len = 0 then loop peek
+       else (
+         wTagptr32 peek;
+         let fun copy i =
+           if i >= len then () else (wTagptr32 (rReadW64' ()); copy (i+1))
+         in copy 1 end;
+         loop (rReadW64' ())))
+   | 1 => ( (* Bytes-kind: opaque raw bytes *)
+       if len = 0 then raise Fail "recode32: Bytes with len=0" else ();
+       let val new_len32 = len * 2
+           val () = wHeader32 (new_len32, flags)
+           val () = wU32 peek
+           val () = wU32 (Word64.>> (peek, 0w32))
+           val () = rPump ((len - 1) * 8) wSlice
+       in loop (rReadW64' ()) end)
+   | _ => ( (* Code/Closure *)
+       wHeader32 (len, flags);
+       if len = 0 then loop peek
+       else raise Fail "recode32: Code/Closure with len > 0")
+end
+
+and loop buf =
+  case rReadW64 () of
+    NONE => wTagptr32 buf  (* EOF: buf was the root tagptr *)
+  | SOME peek => processHeader buf peek
+
+fun main () = (
+  wBytes4 (0wx54, 0wx52, 0wx33, 0wx32);  (* 32-bit magic: "TR32" *)
+  wBytes4 (0w0, 0w0, 0w0, 0wxFF);         (* + \0\0\0\xFF       *)
+  case rReadW64 () of
+    NONE => raise Fail "recode32: empty input"
+  | SOME first => loop first;
+  wFlush ())


### PR DESCRIPTION
## Summary
- Add a streaming `recode32` binary that converts PolyML's 64-bit `.tr` heap dumps to a 32-bit narrow format, halving the size of pointers and headers
- The 32-bit variant is identified by an 8-byte magic `TR32\0\0\0\xFF`; the final byte cannot collide with a valid 64-bit flags byte (which is always 00–03)
- `ProofTraceParser` gains a `Heap32` variant that decodes the narrow format in-place; all `sh*` accessors dispatch on the variant
- `Tracing.export` pipes through `recode32` when the (default-on) `recode_32bit` flag is set
- The recoder raises `Fail` rather than silently truncating when a value does not fit in 32 bits
- `recode32` is built automatically by Holmake (via `POLYC`) into `$HOLDIR/bin/recode32` when `--trknl` is enabled, since `src/tracing/yes` is in the kernel sequence for that build

## Test plan
- [ ] Build with `--trknl` and confirm `$HOLDIR/bin/recode32` is produced
- [ ] Verify `.tr.gz` files are roughly half the size of the 64-bit format
- [ ] Confirm `ProofTraceParser.parse` decodes the new files correctly via `ProofTraceReplay`