### PR TITLE
add NoTrace and export_proof facilities

### DIFF
--- a/src/postkernel/Theory.sig
+++ b/src/postkernel/Theory.sig
@@ -55,6 +55,14 @@ sig
   val add_anonymous_thm      : thm -> int (* for ThyDataSexp only *)
   val export_theory          : unit -> unit
 
+(* Externalize a theorem's proof tree to a side .tr.gz file, then flip
+   the proof ref to Exported_prf. The in-memory proof tree becomes
+   garbage-collectable. Named form uses the given name; anonymous form
+   assigns a sequential number. Both compute the file path automatically
+   from the current theory. *)
+  val export_proof           : string * thm -> unit
+  val export_proof_anon      : thm -> unit
+
 (* Make hooks available so that theory changes can be seen by
    "interested parties" *)
   val delta_hook : TheoryDelta.t Listener.t

--- a/src/postkernel/Theory.sml
+++ b/src/postkernel/Theory.sml
@@ -952,11 +952,28 @@ local
     (TextIO.closeOut ostrm handle _ => ();
      OS.FileSys.remove tmp handle _ => ())
   val anonymous_thms = ref (0,[])
+  val export_proof_counter = ref 0
 in
 fun add_anonymous_thm th = let
   val (n,ls) = !anonymous_thms
   val () = anonymous_thms := (n+1,th::ls)
 in n end
+
+fun export_proof (name, th) = let
+  val thyname = current_theory ()
+  val file = concat [".hol/objs/", thyname, "Theory.", name, ".tr.gz"]
+in
+  Tracing.export_proof {file = file, tag = Thm.SavedName name} th
+end
+
+fun export_proof_anon th = let
+  val n = !export_proof_counter
+  val () = export_proof_counter := n + 1
+  val thyname = current_theory ()
+  val file = concat [".hol/objs/", thyname, "Theory._anon", Int.toString n, ".tr.gz"]
+in
+  Tracing.export_proof {file = file, tag = Thm.SavedAnon n} th
+end
 fun export_theory_return_hash () = let
   val _ = hooks_or_abort (TheoryDelta.ExportTheory (current_theory()))
   val {name=thyname,facts,thydata,mldeps,...} = scrubCT()
@@ -1070,14 +1087,17 @@ fun export_theory_return_hash () = let
                else ()
              end
            else ();
-           Tracing.trace_theory name {
-             theory    = thyname,
-             parents   = #parents structthry,
-             types     = #types structthry,
-             constants = #constants structthry,
-             all_thms  = all_thms,
-             anon_thms = rev(#2(!anonymous_thms)),
-             mldeps    = #mldeps structthry };
+           (case !TraceMode.mode of
+              TraceMode.TraceAndExport =>
+                Tracing.trace_theory name {
+                  theory    = thyname,
+                  parents   = #parents structthry,
+                  types     = #types structthry,
+                  constants = #constants structthry,
+                  all_thms  = all_thms,
+                  anon_thms = rev(#2(!anonymous_thms)),
+                  mldeps    = #mldeps structthry }
+            | _ => ());
            List.app commit_temp temps;
            mesg "done.\n";
            if !report_times then

--- a/src/postkernel/prooftrace/ProofTraceParser.sig
+++ b/src/postkernel/prooftrace/ProofTraceParser.sig
@@ -94,6 +94,7 @@ datatype sh_proof =
 | EQ_IMP_RULE2_prf of thm ptr
 | EQ_MP_prf of thm ptr * thm ptr
 | EXISTS_prf of term ptr * term ptr * thm ptr
+| Exported_prf of string * thm_id ptr
 | GENL_prf of term list ptr * thm ptr
 | GEN_ABS_prf of term option ptr * term list ptr * thm ptr
 | GEN_prf of term ptr * thm ptr
@@ -101,6 +102,7 @@ datatype sh_proof =
 | INST_prf of (term * term) list ptr * thm ptr
 | MK_COMB_prf of thm ptr * thm ptr
 | MP_prf of thm ptr * thm ptr
+| Mark_prf of string * thm ptr
 | Mk_abs_prf of thm ptr * term ptr * thm ptr
 | Mk_comb_prf of thm ptr * thm ptr * thm ptr
 | NOT_ELIM_prf of thm ptr

--- a/src/postkernel/prooftrace/ProofTraceParser.sml
+++ b/src/postkernel/prooftrace/ProofTraceParser.sml
@@ -206,6 +206,7 @@ datatype sh_proof =
 | EQ_IMP_RULE2_prf of thm ptr
 | EQ_MP_prf of thm ptr * thm ptr
 | EXISTS_prf of term ptr * term ptr * thm ptr
+| Exported_prf of string * thm_id ptr
 | GENL_prf of term list ptr * thm ptr
 | GEN_ABS_prf of term option ptr * term list ptr * thm ptr
 | GEN_prf of term ptr * thm ptr
@@ -213,6 +214,7 @@ datatype sh_proof =
 | INST_prf of (term,term)Lib.subst ptr * thm ptr
 | MK_COMB_prf of thm ptr * thm ptr
 | MP_prf of thm ptr * thm ptr
+| Mark_prf of string * thm ptr
 | Mk_abs_prf of thm ptr * term ptr * thm ptr
 | Mk_comb_prf of thm ptr * thm ptr * thm ptr
 | NOT_ELIM_prf of thm ptr
@@ -256,27 +258,29 @@ fun shProof c w = case arg' c w of f =>
   | 0w47 => EQ_IMP_RULE2_prf   (f 8)
   | 0w49 => EQ_MP_prf          (f 8, f 16)
   | 0w51 => EXISTS_prf         (f 8, f 16, f 24)
-  | 0w53 => GENL_prf           (f 8, f 16)
-  | 0w55 => GEN_ABS_prf        (f 8, f 16, f 24)
-  | 0w57 => GEN_prf            (f 8, f 16)
-  | 0w59 => INST_TYPE_prf      (f 8, f 16)
-  | 0w61 => INST_prf           (f 8, f 16)
-  | 0w63 => MK_COMB_prf        (f 8, f 16)
-  | 0w65 => MP_prf             (f 8, f 16)
-  | 0w67 => Mk_abs_prf         (f 8, f 16, f 24)
-  | 0w69 => Mk_comb_prf        (f 8, f 16, f 24)
-  | 0w71 => NOT_ELIM_prf       (f 8)
-  | 0w73 => NOT_INTRO_prf      (f 8)
-  | 0w75 => REFL_prf           (f 8)
-  | 0w77 => SPEC_prf           (f 8, f 16)
-  | 0w79 => SUBST_prf          (f 8, f 16, f 24)
-  | 0w81 => SYM_prf            (f 8)
-  | 0w83 => Specialize_prf     (f 8, f 16)
-  | 0w85 => TRANS_prf          (f 8, f 16)
-  | 0w87 => compute_prf        (f 8, f 16)
-  | 0w89 => deductAntisym_prf  (f 8, f 16)
-  | 0w91 => deleted_prf
-  | 0w93 => save_dep_prf       (f 8)
+  | 0w53 => Exported_prf       (str c (f 8), f 16)
+  | 0w55 => GENL_prf           (f 8, f 16)
+  | 0w57 => GEN_ABS_prf        (f 8, f 16, f 24)
+  | 0w59 => GEN_prf            (f 8, f 16)
+  | 0w61 => INST_TYPE_prf      (f 8, f 16)
+  | 0w63 => INST_prf           (f 8, f 16)
+  | 0w65 => MK_COMB_prf        (f 8, f 16)
+  | 0w67 => MP_prf             (f 8, f 16)
+  | 0w69 => Mark_prf           (str c (f 8), f 16)
+  | 0w71 => Mk_abs_prf         (f 8, f 16, f 24)
+  | 0w73 => Mk_comb_prf        (f 8, f 16, f 24)
+  | 0w75 => NOT_ELIM_prf       (f 8)
+  | 0w77 => NOT_INTRO_prf      (f 8)
+  | 0w79 => REFL_prf           (f 8)
+  | 0w81 => SPEC_prf           (f 8, f 16)
+  | 0w83 => SUBST_prf          (f 8, f 16, f 24)
+  | 0w85 => SYM_prf            (f 8)
+  | 0w87 => Specialize_prf     (f 8, f 16)
+  | 0w89 => TRANS_prf          (f 8, f 16)
+  | 0w91 => compute_prf        (f 8, f 16)
+  | 0w93 => deductAntisym_prf  (f 8, f 16)
+  | 0w95 => deleted_prf
+  | 0w97 => save_dep_prf       (f 8)
   | _ => raise Fail "shProof: parse error"
 
 fun shComputeArgs c w = case arg' c w of f =>

--- a/src/postkernel/prooftrace/ProofTraceReplay.sml
+++ b/src/postkernel/prooftrace/ProofTraceReplay.sml
@@ -314,6 +314,8 @@ let
     | deductAntisym_prf (a, b) => raise Fail "replay_thm: deductAntisym not yet implemented"
     | deleted_prf =>              raise Fail "replay_thm: deleted not yet implemented"
     | save_dep_prf a => th a
+    | Mark_prf (_, a) => th a
+    | Exported_prf _ => raise Fail "replay_thm: Exported not yet implemented"
   end) thm_ptr
 
   fun export p = let

--- a/src/postkernel/prooftrace/ProofTraceWalk.sml
+++ b/src/postkernel/prooftrace/ProofTraceWalk.sml
@@ -189,6 +189,8 @@ fun walk {heap, thyname, named_thms, anon_thms,
       | deductAntisym_prf (a, b) => (th a; th b)
       | deleted_prf => ()
       | save_dep_prf a => th a
+      | Mark_prf (_, a) => th a
+      | Exported_prf _ => ()
     end
   and th p = (incr (castPtr p); walk_thm p)
 

--- a/src/postkernel/prooftrace/tr-format.md
+++ b/src/postkernel/prooftrace/tr-format.md
@@ -171,6 +171,7 @@ datatype proof
   | EQ_IMP_RULE2_prf of thm
   | EQ_MP_prf of thm * thm
   | EXISTS_prf of term * term * thm
+  | Exported_prf of string * thm_id
   | GENL_prf of term list * thm
   | GEN_ABS_prf of term option * term list * thm
   | GEN_prf of term * thm
@@ -178,6 +179,7 @@ datatype proof
   | INST_prf of (term * term) list * thm
   | MK_COMB_prf of thm * thm
   | MP_prf of thm * thm
+  | Mark_prf of string * thm
   | Mk_abs_prf of thm * term * thm
   | Mk_comb_prf of thm * thm * thm
   | NOT_ELIM_prf of thm

--- a/src/prekernel/TraceMode.sig
+++ b/src/prekernel/TraceMode.sig
@@ -1,0 +1,17 @@
+signature TraceMode = sig
+
+  (* Runtime switch for proof-trace machinery. Live reference; writers are
+     responsible for not switching mid-theory (intermediate thms built under
+     NoTrace have their proof refs stored as deleted_prf, which would leave
+     holes if referenced by later thms built under TraceOnly/TraceAndExport). *)
+  datatype trace_mode = NoTrace | TraceOnly | TraceAndExport
+
+  (* Default TraceAndExport, overridable at process start via the
+     HOL_TRACE_MODE env var. Recognised values (case-sensitive):
+       "none"   / "off"      → NoTrace
+       "trace"  / "memory"   → TraceOnly
+       "export" / "on" / ""  → TraceAndExport
+     anything else is treated as TraceAndExport. *)
+  val mode : trace_mode ref
+
+end

--- a/src/prekernel/TraceMode.sml
+++ b/src/prekernel/TraceMode.sml
@@ -1,0 +1,17 @@
+structure TraceMode :> TraceMode = struct
+
+datatype trace_mode = NoTrace | TraceOnly | TraceAndExport
+
+val initial =
+  case OS.Process.getEnv "HOL_TRACE_MODE" of
+    SOME "none"   => NoTrace
+  | SOME "off"    => NoTrace
+  | SOME "trace"  => TraceOnly
+  | SOME "memory" => TraceOnly
+  | SOME "export" => TraceAndExport
+  | SOME "on"     => TraceAndExport
+  | _             => TraceAndExport
+
+val mode : trace_mode ref = ref initial
+
+end

--- a/src/prekernel/mlton/prekernel.mlb
+++ b/src/prekernel/mlton/prekernel.mlb
@@ -21,6 +21,8 @@ stubs.sml
 ../Tag.sml
 ../Count.sig
 ../Count.sml
+../TraceMode.sig
+../TraceMode.sml
 
 (* Final*-sig files needed by Type.sig, Term.sig *)
 ../FinalType-sig.sml

--- a/src/thm/otknl-thm.ML
+++ b/src/thm/otknl-thm.ML
@@ -104,6 +104,13 @@ and proof =
 | deductAntisym_prf of thm * thm
 | compute_prf of (compute_args * thm list) * term
 | save_dep_prf of thm
+| Exported_prf of string * thm_id
+  (* Stub left behind by export_proof: the full inference tree lives in an
+     external .tr.gz file (first field) under the saved name (second). *)
+| Mark_prf of string * thm
+  (* No-op wrapper inserted by the `mark` rule (below); identical at the
+     logical level to its argument, but visible in the trace as a named
+     boundary for source-level instrumentation. *)
 
 withtype compute_args =
   { cval_terms : (string * term) list,
@@ -113,9 +120,18 @@ withtype compute_args =
 
 fun proof (THM(_,_,_,p)) = !p
 fun delete_proof (THM(_,_,_,p)) =
-  (case !p of save_dep_prf (THM(_,_,_,inner)) => inner := deleted_prf
-            | _ => ();
+  (case !p of
+     save_dep_prf (THM(_,_,_,inner))   => inner := deleted_prf
+   | Mark_prf (_, THM(_,_,_,inner))    => inner := deleted_prf
+   | _ => ();
    p := deleted_prf)
+
+fun set_exported (THM(_,_,_,p)) (file, id) =
+  (case !p of
+     save_dep_prf (THM(_,_,_,inner))   => inner := deleted_prf
+   | Mark_prf (_, THM(_,_,_,inner))    => inner := deleted_prf
+   | _ => ();
+   p := Exported_prf (file, id))
 
 fun single_hyp tm = HOLset.singleton Term.compare tm
 val empty_hyp = Term.empty_tmset
@@ -331,7 +347,17 @@ end;
 
 fun dest_thm(t as THM(_,asl,w,_)) = (hyplist t,w) (* Compatible with old code. *)
 fun sdest_thm(THM(_,asl,w,_)) = (asl,w)
-fun make_thm R (x,y,z,p) = (Count.inc_count R; THM (x,y,z,ref p));   (* internal only *)
+(* internal only. When TraceMode is NoTrace, the supplied proof variant is
+   discarded and the thm's proof ref is initialized to deleted_prf instead.
+   The proof argument is still constructed by the caller (one tuple alloc
+   that immediately becomes nursery garbage), but the inference tree it
+   references is never retained. *)
+fun make_thm R (x,y,z,p) = (
+  Count.inc_count R;
+  THM (x,y,z,
+       ref (case !TraceMode.mode of
+              TraceMode.NoTrace => deleted_prf
+            | _                 => p)))
 
 fun thm_frees (t as THM(_,asl,c,_)) = free_varsl (c::hyplist t);
 
@@ -1548,6 +1574,12 @@ fun save_dep thy (th as (THM(t,h,c,p))) =
     thm_order := (!thm_order) + 1;
     THM(Tag.set_dep dep t,h,c,ref(save_dep_prf th))
   end
+
+(* mark: no-op inference wrapper. Preserves tag/hyps/concl; leaves a named
+   Mark_prf in the proof ref so the marker is visible in the trace. Does
+   not touch the Count counters because it is logically an identity rule. *)
+fun mark label (th as THM(t,h,c,_)) =
+  THM(t, h, c, ref (Mark_prf (label, th)))
 
 (* Some OpenTheory kernel rules *)
 fun deductAntisym (th1 as THM(o1,a1,c1,p1)) (th2 as THM(o2,a2,c2,p2)) = let

--- a/src/thm/otknl-thmsig.ML
+++ b/src/thm/otknl-thmsig.ML
@@ -51,12 +51,19 @@ sig
   | deductAntisym_prf of thm * thm
   | compute_prf of (compute_args * thm list) * term
   | save_dep_prf of thm
+  | Exported_prf of string * thm_id
+  | Mark_prf of string * thm
 
   val proof : thm -> proof
   val delete_proof : thm -> unit
+  val set_exported : thm -> string * thm_id -> unit
   val mk_proof_thm : proof -> term list * term -> thm
 
   val deductAntisym : thm -> thm -> thm
+
+  (* A no-op inference wrapper whose only purpose is to leave a named marker
+     in the proof trace. Logically an identity on the theorem. *)
+  val mark : string -> thm -> thm
 
   val set_definition_callback   : (thm -> unit) -> unit
   val clear_definition_callback : unit -> unit

--- a/src/tracing/Tracing.sig
+++ b/src/tracing/Tracing.sig
@@ -10,4 +10,11 @@ val trace_theory : string ->
     anon_thms   : Thm.thm list,
     mldeps      : string list } -> unit
 
+(* Low-level proof export: serialize the theorem's proof tree to a .tr.gz
+   side file, then flip the proof ref to Exported_prf.
+   - `file`: target path for the side file (e.g. ".hol/objs/foo.tr.gz")
+   - `tag`: identifier stored in the Exported_prf stub (e.g. SavedName "lemma")
+   Theory.export_proof provides a higher-level wrapper with automatic naming. *)
+val export_proof : {file: string, tag: Thm.thm_id} -> Thm.thm -> unit
+
 end

--- a/src/tracing/no/Tracing.sml
+++ b/src/tracing/no/Tracing.sml
@@ -2,5 +2,7 @@ structure Tracing :> Tracing =
 struct
 
 fun trace_theory _ _ = ()
+fun export_proof _ _ = ()
+
 
 end

--- a/src/tracing/yes/Tracing.sml
+++ b/src/tracing/yes/Tracing.sml
@@ -20,4 +20,14 @@ fun export (file, x: 'a) = let
 
 fun trace_theory name args = export(concat[".hol/objs/",name,".tr.gz"], args)
 
+fun export_proof {file, tag} th =
+  case !TraceMode.mode of
+    TraceMode.NoTrace => ()
+  | _ => let
+      val prf = Thm.proof th
+    in
+      export (file, prf);
+      Thm.set_exported th (file, tag)
+    end
+
 end


### PR DESCRIPTION
## Summary
- Add a `TraceMode` structure (in `src/prekernel`) governing whether the trace kernel records proofs
- Add `Tracing.export_proof` which writes a theorem's proof tree to a file and rewrites the in-memory proof ref to `Exported_prf (file, thm_id)`, so subsequent trace serialization records the file reference instead of the full subtree
- Add `Thm.mark` and the corresponding `Mark_prf` proof constructor for inserting labeled markers in the proof trace (identity on the theorem, visible in the trace)
- Update `ProofTraceParser` (`sh_proof` datatype and `shProof` decoder), `ProofTraceReplay`, and `ProofTraceWalk` to handle the two new constructors

## Test plan
- [ ] Build with `--trknl` and confirm the kernel compiles
- [ ] Confirm `Thm.mark` produces a theorem whose proof ref is `Mark_prf`
- [ ] Confirm `export_proof` writes a separate file and rewrites the proof ref to `Exported_prf`
- [ ] Replay a trace containing `Mark_prf` and `Exported_prf` proofs via `ProofTraceReplay`