### PR TITLE
markerLib: support cross-theorem Resume dependencies

### DIFF
--- a/src/1/boolLib.sml
+++ b/src/1/boolLib.sml
@@ -110,33 +110,57 @@ end (* local open *)
 
 val def_suffix = ref "_def"
 
-fun has_suspended_subgoals th =
-    let
-      open HolKernel
-      fun issusp_hyp t =
-          let
-            val (fx,_) = dest_comb t
-            val (sl_c, lnm) = dest_comb fx
-            val {Thy,Name,...} = dest_thy_const sl_c
-          in
-            Thy = "marker" andalso Name = "suspendlabel" andalso
-            is_var lnm
-          end handle HOL_ERR _ => false
+(* If t = `suspendlabel <lab> g` for a variable <lab>, return SOME <lab>. *)
+local open HolKernel in
+fun slab_lab_var t =
+    let val (fx, _) = dest_comb t
+        val (sl_c, lnm) = dest_comb fx
+        val {Thy, Name, ...} = dest_thy_const sl_c
     in
-      isSome (HOLset.find issusp_hyp (hypset th))
-    end
+      if Thy = "marker" andalso Name = "suspendlabel" andalso is_var lnm
+      then SOME lnm else NONE
+    end handle HOL_ERR _ => NONE
+end
 
-(* The label variable's name encodes a closure-variable count in the
-   format "N name". Decode to extract the user-visible name and count. *)
+fun has_suspended_subgoals th =
+    isSome (HOLset.find (isSome o slab_lab_var) (Thm.hypset th))
+
+(* The label variable's name encodes the closure-variable count and
+   the user-visible label, and -- for slabs that have been stamped at
+   save-time -- the owning theorem (thy, name).  Two formats:
+
+   Legacy: "N name"
+        N is the closure-variable count, then a single space, then
+        the user's label.
+
+   Owner-stamped: "Nthythmnamename"
+        Same closure count and label, but with the owning (thy, name)
+        embedded between the count and the label, delimited by SOH
+        (ASCII 1).  SOH never appears in HOL identifiers or normal
+        labels, so it's a safe in-band marker. *)
+val owner_sep = "\^A"
+
+fun encode_label (nm, n) = Int.toString n ^ " " ^ nm
+
+fun encode_label_owned ((thy, thmname), nm, n) =
+    Int.toString n ^ owner_sep ^ thy ^ owner_sep ^ thmname ^ owner_sep ^ nm
+
 fun decode_suspend_label s =
-    let val (prefix, rest) =
-            Substring.splitl (fn c => c <> #" ") (Substring.full s)
-    in
-      if Substring.isEmpty rest then (s, 0)
-      else case Int.fromString (Substring.string prefix) of
-               SOME n => (Substring.string (Substring.triml 1 rest), n)
-             | NONE => (s, 0)
-    end
+    case String.fields (fn c => c = #"\^A") s of
+        [n_str, thy, thmname, label] =>
+          (case Int.fromString n_str of
+               SOME n => (label, n, SOME (thy, thmname))
+             | NONE => (s, 0, NONE))
+      | _ =>
+          let val (prefix, rest) =
+                  Substring.splitl (fn c => c <> #" ") (Substring.full s)
+          in
+            if Substring.isEmpty rest then (s, 0, NONE)
+            else case Int.fromString (Substring.string prefix) of
+                     SOME n =>
+                       (Substring.string (Substring.triml 1 rest), n, NONE)
+                   | NONE => (s, 0, NONE)
+          end
 
 fun dest_suspended t =
     let
@@ -182,6 +206,34 @@ fun printable_keys nms =
             A)
         ctab
         []
+    end
+
+(* Rewrite each unstamped suspendlabel hypothesis of th so its label
+   variable encodes the owning (thy, name).  Slabs that already carry
+   a stamp are left untouched. *)
+fun stamp_slab_owners thy thmname th =
+    let
+      open HolKernel
+      fun build h =
+          Option.mapPartial
+            (fn lab_t =>
+                let val (raw, lty) = dest_var lab_t
+                    val (nm, n, owner_opt) = decode_suspend_label raw
+                in
+                  case owner_opt of
+                      SOME _ => NONE
+                    | NONE =>
+                        let val new_raw =
+                                encode_label_owned ((thy, thmname), nm, n)
+                        in
+                          SOME {redex = lab_t,
+                                residue = mk_var (new_raw, lty)}
+                        end
+                end)
+            (slab_lab_var h)
+      val subst = List.mapPartial build (hyp th)
+    in
+      if null subst then th else Thm.INST subst th
     end
 
 local
@@ -245,12 +297,18 @@ in
                       ("Ignoring attributes on suspended theorem " ^ n ^
                        "; apply them at Finalise time instead")
         else ();
-        (* Route the suspended theorem into markerLib's AncestryData
-           store for suspensions rather than saving it to the normal
-           theorem DB.  Finalise will save the clean form under this
-           name when all subgoals have been resumed. *)
-        !suspended_theorem_recorder (n, th);
-        th
+        (* Stamp each fresh slab hypothesis with its owning (thy, n)
+           so that find_res_for can resolve foreign-slab dependencies
+           when this theorem is cited inside another theorem's Resume
+           block.  Then route the (stamped) theorem into markerLib's
+           AncestryData store for suspensions; Finalise will save the
+           clean form under this name when all subgoals have been
+           resumed. *)
+        let val stamped = stamp_slab_owners (current_theory()) n th
+        in
+          !suspended_theorem_recorder (n, stamped);
+          stamped
+        end
       end
 end
 end (* local *)

--- a/src/basicProof/theory_tests/suspCrossThmScript.sml
+++ b/src/basicProof/theory_tests/suspCrossThmScript.sml
@@ -1,20 +1,23 @@
 Theory suspCrossThm[bare]
 
-(* Demonstrates the cross-theorem Resume-dependency limitation
-   tracked at GitHub issue #1963.
+(* Regression test for GitHub issue #1963.
 
    A Resume proof for th1 is allowed to depend on another, still
-   suspended theorem th2: the cycle check from #1960 is scoped
-   to the current parent's slabs, so th2's slab does not match.
-   Finalise th1, however, cannot resolve the foreign slab because
-   find_res_for keys lookups on the current parent's name.
+   suspended theorem th2 (the per-parent cycle check from #1960
+   only rejects dependencies on the current parent's own slabs).
+   Each slab is owner-stamped at save_thm_attrs time, so the
+   assembly loop in Finalise can route foreign-slab lookups
+   through the slab's true owner.
 
-   This test pins down the current behaviour: Resume th1[l1]
-   succeeds, Finalise th2 succeeds, and Finalise th1 then raises
-   a HOL_ERR "No resumption proof found ..." rather than looping
-   (the failure mode #1960 used to exhibit). *)
+   This test exercises that path end to end:
+   - Resume th1[l1] cites th2 (still suspended).
+   - Resume th2[l2] cleanly.
+   - Finalise th2 first; its clean form lands in DB.
+   - Finalise th1 then discharges slab_th2_l2 via the DB-fallback
+     in find_res_for, reconstructing the resumption from th2's
+     clean theorem. *)
 
-Libs HolKernel Parse boolLib markerLib testutils
+Libs HolKernel Parse boolLib markerLib
 
 Theorem th1:
   p ==> T
@@ -28,9 +31,6 @@ Proof
   suspend "l2"
 QED
 
-(* th2 is still suspended at this point; the resume-time check
-   accepts this proof because slab_th2_l2 differs from any of
-   th1's slabs. *)
 Resume th1[l1]:
   MATCH_ACCEPT_TAC th2
 QED
@@ -41,13 +41,4 @@ QED
 
 Finalise th2
 
-val _ = shouldfail {
-  testfn = (fn () =>
-              finalise_suspended_thm (DB_dtype.mkloc(#(FILE),#(LINE),true))
-                                     "th1"),
-  printarg = (fn _ => "Finalise th1 (cross-theorem dependency on th2)"),
-  printresult = (fn _ => "<unexpected success>"),
-  checkexn =
-    check_HOL_ERRexn (fn (_, fnm, msg) =>
-        fnm = "Finalise" andalso String.isSubstring "No resumption" msg)
-} ()
+Finalise th1

--- a/src/marker/markerLib.sig
+++ b/src/marker/markerLib.sig
@@ -126,8 +126,13 @@ sig
       {parent_thy:string, parent_name:string, label:string} -> thm list
 
   val add_suspension_label : string -> thm -> thm
-  val resumption_to_goal : (int * term) list -> (term list * term)
-  val extract_suspended_goal : thm list -> string -> (int * term) list
+  (* Each entry of an ncts list is (lab_t, nclosure, closed_goal),
+     where lab_t is the raw label variable from the corresponding
+     slab hypothesis -- carrying any owner stamp it picked up at
+     save_thm_attrs time. *)
+  val resumption_to_goal : (term * int * term) list -> (term list * term)
+  val extract_suspended_goal :
+      thm list -> string -> (term * int * term) list
   val RESUME_TAC : tactic
 
 end (* sig *)

--- a/src/marker/markerLib.sml
+++ b/src/marker/markerLib.sml
@@ -755,30 +755,35 @@ val (suspimp_t, mk_suspimp, dest_suspimp, is_suspimp) =
     syntax_fns2 "marker" "suspendimp"
 val strip_suspimp = strip_gen_left dest_suspimp
 
-(* The label variable's name encodes both a closure-variable count and the
-   user-supplied label name in the format "N name" where N is the number of
-   universally quantified closure variables wrapping the goal body.
-   The count is always present, even when 0.
-   Decoding is done by decode_suspend_label from boolLib. *)
-fun encode_label (nm, n) = Int.toString n ^ " " ^ nm
+(* Encoder/decoder live in boolLib.  Slabs created by `suspend` start
+   in the unstamped form; save_thm_attrs upgrades them once the
+   containing theorem's name is known. *)
+val encode_label = boolLib.encode_label
+val encode_label_owned = boolLib.encode_label_owned
 
-fun dest_slab t =
+fun dest_slab_full t =
     let val (f, xs) = strip_comb t
         val _ = same_const susp_t f orelse
-                raise ERR "dest_slab" "Term not a suspendlabel"
+                raise ERR "dest_slab_full" "Term not a suspendlabel"
     in
       case xs of
           [labt, arg] =>
             let val (raw, _) = dest_var labt
                                handle HOL_ERR _ =>
-                                      raise ERR "dest_slab"
+                                      raise ERR "dest_slab_full"
                                                 "Label argument invalid"
-                val (nm, nclosure) = boolLib.decode_suspend_label raw
+                val (nm, nclosure, owner) =
+                    boolLib.decode_suspend_label raw
             in
-              (nm, nclosure, arg)
+              {label = nm, closure = nclosure, arg = arg,
+               lab_t = labt, owner = owner}
             end
-        | _ => raise ERR "dest_slab" "Incomplete suspendlabel term"
+        | _ => raise ERR "dest_slab_full" "Incomplete suspendlabel term"
     end
+
+fun dest_slab t =
+    let val {label, closure, arg, ...} = dest_slab_full t
+    in (label, closure, arg) end
 
 (* to keep it tail-recursive, does it "backwards" *)
 fun list_mk_suspimp (asl, g) =
@@ -824,7 +829,10 @@ val labty = slab_def' |> concl |> dest_forall |> #1 |> dest_var |> #2
 fun sDISCH t th =
     CONV_RULE (RATOR_CONV (RATOR_CONV (K simp_def'))) $ DISCH t th
 
-fun add_suspension_label nm th = EQ_MP (SPECL [mk_var(nm, labty), concl th] slab_def') th
+fun add_suspension_label_raw lab_t th =
+    EQ_MP (SPECL [lab_t, concl th] slab_def') th
+fun add_suspension_label nm th =
+    add_suspension_label_raw (mk_var(nm, labty)) th
 
 val elimrc_conv = RATOR_CONV (RATOR_CONV (REWR_CONV resconj_def))
 val elimsi_conv = RATOR_CONV (RATOR_CONV (REWR_CONV suspendimp_def))
@@ -877,10 +885,11 @@ fun strip_n_foralls_vars 0 t = ([], t)
     in (v :: vs, rest)
     end
 
-(* Reconstruct |- suspendlabel (encoded_nm) closed_term from a user-proved
-   theorem th whose conclusion matches body (the term under the closure
-   foralls). *)
-fun prove_suspended0 nm nclosure s_t th tgt =
+(* Reconstruct |- suspendlabel <lab_t> closed_term from a user-proved
+   theorem th whose conclusion matches the body (the term under the
+   closure foralls).  lab_t threads through so owner-stamped slabs
+   reach add_suspension_label_raw with their stamp intact. *)
+fun prove_suspended0 lab_t nclosure s_t th tgt =
     let
       val (closure_vars, body) = strip_n_foralls_vars nclosure s_t
       val result =
@@ -892,31 +901,32 @@ fun prove_suspended0 nm nclosure s_t th tgt =
               itlist sDISCH imps th
             end
       val closed_result = GENL closure_vars result
-      val encoded_nm = encode_label(nm, nclosure)
     in
-      PROVE_HYP (add_suspension_label encoded_nm closed_result) tgt
+      PROVE_HYP (add_suspension_label_raw lab_t closed_result) tgt
     end
 
 (* prove_suspended: handle both single and multi-goal (resconj) cases.
-   ncts is the list of (nclosure, term) pairs from extract_suspended_goal. *)
-fun prove_suspended nm ncts th tgt =
+   ncts is the list of (lab_t, nclosure, term) triples from
+   extract_suspended_goal. *)
+fun prove_suspended ncts th tgt =
   case ncts of
-      [(nc, s_t)] => prove_suspended0 nm nc s_t th tgt
+      [(lab_t, nc, s_t)] => prove_suspended0 lab_t nc s_t th tgt
     | _ =>
       let val ths = RESCONJS th
-          fun foldthis ((nc, s_t), th, tgt) =
-              prove_suspended0 nm nc s_t th tgt
+          fun foldthis ((lab_t, nc, s_t), th, tgt) =
+              prove_suspended0 lab_t nc s_t th tgt
       in
         ListPair.foldl foldthis tgt (ncts, ths)
       end
 
-(* extract_suspended_goal: returns a list of (nclosure, term) pairs,
-   one per hypothesis with the given label. *)
+(* Returns a list of (lab_t, nclosure, closed_goal) triples, one per
+   hypothesis with the given label. *)
 fun extract_suspended_goal thms label =
     let
       fun myhyp t =
-          case total dest_slab t of
-              SOME (nm,nc,t0) => if nm = label then SOME (nc,t0) else NONE
+          case total dest_slab_full t of
+              SOME {label = nm, closure = nc, arg = t0, lab_t, ...} =>
+                if nm = label then SOME (lab_t, nc, t0) else NONE
             | NONE => NONE
       val to_ncts = List.mapPartial myhyp o hyp
     in
@@ -926,21 +936,22 @@ fun extract_suspended_goal thms label =
         | SOME ncts => ncts
     end
 
-(* resumption_to_goal: given the (nclosure, term) list from
+(* resumption_to_goal: given the (lab_t, nclosure, term) list from
    extract_suspended_goal, produce the goal to present to the user.
    For a single hypothesis, strip nclosure foralls then strip suspimps.
    For multiple hypotheses, strip each one's closure foralls individually,
    then combine with resconj. *)
 fun resumption_to_goal ncts =
     case ncts of
-        [(nclosure, r_t)] =>
+        [(_, nclosure, r_t)] =>
           let val (_, body) = strip_n_foralls_vars nclosure r_t
               val (asl0, g) = strip_suspimp body
           in
             (List.rev asl0, g)
           end
       | _ => ([], list_mk_resconj
-                    (map (fn (nc, t) => #2 (strip_n_foralls_vars nc t)) ncts))
+                    (map (fn (_, nc, t) => #2 (strip_n_foralls_vars nc t))
+                         ncts))
 
 
 fun prim_resume (th,label,tac) =
@@ -949,7 +960,7 @@ fun prim_resume (th,label,tac) =
         val sub_th = prove_goal(goal, tac)
     in
       {subresult = sub_th,
-       updated_main = prove_suspended label ncts sub_th th}
+       updated_main = prove_suspended ncts sub_th th}
     end
 
 (* ----------------------------------------------------------------------
@@ -1203,9 +1214,9 @@ fun find_parent nm : (parent_source * string * thm) option =
 (* Build |- suspendlabel "lab" G_i theorems for each matching
    hypothesis, reusing the closure-reconstruction logic of
    prove_suspended0. *)
-fun build_suspendlabel_thms label_nm (ncts, sub_th) =
+fun build_suspendlabel_thms (ncts, sub_th) =
     let
-      fun mk_susp_thm (nc, s_t) th =
+      fun mk_susp_thm (lab_t, nc, s_t) th =
         let
           val (closure_vars, body) = strip_n_foralls_vars nc s_t
           val result =
@@ -1214,9 +1225,8 @@ fun build_suspendlabel_thms label_nm (ncts, sub_th) =
                 let val (imps, _) = strip_suspimp body
                 in itlist sDISCH imps th end
           val closed_result = GENL closure_vars result
-          val encoded_nm = encode_label (label_nm, nc)
         in
-          add_suspension_label encoded_nm closed_result
+          add_suspension_label_raw lab_t closed_result
         end
     in
       case ncts of
@@ -1269,21 +1279,31 @@ fun resume {suspension_name, label_name} tac =
                               \create a cycle at Finalise.")
                          else ())
                        (List.filter (can dest_slab) (hyp sub_th))
-                 (* Build |- suspendlabel "lab" G_i for each hyp i and
-                    record each as its own resumption delta. *)
+                 (* Build |- suspendlabel <lab_t> G_i for each hyp i
+                    and record each as its own resumption delta. *)
                  val susp_thms =
-                     build_suspendlabel_thms
-                         label_name (ncts, sub_th)
+                     build_suspendlabel_thms (ncts, sub_th)
+                 (* For each slab hyp h that rth depends on, index rth
+                    under h's *owner* — read from h's stamp if present,
+                    otherwise fall back to the current Resume's parent
+                    (the suspNested case, where h was introduced by a
+                    suspend tactic inside this very Resume body). *)
                  fun record_suspend_resumptions rth =
-                     List.app (fn h =>
-                                  case total dest_slab h of
-                                      SOME (nm, _, _) =>
-                                      record_resumption_delta
-                                          (AddResumption
-                                               ((parent_thy, suspension_name, nm),
-                                                rth))
-                                    | NONE => ())
-                              (hyp rth)
+                     List.app
+                       (fn h =>
+                         case total dest_slab_full h of
+                             SOME {label = nm, owner, ...} =>
+                               let val (kt, kn) =
+                                       case owner of
+                                           SOME p => p
+                                         | NONE =>
+                                             (parent_thy, suspension_name)
+                               in
+                                 record_resumption_delta
+                                   (AddResumption ((kt, kn, nm), rth))
+                               end
+                           | NONE => ())
+                       (hyp rth)
                  val _ =
                      List.app
                          (fn rth => (
@@ -1334,32 +1354,60 @@ fun assemble_finalised parent_thy parent_nm parent_th =
       val susp_hyps =
           List.filter (Option.isSome o total dest_slab) (hyp parent_th)
       fun find_res_for hyp_t =
-          case total dest_slab hyp_t of
-              NONE => raise ERR "Finalise"
-                        "internal: non-suspendlabel hyp reached assembly"
-            | SOME (label, _, _) =>
-              let
-                val key = (parent_thy, parent_nm, label)
-                val candidates =
-                    case ResTab.lookup (get_res_global ()) key of
-                        NONE => []
-                      | SOME ths => ths
-                (* Pick the candidate whose conclusion aconv-matches
-                   the parent's hyp.  Multiple candidates can exist
-                   when the same label has multiple hypotheses (the
-                   resconj case): each hyp has a distinct term shape
-                   so one candidate will match. *)
-                val pick =
-                    List.find (fn rth => aconv (concl rth) hyp_t)
-                              candidates
-              in
-                case pick of
-                    SOME rth => rth
-                  | NONE =>
+          let
+            val {label, closure, arg = closed_goal, lab_t, owner} =
+                case total dest_slab_full hyp_t of
+                    SOME r => r
+                  | NONE => raise ERR "Finalise"
+                              "internal: non-suspendlabel hyp reached \
+                              \assembly"
+            (* Owner-stamped slabs (#1963) route through the slab's
+               own owner so foreign-slab dependencies resolve even
+               though we're inside a different theorem's assembly. *)
+            val (lookup_thy, lookup_nm) =
+                Option.getOpt (owner, (parent_thy, parent_nm))
+            val candidates =
+                case ResTab.lookup (get_res_global ())
+                                   (lookup_thy, lookup_nm, label) of
+                    NONE => []
+                  | SOME ths => ths
+            val pick =
+                List.find (fn rth => aconv (concl rth) hyp_t) candidates
+            (* If no in-store proof, the owner has already been
+               Finalised and its resumption entries GC'd; reconstruct
+               by re-attaching the suspension label to the closed form
+               of the clean DB theorem. *)
+            fun reconstruct_from_clean (owner_thy, owner_nm) =
+                case DB.lookup {Thy = owner_thy, Name = owner_nm} of
+                    NONE =>
                       raise ERR "Finalise"
-                        ("No resumption proof found for label " ^ label ^
-                         " of " ^ parent_thy ^ "$" ^ parent_nm)
-              end
+                        ("No resumption proof or finalised theorem \
+                         \found for " ^ owner_thy ^ "$" ^ owner_nm ^
+                         " (label " ^ label ^ ")")
+                  | SOME (clean_th, _) =>
+                    let val (vars, body) =
+                            strip_n_foralls_vars closure closed_goal
+                    in
+                      if aconv body (concl clean_th) then
+                        add_suspension_label_raw lab_t
+                          (GENL vars clean_th)
+                      else
+                        raise ERR "Finalise"
+                          ("Finalised theorem " ^ owner_thy ^ "$" ^
+                           owner_nm ^ " no longer matches its original \
+                           \suspension goal for label " ^ label ^
+                           "; has it been re-proved with a different \
+                           \statement?")
+                    end
+          in
+            case (pick, owner) of
+                (SOME rth, _) => rth
+              | (NONE, SOME p) => reconstruct_from_clean p
+              | (NONE, NONE) =>
+                  raise ERR "Finalise"
+                    ("No resumption proof found for label " ^ label ^
+                     " of " ^ parent_thy ^ "$" ^ parent_nm)
+          end
       fun aux current_th current_susp_hyps = let
           val founds = map find_res_for current_susp_hyps
           val finalised = List.foldl (fn (rth, acc) => PROVE_HYP rth acc)


### PR DESCRIPTION
## Summary
- A Resume proof that cites another still-suspended theorem inherits its `suspendlabel` hypotheses. `assemble_finalised` previously keyed lookups on the current parent's name, so those foreign slabs raised `"No resumption proof found ..."` at Finalise time.
- `save_thm_attrs` now stamps each fresh slab on a suspended theorem with its owning `(thy, name)` by encoding them into the label variable's name (delimited by SOH). `find_res_for` decodes the owner and routes the lookup accordingly, with a DB-fallback that reconstructs an rth from the clean theorem when the owner has already been Finalised.

## Test plan
- [x] New regression test `src/basicProof/theory_tests/suspCrossThmScript.sml` exercises the end-to-end case: `Resume th1[l1]` cites suspended `th2`, `Finalise th2` first, `Finalise th1` second.
- [x] `bin/build -t --seq=tools/sequences/upto-parallel` passes; existing `suspTest`, `suspCycle`, `suspNested`, `suspFast`, `suspRerun`, `suspCross{A,B}`, `suspSib{A,B,C,D}` all still pass.

Closes #1963

🤖 Generated with [Claude Code](https://claude.com/claude-code)
