### PR TITLE
Holmake: implement $(info ...), $(warning ...), $(error ...)

### DIFF
--- a/Manual/Description/misc.smd
+++ b/Manual/Description/misc.smd
@@ -619,9 +619,14 @@ at all with the `--holmakefile` command-line option.  The
 combination of `Holmake` and a make-file is supposed to behave as
 much as possible like a standard implementation of `make`.
 
-A make-file consists of two types of entries, variable definitions
-and rules.  Outside of these entries, white-space is insignificant,
-but newline and `TAB` characters are very significant within them.
+A make-file consists of three kinds of entries: variable
+definitions, rules, and *top-level function-call expressions*.
+A top-level function-call expression is a line whose first
+non-whitespace character is `$` (e.g. `$(info hello)`); the line
+is expanded for its side effects and its result is discarded
+(reported as an error if it is non-empty).  Outside of these
+entries, white-space is insignificant, but newline and `TAB`
+characters are very significant within them.
 Comments can be started with hash (`#`) characters and last until
 the end of the line.  Quoting is generally done with use of the
 back-slash (`\`) character.  In particular, a backslash-newline
@@ -882,9 +887,11 @@ Some target names for rules are handled specially by `Holmake`:
 `Holmake` supports some simple functions for manipulating text.
 All functions are written with the general form
 `$(`*function-name* *arg*${}_1$`,`*arg*${}_2$`...,`*arg*${}_n$`)`.
-Arguments can not include commas (use variable references to
-variables whose value are commas instead), but can otherwise be
-arbitrary text.
+Arguments to most functions cannot include commas: use a variable
+reference to a variable whose value is a comma instead.  The
+exceptions are `$(info)`, `$(warning)` and `$(error)`, which rejoin
+their arguments with literal commas before emitting them.
+Otherwise, arguments can be arbitrary text.
 
 **`$(dprot arg)`** quotes (or "protects") the space characters
 that occur in a string so that the string will be treated as a
@@ -903,6 +910,16 @@ includes spaces, then this function can be used to quote them for
 `Holmake`'s benefit.  Note that the `dprot` function does *not*
 do the same thing as `protect` on either Unix or Windows systems.
 
+**`$(error msg)`**
+\index{error@\texttt{error}!Holmake function@\texttt{Holmake} function}
+(a GNU `make` compatibility function) writes
+`<file>:<line>: *** <msg>.  Stop.`
+to standard error and aborts `Holmake` with a non-zero exit
+status.  The reported location is the *use* site — i.e. for
+`X = $(error oops)`, the message points at the line that
+references `$(X)`, not the line that defined `X`.  (GNU `make`
+reports the definition site instead.)
+
 **`$(findstring arg1,arg2)`** checks if `arg1` occurs in (is a
 sub-string of) `arg2`.  If it does so occur, the result is
 `arg1`, otherwise the result is the empty string.
@@ -910,6 +927,13 @@ sub-string of) `arg2`.  If it does so occur, the result is
 **`$(if arg1,arg2,arg3)`** examines `arg1`.  If it is the empty
 string, then the value of the whole is equal to the value of
 `arg3`.  Otherwise, the value is that of `arg2`.
+
+**`$(info msg)`**
+\index{info@\texttt{info}!Holmake function@\texttt{Holmake} function}
+(a GNU `make` compatibility function) writes `msg` followed by a
+newline to standard output.  The expansion of the call itself is
+the empty string.  Unlike `$(warning)` and `$(error)`, no
+`<file>:<line>:` prefix is added.
 
 **`$(patsubst arg1,arg2,text)`** splits `text` into component
 words, and then transforms each word by attempting to see if it
@@ -952,6 +976,15 @@ in `text` with `arg2`.
 produces a (moderately complicated) shell command line that
 behaves like `arg1 | tee arg2`, but whose exit code is `arg1`'s
 rather than `tee`'s.
+
+**`$(warning msg)`**
+\index{warning@\texttt{warning}!Holmake function@\texttt{Holmake} function}
+(a GNU `make` compatibility function) writes
+`<file>:<line>: <msg>`
+followed by a newline to standard error.  The expansion of the
+call itself is the empty string.  As with `$(error)`, the
+location reported is the *use* site rather than the definition
+site.
 
 **`$(which arg)`** is replaced by the full path to an executable
 and readable occurrence of a file called `arg` within a directory

--- a/tools/Holmake/core/Holmake.sml
+++ b/tools/Holmake/core/Holmake.sml
@@ -44,6 +44,10 @@ fun main() = let
 val execname = Path.file (CommandLine.name())
 fun warn s = stdErr_out (execname^": "^s^"\n")
 fun die s = (warn s; Process.exit Process.failure)
+(* like die, but without the "Holmake:" prefix: $(error ...) and other
+   GNU-make-style abort messages already carry their own "file:line:"
+   prefix and shouldn't be re-tagged. *)
+fun die_raw s = (stdErr_out (s ^ "\n"); Process.exit Process.failure)
 
 fun is_src_dir hmd =
     let val s = nice_dir (hmdir.pretty_dir hmd)
@@ -222,7 +226,8 @@ local
               ReadHMF.diagread {warn=warn0,die=die,info=info0}
                                "Holmakefile"
                                (extend_with_cline_vars (read_holpathdb()))
-              handle Fail s =>
+              handle internal_functions.HolmakeError s => die_raw s
+                   | Fail s =>
                      (die ("Bad Holmakefile in " ^ d ^ ": " ^ s);
                       (base,Binarymap.mkDict String.compare,
                        empty_patrules,NONE))
@@ -1453,14 +1458,16 @@ in
       SOME thyname => let
         open Process
         val result = do_cachekey thyname
-            handle Fail s => die ("Fail exception: "^s^"\n")
+            handle internal_functions.HolmakeError s => die_raw s
+                 | Fail s => die ("Fail exception: "^s^"\n")
       in
         exit result
       end
     | NONE => let
       open Process
       val result = work()
-          handle Fail s => die ("Fail exception: "^s^"\n")
+          handle internal_functions.HolmakeError s => die_raw s
+               | Fail s => die ("Fail exception: "^s^"\n")
     in
       exit result
     end

--- a/tools/Holmake/hmf/Holmake_types.sig
+++ b/tools/Holmake/hmf/Holmake_types.sig
@@ -25,6 +25,8 @@ val env_fold : (string -> quotation -> 'b -> 'b) -> env -> 'b -> 'b
 val to_token : env -> pretoken -> token
 
 val perform_substitution : env -> quotation -> string
+val perform_substitution_at : internal_functions.loc option ->
+                              env -> quotation -> string
 
 val tokenize : string -> string list
 val dequote : string -> string

--- a/tools/Holmake/hmf/Holmake_types.sml
+++ b/tools/Holmake/hmf/Holmake_types.sml
@@ -258,7 +258,7 @@ in
   recurse 0 0 0 []
 end
 
-fun perform_substitution env q = let
+fun perform_substitution_at loc env q = let
   open Substring
   fun envfn s =
       case Binarymap.peek(env, s) of
@@ -287,7 +287,7 @@ fun perform_substitution env q = let
                                  (dropl Char.isSpace
                                         (dropr Char.isSpace spc_rest))
                 in
-                  [LIT (function_call (fnname, args, eval))]
+                  [LIT (function_call (fnname, args, eval, loc))]
                 end
               else let
                   val varname = eval ss
@@ -304,6 +304,8 @@ fun perform_substitution env q = let
 in
   finisher (recurse [] q)
 end
+
+val perform_substitution = perform_substitution_at NONE
 
 fun dequote s = let
   open Substring

--- a/tools/Holmake/hmf/ReadHMF.sml
+++ b/tools/Holmake/hmf/ReadHMF.sml
@@ -270,8 +270,24 @@ in
           if c1 = #"\t" then error b "TAB starts an unattached command"
           else
             case first_special s' of
-                NONE => error b ("Unrecognised character: \""^
-                                 String.toString (str c1) ^ "\"")
+                NONE =>
+                  if c1 = #"$" then
+                    (* bare top-level function call (e.g. $(info ...));
+                       expand for its side effects and discard the result.
+                       Anything non-blank after expansion is a typo. *)
+                    let
+                      val txt = strip_trailing_comment s'
+                      val q = extract_normal_quotation (Substring.full txt)
+                      val result = substitute b env q
+                    in
+                      if CharVector.all Char.isSpace result then
+                        process_line env (condstate, advance b)
+                      else
+                        error b ("Top-level expression has non-empty \
+                                 \expansion: \"" ^ result ^ "\"")
+                    end
+                  else error b ("Unrecognised character: \""^
+                                String.toString (str c1) ^ "\"")
               | SOME "=" => ((condstate, advance b),
                               DEFN (strip_trailing_comment s))
               | SOME "+=" => ((condstate, advance b),

--- a/tools/Holmake/hmf/ReadHMF.sml
+++ b/tools/Holmake/hmf/ReadHMF.sml
@@ -57,6 +57,11 @@ fun advance (b as B r) =
 fun error (B r) s =
     raise Fail (#name r ^":"^Int.toString (#lnum r)^": "^s)
 
+fun bufloc (B r) : internal_functions.loc option =
+    SOME {file = #name r, line = #lnum r}
+
+fun substitute b env q = perform_substitution_at (bufloc b) env q
+
 fun strip_leading_wspace s = let
   open Substring
   val ss = full s
@@ -137,7 +142,7 @@ fun evaluate_cond b env s =
             else (true, 5, "ifdef")
         val s' = strip_leading_wspace (String.extract(s, sz, NONE))
         val q = extract_normal_quotation (Substring.full s')
-        val s2 = perform_substitution env q
+        val s2 = substitute b env q
       in
         case String.tokens Char.isSpace s2 of
           [s] => (case lookup env s of
@@ -177,7 +182,7 @@ fun evaluate_cond b env s =
               end
         val (q1, q2) = (extract_normal_quotation (ss arg1),
                         extract_normal_quotation (ss arg2))
-        val (s1, s2) = (perform_substitution env q1, perform_substitution env q2)
+        val (s1, s2) = (substitute b env q1, substitute b env q2)
       in
         SOME ((s1 = s2) = sense)
       end

--- a/tools/Holmake/hmf/internal_functions.sig
+++ b/tools/Holmake/hmf/internal_functions.sig
@@ -1,6 +1,10 @@
 signature internal_functions =
 sig
 
+  exception HolmakeError of string
+
+  type loc = {file : string, line : int}
+
   val subst : (string * string * string) -> string
   val pcsubst : (string * string) -> string
   val patsubst : (string * string * string) -> string
@@ -12,7 +16,8 @@ sig
   val which : string -> string
   val function_call : (string *
                        Substring.substring list *
-                       (Substring.substring -> string)) -> string
+                       (Substring.substring -> string) *
+                       loc option) -> string
   val hol2fs : string -> string
 
 end
@@ -65,11 +70,22 @@ end
    that match are returned. If the pattern doesn't match any files,
    the string is returned as is.
 
-   [function_call(fnname, args, eval)] evaluates the internal function
+   [function_call(fnname, args, eval, loc)] evaluates the internal function
    fnname when applied to arguments args.  These args are not
    evaluated to strings to allow for functions (like if) that don't
    necessarily look at all of their arguments.  Evaluation is provided
-   by the eval function.
+   by the eval function.  The optional loc records the file and line at
+   which the function call appears, and is used by the GNU make
+   compatibility functions info/warning/error to prefix their messages.
+   Note that this is the use site rather than the definition site of the
+   variable in which the call appears (so immediately-expanded uses get
+   the location of the assignment, while deferred uses get the location
+   where the variable is mentioned).
+
+   [HolmakeError msg] is raised by $(error ...).  It is caught at
+   Holmake's top level rather than going through the generic Fail
+   handler so that abort messages keep their bare "file:line: ***"
+   prefix.
 
    [hol2fs s] converts "HOL filename" s to a filename that will actually
    work on the machine.

--- a/tools/Holmake/hmf/internal_functions.sml
+++ b/tools/Holmake/hmf/internal_functions.sml
@@ -2,6 +2,15 @@ structure internal_functions :> internal_functions =
 struct
 
 structure FileSys = HOLFileSys
+
+exception HolmakeError of string
+
+type loc = {file : string, line : int}
+
+fun loc_prefix (NONE : loc option) = ""
+  | loc_prefix (SOME {file,line}) =
+      file ^ ":" ^ Int.toString line ^ ": "
+
 fun member e [] = false
   | member e (h::t) = e = h orelse member e t
 
@@ -312,8 +321,9 @@ fun hol2fs s =
         NONE => s
       | SOME {fullfile,...} => fullfile
 
-fun function_call (fnname, args, eval) = let
+fun function_call (fnname, args, eval, loc) = let
   open Substring
+  fun rejoin args = String.concatWith "," (map eval args)
 in
   case fnname of
     "if" =>
@@ -403,6 +413,15 @@ in
                   in
                     hol2fs (hd args_evalled)
                   end
+  | "info" =>
+      (TextIO.print (rejoin args ^ "\n"); "")
+  | "warning" =>
+      (TextIO.output (TextIO.stdErr,
+                      loc_prefix loc ^ rejoin args ^ "\n");
+       TextIO.flushOut TextIO.stdErr;
+       "")
+  | "error" =>
+      raise HolmakeError (loc_prefix loc ^ "*** " ^ rejoin args ^ ".  Stop.")
   | _ => raise Fail ("Unknown function name: "^fnname)
 end
 

--- a/tools/Holmake/tests/gh569_error/Holmakefile
+++ b/tools/Holmake/tests/gh569_error/Holmakefile
@@ -1,0 +1,4 @@
+gh569_error.log: doit.sh testd/Holmakefile
+	$(tee ./doit.sh $(protect $(HOLDIR)/bin/hol.state0) $(protect $(HOLDIR)/bin/Holmake), $@)
+
+EXTRA_CLEANS = gh569_error.log testd/stdout.txt testd/stderr.txt

--- a/tools/Holmake/tests/gh569_error/Holmakefile
+++ b/tools/Holmake/tests/gh569_error/Holmakefile
@@ -1,4 +1,8 @@
+ifdef POLY
+HOLMAKE_OPTS = --holstate=$(protect $(HOLDIR)/bin/hol.state0)
+endif
+
 gh569_error.log: doit.sh testd/Holmakefile
-	$(tee ./doit.sh $(protect $(HOLDIR)/bin/hol.state0) $(protect $(HOLDIR)/bin/Holmake), $@)
+	$(tee ./doit.sh $(protect $(HOLDIR)/bin/Holmake) $(HOLMAKE_OPTS), $@)
 
 EXTRA_CLEANS = gh569_error.log testd/stdout.txt testd/stderr.txt

--- a/tools/Holmake/tests/gh569_error/doit.sh
+++ b/tools/Holmake/tests/gh569_error/doit.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Driver: testd/Holmakefile invokes $(error stop now); we check that
+# Holmake exits non-zero and emits the GNU-make-style abort line.
+
+set -u
+
+if [ "$#" -ne 2 ]
+then
+    echo "Usage:"
+    echo "  $0 holstate holmake" 1>&2
+    exit 2
+fi
+
+holstate=$1
+holmake=$2
+
+cd testd
+
+"$holmake" --holstate="$holstate" --no_overlay \
+    1>stdout.txt 2>stderr.txt
+rc=$?
+
+if [ $rc -eq 0 ]
+then
+    echo "Holmake unexpectedly succeeded (rc=0)" 1>&2
+    cat stderr.txt 1>&2
+    exit 1
+fi
+
+if ! grep -q -E '/Holmakefile:[0-9]+: \*\*\* stop now\.  Stop\.$' \
+                stderr.txt ; then
+    echo "FAIL: expected $(error ...) message not seen in stderr:" 1>&2
+    cat stderr.txt 1>&2
+    exit 1
+fi
+
+exit 0

--- a/tools/Holmake/tests/gh569_error/doit.sh
+++ b/tools/Holmake/tests/gh569_error/doit.sh
@@ -4,20 +4,19 @@
 
 set -u
 
-if [ "$#" -ne 2 ]
+if [ "$#" -lt 1 ]
 then
     echo "Usage:"
-    echo "  $0 holstate holmake" 1>&2
+    echo "  $0 holmake [extra-holmake-args...]" 1>&2
     exit 2
 fi
 
-holstate=$1
-holmake=$2
+holmake=$1
+shift
 
 cd testd
 
-"$holmake" --holstate="$holstate" --no_overlay \
-    1>stdout.txt 2>stderr.txt
+"$holmake" "$@" --no_overlay 1>stdout.txt 2>stderr.txt
 rc=$?
 
 if [ $rc -eq 0 ]
@@ -29,7 +28,7 @@ fi
 
 if ! grep -q -E '/Holmakefile:[0-9]+: \*\*\* stop now\.  Stop\.$' \
                 stderr.txt ; then
-    echo "FAIL: expected $(error ...) message not seen in stderr:" 1>&2
+    echo 'FAIL: expected $(error ...) message not seen in stderr:' 1>&2
     cat stderr.txt 1>&2
     exit 1
 fi

--- a/tools/Holmake/tests/gh569_error/testd/Holmakefile
+++ b/tools/Holmake/tests/gh569_error/testd/Holmakefile
@@ -1,0 +1,6 @@
+ifeq ($(error stop now),anything)
+endif
+
+.PHONY: all
+all:
+	@true

--- a/tools/Holmake/tests/gh569_error/testd/Holmakefile
+++ b/tools/Holmake/tests/gh569_error/testd/Holmakefile
@@ -1,5 +1,4 @@
-ifeq ($(error stop now),anything)
-endif
+$(error stop now)
 
 .PHONY: all
 all:

--- a/tools/Holmake/tests/gh569_info/Holmakefile
+++ b/tools/Holmake/tests/gh569_info/Holmakefile
@@ -1,0 +1,4 @@
+gh569_info.log: doit.sh testd/Holmakefile
+	$(tee ./doit.sh $(protect $(HOLDIR)/bin/hol.state0) $(protect $(HOLDIR)/bin/Holmake), $@)
+
+EXTRA_CLEANS = gh569_info.log testd/stdout.txt testd/stderr.txt

--- a/tools/Holmake/tests/gh569_info/Holmakefile
+++ b/tools/Holmake/tests/gh569_info/Holmakefile
@@ -1,4 +1,8 @@
+ifdef POLY
+HOLMAKE_OPTS = --holstate=$(protect $(HOLDIR)/bin/hol.state0)
+endif
+
 gh569_info.log: doit.sh testd/Holmakefile
-	$(tee ./doit.sh $(protect $(HOLDIR)/bin/hol.state0) $(protect $(HOLDIR)/bin/Holmake), $@)
+	$(tee ./doit.sh $(protect $(HOLDIR)/bin/Holmake) $(HOLMAKE_OPTS), $@)
 
 EXTRA_CLEANS = gh569_info.log testd/stdout.txt testd/stderr.txt

--- a/tools/Holmake/tests/gh569_info/doit.sh
+++ b/tools/Holmake/tests/gh569_info/doit.sh
@@ -6,20 +6,19 @@
 
 set -u
 
-if [ "$#" -ne 2 ]
+if [ "$#" -lt 1 ]
 then
     echo "Usage:"
-    echo "  $0 holstate holmake" 1>&2
+    echo "  $0 holmake [extra-holmake-args...]" 1>&2
     exit 2
 fi
 
-holstate=$1
-holmake=$2
+holmake=$1
+shift
 
 cd testd
 
-"$holmake" --holstate="$holstate" --no_overlay \
-    1>stdout.txt 2>stderr.txt
+"$holmake" "$@" --no_overlay 1>stdout.txt 2>stderr.txt
 rc=$?
 
 if [ $rc -ne 0 ]

--- a/tools/Holmake/tests/gh569_info/doit.sh
+++ b/tools/Holmake/tests/gh569_info/doit.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Driver for gh569_info.  Runs Holmake in testd/, captures stdout and stderr
+# separately, then checks for expected substrings.  The HOL Holmakefile is
+# read more than once (for INCLUDES discovery and again to build), so we
+# check for presence/absence rather than insisting on an exact line count.
+
+set -u
+
+if [ "$#" -ne 2 ]
+then
+    echo "Usage:"
+    echo "  $0 holstate holmake" 1>&2
+    exit 2
+fi
+
+holstate=$1
+holmake=$2
+
+cd testd
+
+"$holmake" --holstate="$holstate" --no_overlay \
+    1>stdout.txt 2>stderr.txt
+rc=$?
+
+if [ $rc -ne 0 ]
+then
+    echo "Holmake failed (exit $rc)"
+    cat stderr.txt 1>&2
+    exit 1
+fi
+
+check_present () {
+    local stream=$1 pattern=$2 file=$3
+    if ! grep -q -E "$pattern" "$file" ; then
+        echo "FAIL ($stream): expected /$pattern/ not seen in $file" 1>&2
+        exit 1
+    fi
+}
+
+check_absent () {
+    local stream=$1 pattern=$2 file=$3
+    if grep -q -E "$pattern" "$file" ; then
+        echo "FAIL ($stream): unexpected /$pattern/ in $file" 1>&2
+        exit 1
+    fi
+}
+
+check_present stdout '^top-level-info$'       stdout.txt
+check_present stdout '^chosen-branch$'        stdout.txt
+check_present stdout '^one,two,three$'        stdout.txt
+
+check_absent  stdout 'DO-NOT-FIRE'            stdout.txt
+check_absent  stdout 'wrong-branch'           stdout.txt
+
+check_present stderr '/Holmakefile:[0-9]+: top-level-warning$' stderr.txt
+check_absent  stderr 'DO-NOT-FIRE'            stderr.txt
+
+exit 0

--- a/tools/Holmake/tests/gh569_info/testd/Holmakefile
+++ b/tools/Holmake/tests/gh569_info/testd/Holmakefile
@@ -1,0 +1,21 @@
+# Holmake's parser rejects a bare function-call line at the top level, so
+# calls go via ifeq.  Holmake's ifeq arg-splitter is not paren-aware, so
+# function calls with more than one argument go via an intermediate
+# variable, which is expanded by argtokenize (which IS paren-aware).
+
+ifeq ($(info top-level-info)$(warning top-level-warning),)
+endif
+
+LAZY = $(info DO-NOT-FIRE)
+
+IFRESULT = $(if 1,$(info chosen-branch),$(info wrong-branch))
+ifeq ($(IFRESULT),)
+endif
+
+COMMA_VAR = $(info one,two,three)
+ifeq ($(COMMA_VAR),)
+endif
+
+.PHONY: all
+all:
+	@true

--- a/tools/Holmake/tests/gh569_info/testd/Holmakefile
+++ b/tools/Holmake/tests/gh569_info/testd/Holmakefile
@@ -1,20 +1,14 @@
-# Holmake's parser rejects a bare function-call line at the top level, so
-# calls go via ifeq.  Holmake's ifeq arg-splitter is not paren-aware, so
-# function calls with more than one argument go via an intermediate
-# variable, which is expanded by argtokenize (which IS paren-aware).
+$(info top-level-info)
+$(warning top-level-warning)
 
-ifeq ($(info top-level-info)$(warning top-level-warning),)
-endif
-
+# LAZY is never referenced, so its $(info) must not fire.
 LAZY = $(info DO-NOT-FIRE)
 
-IFRESULT = $(if 1,$(info chosen-branch),$(info wrong-branch))
-ifeq ($(IFRESULT),)
-endif
+# $(if) only evaluates the chosen branch.
+$(if 1,$(info chosen-branch),$(info wrong-branch))
 
-COMMA_VAR = $(info one,two,three)
-ifeq ($(COMMA_VAR),)
-endif
+# Commas inside a function call are rejoined literally on output.
+$(info one,two,three)
 
 .PHONY: all
 all:

--- a/tools/Holmake/tests/parallel_tests/Holmakefile
+++ b/tools/Holmake/tests/parallel_tests/Holmakefile
@@ -28,6 +28,8 @@ DIRNAMES = \
   indepchildren \
   empty_script \
   deps_of_depthys \
+  gh569_info \
+  gh569_error \
   gh604 \
   gh1353 \
   ignore_errors/j1 \


### PR DESCRIPTION
## Summary

- Adds GNU make's three control functions to Holmake: `$(info)`, `$(warning)`, and `$(error)`.
- `$(warning)` and `$(error)` carry a `file:line:` prefix (use site, not definition site, in this first cut).
- `$(error)` raises a dedicated `internal_functions.HolmakeError` exception caught at Holmake's top level, so the abort message keeps its bare `file:line: *** msg.  Stop.` shape.

## Test plan

- [x] `bin/build cleanAll && bin/build --no-cache -t` passes (pre-existing parallel_tests flakes in `ignore_errors/j1`, `ignore_errors/j4`, `time-logging/goodlog`, `issue1903` are unrelated).
- [x] New tests under `tools/Holmake/tests/gh569_info` and `tools/Holmake/tests/gh569_error` exercise the three functions, lazy `$(if)` evaluation, and multi-arg comma-joining; both pass.

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)