### PR TITLE
Holmake: dump heap on tactic failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *Theory.sml
 *Theory.html
 *Theory.dat
+*.dumpedheap
 !Theory.sig
 !Theory.sml
 *.uo

--- a/Manual/Description/misc.smd
+++ b/Manual/Description/misc.smd
@@ -529,7 +529,10 @@ absence of the `-k` flag, this failure to build a theory may
 cause `Holmake` to also exit (with a failure).  With the `--noqof`
 option, `Holmake` will cause the running script to use `mk_thm`
 to assert the failed goal, allowing the build to continue and
-other theorems to be proved.
+other theorems to be proved.  Either way, the running script
+also writes a Poly/ML heap snapshot so that the failing proof
+can be inspected interactively — see
+Section \ref{sec:holmake-dumpheap} below.
 
 **`--quiet`** Minimise the amount of output produced by `Holmake`.
 Fatal error messages will still be written to the standard error
@@ -555,6 +558,49 @@ thinks it needs to.  This option is implemented by having
 
 `Holmake` should never exit with error messages such as "Uncaught
 exception".  Such behaviour is a bug, please report it!
+
+### Heap dumps on tactic failure
+
+\label{sec:holmake-dumpheap}
+\index{Holmake@\holmake!dumped heaps}
+\index{dumpedheap files}
+
+When a tactic fails inside `store_thm`, `Q.store_thm`, or the
+`Theorem`-`Proof`-`QED` form during a non-interactive `Holmake`
+build, the running script's Poly/ML heap is saved to a file named
+
+```
+   <theory>.<thmname>.dumpedheap
+```
+
+in the script's working directory.  Before the heap is written,
+the proof manager is seeded with the failing goal so that, on
+reload, the failing proof is sitting on the goal stack ready to be
+explored.  Resume with
+
+```
+   bin/hol --holstate=<theory>.<thmname>.dumpedheap
+```
+
+and the standard proof-manager commands (`e`, `b`, `p`, ...) work
+as usual against the original goal.
+
+The dump is produced in both `--qof` and `--noqof` modes:
+
+  - Under `--qof` (the default), the heap is saved and `Holmake`
+    then exits with failure on the first failing proof.
+
+  - Under `--noqof`, the heap is saved, a CHEAT-tagged oracle
+    theorem is substituted for the failing proof, and the build
+    continues.  A script that fails on multiple proofs will
+    therefore leave multiple `.dumpedheap` files behind.
+
+Under `--fast` the tactic is never evaluated, so no dump is
+produced.  The mechanism is also a no-op under Moscow ML, which
+has no equivalent of Poly/ML's `SaveState.saveChild`.
+
+Dumped heaps are not removed automatically; they can be deleted
+freely once the failing proof has been resolved.
 
 ### Using a make-file with `Holmake`
 

--- a/src/1/boolLib.sml
+++ b/src/1/boolLib.sml
@@ -166,6 +166,31 @@ fun get_suspended_names th =
 val suspended_theorem_recorder : (string * thm -> unit) ref =
     ref (fn _ => ())
 
+(* Hook used by the dump-on-failure path below: proofManagerLib loads
+   later in the build than boolLib, so it cannot be referenced
+   statically; instead proofManagerLib installs the real implementation
+   (essentially proofManagerLib.set_goal) into this ref at load time.
+   The hook seeds the proof manager's state so that the dumped heap,
+   when reloaded via "bin/hol --holstate=<file>", presents the failing
+   goal ready for interactive exploration. *)
+val dump_setup_hook : (goal -> unit) ref = ref (fn _ => ())
+
+(* Name of the theorem currently being proved.  store_thm_at sets this
+   immediately before invoking Tactical.prove so that holmakebuild's
+   basic_prover (which only receives a goal, not a name) can construct
+   a sensible dump-file name on the --noqof failure path.  Cleared again
+   after the prove call so that user code invoking Tactical.prove
+   directly doesn't inherit a stale name. *)
+val current_thm_name : string ref = ref ""
+
+(* Counter used by dump_failure_state when no theorem name is in
+   scope (e.g. raw Tactical.prove invocations outside store_thm_at):
+   yields "anon_<N>.dumpedheap" rather than "<thy>..dumpedheap". *)
+local val n = ref 0 in
+  fun next_anon_thm_name () =
+      (n := !n + 1; "anon_" ^ Int.toString (!n))
+end
+
 (* printable_keys: collapse duplicate label names with a count annotation.
    Used when reporting which suspended subgoals remain in a theorem. *)
 fun printable_keys nms =
@@ -259,6 +284,19 @@ end (* local *)
    needs to see the suspension dictionaries).  The parser-level Finalise
    expansion calls markerLib.finalise_suspended_thm directly. *)
 
+(* Seed the proof manager with the failing goal, then write a Poly/ML
+   heap (a no-op under Moscow ML) to <theory>.<name>.dumpedheap in the
+   current directory.  Returns the file name so the caller can quote
+   it in messages. *)
+fun dump_failure_state (name, g) =
+  let val nm = if name = "" then next_anon_thm_name () else name
+      val file = Theory.current_theory() ^ "." ^ nm ^ ".dumpedheap"
+  in
+    (!dump_setup_hook) g;
+    Portable.save_heap file;
+    file
+  end
+
 local
   open Feedback
   fun tac_failure s1 s2 =
@@ -267,12 +305,24 @@ in
 fun store_thm_at loc (n0,t,tac) =
   let val attrblock = ThmAttribute.extract_attributes n0
       val name = #thmname attrblock
+      val _ = current_thm_name := name
       val th = Tactical.prove(t,tac)
                handle HOL_ERR herr =>
-               let val err_mesg = tac_failure name (message_of herr)
-                   val err = HOL_ERR (set_message err_mesg herr)
-               in render_exn
-                    (wrap_exn "boolLib" "store_thm_at" err) end
+               if !Globals.dumpheap_on_failure then
+                 let val file = dump_failure_state (name, ([], t))
+                 in
+                   TextIO.output (TextIO.stdErr,
+                     "Tactic failure proving " ^ Lib.quote name ^
+                     "; heap saved to " ^ file ^
+                     ".\nResume with: bin/hol --holstate=" ^ file ^ "\n");
+                   OS.Process.exit OS.Process.failure
+                 end
+               else
+                 let val err_mesg = tac_failure name (message_of herr)
+                     val err = HOL_ERR (set_message err_mesg herr)
+                 in render_exn
+                      (wrap_exn "boolLib" "store_thm_at" err) end
+      val _ = current_thm_name := ""
   in
     save_thm_attrs loc (attrblock,th)
     handle e => render_exn

--- a/src/1/boolLib.sml
+++ b/src/1/boolLib.sml
@@ -308,7 +308,9 @@ fun store_thm_at loc (n0,t,tac) =
       val _ = current_thm_name := name
       val th = Tactical.prove(t,tac)
                handle HOL_ERR herr =>
-               if !Globals.dumpheap_on_failure then
+               if !Globals.dumpheap_on_failure andalso
+                  not (!Globals.interactive)
+               then
                  let val file = dump_failure_state (name, ([], t))
                  in
                    TextIO.output (TextIO.stdErr,

--- a/src/1/holmake_not_interactive.sml
+++ b/src/1/holmake_not_interactive.sml
@@ -1,1 +1,2 @@
 val _ = Globals.interactive := false;
+val _ = Globals.dumpheap_on_failure := true;

--- a/src/1/holmakebuild.sml
+++ b/src/1/holmakebuild.sml
@@ -13,6 +13,14 @@ local
            ("*** Proof of \n  " ^ Parse.term_to_string (#2 g) ^
             "\n*** failed (used CHEAT).\n")
          ; HOL_MESG (exn_to_string e)
+         ; if !Globals.dumpheap_on_failure then
+             let val file =
+                   boolLib.dump_failure_state (!boolLib.current_thm_name, g)
+             in
+               HOL_MESG ("Heap saved to " ^ file ^
+                         "; resume with: bin/hol --holstate=" ^ file)
+             end
+           else ()
          ; Thm.mk_oracle_thm holmake_tag g)
 in
    val () = Tactical.set_prover basic_prover

--- a/src/1/holmakebuild.sml
+++ b/src/1/holmakebuild.sml
@@ -13,7 +13,9 @@ local
            ("*** Proof of \n  " ^ Parse.term_to_string (#2 g) ^
             "\n*** failed (used CHEAT).\n")
          ; HOL_MESG (exn_to_string e)
-         ; if !Globals.dumpheap_on_failure then
+         ; if !Globals.dumpheap_on_failure andalso
+              not (!Globals.interactive)
+           then
              let val file =
                    boolLib.dump_failure_state (!boolLib.current_thm_name, g)
              in

--- a/src/portableML/Portable.sig
+++ b/src/portableML/Portable.sig
@@ -106,6 +106,10 @@ sig
 
   val unique_tmp_suffix : unit -> string
 
+  (* Save a Poly/ML heap (child of the currently-loaded state) to the
+     given path.  A no-op under Moscow ML. *)
+  val save_heap : string -> unit
+
   val assoc1 : ''a -> (''a * 'b) list -> (''a * 'b) option
   val assoc2 : ''a -> ('b * ''a) list -> ('b * ''a) option
 

--- a/src/portableML/mlton/MLSYSPortable.sml
+++ b/src/portableML/mlton/MLSYSPortable.sml
@@ -51,4 +51,6 @@ fun syncref init =
 fun unique_tmp_suffix () =
   SysWord.toString (Posix.Process.pidToWord (Posix.ProcEnv.getpid ()))
 
+fun save_heap (_:string) = ()
+
 end

--- a/src/portableML/mosml/MLSYSPortable.sml
+++ b/src/portableML/mosml/MLSYSPortable.sml
@@ -54,4 +54,6 @@ fun syncref init =
    tmpName gives us a fresh unique string per call. *)
 fun unique_tmp_suffix () = OS.Path.file (OS.FileSys.tmpName ())
 
+fun save_heap (_:string) = ()
+
 end (* struct *)

--- a/src/portableML/poly/MLSYSPortable.sml
+++ b/src/portableML/poly/MLSYSPortable.sml
@@ -81,4 +81,6 @@ fun syncref init =
 fun unique_tmp_suffix () =
   SysWord.toString (Posix.Process.pidToWord (Posix.ProcEnv.getpid ()))
 
+fun save_heap file = PolyML.SaveState.saveChild (file, 1)
+
 end

--- a/src/prekernel/Globals.sig
+++ b/src/prekernel/Globals.sig
@@ -34,6 +34,7 @@ sig
 
   val interactive             : bool ref
   val print_thy_loads         : bool ref
+  val dumpheap_on_failure     : bool ref
 
   val hol_clock               : Timer.cpu_timer
   val emitMLDir               : string ref

--- a/src/prekernel/Globals.sml
+++ b/src/prekernel/Globals.sml
@@ -152,6 +152,18 @@ val print_thy_loads = ref false
 
 val interactive = ref false
 
+(* ----------------------------------------------------------------------
+    When a tactic fails during a non-interactive Holmake build, dump a
+    Poly/ML heap (via PolyML.SaveState.saveChild on the Poly side; a
+    no-op under Moscow ML) so the user can resume with
+       bin/hol --holstate=<file>
+    and explore the failing proof.  Flipped on by
+    holmake_not_interactive; default false so the interactive REPL is
+    unaffected.
+   ---------------------------------------------------------------------- *)
+
+val dumpheap_on_failure = ref false
+
 val hol_clock = Timer.startCPUTimer ()
 
 (*---------------------------------------------------------------------------*)

--- a/src/proofman/proofManagerLib.sml
+++ b/src/proofman/proofManagerLib.sml
@@ -165,4 +165,10 @@ val std_goal_pp  = Manager.std_goal_pp
 val pp_proof = Manager.pp_proof
 val pp_proofs = Manager.pp_proofs
 
+(* Install the dump-on-failure hook used by boolLib.store_thm_at /
+   holmakebuild.basic_prover: seed the proof manager with the failing
+   goal so the dumped heap, when reloaded, presents that goal ready
+   for interactive exploration. *)
+val _ = boolLib.dump_setup_hook := (fn g => ignore (set_goal g))
+
 end (* proofManagerLib *)

--- a/tools/Holmake/tests/dumpheap/Holmakefile
+++ b/tools/Holmake/tests/dumpheap/Holmakefile
@@ -1,0 +1,11 @@
+ifdef POLY
+
+dumpheap-selftest.log: selftest.exe
+	$(tee ./$<, $@)
+
+selftest.exe: selftest.uo
+	$(HOLMOSMLC) -o $@ $<
+
+EXTRA_CLEANS = dumpheap-selftest.log selftest.exe
+
+endif

--- a/tools/Holmake/tests/dumpheap/selftest.sml
+++ b/tools/Holmake/tests/dumpheap/selftest.sml
@@ -1,0 +1,37 @@
+open testutils
+
+val _ = OS.FileSys.chDir "testdir"
+
+val holmake = "../../../../../bin/Holmake"
+val dumpfile = "failing.bad_thm.dumpedheap"
+
+fun hm extra =
+  OS.Process.system (holmake ^ " --no-cache " ^ extra)
+
+fun safedelete f = (OS.FileSys.remove f) handle OS.SysErr _ => ()
+
+fun cleanAll () =
+  if OS.Process.isSuccess (hm "cleanAll") then ()
+  else die "Holmake cleanAll failed"
+
+(* --- qof (default): build must fail AND leave a dumpedheap file. *)
+val _ = tprint "qof build fails and writes <thy>.<thm>.dumpedheap"
+val _ = cleanAll ()
+val _ = safedelete dumpfile
+val _ = if OS.Process.isSuccess (hm "") then
+          die "expected qof Holmake to fail (theorem proof should not succeed)"
+        else ()
+val _ = if OS.FileSys.access (dumpfile, []) then OK()
+        else die ("dumpedheap file " ^ dumpfile ^ " not produced")
+
+(* --- noqof: build succeeds (CHEAT used) AND still leaves a dumpedheap. *)
+val _ = tprint "noqof build CHEATs but still writes <thy>.<thm>.dumpedheap"
+val _ = cleanAll ()
+val _ = safedelete dumpfile
+val _ = if OS.Process.isSuccess (hm "--noqof > noqof_output 2>&1") then ()
+        else die "expected noqof Holmake to succeed via CHEAT"
+val _ = if OS.FileSys.access (dumpfile, []) then OK()
+        else die ("dumpedheap file " ^ dumpfile ^ " not produced under --noqof")
+
+val _ = safedelete dumpfile
+val _ = cleanAll ()

--- a/tools/Holmake/tests/dumpheap/testdir/Holmakefile
+++ b/tools/Holmake/tests/dumpheap/testdir/Holmakefile
@@ -2,4 +2,4 @@ ifdef POLY
 CLINE_OPTIONS = --holstate=../../../../../bin/hol.state0
 endif
 
-EXTRA_CLEANS = output usedCheat.anon_1.dumpedheap
+EXTRA_CLEANS = failing.bad_thm.dumpedheap noqof_output

--- a/tools/Holmake/tests/dumpheap/testdir/failingScript.sml
+++ b/tools/Holmake/tests/dumpheap/testdir/failingScript.sml
@@ -1,0 +1,13 @@
+open HolKernel Parse boolLib
+
+val _ = new_theory "failing";
+
+(* ALL_TAC leaves the goal unsolved, so TAC_PROOF raises HOL_ERR.
+   Under default Holmake (qof) this drives the dump-and-exit path in
+   boolLib.store_thm_at; under --noqof it drives the dump-and-continue
+   path in holmakebuild.basic_prover.  Either way, a file named
+   "failing.bad_thm.dumpedheap" should appear in the testdir. *)
+val bad_thm =
+    store_thm("bad_thm", ``!x:bool. x = T \/ x = F``, ALL_TAC);
+
+val _ = export_theory();

--- a/tools/Holmake/tests/parallel_tests/Holmakefile
+++ b/tools/Holmake/tests/parallel_tests/Holmakefile
@@ -38,6 +38,7 @@ DIRNAMES += cachefetch \
             depchain_heap/ \
             depchain_heap/dir2 \
             dirlock \
+            dumpheap \
             heap-size \
             ignore_errors/j4 \
             hollogs \


### PR DESCRIPTION
## Summary

- On a tactic failure during a non-interactive Holmake build, write a Poly/ML heap snapshot to `<theory>.<thmname>.dumpedheap` in the working directory.  Resume with `bin/hol --holstate=<file>` to land in the proof manager at the original goal.
- qof (default): `store_thm_at` dumps and exits at the first failure.
- `--noqof`: `holmakebuild.basic_prover` dumps and continues with the existing CHEAT-tagged oracle, so multiple dumps per script are possible.
- `--fast`: tactic isn't applied, no dump.
- Moscow ML: the portable shim makes `save_heap` a no-op, so the rest of the wiring still runs.

Smaller in scope than #1917 proposes: no goalfrag rewiring, no per-QED checkpoints, no AST interception in `HOLSourceExpand`, no eager-invalidation cache machinery, no `hol4-mcp` integration, no incremental-build story.

## Test plan

- [x] `bin/build -t --seq=tools/sequences/upto-parallel` passes.
- [x] New selftest under `tools/Holmake/tests/dumpheap/` exercises both qof (build fails, dumpedheap present) and `--noqof` (build CHEATs, dumpedheap present).

Closes #1917

🤖 Generated with [Claude Code](https://claude.com/claude-code)
