### PR TITLE
Disable recoding in tracing kernel

### DIFF
--- a/src/tracing/yes/Tracing.sml
+++ b/src/tracing/yes/Tracing.sml
@@ -5,7 +5,7 @@ open TheoryPP
 (* When true, trace_theory recodes the PolyML heap dump from 64-bit to 32-bit
    before gzipping. Produces a backward-incompatible format marked by an
    8-byte magic "TR32\0\0\0\xFF". *)
-val recode_32bit = ref true
+val recode_32bit = ref false
 
 val recode32_path = ref (
   (case OS.Process.getEnv "HOLDIR" of SOME d => d | NONE => ".") ^ "/bin/recode32")


### PR DESCRIPTION
The fallback for recode32_path seems off, as it makes no use of Systeml.HOLDIR. On my system, this results in bool getting stuck and complaining about a file not being found. If I make the path use Systeml.HOLDIR, bool seems to get stuck as well (albeit without a "file not found" error).

Disabling recoding allows the tracer to make some progress.