### PR TITLE
Holmake: stage cache fetches with reflinks, not hardlinks

### DIFF
--- a/tools-poly/Holmake/unix-systeml.sml
+++ b/tools-poly/Holmake/unix-systeml.sml
@@ -105,6 +105,7 @@ val release = ""
 val DOT_PATH = ""
 val MV = ""
 val CP = ""
+val clone_cmd = ""
 val SHASUM = ""
 val DEFAULT_STATE = fullPath [HOLDIR, "bin", "hol.state"]
 

--- a/tools-poly/Holmake/winNT-systeml.sml
+++ b/tools-poly/Holmake/winNT-systeml.sml
@@ -57,6 +57,7 @@ val DYNLIB = false
 val version = 0
 val release = ""
 val DOT_PATH = NONE
+val clone_cmd : string option = NONE
 val POLY = ""
 val POLYC = ""
 val DEFAULT_STATE = fullPath [HOLDIR, "bin", "hol.state"]

--- a/tools-poly/configure.sml
+++ b/tools-poly/configure.sml
@@ -260,6 +260,7 @@ in
    "val DOT_PATH =" --> ("val DOT_PATH = "^optquote DOT_PATH^"\n"),
    "val MV =" -->       ("val MV = "^quote MV^"\n"),
    "val CP =" -->       ("val CP = "^quote CP^"\n"),
+   "val clone_cmd =" --> ("val clone_cmd = "^optquote clone_cmd^"\n"),
    "val SHASUM ="   --> ("val SHASUM = "^quote SHASUM^"\n"),
    "val haveWord64 ="-->("val haveWord64 = "^
                          Bool.toString

--- a/tools-poly/smart-configure.sml
+++ b/tools-poly/smart-configure.sml
@@ -340,6 +340,15 @@ verdict ("GNUMAKE", GNUMAKE);
 
 val MV = dfltverdict ("MV", find_in_bin_or_path "mv");
 val CP = dfltverdict ("CP", find_in_bin_or_path "cp");
+(* Reflink-capable cp invocation, used by the Holmake product cache to
+   stage cache entries with independent inodes (so a sibling repo
+   fetching the same cache entry can't bump our local file's mtime).
+   On non-CoW filesystems the underlying cp falls back to a byte-copy. *)
+val clone_cmd =
+    case OS of
+        "macosx" => SOME (CP ^ " -c")
+      | "linux"  => SOME (CP ^ " --reflink=auto")
+      | _        => NONE;
 val SHASUM =
     if SHASUM = "" then
       dfltverdict (

--- a/tools/Holmake/Systeml.sig
+++ b/tools/Holmake/Systeml.sig
@@ -35,6 +35,14 @@ sig
   val DOT_PATH : string option
   val MV : string
   val CP : string
+
+  (* Command for cloning a file with copy-on-write semantics
+     (independent inode, shared backing blocks where the filesystem
+     allows it; byte-copy fallback otherwise).  Used by the Holmake
+     product cache to avoid the metadata-sharing trap of hardlinks
+     across repos that share a cache directory.  NONE on platforms
+     where no such command is available. *)
+  val clone_cmd : string option
   val SHASUM : string
   val DEFAULT_STATE : string
   val haveWord64 : bool

--- a/tools/Holmake/poly/HM_CacheFetch.sml
+++ b/tools/Holmake/poly/HM_CacheFetch.sml
@@ -4,36 +4,61 @@ struct
 val pid_s = SysWord.toString
               (Posix.Process.pidToWord (Posix.ProcEnv.getpid()))
 
-(* Place [src]'s contents at [dest] atomically: stage at a per-pid temp
-   file (either by hard-linking from [src], or by copying its bytes if
-   the link fails, e.g. across filesystems), then rename over [dest].
-   The rename is atomic, so a concurrent reader of [dest] sees either
-   the previous contents or the new contents, never a partial write. *)
+(* Byte-copy [src] to [dst]; returns true on success.  Used as a
+   fallback when no reflink-capable cp is available, or when the
+   reflink invocation fails (e.g. filesystem doesn't support it and
+   the cp variant doesn't fall back internally). *)
+fun byte_copy src dst =
+    let val instr  = BinIO.openIn src
+        val outstr = BinIO.openOut dst
+        fun loop () =
+            let val v = BinIO.inputN (instr, 1024)
+            in  if Word8Vector.length v = 0
+                then (BinIO.flushOut outstr; BinIO.closeOut outstr;
+                      BinIO.closeIn instr; true)
+                else (BinIO.output (outstr, v); loop ())
+            end
+    in loop () end
+    handle _ => false
+
+(* Stage [src]'s contents at [dst] with an independent inode.  Tries
+   the platform's reflink-capable cp first (gives hardlink-style space
+   efficiency on CoW filesystems like APFS/btrfs/XFS-with-reflink
+   while keeping inodes separate); falls back to a byte-copy when
+   no clone command is configured or it fails.
+
+   Independent inodes matter for the Holmake product cache: a previous
+   implementation hard-linked into the cache, so a subsequent
+   setTime(dst, NONE) bumped the mtime on the *shared* inode, which
+   propagated to any sibling repo whose local Theory.* was also hard-
+   linked to the same cache entry.  The sibling would then see its
+   local Theory.* as newer than its derived .ui/.uo and spuriously
+   rebuild them. *)
+fun clone_or_copy src dst =
+    case Systeml.clone_cmd of
+        SOME cmd =>
+          if OS.Process.isSuccess
+               (OS.Process.system (cmd ^ " " ^ Systeml.protect src ^
+                                   " " ^ Systeml.protect dst))
+          then true
+          else byte_copy src dst
+      | NONE => byte_copy src dst
+
+(* Place [src]'s contents at [dest] atomically: stage at a per-pid
+   temp file via clone_or_copy, then rename over [dest].  The rename
+   is atomic, so a concurrent reader of [dest] sees either the
+   previous contents or the new contents, never a partial write. *)
 fun copy src dest =
     let
       val tmp = dest ^ ".tmp." ^ pid_s
       val _ = OS.FileSys.remove tmp handle _ => ()
       fun fail () = (OS.FileSys.remove tmp handle _ => (); false)
-      val staged_ok =
-          (Posix.FileSys.link {old = src, new = tmp}; true)
-          handle _ =>
-            let val instr  = BinIO.openIn src
-                val outstr = BinIO.openOut tmp
-                fun loop () =
-                    let val v = BinIO.inputN (instr, 1024)
-                    in  if Word8Vector.length v = 0
-                        then (BinIO.flushOut outstr; BinIO.closeOut outstr;
-                              BinIO.closeIn instr; true)
-                        else (BinIO.output (outstr, v); loop ())
-                    end
-            in loop () end
-            handle _ => false
     in
-      if not staged_ok then fail ()
+      if not (clone_or_copy src tmp) then fail ()
       else
-        (* Hard-linked tmp shares src's mtime with the cache; touch to
-           "now" so the link path is indistinguishable from a byte-copy
-           to downstream timestamp-based rebuild checks. *)
+        (* Touch tmp's (independent) inode to "now" so the cache hit
+           looks newer than any in-tree dependency to downstream
+           timestamp-based rebuild checks. *)
         (OS.FileSys.setTime (tmp, NONE) handle _ => ();
          OS.FileSys.rename {old = tmp, new = dest}; true)
         handle _ => fail ()

--- a/tools/Holmake/tests/cache_reflink/Holmakefile
+++ b/tools/Holmake/tests/cache_reflink/Holmakefile
@@ -1,0 +1,11 @@
+ifdef POLY
+
+cache_reflink-selftest.log: selftest.exe
+	$(tee ./$<, $@)
+
+selftest.exe: selftest.uo
+	$(HOLMOSMLC) -o $@ $<
+
+EXTRA_CLEANS = cache_reflink-selftest.log selftest.exe
+
+endif

--- a/tools/Holmake/tests/cache_reflink/selftest.sml
+++ b/tools/Holmake/tests/cache_reflink/selftest.sml
@@ -1,0 +1,44 @@
+(* Verifies the property HM_CacheFetch.copy relies on: when
+   Systeml.clone_cmd is configured, invoking it stages a file with an
+   independent inode (so a downstream setTime doesn't bleed back to
+   the source through hardlink-style metadata sharing). *)
+
+open testutils
+
+val () = tprint "Systeml.clone_cmd matches the platform"
+val () =
+    case (Systeml.OS, Systeml.clone_cmd) of
+        ("macosx", SOME _) => OK ()
+      | ("linux",  SOME _) => OK ()
+      | ("winNT",  NONE)   => OK ()
+      | (other,    _)      => die ("unexpected: OS=" ^ other)
+
+val () =
+    case Systeml.clone_cmd of
+        NONE => ()  (* nothing else to test on this platform *)
+      | SOME cmd =>
+        let
+          val () = tprint ("clone_cmd \"" ^ cmd ^ "\" yields fresh inode")
+          val tmp = OS.FileSys.tmpName ()
+          val src = tmp ^ ".src"
+          val dst = tmp ^ ".dst"
+          fun cleanup () =
+              (OS.FileSys.remove src handle _ => ();
+               OS.FileSys.remove dst handle _ => ())
+          val () = cleanup ()
+          val outstr = BinIO.openOut src
+          val () = BinIO.output (outstr, Byte.stringToBytes "hello\n")
+          val () = BinIO.closeOut outstr
+          val cmd_line =
+              cmd ^ " " ^ Systeml.protect src ^ " " ^ Systeml.protect dst
+          val () =
+              if OS.Process.isSuccess (OS.Process.system cmd_line) then ()
+              else (cleanup (); die ("clone_cmd failed: " ^ cmd_line))
+          val src_ino = Posix.FileSys.ST.ino (Posix.FileSys.stat src)
+          val dst_ino = Posix.FileSys.ST.ino (Posix.FileSys.stat dst)
+        in
+          if SysWord.compare (Posix.FileSys.inoToWord src_ino,
+                              Posix.FileSys.inoToWord dst_ino) = EQUAL
+          then (cleanup (); die "clone produced a shared inode")
+          else (cleanup (); OK ())
+        end

--- a/tools/Holmake/tests/parallel_tests/Holmakefile
+++ b/tools/Holmake/tests/parallel_tests/Holmakefile
@@ -33,7 +33,8 @@ DIRNAMES = \
   time-logging
 
 ifdef POLY
-DIRNAMES += cachefetch \
+DIRNAMES += cache_reflink \
+            cachefetch \
             cheatspotting \
             depchain_heap/ \
             depchain_heap/dir2 \

--- a/tools/Holmake/unix-systeml.sml
+++ b/tools/Holmake/unix-systeml.sml
@@ -110,6 +110,7 @@ val release = ""
 val DOT_PATH = ""
 val MV = ""
 val CP = ""
+val clone_cmd = ""
 val SHASUM = ""
 val DEFAULT_STATE = fullPath [HOLDIR, "bin", "hol.state"]
 

--- a/tools/Holmake/winNT-systeml.sml
+++ b/tools/Holmake/winNT-systeml.sml
@@ -97,6 +97,7 @@ val version = ""
 val ML_SYSNAME = ""
 val release = ""
 val DOT_PATH = ""
+val clone_cmd = ""
 val DEFAULT_STATE = fullPath [HOLDIR, "bin", "hol.state"]
 
 val isUnix = false

--- a/tools/configure.sml
+++ b/tools/configure.sml
@@ -182,7 +182,8 @@ in
    "val release ="  --> ("val release = "^quote release_string^"\n"),
    "val DOT_PATH =" --> ("val DOT_PATH = "^optquote DOT_PATH^"\n"),
    "val MV ="       --> ("val MV = " ^ quote MV^"\n"),
-   "val CP ="       --> ("val CP = " ^ quote CP^"\n")
+   "val CP ="       --> ("val CP = " ^ quote CP^"\n"),
+   "val clone_cmd =" --> "val clone_cmd = NONE\n"
   ];
   use destfile
 end;


### PR DESCRIPTION
## Summary

The Holmake product cache used to hardlink cached `Theory.{sml,sig,dat}` between the cache directory and the local repo's working tree, then `setTime(target, NONE)` to mark the local copy "fresh". Because hardlinks share the underlying inode, the `setTime` bump propagated to every other repo that had also hardlinked the same cache entry — so when one repo pulled from the shared cache, sibling repos would see their local `Theory` files as newer than the derived `.ui`/`.uo` and spuriously recompile them on the next Holmake invocation.

Switch the cache fetch to a filesystem-level **clone** (reflink) — shared backing blocks for storage efficiency, **independent inodes** for metadata isolation:

- `Systeml.clone_cmd : string option`, configured by `smart-configure` / `configure`:
  - macOS → `cp -c` (APFS clonefile)
  - Linux → `cp --reflink=auto` (btrfs, XFS-with-reflink, bcachefs, ZFS)
  - otherwise → `NONE`
- `HM_CacheFetch.copy` now calls a new `clone_or_copy` that runs `Systeml.clone_cmd` when set (which itself falls back to byte-copy on non-CoW filesystems), and falls back to an internal byte-copy when no clone command is available.

Either way the staged file has an independent inode, so the subsequent `setTime` touches only the local copy.

## Test plan

- [x] New selftest `tools/Holmake/tests/cache_reflink/` verifies `Systeml.clone_cmd` matches the platform and that the configured clone command yields a fresh inode (different from the source's).
- [x] `bin/build -t --seq=tools/sequences/upto-parallel` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
