### PR TITLE
Parse: surface case-expression syntax in type-error messages

### DIFF
--- a/src/coretypes/selftest.sml
+++ b/src/coretypes/selftest.sml
@@ -388,4 +388,39 @@ val _ = List.app testq2bnf [
                      [K“:bool”, mutrec_var "foo"]))])
     ]
 
+(* github issue #517: type errors in case expressions should report in
+   surface `case ... of ... => ...` syntax and never leak the parser's
+   internal case-magic constants (fakeconst blob, raw `case_arg` /
+   `case_split` / `case_arrow` combinators) into the error message. *)
+local
+  fun parse_msg q =
+      (Parse.Term q; "<unexpected success>")
+      handle Feedback.HOL_ERR err => Feedback.message_of err
+  fun contains needle hay = String.isSubstring needle hay
+  val forbidden = [GrammarSpecials.fakeconst_special,
+                   "case_arg", "case_split", "case_arrow"]
+  fun readable m =
+      contains "case" m andalso contains "=>" m andalso
+      List.all (fn bad => not (contains bad m)) forbidden
+  fun mk_test desc q =
+      (tprint ("Case type-error readable (#517): " ^ desc);
+       require_msg (check_result readable) (fn m => "got: " ^ m)
+                   parse_msg q)
+in
+val _ = mk_test "outer case Comb (bool scrutinee, option pattern)"
+                `case T of NONE => T | SOME x => x`
+val _ = mk_test "outer case Comb (num option scrutinee, bool arms)"
+                `case (NONE : num option) of NONE => T | SOME n => n`
+val _ = mk_test "outer case Comb (bool scrutinee, pair pattern)"
+                `case T of (x,y) => x`
+(* case as a function argument exercises remove_case_magic on a complete
+   case via the safe_decase wrapper *)
+val _ = mk_test "case as function argument"
+                `FST (case (NONE : bool option) of NONE => T | SOME b => b)`
+(* arms with different return types exercises the arms-disagree formatter
+   (case_split-headed Rator) *)
+val _ = mk_test "case arms with disagreeing return types"
+                `case T of T => () | F => T`
+end
+
 val _ = Process.exit Process.success

--- a/src/parse/GrammarSpecials.sml
+++ b/src/parse/GrammarSpecials.sml
@@ -66,22 +66,20 @@ struct
   val std_binder_precedence = 0
 
 
-  fun mk_case_special0 nm component =
+  val core_case_special = "case_arg"
+  val case_split_special = "case_split"
+  val case_arrow_special = "case_arrow"
+
+  fun mk_case_special nm =
       mk_fakeconst_name {original = SOME {Thy = "case magic", Name = nm},
-                         fake = component}
-  val mk_default_case = mk_case_special0 "default"
-  fun mk_case_special nm = mk_case_special0 nm "case"
+                         fake = "case"}
   fun dest_case_special s =
-    case dest_fakeconst_name s of
-        SOME {original = SOME{Thy="case magic",Name},fake="case"} => SOME Name
-      | _ => NONE
+    if s = core_case_special then SOME "core"
+    else
+      case dest_fakeconst_name s of
+          SOME {original = SOME{Thy="case magic",Name},fake="case"} => SOME Name
+        | _ => NONE
   val is_case_special = isSome o dest_case_special
-
-
-
-  val core_case_special = mk_default_case "case"
-  val case_split_special = mk_default_case "split"
-  val case_arrow_special = mk_default_case "arrow"
 
   open HolKernel
   val compilefn = ref (NONE : (term -> term) option)

--- a/src/parse/Preterm.sml
+++ b/src/parse/Preterm.sml
@@ -628,6 +628,14 @@ fun is_atom (Var _) = true
   | is_atom t = false
 
 
+(* Forward declaration so typecheck_phase1's error messages can render
+   smashed terms after running them through `remove_case_magic` — this lets
+   ConstrainFail messages display recoverable case expressions in their
+   surface `case ... of ...` form rather than as raw case_arg / case_split /
+   case_arrow combinators.  The ref is assigned below after
+   remove_case_magic has been defined. *)
+val rcm_for_msg : (Term.term -> Term.term) ref = ref Lib.I
+
 local
   fun default_typrinter x = "<hol_type>"
   fun default_tmprinter x = "<term>"
@@ -636,12 +644,52 @@ local
   fun smashTm ptm =
     Lib.with_flag (Globals.notify_on_tyvar_guess, false)
                   (smash (overloading_resolution ptm >- (to_term o #1)))
+  fun safe_decase t = !rcm_for_msg t handle HOL_ERR _ => t
 in
 fun typecheck_phase1 printers = let
   val (ptm, pty) =
       case printers of
         SOME (x,y) => (x,y)
       | NONE => (default_tmprinter, default_typrinter)
+  fun pretty_tm t = ptm (safe_decase t)
+  fun bool_op nm t =
+      let val (f, args) = HolKernel.strip_comb t
+      in
+        case Lib.total Term.dest_thy_const f of
+            SOME {Name, Thy, ...} =>
+              if Name = nm andalso Thy = "bool" then SOME args
+              else NONE
+          | _ => NONE
+      end
+  fun ptm_arms t =
+      case bool_op case_split_special t of
+          SOME [l, r] => ptm_arms l ^ " | " ^ ptm_arms r
+        | _ =>
+          case bool_op case_arrow_special t of
+              SOME [pat, body] => pretty_tm pat ^ " => " ^ pretty_tm body
+            | _ => pretty_tm t
+  (* When the AppFail Comb is the partial split application
+     `case_split @ left_arms`, we know we are at the point where two arm
+     groups of a `case ... of ...` expression are being unified.  Reformat
+     the error so the user sees the arms, not the raw combinator term. *)
+  fun arms_disagree_msg left_arms Rand' unify_error =
+      String.concat
+        ["\nType error in case expression: arms have incompatible types.\n",
+         "  ", ptm_arms left_arms, " ",
+              pty(Term.type_of left_arms), "\n",
+         "  ", ptm_arms Rand', " ",
+              pty(Term.type_of Rand'), "\n",
+         "  Reason: ", errorMsg (#1 unify_error), "\n"]
+  (* When the AppFail Comb is `(case_arg @ scrutinee) @ split_tree`, the
+     whole case expression is split across Rator and Rand.  Rebuild a
+     surface `case <scrutinee> of <arms>` view rather than showing the
+     internal combinator structure. *)
+  fun case_app_msg scrut arms_tree unify_error =
+      String.concat
+        ["\nType error in case expression.\n",
+         "  case ", pretty_tm scrut, " ", pty(Term.type_of scrut), "\n",
+         "  of ", ptm_arms arms_tree, "\n",
+         "  Reason: ", errorMsg (#1 unify_error), "\n"]
   fun check(Comb{Rator, Rand, Locn}) =
     check Rator >> check Rand >>
     ptype_of Rator >- (fn rator_ty =>
@@ -651,11 +699,22 @@ fun typecheck_phase1 printers = let
      (fn unify_error => fn env =>
           let val Rator' = smashTm Rator env
               val Rand'  = smashTm Rand env
-              val message = String.concat
-                  ["\nType error in function application.\n",
-                   "  Function: ", ptm Rator', " ", pty(Term.type_of Rator'), "\n",
-                   "  Argument: ", ptm Rand',  " ", pty(Term.type_of Rand'), "\n",
-                   "  Reason: ",   errorMsg (#1 unify_error), "\n"]
+              val message =
+                  case bool_op core_case_special Rator' of
+                      SOME [scrut] =>
+                        case_app_msg scrut Rand' unify_error
+                    | _ =>
+                  case bool_op case_split_special Rator' of
+                      SOME [left_arms] =>
+                        arms_disagree_msg left_arms Rand' unify_error
+                    | _ =>
+                      String.concat
+                        ["\nType error in function application.\n",
+                         "  Function: ", pretty_tm Rator', " ",
+                         pty(Term.type_of Rator'), "\n",
+                         "  Argument: ", pretty_tm Rand',  " ",
+                         pty(Term.type_of Rand'), "\n",
+                         "  Reason: ",   errorMsg (#1 unify_error), "\n"]
           in
             Error (AppFail(Rator',Rand',message), locn Rand)
           end))))
@@ -669,7 +728,7 @@ fun typecheck_phase1 printers = let
                  val constraint = Pretype.toType Ty
                  val message = String.concat
                      ["\nType constraint failure: \n",
-                      "  Term: ", ptm real_term, " ", pty rty, "\n",
+                      "  Term: ", pretty_tm real_term, " ", pty rty, "\n",
                       "  Constraint: ", pty constraint, "\n"]
              in
                Error(ConstrainFail(real_term, constraint, message), Locn)
@@ -845,6 +904,8 @@ end
 fun remove_case_magic tm =
     if GrammarSpecials.case_initialised() then remove_case_magic0 tm
     else tm
+
+val () = rcm_for_msg := remove_case_magic
 
 val post_process_term = ref (I : term -> term);
 val typecheck_listener : (preterm * Pretype.Env.t) Listener.t =


### PR DESCRIPTION
## Summary

- Three case-magic kernel constants in `bool` (the head, split and arrow combinators of the partial pattern-match form) drop their fakeconst encoding for plain readable names `case_arg`, `case_split`, `case_arrow`.
- `Preterm.typecheck_phase1`'s `AppFail` formatter now recognises three case-expression shapes and renders them in surface `case … of …` syntax instead of the raw combinator tree.

After:

```
Type error in case expression.
  case T :bool
  of (NONE :bool option) => T | SOME (x :bool) => (x :bool)
  Reason: Attempt to unify different type operators: min$bool and option$option
```

## Test plan

- [x] `bin/build --no-cache --seq=tools/sequences/upto-parallel` (full core build, passes)
- [x] New tests in `src/coretypes/selftest.sml` (5 distinct failure shapes; `./selftest.exe` passes)
- [ ] CI green on this PR

Closes #517
