### PR TITLE
Holmake: warn on case-only filename collisions in a directory

### DIFF
--- a/tools/Holmake/core/Holmake_tools.sml
+++ b/tools/Holmake/core/Holmake_tools.sml
@@ -849,6 +849,29 @@ fun concatWithf p d [] = ""
     end
 
 
+(* issue #679: catch fooScript.sml vs FooScript.sml collisions early. *)
+fun warn_case_collisions warn src_files =
+    let
+      fun add_one (f, m) =
+          let
+            val k = String.map Char.toLower f
+            val prev = Option.getOpt(Binarymap.peek(m, k), [])
+          in
+            Binarymap.insert(m, k, f :: prev)
+          end
+      val groups = List.foldl add_one
+                              (Binarymap.mkDict String.compare)
+                              src_files
+      fun report (_, fs as _::_::_) =
+            warn ("case-only filename collision in " ^
+                  OS.FileSys.getDir() ^ ": " ^
+                  String.concatWith ", " (List.rev fs) ^
+                  " (the same file on case-insensitive filesystems)")
+        | report _ = ()
+    in
+      Binarymap.app report groups
+    end
+
 fun generate_all_plausible_targets warn first_target =
     case first_target of
         SOME d => [d]
@@ -875,6 +898,7 @@ fun generate_all_plausible_targets warn first_target =
                 | SML _ => true
                 | _ => false
           val src_files = find_files cds (fn s => ok_file s andalso not_a_dot s)
+          val () = warn_case_collisions warn src_files
           fun src_to_target (SIG (Script s)) = UO (Theory s)
             | src_to_target (SML (Script s)) = UO (Theory s)
             | src_to_target (SML s) = (UO s)

--- a/tools/Holmake/tests/gh679/Holmakefile
+++ b/tools/Holmake/tests/gh679/Holmakefile
@@ -1,0 +1,11 @@
+ifdef POLY
+HOLHEAP = $(HOLDIR)/bin/hol.state0
+endif
+
+gh679-selftest.log: selftest.exe
+	@$(tee ./$<, $@)
+
+selftest.exe: selftest.uo
+	$(HOLMOSMLC) -o $@ $<
+
+EXTRA_CLEANS = selftest.exe gh679-selftest.log

--- a/tools/Holmake/tests/gh679/selftest.sml
+++ b/tools/Holmake/tests/gh679/selftest.sml
@@ -1,0 +1,76 @@
+(* Issue #679: warn when directory contents differ only by case. *)
+
+open testutils
+
+val op++ = OS.Path.concat
+val Holmake = Globals.HOLDIR ++ "bin" ++ "Holmake"
+
+val testdir = OS.FileSys.tmpName ()
+val _ = (OS.FileSys.remove testdir handle OS.SysErr _ => ())
+val _ = OS.FileSys.mkDir testdir
+
+fun write_empty f =
+    let val s = TextIO.openOut (testdir ++ f)
+    in TextIO.output (s, "(* empty *)\n"); TextIO.closeOut s end
+
+val _ = write_empty "foo.sml"
+val _ = write_empty "Foo.sml"
+
+fun list_dir d =
+    let val ds = OS.FileSys.openDir d
+        fun loop acc =
+            case OS.FileSys.readDir ds of
+                NONE => (OS.FileSys.closeDir ds; acc)
+              | SOME f => loop (f :: acc)
+    in loop [] end
+
+val entries = list_dir testdir
+val both_present = List.exists (fn f => f = "foo.sml") entries andalso
+                   List.exists (fn f => f = "Foo.sml") entries
+
+fun rm_rf d =
+    let val ds = OS.FileSys.openDir d
+        fun loop () =
+            case OS.FileSys.readDir ds of
+                NONE => ()
+              | SOME f =>
+                  let val p = d ++ f
+                  in
+                    (if OS.FileSys.isDir p then rm_rf p
+                     else OS.FileSys.remove p)
+                    handle OS.SysErr _ => ();
+                    loop ()
+                  end
+    in
+      loop ();
+      OS.FileSys.closeDir ds;
+      OS.FileSys.rmDir d
+    end handle OS.SysErr _ => ()
+
+val _ = tprint "Case-only filename collision emits warning (#679)"
+
+val _ =
+    if not both_present then
+      (rm_rf testdir;
+       print "(filesystem is case-insensitive; skipping) ";
+       OK ())
+    else
+      let
+        val saved = OS.FileSys.getDir ()
+        val _ = OS.FileSys.chDir testdir
+        val cmd = String.concatWith " "
+                    [Systeml.protect Holmake, "-n",
+                     ">", "out", "2>&1"]
+        val _ = OS.Process.system cmd
+        val s = TextIO.openIn "out"
+        val output = TextIO.inputAll s before TextIO.closeIn s
+        val _ = OS.FileSys.chDir saved
+      in
+        if String.isSubstring "case-only filename collision" output
+        then (rm_rf testdir; OK ())
+        else (print "\n--- captured Holmake output ---\n";
+              print output;
+              print "--- end captured output ---\n";
+              rm_rf testdir;
+              die "FAILED: warning not present in Holmake output")
+      end

--- a/tools/Holmake/tests/parallel_tests/Holmakefile
+++ b/tools/Holmake/tests/parallel_tests/Holmakefile
@@ -29,6 +29,7 @@ DIRNAMES = \
   empty_script \
   deps_of_depthys \
   gh604 \
+  gh679 \
   gh1353 \
   ignore_errors/j1 \
   qfreadTheoremsyntax \


### PR DESCRIPTION
Closes #679.

`generate_all_plausible_targets` now groups the source-file listing by
lowercased name and emits a one-line `warn` for each group that contains
more than one entry. This catches `fooScript.sml` vs `FooScript.sml`
collisions on case-sensitive filesystems (the readDir walk shows both
files); on case-insensitive filesystems they cannot coexist on disk and
so cannot be detected this way.

Phase 2 follow-up (deferred): detect the running filesystem's case
behaviour and normalise `load` filenames so that the same source builds
on either kind of FS.

## Test plan
- [x] `tools/Holmake/tests/gh679/selftest.sml` creates the colliding
      pair in a tmpdir, skips gracefully on case-insensitive FS, asserts
      the warning on case-sensitive FS.
- [ ] CI on Linux exercises the case-sensitive path.
