### PR TITLE
markerLib: forbid theorems consuming still-suspended theorems

### DIFF
--- a/src/1/boolLib.sml
+++ b/src/1/boolLib.sml
@@ -158,11 +158,11 @@ fun get_suspended_names th =
       HOLset.foldl foldthis [] (Thm.hypset th)
     end
 
-(* Shim for markerLib to install a recorder that routes suspended
-   theorems into the suspension.theorems AncestryData store.  This
-   module (boolLib) sits below markerLib in the dependency graph, so
-   we cannot call into it directly; markerLib populates the ref when
-   it loads.  Same pattern as term_pp.casesplit_munger. *)
+(* Shims for markerLib to install hooks that route suspended theorems
+   into, and consult, the suspension.theorems AncestryData store.
+   This module (boolLib) sits below markerLib in the dependency
+   graph, so we cannot call into it directly; markerLib populates the
+   refs when it loads.  Same pattern as term_pp.casesplit_munger. *)
 val suspended_theorem_recorder : (string * thm -> unit) ref =
     ref (fn _ => ())
 
@@ -190,6 +190,13 @@ local val n = ref 0 in
   fun next_anon_thm_name () =
       (n := !n + 1; "anon_" ^ Int.toString (!n))
 end
+
+(* Given a suspendlabel term, return SOME (thy, name) for the
+   already-registered suspended theorem that carries it as a hyp,
+   or NONE if no registered theorem owns it.  save_thm_attrs uses
+   this to reject theorems that cite still-suspended theorems. *)
+val slab_owner_lookup : (term -> (string * string) option) ref =
+    ref (fn _ => NONE)
 
 (* printable_keys: collapse duplicate label names with a count annotation.
    Used when reporting which suspended subgoals remain in a theorem. *)
@@ -247,36 +254,61 @@ fun save_thm_attrs loc (attrblock:ThmAttribute.attrblock, th) = let
   val storemod = if rebindok then trace("Theory.allow_rebinds", 1)
                  else (fn f => f)
   fun do_attr (k,vs) = attrf {thm = th, name = n, attrname = k, args = vs}
+  val slabs_with_labels =
+      HOLset.foldl
+        (fn (t,A) =>
+            case dest_suspended t of NONE => A | SOME (lab,_) => (t,lab)::A)
+        [] (Thm.hypset th)
+  fun classify_foreign (slab, lab) =
+      case !slab_owner_lookup slab of
+          NONE => NONE
+        | SOME (Thy,Name) =>
+            if Thy = Theory.current_theory () andalso Name = n then NONE
+            else SOME (lab, {Thy=Thy, Name=Name})
+  val foreign = List.mapPartial classify_foreign slabs_with_labels
 in
-  case get_suspended_names th of
-      [] => storemod save(n,th) before app do_attr attrs
-    | susp_names =>
-      let
-      in
-        case printable_keys susp_names of
-            [nstr] =>
-            HOL_MESG (
-              "Stashing suspended theorem " ^ n ^
-              " with pending subgoal: " ^ nstr ^ "."
-            )
-          | strs =>
-            HOL_MESG (
-              "Stashing suspended theorem " ^ n ^
-              " with pending subgoals: " ^
-              String.concatWith ", " strs ^ "."
-            );
-        if localp orelse not (null attrs) then
-          HOL_WARNING "boolLib" "save_thm_attrs"
-                      ("Ignoring attributes on suspended theorem " ^ n ^
-                       "; apply them at Finalise time instead")
-        else ();
-        (* Route the suspended theorem into markerLib's AncestryData
-           store for suspensions rather than saving it to the normal
-           theorem DB.  Finalise will save the clean form under this
-           name when all subgoals have been resumed. *)
-        !suspended_theorem_recorder (n, th);
-        th
-      end
+  case (slabs_with_labels, foreign) of
+      ([], _) => storemod save(n,th) before app do_attr attrs
+    | (_, []) =>
+        let
+        in
+          (case printable_keys (map #2 slabs_with_labels) of
+               [nstr] =>
+               HOL_MESG (
+                 "Stashing suspended theorem " ^ n ^
+                 " with pending subgoal: " ^ nstr ^ "."
+               )
+             | strs =>
+               HOL_MESG (
+                 "Stashing suspended theorem " ^ n ^
+                 " with pending subgoals: " ^
+                 String.concatWith ", " strs ^ "."
+               ));
+          if localp orelse not (null attrs) then
+            HOL_WARNING "boolLib" "save_thm_attrs"
+                        ("Ignoring attributes on suspended theorem " ^ n ^
+                         "; apply them at Finalise time instead")
+          else ();
+          (* Route the suspended theorem into markerLib's AncestryData
+             store for suspensions rather than saving it to the normal
+             theorem DB.  Finalise will save the clean form under this
+             name when all subgoals have been resumed. *)
+          !suspended_theorem_recorder (n, th);
+          th
+        end
+    | (_, foreigns) =>
+        let
+          fun fmt (lab, kn) =
+              KernelSig.name_toString kn ^ "[" ^ lab ^ "]"
+          val refs = String.concatWith ", " (map fmt foreigns)
+          val plural = case foreigns of [_] => " " | _ => "s "
+        in
+          raise ERR "save_thm_attrs"
+            ("Theorem " ^ Lib.quote n ^
+             " cites still-suspended theorem" ^ plural ^ refs ^
+             ".  Only `Resume X[label]` may consume a still-suspended X; \
+             \finalise the cited theorem(s) first.")
+        end
 end
 end (* local *)
 

--- a/src/basicProof/theory_tests/suspCrossThmScript.sml
+++ b/src/basicProof/theory_tests/suspCrossThmScript.sml
@@ -1,18 +1,13 @@
 Theory suspCrossThm[bare]
 
-(* Demonstrates the cross-theorem Resume-dependency limitation
-   tracked at GitHub issue #1963.
+(* A theorem -- whether a regular `Theorem`, a `Resume` body, or any
+   other saved form -- may only consume already-finalised theorems.
+   The only legal way to consume a still-suspended theorem X is to
+   write `Resume X[label]` for one of its unsolved subgoals (#1963).
 
-   A Resume proof for th1 is allowed to depend on another, still
-   suspended theorem th2: the cycle check from #1960 is scoped
-   to the current parent's slabs, so th2's slab does not match.
-   Finalise th1, however, cannot resolve the foreign slab because
-   find_res_for keys lookups on the current parent's name.
-
-   This test pins down the current behaviour: Resume th1[l1]
-   succeeds, Finalise th2 succeeds, and Finalise th1 then raises
-   a HOL_ERR "No resumption proof found ..." rather than looping
-   (the failure mode #1960 used to exhibit). *)
+   Two rejection points exercised below: markerLib.resume catches the
+   cross-theorem citation inside a Resume body, and
+   boolLib.save_thm_attrs catches the same in a regular Theorem. *)
 
 Libs HolKernel Parse boolLib markerLib testutils
 
@@ -28,26 +23,45 @@ Proof
   suspend "l2"
 QED
 
-(* th2 is still suspended at this point; the resume-time check
-   accepts this proof because slab_th2_l2 differs from any of
-   th1's slabs. *)
+val _ = shouldfail {
+  testfn = (fn () =>
+              resume {suspension_name = "th1", label_name = "l1"}
+                     (MATCH_ACCEPT_TAC th2)),
+  printarg = (fn _ =>
+              "resume th1[l1] with MATCH_ACCEPT_TAC th2 (th2 suspended)"),
+  printresult = (fn _ => "<unexpected success>"),
+  checkexn =
+    check_HOL_ERRexn (fn (_, fnm, msg) =>
+        fnm = "resume" andalso
+        String.isSubstring "still-suspended" msg)
+} ()
+
+(* A regular `Theorem foo Proof <body cites th2> QED` would inherit
+   th2's suspendlabel hypothesis.  Going via save_thm_attrs directly
+   exercises the same path the Theorem parser would. *)
+val _ = shouldfail {
+  testfn = (fn () =>
+              boolLib.save_thm_attrs
+                (DB_dtype.mkloc(#(FILE),#(LINE),true))
+                (ThmAttribute.extract_attributes "foo", th2)),
+  printarg = (fn _ =>
+              "save_thm_attrs \"foo\" of a thm inheriting th2's slab"),
+  printresult = (fn _ => "<unexpected success>"),
+  checkexn =
+    check_HOL_ERRexn (fn (_, fnm, msg) =>
+        fnm = "save_thm_attrs" andalso
+        String.isSubstring "still-suspended" msg)
+} ()
+
+(* Tidy up so the theory exits with no slab-bearing theorems left in
+   the DB; this keeps the export_theory safety net happy. *)
 Resume th1[l1]:
-  MATCH_ACCEPT_TAC th2
+  strip_tac >> ACCEPT_TAC TRUTH
 QED
 
 Resume th2[l2]:
   strip_tac >> ACCEPT_TAC TRUTH
 QED
 
+Finalise th1
 Finalise th2
-
-val _ = shouldfail {
-  testfn = (fn () =>
-              finalise_suspended_thm (DB_dtype.mkloc(#(FILE),#(LINE),true))
-                                     "th1"),
-  printarg = (fn _ => "Finalise th1 (cross-theorem dependency on th2)"),
-  printresult = (fn _ => "<unexpected success>"),
-  checkexn =
-    check_HOL_ERRexn (fn (_, fnm, msg) =>
-        fnm = "Finalise" andalso String.isSubstring "No resumption" msg)
-} ()

--- a/src/basicProof/theory_tests/suspCycleScript.sml
+++ b/src/basicProof/theory_tests/suspCycleScript.sml
@@ -1,30 +1,11 @@
 Theory suspCycle[bare]
 
-(* Regression test for GitHub issue #1960.
-
-   If a Resume proof depends on the parent theorem's own
-   suspendlabel hypotheses (e.g. via `cj 1 useful` where `useful`
-   is the still-suspended parent), the resulting resumption
-   theorem re-introduces those hypotheses every time PROVE_HYP
-   discharges them, so Finalise's assembly loop never converges.
-
-   Reproduced from the issue:
-
-     Theorem useful:
-       (x ==> T) /\ (F ==> T)
-     Proof
-       conj_tac >- suspend "x" >> suspend "F"
-     QED
-     Resume useful[x]:
-       strip_tac >> ACCEPT_TAC TRUTH
-     QED
-     Resume useful[F]:
-       MATCH_ACCEPT_TAC (cj 1 useful)
-     QED
-     Finalise useful
-
-   Used to spin forever inside finalise_suspended_thm; now
-   `resume` rejects the cyclic proof up-front. *)
+(* Regression test for #1960: a resumption body that cites its own
+   parent (e.g. `MATCH_ACCEPT_TAC (cj 1 useful)`) would otherwise
+   re-introduce the parent's suspendlabel hyps at every PROVE_HYP, so
+   Finalise's assembly loop diverges.  `resume` now rejects this at
+   recording time; the same check also covers cross-theorem citation
+   (see suspCrossThm). *)
 
 Libs HolKernel Parse boolLib markerLib testutils
 
@@ -47,5 +28,5 @@ val _ = shouldfail {
   printresult = (fn _ => "<unexpected success>"),
   checkexn =
     check_HOL_ERRexn (fn (_, fnm, msg) =>
-        fnm = "resume" andalso String.isSubstring "cycle" msg)
+        fnm = "resume" andalso String.isSubstring "still-suspended" msg)
 } ()

--- a/src/marker/markerLib.sml
+++ b/src/marker/markerLib.sml
@@ -1154,6 +1154,21 @@ val _ = boolLib.suspended_theorem_recorder :=
                      (AddSuspended
                         ({Thy = Theory.current_theory(), Name = n}, th)))
 
+(* Given a suspendlabel term, return SOME (Thy, Name) for the
+   already-registered suspended theorem that carries it as a hyp, or
+   NONE if no registered theorem owns it -- in which case the slab
+   must be fresh, i.e. introduced by the proof currently in progress.
+   Used both by save_thm_attrs (via the boolLib shim below) and by
+   resume to reject bodies that consume already-suspended theorems. *)
+fun slab_owner_lookup slab =
+    KNametab.get_first
+      (fn ({Thy, Name}, th) =>
+          if HOLset.member (Thm.hypset th, slab) then SOME (Thy, Name)
+          else NONE)
+      (get_susp_global ())
+
+val _ = boolLib.slab_owner_lookup := slab_owner_lookup
+
 (* ----------------------------------------------------------------------
     Finding the parent theorem for a Resume / Finalise.
 
@@ -1252,23 +1267,39 @@ fun resume {suspension_name, label_name} tac =
                let
                  val goal = resumption_to_goal ncts
                  val sub_th = prove_goal (goal, tac)
-                 (* Reject resumption proofs that depend on the parent
-                    theorem's own suspendlabel hypotheses: those hyps
-                    will be re-introduced every time PROVE_HYP discharges
-                    them at Finalise, so assembly never converges. *)
-                 val parent_slabs = HOLset.filter (can dest_slab) (hypset th)
+                 (* A resumption proof may consume only finalised
+                    theorems.  A slab in sub_th's hyps whose owner is
+                    some already-registered suspended theorem means
+                    the body cited either another still-suspended
+                    theorem (cross-theorem use) or the parent itself
+                    (self-cycle, #1960); both are forbidden.  Fresh
+                    slabs whose owner is unknown are legitimate
+                    re-suspends -- the user is deferring the subgoal
+                    further. *)
+                 val owned_in_body =
+                     List.mapPartial
+                       (fn h => case slab_owner_lookup h of
+                                    NONE => NONE
+                                  | SOME (t,n) => SOME (h, t, n))
+                       (List.filter (can dest_slab) (hyp sub_th))
                  val _ =
-                     List.app
-                       (fn h =>
-                         if HOLset.member (parent_slabs, h) then
+                     case owned_in_body of
+                         [] => ()
+                       | owned =>
+                         let val refs = String.concatWith ", "
+                               (map (fn (_,Thy,Name) =>
+                                        KernelSig.name_toString
+                                          {Thy=Thy,Name=Name})
+                                    owned)
+                         in
                            raise ERR "resume"
                              ("Resumption proof for " ^ suspension_name ^
-                              "[" ^ label_name ^ "] depends on a \
-                              \suspendlabel hypothesis of " ^
-                              suspension_name ^ " itself; this would \
-                              \create a cycle at Finalise.")
-                         else ())
-                       (List.filter (can dest_slab) (hyp sub_th))
+                              "[" ^ label_name ^
+                              "] cites still-suspended theorem(s): " ^
+                              refs ^ ".  Only finalised theorems may \
+                              \appear in a Resume body; finalise the \
+                              \cited theorem(s) first.")
+                         end
                  (* Build |- suspendlabel "lab" G_i for each hyp i and
                     record each as its own resumption delta. *)
                  val susp_thms =
@@ -1429,5 +1460,36 @@ fun finalise_suspended_thm loc nm0 =
           end
     end
 
+(* ----------------------------------------------------------------------
+    Safety net at export_theory time: no theorem persisted to the
+    current theory's DB may retain a suspendlabel hypothesis.
+
+    save_thm_attrs and resume already block this at the offending
+    line, but DB inserts via Theory.gen_save_thm (or its
+    save_thm/save_private_thm wrappers) bypass save_thm_attrs.  This
+    hook catches anything that slipped through.
+   ---------------------------------------------------------------------- *)
+
+local
+  open Theory TheoryDelta
+  fun fmt_offender (n, th) =
+      if boolLib.has_suspended_subgoals th then
+        SOME (n ^ " [" ^ String.concatWith ", "
+                           (boolLib.get_suspended_names th) ^ "]")
+      else NONE
+in
+val _ = register_hook
+  ("markerLib.no_suspended_in_DB",
+   fn ExportTheory _ =>
+        (case List.mapPartial fmt_offender (current_theorems ()) of
+             [] => ()
+           | offenders =>
+             raise ERR "export_theory"
+               ("Theorems in the current theory retain suspendlabel \
+                \hypotheses: " ^ String.concatWith ", " offenders ^
+                ".  A theorem may only use already-finalised theorems; \
+                \only `Resume X[label]` may consume a still-suspended X."))
+     | _ => ())
+end
 
 end (* struct *)


### PR DESCRIPTION
## Summary

- A theorem may now only consume already-finalised theorems. The only legal consumer of a still-suspended `X` is `Resume X[label]` for one of its unsolved subgoals.
- Cross-theorem citation (#1963) and self-citation of the parent in a Resume body (#1960) are rejected at the offending line — `boolLib.save_thm_attrs` catches the former, `markerLib.resume` catches both.
- An `ExportTheory` hook in markerLib acts as a safety net for any save path that bypasses `save_thm_attrs`.

This is the alternative design discussed in #1968 (replaces the find_res_for / owner-stamping routing that PR attempted).

## Test plan

- [x] `bin/build cleanAll && bin/build --no-cache --seq=tools/sequences/upto-parallel` — clean rebuild succeeds.
- [x] `src/marker/selftest.exe` — 20/20 OK.
- [x] `src/basicProof/theory_tests` — all 12 suspended-theorem regressions pass (suspCrossThm, suspCycle, suspCross{A,B}, suspSib{A,B,C,D}, suspNested, suspFast, suspRerun, suspTest).
- [x] `src/boss/theory_tests/gh1878Theory` — OK.

Closes #1963
