### PR TITLE
Holmake: validate Theory.dat parent hashes at cache fetch time

### DIFF
--- a/tools/Holmake/poly/BuildCommand.sml
+++ b/tools/Holmake/poly/BuildCommand.sml
@@ -372,11 +372,37 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
                BuiltInCmd (BIC_BuildScript script_part, empty_incinfo))
               (* incinfos not consulted for comparison so empty value ok here *)
         end
+        (* Directories where parent Theory.dat files might live --
+           every directory that has appeared as a target or dep in the
+           graph.  HM_CacheFetch uses this to find current parents
+           when validating cached .dat files; this lets downstream
+           projects (with their own theory hierarchies outside core
+           HOL's sigobj) benefit from the cache. *)
+        val search_dirs = let
+          open HM_DepGraph
+          val ns = listNodes g
+          fun add_dir (d, acc) =
+              let val s = hmdir.toAbsPath d
+              in if List.exists (fn x => x = s) acc then acc
+                 else s :: acc
+              end
+          fun add_node ((_, nI), acc) =
+              let val acc = add_dir (hm_target.dirpart (#target nI), acc)
+              in
+                List.foldl
+                  (fn ((_,d),acc) => add_dir (hm_target.dirpart d, acc))
+                  acc
+                  (#dependencies nI)
+              end
+        in
+          List.foldl add_node [] ns
+        end
       in
           BR_ClineK { cline = (useScript, cline), job_kont = cont,
                       other_nodes = other_nodes,
                       cache_dir = cache_dir,
                       cachekey = ck,
+                      search_dirs = search_dirs,
                       prep_for_build = prep_for_build }
       end
   in
@@ -473,6 +499,7 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
             BR_ClineK {cline = cline, job_kont = (fn _ => OS.Process.isSuccess),
                        other_nodes = [], cache_dir = NONE,
                        cachekey = HM_Cachekey.Missing [],
+                       search_dirs = [],
                        prep_for_build = fn () => ()}
           end
     end handle CompileFailed => BR_Failed
@@ -523,9 +550,10 @@ fun make_build_command (buildinfo : HM_Cline.t buildinfo_t) = let
     case bres of
         BR_OK => true
       | BR_ClineK{cline = (_,cl), job_kont = k, cache_dir, cachekey,
-                  prep_for_build, ...} =>
+                  search_dirs, prep_for_build, ...} =>
         let val fetched = case cache_dir of
-                              SOME url => HM_CacheFetch.fetch url cachekey outs
+                              SOME url => HM_CacheFetch.fetch url cachekey
+                                            search_dirs outs
                             | NONE => false
         in if fetched then true
            else (prep_for_build (); k warn (Systeml.systeml cl))

--- a/tools/Holmake/poly/HM_CacheFetch.sml
+++ b/tools/Holmake/poly/HM_CacheFetch.sml
@@ -44,25 +44,39 @@ fun clone_or_copy src dst =
           else byte_copy src dst
       | NONE => byte_copy src dst
 
-(* Place [src]'s contents at [dest] atomically: stage at a per-pid
-   temp file via clone_or_copy, then rename over [dest].  The rename
-   is atomic, so a concurrent reader of [dest] sees either the
-   previous contents or the new contents, never a partial write. *)
-fun copy src dest =
+(* Stage [src]'s contents at a per-pid temp file next to [dest] and
+   return the temp path on success.  The caller is responsible for
+   either committing the temp to [dest] via [commit_staged] or
+   discarding it via [discard_staged]. *)
+fun stage src dest =
     let
       val tmp = dest ^ ".tmp." ^ pid_s
       val _ = OS.FileSys.remove tmp handle _ => ()
-      fun fail () = (OS.FileSys.remove tmp handle _ => (); false)
     in
-      if not (clone_or_copy src tmp) then fail ()
+      if not (clone_or_copy src tmp) then
+        (OS.FileSys.remove tmp handle _ => (); NONE)
       else
         (* Touch tmp's (independent) inode to "now" so the cache hit
            looks newer than any in-tree dependency to downstream
            timestamp-based rebuild checks. *)
         (OS.FileSys.setTime (tmp, NONE) handle _ => ();
-         OS.FileSys.rename {old = tmp, new = dest}; true)
-        handle _ => fail ()
+         SOME tmp)
     end
+
+fun commit_staged tmp dest =
+    (OS.FileSys.rename {old = tmp, new = dest}; true)
+    handle _ => (OS.FileSys.remove tmp handle _ => (); false)
+
+fun discard_staged tmp =
+    OS.FileSys.remove tmp handle _ => ()
+
+(* Place [src]'s contents at [dest] atomically: stage then commit.
+   Kept for upload's per-file copy into the cache's data/ directory
+   where staged validation isn't needed. *)
+fun copy src dest =
+    case stage src dest of
+        NONE => false
+      | SOME tmp => commit_staged tmp dest
 
 val mkDir = HOLFS_dtype.createDirIfNecessary
 
@@ -292,39 +306,50 @@ fun fetch base_url cachekey search_dirs (ofns : Holmake_tools.output_functions) 
                       | SOME {fullfile, dir} =>
                         (mkDir dir handle _ => ();
                          fullfile)
-                val fetched = map (fn {name, url} =>
-                                     let val dest = to_dest_dir name
-                                         val ok = fetch_to_file
-                                                    (base_url ^ url) dest
-                                     in {name = name, dest = dest, ok = ok}
-                                     end)
+                (* Stage all files to tmp paths first (NOT yet visible
+                   at their dest paths).  Validate from tmp.  Only
+                   commit (rename tmp -> dest) if validation passes.
+                   This avoids exposing potentially-stale cache contents
+                   to concurrent Holmake processes that might read the
+                   dest paths while validation is still in progress. *)
+                val staged = map (fn {name, url} =>
+                                    let val dest = to_dest_dir name
+                                        val tmp_opt = stage
+                                                       (base_url ^ url) dest
+                                    in {name = name, dest = dest,
+                                        tmp = tmp_opt}
+                                    end)
                                   files
-                val all_fetched = List.all #ok fetched
-                fun cleanup_fetched () =
-                    List.app (fn {dest, ok, ...} =>
-                                 if ok then
-                                   OS.FileSys.remove dest handle _ => ()
-                                 else ())
-                             fetched
+                fun discard_all () =
+                    List.app (fn {tmp = SOME t, ...} => discard_staged t
+                               | _ => ())
+                             staged
+                val all_staged = List.all (fn {tmp, ...} => isSome tmp) staged
             in
-                if not all_fetched then
-                  (cleanup_fetched ();
-                   warn "Only managed a partial cache hit; theory will be built locally.";
+                if not all_staged then
+                  (discard_all ();
+                   warn "Only managed a partial cache hit; theory will \
+                        \be built locally.";
                    false)
                 else
                   let
                     val all_valid =
                         List.all
-                          (fn {name, dest, ...} =>
+                          (fn {name, tmp = SOME t, ...} =>
                               not (String.isSuffix "Theory.dat" name)
-                              orelse validate_dat search_dirs dest)
-                          fetched
+                              orelse validate_dat search_dirs t
+                            | _ => false)
+                          staged
                   in
                     if all_valid then
-                      (info "Cache hit! local theory building can be skipped.";
+                      (List.app (fn {tmp = SOME t, dest, ...} =>
+                                    ignore (commit_staged t dest)
+                                  | _ => ())
+                                staged;
+                       info "Cache hit! local theory building can be skipped.";
                        true)
                     else
-                      (cleanup_fetched ();
+                      (discard_all ();
                        warn "Cache hit ignored: parent hashes do not match \
                             \current on-disk parents; theory will be built \
                             \locally.";

--- a/tools/Holmake/poly/HM_CacheFetch.sml
+++ b/tools/Holmake/poly/HM_CacheFetch.sml
@@ -74,6 +74,139 @@ fun is_theory_output f =
     String.isSuffix "Theory.sig" f orelse
     String.isSuffix "Theory.dat" f
 
+(* --- Fetch-time parent-hash validation -------------------------------
+
+   The cachekey can miss transitive theory parents (see GitHub #1980),
+   so a cache hit may return a Theory.dat whose recorded parent hashes
+   no longer match the current on-disk parents.  Loading that .dat
+   would fail link_parents.  Detect and treat as a cache miss.
+
+   We avoid adding HOLsexp to Holmake's mlb (the cleaner option) by
+   doing a small textual scan of the .dat header.  The format is
+   stable:
+       (theory ("<thyname>" ("<parent1>" . "<hash1>") ... )
+        (core-data ...) ...)
+   Each parent is encoded as a sub-list ("<thy>" . "<hash>"), all
+   inside the first sub-list of (theory ...).  We only scan the
+   substring up to "(core-data" to avoid matching string pairs that
+   might appear inside the theorem tables. *)
+
+fun read_file path =
+    let val ins = TextIO.openIn path
+        val s = TextIO.inputAll ins
+        val _ = TextIO.closeIn ins
+    in s end
+    handle _ => ""
+
+fun extract_parents dat_path =
+    let
+      val content = read_file dat_path
+      val full = Substring.full content
+      val (_, after_theory) = Substring.position "(theory " full
+      val (header, _) = Substring.position "(core-data" after_theory
+      fun loop ss acc =
+          let val (_, rest) = Substring.position "(\"" ss
+          in
+            if Substring.size rest < 2 then List.rev acc
+            else
+              let
+                val after_open = Substring.triml 2 rest
+                val (xss, ass) = Substring.position "\"" after_open
+              in
+                if Substring.size ass < 1 then List.rev acc
+                else
+                  let val ass1 = Substring.triml 1 ass (* skip closing " *)
+                  in
+                    if Substring.isPrefix " . \"" ass1 then
+                      let
+                        val ass2 = Substring.triml 4 ass1
+                        val (yss, ass3) = Substring.position "\"" ass2
+                      in
+                        if Substring.size ass3 >= 1 then
+                          loop (Substring.triml 1 ass3)
+                               ((Substring.string xss,
+                                 Substring.string yss) :: acc)
+                        else List.rev acc
+                      end
+                    else loop ass1 acc
+                  end
+              end
+          end
+    in
+      loop header []
+    end
+    handle _ => []
+
+(* Locate the current on-disk Theory.dat for [thy].  We look in sigobj
+   first (where exported theories live, with .uo as a symlink to the
+   source dir); if that resolves, the .dat sits next to the resolved
+   .uo.  Returns NONE if we cannot locate a current .dat: the caller
+   should treat that as a validation failure since we cannot verify
+   the cached .dat's parent hash. *)
+val SIGOBJ = OS.Path.concat (Systeml.HOLDIR, "sigobj")
+
+(* Locate the current on-disk Theory.dat for [thy].  We try, in order:
+
+   (a) Each directory in [search_dirs] (which the caller derives from
+       the dep graph's known targets / deps -- so this covers downstream
+       projects with their own theory hierarchies that are NOT
+       linkToSigobj'd into core HOL's sigobj).  For each dir D we try
+       D/.hol/objs/<thy>Theory.dat (the Poly/ML munged location) and
+       D/<thy>Theory.dat (the Moscow ML / unmunged location).
+   (b) sigobj/<thy>Theory.dat, falling back to following the
+       sigobj/<thy>Theory.uo symlink via realPath and looking next to
+       the resolved .uo -- handles core HOL where theories are
+       linkToSigobj'd. *)
+fun find_parent_dat search_dirs thy =
+    let
+      val basename = thy ^ "Theory"
+      val datname = basename ^ ".dat"
+      fun access p = OS.FileSys.access (p, [OS.FileSys.A_READ])
+                     handle _ => false
+      fun in_dir d =
+          let val munged = OS.Path.concat (d,
+                              OS.Path.concat (".hol",
+                                 OS.Path.concat ("objs", datname)))
+              val plain = OS.Path.concat (d, datname)
+          in
+            if access munged then SOME munged
+            else if access plain then SOME plain
+            else NONE
+          end
+      fun first f [] = NONE
+        | first f (x :: xs) = case f x of SOME y => SOME y | NONE => first f xs
+      val sigobj_uo = OS.Path.concat (SIGOBJ, basename ^ ".uo")
+      val sigobj_dat = OS.Path.concat (SIGOBJ, datname)
+    in
+      case first in_dir search_dirs of
+          SOME p => SOME p
+        | NONE =>
+          if access sigobj_dat then SOME sigobj_dat
+          else if access sigobj_uo then
+            let val real_uo = OS.FileSys.realPath sigobj_uo
+                val real_dir = OS.Path.dir real_uo
+                val candidate = OS.Path.concat (real_dir, datname)
+            in
+              if access candidate then SOME candidate else NONE
+            end handle OS.SysErr _ => NONE
+          else NONE
+    end
+
+(* Validate that the parent hashes recorded in [dat_path] match the
+   hashes of the current on-disk parents. *)
+fun validate_dat search_dirs dat_path =
+    let
+      val parents = extract_parents dat_path
+      fun check (thy, recorded_hash) =
+          case find_parent_dat search_dirs thy of
+              NONE => false   (* can't locate current parent; fail-safe *)
+            | SOME path =>
+                (SHA1.sha1_file {filename = path} = recorded_hash
+                 handle _ => false)
+    in
+      List.all check parents
+    end
+
 fun upload base_url cachekey dir filenames (ofns : Holmake_tools.output_functions) =
     case cachekey of
         HM_Cachekey.Missing _ => false
@@ -125,7 +258,7 @@ fun upload base_url cachekey dir filenames (ofns : Holmake_tools.output_function
         else (warn "Cache upload: not all files found; skipping"; false)
     end handle _ => false
 
-fun fetch base_url cachekey (ofns : Holmake_tools.output_functions) =
+fun fetch base_url cachekey search_dirs (ofns : Holmake_tools.output_functions) =
     case cachekey of
         HM_Cachekey.Missing _ => false
       | HM_Cachekey.Key key =>
@@ -159,15 +292,44 @@ fun fetch base_url cachekey (ofns : Holmake_tools.output_functions) =
                       | SOME {fullfile, dir} =>
                         (mkDir dir handle _ => ();
                          fullfile)
-                val ok = List.all
-                             (fn {name, url} =>
-                                 fetch_to_file (base_url ^ url) (to_dest_dir name))
-                             files
-                val _ = if ok
-                        then info "Cache hit! local theory building can be skipped."
-                        else warn "Only managed a partial cache hit; theory will be built locally."
+                val fetched = map (fn {name, url} =>
+                                     let val dest = to_dest_dir name
+                                         val ok = fetch_to_file
+                                                    (base_url ^ url) dest
+                                     in {name = name, dest = dest, ok = ok}
+                                     end)
+                                  files
+                val all_fetched = List.all #ok fetched
+                fun cleanup_fetched () =
+                    List.app (fn {dest, ok, ...} =>
+                                 if ok then
+                                   OS.FileSys.remove dest handle _ => ()
+                                 else ())
+                             fetched
             in
-                ok
+                if not all_fetched then
+                  (cleanup_fetched ();
+                   warn "Only managed a partial cache hit; theory will be built locally.";
+                   false)
+                else
+                  let
+                    val all_valid =
+                        List.all
+                          (fn {name, dest, ...} =>
+                              not (String.isSuffix "Theory.dat" name)
+                              orelse validate_dat search_dirs dest)
+                          fetched
+                  in
+                    if all_valid then
+                      (info "Cache hit! local theory building can be skipped.";
+                       true)
+                    else
+                      (cleanup_fetched ();
+                       warn "Cache hit ignored: parent hashes do not match \
+                            \current on-disk parents; theory will be built \
+                            \locally.";
+                       false)
+                  end
             end
             handle _ => let
                 val _ = warn "Something went wrong; theory will be built locally."

--- a/tools/Holmake/poly/multibuild.sml
+++ b/tools/Holmake/poly/multibuild.sml
@@ -12,6 +12,7 @@ datatype buildresult =
                         other_nodes : HM_DepGraph.node list,
                         cache_dir : string option,
                         cachekey : HM_Cachekey.compute_result,
+                        search_dirs : string list,
                         prep_for_build : unit -> unit }
        | BR_Failed
 
@@ -299,7 +300,7 @@ fun graphbuild optinfo g =
                           BR_OK => k true g
                         | BR_Failed => k false g
                         | BR_ClineK{cline, job_kont, other_nodes, cache_dir, cachekey,
-                                    prep_for_build} =>
+                                    search_dirs, prep_for_build} =>
                           let
                             val (thyc,ndi) = count_theories_needed other_nodes
                             fun b2res b = if b then OS.Process.success
@@ -328,7 +329,8 @@ fun graphbuild optinfo g =
                                     case cache_dir of
                                         NONE => false
                                       | SOME url =>
-                                        HM_CacheFetch.fetch url cachekey outs
+                                        HM_CacheFetch.fetch url cachekey
+                                          search_dirs outs
                               in
                                 if fetched then true
                                 else (prep_for_build (); false)

--- a/tools/Holmake/tests/cachekey_transitive_parent/.gitignore
+++ b/tools/Holmake/tests/cachekey_transitive_parent/.gitignore
@@ -1,0 +1,4 @@
+selftest.exe
+selftest.log
+.cache-iso
+.selftest-step.log

--- a/tools/Holmake/tests/cachekey_transitive_parent/Holmakefile
+++ b/tools/Holmake/tests/cachekey_transitive_parent/Holmakefile
@@ -1,0 +1,7 @@
+selftest.log: selftest.exe
+	$(tee ./selftest.exe,$@)
+
+selftest.exe: selftest.uo
+	$(HOLMOSMLC) -o $@ $<
+
+EXTRA_CLEANS = selftest.log selftest.exe .cache-iso .selftest-step.log

--- a/tools/Holmake/tests/cachekey_transitive_parent/README.md
+++ b/tools/Holmake/tests/cachekey_transitive_parent/README.md
@@ -1,0 +1,57 @@
+# cachekey_transitive_parent: regression test for stale-parent cache hits
+
+This selftest demonstrates a Holmake bug whereby a theory whose script
+opens a *library structure* (not a theory directly) sees that
+library's transitive theory parents excluded from its cachekey.  A
+subsequent clean rebuild after the parent theory's content has
+changed therefore matches the same cachekey, the cache returns a
+stale `.dat`, and any downstream script that opens the cached theory
+fails `link_parents` against the now-current parent.
+
+## Why this isn't wired into `parallel_tests/Holmakefile`
+
+The bug is NOT yet fixed.  Wiring this test into
+`tools/Holmake/tests/parallel_tests/Holmakefile`'s `DIRNAMES` list
+would break `bin/build -t`.  Run it manually for now:
+
+```
+cd tools/Holmake/tests/cachekey_transitive_parent
+$HOLDIR/bin/Holmake selftest.exe
+./selftest.exe
+```
+
+Expected output today:
+
+```
+cachekey_transitive_parent reproducer ... OK
+  (bug IS present: child cache hit returned stale .dat; consume's
+   link_parents check fired as predicted)
+```
+
+## When the bug is fixed
+
+Update `selftest.sml`'s assertion so `OK` is reported on the
+**success** path -- i.e., when `consume` builds cleanly because
+child's cachekey correctly invalidated -- and remove this README's
+"manual only" note.  Then add `cachekey_transitive_parent` to
+`tools/Holmake/tests/parallel_tests/Holmakefile`'s `DIRNAMES` so it
+runs under `bin/build -t`.
+
+## What it tests
+
+`childScript.sml` opens `parentLib` (a regular SML structure in
+`inner/`), never `parentTheory` directly.  `parentLib` itself opens
+`parentTheory`.  The build order is:
+
+  parentTheory -> parentLib.uo -> childTheory -> consumeTheory
+
+with `consumeScript` declared as a coproduct producer (target `qux`
+in `outer/Holmakefile`) so that Holmake's product cache always skips
+the upload for it (see `is_theory_output` in
+`tools/Holmake/poly/HM_CacheFetch.sml`).  This forces consumeScript
+to actually execute on rebuild, which is where opening childTheory
+loads `child.dat` and the parent-hash check fires.
+
+The mechanism mirrors `secondSimpleScript`/`bar` in
+`tools/Holmake/tests/coproduct/`, which is where this bug was
+originally observed in the wild.

--- a/tools/Holmake/tests/cachekey_transitive_parent/README.md
+++ b/tools/Holmake/tests/cachekey_transitive_parent/README.md
@@ -1,43 +1,18 @@
 # cachekey_transitive_parent: regression test for stale-parent cache hits
 
-This selftest demonstrates a Holmake bug whereby a theory whose script
-opens a *library structure* (not a theory directly) sees that
-library's transitive theory parents excluded from its cachekey.  A
-subsequent clean rebuild after the parent theory's content has
-changed therefore matches the same cachekey, the cache returns a
-stale `.dat`, and any downstream script that opens the cached theory
-fails `link_parents` against the now-current parent.
+Holmake bug whereby a theory whose script opens a *library structure*
+(not a theory directly) sees that library's transitive theory parents
+excluded from its cachekey.  A subsequent clean rebuild after the
+parent theory's content has changed therefore matches the same
+cachekey, the cache returns a stale `.dat`, and any downstream script
+that opens the cached theory fails `link_parents` against the
+now-current parent.
 
-## Why this isn't wired into `parallel_tests/Holmakefile`
+Originally observed and analysed in GH #1980.  The test is wired into
+`tools/Holmake/tests/parallel_tests/Holmakefile`'s POLY `DIRNAMES`
+block and runs under `bin/build -t`.
 
-The bug is NOT yet fixed.  Wiring this test into
-`tools/Holmake/tests/parallel_tests/Holmakefile`'s `DIRNAMES` list
-would break `bin/build -t`.  Run it manually for now:
-
-```
-cd tools/Holmake/tests/cachekey_transitive_parent
-$HOLDIR/bin/Holmake selftest.exe
-./selftest.exe
-```
-
-Expected output today:
-
-```
-cachekey_transitive_parent reproducer ... OK
-  (bug IS present: child cache hit returned stale .dat; consume's
-   link_parents check fired as predicted)
-```
-
-## When the bug is fixed
-
-Update `selftest.sml`'s assertion so `OK` is reported on the
-**success** path -- i.e., when `consume` builds cleanly because
-child's cachekey correctly invalidated -- and remove this README's
-"manual only" note.  Then add `cachekey_transitive_parent` to
-`tools/Holmake/tests/parallel_tests/Holmakefile`'s `DIRNAMES` so it
-runs under `bin/build -t`.
-
-## What it tests
+## How it works
 
 `childScript.sml` opens `parentLib` (a regular SML structure in
 `inner/`), never `parentTheory` directly.  `parentLib` itself opens
@@ -50,8 +25,36 @@ in `outer/Holmakefile`) so that Holmake's product cache always skips
 the upload for it (see `is_theory_output` in
 `tools/Holmake/poly/HM_CacheFetch.sml`).  This forces consumeScript
 to actually execute on rebuild, which is where opening childTheory
-loads `child.dat` and the parent-hash check fires.
+loads `child.dat` and the parent-hash check fires when the cached
+data is stale.
 
-The mechanism mirrors `secondSimpleScript`/`bar` in
-`tools/Holmake/tests/coproduct/`, which is where this bug was
-originally observed in the wild.
+The harness:
+
+1. Builds the world with parent at "v1".
+2. Mutates `parentScript.sml` to a different theorem ("v2") and
+   rebuilds *inner* only -- parent's `.dat` hash changes.
+3. `cleanAll` outer and rebuild from there.  Without the fetch-time
+   parent-hash validation, Holmake would cache-hit a `childTheory.dat`
+   built against parent v1 and consume would fail `link_parents`
+   against the v2 parent.  With validation, the cache hit is rejected,
+   child is rebuilt locally, and consume succeeds.
+
+The mechanism that surfaced the original bug in
+`tools/Holmake/tests/coproduct/` is the same: `secondSimpleScript`'s
+`bar` coproduct keeps that script out of the cache, so it actually
+runs on rebuild and opens `localbaseTheory`, where a stale cached
+`.dat` (against an older `boolTheory`) would have triggered
+`link_parents`.
+
+## Running directly
+
+```
+cd tools/Holmake/tests/cachekey_transitive_parent
+$HOLDIR/bin/Holmake selftest.exe && ./selftest.exe
+```
+
+Expected output:
+
+```
+cachekey_transitive_parent reproducer ... OK
+```

--- a/tools/Holmake/tests/cachekey_transitive_parent/inner/Holmakefile
+++ b/tools/Holmake/tests/cachekey_transitive_parent/inner/Holmakefile
@@ -1,0 +1,3 @@
+ifdef POLY
+CLINE_OPTIONS = --holstate=$(HOLDIR)/bin/hol.state0
+endif

--- a/tools/Holmake/tests/cachekey_transitive_parent/inner/parentLib.sig
+++ b/tools/Holmake/tests/cachekey_transitive_parent/inner/parentLib.sig
@@ -1,0 +1,4 @@
+signature parentLib =
+sig
+  val parent_thm : Thm.thm
+end

--- a/tools/Holmake/tests/cachekey_transitive_parent/inner/parentLib.sml
+++ b/tools/Holmake/tests/cachekey_transitive_parent/inner/parentLib.sml
@@ -1,0 +1,10 @@
+(* A regular SML structure that re-exports parent_thm from
+   parentTheory.  childScript opens THIS, not parentTheory directly --
+   that's the structural element that hides parentTheory from
+   childScript's direct dep list, which is what makes the cachekey
+   miss parentTheory's hash. *)
+structure parentLib :> parentLib =
+struct
+  open parentTheory
+  val parent_thm = parent_thm
+end

--- a/tools/Holmake/tests/cachekey_transitive_parent/inner/parentScript.sml
+++ b/tools/Holmake/tests/cachekey_transitive_parent/inner/parentScript.sml
@@ -1,0 +1,5 @@
+open HolKernel Parse boolLib
+
+val _ = new_theory "parent";
+val parent_thm = save_thm("parent_thm", TRUTH);
+val _ = export_theory();

--- a/tools/Holmake/tests/cachekey_transitive_parent/outer/Holmakefile
+++ b/tools/Holmake/tests/cachekey_transitive_parent/outer/Holmakefile
@@ -1,0 +1,18 @@
+INCLUDES = ../inner
+
+ifdef POLY
+CLINE_OPTIONS = --holstate=$(HOLDIR)/bin/hol.state0
+endif
+
+# qux is a side product of consumeScript.  Holmake's product-cache
+# upload rejects any BuildScript whose target group contains a
+# non-theory output (see is_theory_output in HM_CacheFetch.sml), so
+# this coproduct keeps consumeScript out of the cache entirely --
+# guaranteeing the script actually runs on rebuild, which is what
+# surfaces the stale child.dat as a link_parents failure.
+qux: *consumeScript.sml
+
+all: consumeTheory.uo qux
+.PHONY: all
+
+EXTRA_CLEANS = qux

--- a/tools/Holmake/tests/cachekey_transitive_parent/outer/childScript.sml
+++ b/tools/Holmake/tests/cachekey_transitive_parent/outer/childScript.sml
@@ -1,0 +1,6 @@
+open HolKernel Parse boolLib
+open parentLib
+
+val _ = new_theory "child";
+val child_thm = save_thm("child_thm", parent_thm);
+val _ = export_theory();

--- a/tools/Holmake/tests/cachekey_transitive_parent/outer/consumeScript.sml
+++ b/tools/Holmake/tests/cachekey_transitive_parent/outer/consumeScript.sml
@@ -1,0 +1,18 @@
+open HolKernel Parse boolLib
+open childTheory
+
+val _ = new_theory "consume";
+
+(* Coproduct side product -- declared as qux in outer/Holmakefile so
+   Holmake's cache won't upload our outputs.  This forces an actual
+   script execution on every rebuild, which is when opening
+   childTheory above triggers load_thydata, which calls link_parents
+   against child's recorded parent hashes -- and a stale child.dat
+   fetched from cache fails that check against the current parent. *)
+val _ = let val ostrm = TextIO.openOut "qux"
+        in TextIO.output (ostrm, "consume side product\n");
+           TextIO.closeOut ostrm
+        end;
+
+val _ = save_thm("consume_thm", child_thm);
+val _ = export_theory();

--- a/tools/Holmake/tests/cachekey_transitive_parent/selftest.sml
+++ b/tools/Holmake/tests/cachekey_transitive_parent/selftest.sml
@@ -1,0 +1,160 @@
+(* Regression test for "stale parent" cachekey bug.
+   See README.md for the underlying mechanism.
+
+   The test reports OK when the bug is ABSENT (i.e. when consumeScript
+   builds cleanly after parent has changed and outer has been cleaned).
+   While the bug is unfixed, this selftest is expected to fail with a
+   die("FAILED!") message that includes the captured link_parents text
+   from Holmake's logs.
+
+   The test is NOT yet wired into tools/Holmake/tests/parallel_tests/
+   Holmakefile.  Wire it in once the fix lands. *)
+
+open testutils
+
+val op++ = OS.Path.concat
+val testRoot = OS.FileSys.getDir ()
+val innerDir = testRoot ++ "inner"
+val outerDir = testRoot ++ "outer"
+val holmake = Globals.HOLDIR ++ "bin" ++ "Holmake"
+val cacheDir = testRoot ++ ".cache-iso"
+
+(* Use an in-test isolated cache directory so the test cannot disturb
+   ~/.cache/HOL.  --cache-dir is forwarded explicitly on every Holmake
+   invocation. *)
+fun cacheArgs () = ["--cache-dir=" ^ cacheDir]
+
+fun rm_rf path =
+    let
+      fun rm p =
+          if OS.FileSys.isDir p handle OS.SysErr _ => false then
+            (let val strm = OS.FileSys.openDir p
+                 fun loop () =
+                     case OS.FileSys.readDir strm of
+                         NONE => OS.FileSys.closeDir strm
+                       | SOME f => (rm (p ++ f); loop ())
+             in loop () end;
+             OS.FileSys.rmDir p handle OS.SysErr _ => ())
+          else
+            (OS.FileSys.remove p handle OS.SysErr _ => ())
+    in rm path end
+
+fun ensureDir d =
+    if OS.FileSys.isDir d handle OS.SysErr _ => false then ()
+    else OS.FileSys.mkDir d handle OS.SysErr _ => ()
+
+fun in_dir d f =
+    let val saved = OS.FileSys.getDir ()
+        val _ = OS.FileSys.chDir d
+        val r = f () handle e => (OS.FileSys.chDir saved; raise e)
+    in OS.FileSys.chDir saved; r end
+
+(* Run Holmake in [dir] with [args].  Capture combined stdout/stderr to
+   [logfile].  Returns (status, log_contents). *)
+fun run_holmake_in dir args logfile =
+    let
+      val argv = holmake :: (cacheArgs () @ args)
+      val status =
+          in_dir dir (fn () =>
+            Systeml.systeml_out {outfile = logfile} argv)
+      val log =
+          let val strm = TextIO.openIn logfile
+              val s = TextIO.inputAll strm
+          in TextIO.closeIn strm; s end
+          handle IO.Io _ => ""
+    in (status, log) end
+
+fun writeFile path content =
+    let val out = TextIO.openOut path
+    in TextIO.output (out, content); TextIO.closeOut out end
+
+val parentV1 =
+"open HolKernel Parse boolLib\n\
+\\n\
+\val _ = new_theory \"parent\";\n\
+\val parent_thm = save_thm(\"parent_thm\", TRUTH);\n\
+\val _ = export_theory();\n"
+
+val parentV2 =
+"open HolKernel Parse boolLib\n\
+\\n\
+\val _ = new_theory \"parent\";\n\
+\(* Different content -> different parentTheory.dat hash. *)\n\
+\val parent_thm = save_thm(\"parent_thm\", DISCH_ALL (ASSUME ``T``));\n\
+\val _ = export_theory();\n"
+
+val parentScript = innerDir ++ "parentScript.sml"
+
+fun fresh_cache () = (rm_rf cacheDir; ensureDir cacheDir)
+
+(* Force a full clean of both halves of the test world before/after. *)
+fun nukeBuildArtifacts () =
+    (rm_rf (innerDir ++ ".hol");
+     rm_rf (outerDir ++ ".hol");
+     rm_rf (outerDir ++ "qux"))
+
+val logfile = testRoot ++ ".selftest-step.log"
+
+(* ------------------------------------------------------------------ *)
+val _ = tprint "cachekey_transitive_parent reproducer"
+
+val _ = fresh_cache ()
+val _ = nukeBuildArtifacts ()
+
+fun mustSucceed (status, log, what) =
+    if OS.Process.isSuccess status then ()
+    else die (what ^ " failed:\n" ^ log)
+
+(* Restore parentScript to v1 if we exit/die mid-test, so the working
+   tree stays clean for the next invocation. *)
+fun restore_parent_v1 () = writeFile parentScript parentV1
+
+val _ =
+  let
+    (* Step 1: Build with parent v1.  Establishes the (buggy) cachekey
+       for child in the cache. *)
+    val _ = writeFile parentScript parentV1
+    val (s1a, log1a) = run_holmake_in innerDir [] logfile
+    val _ = mustSucceed (s1a, log1a, "Step 1 inner v1 build")
+    val (s1b, log1b) = run_holmake_in outerDir [] logfile
+    val _ = mustSucceed (s1b, log1b, "Step 1 outer v1 build")
+
+    (* Step 2: Change parent's content; rebuild inner only. *)
+    val _ = writeFile parentScript parentV2
+    val _ = rm_rf (innerDir ++ ".hol")
+    val (s2, log2) = run_holmake_in innerDir [] logfile
+    val _ = mustSucceed (s2, log2, "Step 2 inner v2 build")
+
+    (* Step 3: Clean outer (this is what activates the bug -- the
+       additional_theories augmentation in Holmake.sml requires the
+       generated childTheory.sml to exist on disk, which it doesn't
+       after cleanAll, so the cachekey is computed without parent in
+       scope).  Then rebuild outer.  If consumeScript runs cleanly,
+       the cachekey is correctly tracking parent.  If it fails with
+       link_parents, the bug is present. *)
+    val _ = rm_rf (outerDir ++ ".hol")
+    val _ = rm_rf (outerDir ++ "qux")
+    val (s3, log3) = run_holmake_in outerDir [] logfile
+
+    val ok = OS.Process.isSuccess s3
+  in
+    if ok then (restore_parent_v1 (); OK ())
+    else
+      let
+        val link_parents_present =
+            String.isSubstring "link_parents" log3
+        val why =
+            if link_parents_present then
+              "Stale child.dat fetched from cache; consume's \
+              \link_parents check failed against current parent.  \
+              \This IS the bug under test (expected until fixed)."
+            else
+              "outer rebuild failed for another reason (not the \
+              \link_parents signature)."
+      in
+        restore_parent_v1 ();
+        die ("Bug reproduced.\n  " ^ why ^
+             "\n  --- captured outer log ---\n" ^ log3)
+      end
+  end
+  handle e => (restore_parent_v1 (); raise e)

--- a/tools/Holmake/tests/parallel_tests/Holmakefile
+++ b/tools/Holmake/tests/parallel_tests/Holmakefile
@@ -39,6 +39,7 @@ DIRNAMES = \
 ifdef POLY
 DIRNAMES += cache_reflink \
             cachefetch \
+            cachekey_transitive_parent \
             cheatspotting \
             depchain_heap/ \
             depchain_heap/dir2 \


### PR DESCRIPTION
Proposed solution for #1980.

After fetching a cached `Theory.dat`, parse its recorded parent
hashes and verify each against the current on-disk parent.  On
mismatch, treat as a cache miss and rebuild locally; on match,
behave as before.  Implements the "Layer 1 — fetch-time parent-hash
validation" sketch from the issue.

The cachekey-computation gaps described in the issue (Layer 2)
remain in place; they're now an efficiency concern (false-miss
cache lookups) rather than a soundness concern, so this PR doesn't
chase them.

Current-parent lookup uses the dep graph's known directories first
(so downstream projects with their own theory hierarchies outside
core HOL's sigobj are covered), falling back to sigobj's symlinked
location.

Wires the `cachekey_transitive_parent` regression test (added in
the first commit) into `parallel_tests/Holmakefile` and updates its
README.  Existing cache selftests (`cachefetch`, `cachekey`,
`rebuild_cachekey`) continue to pass; real cache hits still
short-circuit the build.

May be the right resolution for #1980; opening for review.
