### PR TITLE
Holmake: run lastmaker check before parsing -C, not after

### DIFF
--- a/tools/Holmake/core/Holmake.sml
+++ b/tools/Holmake/core/Holmake.sml
@@ -97,6 +97,33 @@ fun getcline args =
     (opts, vars, targets)
   end
 
+(* Run the lastmaker / "am I in the right HOLDIR?" checks BEFORE
+   the full cline parse and any chdir.  We peek at -C/--directory
+   and --nolmbc directly out of argv so do_lastmade_checks can
+   target the user's intended working directory (where its
+   .HOLMK/lastmaker file lives), but the running process stays in
+   its original cwd.  If lastmaker exec-switches to a different
+   Holmake binary, the spawned shell inherits the original cwd and
+   the child's own cline parse handles -C the normal way (one
+   chdir, via set_cwd).  If we don't exec-switch, control falls
+   through to the regular getcline/apply_updates flow below, which
+   sees the same argv and chdirs at its usual point. *)
+local
+  val rawargs = CommandLine.arguments()
+  fun peek_chdir [] = NONE
+    | peek_chdir ("-C" :: d :: _) = SOME d
+    | peek_chdir ("--directory" :: d :: _) = SOME d
+    | peek_chdir (a :: rest) =
+        if String.isPrefix "--directory=" a then
+          SOME (String.extract (a, size "--directory=", NONE))
+        else peek_chdir rest
+in
+val _ = do_lastmade_checks default_ofns
+          {no_lastmakercheck =
+             List.exists (fn s => s = "--nolmbc") rawargs,
+           target_dir = peek_chdir rawargs}
+end
+
 val (master_cline_options, cline_vars, targets) =
   getcline (CommandLine.arguments())
 
@@ -343,8 +370,6 @@ val scan_output_functions =
 *)
 val pass_option_value =
     HM_Cline.fupd_core (HM_Core_Cline.fupd_includes (fn _ => [])) option_value
-
-val _ = do_lastmade_checks outputfns {no_lastmakercheck = no_lastmakercheck}
 
 val _ = diag "startup" (fn _ => "CommandLine.name() = "^CommandLine.name())
 val _ = diag "startup"

--- a/tools/Holmake/core/Holmake_tools.sig
+++ b/tools/Holmake/core/Holmake_tools.sig
@@ -97,8 +97,17 @@ sig
   val check_distrib : string -> string option
     (* check_distrib s returns SOME(HOLDIR/bin/s) if we are under some HOLDIR.*)
   val do_lastmade_checks: output_functions ->
-                          {no_lastmakercheck : bool} ->
+                          {no_lastmakercheck : bool,
+                           target_dir : string option} ->
                           unit
+    (* target_dir = SOME d runs the lastmaker check (and the
+       check_distrib parent walk) as if cwd were d, without
+       leaving the process there: cwd is restored on normal
+       return, and on Systeml.exec the saved cwd is restored
+       first so the spawned shell sees the caller's pre-call
+       cwd.  Used so the early lastmaker call from Holmake.sml
+       can target the user's -C/--directory argument without
+       getting in the way of the later cline-parse chdir. *)
 
 
   (* File IO *)

--- a/tools/Holmake/core/Holmake_tools.sml
+++ b/tools/Holmake/core/Holmake_tools.sml
@@ -306,11 +306,36 @@ in
   traverse() before chDir start
 end
 
-fun do_lastmade_checks (ofns : output_functions) {no_lastmakercheck} = let
+(* Caller passes target_dir = SOME d to peek at the lastmaker state of
+   directory d without yet moving the running process there.  We
+   chdir into d for the lookups (so DEPDIR-relative path resolution
+   and check_distrib's parent walk both operate on d), call
+   find_my_path *before* the chdir (it relies on the original cwd to
+   resolve a `./bin/Holmake`-style invocation), and either:
+
+     - on Systeml.exec, restore the saved cwd first, so the spawned
+       shell inherits the caller's pre-chdir cwd (the exec'd child
+       then handles -C/--directory through the normal cline parse,
+       i.e. exactly one chdir, not two);
+
+     - on the normal return path, restore the saved cwd before
+       returning so the caller's apply_updates/set_cwd flow does
+       the chdir at its usual point and there's no observable
+       cwd change from this call. *)
+fun do_lastmade_checks (ofns : output_functions)
+                       {no_lastmakercheck, target_dir} = let
   val {warn,diag,...} = ofns
   val diag = diag "lastmadecheck"
-  val mypath = find_my_path()
+  val mypath = find_my_path()      (* before any chdir *)
   val _ = diag (K ("running "^mypath))
+  val saved_cwd = FileSys.getDir()
+  val () = case target_dir of
+               NONE => ()
+             | SOME d => (FileSys.chDir d
+                          handle OS.SysErr (msg, _) =>
+                            die_with ("-C " ^ d ^ ": " ^ msg))
+  fun restore_cwd () = FileSys.chDir saved_cwd handle OS.SysErr _ => ()
+  fun exec_in_saved_cwd args = (restore_cwd(); Systeml.exec args)
   val lastmakerfilename = OS.Path.concat (DEPDIR, "lastmaker")
   fun write_lastmaker_file () = let
     val _ = createDirIfNecessary DEPDIR
@@ -343,8 +368,8 @@ fun do_lastmade_checks (ofns : output_functions) {no_lastmakercheck} = let
                   (warn ("*** Switching to execute "^path);
                    warn ("*** (Honouring last Holmake call in this directory)");
                    warn ("*** (Use --nolmbc flag to stop this.)");
-                   Systeml.exec(path,
-                                path::"--nolmbc"::CommandLine.arguments()))
+                   exec_in_saved_cwd
+                     (path, path::"--nolmbc"::CommandLine.arguments()))
               else (warn "Garbage in Last Maker file";
                     write_lastmaker_file())
             end
@@ -352,7 +377,7 @@ fun do_lastmade_checks (ofns : output_functions) {no_lastmakercheck} = let
       else write_lastmaker_file()
 in
   diag (K "Looking to see if I am in a HOL distribution.");
-  case check_distrib "Holmake" of
+  (case check_distrib "Holmake" of
     NONE => let
     in
       diag (K "Not in a HOL distribution");
@@ -365,7 +390,8 @@ in
     else
       (warn ("*** Switching to execute "^p);
        warn ("*** (As we are in/under its HOLDIR)");
-       Systeml.exec (p, p::"--nolmbc"::CommandLine.arguments()))
+       exec_in_saved_cwd (p, p::"--nolmbc"::CommandLine.arguments())));
+  restore_cwd ()
 end
 
 fun chatty_remove act (ofns : output_functions) s =

--- a/tools/Holmake/tests/dashC_lastmaker/Holmakefile
+++ b/tools/Holmake/tests/dashC_lastmaker/Holmakefile
@@ -1,0 +1,9 @@
+CLINE_OPTIONS = --no-cache
+
+dashC_lastmaker-selftest.log: selftest.exe
+	$(tee ./$<, $@)
+
+selftest.exe: selftest.uo
+	$(HOLMOSMLC) -o $@ $<
+
+EXTRA_CLEANS = selftest.exe dashC_lastmaker-selftest.log altHolmake

--- a/tools/Holmake/tests/dashC_lastmaker/Holmakefile
+++ b/tools/Holmake/tests/dashC_lastmaker/Holmakefile
@@ -1,9 +1,16 @@
-CLINE_OPTIONS = --no-cache
+CLINE_OPTIONS = --no-cache --no_overlay
 
-dashC_lastmaker-selftest.log: selftest.exe
-	$(tee ./$<, $@)
+all: selftest.exe
+.PHONY: all
 
 selftest.exe: selftest.uo
 	$(HOLMOSMLC) -o $@ $<
 
 EXTRA_CLEANS = selftest.exe dashC_lastmaker-selftest.log altHolmake
+
+ifdef HOLSELFTESTLEVEL
+all: dashC_lastmaker-selftest.log
+
+dashC_lastmaker-selftest.log: selftest.exe
+	$(tee ./$<, $@)
+endif

--- a/tools/Holmake/tests/dashC_lastmaker/selftest.sml
+++ b/tools/Holmake/tests/dashC_lastmaker/selftest.sml
@@ -26,8 +26,12 @@ val output = "dashC_lastmaker-output"
 val real_holmake = Globals.HOLDIR ++ "bin" ++ "Holmake"
 
 val _ = safedel sym
-val _ = Posix.FileSys.symlink {old = real_holmake, new = sym}
-        handle e => die ("Could not create symlink: " ^ exnMessage e)
+val _ =
+    let val cmd = "ln -s " ^ real_holmake ^ " " ^ sym
+    in
+      if OS.Process.isSuccess (OS.Process.system cmd) then ()
+      else die ("Could not create symlink: " ^ cmd)
+    end
 
 val _ = OS.Process.atExit (fn () => (safedel sym; safedel output))
 

--- a/tools/Holmake/tests/dashC_lastmaker/selftest.sml
+++ b/tools/Holmake/tests/dashC_lastmaker/selftest.sml
@@ -1,0 +1,54 @@
+(* Regression test: -C / --directory must survive the lastmaker
+   exec-switch.  When Holmake's lastmaker check (Holmake_tools.sml's
+   do_lastmade_checks) decides to re-exec a different binary, the
+   original argv has by then already been processed once -- including
+   -C, which chdir'd the parent process.  Naively forwarding the
+   (often relative) -C argument to the exec'd child would make the
+   child re-resolve the path against its already-chdir'd cwd, which
+   generally fails.  This test triggers the switch by invoking Holmake
+   through a symlink whose absolute path differs from the canonical
+   $HOLDIR/bin/Holmake, with -C pointing at a sibling subdirectory. *)
+
+open testutils
+
+infix ++
+val op++ = OS.Path.concat
+
+fun safedel p = OS.FileSys.remove p handle OS.SysErr _ => ()
+
+fun read_file f =
+    let val s = TextIO.openIn f
+    in TextIO.inputAll s before TextIO.closeIn s end
+
+val sym = "altHolmake"
+val output = "dashC_lastmaker-output"
+
+val real_holmake = Globals.HOLDIR ++ "bin" ++ "Holmake"
+
+val _ = safedel sym
+val _ = Posix.FileSys.symlink {old = real_holmake, new = sym}
+        handle e => die ("Could not create symlink: " ^ exnMessage e)
+
+val _ = OS.Process.atExit (fn () => (safedel sym; safedel output))
+
+val _ = tprint "Holmake -C <reldir> survives the lastmaker exec-switch"
+
+(* Without the fix, the exec'd child re-resolves "subdir" against its
+   post-chdir cwd (which is already .../subdir) and dies with
+     Holmake died: -C subdir: No such file or directory *)
+val cmd = String.concatWith " "
+            ["./" ^ sym, "--no-cache", "-C", "subdir", "-n",
+             ">", output, "2>&1"]
+val res = OS.Process.system cmd
+val out = read_file output handle _ => ""
+
+val _ =
+    if not (OS.Process.isSuccess res) then
+      (print "\n--- captured Holmake output ---\n"; print out;
+       print "--- end captured output ---\n";
+       die "Holmake exited non-zero")
+    else if String.isSubstring "No such file or directory" out then
+      (print "\n--- captured Holmake output ---\n"; print out;
+       print "--- end captured output ---\n";
+       die "Holmake reported a missing directory")
+    else OK ()

--- a/tools/sequences/kernel
+++ b/tools/sequences/kernel
@@ -5,7 +5,6 @@
 !tools/Holmake/tests/wildcard
 !tools/Holmake/tests/dashn_works
 !tools/Holmake/tests/dashC_works
-!tools/Holmake/tests/dashC_lastmaker
 !tools/Holmake/tests/dupcommands
 !tools/Holmake/tests/varextension
 tools/set_mtime
@@ -33,6 +32,7 @@ src/postkernel/prooftrace
 # these three directories are required to even run hol --bare
 src/parse
 !tools/Holmake/tests/badincludes
+!tools/Holmake/tests/dashC_lastmaker
 src/opentheory
 (otknl)src/opentheory/logging
 src/bool

--- a/tools/sequences/kernel
+++ b/tools/sequences/kernel
@@ -5,6 +5,7 @@
 !tools/Holmake/tests/wildcard
 !tools/Holmake/tests/dashn_works
 !tools/Holmake/tests/dashC_works
+!tools/Holmake/tests/dashC_lastmaker
 !tools/Holmake/tests/dupcommands
 !tools/Holmake/tests/varextension
 tools/set_mtime


### PR DESCRIPTION
## Summary

- `-C` / `--directory` was failing in combination with the lastmaker exec-switch: `set_cwd` chdir'd the running process to the `-C` target *before* `do_lastmade_checks` decided to re-exec a different Holmake binary, so the spawned shell-child inherited the post-chdir cwd while still carrying `-C <relpath>` in its argv and double-chdir'd.
- Structural fix: peek `-C / --directory` and `--nolmbc` out of argv at the very top of `main()` and run `do_lastmade_checks` with the target as a parameter, *before* `getcline` / `apply_updates`. The function temporarily chdirs into the target for its own lookups (`.HOLMK/lastmaker`, `check_distrib`) and restores the caller's cwd on return — including right before `Systeml.exec`, so the spawned shell inherits the original pre-call cwd. The exec'd child then handles `-C` once via the normal cline parse.

## Test plan

- [ ] `bin/Holmake -C <reldir> <target>` succeeds from a worktree root with a foreign Holmake on `\$PATH` (was previously dying with `-C <reldir>: No such file or directory`).
- [ ] `bin/Holmake -C \$(pwd)/<reldir> <target>` still succeeds (absolute path path was always fine; covered as a regression guard).
- [ ] `bin/Holmake --nolmbc -C <reldir> <target>` still succeeds (lastmaker bypass path).
- [ ] `bin/Holmake --directory=<reldir> <target>` and `bin/Holmake --directory <reldir> <target>` both succeed (alternative spellings of `-C`).
- [ ] New selftest `tools/Holmake/tests/dashC_lastmaker/` (driven by `bin/build -t`) invokes Holmake via a symlink so the exec-switch fires and asserts the build succeeds without "No such file or directory".