### PR TITLE
Holmake tests: clean cross-directory artifacts via top-level EXTRA_CLEANS

### DIFF
--- a/tools/Holmake/tests/badincludes/Holmakefile
+++ b/tools/Holmake/tests/badincludes/Holmakefile
@@ -6,7 +6,12 @@ all: selftest.exe
 selftest.exe: selftest.uo
 	$(HOLMOSMLC) -o $@ $<
 
-EXTRA_CLEANS = selftest.exe badincludes-selftest.log
+# selftest drives Holmake in various error-case subdirs.  The two that
+# actually produce .hol/ trees (the rest are intentionally malformed
+# and never reach build) need cleanup hooks so build cleanAll removes
+# their artifacts.
+EXTRA_CLEANS = selftest.exe badincludes-selftest.log \
+               warnincs/.hol/ loopish_but_ok/dir3/.hol/
 
 ifdef HOLSELFTESTLEVEL
 all: badincludes-selftest.log

--- a/tools/Holmake/tests/cachekey/Holmakefile
+++ b/tools/Holmake/tests/cachekey/Holmakefile
@@ -8,4 +8,8 @@ cachekey-selftest.log: selftest.exe
 selftest.exe: selftest.uo
 	$(HOLMOSMLC) -o $@ $<
 
-EXTRA_CLEANS = selftest.exe cachekey-selftest.log
+# selftest drives Holmake in subdir/, depdir/, sigobj_symlink/ -- subdirs
+# build does not visit via parallel_tests INCLUDES.  List their .hol/
+# trees here so build cleanAll removes them.
+EXTRA_CLEANS = selftest.exe cachekey-selftest.log \
+               depdir/.hol/ subdir/.hol/ sigobj_symlink/.hol/

--- a/tools/Holmake/tests/cheatspotting/Holmakefile
+++ b/tools/Holmake/tests/cheatspotting/Holmakefile
@@ -6,4 +6,9 @@ cheatspotting-selftest.log: selftest.exe
 selftest.exe: selftest.uo
 	$(HOLMOSMLC) -o $@ $<
 
-EXTRA_CLEANS = cheatspotting-selftest.log selftest.exe
+# selftest drives Holmake in testdir/ -- a subdir build does not visit
+# via parallel_tests INCLUDES.  List its artifacts here so build
+# cleanAll removes them.
+EXTRA_CLEANS = cheatspotting-selftest.log selftest.exe \
+               testdir/.hol/ testdir/output \
+               testdir/usedCheat.anon_1.dumpedheap

--- a/tools/Holmake/tests/clinevars/Holmakefile
+++ b/tools/Holmake/tests/clinevars/Holmakefile
@@ -4,4 +4,8 @@ hmclinevars-selftest.log: selftest.exe
 selftest.exe: selftest.uo
 	$(HOLMOSMLC) -o $@ $<
 
-EXTRA_CLEANS = hmclinevars-selftest.log selftest.exe
+# selftest drives Holmake in test/ and test/rec1/ -- subdirs build does
+# not visit via parallel_tests INCLUDES.  List their .hol/ trees here
+# so build cleanAll removes them.
+EXTRA_CLEANS = hmclinevars-selftest.log selftest.exe \
+               test/.hol/ test/rec1/.hol/

--- a/tools/Holmake/tests/coproduct/Holmakefile
+++ b/tools/Holmake/tests/coproduct/Holmakefile
@@ -4,4 +4,9 @@ selftest.log: selftest.exe
 selftest.exe: selftest.uo
 	$(HOLMOSMLC) -o $@ $<
 
-EXTRA_CLEANS = selftest.log selftest.exe
+# selftest drives Holmake in testdir/ and testdir2/ -- subdirs build does
+# not visit via parallel_tests INCLUDES.  List their artifacts here so
+# build cleanAll (which DOES reach this Holmakefile) removes them.
+EXTRA_CLEANS = selftest.log selftest.exe \
+               testdir/foo testdir/bar testdir/master \
+               testdir/.hol/ testdir2/.hol/

--- a/tools/Holmake/tests/dashC_works/Holmakefile
+++ b/tools/Holmake/tests/dashC_works/Holmakefile
@@ -1,1 +1,5 @@
 CLINE_OPTIONS = -C subdir -n
+
+# Holmake is invoked in subdir/ via -C -- not visited by parallel_tests
+# INCLUDES.  Add its .hol/ tree so build cleanAll removes it.
+EXTRA_CLEANS = subdir/.hol/

--- a/tools/Holmake/tests/depchainloop/Holmakefile
+++ b/tools/Holmake/tests/depchainloop/Holmakefile
@@ -9,4 +9,6 @@ depchainloop-selftest.log: selftest.exe
 selftest.exe: selftest.uo
 	$(HOLMOSMLC) -o $@ $<
 
-EXTRA_CLEANS = selftest.exe depchainloop-selftest.log
+# selftest drives Holmake in loopingdir/ -- not visited by INCLUDES from
+# this top.  Add its .hol/ tree so build cleanAll removes it.
+EXTRA_CLEANS = selftest.exe depchainloop-selftest.log loopingdir/.hol/

--- a/tools/Holmake/tests/empty_script/Holmakefile
+++ b/tools/Holmake/tests/empty_script/Holmakefile
@@ -8,4 +8,6 @@ emptyscript-selftest.log: selftest.exe
 selftest.exe: selftest.uo
 	$(MOSMLC) -o $@ $<
 
-EXTRA_CLEANS = selftest.exe emptyscript-selftest.log dir/make.log
+# selftest drives Holmake in dir/ -- not visited by parallel_tests
+# INCLUDES.  Add its .hol/ tree so build cleanAll removes it.
+EXTRA_CLEANS = selftest.exe emptyscript-selftest.log dir/make.log dir/.hol/

--- a/tools/Holmake/tests/gh1353/Holmakefile
+++ b/tools/Holmake/tests/gh1353/Holmakefile
@@ -1,4 +1,7 @@
 gh1353.log: doit.sh testd/bugScript.sml
 	$(tee ./doit.sh $(protect $(HOLDIR)/bin/hol.state0) $(protect $(HOLDIR)/bin/Holmake), $@)
 
-EXTRA_CLEANS = gh1353.log
+# doit.sh drives Holmake in testd/ -- a subdir build does not visit
+# via parallel_tests INCLUDES.  List its .hol/ tree here so build
+# cleanAll removes it.
+EXTRA_CLEANS = gh1353.log testd/.hol/

--- a/tools/Holmake/tests/heap-size/Holmakefile
+++ b/tools/Holmake/tests/heap-size/Holmakefile
@@ -6,6 +6,8 @@ heap-size-selftest.log: selftest.exe
 selftest.exe: selftest.uo
 	$(HOLMOSMLC) -o $@ $<
 
-EXTRA_CLEANS = heap-size-selftest.log selftest.exe
+# selftest drives Holmake in test/ -- not visited by parallel_tests
+# INCLUDES.  List its .hol/ tree here so build cleanAll removes it.
+EXTRA_CLEANS = heap-size-selftest.log selftest.exe test/.hol/
 
 endif

--- a/tools/Holmake/tests/nullary_tgt/Holmakefile
+++ b/tools/Holmake/tests/nullary_tgt/Holmakefile
@@ -1,0 +1,6 @@
+# selftest drives Holmake in test/ -- not visited by parallel_tests
+# INCLUDES (parallel_tests includes ../nullary_tgt, which is this dir,
+# but not test/).  Provide a top Holmakefile whose only purpose is to
+# list test/'s artifacts in EXTRA_CLEANS so build cleanAll removes
+# them.
+EXTRA_CLEANS = test/.hol/ test/output

--- a/tools/Holmake/tests/phony_tgt/Holmakefile
+++ b/tools/Holmake/tests/phony_tgt/Holmakefile
@@ -1,0 +1,6 @@
+# selftest drives Holmake in test1/ and test2/ -- not visited by
+# parallel_tests INCLUDES (which targets ../phony_tgt, this dir, but
+# not test1/ or test2/).  Provide a top Holmakefile whose only purpose
+# is to list those subdirs' artifacts in EXTRA_CLEANS so build cleanAll
+# removes them.
+EXTRA_CLEANS = test1/.hol/ test1/output test2/.hol/ test2/output

--- a/tools/Holmake/tests/theorytarget/Holmakefile
+++ b/tools/Holmake/tests/theorytarget/Holmakefile
@@ -8,4 +8,6 @@ theorytarget-selftest.log: selftest.exe
 selftest.exe: selftest.uo
 	$(HOLMOSMLC) -o $@ $<
 
-EXTRA_CLEANS = selftest.exe theorytarget-selftest.log
+# selftest drives Holmake in subdir/ -- not visited by parallel_tests
+# INCLUDES.  List its .hol/ tree here so build cleanAll removes it.
+EXTRA_CLEANS = selftest.exe theorytarget-selftest.log subdir/.hol/

--- a/tools/Holmake/tests/time-logging/Holmakefile
+++ b/tools/Holmake/tests/time-logging/Holmakefile
@@ -20,4 +20,7 @@ badlog:
 
 
 
-EXTRA_CLEANS = goodlog badlog
+# The good/ and bad/ subdir builds are driven inline (not via INCLUDES)
+# so build cleanAll doesn't recurse there.  List their .hol/ trees so
+# build cleanAll removes them.
+EXTRA_CLEANS = goodlog badlog bad/.hol/ good/.hol/


### PR DESCRIPTION
`bin/build cleanAll` is the ultimate cleanup governor: it runs
`Holmake -r cleanAll` in each directory of its sequence.  But many
`parallel_tests` entries are selftest-driven and run Holmake in
subdirs that the test's top Holmakefile does not (and should not)
reference via `INCLUDES` -- so `bin/build cleanAll` leaves junk
behind in those subdirs.

This PR surveys the leak (run `bin/build -k --no-cache -t
--seq=tools/sequences/upto-parallel` then `bin/build cleanAll`, then
inspect surviving on-disk junk under `tools/Holmake/tests/`) and
patches every test that leaks.  The mechanism in each case is to
list the subdir artifacts in the top Holmakefile's `EXTRA_CLEANS`,
with a trailing `/` on directory entries so `Holmake`'s `clean_dir`
recurses.  Two tests (`nullary_tgt`, `phony_tgt`) didn't have a top
Holmakefile at all -- this PR adds one whose only purpose is to
declare these cleanups.

See the commit message for the full list of affected tests.  After
the patch a full survey cycle leaves no junk under
`tools/Holmake/tests/`.
