### PR TITLE
GitHub actions version upgrade (to Node.js 24)

### DIFF
--- a/.github/workflows/docker-ci-for-pr.yml
+++ b/.github/workflows/docker-ci-for-pr.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: developers/docker-ci/Dockerfile
@@ -33,13 +33,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: developers/docker-ci/Dockerfile
@@ -55,13 +55,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: developers/docker-ci/Dockerfile
@@ -74,13 +74,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: developers/docker-ci/Dockerfile

--- a/.github/workflows/docker-ci-for-pr.yml
+++ b/.github/workflows/docker-ci-for-pr.yml
@@ -17,7 +17,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: developers/docker-ci/Dockerfile
@@ -39,7 +39,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: developers/docker-ci/Dockerfile
@@ -61,7 +61,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: developers/docker-ci/Dockerfile
@@ -80,7 +80,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: developers/docker-ci/Dockerfile

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -15,27 +15,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.USERNAME }}/hol-dev
           tags: |
             type=sha,prefix=ci-,suffix=-stdknl
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ env.USERNAME }}
           password: ${{ env.PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: developers/docker-ci/Dockerfile
@@ -54,27 +54,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.USERNAME }}/hol-dev
           tags: |
             type=sha,prefix=ci-,suffix=-expk
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ env.USERNAME }}
           password: ${{ env.PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: developers/docker-ci/Dockerfile
@@ -93,27 +93,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.USERNAME }}/hol-dev
           tags: |
             type=sha,prefix=ci-,suffix=-mosml
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ env.USERNAME }}
           password: ${{ env.PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: developers/docker-ci/Dockerfile
@@ -129,27 +129,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.USERNAME }}/hol-dev
           tags: |
             type=sha,prefix=ci-,suffix=-otknl
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ env.USERNAME }}
           password: ${{ env.PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: developers/docker-ci/Dockerfile

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: developers/docker-ci/Dockerfile
@@ -74,7 +74,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: developers/docker-ci/Dockerfile
@@ -113,7 +113,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: developers/docker-ci/Dockerfile
@@ -149,7 +149,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: developers/docker-ci/Dockerfile

--- a/.github/workflows/regenerate-cheatsheet.yml
+++ b/.github/workflows/regenerate-cheatsheet.yml
@@ -21,12 +21,12 @@ jobs:
         sudo apt-get install -y build-essential pandoc curl
 
     - name: Checkout HOL
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: hol
 
     - name: Checkout HOL webpages
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: hol-theorem-prover/hol-webpages
         path: hol-webpages

--- a/.github/workflows/self-runner.yml
+++ b/.github/workflows/self-runner.yml
@@ -93,7 +93,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
       -
         name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: developers/docker-ci/${{ env.default_dockerfile }}

--- a/.github/workflows/self-runner.yml
+++ b/.github/workflows/self-runner.yml
@@ -76,7 +76,7 @@ jobs:
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v7
+        uses: docker/metadata-action@v6
         with:
           images: ${{ secrets.DOCKER_HUB_USERNAME }}/hol-dev
           tags: |

--- a/.github/workflows/self-runner.yml
+++ b/.github/workflows/self-runner.yml
@@ -2,7 +2,7 @@ name: self-runner
 
 env:
   default_kernel: 'expk'
-  default_concurrency: '2'
+  default_concurrency: '4'
   default_dockerfile: 'Dockerfile'
   default_platform: 'linux/amd64'
 
@@ -30,7 +30,7 @@ on:
       concurrency:
         description: 'Concurrency'
         required: true
-        default: '2'
+        default: '4'
         type: number
       more-options:
         description: 'More options'
@@ -69,14 +69,14 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v7
         with:
           images: ${{ secrets.DOCKER_HUB_USERNAME }}/hol-dev
           tags: |
@@ -84,16 +84,16 @@ jobs:
             type=sha,prefix={{branch}}-,suffix=-self
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       -
         name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: developers/docker-ci/${{ env.default_dockerfile }}


### PR DESCRIPTION
Hi,

You may have already seen those "Node.js 20 actions are deprecated." warnings when doing CI builds:

- "Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, docker/build-push-action@v5, docker/setup-buildx-action@v3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/"

The solution is to boost all GitHub actions to their next version (i.e. increase the version number by exact one), which supports Node.js 24. That's what this PR does. By greate backward compatibility (of joint efforts between GitHub and Docker), there's no need to change any parameter when calling those actions.

Please squash all commits (because it's only possible to edit the related workflow files one by one using GitHub's Web-based online editor.)

--Chun
