### PR TITLE
TFL: keep cong rule's universal prefix away from user pattern names (gh1961)

### DIFF
--- a/src/tfl/src/Extract.sml
+++ b/src/tfl/src/Extract.sml
@@ -383,7 +383,27 @@ fun simple cnv cps (ant,rst) =
 
 fun complex cnv cps (ant,rst) =
   let val context_frees = free_varsl (#context cps)
-    val ant' = rename_forall_prefix context_frees ant
+    (* The cong rule's universal prefix must also avoid the user's
+       lambda bound names. Otherwise, when the prefix is later
+       generalised by `itlist generalize` below, the binding-by-binding
+       `pairTools.PGEN` (which expands to sequential `Thm.INST`) can
+       collapse names: e.g. if theta is [x_cong |-> y_user,
+       y_cong |-> j_user] (residue of one binding = redex of another),
+       the first INST [j_user |-> y_cong] forces both pair positions to
+       become "y" in the resulting goal.  Pulling the user names into
+       the rename_forall_prefix avoidance list keeps redexes and
+       residues disjoint. *)
+    val vstruct_avoid =
+       let val (_, body0) = strip_forall ant
+           val (_, eq0) = strip_imp_only body0
+           val (lhs0, rhs0) = dest_eq eq0
+           val (_, args0) = strip_comb rhs0
+           val lhsFn0 = fst(dest_combn lhs0 (length args0))
+       in
+         free_varsl (fst (strip_pabs lhsFn0))
+       end handle HOL_ERR _ => []
+    val ant' = rename_forall_prefix
+                  (op_union aconv vstruct_avoid context_frees) ant
     val ant_frees = Term.free_vars ant'
     val (vlist,ceqn) = strip_forall ant'
     val (_,eq) = strip_imp_only ceqn

--- a/src/tfl/src/test/tfl_examplesScript.sml
+++ b/src/tfl/src/test/tfl_examplesScript.sml
@@ -169,3 +169,28 @@ val _ = tDefine "foo"
 `foo x = if (\x. x) x then foo F else ()`
 (WF_REL_TAC `measure (\x. if x then 1 else 0)`);
 
+(* GH #1961: a user pattern variable whose name coincides with the
+   pair_case_cong's universal-prefix bound name (here "y" in the first
+   pair position) used to lose the v = (y,j) binding from the extracted
+   termination condition, leaving the goal unprovable. *)
+val _ = let
+  val _ = Hol_defn "gh1961_foo"
+            `gh1961_foo (s:num list) i = if LENGTH s <= i then NONE
+                                          else SOME (9n:num, i + 1n)`
+  val defn = Hol_defn "gh1961_bar"
+    `gh1961_bar x s i = case gh1961_foo s i of
+                          NONE => SOME (x, i)
+                        | SOME (y, j) => gh1961_bar 0 s j`
+  val tcs = Defn.tcs_of defn
+  val target = ``v = (y:num, j:num)``
+  fun has_pair_eq t =
+    let val (_, body) = boolSyntax.strip_forall t
+        val ants = case Lib.total boolSyntax.dest_imp body
+                    of SOME (a, _) => boolSyntax.strip_conj a
+                     | NONE => []
+    in List.exists (aconv target) ants end
+in
+  if List.exists has_pair_eq tcs then ()
+  else raise Fail "gh1961: extracted TC missing the v = (y,j) constraint"
+end
+


### PR DESCRIPTION
## Summary

- Fixes #1961: termination goal extraction silently drops the `v = (y, j)` pair binding when the user's first pattern variable shares a name with the cong rule's bound prefix variable.
- Root cause is in `Extract.complex`: the substitution `theta` constructed from the cong rule's quantified prefix and the user's lambda vstructs is parallel-correct as built, but the later `itlist generalize` applies it back via `pairTools.PGEN` one binding at a time. When `residue(i) = redex(j)` (e.g. `[x_cong |-> y_user, y_cong |-> j_user]` for user pattern `(y, j)`), the sequential `Thm.INST` collapses both pair positions to the same name.
- Fix: extend the cong rule's `rename_forall_prefix` avoidance list with the user lambda's bound names, so the cong prefix is alpha-renamed to fresh names before stripping. Keeps redexes and residues disjoint, preserves user names in the captured TC.

## How I narrowed it down

1. **Reproduced** with the issue's example under `Hol_defn` + `Defn.tcs_of`, plus three control cases (`(p, j)`, `(p, y)`, `(x, j)`, `(j, x)`). Confirmed only `(y, j)` — i.e. user's first pattern variable matching the cong rule's *later* universal-prefix bound — was broken; `(j, x)` (later matches *earlier*) was fine.
2. **Traced** with `set_trace "Definition.TC extraction" 5` + `set_trace "assumptions" 1`. The trace showed the inner pair_case_cong's third antecedent enter `complex` as
   ```
   !x y. v_cong = (x, y) ==> (λy j. RESTRICT … 0 s j) x y = f' x y
   ```
   and exit it as
   ```
   ∀x' y. v = (y, y) ⇒ (λy j. …) y y = (λy j. …) y y
   ```
   — i.e. the *first* pair position had been overwritten with `y` and the lambda's two args had collapsed.
3. **Located** the collapse in `complex`'s post-extraction `itlist generalize vlist th2`: `pairTools.PGEN v vstr = GEN v (Thm.INST [vstr |-> v] th)`, so the right-fold processes the later binding first, and its `Thm.INST [j_user |-> y_cong]` is a one-shot substitution that catches the `y_user` placed by the earlier binding's residue.
4. **Verified the parallel/sequential distinction** by comparing `(y, j)` against `(j, x)`: both have a redex/residue overlap, but in `(j, x)` the overlap is `redex(0) = residue(1)`, which the right-fold order handles cleanly; in `(y, j)` it's `residue(0) = redex(1)`, which it doesn't.
5. **Chose between two fix shapes**: (A) push the user names into `vstruct_variants`' avoidance list — would have renamed the user's `y` to `y'` in the displayed TC; (B) push them into `rename_forall_prefix`'s avoidance list — renames the *cong rule's* bound vars internally, user names survive. Went with (B).
6. **Sanity-checked the new regression test by reverting only the one-line `rename_forall_prefix` extension**: the new assertion in `tfl_examplesScript.sml` fails on the unfixed code and passes once restored.

## Test plan

- [x] Clean `bin/build cleanAll && bin/build --no-cache --seq=upto-parallel`: green.
- [x] `bin/Holmake -C src/tfl/src/test --no-cache`: `pattern_matchingTheory` and `tfl_examplesTheory` both `OK`.
- [x] Sanity check: temporary revert of the one-line fix → new assertion in `tfl_examplesScript.sml` raises `Fail` as expected; restore → green again.
