### PR TITLE
vim-mode: hG opens a Resume sub-goal via markerLib.set_suspended_goal

### DIFF
--- a/tools/editor-modes/vim/README.md
+++ b/tools/editor-modes/vim/README.md
@@ -79,7 +79,7 @@ Command  | Description
 `hu`     | Send region to HOL in quiet mode.
 `hl`     | Process `load`s for the selected region (e.g. a script file header), as determined by `holdep`.
 `hg`     | Send region (should be a quotation) to `g`, to start a new proof.
-`hG`     | Send region to `new_goalstack` after quoting it, to start a new proof. Any trailing `Proof[...]` modifiers are passed to HOL too.
+`hG`     | Send region to `new_goalstack` after quoting it, to start a new proof. Any trailing `Proof[...]` modifiers are passed to HOL too. If the region contains a `Resume <thm>[<label>]:` header, instead resume the suspended sub-goal of `<thm>` at `<label>` via `markerLib.set_suspended_goal` — the same entry point Holmake uses to set up Resume bodies. The parent theorem must already have been processed up to its `QED` so the suspension is registered.
 `he`     | Send region (should be a tactic) to `e`, to expand a tactic.
 `hS`     | Send region (should be a quotation) as a new subgoal.
 `hF`     | Send region (should be a quotation) to be proved sufficient then proved.

--- a/tools/editor-modes/vim/hol.src
+++ b/tools/editor-modes/vim/hol.src
@@ -108,6 +108,26 @@ endf
 
 fu! HOLUQGoal()
   silent keepjumps normal pG
+  " If the yanked region contains a `Resume <thm>[<label>]:` header,
+  " set up the suspended sub-goal interactively via markerLib instead of
+  " falling through to the Theorem-block handling below.
+  let l:rthm = ''
+  let l:rlabel = ''
+  for l:i in range(1, line('$'))
+    let l:m = matchlist(getline(l:i), '^Resume\s\+\(\S\{-}\)\[\([^]]\+\)\]\s*:')
+    if !empty(l:m)
+      let l:rthm = l:m[1]
+      let l:rlabel = l:m[2]
+      break
+    endif
+  endfor
+  if l:rthm !=# ''
+    keepjumps %d_
+    call setline(1,
+      \ 'markerLib.set_suspended_goal {suspension_name = "' . l:rthm
+      \ . '", label_name = "' . l:rlabel . '"}')
+    return
+  endif
   if search('^Proof','cbW')
     silent keepjumps normal I``) (BasicProvers.mk_tacmod "
     silent keepjumps normal VGJ


### PR DESCRIPTION
Previously `hG` only handled `Theorem name: ... Proof[...] ... QED` blocks (wrapping the region in `proofManagerLib.new_goalstack`). When the yanked region is a `Resume <thm>[<label>]:` header, set the suspended sub-goal on the proof manager via `markerLib.set_suspended_goal` instead — the same entry point Holmake uses, so the interactive goal matches the one the Resume body will be checked against.