### PR TITLE
Document "Equivalence of Lebesuge and Henstock-Kurzweil (Gauge) integration"

### DIFF
--- a/Manual/Description/math.smd
+++ b/Manual/Description/math.smd
@@ -971,7 +971,7 @@ The overloading of `*` (`density_measure`) and `/` (`RN_deriv`) with
 the particular argument order is to syntactically have
 `f * m / m = v / m = f`.
 
-#### Product measures and Fubini's theorem
+### Product measures and Fubini's theorem
 
 HOL provides some basic support for (binary) products of measure
 spaces (in `martingale` theory).
@@ -1159,6 +1159,40 @@ Another consequence of Holder's inequality is the *Minkowski* or
 Holder's inequality is useful in Probability Theory, for example, for
 proving that the sum of random variables having finite second moments
 (i.e. finite variance), has still finite second moments.
+
+### Equivalence of Lebesuge and Henstock-Kurzweil (Gauge) integration
+
+Concrete Lebesgue integrals in the `lborel` measure space may be calculated by
+Fundamental Theorem of Calculus (FTC) of Henstock-Kurzweil (Gauge) integrals.
+Note that, a (Borel-measurable) function is Lebesgue integrable iff it is Gauge
+absolutely integrable. In `lebesgue_measure` theory, the following theorems are
+proved to show the equivalence of the two integration systems:
+
+>>__ load "lebesgue_measureTheory";
+     open lebesgue_measureTheory;
+```repl
+##thm lebesgue_eq_gauge_integral
+
+##thm lebesgue_eq_gauge_integral_alt
+
+##thm lebesgue_eq_gauge_integrable
+```
+
+The basic form of a FTC-like theorem for Lebesgue integration, as a corollary of
+the above theorems and `FUNDAMENTAL_THEOREM_OF_CALCULUS`, is the follow one:
+
+```repl
+##thm FTC_integral_lborel
+```
+
+To satisfy the integrability antecedents in the above theorem, one may need to
+find a _bound_ function `w` such that `!x. abs (g x) <= w x`, which is known to
+be integrable (in Lebesuge) or absolutely integrable (in Gauge).
+
+For improper integrals, i.e. integration over half intervals or the entire reals,
+one can use monotone or dominated convergence theorems to extend the interval
+integrals by a limiting process. (See `examples/probability/distribution` theory
+for some examples.)
 
 ## Probability Theory
 
@@ -1772,4 +1806,3 @@ in general.  The algebraic structures consist of
 :   for finite fields, including existence and uniqueness.
 
 >>__ Parse.temp_set_grammars math_initial_grammars;
-

--- a/Manual/Description/math.smd
+++ b/Manual/Description/math.smd
@@ -1168,8 +1168,6 @@ Note that, a (Borel-measurable) function is Lebesgue integrable iff it is Gauge
 absolutely integrable. In `lebesgue_measure` theory, the following theorems are
 proved to show the equivalence of the two integration systems:
 
->>__ load "lebesgue_measureTheory";
-     open lebesgue_measureTheory;
 ```repl
 ##thm lebesgue_eq_gauge_integral
 

--- a/Manual/Description/math.smd
+++ b/Manual/Description/math.smd
@@ -1178,8 +1178,15 @@ proved to show the equivalence of the two integration systems:
 ##thm lebesgue_eq_gauge_integrable
 ```
 
-The basic form of a FTC-like theorem for Lebesgue integration, as a corollary of
-the above theorems and `FUNDAMENTAL_THEOREM_OF_CALCULUS`, is the follow one:
+Note that various forms of FTCs in `integration` theory can only compute the
+integration of a function over a closed or open interval (excluding at most a
+countable set of points, see `FUNDAMENTAL_THEOREM_OF_CALCULUS_STRONG`). On the
+other hand, Lebesgue integration always integrates a function over the entire
+measure space, and integrating over an interval is equivalent to integrating
+over the entire measure space the same function multiplied with an indicator
+function whose indicating set is the interval. The basic form of a FTC-like
+theorem for Lebesgue integration, based on `FUNDAMENTAL_THEOREM_OF_CALCULUS`, is
+the following one:
 
 ```repl
 ##thm FTC_integral_lborel
@@ -1187,12 +1194,14 @@ the above theorems and `FUNDAMENTAL_THEOREM_OF_CALCULUS`, is the follow one:
 
 To satisfy the integrability antecedents in the above theorem, one may need to
 find a _bound_ function `w` such that `!x. abs (g x) <= w x`, which is known to
-be integrable (in Lebesuge) or absolutely integrable (in Gauge).
+be integrable (in Lebesuge integration) or absolutely integrable (in Gauge
+integration).
 
-For improper integrals, i.e. integration over half intervals or the entire reals,
-one can use monotone or dominated convergence theorems to extend the interval
-integrals by a limiting process. (See `examples/probability/distribution` theory
-for some examples.)
+To compute improper integrals, i.e. integrals over half intervals or the entire
+reals, one can use monotone or Lebesgue dominated convergence theorems to obtain
+the improper integral as the limits of interval integrals.
+(See `examples/probability/distribution` for some examples of improper integrals
+related to normal distributions.)
 
 ## Probability Theory
 

--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -71,6 +71,15 @@ Bugs fixed
 New theories
 ------------
 
+-  `lebesgue_measure`: The equivalence of Lebesgue and Gauge integration.
+   A (measurable) function is Lebesgue integrable iff it is Gauge absolutely
+   integrable. Theorems in this theory (e.g., lebesgue_eq_gauge_integral,
+   lebesgue_eq_gauge_integral_alt, etc.) can be used to calculate concrete
+   Lebesgue integrals found in Probability applications, etc. (in form of
+  `integral lborel (Normal o f)` where `f IN borel_measurable borel`) by
+   Fundamental Theorem of Calculus (FTC) from `integration` theory, if the
+   anti-derivative of `f` is known (or computable by external CAS software).
+
 New tools
 ---------
 

--- a/src/probability/lebesgue_measureScript.sml
+++ b/src/probability/lebesgue_measureScript.sml
@@ -5136,15 +5136,43 @@ Proof
       MATCH_MP_TAC (cj 1 lebesgue_eq_gauge_integral_alt) >> art [] ]
 QED
 
-(* END *)
+Theorem FTC_integral_lborel :
+    !f f' g a b. a <= b /\
+             (!x. x IN interval [a,b] ==>
+                 (f has_vector_derivative f' x) (at x within interval [a,b])) /\
+              f' IN borel_measurable borel /\
+             (!x. g x = f' x * indicator (interval [a,b]) x) /\
+             (integrable lborel (Normal o g) \/
+              g absolutely_integrable_on UNIV) ==>
+              integral lborel (Normal o g) = Normal (f b - f a)
+Proof
+    rpt GEN_TAC
+ >> qabbrev_tac ‘P = (integrable lborel (Normal o g) \/
+                      g absolutely_integrable_on UNIV)’
+ >> STRIP_TAC
+ >> Q.PAT_X_ASSUM ‘!x. g x = _’ (ASSUME_TAC o GSYM)
+ (* applying FTC *)
+ >> MP_TAC (Q.SPECL [‘f’, ‘f'’, ‘a’, ‘b’] FUNDAMENTAL_THEOREM_OF_CALCULUS)
+ >> simp [Once (GSYM HAS_INTEGRAL_MUL_INDICATOR)]
+ >> simp [HAS_INTEGRAL_INTEGRABLE_INTEGRAL]
+ >> STRIP_TAC
+ >> POP_ASSUM (REWRITE_TAC o wrap o SYM)
+ >> fs [Abbr ‘P’, SF ETA_ss]
+ >| [ (* goal 1 (of 2) *)
+      MATCH_MP_TAC (cj 2 lebesgue_eq_gauge_integral) >> art [],
+      (* goal 2 (of 2) *)
+      MATCH_MP_TAC (cj 2 lebesgue_eq_gauge_integral_alt) >> art [] \\
+      Q.PAT_X_ASSUM ‘!x. _ = g x’ (ASSUME_TAC o GSYM) \\
+     ‘g = \x. f' x * indicator (interval [(a,b)]) x’ by rw [FUN_EQ_THM] \\
+      POP_ORW \\
+      HO_MATCH_MP_TAC in_borel_measurable_mul_indicator \\
+      simp [sigma_algebra_borel, CLOSED_interval, borel_measurable_sets] ]
+QED
 
 (* References:
 
   [1] Schilling, R.L.: Measures, Integrals and Martingales (Second Edition).
       Cambridge University Press (2017).
-  [2] Bartle, R.G.: A Modern Theory of Integration. American Mathematical Soc. (2001).
+  [2] Bartle, R.G.: A Modern Theory of Integration. American Math. Soc. (2001).
   [5] Wikipedia: https://en.wikipedia.org/wiki/Henri_Lebesgue
-  [7] Swartz, C.W., Kurtz, D.S.: Theories Of Integration: The Integrals Of Riemann,
-      Lebesgue, Henstock-kurzweil, And Mcshane (2nd Edition).
-      World Scientific Publishing Company (2011).
  *)


### PR DESCRIPTION
Hi,

This PR mentions the new `lebesgue_measure` theory in next release notes and added the main theorems into HOL Description. For this documentation purposes, I also added a new basic FTC-like theorem for Lebesgue integration, by combining the main equivalence results with FTC of Gauge integration:

```
[FTC_integral_lborel]
⊢ ∀f f' g a b.
    a ≤ b ∧
    (∀x. x ∈ interval [(a,b)] ⇒
         (f has_vector_derivative f' x) (at x within interval [(a,b)])) ∧
    f' ∈ borel_measurable borel ∧
    (∀x. g x = f' x * indicator (interval [(a,b)]) x) ∧
    (integrable lborel (Normal ∘ g) ∨ g absolutely_integrable_on 𝕌(:real)) ⇒
    ∫ lborel (Normal ∘ g) = Normal (f b − f a)
```

--Chun