### PR TITLE
Nominal package (next level)

### DIFF
--- a/examples/CCS/CCSScript.sml
+++ b/examples/CCS/CCSScript.sml
@@ -318,7 +318,7 @@ Theorem APPLY_RELAB_THM =
 val _ = (repcode := "crep");
 val _ = (rprefix := "c");
 
-val {tynames, tydata, rep_t, lp} =
+val {tynames, tydata, rep_t, lp, operinfo} =
     nominal_datatype
          ‘CCS = var 'free
               | prefix ('a Action) CCS
@@ -334,10 +334,8 @@ val {tynames, tydata, rep_t, lp} =
  *)
 val tyname = hd tynames; (* "CCS" *)
 
-(* val rep_t = “:'a crep” *)
-val d_tm = mk_var("d", rep_t);
-
 Overload LP = “lp”
+Overload ccslp[local] = “genind ^lp”
 
 val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
      termP, absrep_id, repabs_pseudo_id, term_REP_t, term_ABS_t, newty} =
@@ -347,38 +345,13 @@ val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
     CCS operators
    ---------------------------------------------------------------------- *)
 
-val glam = genind_lam
-Overload ccslp[local] = “genind ^lp”
-
-fun toArb t = subst [“uu:string” |-> “ARB:string”] t
-
-(* var 'free *)
-val var_t = mk_var("var", “:string -> ^newty”)
-val var_pattern = “GLAM uu [s] cvar [][]”
-val var_def = new_definition(
-   "var_def",
-   “^var_t s = ^term_ABS_t ^(toArb var_pattern)”);
-val var_termP = prove(
-  mk_comb(termP, var_pattern),
-  srw_tac [][genind_rules]);
-val var_t = defined_const var_def;
-val var_def' = prove(
-  “^term_ABS_t ^var_pattern = var s”,
-  srw_tac[][var_def, GLAM_NIL_EQ, term_ABS_pseudo11, var_termP])
-
-(* prefix ('a Action) CCS *)
-val prefix_t = mk_var("prefix", “:'a Action -> ^newty -> ^newty”);
-val prefix_pattern = “GLAM uu [] (cprefix u) [] [^term_REP_t E]”
-val prefix_def = new_definition(
-   "prefix_def",
-  “^prefix_t u E = ^term_ABS_t ^(toArb prefix_pattern)”);
-val prefix_termP = prove(
-  mk_comb(termP, prefix_pattern),
-  match_mp_tac glam >> srw_tac [][genind_term_REP]);
-val prefix_t = defined_const prefix_def;
-val prefix_def' = prove(
-  “^term_ABS_t ^prefix_pattern = ^prefix_t u E”,
-    srw_tac [][prefix_def, GLAM_NIL_EQ, term_ABS_pseudo11, prefix_termP]);
+val (_, var_termP,    var_def,    SOME var_def')    = Lib.assoc "var" operinfo;
+val (_, prefix_termP, prefix_def, SOME prefix_def') = Lib.assoc "prefix" operinfo;
+val (_, sum_termP,    sum_def,    SOME sum_def')    = Lib.assoc "sum" operinfo;
+val (_, par_termP,    par_def,    SOME par_def')    = Lib.assoc "par" operinfo;
+val (_, restr_termP,  restr_def,  SOME restr_def')  = Lib.assoc "restr" operinfo;
+val (_, relab_termP,  relab_def,  SOME relab_def')  = Lib.assoc "relab" operinfo;
+val (_, rec_termP,    rec_def,    NONE)             = Lib.assoc "rec" operinfo;
 
 val _ =
     add_rule { term_name = "prefix", fixity = Infixr 700,
@@ -388,56 +361,14 @@ val _ =
 
 val _ = TeX_notation { hol = "..", TeX = ("\\ensuremath{\\ldotp}", 1) };
 
-(* sum CCS CCS *)
-val sum_t = mk_var("sum", “:^newty -> ^newty -> ^newty”);
-val sum_pattern = “GLAM uu [] csum [] [^term_REP_t E1; ^term_REP_t E2]”
-val sum_def = new_definition(
-   "sum_def",
-  “^sum_t E1 E2 = ^term_ABS_t ^(toArb sum_pattern)”);
-val sum_termP = prove(
-  “^termP ^sum_pattern”,
-    match_mp_tac glam >> srw_tac [][genind_term_REP]);
-val sum_t = defined_const sum_def;
-val sum_def' = prove(
-  “^term_ABS_t ^sum_pattern = ^sum_t E1 E2”,
-    srw_tac [][sum_def, GLAM_NIL_EQ, term_ABS_pseudo11, sum_termP]);
-
 val _ = overload_on ("+", ``sum``); (* priority: 500 *)
 val _ = TeX_notation { hol = "+", TeX = ("\\ensuremath{+}", 1) };
-
-(* par CCS CCS *)
-val par_t = mk_var("par", “:^newty -> ^newty -> ^newty”);
-val par_pattern = “GLAM uu [] cpar [] [^term_REP_t E1; ^term_REP_t E2]”
-val par_def = new_definition(
-   "par_def",
-  “^par_t E1 E2 = ^term_ABS_t ^(toArb par_pattern)”);
-val par_termP = prove(
-  “^termP ^par_pattern”,
-    match_mp_tac glam >> srw_tac [][genind_term_REP]);
-val par_t = defined_const par_def;
-val par_def' = prove(
-  “^term_ABS_t ^par_pattern = ^par_t E1 E2”,
-    srw_tac [][par_def, GLAM_NIL_EQ, term_ABS_pseudo11, par_termP]);
 
 val _ = set_mapped_fixity {fixity = Infixl 600,
                            tok = "||", term_name = "par"};
 
 (* val _ = Unicode.unicode_version {u = UTF8.chr 0x007C, tmnm = "par"}; *)
 val _ = TeX_notation { hol = "||", TeX = ("\\ensuremath{\\mid}", 1) };
-
-(* restr ('a Label set) CCS *)
-val restr_t = mk_var("restr", “:'a Label set -> ^newty -> ^newty”);
-val restr_pattern = “GLAM uu [] (crestr L) [] [^term_REP_t E]”
-val restr_def = new_definition(
-   "restr_def",
-  “^restr_t L E = ^term_ABS_t ^(toArb restr_pattern)”);
-val restr_termP = prove(
-  mk_comb(termP, restr_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP]);
-val restr_t = defined_const restr_def;
-val restr_def' = prove(
-  “^term_ABS_t ^restr_pattern = ^restr_t L E”,
-    srw_tac [][restr_def, GLAM_NIL_EQ, term_ABS_pseudo11, restr_termP]);
 
 (* compact representation for single-action restriction *)
 val _ = overload_on("nu", “λ(n :'a) P. restr {name n} P”);
@@ -446,29 +377,6 @@ val _ = add_rule {term_name = "nu", fixity = Closefix,
                   pp_elements = [TOK ("(" ^ UnicodeChars.nu), TM, TOK ")"],
                   paren_style = OnlyIfNecessary,
                   block_style = (AroundEachPhrase, (PP.INCONSISTENT, 2))};
-
-(* relab CCS ('a Relebeling) *)
-val relab_t = mk_var("relab", “:^newty -> 'a Relabeling -> ^newty”);
-val relab_pattern = “GLAM uu [] (crelab rf) [] [^term_REP_t E]”
-val relab_def = new_definition(
-   "relab_def",
-  “^relab_t E rf = ^term_ABS_t ^(toArb relab_pattern)”);
-val relab_termP = prove(
-  mk_comb(termP, relab_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP]);
-val relab_t = defined_const relab_def;
-val relab_def' = prove(
-  “^term_ABS_t ^relab_pattern = ^relab_t E rf”,
-    srw_tac [][relab_def, GLAM_NIL_EQ, term_ABS_pseudo11, relab_termP]);
-
-(* rec 'bound CCS *)
-val rec_t = mk_var("rec", “:string -> ^newty -> ^newty”);
-val rec_pattern = “GLAM X [] crec [^term_REP_t E] []”
-val rec_def = new_definition("rec_def", “^rec_t X E = ^term_ABS_t ^rec_pattern”);
-val rec_termP = prove(
-  mk_comb(termP, rec_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP]);
-val rec_t = defined_const rec_def;
 
 (* ----------------------------------------------------------------------
     tpm (permutation of CCS recursion variables)

--- a/examples/CCS/CCSScript.sml
+++ b/examples/CCS/CCSScript.sml
@@ -351,7 +351,8 @@ val glam = genind_lam
 Overload ccslp[local] = “genind ^lp”
 
 fun toArb t = subst [“uu:string” |-> “ARB:string”] t
-(* var *)
+
+(* var 'free *)
 val var_t = mk_var("var", “:string -> ^newty”)
 val var_pattern = “GLAM uu [s] cvar [][]”
 val var_def = new_definition(
@@ -365,7 +366,7 @@ val var_def' = prove(
   “^term_ABS_t ^var_pattern = var s”,
   srw_tac[][var_def, GLAM_NIL_EQ, term_ABS_pseudo11, var_termP])
 
-(* prefix *)
+(* prefix ('a Action) CCS *)
 val prefix_t = mk_var("prefix", “:'a Action -> ^newty -> ^newty”);
 val prefix_pattern = “GLAM uu [] (cprefix u) [] [^term_REP_t E]”
 val prefix_def = new_definition(
@@ -387,7 +388,7 @@ val _ =
 
 val _ = TeX_notation { hol = "..", TeX = ("\\ensuremath{\\ldotp}", 1) };
 
-(* sum *)
+(* sum CCS CCS *)
 val sum_t = mk_var("sum", “:^newty -> ^newty -> ^newty”);
 val sum_pattern = “GLAM uu [] csum [] [^term_REP_t E1; ^term_REP_t E2]”
 val sum_def = new_definition(
@@ -404,7 +405,7 @@ val sum_def' = prove(
 val _ = overload_on ("+", ``sum``); (* priority: 500 *)
 val _ = TeX_notation { hol = "+", TeX = ("\\ensuremath{+}", 1) };
 
-(* par *)
+(* par CCS CCS *)
 val par_t = mk_var("par", “:^newty -> ^newty -> ^newty”);
 val par_pattern = “GLAM uu [] cpar [] [^term_REP_t E1; ^term_REP_t E2]”
 val par_def = new_definition(
@@ -424,7 +425,7 @@ val _ = set_mapped_fixity {fixity = Infixl 600,
 (* val _ = Unicode.unicode_version {u = UTF8.chr 0x007C, tmnm = "par"}; *)
 val _ = TeX_notation { hol = "||", TeX = ("\\ensuremath{\\mid}", 1) };
 
-(* restr *)
+(* restr ('a Label set) CCS *)
 val restr_t = mk_var("restr", “:'a Label set -> ^newty -> ^newty”);
 val restr_pattern = “GLAM uu [] (crestr L) [] [^term_REP_t E]”
 val restr_def = new_definition(
@@ -446,7 +447,7 @@ val _ = add_rule {term_name = "nu", fixity = Closefix,
                   paren_style = OnlyIfNecessary,
                   block_style = (AroundEachPhrase, (PP.INCONSISTENT, 2))};
 
-(* relab *)
+(* relab CCS ('a Relebeling) *)
 val relab_t = mk_var("relab", “:^newty -> 'a Relabeling -> ^newty”);
 val relab_pattern = “GLAM uu [] (crelab rf) [] [^term_REP_t E]”
 val relab_def = new_definition(
@@ -460,7 +461,7 @@ val relab_def' = prove(
   “^term_ABS_t ^relab_pattern = ^relab_t E rf”,
     srw_tac [][relab_def, GLAM_NIL_EQ, term_ABS_pseudo11, relab_termP]);
 
-(* rec *)
+(* rec 'bound CCS *)
 val rec_t = mk_var("rec", “:string -> ^newty -> ^newty”);
 val rec_pattern = “GLAM X [] crec [^term_REP_t E] []”
 val rec_def = new_definition("rec_def", “^rec_t X E = ^term_ABS_t ^rec_pattern”);

--- a/examples/CCS/CCSScript.sml
+++ b/examples/CCS/CCSScript.sml
@@ -318,7 +318,7 @@ Theorem APPLY_RELAB_THM =
 val _ = (repcode := "crep");
 val _ = (rprefix := "c");
 
-val {tynames, rep_t, lp} =
+val {tynames, tydata, rep_t, lp} =
     nominal_datatype
          ‘CCS = var 'free
               | prefix ('a Action) CCS
@@ -340,8 +340,8 @@ val d_tm = mk_var("d", rep_t);
 Overload LP = “lp”
 
 val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
-     termP, absrep_id, repabs_pseudo_id, term_REP_t, term_ABS_t, newty, ...} =
-    new_type_step1 tyname 0 [] {lp = lp};
+     termP, absrep_id, repabs_pseudo_id, term_REP_t, term_ABS_t, newty} =
+    hd tydata;
 
 (* ----------------------------------------------------------------------
     CCS operators

--- a/examples/formal-languages/pi-calculus/pi_agentScript.sml
+++ b/examples/formal-languages/pi-calculus/pi_agentScript.sml
@@ -77,9 +77,9 @@ val {term_ABS_pseudo11 = term_ABS_pseudo11_2,
     Pi-calculus operators
    ---------------------------------------------------------------------- *)
 
-val glam = genind_lam
 Overload pilp[local] = “genind ^lp”
 
+val glam = genind_lam
 fun toArb t = subst [“uu:string” |-> “ARB:string”] t
 
 (* Nil *)

--- a/examples/formal-languages/pi-calculus/pi_agentScript.sml
+++ b/examples/formal-languages/pi-calculus/pi_agentScript.sml
@@ -21,7 +21,7 @@ Libs
 (* calling nominal_datatype *)
 val _ = (repcode := "repcode");
 
-val {tynames, rep_t, lp} =
+val {tynames, tydata, rep_t, lp} =
     nominal_datatype
           ‘pi   = Nil                         (* 0 *)
                 | Tau pi                      (* tau.P *)
@@ -56,7 +56,7 @@ val {term_ABS_pseudo11 = term_ABS_pseudo11_1,
      repabs_pseudo_id = repabs_pseudo_id1,
      term_REP_t = term_REP_t1,
      term_ABS_t = term_ABS_t1,
-     newty = newty1, ...} = new_type_step1 tyname1 0 [] {lp = lp};
+     newty = newty1, ...} = List.nth (tydata,0);
 
 (* type 2 (:residual) *)
 val {term_ABS_pseudo11 = term_ABS_pseudo11_2,
@@ -68,8 +68,7 @@ val {term_ABS_pseudo11 = term_ABS_pseudo11_2,
      repabs_pseudo_id = repabs_pseudo_id2,
      term_REP_t = term_REP_t2,
      term_ABS_t = term_ABS_t2,
-     newty = newty2, ...} =
-     new_type_step1 tyname2 1 [genind_exists1] {lp = lp};
+     newty = newty2, ...} = List.nth (tydata,1);
 
 (* ----------------------------------------------------------------------
     Pi-calculus operators

--- a/examples/formal-languages/pi-calculus/pi_agentScript.sml
+++ b/examples/formal-languages/pi-calculus/pi_agentScript.sml
@@ -46,6 +46,9 @@ val d_tm = mk_var("d", rep_t);
 (* This is often useful for debugging purposes *)
 Overload LP = lp;
 
+val tydata1 = List.nth (tydata,0);
+val tydata2 = List.nth (tydata,1);
+
 (* type 1 (:pi) *)
 val {term_ABS_pseudo11 = term_ABS_pseudo11_1,
      term_REP_11 = term_REP_11_1,
@@ -56,7 +59,7 @@ val {term_ABS_pseudo11 = term_ABS_pseudo11_1,
      repabs_pseudo_id = repabs_pseudo_id1,
      term_REP_t = term_REP_t1,
      term_ABS_t = term_ABS_t1,
-     newty = newty1, ...} = List.nth (tydata,0);
+     newty = newty1} = tydata1;
 
 (* type 2 (:residual) *)
 val {term_ABS_pseudo11 = term_ABS_pseudo11_2,
@@ -68,7 +71,7 @@ val {term_ABS_pseudo11 = term_ABS_pseudo11_2,
      repabs_pseudo_id = repabs_pseudo_id2,
      term_REP_t = term_REP_t2,
      term_ABS_t = term_ABS_t2,
-     newty = newty2, ...} = List.nth (tydata,1);
+     newty = newty2} = tydata2;
 
 (* ----------------------------------------------------------------------
     Pi-calculus operators
@@ -76,6 +79,7 @@ val {term_ABS_pseudo11 = term_ABS_pseudo11_2,
 
 val glam = genind_lam
 Overload pilp[local] = “genind ^lp”
+
 fun toArb t = subst [“uu:string” |-> “ARB:string”] t
 
 (* Nil *)
@@ -92,7 +96,7 @@ val Nil_def' = prove(
   “^term_ABS_t1 ^Nil_pattern = ^Nil_t”,
     srw_tac [][Nil_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Nil_termP]);
 
-(* Tau prefix *)
+(* Tau pi *)
 val Tau_t = mk_var("Tau", “:^newty1 -> ^newty1”);
 val Tau_pattern = “GLAM uu [] rTau [] [^term_REP_t1 P]”;
 val Tau_def = new_definition(
@@ -106,7 +110,7 @@ val Tau_def' = prove(
   “^term_ABS_t1 ^Tau_pattern = ^Tau_t P”,
     srw_tac [][Tau_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Tau_termP]);
 
-(* Input prefix *)
+(* Input 'free 'bound pi *)
 val Input_t = mk_var("Input", “:string -> string -> ^newty1 -> ^newty1”);
 val Input_pattern = “GLAM x [a] rInput [^term_REP_t1 P] []”;
 val Input_def = new_definition(
@@ -117,7 +121,7 @@ val Input_termP = prove(
     match_mp_tac glam >> srw_tac [][genind_term_REP1]);
 val Input_t = defined_const Input_def;
 
-(* Output prefix *)
+(* Output 'free 'free pi *)
 val Output_t = mk_var("Output", “:string -> string -> ^newty1 -> ^newty1”);
 val Output_pattern = “GLAM uu [a; b] rOutput [] [^term_REP_t1 P]”;
 val Output_def = new_definition(
@@ -131,7 +135,7 @@ val Output_def' = prove(
   “^term_ABS_t1 ^Output_pattern = ^Output_t a b P”,
     srw_tac [][Output_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Output_termP]);
 
-(* Match *)
+(* Match 'free 'free pi *)
 val Match_t = mk_var("Match", “:string -> string -> ^newty1 -> ^newty1”);
 val Match_pattern = “GLAM uu [a; b] rMatch [] [^term_REP_t1 P]”;
 val Match_def = new_definition(
@@ -145,7 +149,7 @@ val Match_def' = prove(
   “^term_ABS_t1 ^Match_pattern = ^Match_t a b P”,
     srw_tac [][Match_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Match_termP]);
 
-(* Mismatch *)
+(* Mismatch 'free 'free pi *)
 val Mismatch_t = mk_var("Mismatch", “:string -> string -> ^newty1 -> ^newty1”);
 val Mismatch_pattern = “GLAM uu [a; b] rMismatch [] [^term_REP_t1 P]”;
 val Mismatch_def = new_definition(
@@ -159,7 +163,7 @@ val Mismatch_def' = prove(
   “^term_ABS_t1 ^Mismatch_pattern = ^Mismatch_t a b P”,
     srw_tac [][Mismatch_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Mismatch_termP]);
 
-(* Sum (Choice) *)
+(* Sum pi pi *)
 val Sum_t = mk_var("Sum", “:^newty1 -> ^newty1 -> ^newty1”);
 val Sum_pattern = “GLAM uu [] rSum [] [^term_REP_t1 P; ^term_REP_t1 Q]”;
 val Sum_def = new_definition(
@@ -173,7 +177,7 @@ val Sum_def' = prove(
   “^term_ABS_t1 ^Sum_pattern = ^Sum_t P Q”,
     srw_tac [][Sum_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Sum_termP]);
 
-(* Parallel Composition *)
+(* Par pi pi *)
 val Par_t = mk_var("Par", “:^newty1 -> ^newty1 -> ^newty1”);
 val Par_pattern = “GLAM uu [] rPar [] [^term_REP_t1 P; ^term_REP_t1 Q]”;
 val Par_def = new_definition(
@@ -187,7 +191,7 @@ val Par_def' = prove(
   “^term_ABS_t1 ^Par_pattern = ^Par_t P Q”,
     srw_tac [][Par_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Par_termP]);
 
-(* Restriction *)
+(* Res 'bound pi *)
 val Res_t = mk_var("Res", “:string -> ^newty1 -> ^newty1”);
 val Res_pattern = “GLAM v [] rRes [^term_REP_t1 P] []”;
 val Res_def = new_definition(
@@ -198,7 +202,7 @@ val Res_termP = prove(
     match_mp_tac glam >> srw_tac [][genind_term_REP1]);
 val Res_t = defined_const Res_def;
 
-(* TauR *)
+(* TauR pi *)
 val TauR_t = mk_var("TauR", “:^newty1 -> ^newty2”);
 val TauR_pattern = “GLAM uu [] rTauR [] [^term_REP_t1 P]”;
 val TauR_def = new_definition(
@@ -212,7 +216,18 @@ val TauR_def' = prove(
   “^term_ABS_t2 ^TauR_pattern = ^TauR_t P”,
     srw_tac [][TauR_def, GLAM_NIL_EQ, term_ABS_pseudo11_2, TauR_termP]);
 
-(* Bound output (residual) *)
+(* InputS 'free 'bound pi *)
+val InputS_t = mk_var("InputS", “:string -> string -> ^newty1 -> ^newty2”);
+val InputS_pattern = “GLAM x [a] rInputS [^term_REP_t1 P] []”;
+val InputS_def = new_definition(
+   "InputS_def",
+  “^InputS_t a x P = ^term_ABS_t2 ^InputS_pattern”);
+val InputS_termP = prove(
+    mk_comb(termP2, InputS_pattern),
+    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
+val InputS_t = defined_const InputS_def;
+
+(* BoundOutput 'free 'bound pi *)
 val BoundOutput_t =
     mk_var("BoundOutput", “:string -> string -> ^newty1 -> ^newty2”);
 val BoundOutput_pattern = “GLAM x [a] rBoundOutput [^term_REP_t1 P] []”;
@@ -224,18 +239,7 @@ val BoundOutput_termP = prove(
     match_mp_tac glam >> srw_tac [][genind_term_REP1]);
 val BoundOutput_t = defined_const BoundOutput_def;
 
-(* Input residual *)
-val InputS_t = mk_var("InputS", “:string -> string -> ^newty1 -> ^newty2”);
-val InputS_pattern = “GLAM x [a] rInputS [^term_REP_t1 P] []”;
-val InputS_def = new_definition(
-   "InputS_def",
-  “^InputS_t a x P = ^term_ABS_t2 ^InputS_pattern”);
-val InputS_termP = prove(
-    mk_comb(termP2, InputS_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
-val InputS_t = defined_const InputS_def;
-
-(* Free output (residual) *)
+(* FreeOutput 'free 'free pi *)
 val FreeOutput_t =
     mk_var("FreeOutput", “:string -> string -> ^newty1 -> ^newty2”);
 val FreeOutput_pattern = “GLAM uu [a; b] rFreeOutput [] [^term_REP_t1 P]”;

--- a/examples/formal-languages/pi-calculus/pi_agentScript.sml
+++ b/examples/formal-languages/pi-calculus/pi_agentScript.sml
@@ -21,7 +21,7 @@ Libs
 (* calling nominal_datatype *)
 val _ = (repcode := "repcode");
 
-val {tynames, tydata, rep_t, lp} =
+val {tynames, tydata, rep_t, lp, operinfo} =
     nominal_datatype
           ‘pi   = Nil                         (* 0 *)
                 | Tau pi                      (* tau.P *)
@@ -41,13 +41,9 @@ val {tynames, tydata, rep_t, lp} =
 val tyname1 = List.nth (tynames,0);
 val tyname2 = List.nth (tynames,1);
 
-val d_tm = mk_var("d", rep_t);
-
 (* This is often useful for debugging purposes *)
 Overload LP = lp;
-
-val tydata1 = List.nth (tydata,0);
-val tydata2 = List.nth (tydata,1);
+Overload pilp[local] = “genind ^lp”
 
 (* type 1 (:pi) *)
 val {term_ABS_pseudo11 = term_ABS_pseudo11_1,
@@ -59,7 +55,7 @@ val {term_ABS_pseudo11 = term_ABS_pseudo11_1,
      repabs_pseudo_id = repabs_pseudo_id1,
      term_REP_t = term_REP_t1,
      term_ABS_t = term_ABS_t1,
-     newty = newty1} = tydata1;
+     newty = newty1} = List.nth (tydata,0);
 
 (* type 2 (:residual) *)
 val {term_ABS_pseudo11 = term_ABS_pseudo11_2,
@@ -71,189 +67,31 @@ val {term_ABS_pseudo11 = term_ABS_pseudo11_2,
      repabs_pseudo_id = repabs_pseudo_id2,
      term_REP_t = term_REP_t2,
      term_ABS_t = term_ABS_t2,
-     newty = newty2} = tydata2;
+     newty = newty2} = List.nth (tydata,1);
 
 (* ----------------------------------------------------------------------
     Pi-calculus operators
    ---------------------------------------------------------------------- *)
 
-Overload pilp[local] = “genind ^lp”
-
-val glam = genind_lam
-fun toArb t = subst [“uu:string” |-> “ARB:string”] t
-
-(* Nil *)
-val Nil_t = mk_var("Nil", “:^newty1”);
-val Nil_pattern = “GLAM uu [] rNil [][]”;
-val Nil_def = new_definition(
-   "Nil_def",
-  “^Nil_t = ^term_ABS_t1 ^(toArb Nil_pattern)”);
-val Nil_termP = prove(
-    mk_comb(termP1, Nil_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
-val Nil_t = defined_const Nil_def;
-val Nil_def' = prove(
-  “^term_ABS_t1 ^Nil_pattern = ^Nil_t”,
-    srw_tac [][Nil_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Nil_termP]);
-
-(* Tau pi *)
-val Tau_t = mk_var("Tau", “:^newty1 -> ^newty1”);
-val Tau_pattern = “GLAM uu [] rTau [] [^term_REP_t1 P]”;
-val Tau_def = new_definition(
-   "Tau_def",
-  “^Tau_t P = ^term_ABS_t1 ^(toArb Tau_pattern)”);
-val Tau_termP = prove(
-    mk_comb(termP1, Tau_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
-val Tau_t = defined_const Tau_def;
-val Tau_def' = prove(
-  “^term_ABS_t1 ^Tau_pattern = ^Tau_t P”,
-    srw_tac [][Tau_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Tau_termP]);
-
-(* Input 'free 'bound pi *)
-val Input_t = mk_var("Input", “:string -> string -> ^newty1 -> ^newty1”);
-val Input_pattern = “GLAM x [a] rInput [^term_REP_t1 P] []”;
-val Input_def = new_definition(
-   "Input_def",
-  “^Input_t a x P = ^term_ABS_t1 ^Input_pattern”);
-val Input_termP = prove(
-    mk_comb(termP1, Input_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
-val Input_t = defined_const Input_def;
-
-(* Output 'free 'free pi *)
-val Output_t = mk_var("Output", “:string -> string -> ^newty1 -> ^newty1”);
-val Output_pattern = “GLAM uu [a; b] rOutput [] [^term_REP_t1 P]”;
-val Output_def = new_definition(
-   "Output_def",
-  “^Output_t a b P = ^term_ABS_t1 ^(toArb Output_pattern)”);
-val Output_termP = prove(
-    mk_comb(termP1, Output_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
-val Output_t = defined_const Output_def;
-val Output_def' = prove(
-  “^term_ABS_t1 ^Output_pattern = ^Output_t a b P”,
-    srw_tac [][Output_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Output_termP]);
-
-(* Match 'free 'free pi *)
-val Match_t = mk_var("Match", “:string -> string -> ^newty1 -> ^newty1”);
-val Match_pattern = “GLAM uu [a; b] rMatch [] [^term_REP_t1 P]”;
-val Match_def = new_definition(
-   "Match_def",
-  “^Match_t a b P = ^term_ABS_t1 ^(toArb Match_pattern)”);
-val Match_termP = prove(
-    mk_comb(termP1, Match_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
-val Match_t = defined_const Match_def;
-val Match_def' = prove(
-  “^term_ABS_t1 ^Match_pattern = ^Match_t a b P”,
-    srw_tac [][Match_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Match_termP]);
-
-(* Mismatch 'free 'free pi *)
-val Mismatch_t = mk_var("Mismatch", “:string -> string -> ^newty1 -> ^newty1”);
-val Mismatch_pattern = “GLAM uu [a; b] rMismatch [] [^term_REP_t1 P]”;
-val Mismatch_def = new_definition(
-   "Mismatch_def",
-  “^Mismatch_t a b P = ^term_ABS_t1 ^(toArb Mismatch_pattern)”);
-val Mismatch_termP = prove(
-    mk_comb(termP1, Mismatch_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
-val Mismatch_t = defined_const Mismatch_def;
-val Mismatch_def' = prove(
-  “^term_ABS_t1 ^Mismatch_pattern = ^Mismatch_t a b P”,
-    srw_tac [][Mismatch_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Mismatch_termP]);
-
-(* Sum pi pi *)
-val Sum_t = mk_var("Sum", “:^newty1 -> ^newty1 -> ^newty1”);
-val Sum_pattern = “GLAM uu [] rSum [] [^term_REP_t1 P; ^term_REP_t1 Q]”;
-val Sum_def = new_definition(
-   "Sum_def",
-  “^Sum_t P Q = ^term_ABS_t1 ^(toArb Sum_pattern)”);
-val Sum_termP = prove(
-    mk_comb(termP1, Sum_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
-val Sum_t = defined_const Sum_def;
-val Sum_def' = prove(
-  “^term_ABS_t1 ^Sum_pattern = ^Sum_t P Q”,
-    srw_tac [][Sum_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Sum_termP]);
-
-(* Par pi pi *)
-val Par_t = mk_var("Par", “:^newty1 -> ^newty1 -> ^newty1”);
-val Par_pattern = “GLAM uu [] rPar [] [^term_REP_t1 P; ^term_REP_t1 Q]”;
-val Par_def = new_definition(
-   "Par_def",
-  “^Par_t P Q = ^term_ABS_t1 ^(toArb Par_pattern)”);
-val Par_termP = prove(
-    mk_comb(termP1, Par_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
-val Par_t = defined_const Par_def;
-val Par_def' = prove(
-  “^term_ABS_t1 ^Par_pattern = ^Par_t P Q”,
-    srw_tac [][Par_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Par_termP]);
-
-(* Res 'bound pi *)
-val Res_t = mk_var("Res", “:string -> ^newty1 -> ^newty1”);
-val Res_pattern = “GLAM v [] rRes [^term_REP_t1 P] []”;
-val Res_def = new_definition(
-   "Res_def",
-  “^Res_t v P = ^term_ABS_t1 ^Res_pattern”);
-val Res_termP = prove(
-    mk_comb (termP1, Res_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
-val Res_t = defined_const Res_def;
-
-(* TauR pi *)
-val TauR_t = mk_var("TauR", “:^newty1 -> ^newty2”);
-val TauR_pattern = “GLAM uu [] rTauR [] [^term_REP_t1 P]”;
-val TauR_def = new_definition(
-   "TauR_def",
-  “^TauR_t P = ^term_ABS_t2 ^(toArb TauR_pattern)”);
-val TauR_termP = prove(
-    mk_comb(termP2, TauR_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
-val TauR_t = defined_const TauR_def;
-val TauR_def' = prove(
-  “^term_ABS_t2 ^TauR_pattern = ^TauR_t P”,
-    srw_tac [][TauR_def, GLAM_NIL_EQ, term_ABS_pseudo11_2, TauR_termP]);
-
-(* InputS 'free 'bound pi *)
-val InputS_t = mk_var("InputS", “:string -> string -> ^newty1 -> ^newty2”);
-val InputS_pattern = “GLAM x [a] rInputS [^term_REP_t1 P] []”;
-val InputS_def = new_definition(
-   "InputS_def",
-  “^InputS_t a x P = ^term_ABS_t2 ^InputS_pattern”);
-val InputS_termP = prove(
-    mk_comb(termP2, InputS_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
-val InputS_t = defined_const InputS_def;
-
-(* BoundOutput 'free 'bound pi *)
-val BoundOutput_t =
-    mk_var("BoundOutput", “:string -> string -> ^newty1 -> ^newty2”);
-val BoundOutput_pattern = “GLAM x [a] rBoundOutput [^term_REP_t1 P] []”;
-val BoundOutput_def = new_definition(
-   "BoundOutput_def",
-  “^BoundOutput_t a x P = ^term_ABS_t2 ^BoundOutput_pattern”);
-val BoundOutput_termP = prove(
-    mk_comb(termP2, BoundOutput_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
-val BoundOutput_t = defined_const BoundOutput_def;
-
-(* FreeOutput 'free 'free pi *)
-val FreeOutput_t =
-    mk_var("FreeOutput", “:string -> string -> ^newty1 -> ^newty2”);
-val FreeOutput_pattern = “GLAM uu [a; b] rFreeOutput [] [^term_REP_t1 P]”;
-val FreeOutput_def = new_definition(
-   "FreeOutput_def",
-  “^FreeOutput_t a b P = ^term_ABS_t2 ^(toArb FreeOutput_pattern)”);
-val FreeOutput_termP = prove(
-    mk_comb(termP2, FreeOutput_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
-val FreeOutput_t = defined_const FreeOutput_def;
-val FreeOutput_def' = prove(
-  “^term_ABS_t2 ^FreeOutput_pattern = ^FreeOutput_t a b P”,
-    srw_tac [][FreeOutput_def, GLAM_NIL_EQ, term_ABS_pseudo11_2,
-               FreeOutput_termP]);
+val (_, Nil_termP, Nil_def, SOME Nil_def') = Lib.assoc "Nil" operinfo;
+val (_, Tau_termP, Tau_def, SOME Tau_def') = Lib.assoc "Tau" operinfo;
+val (_, Input_termP, Input_def, NONE)      = Lib.assoc "Input" operinfo;
+val (_, Output_termP, Output_def, SOME Output_def')
+                                           = Lib.assoc "Output" operinfo;
+val (_, Match_termP, Match_def, SOME Match_def')
+                                           = Lib.assoc "Match" operinfo;
+val (_, Mismatch_termP, Mismatch_def, SOME Mismatch_def')
+                                           = Lib.assoc "Mismatch" operinfo;
+val (_, Sum_termP, Sum_def, SOME Sum_def') = Lib.assoc "Sum" operinfo;
+val (_, Par_termP, Par_def, SOME Par_def') = Lib.assoc "Par" operinfo;
+val (_, Res_termP, Res_def, NONE)          = Lib.assoc "Res" operinfo;
+val (_, TauR_termP, TauR_def, SOME TauR_def')
+                                           = Lib.assoc "TauR" operinfo;
+val (_, InputS_termP, InputS_def, NONE)    = Lib.assoc "InputS" operinfo;
+val (_, BoundOutput_termP, BoundOutput_def, NONE)
+                                           = Lib.assoc "BoundOutput" operinfo;
+val (_, FreeOutput_termP, FreeOutput_def, SOME FreeOutput_def')
+                                           = Lib.assoc "FreeOutput" operinfo;
 
 (* ----------------------------------------------------------------------
     tpm - permutation of pi-calculus binding variables

--- a/examples/lambda/barendregt/labelledTermsScript.sml
+++ b/examples/lambda/barendregt/labelledTermsScript.sml
@@ -8,7 +8,7 @@ Libs
 val _ = (repcode := "lrep");
 val _ = (rprefix := "l");
 
-val {tynames, tydata, rep_t, lp} =
+val {tynames, tydata, rep_t, lp, operinfo} =
     nominal_datatype
       ‘lterm = VAR 'free
              | APP lterm lterm
@@ -23,58 +23,10 @@ val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
 
 val _ = temp_overload_on ("termP", termP)
 
-val glam = genind_lam
-val qnewty = ty_antiq newty
-
-fun defined_const th = th |> concl |> strip_forall |> #2 |> lhs |> repeat rator
-
-val LAM_t = mk_var("LAM", “:string -> ^newty -> ^newty”)
-val LAM_def = new_definition(
-  "LAM_def",
-  “^LAM_t v t = ^term_ABS_t (GLAM v [] lLAM [^term_REP_t t] [])”);
-val LAM_termP = prove(
-  mk_comb(termP, LAM_def |> SPEC_ALL |> concl |> rhs |> rand),
-  match_mp_tac glam >> srw_tac [][genind_term_REP])
-val LAM_t = defined_const LAM_def
-
-(* NOTE: in ‘(LAMi n v t1) t2’, only t1 is bounded (by v), t2 is not. *)
-val LAMi_t = mk_var("LAMi", “:num -> string -> ^newty -> ^newty -> ^newty”)
-val LAMi_def = new_definition(
-  "LAMi_def",
-  “^LAMi_t n v t1 t2 =
-      ^term_ABS_t (GLAM v [] (lLAMi n) [^term_REP_t t1] [^term_REP_t t2])”);
-val LAMi_termP = prove(
-  mk_comb(termP, LAMi_def |> SPEC_ALL |> concl |> rhs |> rand),
-  match_mp_tac glam >> srw_tac [][genind_term_REP]);
-val LAMi_t = defined_const LAMi_def
-
-val APP_t = mk_var("APP", “:^newty -> ^newty -> ^newty”)
-val APP_pattern = “GLAM v [] lAPP [] [^term_REP_t t1; ^term_REP_t t2]”
-val APP_def = new_definition(
-  "APP_def",
-  “^APP_t t1 t2 =
-      ^term_ABS_t ^(subst [“v:string” |-> “ARB:string”] APP_pattern)”);
-val APP_t = defined_const APP_def
-val APP_termP = prove(
-  mk_comb(termP, APP_pattern),
-  match_mp_tac glam >> srw_tac [][genind_term_REP]);
-
-val APP_def' = prove(
-  “^term_ABS_t ^APP_pattern = ^APP_t t1 t2”,
-  srw_tac [][APP_def, GLAM_NIL_EQ, term_ABS_pseudo11, APP_termP]);
-
-val VAR_t = mk_var("VAR", “:string -> ^newty”)
-val VAR_pattern = “GLAM u [v] lVAR [][]”
-val VAR_def = new_definition(
-  "VAR_def",
-  “^VAR_t v = ^term_ABS_t ^(subst [“u:string” |-> “ARB:string”] VAR_pattern)”);
-val VAR_t = defined_const VAR_def
-val VAR_termP = prove(
-  mk_comb(termP, VAR_pattern),
-  match_mp_tac glam >> srw_tac [][genind_term_REP]);
-val VAR_def' = prove(
-  “^term_ABS_t ^VAR_pattern = ^VAR_t v”,
-  srw_tac[][VAR_def, GLAM_NIL_EQ, term_ABS_pseudo11, VAR_termP])
+val (LAM_t,  LAM_termP,  LAM_def,  NONE)          = Lib.assoc "LAM" operinfo;
+val (LAMi_t, LAMi_termP, LAMi_def, NONE)          = Lib.assoc "LAMi" operinfo;
+val (APP_t,  APP_termP,  APP_def,  SOME APP_def') = Lib.assoc "APP" operinfo;
+val (VAR_t,  VAR_termP,  VAR_def,  SOME VAR_def') = Lib.assoc "VAR" operinfo;
 
 val cons_info =
     [{con_termP = VAR_termP, con_def = SYM VAR_def'},
@@ -100,7 +52,6 @@ Proof
   METIS_TAC [pmact_inverse]
 QED
 
-(* support *)
 (* support *)
 val term_REP_eqv = prove(
    “support (fn_pmact ^t_pmact_t gt_pmact) ^term_REP_t {}” ,

--- a/examples/lambda/barendregt/labelledTermsScript.sml
+++ b/examples/lambda/barendregt/labelledTermsScript.sml
@@ -8,7 +8,7 @@ Libs
 val _ = (repcode := "lrep");
 val _ = (rprefix := "l");
 
-val {tynames, rep_t, lp} =
+val {tynames, tydata, rep_t, lp} =
     nominal_datatype
       ‘lterm = VAR 'free
              | APP lterm lterm
@@ -18,8 +18,8 @@ val {tynames, rep_t, lp} =
 val tyname = hd tynames; (* "lterm" *)
 
 val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
-     termP, absrep_id, repabs_pseudo_id, newty, term_REP_t, term_ABS_t,...} =
-    new_type_step1 tyname 0 [] {lp = lp};
+     termP, absrep_id, repabs_pseudo_id, newty, term_REP_t, term_ABS_t} =
+    hd tydata;
 
 val _ = temp_overload_on ("termP", termP)
 

--- a/examples/lambda/basics/ctermScript.sml
+++ b/examples/lambda/basics/ctermScript.sml
@@ -8,7 +8,7 @@ Libs
 val _ = (repcode := "ctrep");
 val _ = (rprefix := "ct");
 
-val {tynames, tydata, rep_t, lp} =
+val {tynames, tydata, rep_t, lp, operinfo} =
     nominal_datatype
       ‘cterm = VAR 'free | APP cterm cterm | LAM 'bound cterm | CONST 'a’;
 
@@ -23,60 +23,10 @@ val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
      termP, absrep_id, repabs_pseudo_id, term_REP_t, term_ABS_t, newty} =
     hd tydata;
 
-val glam = genind_lam
-
-val LAM_t = mk_var("LAM", ``:string -> ^newty -> ^newty``)
-val LAM_def = new_definition(
-  "LAM_def",
-  ``^LAM_t v t = ^term_ABS_t (GLAM v [] ctLAM [^term_REP_t t] [])``)
-val LAM_termP = prove(
-  mk_comb(termP, LAM_def |> SPEC_ALL |> concl |> rhs |> rand),
-  match_mp_tac glam >> srw_tac [][genind_term_REP]);
-val LAM_t = defined_const LAM_def
-
-val APP_t = mk_var("APP", ``:^newty -> ^newty -> ^newty``)
-val APP_def = new_definition(
-  "APP_def",
-  ``^APP_t t1 t2 =
-       ^term_ABS_t (GLAM ARB [] ctAPP [] [^term_REP_t t1; ^term_REP_t t2])``);
-val APP_termP = prove(
-  ``^termP (GLAM x [] ctAPP [] [^term_REP_t t1; ^term_REP_t t2])``,
-  match_mp_tac glam >> srw_tac [][genind_term_REP])
-val APP_t = defined_const APP_def
-
-val APP_def' = prove(
-  ``^term_ABS_t (GLAM v [] ctAPP [] [^term_REP_t t1; ^term_REP_t t2]) =
-    ^APP_t t1 t2``,
-  srw_tac [][APP_def, GLAM_NIL_EQ, term_ABS_pseudo11, APP_termP]);
-
-val VAR_t = mk_var("VAR", ``:string -> ^newty``)
-val VAR_def = new_definition(
-  "VAR_def",
-  ``^VAR_t s = ^term_ABS_t (GLAM ARB [s] ctVAR [][])``);
-Theorem VAR_termP[local]:
-  ^termP (GLAM u [v] ctVAR [][])
-Proof
-  srw_tac [][genind_rules]
-QED
-val VAR_t = defined_const VAR_def
-Theorem VAR_def':
-  ^term_ABS_t (GLAM u [v] ctVAR [][]) = VAR v
-Proof
-  srw_tac[][VAR_def, GLAM_NIL_EQ, term_ABS_pseudo11, VAR_termP]
-QED
-
-val CONST_t = mk_var("CONST", “:'a -> ^newty”)
-val CONST_def = new_definition(
-  "CONST_def",
-  “^CONST_t a = ^term_ABS_t (GLAM ARB [] (ctCONST a) [][])”);
-val CONST_termP = prove(
-  “^termP (GLAM v [] (ctCONST a) [][])”,
-  srw_tac[][genind_rules]);
-val CONST_t = defined_const CONST_def
-
-val CONST_def' = prove(
-  “^term_ABS_t (GLAM v [] (ctCONST a) [] []) = ^CONST_t a”,
-  srw_tac[][CONST_def, GLAM_NIL_EQ, term_ABS_pseudo11, CONST_termP]);
+val (_, LAM_termP,   LAM_def,   NONE)            = Lib.assoc "LAM" operinfo;
+val (_, APP_termP,   APP_def,   SOME APP_def')   = Lib.assoc "APP" operinfo;
+val (_, VAR_termP,   VAR_def,   SOME VAR_def')   = Lib.assoc "VAR" operinfo;
+val (_, CONST_termP, CONST_def, SOME CONST_def') = Lib.assoc "CONST" operinfo;
 
 val cons_info =
     [{con_termP = VAR_termP, con_def = SYM VAR_def'},

--- a/examples/lambda/basics/ctermScript.sml
+++ b/examples/lambda/basics/ctermScript.sml
@@ -8,7 +8,7 @@ Libs
 val _ = (repcode := "ctrep");
 val _ = (rprefix := "ct");
 
-val {tynames, rep_t, lp} =
+val {tynames, tydata, rep_t, lp} =
     nominal_datatype
       ‘cterm = VAR 'free | APP cterm cterm | LAM 'bound cterm | CONST 'a’;
 
@@ -20,8 +20,8 @@ Definition is_ctc_def[simp]:
 End
 
 val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
-     termP, absrep_id, repabs_pseudo_id, term_REP_t, term_ABS_t, newty, ...} =
-    new_type_step1 tyname 0 [] {lp = lp};
+     termP, absrep_id, repabs_pseudo_id, term_REP_t, term_ABS_t, newty} =
+    hd tydata;
 
 val glam = genind_lam
 

--- a/examples/lambda/basics/nomdatatype.sig
+++ b/examples/lambda/basics/nomdatatype.sig
@@ -3,9 +3,7 @@ sig
 
   include Abbrev
   type coninfo = {con_termP : thm, con_def : thm}
-
-  val new_type_step1 : string -> int -> thm list -> {lp:term} ->
-                       {term_ABS_pseudo11 : thm,
+  type nomtyinfo = {term_ABS_pseudo11 : thm,
                         term_REP_11 : thm,
                         term_REP_t : term,
                         term_ABS_t : term,
@@ -15,6 +13,8 @@ sig
                         genind_exists : thm,
                         newty : hol_type,
                         termP : term}
+
+  val new_type_step1 : string -> int -> thm list -> {lp:term} -> nomtyinfo
 
   val termP_removal :
       {elimth : thm, absrep_id : thm, tpm_def : thm, termP : term,
@@ -53,6 +53,7 @@ sig
   val rprefix      : string ref
   val nominal_datatype : hol_type quotation ->
                         {tynames : string list,
+                         tydata  : nomtyinfo list,
                          rep_t   : hol_type,
                          lp      : term}
 

--- a/examples/lambda/basics/nomdatatype.sig
+++ b/examples/lambda/basics/nomdatatype.sig
@@ -3,6 +3,8 @@ sig
 
   include Abbrev
   type coninfo = {con_termP : thm, con_def : thm}
+
+  type operinfo  = {oper_termP : thm, oper_def : thm, oper_def' : thm option}
   type nomtyinfo = {term_ABS_pseudo11 : thm,
                         term_REP_11 : thm,
                         term_REP_t : term,

--- a/examples/lambda/basics/nomdatatype.sig
+++ b/examples/lambda/basics/nomdatatype.sig
@@ -4,7 +4,6 @@ sig
   include Abbrev
   type coninfo = {con_termP : thm, con_def : thm}
 
-  type operinfo  = {oper_termP : thm, oper_def : thm, oper_def' : thm option}
   type nomtyinfo = {term_ABS_pseudo11 : thm,
                         term_REP_11 : thm,
                         term_REP_t : term,
@@ -54,9 +53,10 @@ sig
   val repcode      : string ref
   val rprefix      : string ref
   val nominal_datatype : hol_type quotation ->
-                        {tynames : string list,
-                         tydata  : nomtyinfo list,
-                         rep_t   : hol_type,
-                         lp      : term}
-
+                        {tynames  : string list,
+                         tydata   : nomtyinfo list,
+                         rep_t    : hol_type,
+                         lp       : term,
+                         operinfo : (string *
+                                     (term * thm * thm * thm option)) list}
 end

--- a/examples/lambda/basics/nomdatatype.sml
+++ b/examples/lambda/basics/nomdatatype.sml
@@ -877,28 +877,44 @@ fun pretypeToType2 pty tymap =
 val GLAM = “GLAM :string ->
               string list -> 'a -> 'a gterm list -> 'a gterm list -> 'a gterm”;
 
-fun build_pattern (tymap,tydata,newty,cname,ptys,rep_t) = let
+fun build_pattern (tymap,tydata :nomtyinfo list,
+                   newty,cname,ptys,rep_t) = let
     val glam_t       = inst [alpha |-> rep_t] GLAM;
     val repcode_args = build_repcode_args ptys;
     val repcode      = build_repcode cname repcode_args rep_t;
     val dv_free      = dVartype (!free_tyname);
     val dv_bound     = dVartype (!bound_tyname);
     val free_names   = List.filter (fn e => e = dv_free) ptys;
-    val nfree        = List.length free_names;
+    val free_int     = List.length free_names;
     val free_args    = List.map (fn e => mk_var (e,“:string”))
-                                (gen_names "f" nfree []);
+                                (gen_names "f" free_int []);
     val free_args_t  = mk_list (free_args, “:string”);
     val bound_names  = List.filter (fn e => e = dv_bound) ptys;
     val bound_p      = not (null bound_names);
     val bound_arg    = if bound_p then “x :string” else “uu :string”
     val tynames      = List.map fst tymap;
-    val tns          = build_tns_inner ptys tynames;
-    val uns          = build_uns_inner ptys tynames;
+    val tns          = List.map int_of_term (build_tns_inner ptys tynames);
+    val uns          = List.map int_of_term (build_uns_inner ptys tynames);
+    val tns_rep      = List.map (fn i => #term_REP_t (List.nth (tydata,i))) tns;
+    val uns_rep      = List.map (fn i => #term_REP_t (List.nth (tydata,i))) uns;
+    val tns_argty    = List.map (fn i => #newty (List.nth (tydata,i))) tns;
+    val uns_argty    = List.map (fn i => #newty (List.nth (tydata,i))) uns;
+    val tns_argnames = gen_names "P" (List.length tns) [];
+    val uns_argnames = gen_names "Q" (List.length uns) [];
+    val tns_argv     = List.map mk_var (Lib.zip tns_argnames tns_argty);
+    val uns_argv     = List.map mk_var (Lib.zip uns_argnames uns_argty);
+    val tns_args     = List.map mk_comb (Lib.zip tns_rep tns_argv);
+    val uns_args     = List.map mk_comb (Lib.zip uns_rep uns_argv);
+    val arglist_ty   = type_subst [alpha |-> rep_t] “:'a gterm”;
+    val tns_t        = mk_list (tns_args, arglist_ty);
+    val uns_t        = mk_list (uns_args, arglist_ty);
     val pattern0     = mk_comb (glam_t, bound_arg);
     val pattern1     = mk_comb (pattern0, free_args_t);
     val pattern2     = mk_comb (pattern1, repcode);
+    val pattern3     = mk_comb (pattern2, tns_t);
+    val pattern4     = mk_comb (pattern3, uns_t);
 in
-    (pattern2, tns, uns)
+    pattern4
 end;
 
 (*

--- a/examples/lambda/basics/nomdatatype.sml
+++ b/examples/lambda/basics/nomdatatype.sml
@@ -847,34 +847,68 @@ val Tau_def' = prove(
   “^term_ABS_t1 ^Tau_pattern = ^Tau_t P”,
     srw_tac [][Tau_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Tau_termP]);
 
-(* Input 'free 'bound pi *)
-val Input_t = mk_var("Input", “:string -> string -> ^newty1 -> ^newty1”);
-val Input_pattern = “GLAM x [a] rInput [^term_REP_t1 P] []”;
-val Input_def = new_definition(
-   "Input_def",
-  “^Input_t a x P = ^term_ABS_t1 ^Input_pattern”);
-val Input_termP = prove(
-    mk_comb(termP1, Input_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
-val Input_t = defined_const Input_def;
-
     only Tau_termP, Tau_def and Tau_def' (into operinfo), etc. are needed later.
  *)
-fun build_cons_inner cptys tyname tymap tydata = let
+fun pretypeToType2 pty tymap =
+  case pty of
+    dVartype s => if s = !free_tyname orelse s = !bound_tyname then
+                      “:string”
+                  else
+                      Type.mk_vartype s
+  | dTyop {Tyop = s, Thy, Args} => let
+    in
+      case Thy of
+        NONE => assoc s tymap (* a nominal type here *)
+      | SOME t => Type.mk_thy_type{Tyop = s, Thy = t,
+                                   Args = List.map pretypeToType Args}
+    end
+  | dAQ pty => pty;
+
+(* val Input_pattern = “GLAM x [a] rInput [^term_REP_t1 P] []”;
+
+   x is the only bound name (otherwise it's “uu :string” here)
+   [a] is the list of free names (a0, a1, a2, ...)
+   rInput is the repcode
+   [^term_REP_t1 P]: the first list is the (only) bound nominal argument (P)
+   []: the second list is free nominal arguments (Q0, Q1, Q2, ...)
+
+   External arguments are part of the repcode, e.g. in CCS:
+
+   val prefix_pattern = “GLAM uu [] (cprefix u) [] [^term_REP_t E]”
+
+   ``(GLAM :string ->
+            string list -> 'a -> 'a gterm list -> 'a gterm list -> 'a gterm)``
+   where 'a is instantiated to rep_t
+ *)
+val glam_t = “GLAM :string ->
+               string list -> 'a -> 'a gterm list -> 'a gterm list -> 'a gterm”;
+
+fun build_pattern tymap ty cname ptys rep_t = inst [alpha |-> rep_t] glam_t;
+
+fun build_constructor tymap ty cname ptys rep_t = let
+    val c_ty = list_mk_fun (List.map (fn e => pretypeToType2 e tymap) ptys, ty);
+    val c_t = mk_var(cname, c_ty);
+    val c_pattern = build_pattern tymap ty cname ptys rep_t
+in
+    (c_t, c_pattern)
+end;
+
+fun build_cons_inner cptys tyname tymap tydata rep_t = let
     val current_type = assoc tyname tymap
 in
     List.map (fn (c:string,ptys) =>
-                 (current_type,c)) cptys
+                 build_constructor tymap current_type c ptys rep_t) cptys
 end;
 
-fun build_cons tynames (asts :AST list) (tydata :nomtyinfo list) = let
+fun build_cons tynames (asts :AST list)
+                       (tydata :nomtyinfo list) rep_t = let
     val newtys = List.map (fn e => #newty e) tydata;
     val tymap = zip tynames newtys
 in
     List.concat (List.map (fn (tyname,df) =>
                               case df of
                                   Constructors cs =>
-                                  build_cons_inner cs tyname tymap tydata
+                                  build_cons_inner cs tyname tymap tydata rep_t
                                 | Record _ => []) asts)
 end;
 
@@ -885,7 +919,7 @@ fun nominal_datatype q = let
   val rep_t = define_repcode asts;
   val lp = build_lp asts rep_t;
   val tydata = build_tydata tynames 0 lp [];
-  val cons = build_cons tynames asts tydata
+  val cons = build_cons tynames asts tydata rep_t
 in
     {tynames = tynames,
      tydata  = tydata,

--- a/examples/lambda/basics/nomdatatype.sml
+++ b/examples/lambda/basics/nomdatatype.sml
@@ -513,7 +513,9 @@ fun constructors (asts :AST list) = List.map fst (constructor_and_types asts);
 val free_tyname  = ref "'free";
 val bound_tyname = ref "'bound";
 
-(* This variant of pretypeToType returns only external types *)
+(* NOTE: This variant of pretypeToType returns only external types. Outputs for
+   "dAQ pty" is meaningless (not supported).
+ *)
 fun pretypeToType1 pty =
   case pty of
     dVartype s => if s = !free_tyname orelse s = !bound_tyname then
@@ -525,7 +527,7 @@ fun pretypeToType1 pty =
       case Thy of
         NONE => NONE (* This is referring to nominal types being defined *)
       | SOME t => SOME (Type.mk_thy_type{Tyop = s, Thy = t,
-                                         Args = map pretypeToType Args})
+                                         Args = List.map pretypeToType Args})
     end
   | dAQ pty => SOME pty;
 
@@ -688,7 +690,8 @@ fun filter_this_next e l acc =
 fun build_tns ptys tynames = let
     val dv = dVartype (!bound_tyname);
     val bound_args = filter_this_next dv ptys [];
-    val indexes = map (fn e => index_of (pretypeToName e) tynames) bound_args
+    val indexes = List.map (fn e => index_of (pretypeToName e) tynames)
+                           bound_args
 in
     mk_eq (“tns :num list”, mk_list (indexes, numSyntax.num))
 end;
@@ -726,6 +729,7 @@ fun gen_names n acc =
     else
         gen_names (n - 1) (("a" ^ Int.toString (n - 1))::acc);
 
+(* NOTE: This function only builds "external" arguments of each constructor. *)
 fun build_args ptys = let
     val tys = List.map Option.valOf
                        (List.filter Option.isSome (List.map pretypeToType1 ptys));
@@ -747,19 +751,9 @@ in
                   build_uns ptys tynames)) cptys
 end;
 
-fun build_d_term cname args rep_t = let
-    val rcname = !rprefix ^ cname;
-    val argtypes = List.map type_of args;
-    val c_ty = list_mk_fun (argtypes, rep_t);
-    val c_tm = mk_const (rcname,c_ty);
-    val d_tm = list_mk_comb (c_tm, args)
-in
-    mk_eq (mk_var("d",rep_t), d_tm)
-end;
-
 (* NOTE: For lterm (LabelledTerm), the "LAMi" constructor has two recursive
    parameters, the first is bound (because it's immediately after 'bound), the
-   second is free: LAMi num 'bound lterm lterm.
+   second is free: ‘LAMi num 'bound lterm lterm’.
 
    We need to make sure the generated tns and uns lists each contain one value:
 
@@ -769,14 +763,41 @@ val data =
     (``n = 0``, ``lfvs = 0``, "LAM", [], ``tns = [0]``, ``uns = []``),
     (``n = 0``, ``lfvs = 0``, "LAMi", [``a0``], ``tns = [0]``, ``uns = [0]``)]:
    (term * term * string * term list * term * term) list
-*)
-fun build_lp (asts :AST list) rep_t = let
+ *)
+fun build_lp_data (asts :AST list) = let
     val tynames = extract_tynames asts;
-    val data = List.concat (List.map (fn (tyname,df) =>
-                                         case df of
-                                             Constructors cs =>
-                                             build_lp_inner cs tyname tynames
-                                           | Record _ => []) asts);
+in
+    List.concat (List.map (fn (tyname,df) =>
+                              case df of
+                                  Constructors cs =>
+                                  build_lp_inner cs tyname tynames
+                                | Record _ => []) asts)
+end;
+
+(* “d = _” *)
+fun build_d_term cname args rep_t = let
+    val rcname = !rprefix ^ cname;
+    val argtypes = List.map type_of args;
+    val c_ty = list_mk_fun (argtypes, rep_t);
+    val c_tm = mk_const (rcname,c_ty);
+    val d_tm = list_mk_comb (c_tm, args)
+in
+    mk_eq (mk_var("d", rep_t), d_tm)
+end;
+
+(* val it =
+   ``\n lfvs d tns uns.
+         n = 0 /\ lfvs = 1 /\ d = rvar /\ tns = [] /\ uns = [] \/
+         (?a0. n = 0 /\ lfvs = 0 /\ d = rprefix a0 /\ tns = [] /\ uns = [0]) \/
+         n = 0 /\ lfvs = 0 /\ d = rsum /\ tns = [] /\ uns = [0; 0] \/
+         n = 0 /\ lfvs = 0 /\ d = rpar /\ tns = [] /\ uns = [0; 0] \/
+         (?a0. n = 0 /\ lfvs = 0 /\ d = rrestr a0 /\ tns = [] /\ uns = [0]) \/
+         (?a0. n = 0 /\ lfvs = 0 /\ d = rrelab a0 /\ tns = [] /\ uns = [0]) \/
+         n = 0 /\ lfvs = 0 /\ d = rrec /\ tns = [0] /\ uns = []``: term
+ *)
+fun build_lp (asts :AST list) rep_t = let
+    (* (n_tm,lfvs_tm,cname,args,tns_tm,uns_tm) *)
+    val data = build_lp_data asts;
     val c_tms = List.map
                     (fn (n_tm,lfvs_tm,cname,args,tns_tm,uns_tm) =>
                         list_mk_exists
@@ -803,8 +824,59 @@ fun build_tydata [] index lp ths = []
     let val tyinfo = new_type_step1 tyname index ths {lp = lp};
         val th = #genind_exists tyinfo
     in
-        tyinfo :: build_tydata tynames (index + 1) lp (th::ths)
+        tyinfo :: build_tydata tynames (index + 1) lp (th :: ths)
     end;
+
+type operinfo  = {oper_termP : thm, oper_def : thm, oper_def' : thm option}
+
+val glam = genind_lam
+val toArb = subst [“uu:string” |-> “ARB:string”]
+
+(* Samples:
+(* Tau pi *)
+val Tau_t = mk_var("Tau", “:^newty1 -> ^newty1”);
+val Tau_pattern = “GLAM uu [] rTau [] [^term_REP_t1 P]”;
+val Tau_def = new_definition(
+   "Tau_def",
+  “^Tau_t P = ^term_ABS_t1 ^(toArb Tau_pattern)”);
+val Tau_termP = prove(
+    mk_comb(termP1, Tau_pattern),
+    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
+val Tau_t = defined_const Tau_def;
+val Tau_def' = prove(
+  “^term_ABS_t1 ^Tau_pattern = ^Tau_t P”,
+    srw_tac [][Tau_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Tau_termP]);
+
+(* Input 'free 'bound pi *)
+val Input_t = mk_var("Input", “:string -> string -> ^newty1 -> ^newty1”);
+val Input_pattern = “GLAM x [a] rInput [^term_REP_t1 P] []”;
+val Input_def = new_definition(
+   "Input_def",
+  “^Input_t a x P = ^term_ABS_t1 ^Input_pattern”);
+val Input_termP = prove(
+    mk_comb(termP1, Input_pattern),
+    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
+val Input_t = defined_const Input_def;
+
+    only Tau_termP, Tau_def and Tau_def' (into operinfo), etc. are needed later.
+ *)
+fun build_cons_inner cptys tyname tymap tydata = let
+    val current_type = assoc tyname tymap
+in
+    List.map (fn (c:string,ptys) =>
+                 (current_type,c)) cptys
+end;
+
+fun build_cons tynames (asts :AST list) (tydata :nomtyinfo list) = let
+    val newtys = List.map (fn e => #newty e) tydata;
+    val tymap = zip tynames newtys
+in
+    List.concat (List.map (fn (tyname,df) =>
+                              case df of
+                                  Constructors cs =>
+                                  build_cons_inner cs tyname tymap tydata
+                                | Record _ => []) asts)
+end;
 
 (* The final API (so far) *)
 fun nominal_datatype q = let
@@ -812,7 +884,8 @@ fun nominal_datatype q = let
   val tynames = extract_tynames asts;
   val rep_t = define_repcode asts;
   val lp = build_lp asts rep_t;
-  val tydata = build_tydata tynames 0 lp []
+  val tydata = build_tydata tynames 0 lp [];
+  val cons = build_cons tynames asts tydata
 in
     {tynames = tynames,
      tydata  = tydata,

--- a/examples/lambda/basics/nomdatatype.sml
+++ b/examples/lambda/basics/nomdatatype.sml
@@ -119,11 +119,23 @@ fun first2 l =
       (x::y::_) => (x,y)
     | _ => raise Fail "first2: list doesn't have at least two elements"
 
-(* NOTE: In case multiple mutually recursive nominal types are being defined, "witnesses"
-   argument takes a list of [genind_exists] theorems generated from previous calls to the
-   current function, otherwise the proof of term_exists may not succeed.
+(* NOTE: In case multiple mutually recursive nominal types are being defined,
+  "witnesses" argument takes a list of [genind_exists] theorems generated from
+   previous calls to the current function, otherwise the proof of term_exists
+   may not succeed.
  *)
-fun new_type_step1 tyname n witnesses {lp} = let
+type nomtyinfo = {term_ABS_pseudo11 : thm,
+                        term_REP_11 : thm,
+                        term_REP_t : term,
+                        term_ABS_t : term,
+                        absrep_id : thm,
+                        repabs_pseudo_id : thm,
+                        genind_term_REP : thm,
+                        genind_exists : thm,
+                        newty : hol_type,
+                        termP : term};
+
+fun new_type_step1 tyname n witnesses {lp} :nomtyinfo = let
   val list_mk_icomb = uncurry (List.foldl (mk_icomb o swap))
   val termP =
       list_mk_icomb (genind_t, [lp,numSyntax.mk_numeral (Arbnum.fromInt n)])
@@ -773,19 +785,25 @@ in
     list_mk_abs ([n_tm, lfvs_tm, d_tm, tns_tm, uns_tm], list_mk_disj c_tms)
 end;
 
-(* Step 1: parse datatype quotation
-   Step 2: define repcode (intermediate datatype)
-   Step 3: generate lp term
- *)
+fun build_tydata [] index lp ths = []
+  | build_tydata (tyname::tynames) index lp ths =
+    let val tyinfo = new_type_step1 tyname index ths {lp = lp};
+        val th = #genind_exists tyinfo
+    in
+        tyinfo :: build_tydata tynames (index + 1) lp (th::ths)
+    end;
+
 fun nominal_datatype q = let
   val asts = parse_datatype q;
   val tynames = extract_tynames asts;
   val rep_t = define_repcode asts;
-  val lp_tm = build_lp asts rep_t
+  val lp = build_lp asts rep_t;
+  val tydata = build_tydata tynames 0 lp []
 in
     {tynames = tynames,
+     tydata = tydata,
      rep_t = rep_t,
-     lp = lp_tm}
+     lp = lp}
 end;
 
 end (* struct *)

--- a/examples/lambda/basics/nomdatatype.sml
+++ b/examples/lambda/basics/nomdatatype.sml
@@ -621,7 +621,7 @@ val lp =
      n = 1 /\ lfvs = 2 /\ d = rFreeOutput /\ tns = [] /\ uns = [0]
     )”;
 
-Example 2 (mixed free and bound recursive terms; external data):
+Example 2 (mixed free and bound recursive terms; with external type :num):
 
 val q = ‘lterm = VAR 'free
                | APP lterm lterm
@@ -642,7 +642,7 @@ val lp = “λn lfvs (d:lrep) tns uns.
   uns is the list of indexes of unbounded (free) arguments.
 *)
 
-(* NOTE: index_of "b" ["a", "b", "c"] = “1 :num” *)
+(* index_of "b" ["a", "b", "c"] = “1 :num” *)
 local
     open Arbnum
     fun index_of_inner (n :num) e l =
@@ -652,6 +652,7 @@ in
 fun index_of e l = numSyntax.mk_numeral (index_of_inner Arbnum.zero e l)
 end;
 
+(* NOTE: “lfvs = _” where “_” is the number of “:free” of the constructor *)
 fun build_lfvs (ptys) = let
     val i = List.length (List.filter (fn e => e = dVartype (!free_tyname)) ptys)
 in
@@ -661,6 +662,7 @@ end;
 (* find_prev 2 [1,2,3,4,5] = 3 *)
 fun find_next e l = if hd l = e then hd (tl l) else find_next e (tl l);
 
+(* NOTE: The "dAQ" contructor is not supported *)
 fun pretypeToName pty =
     case pty of
         dVartype s => s
@@ -691,6 +693,7 @@ in
     mk_eq (“tns :num list”, mk_list (indexes, numSyntax.num))
 end;
 
+(* NOTE: The "dAQ" constructor is not supported *)
 fun pretypeIsNominal pty =
     case pty of
         dVartype s => false
@@ -754,7 +757,12 @@ in
     mk_eq (mk_var("d",rep_t), d_tm)
 end;
 
-(*
+(* NOTE: For lterm (LabelledTerm), the "LAMi" constructor has two recursive
+   parameters, the first is bound (because it's immediately after 'bound), the
+   second is free: LAMi num 'bound lterm lterm.
+
+   We need to make sure the generated tns and uns lists each contain one value:
+
 val data =
    [(``n = 0``, ``lfvs = 1``, "VAR", [], ``tns = []``, ``uns = []``),
     (``n = 0``, ``lfvs = 0``, "APP", [], ``tns = []``, ``uns = [0; 0]``),
@@ -785,6 +793,11 @@ in
     list_mk_abs ([n_tm, lfvs_tm, d_tm, tns_tm, uns_tm], list_mk_disj c_tms)
 end;
 
+(* NOTE: When calling "new_type_step1" for next tyname, the genind_exists slot
+   of nomtyinfo from previous calls of "new_type_step1", must be supplied.
+   This works for pi-calculus but perhaps not works for mutually exclusive types
+   that we haven't met yet.
+ *)
 fun build_tydata [] index lp ths = []
   | build_tydata (tyname::tynames) index lp ths =
     let val tyinfo = new_type_step1 tyname index ths {lp = lp};
@@ -793,6 +806,7 @@ fun build_tydata [] index lp ths = []
         tyinfo :: build_tydata tynames (index + 1) lp (th::ths)
     end;
 
+(* The final API (so far) *)
 fun nominal_datatype q = let
   val asts = parse_datatype q;
   val tynames = extract_tynames asts;
@@ -801,9 +815,9 @@ fun nominal_datatype q = let
   val tydata = build_tydata tynames 0 lp []
 in
     {tynames = tynames,
-     tydata = tydata,
-     rep_t = rep_t,
-     lp = lp}
+     tydata  = tydata,
+     rep_t   = rep_t,
+     lp      = lp}
 end;
 
 end (* struct *)

--- a/examples/lambda/basics/nomdatatype.sml
+++ b/examples/lambda/basics/nomdatatype.sml
@@ -839,8 +839,6 @@ fun build_tydata [] index lp ths = []
         tyinfo :: build_tydata tynames (index + 1) lp (th :: ths)
     end;
 
-type operinfo = {oper_termP : thm, oper_def : thm, oper_def' : thm option};
-
 val glam = genind_lam;
 val toArb = subst [“uu:string” |-> “ARB:string”];
 
@@ -862,6 +860,58 @@ fun pretypeToType2 pty tymap =
     end
   | dAQ pty => pty;
 
+(* NOTE: This function translates ptys (pretypes) to a list of argument terms.
+   Naming conventions are the following:
+
+   External (repcode) arguments: a0, a1, ...
+   Free names: v0, v1, ...
+   Bound names (at most one is currently supported): x
+   Bound nominal arguments (at most one, in fact): P0, P1, ...
+   Free nominal arguments: Q0, Q1, ...
+
+   Order of all arguments must be preserved. Note that the only bound argument
+   must be immediately following the (only) bound name. And this is the only
+   way to know if a nominal argument is free or bound. This function only returns
+   a list of names following the naming conventions.
+ *)
+fun pretypeToType3 pty =
+  case pty of
+    dVartype s => if s = !free_tyname then "v"
+                  else if s = !bound_tyname then "x"
+                  else "a" (* repcode argument *)
+  | dTyop {Tyop = s, Thy, Args} => let
+    in
+      case Thy of
+        NONE   => "Q"
+      | SOME t => "a" (* repcode argument *)
+    end
+  | dAQ pty => "";
+
+(* NOTE: The parameters a v p g are used as counters for generating names. Each
+   round only one of them gets increased. Stupid but working.
+ *)
+fun build_args_inner [] a (x :bool) v p q = []
+  | build_args_inner (pty::ptys) a x v p q =
+    let val s = pretypeToType3 pty;
+        val s' = if s = "Q" andalso x then "P" else s;
+        val n  = if s' = "a" then
+                     s' ^ int_to_string a
+                 else if s' = "x" then s' (* only one is supported *)
+                 else if s' = "v" then s' ^ int_to_string v
+                 else if s' = "P" then s' ^ int_to_string p
+                 else if s' = "Q" then s' ^ int_to_string q
+                 else
+                     s';
+        val a' = if s' = "a" then a + 1 else a;
+        val v' = if s' = "v" then v + 1 else v;
+        val p' = if s' = "P" then p + 1 else p;
+        val q' = if s' = "Q" then q + 1 else q;
+    in
+        n :: build_args_inner ptys a' (s' = "x") v' p' q'
+    end;
+
+fun build_args ptys = build_args_inner ptys 0 false 0 0 0;
+
 (* val Input_pattern = “GLAM x [a] rInput [^term_REP_t1 P] []”;
 
    x is the only bound name (otherwise it's “uu :string” here)
@@ -877,8 +927,7 @@ fun pretypeToType2 pty tymap =
 val GLAM = “GLAM :string ->
               string list -> 'a -> 'a gterm list -> 'a gterm list -> 'a gterm”;
 
-fun build_pattern (tymap,tydata :nomtyinfo list,
-                   newty,cname,ptys,rep_t) = let
+fun build_pattern (tymap,tydata :nomtyinfo list,newty,cname,ptys,rep_t) = let
     val glam_t       = inst [alpha |-> rep_t] GLAM;
     val repcode_args = build_repcode_args ptys;
     val repcode      = build_repcode cname repcode_args rep_t;
@@ -887,7 +936,7 @@ fun build_pattern (tymap,tydata :nomtyinfo list,
     val free_names   = List.filter (fn e => e = dv_free) ptys;
     val free_int     = List.length free_names;
     val free_args    = List.map (fn e => mk_var (e,“:string”))
-                                (gen_names "f" free_int []);
+                                (gen_names "v" free_int []);
     val free_args_t  = mk_list (free_args, “:string”);
     val bound_names  = List.filter (fn e => e = dv_bound) ptys;
     val bound_p      = not (null bound_names);
@@ -913,11 +962,24 @@ fun build_pattern (tymap,tydata :nomtyinfo list,
     val pattern2     = mk_comb (pattern1, repcode);
     val pattern3     = mk_comb (pattern2, tns_t);
     val pattern4     = mk_comb (pattern3, uns_t);
+ (* NOTE: now we collect all constructor argument terms into a list, but
+    the order may be wrong. We need to use the list of names returned by
+    build_args to re-order it.
+  *)
+    val unordered    = List.concat [repcode_args,
+                                   free_args,
+                                   if bound_p then [bound_arg] else [],
+                                   tns_argv, uns_argv];
+    val argnames     = build_args ptys;
+    val arglist      =
+        List.map (fn e => valOf (List.find (fn v => fst (dest_var v) = e)
+                                           unordered)) argnames;
 in
-    pattern4
+    (pattern4, arglist, bound_p)
 end;
 
-(*
+(* Example 1 (bound_p = false):
+
 val Tau_t = mk_var("Tau", “:^newty1 -> ^newty1”);
 val Tau_pattern = “GLAM uu [] rTau [] [^term_REP_t1 P]”;
 val Tau_def = new_definition(
@@ -931,26 +993,55 @@ val Tau_def' = prove(
   “^term_ABS_t1 ^Tau_pattern = ^Tau_t P”,
     srw_tac [][Tau_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Tau_termP]);
 
+   Example 2 (bound_p = true):
+
+(* Input 'free 'bound pi *)
+val Input_t = mk_var("Input", “:string -> string -> ^newty1 -> ^newty1”);
+val Input_pattern = “GLAM x [a] rInput [^term_REP_t1 P] []”;
+val Input_def = new_definition(
+   "Input_def",
+  “^Input_t a x P = ^term_ABS_t1 ^Input_pattern”);
+val Input_termP = prove(
+    mk_comb(termP1, Input_pattern),
+    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
+val Input_t = defined_const Input_def;
+
     only Tau_termP, Tau_def and Tau_def' (into operinfo), etc. are needed later.
  *)
-fun build_constructor (tymap,tydata,newty,cname,ptys,rep_t) = let
-    val c_ty = list_mk_fun
-                 (List.map (fn e => pretypeToType2 e tymap) ptys,newty);
-    val c_t = mk_var (cname,c_ty);
-    val c_pattern = build_pattern (tymap,tydata,newty,cname,ptys,rep_t)
+fun build_constructor (tymap,tydata,tyname,cname,ptys,rep_t) = let
+    val newty   = Lib.assoc tyname tymap;
+    val c_ty    = list_mk_fun
+                    (List.map (fn e => pretypeToType2 e tymap) ptys,newty);
+    val c_t     = mk_var (cname,c_ty);
+    val (c_pattern,arglist,bound_p)
+                = build_pattern (tymap,tydata,newty,cname,ptys,rep_t);
+    val tynames = List.map fst tymap;
+    val index   = int_of_term (index_of tyname tynames);
+    val lhs     = list_mk_comb (c_t,arglist);
+    val tydata1 = List.nth (tydata,index);
+    val rhs     = mk_comb (#term_ABS_t tydata1,toArb c_pattern);
+    val c_def   = new_definition (cname ^ "_def", mk_eq (lhs,rhs));
+    val ths     = List.map #genind_term_REP tydata;
+    val c_termP = prove(mk_comb(#termP tydata1, c_pattern),
+                        match_mp_tac glam >> srw_tac [] ths);
+    val c_tm    = defined_const c_def;
+    val lhs'    = mk_comb (#term_ABS_t tydata1,c_pattern);
+    val rhs'    = list_mk_comb (c_tm,arglist);
+    val ths'    = [c_def, GLAM_NIL_EQ, #term_ABS_pseudo11 tydata1, c_termP];
+    val c_def'  = if bound_p then NONE
+                  else
+                      SOME (prove (mk_eq (lhs',rhs'),srw_tac [] ths'))
 in
-    (c_t, c_pattern)
+    (cname,(c_tm,c_termP,c_def,c_def'))
 end;
 
-fun build_cons_inner (cptys,tyname,tymap,tydata,rep_t) = let
-    val newty = Lib.assoc tyname tymap
-in
+fun build_operinfo_inner (cptys,tyname,tymap,tydata,rep_t) =
     List.map (fn (cname,ptys) =>
-                 build_constructor (tymap,tydata,newty,cname,ptys,rep_t)) cptys
-end;
+                 build_constructor (tymap,tydata,tyname,cname,ptys,rep_t))
+             cptys;
 
 (* This function builds definitional theorems for each constructor. *)
-fun build_cons tynames asts (tydata :nomtyinfo list) rep_t = let
+fun build_operinfo tynames asts (tydata :nomtyinfo list) rep_t = let
     val newtys = List.map (fn e => #newty e) tydata;
     val tymap = Lib.zip tynames newtys
 in
@@ -958,23 +1049,24 @@ in
         (List.map (fn (tyname,df) =>
                       case df of
                           Constructors cs =>
-                          build_cons_inner (cs,tyname,tymap,tydata,rep_t)
+                          build_operinfo_inner (cs,tyname,tymap,tydata,rep_t)
                         | Record _ => []) asts)
 end;
 
 (* The final API (so far) *)
 fun nominal_datatype q = let
-  val asts    = parse_datatype q;
-  val tynames = extract_tynames asts;
-  val rep_t   = define_repcode asts;
-  val lp      = build_lp asts rep_t;
-  val tydata  = build_tydata tynames 0 lp [];
-  val cons    = build_cons tynames asts tydata rep_t
+  val asts     = parse_datatype q;
+  val tynames  = extract_tynames asts;
+  val rep_t    = define_repcode asts;
+  val lp       = build_lp asts rep_t;
+  val tydata   = build_tydata tynames 0 lp [];
+  val operinfo = build_operinfo tynames asts tydata rep_t
 in
-    {tynames = tynames,
-     tydata  = tydata,
-     rep_t   = rep_t,
-     lp      = lp}
+    {tynames  = tynames,
+     tydata   = tydata,
+     rep_t    = rep_t,
+     lp       = lp,
+     operinfo = operinfo}
 end;
 
 end (* struct *)

--- a/examples/lambda/basics/nomdatatype.sml
+++ b/examples/lambda/basics/nomdatatype.sml
@@ -687,13 +687,17 @@ fun filter_this_next e l acc =
                dTyop {Args = [], Thy = NONE, Tyop = "pi"}]
    ==> tns = [0]
  *)
-fun build_tns ptys tynames = let
+fun build_tns_inner ptys tynames = let
     val dv = dVartype (!bound_tyname);
     val bound_args = filter_this_next dv ptys [];
-    val indexes = List.map (fn e => index_of (pretypeToName e) tynames)
-                           bound_args
 in
-    mk_eq (“tns :num list”, mk_list (indexes, numSyntax.num))
+    List.map (fn e => index_of (pretypeToName e) tynames) bound_args
+end;
+
+fun build_tns ptys tynames = let
+    val tns = build_tns_inner ptys tynames
+in
+    mk_eq (“tns :num list”, mk_list (tns,numSyntax.num))
 end;
 
 (* NOTE: The "dAQ" constructor is not supported *)
@@ -715,40 +719,33 @@ fun filter_out_this_next e l acc =
 (* The “uns” list contains indexes of all nominal types, excluding the one
    after 'bound (which is put into the “tns” list).
  *)
-fun build_uns ptys tynames = let
+fun build_uns_inner ptys tynames = let
     val l1 = filter_out_this_next (dVartype (!bound_tyname)) ptys [];
     val l2 = List.filter pretypeIsNominal l1;
-    val uns = List.map (fn e => index_of (pretypeToName e) tynames) l2
+in
+    List.map (fn e => index_of (pretypeToName e) tynames) l2
+end;
+
+fun build_uns ptys tynames = let
+    val uns = build_uns_inner ptys tynames
 in
     mk_eq (“uns :num list”, mk_list (uns, numSyntax.num))
 end;
 
-(* gen_names 3 [] = ["a0", "a1", "a2"] *)
-fun gen_names n acc =
+(* gen_names "a" 3 [] = ["a0", "a1", "a2"] *)
+fun gen_names prefix n acc =
     if n = 0 then acc
     else
-        gen_names (n - 1) (("a" ^ Int.toString (n - 1))::acc);
+        gen_names prefix (n - 1) ((prefix ^ Int.toString (n - 1))::acc);
 
 (* NOTE: This function only builds "external" arguments of each constructor. *)
-fun build_args ptys = let
+fun build_repcode_args ptys = let
     val tys = List.map Option.valOf
                        (List.filter Option.isSome (List.map pretypeToType1 ptys));
     val n = List.length tys; (* could be zero *)
-    val names = gen_names n []
+    val names = gen_names "a" n []
 in
     List.map mk_var (zip names tys)
-end;
-
-fun build_lp_inner cptys tyname tynames = let
-    val n_tm = index_of tyname tynames
-in
-    List.map (fn (c:string,ptys) =>
-                 (mk_eq (“n :num”, n_tm),
-                  build_lfvs ptys,
-                  c,
-                  build_args ptys,
-                  build_tns ptys tynames,
-                  build_uns ptys tynames)) cptys
 end;
 
 (* NOTE: For lterm (LabelledTerm), the "LAMi" constructor has two recursive
@@ -764,23 +761,39 @@ val data =
     (``n = 0``, ``lfvs = 0``, "LAMi", [``a0``], ``tns = [0]``, ``uns = [0]``)]:
    (term * term * string * term list * term * term) list
  *)
+fun build_lp_data_inner cptys tyname tynames = let
+    val n_tm = index_of tyname tynames
+in
+    List.map (fn (c:string,ptys) =>
+                 (mk_eq (“n :num”, n_tm),
+                  build_lfvs ptys,
+                  c,
+                  build_repcode_args ptys,
+                  build_tns ptys tynames,
+                  build_uns ptys tynames)) cptys
+end;
+
 fun build_lp_data (asts :AST list) = let
     val tynames = extract_tynames asts;
 in
     List.concat (List.map (fn (tyname,df) =>
                               case df of
                                   Constructors cs =>
-                                  build_lp_inner cs tyname tynames
+                                  build_lp_data_inner cs tyname tynames
                                 | Record _ => []) asts)
 end;
 
-(* “d = _” *)
-fun build_d_term cname args rep_t = let
+fun build_repcode cname args rep_t = let
     val rcname = !rprefix ^ cname;
     val argtypes = List.map type_of args;
     val c_ty = list_mk_fun (argtypes, rep_t);
-    val c_tm = mk_const (rcname,c_ty);
-    val d_tm = list_mk_comb (c_tm, args)
+    val c_tm = mk_const (rcname,c_ty)
+in
+    list_mk_comb (c_tm, args)
+end;
+
+fun build_dterm cname args rep_t = let
+    val d_tm = build_repcode cname args rep_t
 in
     mk_eq (mk_var("d", rep_t), d_tm)
 end;
@@ -796,14 +809,13 @@ end;
          n = 0 /\ lfvs = 0 /\ d = rrec /\ tns = [0] /\ uns = []``: term
  *)
 fun build_lp (asts :AST list) rep_t = let
-    (* (n_tm,lfvs_tm,cname,args,tns_tm,uns_tm) *)
     val data = build_lp_data asts;
     val c_tms = List.map
                     (fn (n_tm,lfvs_tm,cname,args,tns_tm,uns_tm) =>
                         list_mk_exists
                             (args,
                              list_mk_conj [n_tm, lfvs_tm,
-                                           build_d_term cname args rep_t,
+                                           build_dterm cname args rep_t,
                                            tns_tm, uns_tm])) data;
     val n_tm    = “n :num”
     and lfvs_tm = “lfvs :num”
@@ -827,27 +839,13 @@ fun build_tydata [] index lp ths = []
         tyinfo :: build_tydata tynames (index + 1) lp (th :: ths)
     end;
 
-type operinfo  = {oper_termP : thm, oper_def : thm, oper_def' : thm option}
+type operinfo = {oper_termP : thm, oper_def : thm, oper_def' : thm option};
 
-val glam = genind_lam
-val toArb = subst [“uu:string” |-> “ARB:string”]
+val glam = genind_lam;
+val toArb = subst [“uu:string” |-> “ARB:string”];
 
-(* Samples:
-(* Tau pi *)
-val Tau_t = mk_var("Tau", “:^newty1 -> ^newty1”);
-val Tau_pattern = “GLAM uu [] rTau [] [^term_REP_t1 P]”;
-val Tau_def = new_definition(
-   "Tau_def",
-  “^Tau_t P = ^term_ABS_t1 ^(toArb Tau_pattern)”);
-val Tau_termP = prove(
-    mk_comb(termP1, Tau_pattern),
-    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
-val Tau_t = defined_const Tau_def;
-val Tau_def' = prove(
-  “^term_ABS_t1 ^Tau_pattern = ^Tau_t P”,
-    srw_tac [][Tau_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Tau_termP]);
-
-    only Tau_termP, Tau_def and Tau_def' (into operinfo), etc. are needed later.
+(* NOTE: This function translates every pretype to the final type. The special
+   markers 'free and 'bound are translated to :string. "dAQ" is not supported.
  *)
 fun pretypeToType2 pty tymap =
   case pty of
@@ -870,56 +868,92 @@ fun pretypeToType2 pty tymap =
    [a] is the list of free names (a0, a1, a2, ...)
    rInput is the repcode
    [^term_REP_t1 P]: the first list is the (only) bound nominal argument (P)
-   []: the second list is free nominal arguments (Q0, Q1, Q2, ...)
+   []: the second list is the free nominal arguments (Q0, Q1, Q2, ...)
 
-   External arguments are part of the repcode, e.g. in CCS:
+   External (free) arguments are part of the repcode, e.g. in CCS:
 
    val prefix_pattern = “GLAM uu [] (cprefix u) [] [^term_REP_t E]”
-
-   ``(GLAM :string ->
-            string list -> 'a -> 'a gterm list -> 'a gterm list -> 'a gterm)``
-   where 'a is instantiated to rep_t
  *)
-val glam_t = “GLAM :string ->
-               string list -> 'a -> 'a gterm list -> 'a gterm list -> 'a gterm”;
+val GLAM = “GLAM :string ->
+              string list -> 'a -> 'a gterm list -> 'a gterm list -> 'a gterm”;
 
-fun build_pattern tymap ty cname ptys rep_t = inst [alpha |-> rep_t] glam_t;
+fun build_pattern (tymap,tydata,newty,cname,ptys,rep_t) = let
+    val glam_t       = inst [alpha |-> rep_t] GLAM;
+    val repcode_args = build_repcode_args ptys;
+    val repcode      = build_repcode cname repcode_args rep_t;
+    val dv_free      = dVartype (!free_tyname);
+    val dv_bound     = dVartype (!bound_tyname);
+    val free_names   = List.filter (fn e => e = dv_free) ptys;
+    val nfree        = List.length free_names;
+    val free_args    = List.map (fn e => mk_var (e,“:string”))
+                                (gen_names "f" nfree []);
+    val free_args_t  = mk_list (free_args, “:string”);
+    val bound_names  = List.filter (fn e => e = dv_bound) ptys;
+    val bound_p      = not (null bound_names);
+    val bound_arg    = if bound_p then “x :string” else “uu :string”
+    val tynames      = List.map fst tymap;
+    val tns          = build_tns_inner ptys tynames;
+    val uns          = build_uns_inner ptys tynames;
+    val pattern0     = mk_comb (glam_t, bound_arg);
+    val pattern1     = mk_comb (pattern0, free_args_t);
+    val pattern2     = mk_comb (pattern1, repcode);
+in
+    (pattern2, tns, uns)
+end;
 
-fun build_constructor tymap ty cname ptys rep_t = let
-    val c_ty = list_mk_fun (List.map (fn e => pretypeToType2 e tymap) ptys, ty);
-    val c_t = mk_var(cname, c_ty);
-    val c_pattern = build_pattern tymap ty cname ptys rep_t
+(*
+val Tau_t = mk_var("Tau", “:^newty1 -> ^newty1”);
+val Tau_pattern = “GLAM uu [] rTau [] [^term_REP_t1 P]”;
+val Tau_def = new_definition(
+   "Tau_def",
+  “^Tau_t P = ^term_ABS_t1 ^(toArb Tau_pattern)”);
+val Tau_termP = prove(
+    mk_comb(termP1, Tau_pattern),
+    match_mp_tac glam >> srw_tac [][genind_term_REP1]);
+val Tau_t = defined_const Tau_def;
+val Tau_def' = prove(
+  “^term_ABS_t1 ^Tau_pattern = ^Tau_t P”,
+    srw_tac [][Tau_def, GLAM_NIL_EQ, term_ABS_pseudo11_1, Tau_termP]);
+
+    only Tau_termP, Tau_def and Tau_def' (into operinfo), etc. are needed later.
+ *)
+fun build_constructor (tymap,tydata,newty,cname,ptys,rep_t) = let
+    val c_ty = list_mk_fun
+                 (List.map (fn e => pretypeToType2 e tymap) ptys,newty);
+    val c_t = mk_var (cname,c_ty);
+    val c_pattern = build_pattern (tymap,tydata,newty,cname,ptys,rep_t)
 in
     (c_t, c_pattern)
 end;
 
-fun build_cons_inner cptys tyname tymap tydata rep_t = let
-    val current_type = assoc tyname tymap
+fun build_cons_inner (cptys,tyname,tymap,tydata,rep_t) = let
+    val newty = Lib.assoc tyname tymap
 in
-    List.map (fn (c:string,ptys) =>
-                 build_constructor tymap current_type c ptys rep_t) cptys
+    List.map (fn (cname,ptys) =>
+                 build_constructor (tymap,tydata,newty,cname,ptys,rep_t)) cptys
 end;
 
-fun build_cons tynames (asts :AST list)
-                       (tydata :nomtyinfo list) rep_t = let
+(* This function builds definitional theorems for each constructor. *)
+fun build_cons tynames asts (tydata :nomtyinfo list) rep_t = let
     val newtys = List.map (fn e => #newty e) tydata;
-    val tymap = zip tynames newtys
+    val tymap = Lib.zip tynames newtys
 in
-    List.concat (List.map (fn (tyname,df) =>
-                              case df of
-                                  Constructors cs =>
-                                  build_cons_inner cs tyname tymap tydata rep_t
-                                | Record _ => []) asts)
+    List.concat
+        (List.map (fn (tyname,df) =>
+                      case df of
+                          Constructors cs =>
+                          build_cons_inner (cs,tyname,tymap,tydata,rep_t)
+                        | Record _ => []) asts)
 end;
 
 (* The final API (so far) *)
 fun nominal_datatype q = let
-  val asts = parse_datatype q;
+  val asts    = parse_datatype q;
   val tynames = extract_tynames asts;
-  val rep_t = define_repcode asts;
-  val lp = build_lp asts rep_t;
-  val tydata = build_tydata tynames 0 lp [];
-  val cons = build_cons tynames asts tydata rep_t
+  val rep_t   = define_repcode asts;
+  val lp      = build_lp asts rep_t;
+  val tydata  = build_tydata tynames 0 lp [];
+  val cons    = build_cons tynames asts tydata rep_t
 in
     {tynames = tynames,
      tydata  = tydata,

--- a/examples/lambda/basics/termScript.sml
+++ b/examples/lambda/basics/termScript.sml
@@ -16,7 +16,7 @@ Libs
 val _ = set_fixity "=" (Infix(NONASSOC, 450))
 
 (* calling nominal_datatype *)
-val {tynames, tydata, rep_t, lp} =
+val {tynames, tydata, rep_t, lp, operinfo} =
     nominal_datatype ‘term = VAR 'free | APP term term | LAM 'bound term’;
 
 val tyname = hd tynames; (* "term" *)
@@ -25,50 +25,9 @@ val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
      termP, absrep_id, repabs_pseudo_id, term_REP_t, term_ABS_t, newty} =
     hd tydata;
 
-val glam = genind_lam
-
-val LAM_t = mk_var("LAM", ``:string -> ^newty -> ^newty``)
-val LAM_def = new_definition(
-  "LAM_def",
-  ``^LAM_t v t = ^term_ABS_t (GLAM v [] rLAM [^term_REP_t t] [])``);
-
-val LAM_termP = prove(
-  mk_comb(termP, LAM_def |> SPEC_ALL |> concl |> rhs |> rand),
-  match_mp_tac glam >> srw_tac [][genind_term_REP]);
-val LAM_t = defined_const LAM_def
-
-val APP_t = mk_var("APP", ``:^newty -> ^newty -> ^newty``)
-val APP_def = new_definition(
-  "APP_def",
-  ``^APP_t t1 t2 =
-       ^term_ABS_t (GLAM ARB [] rAPP []
-                         [^term_REP_t t1; ^term_REP_t t2])``);
-val APP_termP = prove(
-  ``^termP (GLAM x [] rAPP [] [^term_REP_t t1; ^term_REP_t t2])``,
-  match_mp_tac glam >> srw_tac [][genind_term_REP])
-val APP_t = defined_const APP_def
-
-Theorem APP_def':
-  ^term_ABS_t (GLAM v [] rAPP [] [^term_REP_t t1; ^term_REP_t t2]) =
-  ^APP_t t1 t2
-Proof srw_tac [][APP_def, GLAM_NIL_EQ, term_ABS_pseudo11, APP_termP]
-QED
-
-val VAR_t = mk_var("VAR", ``:string -> ^newty``)
-val VAR_def = new_definition(
-  "VAR_def",
-  ``^VAR_t s = ^term_ABS_t (GLAM ARB [s] rVAR [] [])``);
-Theorem VAR_termP[local]:
-  ^termP (GLAM u [v] rVAR [][])
-Proof irule glam >> srw_tac[][genind_term_REP]
-QED
-val VAR_t = defined_const VAR_def
-
-Theorem VAR_def':
-  ^term_ABS_t (GLAM u [v] rVAR [] []) = ^VAR_t v
-Proof
-  srw_tac[][VAR_def, GLAM_NIL_EQ, term_ABS_pseudo11, VAR_termP]
-QED
+val (_, LAM_termP, LAM_def, NONE)          = Lib.assoc "LAM" operinfo;
+val (_, APP_termP, APP_def, SOME APP_def') = Lib.assoc "APP" operinfo;
+val (_, VAR_termP, VAR_def, SOME VAR_def') = Lib.assoc "VAR" operinfo;
 
 val cons_info =
     [{con_termP = VAR_termP, con_def = SYM VAR_def'},

--- a/examples/lambda/basics/termScript.sml
+++ b/examples/lambda/basics/termScript.sml
@@ -16,14 +16,14 @@ Libs
 val _ = set_fixity "=" (Infix(NONASSOC, 450))
 
 (* calling nominal_datatype *)
-val {tynames, rep_t, lp} =
+val {tynames, tydata, rep_t, lp} =
     nominal_datatype ‘term = VAR 'free | APP term term | LAM 'bound term’;
 
 val tyname = hd tynames; (* "term" *)
 
 val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
-     termP, absrep_id, repabs_pseudo_id, term_REP_t, term_ABS_t, newty, ...} =
-    new_type_step1 tyname 0 [] {lp = lp};
+     termP, absrep_id, repabs_pseudo_id, term_REP_t, term_ABS_t, newty} =
+    hd tydata;
 
 val glam = genind_lam
 


### PR DESCRIPTION
Hi,

This PR deleting more lines than adding them. Now the definitions of each operators in the nominal datatype are automated by the `nominal_datatype` API. In case of labelled term (`lterm`), the beginning part of creating this nominal datatype is the following code:
```
(* calling nominal_datatype *)
val _ = (repcode := "lrep");
val _ = (rprefix := "l");

val {tynames, tydata, rep_t, lp, operinfo} =
    nominal_datatype
      ‘lterm = VAR 'free
             | APP lterm lterm
             | LAM 'bound lterm
             | LAMi num 'bound lterm lterm’;

val tyname = hd tynames; (* "lterm" *)

val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
     termP, absrep_id, repabs_pseudo_id, newty, term_REP_t, term_ABS_t} = hd tydata;

val (LAM_t,  LAM_termP,  LAM_def,  NONE)          = Lib.assoc "LAM" operinfo;
val (LAMi_t, LAMi_termP, LAMi_def, NONE)          = Lib.assoc "LAMi" operinfo;
val (APP_t,  APP_termP,  APP_def,  SOME APP_def') = Lib.assoc "APP" operinfo;
val (VAR_t,  VAR_termP,  VAR_def,  SOME VAR_def') = Lib.assoc "VAR" operinfo;
```

Each operator has an exported definition (`XXX_def`). For those *without* bound names, another "dual" definition (`XXX_def'`) is also returned (but it's not exported). The operator term (`XXX_t`) and the `termP` theorems are used for the rest of code.

P.S. Currently my code in `nomdatatype.sml` lacks of error handling (e.g. it should reject any nominal datatype definition where a constructor has more than one bound names). It just works for all existing samples (`term`, `cterm`, `lterm`, `CCS` and `pi`/`residual`.)

Please squash all commits when merging.

--Chun