### PR TITLE
define_permutation inside nominal_datatype

### DIFF
--- a/examples/CCS/CCSScript.sml
+++ b/examples/CCS/CCSScript.sml
@@ -318,7 +318,7 @@ Theorem APPLY_RELAB_THM =
 val _ = (repcode := "crep");
 val _ = (rprefix := "c");
 
-val {tynames, tydata, rep_t, lp, operinfo} =
+val {tynames, tyinfo, consinfo, tpminfo, rep_t, lp} =
     nominal_datatype
          ‘CCS = var 'free
               | prefix ('a Action) CCS
@@ -339,19 +339,23 @@ Overload ccslp[local] = “genind ^lp”
 
 val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
      termP, absrep_id, repabs_pseudo_id, term_REP_t, term_ABS_t, newty} =
-    hd tydata;
+    hd tyinfo;
 
 (* ----------------------------------------------------------------------
     CCS operators
    ---------------------------------------------------------------------- *)
+val [var_def, var_def', prefix_def, prefix_def',
+     sum_def, sum_def', par_def, par_def',
+     restr_def, restr_def', relab_def, relab_def', rec_def] =
+    List.map (DB.fetch "-") ["var_def", "var_def'",
+                             "prefix_def", "prefix_def'",
+                             "sum_def", "sum_def'", "par_def", "par_def'",
+                             "restr_def", "restr_def'",
+                             "relab_def", "relab_def'", "rec_def"];
 
-val (_, var_termP,    var_def,    SOME var_def')    = Lib.assoc "var" operinfo;
-val (_, prefix_termP, prefix_def, SOME prefix_def') = Lib.assoc "prefix" operinfo;
-val (_, sum_termP,    sum_def,    SOME sum_def')    = Lib.assoc "sum" operinfo;
-val (_, par_termP,    par_def,    SOME par_def')    = Lib.assoc "par" operinfo;
-val (_, restr_termP,  restr_def,  SOME restr_def')  = Lib.assoc "restr" operinfo;
-val (_, relab_termP,  relab_def,  SOME relab_def')  = Lib.assoc "relab" operinfo;
-val (_, rec_termP,    rec_def,    NONE)             = Lib.assoc "rec" operinfo;
+val cons_info = hd consinfo;
+val [var_termP, prefix_termP, sum_termP, par_termP,
+     restr_termP, relab_termP, rec_termP] = List.map #con_termP cons_info;
 
 val _ =
     add_rule { term_name = "prefix", fixity = Infixr 700,
@@ -382,24 +386,7 @@ val _ = add_rule {term_name = "nu", fixity = Closefix,
     tpm (permutation of CCS recursion variables)
    ---------------------------------------------------------------------- *)
 
-val cons_info =
-    [{con_termP = var_termP,    con_def = SYM var_def'},
-     {con_termP = prefix_termP, con_def = SYM prefix_def'},
-     {con_termP = sum_termP,    con_def = SYM sum_def'},
-     {con_termP = par_termP,    con_def = SYM par_def'},
-     {con_termP = restr_termP,  con_def = SYM restr_def'},
-     {con_termP = relab_termP,  con_def = SYM relab_def'},
-     {con_termP = rec_termP,    con_def = rec_def}];
-
-val tpm_name_pfx = "t";
-val {tpm_thm, term_REP_tpm, t_pmact_t, tpm_t} =
-    define_permutation {name_pfx = tpm_name_pfx, name = tyname,
-                        term_REP_t = term_REP_t,
-                        term_ABS_t = term_ABS_t,
-                        absrep_id = absrep_id,
-                        repabs_pseudo_id = repabs_pseudo_id,
-                        cons_info = cons_info, newty = newty,
-                        genind_term_REP = genind_term_REP};
+val {tpm_thm, term_REP_tpm, t_pmact_t, tpm_t} = List.nth (tpminfo,0);
 
 Theorem tpm_eqr :
     t = tpm pi u <=> tpm (REVERSE pi) t = (u :'a CCS)

--- a/examples/formal-languages/pi-calculus/pi_agentScript.sml
+++ b/examples/formal-languages/pi-calculus/pi_agentScript.sml
@@ -20,8 +20,9 @@ Libs
 
 (* calling nominal_datatype *)
 val _ = (repcode := "repcode");
+val _ = (tpm_name_pfx := ["t", "r"]);
 
-val {tynames, tydata, rep_t, lp, operinfo} =
+val {tynames, tyinfo, consinfo, tpminfo, rep_t, lp} =
     nominal_datatype
           ‘pi   = Nil                         (* 0 *)
                 | Tau pi                      (* tau.P *)
@@ -55,7 +56,7 @@ val {term_ABS_pseudo11 = term_ABS_pseudo11_1,
      repabs_pseudo_id = repabs_pseudo_id1,
      term_REP_t = term_REP_t1,
      term_ABS_t = term_ABS_t1,
-     newty = newty1} = List.nth (tydata,0);
+     newty = newty1} = List.nth (tyinfo,0);
 
 (* type 2 (:residual) *)
 val {term_ABS_pseudo11 = term_ABS_pseudo11_2,
@@ -67,78 +68,48 @@ val {term_ABS_pseudo11 = term_ABS_pseudo11_2,
      repabs_pseudo_id = repabs_pseudo_id2,
      term_REP_t = term_REP_t2,
      term_ABS_t = term_ABS_t2,
-     newty = newty2} = List.nth (tydata,1);
+     newty = newty2} = List.nth (tyinfo,1);
 
 (* ----------------------------------------------------------------------
     Pi-calculus operators
    ---------------------------------------------------------------------- *)
 
-val (_, Nil_termP, Nil_def, SOME Nil_def') = Lib.assoc "Nil" operinfo;
-val (_, Tau_termP, Tau_def, SOME Tau_def') = Lib.assoc "Tau" operinfo;
-val (_, Input_termP, Input_def, NONE)      = Lib.assoc "Input" operinfo;
-val (_, Output_termP, Output_def, SOME Output_def')
-                                           = Lib.assoc "Output" operinfo;
-val (_, Match_termP, Match_def, SOME Match_def')
-                                           = Lib.assoc "Match" operinfo;
-val (_, Mismatch_termP, Mismatch_def, SOME Mismatch_def')
-                                           = Lib.assoc "Mismatch" operinfo;
-val (_, Sum_termP, Sum_def, SOME Sum_def') = Lib.assoc "Sum" operinfo;
-val (_, Par_termP, Par_def, SOME Par_def') = Lib.assoc "Par" operinfo;
-val (_, Res_termP, Res_def, NONE)          = Lib.assoc "Res" operinfo;
-val (_, TauR_termP, TauR_def, SOME TauR_def')
-                                           = Lib.assoc "TauR" operinfo;
-val (_, InputS_termP, InputS_def, NONE)    = Lib.assoc "InputS" operinfo;
-val (_, BoundOutput_termP, BoundOutput_def, NONE)
-                                           = Lib.assoc "BoundOutput" operinfo;
-val (_, FreeOutput_termP, FreeOutput_def, SOME FreeOutput_def')
-                                           = Lib.assoc "FreeOutput" operinfo;
+val [Nil_def, Nil_def',
+     Tau_def, Tau_def', Input_def,
+     Output_def, Output_def',
+     Match_def, Match_def',
+     Mismatch_def, Mismatch_def',
+     Sum_def, Sum_def',
+     Par_def, Par_def', Res_def,
+     TauR_def, TauR_def',
+     InputS_def, BoundOutput_def,
+     FreeOutput_def, FreeOutput_def'] =
+    List.map (DB.fetch "-") ["Nil_def", "Nil_def'",
+                             "Tau_def", "Tau_def'", "Input_def",
+                             "Output_def", "Output_def'",
+                             "Match_def", "Match_def'",
+                             "Mismatch_def", "Mismatch_def'",
+                             "Sum_def", "Sum_def'",
+                             "Par_def", "Par_def'", "Res_def",
+                             "TauR_def", "TauR_def'",
+                             "InputS_def", "BoundOutput_def",
+                             "FreeOutput_def", "FreeOutput_def'"];
+
+val  cons_info = List.nth (consinfo, 0);
+val rcons_info = List.nth (consinfo, 1);
+
+val [Nil_termP, Tau_termP, Input_termP, Output_termP, Match_termP,
+     Mismatch_termP, Sum_termP, Par_termP, Res_termP] =
+    List.map #con_termP cons_info;
+
+val [TauR_termP, InputS_termP, BoundOutput_termP, FreeOutput_termP] =
+    List.map #con_termP rcons_info;
 
 (* ----------------------------------------------------------------------
     tpm - permutation of pi-calculus binding variables
    ---------------------------------------------------------------------- *)
 
-val cons_info =
-    [{con_termP = Nil_termP,      con_def = SYM Nil_def'},
-     {con_termP = Tau_termP,      con_def = SYM Tau_def'},
-     {con_termP = Input_termP,    con_def = Input_def},
-     {con_termP = Output_termP,   con_def = SYM Output_def'},
-     {con_termP = Match_termP,    con_def = SYM Match_def'},
-     {con_termP = Mismatch_termP, con_def = SYM Mismatch_def'},
-     {con_termP = Sum_termP,      con_def = SYM Sum_def'},
-     {con_termP = Par_termP,      con_def = SYM Par_def'},
-     {con_termP = Res_termP,      con_def = Res_def}];
-
-val tpm_name_pfx = "t";
-val {tpm_thm, term_REP_tpm, t_pmact_t, tpm_t} =
-    define_permutation {name_pfx = tpm_name_pfx, name = tyname1,
-                        term_REP_t = term_REP_t1,
-                        term_ABS_t = term_ABS_t1,
-                        absrep_id = absrep_id1,
-                        repabs_pseudo_id = repabs_pseudo_id1,
-                        cons_info = cons_info,
-                        newty = newty1,
-                        genind_term_REP = genind_term_REP1};
-
-(* |- (!pi. tpm pi Nil = Nil) /\ (!pi P. tpm pi (Tau P) = Tau (tpm pi P)) /\
-      (!x pi a P.
-         tpm pi (Input a x P) =
-         Input (lswapstr pi a) (lswapstr pi x) (tpm pi P)) /\
-      (!pi b a P.
-         tpm pi (Output a b P) =
-         Output (lswapstr pi a) (lswapstr pi b) (tpm pi P)) /\
-      (!pi b a P.
-         tpm pi (Match a b P) =
-         Match (lswapstr pi a) (lswapstr pi b) (tpm pi P)) /\
-      (!pi b a P.
-         tpm pi (Mismatch a b P) =
-         Mismatch (lswapstr pi a) (lswapstr pi b) (tpm pi P)) /\
-      (!pi Q P. tpm pi (Sum P Q) = Sum (tpm pi P) (tpm pi Q)) /\
-      (!pi Q P. tpm pi (Par P Q) = Par (tpm pi P) (tpm pi Q)) /\
-      !v pi P. tpm pi (Res v P) = Res (lswapstr pi v) (tpm pi P)
- *)
-Theorem tpm_thm[allow_rebind] =
-        tpm_thm |> REWRITE_RULE [GSYM Input_def, Output_def',
-                                 Match_def', Mismatch_def'];
+val {tpm_thm, term_REP_tpm, t_pmact_t, tpm_t} = List.nth (tpminfo,0);
 
 Theorem tpm_eqr :
     t = tpm pi u <=> tpm (REVERSE pi) t = (u :pi)
@@ -162,26 +133,10 @@ QED
     rpm - permutation of pi-calculus residuals
    ---------------------------------------------------------------------- *)
 
-val rcons_info =
-    [{con_termP = TauR_termP,        con_def = SYM TauR_def'},
-     {con_termP = BoundOutput_termP, con_def = BoundOutput_def},
-     {con_termP = InputS_termP,      con_def = InputS_def},
-     {con_termP = FreeOutput_termP,  con_def = SYM FreeOutput_def'}];
-
-val rpm_name_pfx = "r";
-
 val {tpm_thm = rpm_thm,
      term_REP_tpm = term_REP_rpm,
      t_pmact_t = r_pmact_t,
-     tpm_t = rpm_t} =
-    define_permutation {name_pfx = rpm_name_pfx, name = tyname2,
-                        term_REP_t = term_REP_t2,
-                        term_ABS_t = term_ABS_t2,
-                        absrep_id = absrep_id2,
-                        repabs_pseudo_id = repabs_pseudo_id2,
-                        cons_info = rcons_info,
-                        newty = newty2,
-                        genind_term_REP = genind_term_REP2};
+     tpm_t = rpm_t} = List.nth (tpminfo,1);
 
 (* |- (!pi P. rpm pi (TauR P) = TauR (tpm pi P)) /\
       (!x pi a P.

--- a/examples/lambda/barendregt/labelledTermsScript.sml
+++ b/examples/lambda/barendregt/labelledTermsScript.sml
@@ -7,8 +7,9 @@ Libs
 (* calling nominal_datatype *)
 val _ = (repcode := "lrep");
 val _ = (rprefix := "l");
+val _ = (tpm_name_pfx := ["lt"]);
 
-val {tynames, tydata, rep_t, lp, operinfo} =
+val {tynames, tyinfo, consinfo, tpminfo, rep_t, lp} =
     nominal_datatype
       ‘lterm = VAR 'free
              | APP lterm lterm
@@ -19,32 +20,23 @@ val tyname = hd tynames; (* "lterm" *)
 
 val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
      termP, absrep_id, repabs_pseudo_id, newty, term_REP_t, term_ABS_t} =
-    hd tydata;
+    hd tyinfo;
 
 val _ = temp_overload_on ("termP", termP)
 
-val (LAM_t,  LAM_termP,  LAM_def,  NONE)          = Lib.assoc "LAM" operinfo;
-val (LAMi_t, LAMi_termP, LAMi_def, NONE)          = Lib.assoc "LAMi" operinfo;
-val (APP_t,  APP_termP,  APP_def,  SOME APP_def') = Lib.assoc "APP" operinfo;
-val (VAR_t,  VAR_termP,  VAR_def,  SOME VAR_def') = Lib.assoc "VAR" operinfo;
+val [LAM_def, LAMi_def, APP_def, APP_def', VAR_def, VAR_def'] =
+    List.map (DB.fetch "-") ["LAM_def", "LAMi_def", "APP_def", "APP_def'",
+                             "VAR_def", "VAR_def'"];
 
-val cons_info =
-    [{con_termP = VAR_termP, con_def = SYM VAR_def'},
-     {con_termP = APP_termP, con_def = SYM APP_def'},
-     {con_termP = LAM_termP, con_def = LAM_def},
-     {con_termP = LAMi_termP, con_def = LAMi_def}]
+val cons_info = hd consinfo;
+val [VAR_termP, APP_termP, LAM_termP, LAMi_termP] =
+    List.map #con_termP cons_info;
+
+val [VAR_t, APP_t, LAM_t, LAMi_t] =
+    List.map defined_const [VAR_def, APP_def, LAM_def, LAMi_def];
 
 (* tpm *)
-val name_pfx = "lt"
-val tpm_name = name_pfx ^ "pm"
-val {tpm_thm, term_REP_tpm, t_pmact_t, tpm_t} =
-    define_permutation { name_pfx = "lt", name = tyname,
-                         term_REP_t = term_REP_t,
-                         term_ABS_t = term_ABS_t,
-                         absrep_id = absrep_id,
-                         repabs_pseudo_id = repabs_pseudo_id,
-                         cons_info = cons_info, newty = newty,
-                         genind_term_REP = genind_term_REP}
+val {tpm_thm, term_REP_tpm, t_pmact_t, tpm_t} = List.nth (tpminfo,0);
 
 Theorem ltpm_eqr:
    (t = ltpm pi u) = (ltpm (REVERSE pi) t = u)

--- a/examples/lambda/basics/ctermScript.sml
+++ b/examples/lambda/basics/ctermScript.sml
@@ -7,8 +7,9 @@ Libs
 (* calling nominal_datatype *)
 val _ = (repcode := "ctrep");
 val _ = (rprefix := "ct");
+val _ = (tpm_name_pfx := ["ct"]);
 
-val {tynames, tydata, rep_t, lp, operinfo} =
+val {tynames, tyinfo, consinfo, tpminfo, rep_t, lp} =
     nominal_datatype
       ‘cterm = VAR 'free | APP cterm cterm | LAM 'bound cterm | CONST 'a’;
 
@@ -21,27 +22,19 @@ End
 
 val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
      termP, absrep_id, repabs_pseudo_id, term_REP_t, term_ABS_t, newty} =
-    hd tydata;
+    hd tyinfo;
 
-val (_, LAM_termP,   LAM_def,   NONE)            = Lib.assoc "LAM" operinfo;
-val (_, APP_termP,   APP_def,   SOME APP_def')   = Lib.assoc "APP" operinfo;
-val (_, VAR_termP,   VAR_def,   SOME VAR_def')   = Lib.assoc "VAR" operinfo;
-val (_, CONST_termP, CONST_def, SOME CONST_def') = Lib.assoc "CONST" operinfo;
+val [LAM_def, APP_def, APP_def', VAR_def, VAR_def', CONST_def, CONST_def'] =
+    List.map (DB.fetch "-") ["LAM_def", "APP_def", "APP_def'",
+                             "VAR_def", "VAR_def'",
+                             "CONST_def", "CONST_def'"];
 
-val cons_info =
-    [{con_termP = VAR_termP, con_def = SYM VAR_def'},
-     {con_termP = APP_termP, con_def = SYM APP_def'},
-     {con_termP = LAM_termP, con_def = LAM_def},
-     {con_termP = CONST_termP, con_def = SYM CONST_def'}]
+val cons_info = hd consinfo;
+val [VAR_termP, APP_termP, LAM_termP, CONST_termP] =
+    List.map #con_termP cons_info;
 
-val tpm_name_pfx = "ct"
-val {tpm_thm, term_REP_tpm, t_pmact_t, tpm_t} =
-    define_permutation {name_pfx = "ct", name = tyname,
-                        term_REP_t = term_REP_t,
-                        term_ABS_t = term_ABS_t, absrep_id = absrep_id,
-                        repabs_pseudo_id = repabs_pseudo_id,
-                        cons_info = cons_info, newty = newty,
-                        genind_term_REP = genind_term_REP}
+(* tpm *)
+val {tpm_thm, term_REP_tpm, t_pmact_t, tpm_t} = List.nth (tpminfo,0);
 
 (* support *)
 val term_REP_eqv = prove(

--- a/examples/lambda/basics/nomdatatype.sig
+++ b/examples/lambda/basics/nomdatatype.sig
@@ -15,6 +15,8 @@ sig
                         newty : hol_type,
                         termP : term}
 
+  type tpminfo = {t_pmact_t: term, term_REP_tpm: thm, tpm_t: term, tpm_thm: thm}
+
   val new_type_step1 : string -> int -> thm list -> {lp:term} -> nomtyinfo
 
   val termP_removal :
@@ -27,14 +29,11 @@ sig
          permutation action for the new type.  I.e., this will presumably
          be something like ``pmact something``. *)
 
-
   val define_permutation : { name_pfx : string, name : string,
                              term_REP_t : term, term_ABS_t : term,
                              absrep_id : thm, repabs_pseudo_id : thm,
                              cons_info : coninfo list, newty : hol_type,
-                             genind_term_REP : thm} ->
-                           { tpm_thm : thm, term_REP_tpm : thm,
-                             t_pmact_t : term, tpm_t : term}
+                             genind_term_REP : thm} -> tpminfo
 
   (* datatype utility functions *)
   val rpt_hyp_dest_conj : thm -> thm
@@ -52,11 +51,14 @@ sig
   val bound_tyname : string ref
   val repcode      : string ref
   val rprefix      : string ref
+  val tpm_name_pfx : string list ref
+
   val nominal_datatype : hol_type quotation ->
                         {tynames  : string list,
-                         tydata   : nomtyinfo list,
+                         tyinfo   : nomtyinfo list,
+                         consinfo : coninfo list list,
+                         tpminfo  : tpminfo list,
                          rep_t    : hol_type,
-                         lp       : term,
-                         operinfo : (string *
-                                     (term * thm * thm * thm option)) list}
+                         lp       : term}
+
 end

--- a/examples/lambda/basics/nomdatatype.sml
+++ b/examples/lambda/basics/nomdatatype.sml
@@ -289,9 +289,11 @@ val pmact_absrep' = pmact_bijections |> CONJUNCT2 |> GSYM
 
 fun Save_thm(n, th) = save_thm(n,th) before BasicProvers.export_rewrites [n]
 
+type tpminfo = {t_pmact_t: term, term_REP_tpm: thm, tpm_t: term, tpm_thm: thm}
+
 fun define_permutation { name_pfx, name, term_ABS_t, term_REP_t,
                          absrep_id, repabs_pseudo_id, newty,
-                         genind_term_REP, cons_info} = let
+                         genind_term_REP, cons_info} :tpminfo = let
   val tpm_name = name_pfx ^ "pm"
   val raw_tpm_name = "raw_" ^ tpm_name
   val raw_tpm_t = mk_var(raw_tpm_name, cpm_ty --> newty --> newty)
@@ -831,12 +833,12 @@ end;
    This works for pi-calculus but perhaps not works for mutually exclusive types
    that we haven't met yet.
  *)
-fun build_tydata [] index lp ths = []
-  | build_tydata (tyname::tynames) index lp ths =
+fun build_tyinfo [] index lp ths = []
+  | build_tyinfo (tyname::tynames) index lp ths =
     let val tyinfo = new_type_step1 tyname index ths {lp = lp};
         val th = #genind_exists tyinfo
     in
-        tyinfo :: build_tydata tynames (index + 1) lp (th :: ths)
+        tyinfo :: build_tyinfo tynames (index + 1) lp (th :: ths)
     end;
 
 val glam = genind_lam;
@@ -927,7 +929,7 @@ fun build_args ptys = build_args_inner ptys 0 false 0 0 0;
 val GLAM = “GLAM :string ->
               string list -> 'a -> 'a gterm list -> 'a gterm list -> 'a gterm”;
 
-fun build_pattern (tymap,tydata :nomtyinfo list,newty,cname,ptys,rep_t) = let
+fun build_pattern (tymap,tyinfo :nomtyinfo list,newty,cname,ptys,rep_t) = let
     val glam_t       = inst [alpha |-> rep_t] GLAM;
     val repcode_args = build_repcode_args ptys;
     val repcode      = build_repcode cname repcode_args rep_t;
@@ -944,10 +946,10 @@ fun build_pattern (tymap,tydata :nomtyinfo list,newty,cname,ptys,rep_t) = let
     val tynames      = List.map fst tymap;
     val tns          = List.map int_of_term (build_tns_inner ptys tynames);
     val uns          = List.map int_of_term (build_uns_inner ptys tynames);
-    val tns_rep      = List.map (fn i => #term_REP_t (List.nth (tydata,i))) tns;
-    val uns_rep      = List.map (fn i => #term_REP_t (List.nth (tydata,i))) uns;
-    val tns_argty    = List.map (fn i => #newty (List.nth (tydata,i))) tns;
-    val uns_argty    = List.map (fn i => #newty (List.nth (tydata,i))) uns;
+    val tns_rep      = List.map (fn i => #term_REP_t (List.nth (tyinfo,i))) tns;
+    val uns_rep      = List.map (fn i => #term_REP_t (List.nth (tyinfo,i))) uns;
+    val tns_argty    = List.map (fn i => #newty (List.nth (tyinfo,i))) tns;
+    val uns_argty    = List.map (fn i => #newty (List.nth (tyinfo,i))) uns;
     val tns_argnames = gen_names "P" (List.length tns) [];
     val uns_argnames = gen_names "Q" (List.length uns) [];
     val tns_argv     = List.map mk_var (Lib.zip tns_argnames tns_argty);
@@ -1008,50 +1010,68 @@ val Input_t = defined_const Input_def;
 
     only Tau_termP, Tau_def and Tau_def' (into operinfo), etc. are needed later.
  *)
-fun build_constructor (tymap,tydata,tyname,cname,ptys,rep_t) = let
+fun build_constructor (tymap,tyinfo,tyname,cname,ptys,rep_t) : coninfo = let
     val newty   = Lib.assoc tyname tymap;
     val c_ty    = list_mk_fun
                     (List.map (fn e => pretypeToType2 e tymap) ptys,newty);
     val c_t     = mk_var (cname,c_ty);
-    val (c_pattern,arglist,bound_p)
-                = build_pattern (tymap,tydata,newty,cname,ptys,rep_t);
+    val (c_pattern,arglist,boundp)
+                = build_pattern (tymap,tyinfo,newty,cname,ptys,rep_t);
     val tynames = List.map fst tymap;
     val index   = int_of_term (index_of tyname tynames);
     val lhs     = list_mk_comb (c_t,arglist);
-    val tydata1 = List.nth (tydata,index);
-    val rhs     = mk_comb (#term_ABS_t tydata1,toArb c_pattern);
+    val tyinfo1 = List.nth (tyinfo,index);
+    val rhs     = mk_comb (#term_ABS_t tyinfo1,toArb c_pattern);
     val c_def   = new_definition (cname ^ "_def", mk_eq (lhs,rhs));
-    val ths     = List.map #genind_term_REP tydata;
-    val c_termP = prove(mk_comb(#termP tydata1, c_pattern),
+    val ths     = List.map #genind_term_REP tyinfo;
+    val c_termP = prove(mk_comb(#termP tyinfo1, c_pattern),
                         match_mp_tac glam >> srw_tac [] ths);
     val c_tm    = defined_const c_def;
-    val lhs'    = mk_comb (#term_ABS_t tydata1,c_pattern);
+    val lhs'    = mk_comb (#term_ABS_t tyinfo1,c_pattern);
     val rhs'    = list_mk_comb (c_tm,arglist);
-    val ths'    = [c_def, GLAM_NIL_EQ, #term_ABS_pseudo11 tydata1, c_termP];
-    val c_def'  = if bound_p then NONE
-                  else
-                      SOME (prove (mk_eq (lhs',rhs'),srw_tac [] ths'))
+    val ths'    = [c_def, GLAM_NIL_EQ, #term_ABS_pseudo11 tyinfo1, c_termP];
+    val c_def'  = if boundp then NONE else
+                  SOME (store_thm (cname ^ "_def'",
+                                   mk_eq (lhs',rhs'),
+                                   srw_tac [] ths'))
 in
-    (cname,(c_tm,c_termP,c_def,c_def'))
+    {con_termP = c_termP,
+     con_def   = if boundp then c_def else SYM (valOf c_def')}
 end;
 
-fun build_operinfo_inner (cptys,tyname,tymap,tydata,rep_t) =
+fun build_consinfo_inner (cptys,tyname,tymap,tyinfo,rep_t) =
     List.map (fn (cname,ptys) =>
-                 build_constructor (tymap,tydata,tyname,cname,ptys,rep_t))
+                 build_constructor (tymap,tyinfo,tyname,cname,ptys,rep_t))
              cptys;
 
 (* This function builds definitional theorems for each constructor. *)
-fun build_operinfo tynames asts (tydata :nomtyinfo list) rep_t = let
-    val newtys = List.map (fn e => #newty e) tydata;
+fun build_consinfo tynames newtys asts (tyinfo :nomtyinfo list) rep_t = let
     val tymap = Lib.zip tynames newtys
 in
     List.concat
-        (List.map (fn (tyname,df) =>
-                      case df of
-                          Constructors cs =>
-                          build_operinfo_inner (cs,tyname,tymap,tydata,rep_t)
-                        | Record _ => []) asts)
+      (List.map (fn (tyname,df) =>
+                    case df of
+                        Constructors cs =>
+                          [build_consinfo_inner (cs,tyname,tymap,tyinfo,rep_t)]
+                      | Record _ => []) asts)
 end;
+
+val tpm_name_pfx = ref ["t"];
+
+fun build_tpm_inner tpm_name_pfx tyname newty cons_info (d :nomtyinfo) =
+    define_permutation {name_pfx = tpm_name_pfx, name = tyname,
+                        term_REP_t = #term_REP_t d,
+                        term_ABS_t = #term_ABS_t d,
+                        absrep_id = #absrep_id d,
+                        repabs_pseudo_id = #repabs_pseudo_id d,
+                        cons_info = cons_info,
+                        newty = newty,
+                        genind_term_REP = #genind_term_REP d};
+
+fun build_tpm [] [] [] [] [] = []
+  | build_tpm (p::prefix) (t::tynames) (n::newtys) (c::consinfo) (d::tyinfo) =
+    build_tpm_inner p t n c d ::
+    build_tpm prefix tynames newtys consinfo tyinfo;
 
 (* The final API (so far) *)
 fun nominal_datatype q = let
@@ -1059,14 +1079,17 @@ fun nominal_datatype q = let
   val tynames  = extract_tynames asts;
   val rep_t    = define_repcode asts;
   val lp       = build_lp asts rep_t;
-  val tydata   = build_tydata tynames 0 lp [];
-  val operinfo = build_operinfo tynames asts tydata rep_t
+  val tyinfo   = build_tyinfo tynames 0 lp [];
+  val newtys   = List.map (fn e => #newty e) tyinfo;
+  val consinfo = build_consinfo tynames newtys asts tyinfo rep_t;
+  val tpminfo  = build_tpm (!tpm_name_pfx) tynames newtys consinfo tyinfo
 in
     {tynames  = tynames,
-     tydata   = tydata,
+     tyinfo   = tyinfo,
+     consinfo = consinfo,
+     tpminfo  = tpminfo,
      rep_t    = rep_t,
-     lp       = lp,
-     operinfo = operinfo}
+     lp       = lp}
 end;
 
 end (* struct *)

--- a/examples/lambda/basics/termScript.sml
+++ b/examples/lambda/basics/termScript.sml
@@ -16,33 +16,23 @@ Libs
 val _ = set_fixity "=" (Infix(NONASSOC, 450))
 
 (* calling nominal_datatype *)
-val {tynames, tydata, rep_t, lp, operinfo} =
+val {tynames, tyinfo, consinfo, tpminfo, rep_t, lp} =
     nominal_datatype ‘term = VAR 'free | APP term term | LAM 'bound term’;
 
 val tyname = hd tynames; (* "term" *)
 
 val {term_ABS_pseudo11, term_REP_11, genind_term_REP, genind_exists,
      termP, absrep_id, repabs_pseudo_id, term_REP_t, term_ABS_t, newty} =
-    hd tydata;
+    hd tyinfo;
 
-val (_, LAM_termP, LAM_def, NONE)          = Lib.assoc "LAM" operinfo;
-val (_, APP_termP, APP_def, SOME APP_def') = Lib.assoc "APP" operinfo;
-val (_, VAR_termP, VAR_def, SOME VAR_def') = Lib.assoc "VAR" operinfo;
+val [LAM_def, APP_def, APP_def', VAR_def, VAR_def'] =
+    List.map (DB.fetch "-") ["LAM_def", "APP_def", "APP_def'",
+                             "VAR_def", "VAR_def'"];
 
-val cons_info =
-    [{con_termP = VAR_termP, con_def = SYM VAR_def'},
-     {con_termP = APP_termP, con_def = SYM APP_def'},
-     {con_termP = LAM_termP, con_def = LAM_def}]
+val cons_info = hd consinfo;
+val [VAR_termP, APP_termP, LAM_termP] = List.map #con_termP cons_info;
 
-(* tpm *)
-val tpm_name_pfx = "t"
-val {tpm_thm, term_REP_tpm, t_pmact_t, tpm_t} =
-    define_permutation {name_pfx = "t", name = tyname,
-                        term_REP_t = term_REP_t,
-                        term_ABS_t = term_ABS_t, absrep_id = absrep_id,
-                        repabs_pseudo_id = repabs_pseudo_id,
-                        cons_info = cons_info, newty = newty,
-                        genind_term_REP = genind_term_REP};
+val {tpm_thm, term_REP_tpm, t_pmact_t, tpm_t} = hd tpminfo;
 
 (* support *)
 val term_REP_eqv = prove(


### PR DESCRIPTION
Hi,

This PR further improves yesterday's work. Now `define_permutation` (a routine process) is called automatically inside the `nominal_datatype` API.  This also includes generating the `cons_info` structure automatically. The `tpm` prefixes, if not default "t" or more than one (in π-calculus), must be supplied before calling `nominal_datatype`:
```
val _ = (repcode := "repcode");
val _ = (tpm_name_pfx := ["t", "r"]); (* HERE *)

val {tynames, tyinfo, consinfo, tpminfo, rep_t, lp} =
    nominal_datatype
          ‘pi   = Nil                         (* 0 *)
                | Tau pi                      (* tau.P *)
                | Input 'free 'bound pi       (* a(x).P *)
                | Output 'free 'free pi       (* {a}b.P *)
                | Match 'free 'free pi        (* [a == b] P *)
                | Mismatch 'free 'free pi     (* [a <> b] P *)
                | Sum pi pi                   (* P + Q *)
                | Par pi pi                   (* P | Q *)
                | Res 'bound pi               (* nu x. P *)
                ;
       residual = TauR pi                     (* tau.P *)
                | InputS 'free 'bound pi      (* a(x).P *)
                | BoundOutput 'free 'bound pi (* a{x}.P *)
                | FreeOutput 'free 'free pi   (* {a}b.P *)’;
```

 Now I also export the `_def'` theorems for each nominal constructors, so that these theorems can be retrieved by `DB.fetch` instead of returning as values:
```
val [Nil_def, Nil_def',
     Tau_def, Tau_def', Input_def,
     Output_def, Output_def',
     Match_def, Match_def',
     Mismatch_def, Mismatch_def',
     Sum_def, Sum_def',
     Par_def, Par_def', Res_def,
     TauR_def, TauR_def',
     InputS_def, BoundOutput_def,
     FreeOutput_def, FreeOutput_def'] =
    List.map (DB.fetch "-") ["Nil_def", "Nil_def'",
                             "Tau_def", "Tau_def'", "Input_def",
                             "Output_def", "Output_def'",
                             "Match_def", "Match_def'",
                             "Mismatch_def", "Mismatch_def'",
                             "Sum_def", "Sum_def'",
                             "Par_def", "Par_def'", "Res_def",
                             "TauR_def", "TauR_def'",
                             "InputS_def", "BoundOutput_def",
                             "FreeOutput_def", "FreeOutput_def'"];
```

Once again, this PR deletes (slightly) more code than adding them into the code base.

--Chun