### PR TITLE
Report absolute path for interactive config file

### DIFF
--- a/tools/check-intconfig.sml
+++ b/tools/check-intconfig.sml
@@ -24,8 +24,10 @@ let
     if FileSys.access (f, [FileSys.A_READ]) then SOME f else NONE
   fun loadConfig f = let
       val oldq = HOL_Interactive.amquiet()
+      val absf = if Path.isAbsolute f then f
+                 else Path.mkAbsolute {path = f, relativeTo = FileSys.getDir()}
     in
-      print ("[Use-ing configuration file "^f^"]\n");
+      print ("[Use-ing configuration file "^absf^"]\n");
       oldq orelse HOL_Interactive.toggle_quietdec();
       use f;
       ignore (oldq orelse HOL_Interactive.toggle_quietdec())


### PR DESCRIPTION
Closes #1141.

This PR makes the interactive configuration-file diagnostic report the absolute path of the configuration file being loaded.

Scope:
- changes only `tools/check-intconfig.sml`
- preserves existing config discovery order
- preserves existing config loading behavior
- does not change parsing, build semantics, theorem logic, or kernel behavior

Validation:
- baseline HOL build passed before the patch
- targeted HOL_CONFIG diagnostic test passed
- `bin/build` passed after the patch
- `bin/hol < /dev/null` startup smoke check passed
- `git diff --check` passed