### PR TITLE
Remove stix package which globally changes TeX fonts

### DIFF
--- a/src/TeX/holtexbasic.sty
+++ b/src/TeX/holtexbasic.sty
@@ -6,7 +6,7 @@
 % -------------------------------------------------------
 
 \NeedsTeXFormat{LaTeX2e}
-\usepackage{amssymb, underscore, fancyvrb, amsmath, stix}
+\usepackage{amssymb, underscore, fancyvrb, amsmath}
 
 \fvset{commandchars=\\\{\},xleftmargin=1mm,framesep=1.2mm,fontsize=\small}
 

--- a/src/TeX/holtexbasic.sty
+++ b/src/TeX/holtexbasic.sty
@@ -8,6 +8,10 @@
 \NeedsTeXFormat{LaTeX2e}
 \usepackage{amssymb, underscore, fancyvrb, amsmath}
 
+% Do not change the default text and math fonts (violating paper submission rules)
+% As of April 2018 the {stix} package is considered obsolete. Use {stix2} instead.
+\usepackage[notext,nomath]{stix2}
+
 \fvset{commandchars=\\\{\},xleftmargin=1mm,framesep=1.2mm,fontsize=\small}
 
 \newcommand{\HOLpagestyle}{}


### PR DESCRIPTION
Hi,

In HOL's provided `holtexbasic` TeX package, there's the use of `stix` font package. Its only purpose is to globally change the text (and math text) fonts, ranther than providing new TeX commands (therefore removing this package doesn't break anything.) Note that the `stix` font is more compact (and maybe also nicer) than the Computer Modern font (default of LaTeX `article` and many conference/journal templates), and as a side effect the paper writer may end up in putting more contents into limited page space...

Strictly speaking, changing fonts in LaTeX template when submitting papers, is a voilation of rules. The fact that in practice it didn't cause any problem, is (perhaps) because many people are so blind to see the font difference unless it's too obvious.

I suggest removing `stix` from `holtexbasic.sty`, and any user who still wants to "cheat" on fonts, should explicitly do it. (HOL official has nothing to do with it, after merging this PR.)

--Chun