### PR TITLE
CLT fixes (due to wrong definitions)

### DIFF
--- a/examples/lambda/barendregt/semi_sensibleScript.sml
+++ b/examples/lambda/barendregt/semi_sensibleScript.sml
@@ -136,7 +136,18 @@ Theorem separable_def =
         gen_separable_alt |> Q.SPEC ‘UNCURRY (==)’
                           |> SRULE [lambdathy_lameq]
 
-Theorem separable_incompatible :
+(* |- !Ms.
+        EVERY closed Ms ==>
+        (separable Ms <=>
+         !Ns.
+           LENGTH Ns = LENGTH Ms ==>
+           ?f. !i. i < LENGTH Ms ==> f @@ EL i Ms == EL i Ns)
+ *)
+Theorem separable_alt_closed =
+        gen_separable_alt_closed |> Q.SPEC ‘UNCURRY (==)’
+                                 |> SRULE [lambdathy_lameq]
+
+Theorem separable_imp_incompatible :
     !M N. separable [M; N] ==> M # N
 Proof
     rw [separable_def, incompatible_def]
@@ -160,10 +171,10 @@ Proof
  >> MATCH_MP_TAC asmlam_eqn >> rw []
 QED
 
-Theorem separable_not_lameq :
+Theorem separable_imp_not_lameq :
     !M N. separable [M; N] ==> ~(M == N)
 Proof
-    METIS_TAC [separable_incompatible, incompatible_not_lameq]
+    METIS_TAC [separable_imp_incompatible, incompatible_not_lameq]
 QED
 
 (* “eta_separable” is another common instance with beta- and eta-conversion. *)
@@ -178,6 +189,17 @@ Overload eta_separable = “gen_separable (UNCURRY lameta)”
 Theorem eta_separable_def =
         gen_separable_alt |> Q.SPEC ‘UNCURRY lameta’
                           |> SRULE [lambdathy_lameta]
+
+(* |- !Ms.
+        EVERY closed Ms ==>
+        (eta_separable Ms <=>
+         !Ns.
+           LENGTH Ns = LENGTH Ms ==>
+           ?f. !i. i < LENGTH Ms ==> f @@ EL i Ms === EL i Ns)
+ *)
+Theorem eta_separable_alt_closed =
+        gen_separable_alt_closed |> Q.SPEC ‘UNCURRY lameta’
+                                 |> SRULE [lambdathy_lameta]
 
 Theorem eta_separable_thm :
     !M N. has_benf M /\ has_benf N /\ M =/== N ==> eta_separable [M; N]
@@ -229,6 +251,14 @@ Proof
  >> ASM_SIMP_TAC bool_ss [GSYM EL]
  >> Q_TAC (TRANS_TAC lameq_TRANS) ‘apply pi M’ >> art []
  >> MATCH_MP_TAC lameq_SYM >> art []
+QED
+
+Theorem separable_thm' :
+    !M N. benf M /\ benf N /\ M <> N ==> separable [M; N]
+Proof
+    rpt STRIP_TAC
+ >> MATCH_MP_TAC separable_thm
+ >> simp [benf_has_benf, benf_lameta_iff_eq]
 QED
 
 (* END *)

--- a/examples/probability/central_limitScript.sml
+++ b/examples/probability/central_limitScript.sml
@@ -1374,12 +1374,9 @@ Proof
  >> rw [extreal_11] >> REAL_ARITH_TAC
 QED
 
-Definition third_moment_def:
-  third_moment p X = central_moment p X 3
-End
-
-Definition absolute_third_moment_def:
-  absolute_third_moment p X = absolute_moment p X 0 3
+(* NOTE: This is also a central moment (a = expectation p X) *)
+Definition absolute_third_moment_def :
+  absolute_third_moment p X = absolute_moment p X (expectation p X) 3
 End
 
 Definition absolute_third_moments_def :
@@ -1388,10 +1385,6 @@ End
 
 Definition second_moments_def:
   second_moments p X n = SIGMA (λi. central_moment p (X i) 2) (count n)
-End
-
-Definition third_moments_def:
-  third_moments p X n = SIGMA (λi. third_moment p (X i)) (count n)
 End
 
 Definition ext_normal_density_def:
@@ -6349,7 +6342,7 @@ Definition CLT_def :
      (in_distribution p)
 End
 
-Theorem central_limit_theorem :
+Theorem central_limit_theorem[local] :
     ∀p X N.
       prob_space p ∧ ext_normal_rv N p 0 1 ∧
       (∀i. real_random_variable (X i) p) ∧
@@ -6437,7 +6430,8 @@ Proof
  >> fs [LIM_SEQUENTIALLY]
  >> Q.PAT_X_ASSUM ‘((λx. M x − Q) ⟶ 0) sequentially ⇔ _’ K_TAC
  (*To rewrite b n / s n pow 3 *)
-    >> MP_TAC (Q.SPECL [‘λn. b (SUC n) / (s (SUC n))³’, ‘0’] lim_null_equiv_extreal_real)
+ >> MP_TAC (Q.SPECL [‘\n. b (SUC n) / s (SUC n) pow 3’, ‘0’]
+                    lim_null_equiv_extreal_real)
 
  >> impl_tac >> simp []
  >- (qexists ‘1’ >> gs [] \\
@@ -6978,249 +6972,14 @@ Proof
  >> MATCH_MP_TAC REAL_LE_ADD >> simp []
 QED
 
-Theorem extreal_mr1_dist_0_mono :
-    ∀x y.
-      0 ≤ x ∧ x ≤ y ⇒ dist extreal_mr1 (x,0) ≤ dist extreal_mr1 (y,0)
-Proof
-    rw []
- >> ‘0 ≤ y’ by METIS_TAC [le_trans]
- >> Cases_on ‘x’
- >> Cases_on ‘y’
- >> fs [extreal_mr1_thm, extreal_dist_def, extreal_0_simps]
- >> rw [extreal_dist_normal', extreal_dist_def, extreal_of_num_def]
- >- (irule REAL_SUB_LE_SELF \\
-     simp [REAL_LE_INV_EQ] >> REAL_ARITH_TAC)
- >> simp [REAL_LE_SUB_CANCEL1]
- >> MATCH_MP_TAC REAL_LE_INV2 >> simp []
- >> CONJ_TAC >- (REAL_ARITH_TAC)
- >> METIS_TAC [ABS_REFL]
-QED
-
-Theorem lim_sequentially_bound :
-    ∀f g.
-      (∀n. 0 ≤ f n) ∧ (∀n. f n ≤ g n) ∧ (g ⟶ 0) sequentially ⇒
-      (f ⟶ 0) sequentially
-Proof
-    rw [EXTREAL_LIM_SEQUENTIALLY]
- >> Q.PAT_X_ASSUM ‘∀e. 0 < e ⇒ ∃N. ∀n. N ≤ n ⇒ _’ (STRIP_ASSUME_TAC o Q.SPEC ‘e’)
- >> gvs []
- >> qexists ‘N’ >> rw []
- >> Q.PAT_X_ASSUM ‘∀n. N ≤ n ⇒ dist extreal_mr1 (g n,0) < e’  (STRIP_ASSUME_TAC o Q.SPEC ‘n’)
- >> gvs []
- >> MATCH_MP_TAC REAL_LET_TRANS
- >> qexists ‘dist extreal_mr1 (g n,0)’ >> fs []
- >> METIS_TAC [extreal_mr1_dist_0_mono]
-QED
-
-Theorem absolute_third_moments_pos :
-    ∀p X n. prob_space p ⇒ 0 ≤ absolute_third_moments p X n
-Proof
-    rw [absolute_third_moments_def, absolute_moment_def, absolute_third_moment_def]
- >> HO_MATCH_MP_TAC EXTREAL_SUM_IMAGE_POS >> rw []
- >> HO_MATCH_MP_TAC expectation_pos >> rw [pow_pos_le, abs_pos]
-QED
-
-val clt_integrable_sub_const_i =
- irule integrable_bounded >> fs [prob_space_def] \\
-     CONJ_TAC >- (HO_MATCH_MP_TAC IN_MEASURABLE_BOREL_POW \\
-                  HO_MATCH_MP_TAC IN_MEASURABLE_BOREL_ABS \\
-                  qexists ‘λx. X i x − expectation p (X i)’ \\
-                  fs [MEASURE_SPACE_SIGMA_ALGEBRA] \\
-                  irule IN_MEASURABLE_BOREL_SUB' \\
-                  fs [MEASURE_SPACE_SIGMA_ALGEBRA] \\
-                  qexistsl [‘λx. X i x’, ‘λx.  expectation p (X i)’] \\
-                  fs [IN_MEASURABLE_BOREL_CONST', MEASURE_SPACE_SIGMA_ALGEBRA,
-                      real_random_variable, p_space_def, events_def] \\
-                  METIS_TAC []) \\
-     qexists ‘λx. 4 * (abs (X i x))³ + 4 * (abs (expectation p (X i)))³’ \\
-     CONJ_TAC >- (rw [abs_abs, pow_abs] \\
-                  HO_MATCH_MP_TAC abs_sub_pow3_bound \\
-                  fs [real_random_variable, expectation_def] \\
-                  METIS_TAC [integrable_finite_integral, p_space_def]) \\
-     HO_MATCH_MP_TAC integrable_add' >> simp [] \\
-     CONJ_TAC >- (METIS_TAC [integrable_cmul, extreal_of_num_def]) \\
-     ‘expectation p (X i) ≠ PosInf ∧ expectation p (X i) ≠ NegInf’
-       by METIS_TAC [integrable_finite_integral, prob_space_def,
-                     expectation_def, extreal_cases] \\
-     ‘∃r. expectation p (X i) = Normal r’ by METIS_TAC [extreal_cases] \\
-     rw [extreal_abs_def, extreal_mul_eq, extreal_of_num_def, extreal_pow_def] \\
-irule integrable_const >> fs [extreal_1_simps];
-
-Theorem neg_abs_le:
-    ∀(a:extreal). -abs a ≤ a
-Proof
-    METIS_TAC [le_abs, le_neg, neg_neg]
-QED
-
-Theorem abs_expectation_le_expectation_abs:
-    ∀p X.
-      prob_space p ∧ real_random_variable X p ∧ integrable p X ⇒
-      abs (expectation p X) ≤ expectation p (λx. abs (X x))
-Proof
-    rpt STRIP_TAC
- >> MP_TAC (Q.SPECL [‘expectation p X’, ‘expectation p (λx. abs (X x))’] abs_bounds)
- >> Rewr
- >> CONJ_TAC
- >- (‘-expectation p (λx. abs (X x)) = -1 * expectation p (λx. abs (X x))’ by METIS_TAC [neg_minus1] \\
-     POP_ORW \\
-     ‘-1 = Normal (-1)’ by METIS_TAC [extreal_ainv_def, GSYM extreal_of_num_def] \\
-     POP_ORW \\
-     ‘Normal (-1) * expectation p (λx. abs (X x)) = expectation p (λx. Normal (-1) * abs (X x))’
-       by (HO_MATCH_MP_TAC (GSYM expectation_cmul) \\
-           METIS_TAC [integrable_abs, o_DEF, prob_space_def]) \\
-     POP_ORW \\
-     HO_MATCH_MP_TAC expectation_mono >> fs [] \\
-     CONJ_TAC >- (HO_MATCH_MP_TAC integrable_cmul >> METIS_TAC [integrable_abs, o_DEF, prob_space_def]) \\
-     ‘Normal (-1) = -1’ by METIS_TAC [extreal_ainv_def, GSYM extreal_of_num_def] \\
-     rw [GSYM neg_minus1, neg_abs_le])
- >> HO_MATCH_MP_TAC expectation_mono >> fs []
- >> CONJ_TAC >- (METIS_TAC [integrable_abs, o_DEF, prob_space_def])
- >> rw [cj 1 le_abs]
-QED
-
-Theorem abs_expectation_pow_le_expectation_abs_pow :
-    ∀p X (n :num).
-      prob_space p ∧ real_random_variable X p ∧ integrable p X ∧
-      0 < n ∧ integrable p (λx. (abs (X x)) pow n) ⇒
-      (abs (expectation p X)) pow n ≤ expectation p (λx. (abs (X x)) pow n)
-Proof
-    rpt STRIP_TAC
- >> Cases_on ‘n = 1’ >> simp [abs_expectation_le_expectation_abs]
- >> ‘1 < n’ by simp []
- >> MP_TAC (Q.SPECL [‘p’, ‘X’, ‘Normal 1’, ‘Normal (&n)’] Lyapunov_ineq_rv)
- >> impl_tac
- >- (gvs [normal_1, GSYM extreal_of_num_def] \\
-     fs [L1_space_alt_integrable, prob_space_def] \\
-     fs [lp_space_def, real_random_variable, events_def, p_space_def] \\
-     ‘∀x. abs (X x) powr &n = abs (X x) pow n’ by METIS_TAC [abs_pos, gen_powr] >> POP_ORW \\
-     gvs [integrable_alt_def, abs_abs, o_DEF, pos_fn_integral_pos, integral_pos_fn, pow_abs, pow_pos_le])
- >> rw [seminorm_def, expectation_def, GSYM extreal_of_num_def, powr_1, abs_pos, inv_one]
- >> MATCH_MP_TAC le_trans
- >> qexists ‘(∫ p (λx. abs (X x))) pow n’
- >> CONJ_TAC >- (irule pow_le \\
-                 METIS_TAC [GSYM expectation_def, abs_expectation_le_expectation_abs, abs_pos])
- >> gvs [powr_1, pos_fn_integral_pos, prob_space_def, p_space_def, abs_pos]
- >> ‘∫⁺ p (λx. abs (X x)) = ∫ p (λx. abs (X x))’
-   by (irule (GSYM integral_pos_fn) >> METIS_TAC [abs_pos, ETA_AX])
- >> ‘∀x. abs (X x) powr &n = abs (X x) pow n’ by METIS_TAC [abs_pos, gen_powr]
- >> gvs []
- >> ‘∫⁺ p (λx. abs (X x) pow n) = ∫ p (λx. abs (X x) pow n)’
-   by (irule (GSYM integral_pos_fn) >> METIS_TAC [abs_pos, ETA_AX, pow_pos_le])
- >> gvs []
- >> NTAC 3 (POP_ASSUM K_TAC)
- >> Q.ABBREV_TAC ‘A = ∫ p (λx. abs (X x))’
- >> Q.ABBREV_TAC ‘B = ∫ p (λx. abs (X x) pow n)’
- >> MP_TAC (Q.SPECL [‘n’, ‘A’, ‘ B powr (&n)⁻¹’] pow_le)
- >> impl_tac >- (gvs [Abbr ‘A’, Abbr ‘B’] \\
-                 gvs [integral_pos, abs_pos, pow_pos_le, powr_pos])
- >> ‘0 ≤ B’ by gvs [Abbr ‘B’, integral_pos, abs_pos, pow_pos_le]
- >> ‘0 ≤ B powr (&n)⁻¹’ by gvs [powr_pos]
- >> ‘(B powr (&n)⁻¹) pow n = (B powr (&n)⁻¹) powr (&n)’ by gvs [gen_powr]
- >> Know ‘(B powr (&n)⁻¹) powr (&n) = B’
- >- (‘0 < &n’ by gvs [] \\
-     ‘0 < inv (&n)’ by gvs [inv_pos'] \\
-     ‘(B powr (&n)⁻¹) powr &n = B powr ((&n)⁻¹ * (&n))’
-       by (irule powr_powr >> gvs [num_not_infty, inv_not_infty, lt_imp_ne]) \\
-     POP_ORW >> gvs [mul_linv_pos, powr_1])
- >> gvs []
-QED
-
-Theorem absolute_third_moments_center_bound:
-    ∀p X n. prob_space p ∧ (∀i. real_random_variable (X i) p) ∧
-            (∀i. integrable p (λx. (abs (X i x))³)) ∧
-            (∀i. integrable p (λx. X i x)) ⇒
-            absolute_third_moments p (λi x. X i x − expectation p (X i)) n
-            ≤ 8 * absolute_third_moments p X n
-Proof
-    rw [absolute_third_moments_def, absolute_moment_def, absolute_third_moment_def]
- >> Know ‘∀i. integrable p (λx. (abs (X i x − expectation p (X i)))³)’
- >- (Q.X_GEN_TAC ‘i’ >> clt_integrable_sub_const_i)
- >> DISCH_TAC
- >> Know ‘∀i. integrable p (λx. (abs (X i x))³ + (abs (expectation p (X i)))³)’
- >- (Q.X_GEN_TAC ‘i’ \\
-     HO_MATCH_MP_TAC integrable_add' >> fs [prob_space_def] \\
-     ‘expectation p (X i) ≠ PosInf ∧ expectation p (X i) ≠ NegInf’
-       by METIS_TAC [integrable_finite_integral, prob_space_def,
-                     expectation_def, extreal_cases] \\
-     ‘∃r. expectation p (X i) = Normal r’ by METIS_TAC [extreal_cases] \\
-     gvs [pow_abs, extreal_abs_def, extreal_pow_def, integrable_const])
- >> DISCH_TAC
- >> Know ‘∀i. integrable p (λx. Normal 4 * (abs (X i x))³ +
-                                Normal 4 * (abs (expectation p (X i)))³)’
- >- (Q.X_GEN_TAC ‘i’ \\
-     gvs [GSYM add_ldistrib_pos, abs_pos, GSYM pow_abs] \\
-     HO_MATCH_MP_TAC integrable_cmul >> fs [prob_space_def])
- >> DISCH_TAC
- >> (MP_TAC o (Q.SPECL [‘count n’]) o
-            (INST_TYPE [alpha |-> ``:num``])) (GSYM EXTREAL_SUM_IMAGE_CMUL)
- >> rw [extreal_of_num_def]
- >> POP_ASSUM (STRIP_ASSUME_TAC o Q.SPECL [‘λi. expectation p (λx. (abs (X i x))³)’, ‘8’])
- >> ‘(∀x. x < n ⇒ (λi. expectation p (λx. (abs (X i x))³)) x ≠ −∞)’
-   by METIS_TAC [cj 2 integrable_imp_finite_expectation] >> gvs []
- >> HO_MATCH_MP_TAC EXTREAL_SUM_IMAGE_MONO' >> simp []
- >> Q.X_GEN_TAC ‘i’ >> STRIP_TAC
- >> MATCH_MP_TAC le_trans
- >> qexists ‘expectation p (λx. Normal 4 * (abs (X i x))³ +
-                                Normal 4 * (abs (expectation p (X i)))³)’
- >> CONJ_TAC
- >- (irule expectation_mono >> gvs [GSYM extreal_of_num_def] \\
-     Q.X_GEN_TAC ‘x’ >> STRIP_TAC \\
-     HO_MATCH_MP_TAC abs_sub_pow3_bound \\
-     METIS_TAC [real_random_variable, integrable_imp_finite_expectation])
- >> Know ‘expectation p
-           (λx. Normal 4 * (abs (X i x))³ +
-                Normal 4 * (abs (expectation p (X i)))³) =
-          Normal 4 * expectation p (λx. (abs (X i x))³) +
-          Normal 4 * (abs (expectation p (X i)))³’
- >- (gvs [expectation_cmul, GSYM add_ldistrib_pos, expectation_pos, abs_pos, pow_pos_le] \\
-     gvs [mul_lcancel] \\
-     ‘expectation p (X i) ≠ PosInf ∧ expectation p (X i) ≠ NegInf’
-       by METIS_TAC [integrable_finite_integral, prob_space_def,
-                     expectation_def, extreal_cases] \\
-     ‘∃r. expectation p (X i) = Normal r’ by METIS_TAC [extreal_cases] \\
-     gvs [pow_abs, extreal_abs_def, extreal_pow_def] \\
-     MP_TAC (Q.SPECL [‘p’, ‘λx. (abs (X (i:num) x))³’, ‘λx. Normal (abs r)³’] (expectation_add)) \\
-     fs [integrable_const, prob_space_def] >> DISCH_TAC \\
-     POP_ASSUM K_TAC \\
-     METIS_TAC [expectation_const, prob_space_def])
- >> Rewr
- >> MATCH_MP_TAC leeq_trans
- >> qexists ‘Normal 4 * expectation p (λx. (abs (X i x))³) +
-             Normal 4 * expectation p (λx. (abs (X i x))³)’
- >> reverse CONJ_TAC
- >- (‘expectation p (λx. (abs (X i x))³) ≠ NegInf ∧ expectation p (λx. (abs (X i x))³) ≠ PosInf’
-       by METIS_TAC [integrable_imp_finite_expectation] \\
-     ‘∃r. expectation p (λx. (abs (X i x))³) = Normal r’ by METIS_TAC [extreal_cases] \\
-     gvs [extreal_mul_eq, extreal_add_eq] >> REAL_ARITH_TAC)
- >> MATCH_MP_TAC le_ladd_imp
- >> MATCH_MP_TAC le_lmul_imp >> simp []
- >> HO_MATCH_MP_TAC abs_expectation_pow_le_expectation_abs_pow >> gvs []
- >> METIS_TAC []
-QED
-
-val clt_handle_moments =
-    POP_ASSUM (STRIP_ASSUME_TAC o Q.SPEC ‘n’) \\
-    Q.PAT_X_ASSUM ‘∀n. (sqrt (second_moments p X (SUC n)))³ ≠ +∞’
-     (STRIP_ASSUME_TAC o Q.SPEC ‘n’) \\
-    Q.PAT_X_ASSUM ‘∀n. 0 < (sqrt (second_moments p X (SUC n)))³’
-     (STRIP_ASSUME_TAC o Q.SPEC ‘n’) \\
-    ‘∃r. (sqrt (second_moments p X (SUC n)))³ = Normal r’ by METIS_TAC [extreal_cases] \\
-    gvs [] \\
-    ‘0 ≤ absolute_third_moments p X (SUC n)’ by METIS_TAC [absolute_third_moments_pos] \\
-    ‘absolute_third_moments p X (SUC n) ≠ NegInf’
-  by METIS_TAC [extreal_0_simps, lt_trans] \\
-    Know ‘absolute_third_moments p X (SUC n) ≠ PosInf’
-    >- (rw [absolute_third_moments_def, absolute_moment_def, absolute_third_moment_def] \\
-        HO_MATCH_MP_TAC EXTREAL_SUM_IMAGE_NOT_POSINF >> rw [] \\
-        HO_MATCH_MP_TAC (cj 1 integrable_imp_finite_expectation) >> fs []) \\
-    DISCH_TAC \\
-    ‘∃d. absolute_third_moments p X (SUC n) = Normal d’ by METIS_TAC [extreal_cases];
-
+(* NOTE: This is the final version, which removes “!n. expectation p (X n) = 0)”
+   from the previous [CLT_Lyapunov'].
+ *)
 Theorem CLT_Lyapunov :
     !p X N. prob_space p /\ ext_normal_rv N p 0 1 /\
             (!n. real_random_variable (X n) p) /\
             (!n. indep_vars p X (\i. Borel) (count n)) /\
-           (!n. integrable p (\x. (abs (X n x)) pow 3)) /\
+            (!n. integrable p (\x. (abs (X n x)) pow 3)) /\
             (!n. variance p (X n) <> 0) /\
             ((\n. absolute_third_moments p X (SUC n) /
                   sqrt (second_moments p X (SUC n)) pow 3) --> 0) sequentially
@@ -7250,7 +7009,31 @@ Proof
  >- (Q.X_GEN_TAC ‘i’ \\
      MP_TAC (Q.SPECL [‘p’, ‘Y (i :num)’, ‘3’] (GSYM expectation_finite_eq_integrable)) \\
      fs [] >> Rewr \\
-     rw [Abbr ‘Y’] >> clt_integrable_sub_const_i)
+     rw [Abbr ‘Y’] \\
+     irule integrable_bounded >> fs [prob_space_def] \\
+     CONJ_TAC >- (HO_MATCH_MP_TAC IN_MEASURABLE_BOREL_POW \\
+                  HO_MATCH_MP_TAC IN_MEASURABLE_BOREL_ABS \\
+                  qexists ‘λx. X i x − expectation p (X i)’ \\
+                  fs [MEASURE_SPACE_SIGMA_ALGEBRA] \\
+                  irule IN_MEASURABLE_BOREL_SUB' \\
+                  fs [MEASURE_SPACE_SIGMA_ALGEBRA] \\
+                  qexistsl [‘λx. X i x’, ‘λx.  expectation p (X i)’] \\
+                  fs [IN_MEASURABLE_BOREL_CONST', MEASURE_SPACE_SIGMA_ALGEBRA,
+                      real_random_variable, p_space_def, events_def] \\
+                  METIS_TAC []) \\
+     qexists ‘λx. 4 * (abs (X i x))³ + 4 * (abs (expectation p (X i)))³’ \\
+     CONJ_TAC >- (rw [abs_abs, pow_abs] \\
+                  HO_MATCH_MP_TAC abs_sub_pow3_bound \\
+                  fs [real_random_variable, expectation_def] \\
+                  METIS_TAC [integrable_finite_integral, p_space_def]) \\
+     HO_MATCH_MP_TAC integrable_add' >> simp [] \\
+     CONJ_TAC >- (METIS_TAC [integrable_cmul, extreal_of_num_def]) \\
+     ‘expectation p (X i) ≠ PosInf ∧ expectation p (X i) ≠ NegInf’
+       by METIS_TAC [integrable_finite_integral, prob_space_def,
+                     expectation_def, extreal_cases] \\
+     ‘∃r. expectation p (X i) = Normal r’ by METIS_TAC [extreal_cases] \\
+     rw [extreal_abs_def, extreal_mul_eq, extreal_of_num_def, extreal_pow_def] \\
+     irule integrable_const >> fs [extreal_1_simps])
  >> DISCH_TAC
  >> Know ‘∀i. integrable p (Y i)’
  >- (rw [Abbr ‘Y’] \\
@@ -7273,8 +7056,9 @@ Proof
          >- (HO_MATCH_MP_TAC variance_real_affine' \\
              METIS_TAC []) >> Rewr' \\
          METIS_TAC []) \\
-     CONJ_TAC >- (rw [Abbr ‘Y’] \\
-                  irule expectation_center >> METIS_TAC []) \\
+     CONJ_ASM1_TAC
+     >- (rw [Abbr ‘Y’] \\
+         irule expectation_center >> METIS_TAC []) \\
      CONJ_TAC >- (rw [GSYM pow_abs, GSYM o_DEF] \\
                   irule integrable_abs >> fs [prob_space_def] \\
                   irule (cj 3 clt_integrable_lemma) >> art [prob_space_def]) \\
@@ -7296,49 +7080,10 @@ Proof
          rw [Abbr ‘Y’, second_moments_def] \\
          irule EXTREAL_SUM_IMAGE_EQ' >> rw [expectation_center, central_moment_def, moment_def] \\
          rw [GSYM variance_alt] >> METIS_TAC [variance_center]) >> Rewr \\
-     irule lim_sequentially_bound \\
-     ‘∀n. 0 ≤ second_moments p X (SUC n)’ by METIS_TAC [second_moments_pos] \\
-     Know ‘∀n. 0 < second_moments p X (SUC n)’
-     >- (rw [second_moments_variance_def] \\
-         irule EXTREAL_SUM_IMAGE_SPOS >> rw [] \\
-         METIS_TAC [variance_pos, GSYM lt_le]) \\
-     DISCH_TAC \\
-     ‘∀n. 0 < sqrt (second_moments p X (SUC n))’ by METIS_TAC [sqrt_pos_lt] \\
-     ‘∀n. 0 < (sqrt (second_moments p X (SUC n))) pow 3’ by METIS_TAC [pow_pos_lt] \\
-     Know ‘∀n. (sqrt (second_moments p X (SUC n)))³ ≠ PosInf’
-     >- (rw [] >> irule (cj 2 pow_not_infty) \\
-         CONJ_TAC >- (METIS_TAC [sqrt_pos_le, extreal_0_simps, lt_trans]) \\
-         irule sqrt_infty >> fs [] \\
-         METIS_TAC [finite_variance_imp_second_moments, lt_imp_ne]) \\
-     DISCH_TAC \\
-     Know ‘∀n. (sqrt (second_moments p X (SUC n)))³ ≠ NegInf’
-     >- (rw [] >> irule (cj 1 pow_not_infty) \\
-         CONJ_TAC >- (METIS_TAC [sqrt_pos_le, extreal_0_simps, lt_trans]) \\
-         irule sqrt_infty >> fs [] \\
-         METIS_TAC [finite_variance_imp_second_moments, lt_imp_ne]) \\
-     DISCH_TAC \\
-     CONJ_TAC >- (Q.X_GEN_TAC ‘n’ \\
-                  POP_ASSUM (STRIP_ASSUME_TAC o Q.SPEC ‘n’) \\
-                  Q.PAT_X_ASSUM ‘∀n. (sqrt (second_moments p X (SUC n)))³ ≠ +∞’ (STRIP_ASSUME_TAC o Q.SPEC ‘n’) \\
-                  Q.PAT_X_ASSUM ‘∀n. 0 < (sqrt (second_moments p X (SUC n)))³’ (STRIP_ASSUME_TAC o Q.SPEC ‘n’) \\
-                  ‘∃r. (sqrt (second_moments p X (SUC n)))³ = Normal r’ by METIS_TAC [extreal_cases] \\
-                  gvs [] \\
-                  irule le_div >> fs [absolute_third_moments_pos]) \\
-     Q.ABBREV_TAC ‘g = λn. absolute_third_moments p X (SUC n) / (sqrt (second_moments p X (SUC n)))³’ \\
-     gvs [] \\
-     qexists ‘λn. 8 * g n’ \\
-     reverse CONJ_TAC >- (MP_TAC (Q.SPECL [‘g’, ‘0’, ‘8’] lim_sequentially_cmul) \\
-                          impl_tac >- (fs [Abbr ‘g’] \\
-                                       Q.X_GEN_TAC ‘n’ \\
-                                       clt_handle_moments \\
-                                       gvs [REAL_LT_IMP_NE, extreal_div_eq]) \\
-                          fs [extreal_0_simps]) \\
-     Q.X_GEN_TAC ‘n’ >> gvs [Abbr ‘g’] \\
-     clt_handle_moments \\
-     gvs [GSYM mul_div_assoc] \\
-     irule ldiv_le_imp >> gvs [] \\
-     POP_ASSUM (rw o wrap o SYM) \\
-     fs [absolute_third_moments_center_bound, Abbr ‘Y’])
+     Suff ‘!n. absolute_third_moments p Y (SUC n) =
+               absolute_third_moments p X (SUC n)’ >- simp [] \\
+     rw [absolute_third_moments_def, absolute_third_moment_def,
+         absolute_moment_def])
  >> rw [CLT_def]
  >> Q.ABBREV_TAC ‘A = (λn x.
                          (∑ (λi. Y i x) (count1 n) −  expectation p (λx. ∑ (λi. Y i x) (count1 n))) /


### PR DESCRIPTION
Hi,

In current `central_limitTheory`, the definition of `absolute_third_moment` is (unfortunately) wrong. It should be a central moment (having `expectation p X` as the center, instead of 0):
```
[absolute_third_moment_def] (old)
    ⊢ ∀p X. absolute_third_moment p X = absolute_moment p X 0 3

[absolute_third_moment_def] (new)
    ⊢ ∀p X. absolute_third_moment p X = absolute_moment p X (expectation p X) 3
```
The old and new definitions are equivalent in the staged CLT results where all involved random variables (r.v.'s) have zero expectations, i.e. `expectation p (X n) = 0`. But in the final, more general version of CLT where the involved r.v.'s may have non-zero expectations, the wrong definition `absolute_third_moment` will lead to a much harder proof of CLT (it surprisingly can still be proved), whose overall statements are ...just wrong.

This PR fixes the wrong definition, and then greately simplified the recently added proof of `[CLT_Lyapunov]` (the final non-zero-mean version). Unused lemmas (and two definitions) are removed.  This fix is *urgent* because it seems that next HOL releases may come any time from now on.

P. S. Taking this chance, I also added a little new contents into `semi_sensibleTheory` of lambda examples (variants of the separability results)

--Chun