### PR TITLE
add missing } to regexpLib.sml

### DIFF
--- a/examples/formal-languages/regular/regexpLib.sml
+++ b/examples/formal-languages/regular/regexpLib.sml
@@ -340,7 +340,7 @@ fun gen_dfa_conv r =
            Ty = (regexp_ty --> regexp_ty --> ordering_ty) -->
                 regexp_ty -->
                 regexp_num_map_ty -->
-                optionSyntax.mk_option numSyntax.num
+                optionSyntax.mk_option numSyntax.num}
       (* “:(regexp -> regexp -> ordering) ->
            regexp -> (regexp, num) balanced_map -> num option” *)
      val init_regexp_tm =


### PR DESCRIPTION
This was getting auto-patched by the parser, leading to Holmake producing a build artifact and then failing.

Subsequent runs of Holmake would see the build artifact and deem the build complete.