### PR TITLE
Changed lex_plus empty list case to return NONE

### DIFF
--- a/examples/formal-languages/json/parse_jsonScript.sml
+++ b/examples/formal-languages/json/parse_jsonScript.sml
@@ -407,7 +407,7 @@ Definition lex_frac_def:
 End
 
 Definition lex_plus_def:
-  lex_plus [] = SOME (NONE, []) /\
+  lex_plus [] = NONE /\
   (lex_plus (c::cs) =
     if c = #"+" then
       if is_next_digit cs then


### PR DESCRIPTION
Fixes #2016.

Changing the base case of `lex_plus` to return `NONE` instead of `SOME (NONE, [])` should fix the issue, as we want to be returning `NONE` from `lex_plus` on the empty list as there is no exponent there to lex.
The example:
```
> EVAL ``lex "1E" []``;
val it = ⊢ lex "1E" [] = INL [NUM ((POS,1),NONE,NONE)]: thm
```
Now returns properly:
```
> EVAL ``lex "1E" []``;
val it = ⊢ lex "1E" [] = INR "unexpected characters: 1E": thm
```
As do other invalid json examples with the same issue:
```
EVAL ``lex "0.9230E" []``;
val it = ⊢ lex "0.9230E" [] = INR "unexpected characters: 0.9230E": thm
```
```
> EVAL ``lex "-1000.02E" []``;
val it = ⊢ lex "-1000.02E" [] = INR "unexpected characters: -1000.02E": thm
```
The change does not seem to affect any off the proofs in the file from my testing, so I do not think any other changes are necessary.

That being said, I would like a second opinion from @didriklundberg to see if he thinks these changes are good.