### PR TITLE
metis: remove the bogus Time handler in FOL_SOLVE

### DIFF
--- a/src/metis/folTools.sml
+++ b/src/metis/folTools.sml
@@ -504,8 +504,6 @@ fun FOL_SOLVE solv lmap lim =
     val solver =
       timed_fn "solver initialization"
       (initialize_solver solv) {thms = thms, hyps = hyps, limit = lim}
-    fun exn_handler f x = f x
-      handle Time => raise ERR "FOL_SOLVER" "Time exception raised"
   in
     fn query =>
     let
@@ -515,7 +513,7 @@ fun FOL_SOLVE solv lmap lim =
       val () = save_fol_problem (thms, hyps, q)
       val lift = fol_thms_to_hol (#mapping_parm parm) (C assoc axioms) query
       val timed_lift = timed_fn "proof translation" lift
-      val timed_stream = map_thk (timed_fn "proof search" o exn_handler)
+      val timed_stream = map_thk (timed_fn "proof search")
     in
       eliminate consts
       (mlibStream.map timed_lift (timed_stream (fn () => solver q) ()))


### PR DESCRIPTION
I ran into an issue where a Ctrl+C issued during the metis tactic triggered a bogus "Time exception raised" error. I'm including the complete commit message below, which describes the issue:

`Time` is not bound as an exception constructor anywhere in scope, so the handler pattern was a plain variable and caught *every* exception raised during proof search (mlibUseful.Error and Bug, HOL_ERRs, Overflow, Interrupt), relabelling it "Time exception raised" -- a message that was never accurate.  Swallowing `Interrupt` was the worst of it: contrary to the convention in Portable.sml, Ctrl-C during a long METIS_TAC became an ordinary tactic failure that ORELSE would then recover from.

Nothing time-related was ever raised there in any case.  Metis's limits are non-exceptional: mlibMeter.check_meter returns a bool and the solvers truncate their streams with it, so an exhausted limit surfaces as an empty stream and then FOL_FIND's "no solution found". Dropping the wrapper leaves the "proof search" timing untouched and lets real exceptions propagate with their own messages.

The handler dates from the initial metis check-in in 2002 (01d2e53d8).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>