### PR TITLE
Prove cv_compute selftest termination instead of cheating

### DIFF
--- a/src/num/theories/cv_compute/automation/selftest.sml
+++ b/src/num/theories/cv_compute/automation/selftest.sml
@@ -323,9 +323,15 @@ val exp_size_alt_def = tDefine "exp_size_alt" `
   exp_size_alt (Op a0 a1 a2) = 1 + exp_sizes_alt a2 /\
   exp_sizes_alt [] = 0 /\
   exp_sizes_alt (x::xs) = exp_size_alt x + exp_sizes_alt xs`
- cheat
+ ALL_TAC
 
-val pre = cv_auto_trans_pre_rec "" exp_size_alt_def cheat;
+val pre =
+  cv_auto_trans_pre_rec "" exp_size_alt_def
+    (WF_REL_TAC ‘measure $ λx. case x of
+                               INL v => cv_size v
+                             | INR v => cv_size v’
+     \\ rw []
+     \\ cv_termination_tac);
 
 val can_raise_def = Define ` can_raise x = T `
 


### PR DESCRIPTION
The `exp_size_alt` example in `src/num/theories/cv_compute/automation/selftest.sml`
reached for `cheat` twice: once for the tactic argument of `tDefine`, and once for
the precondition goal handed to `cv_auto_trans_pre_rec`.

This PR discharges both obligations honestly:

  - **`tDefine`**: the definition is primitive recursive — as the comment sitting
    above it already remarks — so there is no termination argument to make, and
    `ALL_TAC` suffices.
  - **`cv_auto_trans_pre_rec`**: the precondition of the translated function is a
    termination argument over the sum type into which the two mutually recursive
    functions are packed, so a `measure` taking `cv_size` in either injection,
    followed by `cv_termination_tac`, proves it.

No change to any non-test source; the only effect is that the selftest now
actually exercises the translator's precondition machinery.
