### PR TITLE
Stop REAL_RAT_REDUCE_CONV diverging on rational literals

### DIFF
--- a/src/real/RealField.sml
+++ b/src/real/RealField.sml
@@ -446,22 +446,8 @@ val sgn_tm = “real_sgn :real -> real”;
 val max_tm = “max :real -> real -> real”;
 val min_tm = “min :real -> real -> real”;
 
-(* computeLib re-evaluates whatever a registered conversion hands back, so
-   one that reports success without changing its term sends CBV_CONV round
-   the same term forever.  Several of these are no-ops on an argument that
-   is already reduced: REAL_RAT_DIV_CONV rewrites x / y to x * inv y and
-   back, so it takes &1 / &3 to &1 / &3 and REAL_RAT_REDUCE_CONV does not
-   terminate on any term containing a non-integral rational literal.  The
-   guard therefore belongs on every entry rather than on the one operator
-   (negation) whose no-op was noticed first.
-
-   A conversion can report no progress two ways: return a reflexive
-   theorem, or raise UNCHANGED (as ALL_CONV, hence TRY_CONV, does).
-   CHANGED_CONV catches both -- it turns the raise into a HOL_ERR, which
-   is what reduce_cst looks for when moving on to the next rule -- so it
-   needs no QCHANGED_CONV around it.  QCHANGED_CONV alone would not do:
-   it catches only the raise and lets the reflexive theorem through,
-   which is the diverging mode. *)
+(* computeLib retries reflexive results and does not catch UNCHANGED.
+   CHANGED_CONV converts both no-progress cases to the HOL_ERR it expects. *)
 fun add_reduce_conv entry compset =
   let
     val (operator, arity, conv) = entry

--- a/src/real/RealField.sml
+++ b/src/real/RealField.sml
@@ -446,24 +446,47 @@ val sgn_tm = “real_sgn :real -> real”;
 val max_tm = “max :real -> real -> real”;
 val min_tm = “min :real -> real -> real”;
 
+(* computeLib re-evaluates whatever a registered conversion hands back, so
+   one that reports success without changing its term sends CBV_CONV round
+   the same term forever.  Several of these are no-ops on an argument that
+   is already reduced: REAL_RAT_DIV_CONV rewrites x / y to x * inv y and
+   back, so it takes &1 / &3 to &1 / &3 and REAL_RAT_REDUCE_CONV does not
+   terminate on any term containing a non-integral rational literal.  The
+   guard therefore belongs on every entry rather than on the one operator
+   (negation) whose no-op was noticed first.
+
+   A conversion can report no progress two ways: return a reflexive
+   theorem, or raise UNCHANGED (as ALL_CONV, hence TRY_CONV, does).
+   CHANGED_CONV catches both -- it turns the raise into a HOL_ERR, which
+   is what reduce_cst looks for when moving on to the next rule -- so it
+   needs no QCHANGED_CONV around it.  QCHANGED_CONV alone would not do:
+   it catches only the raise and lets the reflexive theorem through,
+   which is the diverging mode. *)
+fun add_reduce_conv entry compset =
+  let
+    val (operator, arity, conv) = entry
+  in
+    computeLib.add_conv (operator, arity, CHANGED_CONV conv) compset
+  end
+
 fun real_rat_compset () =
   reduceLib.num_compset
-  |> computeLib.add_conv (leq_tm,     2, REAL_RAT_LE_CONV)
-  |> computeLib.add_conv (less_tm,    2, REAL_RAT_LT_CONV)
-  |> computeLib.add_conv (geq_tm,     2, REAL_RAT_GE_CONV)
-  |> computeLib.add_conv (greater_tm, 2, REAL_RAT_GT_CONV)
-  |> computeLib.add_conv (real_eq_tm, 2, REAL_RAT_EQ_CONV)
-  |> computeLib.add_conv (negate_tm,  1, CHANGED_CONV REAL_RAT_NEG_CONV)
-  |> computeLib.add_conv (sgn_tm,     1, REAL_RAT_SGN_CONV)
-  |> computeLib.add_conv (absval_tm,  1, REAL_RAT_ABS_CONV)
-  |> computeLib.add_conv (inv_tm,     1, REAL_RAT_INV_CONV)
-  |> computeLib.add_conv (plus_tm,    2, REAL_RAT_ADD_CONV)
-  |> computeLib.add_conv (minus_tm,   2, REAL_RAT_SUB_CONV)
-  |> computeLib.add_conv (mult_tm,    2, REAL_RAT_MUL_CONV)
-  |> computeLib.add_conv (div_tm,     2, REAL_RAT_DIV_CONV)
-  |> computeLib.add_conv (exp_tm,     2, REAL_RAT_POW_CONV)
-  |> computeLib.add_conv (max_tm,     2, REAL_RAT_MAX_CONV)
-  |> computeLib.add_conv (min_tm,     2, REAL_RAT_MIN_CONV)
+  |> add_reduce_conv (leq_tm,     2, REAL_RAT_LE_CONV)
+  |> add_reduce_conv (less_tm,    2, REAL_RAT_LT_CONV)
+  |> add_reduce_conv (geq_tm,     2, REAL_RAT_GE_CONV)
+  |> add_reduce_conv (greater_tm, 2, REAL_RAT_GT_CONV)
+  |> add_reduce_conv (real_eq_tm, 2, REAL_RAT_EQ_CONV)
+  |> add_reduce_conv (negate_tm,  1, REAL_RAT_NEG_CONV)
+  |> add_reduce_conv (sgn_tm,     1, REAL_RAT_SGN_CONV)
+  |> add_reduce_conv (absval_tm,  1, REAL_RAT_ABS_CONV)
+  |> add_reduce_conv (inv_tm,     1, REAL_RAT_INV_CONV)
+  |> add_reduce_conv (plus_tm,    2, REAL_RAT_ADD_CONV)
+  |> add_reduce_conv (minus_tm,   2, REAL_RAT_SUB_CONV)
+  |> add_reduce_conv (mult_tm,    2, REAL_RAT_MUL_CONV)
+  |> add_reduce_conv (div_tm,     2, REAL_RAT_DIV_CONV)
+  |> add_reduce_conv (exp_tm,     2, REAL_RAT_POW_CONV)
+  |> add_reduce_conv (max_tm,     2, REAL_RAT_MAX_CONV)
+  |> add_reduce_conv (min_tm,     2, REAL_RAT_MIN_CONV)
 
 val REAL_RAT_REDUCE_CONV =
   (* ensure that REDUCE_CONV will look at all of a term, even

--- a/src/real/selftest.sml
+++ b/src/real/selftest.sml
@@ -430,6 +430,25 @@ val _ = require_msg (check_result (aconv expected2)) term_to_string
                     (quietly Parse.Term) ‘0 < x’
 val _ = temp_set_grammars grammars
 
+(* REAL_RAT_DIV_CONV rewrites x / y to x * inv y and back, so it is a
+   no-op on a rational literal already in lowest terms while still
+   reporting success.  computeLib re-evaluates whatever a registered
+   conversion returns, so before the compset guarded its entries this
+   made REAL_RAT_REDUCE_CONV diverge on every term containing such a
+   literal. *)
+val _ = let
+  val _ = tprint "REAL_RAT_REDUCE_CONV terminates on 1/3 * x"
+  val tm = ``&1 / &3 * (x:real)``
+in
+  if aconv (rhs (concl (QCONV REAL_RAT_REDUCE_CONV tm))) tm then OK()
+  else die "FAILED: unexpected reduction"
+end
+
+val _ = convtest("REAL_RAT_REDUCE_CONV still adds rational literals",
+                 REAL_RAT_REDUCE_CONV,
+                 ``&1 / &3 + &1 / &6 :real``,
+                 ``&1 / &2 :real``)
+
 (* tests for bitArithLib *)
 val _ = convtest("Testing karatsuba_conv on ``1 * 2``",
                   karatsuba_conv,

--- a/src/real/selftest.sml
+++ b/src/real/selftest.sml
@@ -430,19 +430,10 @@ val _ = require_msg (check_result (aconv expected2)) term_to_string
                     (quietly Parse.Term) ‘0 < x’
 val _ = temp_set_grammars grammars
 
-(* REAL_RAT_DIV_CONV rewrites x / y to x * inv y and back, so it is a
-   no-op on a rational literal already in lowest terms while still
-   reporting success.  computeLib re-evaluates whatever a registered
-   conversion returns, so before the compset guarded its entries this
-   made REAL_RAT_REDUCE_CONV diverge on every term containing such a
-   literal. *)
-val _ = let
-  val _ = tprint "REAL_RAT_REDUCE_CONV terminates on 1/3 * x"
-  val tm = ``&1 / &3 * (x:real)``
-in
-  if aconv (rhs (concl (QCONV REAL_RAT_REDUCE_CONV tm))) tm then OK()
-  else die "FAILED: unexpected reduction"
-end
+val _ = convtest("REAL_RAT_REDUCE_CONV terminates on 1/3 * x",
+                 QCONV REAL_RAT_REDUCE_CONV,
+                 ``&1 / &3 * (x:real)``,
+                 ``&1 / &3 * (x:real)``)
 
 val _ = convtest("REAL_RAT_REDUCE_CONV still adds rational literals",
                  REAL_RAT_REDUCE_CONV,


### PR DESCRIPTION
## The bug

`REAL_RAT_DIV_CONV` rewrites `x / y` to `x * inv y` and back, so on a
literal already in lowest terms it returns `|- &1 / &3 = &1 / &3` —
success, no change.  `computeLib` re-evaluates whatever a registered
conversion hands back, so `CBV_CONV` went round that term forever:
`REAL_RAT_REDUCE_CONV` did not terminate on *any* term containing a
non-integral rational literal.

## The fix

`real_rat_compset` already guarded one entry — `REAL_RAT_NEG_CONV` —
with `CHANGED_CONV`.  Several of the others are no-ops on an
already-reduced argument in the same way, so the guard belongs on every
entry rather than on whichever operator's no-op was noticed first.  The
compset now adds all of them through a single `add_reduce_conv` that
applies it.

A registered conversion can report no progress in two ways: return a
reflexive theorem, or raise `UNCHANGED` (as `ALL_CONV`, hence
`TRY_CONV`, does).  Both are fatal — the first loops, the second escapes
`CBV_CONV` entirely, because `reduce_cst` catches only `HOL_ERR` when
deciding to move on to the next rule.  `Conv.CHANGED_CONV` covers both,
so it needs no `QCHANGED_CONV` around it; `QCHANGED_CONV` in its place
would be a regression, since it catches only the raise and lets the
diverging mode through.  A comment at the site records this so the
question is not reopened.

## Tests

`src/real/selftest.sml` gains a test that the conversion terminates on
`&1 / &3 * x`, plus a companion pinning that `&1 / &3 + &1 / &6` still
reduces to `&1 / &2` — so the termination guard cannot be satisfied by
simply disabling reduction.

## Scope

This is the instance half of #2034.  The underlying `computeLib`
mechanism — `reduce_cst` counting a reflexive result as progress — and
the `add_conv` documentation that never stated the contract are
deliberately left alone here.
