### PR TITLE
build: warn when bin/hol or bin/unquote is older than its sources

### DIFF
--- a/tools-poly/build.sml
+++ b/tools-poly/build.sml
@@ -192,6 +192,21 @@ in
     die ("No Holmake executable in " ^ fP [HOLDIR, "bin"])
 end
 
+(* The quote filter's lexer is generated from tools/parsing/HolLex by
+   configure, and by no Holmakefile rule, so pulling in a grammar change
+   leaves a stale bin/unquote that silently mis-lexes the new syntax.
+   The app_sml_files sweep above cannot catch it: HolLex has no .sml
+   extension and does not live under tools/Holmake. *)
+val _ = let
+  val fP = fullPath
+  open HOLFileSys
+  val unquote = fP [HOLDIR,"bin",xable_string "unquote"]
+in
+  if access(unquote, [A_READ, A_EXEC]) then
+    check_against unquote "tools/parsing/HolLex"
+  else ()
+end
+
 
 
 

--- a/tools-poly/build.sml
+++ b/tools-poly/build.sml
@@ -192,19 +192,17 @@ in
     die ("No Holmake executable in " ^ fP [HOLDIR, "bin"])
 end
 
-(* bin/hol is likewise compiled by configure and by no Holmakefile rule,
-   from tools-poly/hol.ML and from the Holmake sources it links against.
-   Neither check above reaches it: the sweep compares those sources with
-   bin/Holmake, so a tree whose Holmake is current can still be running
-   a hol built from different sources, and hol.ML is caught by nothing
-   at all.  A stale bin/hol misdirects the interactive load path and
-   fails tools/Holmake/tests/repl, which -t reaches while still inside
+(* bin/hol is compiled by configure and by no Holmakefile rule, from
+   tools-poly/hol.ML, the Holmake sources, and tools/parsing (the quote
+   filter is linked in rather than run as bin/unquote; HolLex.sml is
+   generated from HolLex by configure).  The sweep above compares those
+   sources against bin/Holmake only, so hol can be stale while Holmake
+   is current, and hol.ML is checked nowhere.  A stale bin/hol
+   misdirects the interactive load path and fails
+   tools/Holmake/tests/repl, which -t reaches while still inside
    sequences/kernel -- so the whole selftest build stops there.
-
-   tools/parsing is included because the quote filter is linked in, not
-   run as bin/unquote (HolLex.sml is generated from HolLex by
-   configure); Holmake embeds it too, but configure builds Holmake
-   before hol, so checking hol covers both. *)
+   Checking hol covers Holmake's embedded filter too: configure builds
+   Holmake first. *)
 val _ = let
   val fP = fullPath
   open HOLFileSys

--- a/tools-poly/build.sml
+++ b/tools-poly/build.sml
@@ -192,21 +192,6 @@ in
     die ("No Holmake executable in " ^ fP [HOLDIR, "bin"])
 end
 
-(* The quote filter's lexer is generated from tools/parsing/HolLex by
-   configure, and by no Holmakefile rule, so pulling in a grammar change
-   leaves a stale bin/unquote that silently mis-lexes the new syntax.
-   The app_sml_files sweep above cannot catch it: HolLex has no .sml
-   extension and does not live under tools/Holmake. *)
-val _ = let
-  val fP = fullPath
-  open HOLFileSys
-  val unquote = fP [HOLDIR,"bin",xable_string "unquote"]
-in
-  if access(unquote, [A_READ, A_EXEC]) then
-    check_against unquote "tools/parsing/HolLex"
-  else ()
-end
-
 (* bin/hol is likewise compiled by configure and by no Holmakefile rule,
    from tools-poly/hol.ML and from the Holmake sources it links against.
    Neither check above reaches it: the sweep compares those sources with
@@ -214,7 +199,12 @@ end
    a hol built from different sources, and hol.ML is caught by nothing
    at all.  A stale bin/hol misdirects the interactive load path and
    fails tools/Holmake/tests/repl, which -t reaches while still inside
-   sequences/kernel -- so the whole selftest build stops there. *)
+   sequences/kernel -- so the whole selftest build stops there.
+
+   tools/parsing is included because the quote filter is linked in, not
+   run as bin/unquote (HolLex.sml is generated from HolLex by
+   configure); Holmake embeds it too, but configure builds Holmake
+   before hol, so checking hol covers both. *)
 val _ = let
   val fP = fullPath
   open HOLFileSys
@@ -225,7 +215,10 @@ in
      app_sml_files (check_against hol)
                    {dirname = fP [HOLDIR, "tools-poly", "Holmake"]};
      app_sml_files (check_against hol)
-                   {dirname = fP [HOLDIR, "tools", "Holmake"]})
+                   {dirname = fP [HOLDIR, "tools", "Holmake"]};
+     check_against hol "tools/parsing/HolLex";
+     app_sml_files (check_against hol)
+                   {dirname = fP [HOLDIR, "tools", "parsing"]})
   else ()
 end
 

--- a/tools-poly/build.sml
+++ b/tools-poly/build.sml
@@ -207,6 +207,28 @@ in
   else ()
 end
 
+(* bin/hol is likewise compiled by configure and by no Holmakefile rule,
+   from tools-poly/hol.ML and from the Holmake sources it links against.
+   Neither check above reaches it: the sweep compares those sources with
+   bin/Holmake, so a tree whose Holmake is current can still be running
+   a hol built from different sources, and hol.ML is caught by nothing
+   at all.  A stale bin/hol misdirects the interactive load path and
+   fails tools/Holmake/tests/repl, which -t reaches while still inside
+   sequences/kernel -- so the whole selftest build stops there. *)
+val _ = let
+  val fP = fullPath
+  open HOLFileSys
+  val hol = fP [HOLDIR,"bin",xable_string "hol"]
+in
+  if access(hol, [A_READ, A_EXEC]) then
+    (check_against hol "tools-poly/hol.ML";
+     app_sml_files (check_against hol)
+                   {dirname = fP [HOLDIR, "tools-poly", "Holmake"]};
+     app_sml_files (check_against hol)
+                   {dirname = fP [HOLDIR, "tools", "Holmake"]})
+  else ()
+end
+
 
 
 

--- a/tools/build/build.sml
+++ b/tools/build/build.sml
@@ -164,6 +164,21 @@ in
     die ("No Holmake executable in " ^ fP [HOLDIR, "bin"])
 end
 
+(* The quote filter's lexer is generated from tools/parsing/HolLex by
+   configure, and by no Holmakefile rule, so pulling in a grammar change
+   leaves a stale bin/unquote that silently mis-lexes the new syntax.
+   The app_sml_files sweep above cannot catch it: HolLex has no .sml
+   extension and does not live under tools/Holmake. *)
+val _ = let
+  val fP = fullPath
+  open OS.FileSys
+  val unquote = fP [HOLDIR,"bin",xable_string "unquote"]
+in
+  if access(unquote, [A_READ, A_EXEC]) then
+    check_against unquote "tools/parsing/HolLex"
+  else ()
+end
+
 
 val _ =
     case cmdline of


### PR DESCRIPTION
## Problem

Several `bin/` binaries are compiled by `configure` and by no Holmakefile rule, so pulling in a source change leaves them stale and silently wrong. `build.sml` guards this class of staleness with `check_against`, but its sweep only covers `.sml` files under `tools/Holmake` and `tools-poly/Holmake`, compared against `bin/Holmake`. Three gaps:

  - Under Moscow ML, `bin/unquote` runs as a pipe filter and mis-lexes new syntax when `tools/parsing/HolLex` changes. `HolLex` has no `.sml` extension and is not under a `Holmake` directory, so the sweep misses it.
  - Under Poly/ML nothing runs `bin/unquote` (`emit_hol_unquote_script` is a no-op); the filter is linked into `bin/Holmake` and `bin/hol` via `hmcore.ML`. So a stale `unquote` breaks nothing, while the binaries that do mis-lex go unchecked — and not just for `HolLex`: `HOLSource*` and `AttributeSyntax` in `tools/parsing` are baked in the same way.
  - Nothing checks `bin/hol` at all. `tools-poly/hol.ML` is swept by nothing, and a tree with a current `bin/Holmake` can still run a `hol` built from other sources. A stale `hol` misdirects the interactive load path and fails `tools/Holmake/tests/repl`, which `-t` reaches inside `sequences/kernel` — halting the selftest build.

## Change

`tools/build/build.sml` (mosml): check `bin/unquote` against `tools/parsing/HolLex`.

`tools-poly/build.sml` (Poly/ML): check `bin/hol` against everything linked into it — `tools-poly/hol.ML`, the two `Holmake` sweeps, `tools/parsing/HolLex` explicitly, and an `app_sml_files` sweep of `tools/parsing`. No `unquote` check, which is not in the loop here. Checking `hol` covers Holmake's embedded filter too: `configure` builds `Holmake` first.

Both follow the existing check's shape — fire only if the executable is present, and warn ("you should reconfigure the system", Ctrl-C or RETURN) rather than fail.

## Notes

  - Purely diagnostic; no behaviour change on an up-to-date tree.
  - An absent executable is skipped, not fatal, unlike the `bin/Holmake` check.
