### PR TITLE
Add theorems for relations and bisimulations

### DIFF
--- a/Manual/Description/theories.smd
+++ b/Manual/Description/theories.smd
@@ -4235,9 +4235,9 @@ type of a relation is an instance of
 $\alpha\to\alpha\to\konst{bool}$, but the extra generality
 doesn't hurt.)  The theory `relation` provides definitions of
 basic properties and operations on relations, defines various
-kinds of orders and closures, defines wellfoundedness and proves
-the wellfounded recursion theorem, and develops some basic
-results used in Term Rewriting.
+kinds of orders and closures, defines basic properties of relation transformers,
+defines wellfoundedness and proves the wellfounded recursion theorem, and
+develops some basic results used in Term Rewriting.
 
 **Basic properties.**
 The following basic properties of relations are defined.
@@ -4367,6 +4367,21 @@ applied to the transitive closure of the symmetric closure of
 ##thm RC_DEF
 ##thm SC_DEF
 ##thm EQC_DEF
+```
+
+These closures are an example of a relation transformer, which are of type
+$b:(\alpha\to\alpha\to\konst{bool})\to\alpha\to\alpha\to\konst{bool}$. A
+transformer is monotone (`rmonotone`) if it respects `RSUBSET`. A transformer
+preserves a property `f` (`rpreserves`) if relations with property `f` continue
+to have property `f` after being transformed. Finally, a transformer `b` is the
+closure of a property `f` when it maps all relations `R` to their `f`-closures.
+Theorems for these transformer properties involving the relation properties/closures
+above have been added to the simpset.
+
+```repl
+##thm rmonotone_def
+##thm rpreserves_def
+##thm is_closure_op_def
 ```
 
 **Wellfounded relations.**
@@ -4517,6 +4532,21 @@ in this way is actually equivalent to the original definition
 [^bisim-original]: Starting with the *original definition* it is
     not that easy to derive the coinduction principle, which is
     very useful in practice.
+
+There are additional theorems that provide basic enhanced coinduction theorems for
+BISIM_REL. When exhibiting a candidate relation, these principles allow for stepping into a
+larger relation for free. The strong theorem `BISIM_REL_strong_thm` adds the diagonal, which
+allows assuming equal things are related. The symmetry theorem `BISIM_REL_sym_thm` reduces the
+proof to just one side of simulation, provided the relation is symemtric. The combination of both
+(`BISIM_REL_sym_strong_thm`) is provided as well. These theorems all have `_coind` variants as
+`ho_match_mp_tac` can use them to infer the relation from the structure of the goal.
+
+```repl
+##thm BISIM_REL_strong_thm
+##thm BISIM_REL_sym_thm
+##thm BISIM_REL_sym_strong_thm
+##thm BISIM_REL_sym_strong_coind
+```
 
 The bisimulation and bisimulation relation considered so far are
 the *strong* ones, in the sense that all involved transitions

--- a/Manual/Description/theories.smd
+++ b/Manual/Description/theories.smd
@@ -4372,9 +4372,9 @@ applied to the transitive closure of the symmetric closure of
 These closures are an example of a relation transformer, which are of type
 $b:(\alpha\to\alpha\to\konst{bool})\to\alpha\to\alpha\to\konst{bool}$. A
 transformer is monotone (`rmonotone`) if it respects `RSUBSET`. A transformer
-preserves a property `f` (`rpreserves`) if relations with property `f` continue
-to have property `f` after being transformed. Finally, a transformer `b` is the
-closure of a property `f` when it maps all relations `R` to their `f`-closures.
+preserves a property `P` (`rpreserves`) if relations with property `P` continue
+to have property `P` after being transformed. Finally, a transformer `b` is the
+closure of a property `P` when it maps all relations `R` to their `P`-closures.
 Theorems for these transformer properties involving the relation properties/closures
 above have been added to the simpset.
 

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -9600,4 +9600,39 @@ Proof
     PROVE_TAC [COUNTABLE_NUM]
 QED
 
+(* Some theorems for relationTheory consts that require set operations *)
+
+Theorem equivalence_thm:
+  equivalence = reflexive ∩ symmetric ∩ transitive
+Proof
+  SRW_TAC[][FUN_EQ_THM, equivalence_def, SPECIFICATION, CONJ_ASSOC]
+QED
+
+Theorem rpreserves_inter:
+  rpreserves f b ∧ rpreserves g b ==> rpreserves (f ∩ g) b
+Proof
+  SRW_TAC[][rpreserves_def, SPECIFICATION]
+QED
+
+Theorem is_closure_inter:
+  is_closure_op f a ∧ is_closure_op g b ∧ rpreserves g a ==> is_closure_op (f ∩ g) (a o b)
+Proof
+  SRW_TAC[][is_closure_op_def, SPECIFICATION, rpreserves_def]
+  >> METIS_TAC[RSUBSET_TRANS]
+QED
+
+Theorem is_closure_op_reflexive_transitive_RTC[simp]:
+  is_closure_op (reflexive ∩ transitive) RTC
+Proof
+  SRW_TAC[][RTC_RC_o_TC, is_closure_inter]
+QED
+
+Theorem is_closure_op_equivalence_EQC[simp]:
+  is_closure_op equivalence EQC
+Proof
+  SRW_TAC[][EQC_THM, equivalence_thm, GSYM INTER_ASSOC]
+  >> HO_MATCH_MP_TAC is_closure_inter
+  >> SRW_TAC[][rpreserves_inter, Once INTER_COMM, is_closure_inter]
+QED
+
 (* END *)

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -9609,13 +9609,14 @@ Proof
 QED
 
 Theorem rpreserves_inter:
-  rpreserves f b ∧ rpreserves g b ==> rpreserves (f ∩ g) b
+  ∀f g b. rpreserves f b ∧ rpreserves g b ==> rpreserves (f ∩ g) b
 Proof
   SRW_TAC[][rpreserves_def, SPECIFICATION]
 QED
 
 Theorem is_closure_inter:
-  is_closure_op f a ∧ is_closure_op g b ∧ rpreserves g a ==> is_closure_op (f ∩ g) (a o b)
+  ∀f g a b. is_closure_op f a ∧ is_closure_op g b ∧ rpreserves g a
+    ==> is_closure_op (f ∩ g) (a o b)
 Proof
   SRW_TAC[][is_closure_op_def, SPECIFICATION, rpreserves_def]
   >> METIS_TAC[RSUBSET_TRANS]

--- a/src/pred_set/src/pred_setScript.sml
+++ b/src/pred_set/src/pred_setScript.sml
@@ -9602,12 +9602,6 @@ QED
 
 (* Some theorems for relationTheory consts that require set operations *)
 
-Theorem equivalence_thm:
-  equivalence = reflexive ∩ symmetric ∩ transitive
-Proof
-  SRW_TAC[][FUN_EQ_THM, equivalence_def, SPECIFICATION, CONJ_ASSOC]
-QED
-
 Theorem rpreserves_inter:
   ∀f g b. rpreserves f b ∧ rpreserves g b ==> rpreserves (f ∩ g) b
 Proof
@@ -9631,7 +9625,8 @@ QED
 Theorem is_closure_op_equivalence_EQC[simp]:
   is_closure_op equivalence EQC
 Proof
-  SRW_TAC[][EQC_THM, equivalence_thm, GSYM INTER_ASSOC]
+  `equivalence = reflexive ∩ symmetric ∩ transitive` by SRW_TAC[][FUN_EQ_THM, equivalence_def, SPECIFICATION, CONJ_ASSOC]
+  >> SRW_TAC[][EQC_THM, GSYM INTER_ASSOC]
   >> HO_MATCH_MP_TAC is_closure_inter
   >> SRW_TAC[][rpreserves_inter, Once INTER_COMM, is_closure_inter]
 QED

--- a/src/relation/bisimulationScript.sml
+++ b/src/relation/bisimulationScript.sml
@@ -213,6 +213,25 @@ Proof
  >> ASM_REWRITE_TAC []
 QED
 
+Theorem ETS_CASES:
+  ETS ts tau p p' <=> p = p' ∨ ∃u. ts p tau u ∧ ETS ts tau u p'
+Proof
+  SRW_TAC[][ETS_def, Once RTC_CASES1]
+QED
+
+Theorem ETS_INDUCT[rule_induction]:
+  ∀P. (∀p. P p p) ∧ (
+    (∀p p' q. ts p tau p' ∧ P p' q ⇒ P p q) ∨
+    (∀p q' q. P p q' ∧ ts q' tau q ⇒ P p q)
+  ) ⇒ ∀p0 q0. ETS ts tau p0 q0 ⇒ P p0 q0
+Proof
+    GEN_TAC >> STRIP_TAC
+ >> REWRITE_TAC [ETS_def]
+ >| [HO_MATCH_MP_TAC RTC_INDUCT, HO_MATCH_MP_TAC RTC_INDUCT_RIGHT1]
+ >> METIS_TAC []
+QED
+
+
 Theorem lemma1[local]:
     !R. (!p q.   ts p tau q ==> R p q) /\
         (!p.     R p p) /\

--- a/src/relation/bisimulationScript.sml
+++ b/src/relation/bisimulationScript.sml
@@ -158,7 +158,7 @@ Proof
 QED
 
 Theorem BISIM_REL_strong_thm:
-  ∀ts. 
+  ∀ts.
   BISIM_REL ts p0 q0 <=> ∃R. R p0 q0 ∧
     (∀p q. R p q ⇒
       ∀l. (∀p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ (R p' q' ∨ BISIM_REL ts p' q')) ∧
@@ -174,7 +174,7 @@ Proof
 QED
 
 Theorem BISIM_REL_strong_coind:
-  ∀ts. 
+  ∀ts.
     (∀p q. R p q ⇒
       ∀l. (∀p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ (R p' q' ∨ BISIM_REL ts p' q')) ∧
            (∀q'. ts q l q' ⇒ ∃p'. ts p l p' ∧ (R p' q' ∨ BISIM_REL ts p' q')))
@@ -196,7 +196,7 @@ Proof
 QED
 
 Theorem BISIM_REL_sym_coind:
-  ∀ts. symmetric R ∧ 
+  ∀ts. symmetric R ∧
     (∀p q. R p q ⇒ ∀l p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ R p' q')
   ==> ∀p0 q0. R p0 q0 ==> BISIM_REL ts p0 q0
 Proof
@@ -218,7 +218,7 @@ Proof
 QED
 
 Theorem BISIM_REL_sym_strong_coind:
-  ∀ts. symmetric R ∧ 
+  ∀ts. symmetric R ∧
     (∀p q. R p q ⇒ ∀l p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ (R p' q' ∨ BISIM_REL ts p' q'))
   ==> ∀p0 q0. R p0 q0 ==> BISIM_REL ts p0 q0
 Proof

--- a/src/relation/bisimulationScript.sml
+++ b/src/relation/bisimulationScript.sml
@@ -146,12 +146,15 @@ QED
 
 Theorem BISIM_REL_EQUIV_rules =
   BISIM_REL_IS_EQUIV_REL
-  |> SIMP_RULE bool_ss [equivalence_def, reflexive_def, symmetric_def, transitive_def];
+  |> SIMP_RULE bool_ss
+     [equivalence_def, reflexive_def, symmetric_def, transitive_def];
 
 Theorem BISIM_REL_ts:
   ∀ts.
-  (∀p q l p'. BISIM_REL ts p q ∧ ts p l p' ==> ∃q'. ts q l q' ∧ BISIM_REL ts p' q') ∧
-  (∀p q l q'. BISIM_REL ts p q ∧ ts q l q' ==> ∃p'. ts p l p' ∧ BISIM_REL ts p' q')
+  (∀p q l p'. BISIM_REL ts p q ∧ ts p l p'
+    ==> ∃q'. ts q l q' ∧ BISIM_REL ts p' q') ∧
+  (∀p q l q'. BISIM_REL ts p q ∧ ts q l q'
+    ==> ∃p'. ts p l p' ∧ BISIM_REL ts p' q')
 Proof
   SRW_TAC[][BISIM_REL_def]
   >> METIS_TAC[BISIM_def]
@@ -208,7 +211,8 @@ QED
 Theorem BISIM_REL_sym_strong_thm:
   ∀ts R.
   BISIM_REL ts p0 q0 <=> ∃R. symmetric R ∧ R p0 q0 ∧
-    (∀p q. R p q ⇒ ∀l p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ (R p' q' ∨ BISIM_REL ts p' q'))
+    (∀p q. R p q ⇒ ∀l p'. ts p l p'
+      ==> ∃q'. ts q l q' ∧ (R p' q' ∨ BISIM_REL ts p' q'))
 Proof
   SRW_TAC[][EQ_IMP_THM]
   >- METIS_TAC[BISIM_REL_sym_thm]
@@ -219,7 +223,8 @@ QED
 
 Theorem BISIM_REL_sym_strong_coind:
   ∀ts R. symmetric R ∧
-    (∀p q. R p q ⇒ ∀l p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ (R p' q' ∨ BISIM_REL ts p' q'))
+    (∀p q. R p q ==> ∀l p'. ts p l p'
+      ==> ∃q'. ts q l q' ∧ (R p' q' ∨ BISIM_REL ts p' q'))
   ==> ∀p0 q0. R p0 q0 ==> BISIM_REL ts p0 q0
 Proof
   SRW_TAC[][EQ_IMP_THM] >> SRW_TAC[][Once BISIM_REL_sym_strong_thm]
@@ -492,14 +497,19 @@ QED
 
 Theorem WBISIM_REL_EQUIV_rules =
   WBISIM_REL_IS_EQUIV_REL
-  |> SIMP_RULE bool_ss [equivalence_def, reflexive_def, symmetric_def, transitive_def];
+  |> SIMP_RULE bool_ss
+     [equivalence_def, reflexive_def, symmetric_def, transitive_def];
 
 Theorem WBISIM_REL_ts:
   ∀ts tau.
-  (∀p q l p'. WBISIM_REL ts tau p q ∧ ts p l p' ∧ l ≠ tau ==> ∃q'. WTS ts tau q l q' ∧ WBISIM_REL ts tau p' q') ∧
-  (∀p q l q'. WBISIM_REL ts tau p q ∧ ts q l q' ∧ l ≠ tau ==> ∃p'. WTS ts tau p l p' ∧ WBISIM_REL ts tau p' q') ∧
-  (∀p q p'. WBISIM_REL ts tau p q ∧ ts p tau p' ==> ∃q'. ETS ts tau q q' ∧ WBISIM_REL ts tau p' q') ∧
-  (∀p q q'. WBISIM_REL ts tau p q ∧ ts q tau q' ==> ∃p'. ETS ts tau p p' ∧ WBISIM_REL ts tau p' q')
+  (∀p q l p'. WBISIM_REL ts tau p q ∧ ts p l p' ∧ l ≠ tau
+    ==> ∃q'. WTS ts tau q l q' ∧ WBISIM_REL ts tau p' q') ∧
+  (∀p q l q'. WBISIM_REL ts tau p q ∧ ts q l q' ∧ l ≠ tau
+    ==> ∃p'. WTS ts tau p l p' ∧ WBISIM_REL ts tau p' q') ∧
+  (∀p q p'. WBISIM_REL ts tau p q ∧ ts p tau p'
+    ==> ∃q'. ETS ts tau q q' ∧ WBISIM_REL ts tau p' q') ∧
+  (∀p q q'. WBISIM_REL ts tau p q ∧ ts q tau q'
+    ==> ∃p'. ETS ts tau p p' ∧ WBISIM_REL ts tau p' q')
 Proof
   SRW_TAC[][WBISIM_REL_def]
   >> METIS_TAC[WBISIM_def]

--- a/src/relation/bisimulationScript.sml
+++ b/src/relation/bisimulationScript.sml
@@ -144,6 +144,88 @@ Proof
      METIS_TAC [O_DEF, BISIM_O])
 QED
 
+Theorem BISIM_REL_EQUIV_rules =
+  BISIM_REL_IS_EQUIV_REL
+  |> SIMP_RULE bool_ss [equivalence_def, reflexive_def, symmetric_def, transitive_def];
+
+Theorem BISIM_REL_ts:
+  ∀ts.
+  (BISIM_REL ts p q ∧ ts p l p' ==> ∃q'. ts q l q' ∧ BISIM_REL ts p' q') ∧
+  (BISIM_REL ts p q ∧ ts q l q' ==> ∃p'. ts p l p' ∧ BISIM_REL ts p' q')
+Proof
+  SRW_TAC[][BISIM_REL_def]
+  >> METIS_TAC[BISIM_def]
+QED
+
+Theorem BISIM_REL_strong_thm:
+  ∀ts. 
+  BISIM_REL ts p0 q0 <=> ∃R. R p0 q0 ∧
+    (∀p q. R p q ⇒
+      ∀l. (∀p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ (R p' q' ∨ BISIM_REL ts p' q')) ∧
+           (∀q'. ts q l q' ⇒ ∃p'. ts p l p' ∧ (R p' q' ∨ BISIM_REL ts p' q')))
+Proof
+  SRW_TAC[][EQ_IMP_THM]
+  >- (Q.EXISTS_TAC `BISIM_REL ts`
+      >> SRW_TAC[][BISIM_REL_def, BISIM_def]
+      >> METIS_TAC[])
+  >> SRW_TAC[][BISIM_REL_def, BISIM_def]
+  >> Q.EXISTS_TAC `λp q. R p q ∨ BISIM_REL ts p q`
+  >> METIS_TAC[BISIM_REL_def, BISIM_def]
+QED
+
+Theorem BISIM_REL_strong_coind:
+  ∀ts. 
+    (∀p q. R p q ⇒
+      ∀l. (∀p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ (R p' q' ∨ BISIM_REL ts p' q')) ∧
+           (∀q'. ts q l q' ⇒ ∃p'. ts p l p' ∧ (R p' q' ∨ BISIM_REL ts p' q')))
+  ==> ∀p0 q0. R p0 q0 ==> BISIM_REL ts p0 q0
+Proof
+  SRW_TAC[][EQ_IMP_THM] >> SRW_TAC[][Once BISIM_REL_strong_thm]
+  >> Q.EXISTS_TAC `R` >> SRW_TAC[][]
+  >> METIS_TAC[]
+QED
+
+Theorem BISIM_REL_sym_thm:
+  ∀ts.
+  BISIM_REL ts p0 q0 <=> ∃R. symmetric R ∧ R p0 q0 ∧
+    (∀p q. R p q ⇒ ∀l p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ R p' q')
+Proof
+  SRW_TAC[][EQ_IMP_THM, symmetric_def, BISIM_REL_def]
+  >| [Q.EXISTS_TAC `λp q. R p q ∨ R q p`, SRW_TAC[][]]
+  >> METIS_TAC[BISIM_INV, BISIM_def]
+QED
+
+Theorem BISIM_REL_sym_coind:
+  ∀ts. symmetric R ∧ 
+    (∀p q. R p q ⇒ ∀l p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ R p' q')
+  ==> ∀p0 q0. R p0 q0 ==> BISIM_REL ts p0 q0
+Proof
+  SRW_TAC[][EQ_IMP_THM] >> SRW_TAC[][Once BISIM_REL_sym_thm]
+  >> Q.EXISTS_TAC `R` >> SRW_TAC[][]
+  >> METIS_TAC[]
+QED
+
+Theorem BISIM_REL_sym_strong_thm:
+  ∀ts.
+  BISIM_REL ts p0 q0 <=> ∃R. symmetric R ∧ R p0 q0 ∧
+    (∀p q. R p q ⇒ ∀l p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ (R p' q' ∨ BISIM_REL ts p' q'))
+Proof
+  SRW_TAC[][EQ_IMP_THM]
+  >- METIS_TAC[BISIM_REL_sym_thm]
+  >> PURE_ONCE_REWRITE_TAC[BISIM_REL_strong_thm]
+  >> Q.EXISTS_TAC `λp q. R p q ∨ R q p`
+  >> METIS_TAC[symmetric_def, BISIM_REL_EQUIV_rules]
+QED
+
+Theorem BISIM_REL_sym_strong_coind:
+  ∀ts. symmetric R ∧ 
+    (∀p q. R p q ⇒ ∀l p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ (R p' q' ∨ BISIM_REL ts p' q'))
+  ==> ∀p0 q0. R p0 q0 ==> BISIM_REL ts p0 q0
+Proof
+  SRW_TAC[][EQ_IMP_THM] >> SRW_TAC[][Once BISIM_REL_sym_strong_thm]
+  >> Q.EXISTS_TAC `R` >> SRW_TAC[][]
+  >> METIS_TAC[]
+QED
 
 (*---------------------------------------------------------------------------*)
 (*  Weak bisimulation                                                        *)
@@ -230,7 +312,6 @@ Proof
  >| [HO_MATCH_MP_TAC RTC_INDUCT, HO_MATCH_MP_TAC RTC_INDUCT_RIGHT1]
  >> METIS_TAC []
 QED
-
 
 Theorem lemma1[local]:
     !R. (!p q.   ts p tau q ==> R p q) /\
@@ -409,6 +490,19 @@ Proof
       METIS_TAC [WBISIM_O, O_DEF])
 QED
 
+Theorem WBISIM_REL_EQUIV_rules =
+  WBISIM_REL_IS_EQUIV_REL
+  |> SIMP_RULE bool_ss [equivalence_def, reflexive_def, symmetric_def, transitive_def];
+
+Theorem WBISIM_REL_ts:
+  (WBISIM_REL ts tau p q ∧ ts p l p' ∧ l ≠ tau ==> ∃q'. WTS ts tau q l q' ∧ WBISIM_REL ts tau p' q') ∧
+  (WBISIM_REL ts tau p q ∧ ts q l q' ∧ l ≠ tau ==> ∃p'. WTS ts tau p l p' ∧ WBISIM_REL ts tau p' q') ∧
+  (WBISIM_REL ts tau p q ∧ ts p tau p' ==> ∃q'. ETS ts tau q q' ∧ WBISIM_REL ts tau p' q') ∧
+  (WBISIM_REL ts tau p q ∧ ts q tau q' ==> ∃p'. ETS ts tau p p' ∧ WBISIM_REL ts tau p' q')
+Proof
+  SRW_TAC[][WBISIM_REL_def]
+  >> METIS_TAC[WBISIM_def]
+QED
 
 (*---------------------------------------------------------------------------*)
 (*  Relations between strong and weak bisimulations                          *)
@@ -448,5 +542,3 @@ Theorem BISIM_REL_IMP_WBISIM_REL :
 Proof
     REWRITE_TAC [GSYM RSUBSET, BISIM_REL_RSUBSET_WBISIM_REL]
 QED
-
-

--- a/src/relation/bisimulationScript.sml
+++ b/src/relation/bisimulationScript.sml
@@ -89,44 +89,6 @@ Proof
   >> METIS_TAC[BISIM_INV, inv_DEF]
 QED
 
-Theorem BISIM_REL_strong_thm:
-  BISIM_REL ts p0 q0 <=> ∃R. R p0 q0 ∧
-    (∀p q. R p q ⇒
-      ∀l. (∀p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ (R p' q' ∨ BISIM_REL ts p' q')) ∧
-           (∀q'. ts q l q' ⇒ ∃p'. ts p l p' ∧ (R p' q' ∨ BISIM_REL ts p' q')))
-Proof
-  SRW_TAC[][EQ_IMP_THM]
-  >- (Q.EXISTS_TAC `BISIM_REL ts`
-      >> SRW_TAC[][BISIM_REL_def, BISIM_def]
-      >> METIS_TAC[])
-  >> SRW_TAC[][BISIM_REL_def, BISIM_def]
-  >> Q.EXISTS_TAC `λp q. R p q ∨ BISIM_REL ts p q`
-  >> METIS_TAC[BISIM_REL_def, BISIM_def]
-QED
-
-Theorem BISIM_REL_sym_thm:
-  BISIM_REL ts p0 q0 <=> ∃R. symmetric R ∧ R p0 q0 ∧
-    (∀p q. R p q ⇒ ∀l p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ R p' q')
-Proof
-  SRW_TAC[][EQ_IMP_THM, symmetric_def, BISIM_REL_def]
-  >| [Q.EXISTS_TAC `λp q. R p q ∨ R q p`, SRW_TAC[][]]
-  >> METIS_TAC[BISIM_INV, BISIM_def]
-QED
-
-Theorem BISIM_REL_sym_strong_thm:
-  BISIM_REL ts p0 q0 <=>
-    ∃R. symmetric R ∧ R p0 q0 ∧
-        (∀p q. R p q ⇒
-               ∀l p'. ts p l p' ⇒
-                      ∃q'. ts q l q' ∧ (R p' q' ∨ BISIM_REL ts p' q'))
-Proof
-  SRW_TAC[][EQ_IMP_THM]
-  >- METIS_TAC[BISIM_REL_sym_thm]
-  >> PURE_ONCE_REWRITE_TAC[BISIM_REL_strong_thm]
-  >> Q.EXISTS_TAC `λp q. R p q ∨ R q p`
-  >> METIS_TAC[symmetric_def, BISIM_REL_sym]
-QED
-
 Theorem BISIM_REL_IS_EQUIV_REL :
     !ts. equivalence (BISIM_REL ts)
 Proof

--- a/src/relation/bisimulationScript.sml
+++ b/src/relation/bisimulationScript.sml
@@ -150,8 +150,8 @@ Theorem BISIM_REL_EQUIV_rules =
 
 Theorem BISIM_REL_ts:
   ∀ts.
-  (BISIM_REL ts p q ∧ ts p l p' ==> ∃q'. ts q l q' ∧ BISIM_REL ts p' q') ∧
-  (BISIM_REL ts p q ∧ ts q l q' ==> ∃p'. ts p l p' ∧ BISIM_REL ts p' q')
+  (∀p q l p'. BISIM_REL ts p q ∧ ts p l p' ==> ∃q'. ts q l q' ∧ BISIM_REL ts p' q') ∧
+  (∀p q l q'. BISIM_REL ts p q ∧ ts q l q' ==> ∃p'. ts p l p' ∧ BISIM_REL ts p' q')
 Proof
   SRW_TAC[][BISIM_REL_def]
   >> METIS_TAC[BISIM_def]
@@ -174,7 +174,7 @@ Proof
 QED
 
 Theorem BISIM_REL_strong_coind:
-  ∀ts.
+  ∀ts R.
     (∀p q. R p q ⇒
       ∀l. (∀p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ (R p' q' ∨ BISIM_REL ts p' q')) ∧
            (∀q'. ts q l q' ⇒ ∃p'. ts p l p' ∧ (R p' q' ∨ BISIM_REL ts p' q')))
@@ -186,7 +186,7 @@ Proof
 QED
 
 Theorem BISIM_REL_sym_thm:
-  ∀ts.
+  ∀ts R.
   BISIM_REL ts p0 q0 <=> ∃R. symmetric R ∧ R p0 q0 ∧
     (∀p q. R p q ⇒ ∀l p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ R p' q')
 Proof
@@ -196,7 +196,7 @@ Proof
 QED
 
 Theorem BISIM_REL_sym_coind:
-  ∀ts. symmetric R ∧
+  ∀ts R. symmetric R ∧
     (∀p q. R p q ⇒ ∀l p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ R p' q')
   ==> ∀p0 q0. R p0 q0 ==> BISIM_REL ts p0 q0
 Proof
@@ -206,7 +206,7 @@ Proof
 QED
 
 Theorem BISIM_REL_sym_strong_thm:
-  ∀ts.
+  ∀ts R.
   BISIM_REL ts p0 q0 <=> ∃R. symmetric R ∧ R p0 q0 ∧
     (∀p q. R p q ⇒ ∀l p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ (R p' q' ∨ BISIM_REL ts p' q'))
 Proof
@@ -218,7 +218,7 @@ Proof
 QED
 
 Theorem BISIM_REL_sym_strong_coind:
-  ∀ts. symmetric R ∧
+  ∀ts R. symmetric R ∧
     (∀p q. R p q ⇒ ∀l p'. ts p l p' ⇒ ∃q'. ts q l q' ∧ (R p' q' ∨ BISIM_REL ts p' q'))
   ==> ∀p0 q0. R p0 q0 ==> BISIM_REL ts p0 q0
 Proof
@@ -296,13 +296,13 @@ Proof
 QED
 
 Theorem ETS_CASES:
-  ETS ts tau p p' <=> p = p' ∨ ∃u. ts p tau u ∧ ETS ts tau u p'
+  ∀ts tau p p'. ETS ts tau p p' <=> p = p' ∨ ∃u. ts p tau u ∧ ETS ts tau u p'
 Proof
   SRW_TAC[][ETS_def, Once RTC_CASES1]
 QED
 
 Theorem ETS_INDUCT[rule_induction]:
-  ∀P. (∀p. P p p) ∧ (
+  ∀ts tau P. (∀p. P p p) ∧ (
     (∀p p' q. ts p tau p' ∧ P p' q ⇒ P p q) ∨
     (∀p q' q. P p q' ∧ ts q' tau q ⇒ P p q)
   ) ⇒ ∀p0 q0. ETS ts tau p0 q0 ⇒ P p0 q0
@@ -495,10 +495,11 @@ Theorem WBISIM_REL_EQUIV_rules =
   |> SIMP_RULE bool_ss [equivalence_def, reflexive_def, symmetric_def, transitive_def];
 
 Theorem WBISIM_REL_ts:
-  (WBISIM_REL ts tau p q ∧ ts p l p' ∧ l ≠ tau ==> ∃q'. WTS ts tau q l q' ∧ WBISIM_REL ts tau p' q') ∧
-  (WBISIM_REL ts tau p q ∧ ts q l q' ∧ l ≠ tau ==> ∃p'. WTS ts tau p l p' ∧ WBISIM_REL ts tau p' q') ∧
-  (WBISIM_REL ts tau p q ∧ ts p tau p' ==> ∃q'. ETS ts tau q q' ∧ WBISIM_REL ts tau p' q') ∧
-  (WBISIM_REL ts tau p q ∧ ts q tau q' ==> ∃p'. ETS ts tau p p' ∧ WBISIM_REL ts tau p' q')
+  ∀ts tau.
+  (∀p q l p'. WBISIM_REL ts tau p q ∧ ts p l p' ∧ l ≠ tau ==> ∃q'. WTS ts tau q l q' ∧ WBISIM_REL ts tau p' q') ∧
+  (∀p q l q'. WBISIM_REL ts tau p q ∧ ts q l q' ∧ l ≠ tau ==> ∃p'. WTS ts tau p l p' ∧ WBISIM_REL ts tau p' q') ∧
+  (∀p q p'. WBISIM_REL ts tau p q ∧ ts p tau p' ==> ∃q'. ETS ts tau q q' ∧ WBISIM_REL ts tau p' q') ∧
+  (∀p q q'. WBISIM_REL ts tau p q ∧ ts q tau q' ==> ∃p'. ETS ts tau p p' ∧ WBISIM_REL ts tau p' q')
 Proof
   SRW_TAC[][WBISIM_REL_def]
   >> METIS_TAC[WBISIM_def]

--- a/src/relation/bisimulationScript.sml
+++ b/src/relation/bisimulationScript.sml
@@ -307,7 +307,7 @@ Theorem ETS_INDUCT[rule_induction]:
     (∀p q' q. P p q' ∧ ts q' tau q ⇒ P p q)
   ) ⇒ ∀p0 q0. ETS ts tau p0 q0 ⇒ P p0 q0
 Proof
-    GEN_TAC >> STRIP_TAC
+    STRIP_TAC >> STRIP_TAC >> GEN_TAC >> STRIP_TAC
  >> REWRITE_TAC [ETS_def]
  >| [HO_MATCH_MP_TAC RTC_INDUCT, HO_MATCH_MP_TAC RTC_INDUCT_RIGHT1]
  >> METIS_TAC []

--- a/src/relation/relationScript.sml
+++ b/src/relation/relationScript.sml
@@ -2746,7 +2746,8 @@ QED
 (* rmonotone RC ∧ rmonotone SC ∧ rmonotone TC ∧ rmonotone RTC ∧ rmonotone EQC *)
 fun rmonotone_from_thm thm = thm |> GEN_ALL |> MATCH_MP (iffRL rmonotone_thm)
 Theorem rmonotone_closures[simp] =
-  [RC_MONOTONE, SC_MONOTONE, TC_MONOTONE, RTC_MONOTONE, EQC_MONOTONE |> Q.INST [`R'` |-> `Q`]]
+  [RC_MONOTONE, SC_MONOTONE, TC_MONOTONE, RTC_MONOTONE,
+   EQC_MONOTONE |> Q.INST [`R'` |-> `Q`]]
   |> map rmonotone_from_thm
   |> LIST_CONJ;
 
@@ -2785,7 +2786,8 @@ Theorem rpreserves_symmetric[simp]:
   rpreserves symmetric RC ∧ rpreserves symmetric TC
 Proof
   SRW_TAC[][rpreserves_def, symmetric_def, RC_SUBSET, TC_SUBSET] >> EQ_TAC
-  >| [Q.ID_SPEC_TAC `y` >> Q.ID_SPEC_TAC `x`, Q.ID_SPEC_TAC `x` >> Q.ID_SPEC_TAC `y`]
+  >| [Q.ID_SPEC_TAC `y` >> Q.ID_SPEC_TAC `x`,
+      Q.ID_SPEC_TAC `x` >> Q.ID_SPEC_TAC `y`]
   >> HO_MATCH_MP_TAC TC_INDUCT_LEFT1 >> SRW_TAC[][TC_SUBSET]
   >> METIS_TAC[TC_RIGHT1_I]
 QED
@@ -2858,7 +2860,8 @@ Proof
 QED
 
 Theorem RMONOTONE_IMP_CLOSURE_RSUBSET:
-  ∀P C b. is_closure_op P C ∧ rmonotone b ∧ rpreserves P b ==> ∀R. C (b R) ⊆ᵣ b (C R)
+  ∀P C b.
+  is_closure_op P C ∧ rmonotone b ∧ rpreserves P b ==> ∀R. C (b R) ⊆ᵣ b (C R)
 Proof
   SRW_TAC[][] >> drule $ iffLR is_closure_op_def >> STRIP_TAC
   >> LAST_X_ASSUM $ Q.SPEC_THEN `b R` MP_TAC >> SRW_TAC[][]

--- a/src/relation/relationScript.sml
+++ b/src/relation/relationScript.sml
@@ -122,6 +122,11 @@ val _ = add_rule { fixity = Suffix 2100,
                    pp_elements = [TOK "^="],
                    term_name = "EQC" }
 
+Theorem EQC_THM:
+  EQC = RC o TC o SC
+Proof
+  SRW_TAC[][FUN_EQ_THM, EQC_DEF]
+QED
 
 Theorem SC_SYMMETRIC:
     !R. symmetric (SC R)
@@ -273,6 +278,12 @@ Theorem transitive_RC:
     !R. transitive R ==> transitive (RC R)
 Proof
   SRW_TAC [][transitive_def, RC_DEF] THEN PROVE_TAC []
+QED
+
+Theorem SC_SUBSET:
+  ∀R x (y: 'a). R x y ==> SC R x y
+Proof
+  SRW_TAC[][SC_DEF]
 QED
 
 Theorem TC_SUBSET:
@@ -550,6 +561,18 @@ Proof
     Q.ID_SPEC_TAC `v` THEN Q.ID_SPEC_TAC `u` THEN
     HO_MATCH_MP_TAC RTC_INDUCT THEN MESON_TAC [TC_RULES, RC_DEF]
   ]
+QED
+
+Theorem RTC_TC_o_RC:
+  RTC = TC o RC
+Proof
+  SRW_TAC[][Once FUN_EQ_THM, TC_RC_EQNS]
+QED
+
+Theorem RTC_RC_o_TC:
+  RTC = RC o TC
+Proof
+  SRW_TAC[][Once FUN_EQ_THM, TC_RC_EQNS]
 QED
 
 Theorem TC_LEFT1_I:
@@ -2009,6 +2032,18 @@ val _ = Unicode.unicode_version {u = UnicodeChars.subset ^ UnicodeChars.sub_r,
 val _ = TeX_notation { hol = UnicodeChars.subset ^ UnicodeChars.sub_r,
                        TeX = ("\\HOLTokenRSubset{}", 1) }
 
+Theorem RSUBSET_REFL:
+  R RSUBSET R
+Proof
+  SRW_TAC[][RSUBSET]
+QED
+
+Theorem RSUBSET_TRANS:
+  P RSUBSET Q ∧ Q RSUBSET R ==> P RSUBSET R
+Proof
+  SRW_TAC[][RSUBSET]
+QED
+
 Theorem irreflexive_RSUBSET:
     !R1 R2. irreflexive R2 /\ R1 RSUBSET R2 ==> irreflexive R1
 Proof
@@ -2616,3 +2651,204 @@ Theorem RSUBSET_RINSERT :
 Proof
     SRW_TAC [] [RSUBSET, RINSERT]
 QED
+
+(* ==========================================================================
+   Some theorems about interaction between the relation operators
+   Naming convention used below:
+     P, Q, R  : relations ('a -> 'a -> bool)
+     f, g     : predicates on relations ('a -> 'a -> bool) -> bool,
+                e.g. reflexive, symmetric, transitive, equivalence
+     a, b     : relation transformers/operators
+                (('a -> 'a -> bool) -> 'a -> 'a -> bool),
+                e.g closures like RC, SC, TC, RTC, EQC
+   ===========================================================================*)
+
+Theorem RUNION_RSUBSET:
+  P ∪ᵣ Q ⊆ᵣ R <=> P ⊆ᵣ R ∧ Q ⊆ᵣ R
+Proof
+  SRW_TAC[][RUNION, RSUBSET] >> METIS_TAC[]
+QED
+
+Theorem RINTER_RSUBSET:
+  P ⊆ᵣ R ∨ Q ⊆ᵣ R ==> P ∩ᵣ Q ⊆ᵣ R
+Proof
+  SRW_TAC[][RINTER, RSUBSET] >> METIS_TAC[]
+QED
+
+Theorem RSUBSET_RUNION:
+  R ⊆ᵣ P ∨ R ⊆ᵣ Q ==> R ⊆ᵣ P ∪ᵣ Q
+Proof
+  SRW_TAC[][RUNION, RSUBSET] >> METIS_TAC[]
+QED
+
+Theorem RSUBSET_RINTER:
+  R ⊆ᵣ P ∩ᵣ Q <=> R ⊆ᵣ P ∧ R ⊆ᵣ Q
+Proof
+  SRW_TAC[][RINTER, RSUBSET] >> METIS_TAC[]
+QED
+
+Theorem INV_RUNION:
+  (P ∪ᵣ Q)ᵀ = Pᵀ ∪ᵣ Qᵀ
+Proof
+  SRW_TAC[][FUN_EQ_THM, RUNION] >> METIS_TAC[]
+QED
+
+Theorem INV_RINTER:
+  (P ∩ᵣ Q)ᵀ = Pᵀ ∩ᵣ Qᵀ
+Proof
+  SRW_TAC[][FUN_EQ_THM, RINTER] >> METIS_TAC[]
+QED
+
+Theorem INV_RSUBSET:
+  Pᵀ ⊆ᵣ Q <=> P ⊆ᵣ Qᵀ
+Proof
+  SRW_TAC[][EQ_IMP_THM, RSUBSET]
+QED
+
+Theorem SC_THM:
+  SC R = R ∪ᵣ Rᵀ
+Proof
+  SRW_TAC[][SC_DEF, FUN_EQ_THM, RUNION]
+QED
+
+Theorem SYMMETRIC_RUNION:
+  symmetric P ∧ symmetric Q ==> symmetric (P ∪ᵣ Q)
+Proof
+  SRW_TAC[][symmetric_def, RUNION]
+QED
+
+Theorem SYMMETRIC_RINTER:
+  symmetric P ∧ symmetric Q ==> symmetric (P ∩ᵣ Q)
+Proof
+  SRW_TAC[][symmetric_def, RINTER]
+QED
+
+(* b respects the ⊆ᵣ relation: enlarging P never shrinks b P *)
+val rmonotone_def = new_definition(
+  "rmonotone_def",
+  ``rmonotone (b: ('a -> 'a -> bool) -> 'a -> 'a -> bool) <=>
+    ∀P Q. P ⊆ᵣ Q ==> b P ⊆ᵣ b Q``
+);
+
+(* Used to convert existing theorems *)
+Theorem rmonotone_thm:
+  rmonotone b <=> ∀y x R Q. (∀x y. R x y ==> Q x y) ==> b R x y ==> b Q x y
+Proof
+  SRW_TAC[][rmonotone_def, RSUBSET] >> METIS_TAC[]
+QED
+
+(* rmonotone RC ∧ rmonotone SC ∧ rmonotone TC ∧ rmonotone RTC ∧ rmonotone EQC *)
+fun rmonotone_from_thm thm = thm |> GEN_ALL |> MATCH_MP (iffRL rmonotone_thm)
+Theorem rmonotone_closures[simp] =
+  [RC_MONOTONE, SC_MONOTONE, TC_MONOTONE, RTC_MONOTONE, EQC_MONOTONE |> Q.INST [`R'` |-> `Q`]]
+  |> map rmonotone_from_thm
+  |> LIST_CONJ;
+
+Theorem rmonotone_RUNION:
+  rmonotone ($RUNION P)
+Proof
+  SRW_TAC[][rmonotone_def, RUNION_RSUBSET, RSUBSET_RUNION, RSUBSET_REFL]
+QED
+
+Theorem rmonotone_RINTER:
+  rmonotone ($RINTER P)
+Proof
+  SRW_TAC[][rmonotone_def, RINTER_RSUBSET, RSUBSET_RINTER, RSUBSET_REFL]
+QED
+
+(* If you have a relation P with property f, then b P also has property f *)
+val rpreserves_def = new_definition(
+  "rpreserves_def",
+  ``rpreserves (f: ('a -> 'a -> bool) -> bool) b <=>
+    ∀P. f P ==> f (b P)``
+);
+
+Theorem rpreserves_o:
+  rpreserves f a ∧ rpreserves f b ==> rpreserves f (a o b)
+Proof
+  SRW_TAC[][rpreserves_def]
+QED
+
+Theorem rpreserves_reflexive[simp]:
+  rpreserves reflexive TC ∧ rpreserves reflexive SC
+Proof
+  SRW_TAC[][rpreserves_def, reflexive_def, SC_SUBSET, TC_SUBSET]
+QED
+
+Theorem rpreserves_symmetric[simp]:
+  rpreserves symmetric RC ∧ rpreserves symmetric TC
+Proof
+  SRW_TAC[][rpreserves_def, symmetric_def, RC_SUBSET, TC_SUBSET] >> EQ_TAC
+  >| [Q.ID_SPEC_TAC `y` >> Q.ID_SPEC_TAC `x`, Q.ID_SPEC_TAC `x` >> Q.ID_SPEC_TAC `y`]
+  >> HO_MATCH_MP_TAC TC_INDUCT_LEFT1 >> SRW_TAC[][TC_SUBSET]
+  >> METIS_TAC[TC_RIGHT1_I]
+QED
+
+Theorem rpreserves_transitive[simp]:
+  rpreserves transitive RC
+Proof
+  SRW_TAC[][rpreserves_def, transitive_def, RC_DEF] >> METIS_TAC[]
+QED
+
+Theorem rpreserves_symmetric_RTC[simp]:
+  rpreserves symmetric RTC
+Proof
+  SRW_TAC[][RTC_RC_o_TC, rpreserves_o]
+QED
+
+Theorem rpreserves_symmetric_inv:
+  rpreserves symmetric b ∧ symmetric R ==> (b R)ᵀ = b Rᵀ
+Proof
+  SRW_TAC[][symmetric_inv_identity, rpreserves_def]
+QED
+
+(* C is the closure operator for property f, so
+  (1) C R has property f
+  (2) R ⊆ᵣ C R
+  (3) C R is the smallest such relation, in the sense that
+      if P is a relation satisfying (1) and (2), then C R ⊆ᵣ P
+  *)
+val is_closure_op_def = new_definition(
+  "is_closure_op_def",
+  ``is_closure_op f b <=>
+    ∀R. f (b R) ∧ R ⊆ᵣ (b R) ∧ ∀P. f P ∧ R ⊆ᵣ P ==> b R ⊆ᵣ P``
+);
+
+Theorem is_closure_op_closed:
+  is_closure_op f C ==> f (C R)
+Proof
+  SRW_TAC[][is_closure_op_def]
+QED
+
+Theorem is_closure_op_reflexive_RC[simp]:
+  is_closure_op reflexive RC
+Proof
+  SRW_TAC[][is_closure_op_def, RSUBSET, RC_DEF, reflexive_def] >> SRW_TAC[][]
+QED
+
+Theorem is_closure_op_symmetric_SC[simp]:
+  is_closure_op symmetric SC
+Proof
+  SRW_TAC[][is_closure_op_def, RSUBSET, SC_DEF, symmetric_def] >> METIS_TAC[]
+QED
+
+Theorem is_closure_op_transitive_TC[simp]:
+  is_closure_op transitive TC
+Proof
+  SRW_TAC[][is_closure_op_def, RSUBSET, Once TC_DEF, transitive_def]
+  >> FIRST_X_ASSUM MP_TAC
+  >> Q.ID_SPEC_TAC `y` >> Q.ID_SPEC_TAC `x`
+  >> HO_MATCH_MP_TAC TC_INDUCT >> SRW_TAC[][]
+  >> METIS_TAC[]
+QED
+
+Theorem RMONOTONE_IMP_CLOSURE_RSUBSET:
+  is_closure_op f C ∧ rmonotone b ∧ rpreserves f b ==> C (b R) ⊆ᵣ b (C R)
+Proof
+  SRW_TAC[][] >> drule $ iffLR is_closure_op_def >> STRIP_TAC
+  >> LAST_X_ASSUM $ Q.SPEC_THEN `b R` MP_TAC >> SRW_TAC[][]
+  >> FIRST_X_ASSUM irule >> SRW_TAC[][]
+  >- METIS_TAC[rpreserves_def, is_closure_op_closed]
+  >> METIS_TAC[is_closure_op_def, rmonotone_def]
+QED
+

--- a/src/relation/relationScript.sml
+++ b/src/relation/relationScript.sml
@@ -2820,6 +2820,17 @@ Proof
   SRW_TAC[][is_closure_op_def]
 QED
 
+Theorem is_closure_op_rmonotone:
+  ∀f C. is_closure_op f C ==> rmonotone C
+Proof
+  SRW_TAC[][is_closure_op_def, rmonotone_def]
+  >> FIRST_ASSUM $ Q.SPEC_THEN `Q` MP_TAC
+  >> FIRST_X_ASSUM $ Q.SPEC_THEN `P` MP_TAC
+  >> SRW_TAC[][]
+  >> LAST_X_ASSUM $ Q.SPEC_THEN `C Q` MP_TAC
+  >> METIS_TAC[RSUBSET_TRANS]
+QED
+
 Theorem is_closure_op_reflexive_RC[simp]:
   is_closure_op reflexive RC
 Proof
@@ -2851,4 +2862,3 @@ Proof
   >- METIS_TAC[rpreserves_def, is_closure_op_closed]
   >> METIS_TAC[is_closure_op_def, rmonotone_def]
 QED
-

--- a/src/relation/relationScript.sml
+++ b/src/relation/relationScript.sml
@@ -2664,61 +2664,61 @@ QED
    ===========================================================================*)
 
 Theorem RUNION_RSUBSET:
-  P ∪ᵣ Q ⊆ᵣ R <=> P ⊆ᵣ R ∧ Q ⊆ᵣ R
+  ∀P Q R. P ∪ᵣ Q ⊆ᵣ R <=> P ⊆ᵣ R ∧ Q ⊆ᵣ R
 Proof
   SRW_TAC[][RUNION, RSUBSET] >> METIS_TAC[]
 QED
 
 Theorem RINTER_RSUBSET:
-  P ⊆ᵣ R ∨ Q ⊆ᵣ R ==> P ∩ᵣ Q ⊆ᵣ R
+  ∀P Q R. P ⊆ᵣ R ∨ Q ⊆ᵣ R ==> P ∩ᵣ Q ⊆ᵣ R
 Proof
   SRW_TAC[][RINTER, RSUBSET] >> METIS_TAC[]
 QED
 
 Theorem RSUBSET_RUNION:
-  R ⊆ᵣ P ∨ R ⊆ᵣ Q ==> R ⊆ᵣ P ∪ᵣ Q
+  ∀R P Q. R ⊆ᵣ P ∨ R ⊆ᵣ Q ==> R ⊆ᵣ P ∪ᵣ Q
 Proof
   SRW_TAC[][RUNION, RSUBSET] >> METIS_TAC[]
 QED
 
 Theorem RSUBSET_RINTER:
-  R ⊆ᵣ P ∩ᵣ Q <=> R ⊆ᵣ P ∧ R ⊆ᵣ Q
+  ∀R P Q. R ⊆ᵣ P ∩ᵣ Q <=> R ⊆ᵣ P ∧ R ⊆ᵣ Q
 Proof
   SRW_TAC[][RINTER, RSUBSET] >> METIS_TAC[]
 QED
 
 Theorem INV_RUNION:
-  (P ∪ᵣ Q)ᵀ = Pᵀ ∪ᵣ Qᵀ
+  ∀P Q. (P ∪ᵣ Q)ᵀ = Pᵀ ∪ᵣ Qᵀ
 Proof
   SRW_TAC[][FUN_EQ_THM, RUNION] >> METIS_TAC[]
 QED
 
 Theorem INV_RINTER:
-  (P ∩ᵣ Q)ᵀ = Pᵀ ∩ᵣ Qᵀ
+  ∀P Q. (P ∩ᵣ Q)ᵀ = Pᵀ ∩ᵣ Qᵀ
 Proof
   SRW_TAC[][FUN_EQ_THM, RINTER] >> METIS_TAC[]
 QED
 
 Theorem INV_RSUBSET:
-  Pᵀ ⊆ᵣ Q <=> P ⊆ᵣ Qᵀ
+  ∀P Q. Pᵀ ⊆ᵣ Q <=> P ⊆ᵣ Qᵀ
 Proof
   SRW_TAC[][EQ_IMP_THM, RSUBSET]
 QED
 
 Theorem SC_THM:
-  SC R = R ∪ᵣ Rᵀ
+  ∀R. SC R = R ∪ᵣ Rᵀ
 Proof
   SRW_TAC[][SC_DEF, FUN_EQ_THM, RUNION]
 QED
 
 Theorem SYMMETRIC_RUNION:
-  symmetric P ∧ symmetric Q ==> symmetric (P ∪ᵣ Q)
+  ∀P Q. symmetric P ∧ symmetric Q ==> symmetric (P ∪ᵣ Q)
 Proof
   SRW_TAC[][symmetric_def, RUNION]
 QED
 
 Theorem SYMMETRIC_RINTER:
-  symmetric P ∧ symmetric Q ==> symmetric (P ∩ᵣ Q)
+  ∀P Q. symmetric P ∧ symmetric Q ==> symmetric (P ∩ᵣ Q)
 Proof
   SRW_TAC[][symmetric_def, RINTER]
 QED
@@ -2732,7 +2732,7 @@ val rmonotone_def = new_definition(
 
 (* Used to convert existing theorems *)
 Theorem rmonotone_thm:
-  rmonotone b <=> ∀y x R Q. (∀x y. R x y ==> Q x y) ==> b R x y ==> b Q x y
+  ∀b. rmonotone b <=> ∀y x R Q. (∀x y. R x y ==> Q x y) ==> b R x y ==> b Q x y
 Proof
   SRW_TAC[][rmonotone_def, RSUBSET] >> METIS_TAC[]
 QED
@@ -2745,13 +2745,13 @@ Theorem rmonotone_closures[simp] =
   |> LIST_CONJ;
 
 Theorem rmonotone_RUNION:
-  rmonotone ($RUNION P)
+  ∀P. rmonotone ($RUNION P)
 Proof
   SRW_TAC[][rmonotone_def, RUNION_RSUBSET, RSUBSET_RUNION, RSUBSET_REFL]
 QED
 
 Theorem rmonotone_RINTER:
-  rmonotone ($RINTER P)
+  ∀P. rmonotone ($RINTER P)
 Proof
   SRW_TAC[][rmonotone_def, RINTER_RSUBSET, RSUBSET_RINTER, RSUBSET_REFL]
 QED
@@ -2764,7 +2764,7 @@ val rpreserves_def = new_definition(
 );
 
 Theorem rpreserves_o:
-  rpreserves f a ∧ rpreserves f b ==> rpreserves f (a o b)
+  ∀f a b. rpreserves f a ∧ rpreserves f b ==> rpreserves f (a o b)
 Proof
   SRW_TAC[][rpreserves_def]
 QED
@@ -2815,7 +2815,7 @@ val is_closure_op_def = new_definition(
 );
 
 Theorem is_closure_op_closed:
-  is_closure_op f C ==> f (C R)
+  ∀f C R. is_closure_op f C ==> f (C R)
 Proof
   SRW_TAC[][is_closure_op_def]
 QED
@@ -2843,7 +2843,7 @@ Proof
 QED
 
 Theorem RMONOTONE_IMP_CLOSURE_RSUBSET:
-  is_closure_op f C ∧ rmonotone b ∧ rpreserves f b ==> C (b R) ⊆ᵣ b (C R)
+  ∀f C b. is_closure_op f C ∧ rmonotone b ∧ rpreserves f b ==> C (b R) ⊆ᵣ b (C R)
 Proof
   SRW_TAC[][] >> drule $ iffLR is_closure_op_def >> STRIP_TAC
   >> LAST_X_ASSUM $ Q.SPEC_THEN `b R` MP_TAC >> SRW_TAC[][]

--- a/src/relation/relationScript.sml
+++ b/src/relation/relationScript.sml
@@ -2033,13 +2033,13 @@ val _ = TeX_notation { hol = UnicodeChars.subset ^ UnicodeChars.sub_r,
                        TeX = ("\\HOLTokenRSubset{}", 1) }
 
 Theorem RSUBSET_REFL:
-  R RSUBSET R
+  ∀R. R RSUBSET R
 Proof
   SRW_TAC[][RSUBSET]
 QED
 
 Theorem RSUBSET_TRANS:
-  P RSUBSET Q ∧ Q RSUBSET R ==> P RSUBSET R
+  ∀R1 R2 R3. R1 RSUBSET R2 ∧ R2 RSUBSET R3 ==> R1 RSUBSET R3
 Proof
   SRW_TAC[][RSUBSET]
 QED
@@ -2653,54 +2653,60 @@ Proof
 QED
 
 (* ==========================================================================
-   Some theorems about interaction between the relation operators
-   Naming convention used below:
-     P, Q, R  : relations ('a -> 'a -> bool)
-     f, g     : predicates on relations ('a -> 'a -> bool) -> bool,
-                e.g. reflexive, symmetric, transitive, equivalence
-     a, b     : relation transformers/operators
-                (('a -> 'a -> bool) -> 'a -> 'a -> bool),
-                e.g closures like RC, SC, TC, RTC, EQC
+   Some theorems about interaction between the relation operators, of type
+   b: ('a -> 'a -> bool) -> 'a -> 'a -> bool
    ===========================================================================*)
 
+Theorem RUNION_IDEMPOT[simp]:
+  ∀R. R ∪ᵣ R = R
+Proof
+  SRW_TAC[][FUN_EQ_THM, RUNION]
+QED
+
+Theorem RINTER_IDEMPOT[simp]:
+  ∀R. R ∩ᵣ R = R
+Proof
+  SRW_TAC[][FUN_EQ_THM, RINTER]
+QED
+
 Theorem RUNION_RSUBSET:
-  ∀P Q R. P ∪ᵣ Q ⊆ᵣ R <=> P ⊆ᵣ R ∧ Q ⊆ᵣ R
+  ∀R1 R2 R3. R1 ∪ᵣ R2 ⊆ᵣ R3 <=> R1 ⊆ᵣ R3 ∧ R2 ⊆ᵣ R3
 Proof
   SRW_TAC[][RUNION, RSUBSET] >> METIS_TAC[]
 QED
 
 Theorem RINTER_RSUBSET:
-  ∀P Q R. P ⊆ᵣ R ∨ Q ⊆ᵣ R ==> P ∩ᵣ Q ⊆ᵣ R
+  ∀R1 R2 R3. R1 ⊆ᵣ R3 ∨ R2 ⊆ᵣ R3 ==> R1 ∩ᵣ R2 ⊆ᵣ R3
 Proof
   SRW_TAC[][RINTER, RSUBSET] >> METIS_TAC[]
 QED
 
 Theorem RSUBSET_RUNION:
-  ∀R P Q. R ⊆ᵣ P ∨ R ⊆ᵣ Q ==> R ⊆ᵣ P ∪ᵣ Q
+  ∀R1 R2 R3. R1 ⊆ᵣ R2 ∨ R1 ⊆ᵣ R3 ==> R1 ⊆ᵣ R2 ∪ᵣ R3
 Proof
   SRW_TAC[][RUNION, RSUBSET] >> METIS_TAC[]
 QED
 
 Theorem RSUBSET_RINTER:
-  ∀R P Q. R ⊆ᵣ P ∩ᵣ Q <=> R ⊆ᵣ P ∧ R ⊆ᵣ Q
+  ∀R1 R2 R3. R1 ⊆ᵣ R2 ∩ᵣ R3 <=> R1 ⊆ᵣ R2 ∧ R1 ⊆ᵣ R3
 Proof
   SRW_TAC[][RINTER, RSUBSET] >> METIS_TAC[]
 QED
 
 Theorem INV_RUNION:
-  ∀P Q. (P ∪ᵣ Q)ᵀ = Pᵀ ∪ᵣ Qᵀ
+  ∀R1 R2. (R1 ∪ᵣ R2)ᵀ = R1ᵀ ∪ᵣ R2ᵀ
 Proof
   SRW_TAC[][FUN_EQ_THM, RUNION] >> METIS_TAC[]
 QED
 
 Theorem INV_RINTER:
-  ∀P Q. (P ∩ᵣ Q)ᵀ = Pᵀ ∩ᵣ Qᵀ
+  ∀R1 R2. (R1 ∩ᵣ R2)ᵀ = R1ᵀ ∩ᵣ R2ᵀ
 Proof
   SRW_TAC[][FUN_EQ_THM, RINTER] >> METIS_TAC[]
 QED
 
 Theorem INV_RSUBSET:
-  ∀P Q. Pᵀ ⊆ᵣ Q <=> P ⊆ᵣ Qᵀ
+  ∀R1 R2. R1ᵀ ⊆ᵣ R2 <=> R1 ⊆ᵣ R2ᵀ
 Proof
   SRW_TAC[][EQ_IMP_THM, RSUBSET]
 QED
@@ -2712,13 +2718,13 @@ Proof
 QED
 
 Theorem SYMMETRIC_RUNION:
-  ∀P Q. symmetric P ∧ symmetric Q ==> symmetric (P ∪ᵣ Q)
+  ∀R1 R2. symmetric R1 ∧ symmetric R2 ==> symmetric (R1 ∪ᵣ R2)
 Proof
   SRW_TAC[][symmetric_def, RUNION]
 QED
 
 Theorem SYMMETRIC_RINTER:
-  ∀P Q. symmetric P ∧ symmetric Q ==> symmetric (P ∩ᵣ Q)
+  ∀R1 R2. symmetric R1 ∧ symmetric R2 ==> symmetric (R1 ∩ᵣ R2)
 Proof
   SRW_TAC[][symmetric_def, RINTER]
 QED
@@ -2727,7 +2733,7 @@ QED
 val rmonotone_def = new_definition(
   "rmonotone_def",
   ``rmonotone (b: ('a -> 'a -> bool) -> 'a -> 'a -> bool) <=>
-    ∀P Q. P ⊆ᵣ Q ==> b P ⊆ᵣ b Q``
+    ∀R1 R2. R1 ⊆ᵣ R2 ==> b R1 ⊆ᵣ b R2``
 );
 
 (* Used to convert existing theorems *)
@@ -2745,26 +2751,26 @@ Theorem rmonotone_closures[simp] =
   |> LIST_CONJ;
 
 Theorem rmonotone_RUNION:
-  ∀P. rmonotone ($RUNION P)
+  ∀R. rmonotone ($RUNION R)
 Proof
   SRW_TAC[][rmonotone_def, RUNION_RSUBSET, RSUBSET_RUNION, RSUBSET_REFL]
 QED
 
 Theorem rmonotone_RINTER:
-  ∀P. rmonotone ($RINTER P)
+  ∀R. rmonotone ($RINTER R)
 Proof
   SRW_TAC[][rmonotone_def, RINTER_RSUBSET, RSUBSET_RINTER, RSUBSET_REFL]
 QED
 
-(* If you have a relation P with property f, then b P also has property f *)
+(* If you have a relation R with property P, then b R also has property P *)
 val rpreserves_def = new_definition(
   "rpreserves_def",
-  ``rpreserves (f: ('a -> 'a -> bool) -> bool) b <=>
-    ∀P. f P ==> f (b P)``
+  ``rpreserves (P: ('a -> 'a -> bool) -> bool) b <=>
+    ∀R. P R ==> P (b R)``
 );
 
 Theorem rpreserves_o:
-  ∀f a b. rpreserves f a ∧ rpreserves f b ==> rpreserves f (a o b)
+  ∀P a b. rpreserves P a ∧ rpreserves P b ==> rpreserves P (a o b)
 Proof
   SRW_TAC[][rpreserves_def]
 QED
@@ -2802,33 +2808,31 @@ Proof
   SRW_TAC[][symmetric_inv_identity, rpreserves_def]
 QED
 
-(* C is the closure operator for property f, so
-  (1) C R has property f
+(* C is the closure operator for property P, so
+  (1) C R has property P
   (2) R ⊆ᵣ C R
-  (3) C R is the smallest such relation, in the sense that
-      if P is a relation satisfying (1) and (2), then C R ⊆ᵣ P
+  (3) C R2 is the smallest such relation for R2, in the sense that
+      if R1 is a relation satisfying (1) and (2), then C R1 ⊆ᵣ R2
   *)
 val is_closure_op_def = new_definition(
   "is_closure_op_def",
-  ``is_closure_op f b <=>
-    ∀R. f (b R) ∧ R ⊆ᵣ (b R) ∧ ∀P. f P ∧ R ⊆ᵣ P ==> b R ⊆ᵣ P``
+  ``is_closure_op P C <=>
+    (∀R. P (C R)) ∧
+    (∀R. R ⊆ᵣ (C R)) ∧
+    (∀R1 R2. P R2 ∧ R1 ⊆ᵣ R2 ==> C R1 ⊆ᵣ R2)``
 );
 
 Theorem is_closure_op_closed:
-  ∀f C R. is_closure_op f C ==> f (C R)
+  ∀P C R. is_closure_op P C ==> P (C R)
 Proof
   SRW_TAC[][is_closure_op_def]
 QED
 
 Theorem is_closure_op_rmonotone:
-  ∀f C. is_closure_op f C ==> rmonotone C
+  ∀P C. is_closure_op P C ==> rmonotone C
 Proof
-  SRW_TAC[][is_closure_op_def, rmonotone_def]
-  >> FIRST_ASSUM $ Q.SPEC_THEN `Q` MP_TAC
-  >> FIRST_X_ASSUM $ Q.SPEC_THEN `P` MP_TAC
-  >> SRW_TAC[][]
-  >> LAST_X_ASSUM $ Q.SPEC_THEN `C Q` MP_TAC
-  >> METIS_TAC[RSUBSET_TRANS]
+  SRW_TAC[][is_closure_op_def, rmonotone_def, RSUBSET]
+  >> METIS_TAC[]
 QED
 
 Theorem is_closure_op_reflexive_RC[simp]:
@@ -2854,7 +2858,7 @@ Proof
 QED
 
 Theorem RMONOTONE_IMP_CLOSURE_RSUBSET:
-  ∀f C b. is_closure_op f C ∧ rmonotone b ∧ rpreserves f b ==> C (b R) ⊆ᵣ b (C R)
+  ∀P C b. is_closure_op P C ∧ rmonotone b ∧ rpreserves P b ==> ∀R. C (b R) ⊆ᵣ b (C R)
 Proof
   SRW_TAC[][] >> drule $ iffLR is_closure_op_def >> STRIP_TAC
   >> LAST_X_ASSUM $ Q.SPEC_THEN `b R` MP_TAC >> SRW_TAC[][]


### PR DESCRIPTION
Adds:
- Cases and induction theorems for bisimulationScript's ETS
- Theorems for BISIM_REL for easy conversion for a particular transition system to complete the existing set of theorems, and a WBISIM theorem
- Theorems for interactions between RSUBSET, RUNION, RINTER, and inv, to allow for point free reasoning in proofs
- Definitions and theorems involving relation transformers: rmonotone, rpreserves, and is_closure_op (links together things like symmetric and SC)

Last three definitions are for the final theorem
```
Theorem RMONOTONE_IMP_CLOSURE_RSUBSET:
  is_closure_op f C ∧ rmonotone b ∧ rpreserves f b ==> C (b R) ⊆ᵣ b (C R)
```
which I needed for a proof.

Some theorems involving set theory constructs (reflexive and transitive are sets for example) were moved to pred_setScript.sml