### PR TITLE
computeLib: thread the accumulator when discharging rule antecedents

### DIFF
--- a/src/compute/src/equations.sml
+++ b/src/compute/src/equations.sml
@@ -162,10 +162,13 @@ fun reduce_cst rws (th,{Head, Args, Rws=Try{Hcst,Rws=Rewrite rls,Tail},Skip}) =
            NONE => false
          | SOME f => f Head
        val (spec_thm, new_rhs, cl, ants) = inst_rw (rule_inst, monitoring_p)
+       (* `thml` lists the antecedent proofs in the order of `ants`, which is
+          the order the implications are nested in, so each `MP` discharges
+          the current leading antecedent of the accumulator. *)
        fun mk_thm thml =
          TRANS th
                (List.foldl (fn (ant_eq_t, thm) =>
-                              MP spec_thm (EQT_ELIM ant_eq_t))
+                              MP thm (EQT_ELIM ant_eq_t))
                            spec_thm
                            thml)
      in

--- a/src/compute/src/selftest.sml
+++ b/src/compute/src/selftest.sml
@@ -92,6 +92,29 @@ val _ = if lhs (concl th) ~~ t1 andalso rhs (concl th) ~~ lhand (lhs (concl th))
 val _ = assert_reduces_to “f1 y” “result1”;
 val _ = assert_reduces_to “f2 z” “result3”;
 
+(* A rule with several antecedents: each proof must be discharged from the
+   theorem left by the previous discharge, not from the original rule.  The
+   first clause is abandoned after its first antecedent has been proved. *)
+val _ = new_constant("result4", “:ind”)
+
+val P3_def = new_definition(
+  "P3",
+  “P3 (x :ind) = T”)
+
+val f3_def = new_specification(
+  "f3_def",
+  ["f3"],
+  prove(
+    “∃f3. ∀x :ind. (P2 x ⇒ P1 x ⇒ f3 x = result2) ∧
+                   (P2 x ⇒ P3 x ⇒ P2 x ⇒ f3 x = result4)”,
+    EXISTS_TAC “λx :ind. result4” >>
+    REWRITE_TAC [P1_def, P2_def, P3_def]))
+
+val _ = computeLib.add_funs([P3_def, f3_def])
+
+val _ = tprint "Checking rewrites with several antecedents"
+val _ = assert_reduces_to “f3 z” “result4”;
+
 (* Tests for seal and copy functions *)
 
 val _ = tprint "Checking seal prevents adding rules for existing constants"


### PR DESCRIPTION
## Issue

`computeLib` accepts implications as rewrite rules (since 0c1640182): a
theorem `|- a1 ==> a2 ==> ... ==> lhs = rhs` is used by `CBV_CONV` when
every antecedent `ai` reduces to `T`.  Rules with a single antecedent
work.  Rules with two or more antecedents do not: `CBV_CONV` raises
from `Thm.MP` (or from `Thm.TRANS` when the antecedents happen to be
identical), and depending on where that exception is caught the redex
is either reported as an error or silently left stuck.

Minimal reproduction:

    val Q1_def = new_definition ("Q1", ``Q1 (x:ind) = T``);
    val Q2_def = new_definition ("Q2", ``Q2 (x:ind) = T``);
    val g_def  = new_specification ("g_def", ["g"],
      prove (``?g. !x:ind. Q1 x ==> Q2 x ==> g x = r1``,
             EXISTS_TAC ``\x:ind. r1`` THEN REWRITE_TAC [Q1_def, Q2_def]));
    CBV_CONV (new_compset [Q1_def, Q2_def, g_def]) ``g y``;

    Exception- HOL_ERR (at Thm.MP: antecedent of first thm not
      alpha-convertible to concl. of second)

### Cause

In `reduce_cst`'s `Rewrite` branch (`src/compute/src/equations.sml`),
the result theorem for a conditional rule is built by folding over the
proofs of its antecedents.  The fold binds an accumulator `thm` and then
ignores it, applying `MP` to the original instantiated rule `spec_thm`
on every iteration:

    List.foldl (fn (ant_eq_t, thm) => MP spec_thm (EQT_ELIM ant_eq_t))
               spec_thm thml

With one antecedent the single iteration is exactly right, which is why
the defect is invisible in ordinary use.  With two or more, the second
`MP` is applied to a theorem whose first antecedent is `a1` again, but
the proof supplied is of `a2`, and `MP` fails.  Multi-antecedent rules
are rare in the distribution's compsets because non-trivial side
conditions are usually wired in via `add_conv`, which takes the `Conv`
branch and never reaches this code.

## Fix

Thread the partially discharged theorem through the fold:

    List.foldl (fn (ant_eq_t, thm) => MP thm (EQT_ELIM ant_eq_t))
               spec_thm thml

The antecedent proofs arrive in the order the implications are nested
(`inst_rw` strips them front to back and `prove_ants` reverses its
cons-built accumulator before calling `mk_thm`), so `List.foldl`
consumes them in the order `MP` expects.  Rules with zero or one
antecedent are unaffected.

## Test

`src/compute/src/selftest.sml` gains "Checking rewrites with several
antecedents".  It registers a constant with two clauses: one that is
abandoned after its first antecedent has been proved and its second
reduces to `F`, and one with three distinct antecedents that all reduce
to `T`.  The redex must reduce to the second clause's result.  With the
fix reverted the check dies on `Thm.MP`; with it, the compute selftest
is green.

`bin/build -t --seq=tools/sequences/upto-parallel` completes with no
failures.
