### PR TITLE
ThmSetData: apply a theorem-set delta before recording it

### DIFF
--- a/src/1/DefnBaseCore.sml
+++ b/src/1/DefnBaseCore.sml
@@ -120,12 +120,12 @@ fun register_defn {tag, thmname} =
       val add = ThmSetData.mk_add thmname
       val p = case add of ThmSetData.ADD p => p | _ => raise Fail "Impossible"
     in
+      #update_global_value userdefs_db (register_defn_p tag p);
       if tag <> "user" then
         HOL_WARNING "DefnBase" "register_defn"
                     "Non-'user' definitions are only stored transiently"
       else
-        #record_delta userdefs_db add;
-      #update_global_value userdefs_db (register_defn_p tag p)
+        #record_delta userdefs_db add
     end
 
 

--- a/src/1/ThmSetData.sml
+++ b/src/1/ThmSetData.sml
@@ -281,8 +281,10 @@ fun export_with_ancestry
           if null args then
             let val d = rADD(lift name)
             in
-              #record_delta fullresult d;
-              #update_global_value fullresult (raw_apply_global d)
+              (* apply first: a delta the set type rejects must not be
+                 recorded, or every descendant theory fails to load *)
+              #update_global_value fullresult (raw_apply_global d);
+              #record_delta fullresult d
             end
           else raise ERR "store_attrfun"
                      ("Arguments not allowed for attribute " ^ attrname)

--- a/src/1/ThmSetData.sml
+++ b/src/1/ThmSetData.sml
@@ -281,8 +281,8 @@ fun export_with_ancestry
           if null args then
             let val d = rADD(lift name)
             in
-              (* apply first: a delta the set type rejects must not be
-                 recorded, or every descendant theory fails to load *)
+              (* apply first: a delta rejected by apply_to_global must not
+                 reach the segment, where it would raise on every load *)
               #update_global_value fullresult (raw_apply_global d);
               #record_delta fullresult d
             end

--- a/src/IndDef/IndDefLib.sml
+++ b/src/IndDef/IndDefLib.sml
@@ -107,8 +107,8 @@ fun add_rule_induction th =
 fun export_rule_induction s =
     let val d = ThmSetData.mk_add s
     in
-      rule_ind_record_delta d;
-      rule_ind_apply_global_update (apply_delta d)
+      rule_ind_apply_global_update (apply_delta d);
+      rule_ind_record_delta d
     end
 
 fun thy_rule_inductions thyname = let

--- a/src/IndDef/selftest.sml
+++ b/src/IndDef/selftest.sml
@@ -88,12 +88,16 @@ val _ = if can ThmSetData.current_data{settype = "rule_induction"} then OK()
         else die ""
 
 (* a theorem the rule_induction set type rejects (its clause hypothesis is
-   headed by a variable) must leave no delta in the theory segment *)
+   headed by a variable) must leave no delta in the theory segment; an
+   accepted one must, which also shows the delta count below is live *)
 local
   val nm = "malformed_rule_induction"
   val th = GEN “P:num -> bool”
                (DISCH T (GEN “x:num” (DISCH “(P:num -> bool) x” TRUTH)))
   val _ = save_thm(nm, th)
+  val ok_nm = "wellformed_rule_induction"
+  val ok_th = DISCH T (GEN “x:num” (DISCH “even x” (ASSUME “even x”)))
+  val _ = save_thm(ok_nm, ok_th)
   fun count () = length (thy_rule_inductions "scratch")
   fun rejected f = (f (); false) handle HOL_ERR _ => true
   fun check msg f =
@@ -106,6 +110,13 @@ local
         else OK()
       end
 in
+val _ = (tprint "Accepted export_rule_induction is persisted";
+         let val n0 = count ()
+         in
+           export_rule_induction ok_nm;
+           if count () = n0 + 1 then OK()
+           else die "accepted delta was not recorded"
+         end)
 val _ = check "Rejected stored [rule_induction] attribute is not persisted"
               (fn () => ThmAttribute.store_at_attribute
                           {name = nm, attrname = "rule_induction", args = [],

--- a/src/IndDef/selftest.sml
+++ b/src/IndDef/selftest.sml
@@ -87,6 +87,33 @@ val _ = tprint "Can still look at rule_induction data"
 val _ = if can ThmSetData.current_data{settype = "rule_induction"} then OK()
         else die ""
 
+(* a theorem the rule_induction set type rejects (its clause hypothesis is
+   headed by a variable) must leave no delta in the theory segment *)
+local
+  val nm = "malformed_rule_induction"
+  val th = GEN “P:num -> bool”
+               (DISCH T (GEN “x:num” (DISCH “(P:num -> bool) x” TRUTH)))
+  val _ = save_thm(nm, th)
+  fun count () = length (thy_rule_inductions "scratch")
+  fun rejected f = (f (); false) handle HOL_ERR _ => true
+  fun check msg f =
+      let
+        val _ = tprint msg
+        val n0 = count ()
+      in
+        if not (rejected f) then die "malformed theorem accepted"
+        else if count () <> n0 then die "rejected delta was recorded"
+        else OK()
+      end
+in
+val _ = check "Rejected stored [rule_induction] attribute is not persisted"
+              (fn () => ThmAttribute.store_at_attribute
+                          {name = nm, attrname = "rule_induction", args = [],
+                           thm = th})
+val _ = check "Rejected export_rule_induction is not persisted"
+              (fn () => export_rule_induction nm)
+end
+
 val _ = shouldfail {testfn = quietly (in_repl_mode (xHol_reln "tr")),
                     printresult = (fn (th,_,_) => thm_to_string th),
                     printarg = K "With Unicode should fail",

--- a/src/IndDef/selftest.sml
+++ b/src/IndDef/selftest.sml
@@ -98,7 +98,7 @@ local
   val ok_nm = "wellformed_rule_induction"
   val ok_th = DISCH T (GEN “x:num” (DISCH “even x” (ASSUME “even x”)))
   val _ = save_thm(ok_nm, ok_th)
-  fun count () = length (thy_rule_inductions "scratch")
+  fun count () = length (thy_rule_inductions (current_theory ()))
   fun rejected f = (f (); false) handle HOL_ERR _ => true
   fun check msg f =
       let

--- a/src/basicProof/BasicProvers.sml
+++ b/src/basicProof/BasicProvers.sml
@@ -1324,13 +1324,13 @@ val srw_tac = SRW_TAC
 fun export_rewrites slist =
     let val ds = map ThmSetData.mk_add slist
     in
-      List.app record_delta ds;
-      update_global_value (rev_itlist apply_to_global ds)
+      update_global_value (rev_itlist apply_to_global ds);
+      List.app record_delta ds
     end
 
 fun delsimps names =
-    (List.app (record_delta o ThmSetData.REMOVE) names;
-     temp_delsimps names)
+    (temp_delsimps names;
+     List.app (record_delta o ThmSetData.REMOVE) names)
 
 (* assume that there aren't any removes for things added in this theory;
    it's not rational to do that; one should add it locally only, or not

--- a/src/combin/combinpp.sml
+++ b/src/combin/combinpp.sml
@@ -355,8 +355,8 @@ fun new_form r =
       val d = ADD (DD r)
     in
       addlform left right;
-      record_delta d;
       update_global_value (apply_delta d);
+      record_delta d;
       add_user_printer("combinpp.general_printer", updt);
       case lookup_term_name of
           NONE => ()

--- a/src/marker/markerLib.sml
+++ b/src/marker/markerLib.sml
@@ -1026,8 +1026,8 @@ val {record_delta = record_suspension_delta_raw,
 
 (* Wrapper that both persists the delta and updates the in-memory global *)
 fun record_suspension_delta d =
-    (record_suspension_delta_raw d;
-     update_susp_global (apply_susp_delta d))
+    (update_susp_global (apply_susp_delta d);
+     record_suspension_delta_raw d)
 
 (* --- suspension.resumptions store --- *)
 
@@ -1103,8 +1103,8 @@ val {record_delta = record_resumption_delta_raw,
 
 (* Wrapper that both persists the delta and updates the in-memory global *)
 fun record_resumption_delta d =
-    (record_resumption_delta_raw d;
-     update_res_global (apply_res_delta d))
+    (update_res_global (apply_res_delta d);
+     record_resumption_delta_raw d)
 
 (* Public lookup helpers. *)
 

--- a/src/transfer/transferLib.sml
+++ b/src/transfer/transferLib.sml
@@ -842,8 +842,8 @@ val adresult = AncestryData.fullmake {
 fun temp_add_atomic_term nmt =
     upd_ruledb (apply_to_ruledb (ADD nmt))
 fun add_atomic_term nmt =
-      (#record_delta adresult (ADD nmt);
-       temp_add_atomic_term nmt)
+      (temp_add_atomic_term nmt;
+       #record_delta adresult (ADD nmt))
 val atomic_terms = #get_global_value adresult
 
 


### PR DESCRIPTION
## Issue

`ThmSetData.export_with_ancestry` registers a stored-attribute handler
(`store_attrfun`) for every theorem set created through it. That is the
path behind `Theorem foo[rule_induction]`, `store_thm` with an
attribute, and `ThmAttribute.store_at_attribute`. The handler did two
things in the wrong order:

```sml
#record_delta fullresult d;                            (* persist *)
#update_global_value fullresult (raw_apply_global d)   (* apply   *)
```

The delta was written into the current theory segment first, and only
then applied to the live global value. If the set type's
`apply_to_global` rejected the theorem, the exception escaped with the
delta already recorded. The bad delta was then exported with the theory,
and every descendant theory re-applied it on load, where it raised again
inside `apply_delta`. There is no user-level way to remove such a delta,
so one malformed attribute in one theory made every theory below it
unloadable.

Any set type whose `apply_to_global` can raise is affected. On `develop`
that includes `rule_induction`: `IndDefLib.ind_thm_to_consts` uses
`dest_imp` and `dest_thy_const` without a handler, so a theorem that is
not of the shape `!vs. premises ==> clauses`, or whose clause hypothesis
is headed by a variable, raises `HOL_ERR`.

Reproduction in a scratch theory:

```sml
val bad = GEN “P:num -> bool”
              (DISCH T (GEN “x:num” (DISCH “(P:num -> bool) x” TRUTH)))
val _ = save_thm ("bad", bad)
val _ = ThmAttribute.store_at_attribute
          {name = "bad", attrname = "rule_induction", args = [], thm = bad}
(* raises HOL_ERR, as it should *)
val _ = length (IndDefLib.thy_rule_inductions (current_theory ()))
(* one more than before: the rejected theorem was recorded anyway *)
```

`IndDefLib.export_rule_induction` had the same order, and so did a
handful of other exporters built directly on `AncestryData.fullmake`.
The exporters produced by `export_simple_dictionary` and friends were
already correct: they publish first, so a failed apply leaves nothing
recorded.

## Fix

Apply first, record only on success. `Context.Data.modify` leaves the
global value untouched when its callback raises, so nothing is
half-applied on the failure path either. The same swap is applied at
every remaining record-before-apply site so the rule is uniform:

- `src/1/ThmSetData.sml`: `store_attrfun` (the reported bug)
- `src/IndDef/IndDefLib.sml`: `export_rule_induction`
- `src/basicProof/BasicProvers.sml`: `export_rewrites`, `delsimps`
- `src/1/DefnBaseCore.sml`: `register_defn`
- `src/combin/combinpp.sml`: `new_form`
- `src/transfer/transferLib.sml`: `add_atomic_term`
- `src/marker/markerLib.sml`: `record_suspension_delta`,
  `record_resumption_delta`

Not addressed: publication and recording are still two steps, so an
asynchronous `Interrupt` between them can leave the live value and the
recorded delta out of step. Closing that window needs an
interrupt-masked critical section and a portable primitive that also
works under Moscow ML. It is independent of this fix and left as a
follow-up.

## Tests

Two rows added to `src/IndDef/selftest.sml`. A theorem that
`rule_induction` rejects is stored through the attribute path and
through `export_rule_induction`; in both cases the call must raise
`HOL_ERR` and the theory's recorded delta count must be unchanged. Each
row was checked against its own ablation: the attribute row fails with
the `ThmSetData` swap reverted, and the export row fails with only the
`IndDefLib` swap reverted.
