### PR TITLE
markerLib: make the theorem-list directive vocabulary a datatype

### DIFF
--- a/src/1/BoundedRewrites.sml
+++ b/src/1/BoundedRewrites.sml
@@ -12,8 +12,10 @@ struct
       else
     ADD_ASSUM (mk_comb(bounded_tm, mk_var(Int.toString n, bool))) th
 
+  fun is_bound h = is_comb h andalso aconv bounded_tm (rator h)
+
   fun DEST_BOUNDED th =
-      case HOLset.find (aconv bounded_tm o rator) (hypset th) of
+      case HOLset.find is_bound (hypset th) of
         SOME h => let
           val arg = rand h
         in

--- a/src/1/selftest.sml
+++ b/src/1/selftest.sml
@@ -1588,3 +1588,22 @@ in
     die "retired constant still reachable from the term parser"
   else OK()
 end
+
+(* A bound must be found whatever else the theorem assumes; a variable
+   hypothesis used to make the search raise, so the theorem was treated
+   as unbounded and its BOUNDED hypothesis reached the rewrite results. *)
+val _ =
+  let
+    val th = ASSUME (mk_var("p", bool))
+    fun check (name, th) =
+        (tprint ("DEST_BOUNDED: " ^ name);
+         require_msg
+           (check_result
+              (fn (th', n) => n = 2 andalso
+                              HOLset.equal(hypset th', hypset th) andalso
+                              concl th' ~~ concl th))
+           (fn (th', n) => thm_to_string th' ^ " @ " ^ Int.toString n)
+           BoundedRewrites.DEST_BOUNDED (BoundedRewrites.Ntimes th 2))
+  in
+    check ("variable hypothesis", th)
+  end

--- a/src/marker/Holmakefile
+++ b/src/marker/Holmakefile
@@ -14,7 +14,8 @@ endif
 # functor applications.
 markerLib.uo: markerLib.sml markerLib.ui $(TABLE_UID) markerSyntax.uo \
               markerTheory.uo $(dprot $(SIGOBJ)/HolKernel.ui) \
-              $(dprot $(SIGOBJ)/KNametab.ui)
+              $(dprot $(SIGOBJ)/KNametab.ui) \
+              $(dprot $(SIGOBJ)/BoundedRewrites.ui)
 	$(HOLMOSMLC) Overlay.ui Table.ui -c $<
 
 selftest.exe: selftest.uo

--- a/src/marker/markerLib.sig
+++ b/src/marker/markerLib.sig
@@ -37,6 +37,28 @@ sig
   val dest_ReqD : thm -> thm option
   val mk_require_tac : (thm list -> tactic) -> (thm list -> tactic)
 
+  (* The theorem-list directive vocabulary: theorems that control the
+     tactic or simpset they are passed to instead of being used as facts.
+     Every consumer of a theorem list must classify through
+     dest_directive, dropping or rejecting a directive it cannot honour
+     rather than using it as a rewrite.  Hypothesis-carried wrappers
+     (Req0, ReqD, bounds) are reported before the payload's own head. *)
+  datatype directive =
+      DAC of thm * thm
+    | DCong of thm
+    | DExcl of string
+    | DExclSF of string
+    | DFRAG of string
+    | DReq0 of thm
+    | DReqD of thm
+    | DBounded of thm * int
+    | DNoAsms
+    | DIgnAsm of string
+    | DAbbr of string
+    | DLabel of string
+  val dest_directive : thm -> directive option
+  val is_directive   : thm -> bool
+
   val ABB                 : term -> term -> tactic
   val ABB'                : {redex : term, residue : term} -> tactic
   val ABBREV_TAC          : term -> tactic

--- a/src/marker/markerLib.sml
+++ b/src/marker/markerLib.sml
@@ -645,30 +645,74 @@ val _ = Parse.temp_add_user_printer("markerLib.IgnAsm",
                                     mk_comb(IgnAsm_t, mk_var("x", alpha)),
                                     print_ignasm)
 
-val abbrev_vartype = mk_vartype "'abbrev"
+(*---------------------------------------------------------------------------*)
+(* The theorem-list directive vocabulary.  Hypothesis-carried wrappers are  *)
+(* reported first: they enclose whatever the conclusion says, and a         *)
+(* consumer strips them before looking at the payload.                      *)
+(*---------------------------------------------------------------------------*)
+
+datatype directive =
+    DAC of thm * thm
+  | DCong of thm
+  | DExcl of string
+  | DExclSF of string
+  | DFRAG of string
+  | DReq0 of thm
+  | DReqD of thm
+  | DBounded of thm * int
+  | DNoAsms
+  | DIgnAsm of string
+  | DAbbr of string
+  | DLabel of string
+
+fun has_marker_head marker th =
+    same_const marker (#1 (strip_comb (concl th)))
+    handle HOL_ERR _ => false
+
+fun dest_directive th =
+    let
+      fun wrapper () =
+          case dest_Req0 th of
+              SOME p => SOME (DReq0 p)
+            | NONE =>
+              case dest_ReqD th of
+                  SOME p => SOME (DReqD p)
+                | NONE => Option.map DBounded
+                                     (total BoundedRewrites.DEST_BOUNDED th)
+      fun head () =
+          if has_marker_head AC_tm th then SOME (DAC (unAC th))
+          else if has_marker_head Cong_tm th then SOME (DCong (unCong th))
+          else if aconv (concl th) NoAsms_t then SOME DNoAsms
+          else if has_marker_head IgnAsm_t th then
+            SOME (DIgnAsm (#1 (dest_var (rand (concl th)))))
+          else if is_abbr th then SOME (DAbbr (dest_abbr th))
+          else NONE
+      val named = [(destExcl, DExcl), (destExclSF, DExclSF),
+                   (destFRAG, DFRAG), (total dest_label_ref, DLabel)]
+    in
+      case wrapper () of
+          SOME d => SOME d
+        | NONE =>
+          case head () of
+              SOME d => SOME d
+            | NONE => get_first (fn (dest, mk) => Option.map mk (dest th))
+                                named
+    end
+
+val is_directive = Option.isSome o dest_directive
+
 datatype tacoptions = TO_NoAsms | TO_IgnAsm of string |
                       TO_Abbr of string | TO_Label of string |
                       TO_thm of thm
 datatype aslP = AP_NoAsms | AP_Ign of string
 
 fun dest_tacmarked th =
-    let val c = concl th
-        val (f, args) = strip_comb c
-    in
-      (* asm control *)
-      if same_const c NoAsms_t then TO_NoAsms
-      else if same_const f IgnAsm_t then TO_IgnAsm (#1 (dest_var (hd args)))
-      else if same_const equality f then
-        let val arg1 = hd args
-            val arg1ty = type_of (hd args)
-        in
-          if arg1ty = abbrev_vartype then
-            TO_Abbr (#1 (dest_var arg1))
-          else
-            TO_Label (dest_label_ref th)
-        end
-      else TO_thm th
-    end handle HOL_ERR _ => TO_thm th
+    case dest_directive th of
+        SOME DNoAsms => TO_NoAsms
+      | SOME (DIgnAsm s) => TO_IgnAsm s
+      | SOME (DAbbr s) => TO_Abbr s
+      | SOME (DLabel s) => TO_Label s
+      | _ => TO_thm th
 
 fun optcons NONE l = l
   | optcons (SOME x) xs = x::xs

--- a/src/marker/selftest.sml
+++ b/src/marker/selftest.sml
@@ -4,6 +4,58 @@ val _ = new_theory "scratch"
 
 val _ = set_trace "Unicode" 0
 
+(* Every directive constructor must be recognised with the identity and
+   payload its consumer needs, and nothing else may be. *)
+val _ =
+  let
+    val th = ASSUME “p:bool”
+    fun same th' =
+        HOLset.equal(hypset th, hypset th') andalso concl th ~~ concl th'
+    fun check (name, mk, ok) =
+        (tprint ("dest_directive: " ^ name);
+         case dest_directive (mk ()) of
+             NONE => die "not recognised"
+           | SOME d => if ok d then OK ()
+                       else die "wrong identity or payload")
+    fun rejects (name, mk) =
+        (tprint ("dest_directive: " ^ name ^ " is not a directive");
+         if isSome (dest_directive (mk ())) then die "recognised"
+         else OK ())
+  in
+    List.app check [
+      ("AC", fn () => AC th TRUTH,
+       fn DAC (a, b) => same a andalso concl b ~~ T | _ => false),
+      ("Cong", fn () => Cong th, fn DCong a => same a | _ => false),
+      ("Excl", fn () => Excl "nm", fn DExcl "nm" => true | _ => false),
+      ("ExclSF", fn () => ExclSF "nm", fn DExclSF "nm" => true | _ => false),
+      ("FRAG", fn () => FRAG "nm", fn DFRAG "nm" => true | _ => false),
+      ("Req0", fn () => mk_Req0 th, fn DReq0 a => same a | _ => false),
+      ("ReqD", fn () => mk_ReqD th, fn DReqD a => same a | _ => false),
+      ("Once", fn () => BoundedRewrites.Once th,
+       fn DBounded (a, 1) => same a | _ => false),
+      ("Ntimes 3", fn () => BoundedRewrites.Ntimes th 3,
+       fn DBounded (a, 3) => same a | _ => false),
+      ("NoAsms", fn () => NoAsms, fn DNoAsms => true | _ => false),
+      ("IgnAsm", fn () => IgnAsm ‘x = _’,
+       fn DIgnAsm s => String.isSuffix "x = _" s | _ => false),
+      ("Abbr", fn () => Abbr`v`, fn DAbbr "v" => true | _ => false),
+      ("L", fn () => L "lab", fn DLabel "lab" => true | _ => false),
+      ("Req0 wraps Cong", fn () => mk_Req0 (Cong th),
+       fn DReq0 a => (case dest_directive a of
+                          SOME (DCong b) => same b
+                        | _ => false)
+        | _ => false)
+    ];
+    List.app rejects [
+      ("TRUTH", fn () => TRUTH),
+      ("assumption", fn () => th),
+      ("reflexive equation", fn () => REFL “x:'a”),
+      ("equation", fn () => ASSUME “x:'a = y”),
+      ("implication from a marker", fn () => ASSUME “marker$Req0 ==> p”)
+    ]
+  end
+
+
 fun testtac tac = #1 o VALID tac
 val goal_print = HOLPP.pp_to_string 75 goalStack.pp_goal
 

--- a/src/simp/src/selftest.sml
+++ b/src/simp/src/selftest.sml
@@ -487,4 +487,30 @@ in
   ]
 end
 
+(* The simpset layer must never use a directive as a rewrite: requirement
+   directives are refused (their marker$ hypothesis would otherwise reach
+   the result), tactic-only ones are dropped. *)
+val _ =
+  let
+    val q = mk_var("q", bool)
+    val th = ASSUME q
+    fun refuses (name, d) =
+        (tprint ("SIMP_CONV refuses " ^ name);
+         shouldfail {testfn = fn l => SIMP_CONV bool_ss l q,
+                     printresult = thm_to_string,
+                     printarg = fn _ => name,
+                     checkexn = check_HOL_ERRexn
+                                  (fn (_, f, _) => f = "process_tags")}
+                    [d])
+    fun drops (name, d, t) =
+        (tprint ("SIMP_CONV drops " ^ name);
+         require_msg (check_result (fn th => rhs (concl th) ~~ t))
+                     thm_to_string (QCONV (SIMP_CONV bool_ss [d])) t)
+  in
+    List.app refuses [("Req0", Req0 th), ("ReqD", ReqD th)];
+    List.app drops [("NoAsms", markerLib.NoAsms, concl markerLib.NoAsms),
+                    ("IgnAsm", markerLib.IgnAsm ‘x = _’,
+                     concl (markerLib.IgnAsm ‘x = _’))]
+  end
+
 val _ = exit_count0 failcount

--- a/src/simp/src/simpLib.sml
+++ b/src/simp/src/simpLib.sml
@@ -800,32 +800,12 @@ val ExclSF = markerLib.ExclSF
 val Req0   = markerLib.mk_Req0
 val ReqD   = markerLib.mk_ReqD
 
-local open markerSyntax markerLib
+local open markerLib
 in
-fun is_AC thm = same_const(fst(strip_comb(concl thm))) AC_tm
-fun is_Cong thm = same_const(fst(strip_comb(concl thm))) Cong_tm
-
-fun extract_excls (excls, exfrags, rest) l =
-    case l of
-        [] => (List.rev excls, List.rev exfrags, List.rev rest)
-      | th::ths =>
-        case markerLib.destExcl th of
-            SOME nm => extract_excls (nm::excls, exfrags, rest) ths
-          | NONE => case markerLib.destExclSF th of
-                        NONE => extract_excls (excls, exfrags, th::rest) ths
-                      | SOME nm => extract_excls (excls, nm::exfrags, rest) ths
-
-fun extract_frags (frags, rest) l =
-    case l of
-        [] => (List.rev frags, List.rev rest)
-      | th :: ths => case markerLib.destFRAG th of
-                         NONE => extract_frags (frags, th :: rest) ths
-                       | SOME fragnm => (
-                         case lookup_named_frag fragnm of
-                             NONE => raise ERR ("extract_frags",
-                                                "No frag called " ^ fragnm)
-                           | SOME sf => extract_frags (sf::frags, rest) ths
-                       )
+fun frag_of fragnm =
+    case lookup_named_frag fragnm of
+        NONE => raise ERR ("process_tags", "No frag called " ^ fragnm)
+      | SOME sf => sf
 
 fun SF ssfrag =
     case frag_name ssfrag of
@@ -840,20 +820,52 @@ fun SF ssfrag =
                        | _ => ());
                     markerLib.FRAG nm)
 
+fun tactic_only name =
+    raise ERR ("process_tags",
+               name ^ " is a tactic directive; it cannot be honoured by a " ^
+               "conversion or rule")
+
+(* Sort a theorem-list argument by directive, keeping argument order.
+   Requirement directives are honoured only by the tactics, which strip
+   them (mk_require_tac) before reaching here; one arriving anyway would
+   be used as a rewrite and carry its marker$ hypothesis into every
+   result, so it is an error.  Assumption-policy directives are the
+   tactic layer's too, but rule-level calls inside a tactic (SIMP_RULE
+   within FULL_SIMP_TAC) still see them, so they are dropped.  Bounded
+   rewrites are honoured by the rewriter and pass through. *)
 fun process_tags ss thl =
-    let val (Congs,rst) = Lib.partition is_Cong thl
-        val (ACs,rst) = Lib.partition is_AC rst
-        val (excludes, exclfrags, rst) = extract_excls ([],[],[]) rst
-        val (frags, rst) = extract_frags ([],[]) rst
+    let
+      fun sort (th, acc as (congs, acs, excls, exclfrags, frags, rest)) =
+          case dest_directive th of
+              NONE => (congs, acs, excls, exclfrags, frags, th :: rest)
+            | SOME (DCong c) =>
+                (normCong c :: congs, acs, excls, exclfrags, frags, rest)
+            | SOME (DAC p) => (congs, p :: acs, excls, exclfrags, frags, rest)
+            | SOME (DExcl nm) =>
+                (congs, acs, nm :: excls, exclfrags, frags, rest)
+            | SOME (DExclSF nm) =>
+                (congs, acs, excls, nm :: exclfrags, frags, rest)
+            | SOME (DFRAG nm) =>
+                (congs, acs, excls, exclfrags, frag_of nm :: frags, rest)
+            | SOME (DBounded _) =>
+                (congs, acs, excls, exclfrags, frags, th :: rest)
+            | SOME (DReq0 _) => tactic_only "Req0"
+            | SOME (DReqD _) => tactic_only "ReqD"
+            | SOME DNoAsms => acc
+            | SOME (DIgnAsm _) => acc
+            | SOME (DAbbr _) => acc
+            | SOME (DLabel _) => acc
+      val (congs, acs, excludes, exclfrags, frags, rst) =
+          List.foldr sort ([], [], [], [], [], []) thl
     in
-      if null Congs andalso null ACs andalso null excludes andalso
+      if null congs andalso null acs andalso null excludes andalso
          null frags andalso null exclfrags
-      then (ss,thl)
+      then (ss, rst)
       else
         let val base = remove_ssfrags exclfrags ss handle Conv.UNCHANGED => ss
             val cong_ac =
                 SSFRAG_CON{name=SOME"Cong and/or AC", relsimps = [],
-                           ac=map unAC ACs, congs=map (normCong o unCong) Congs,
+                           ac=acs, congs=congs,
                            convs=[],rewrs=[],filter=NONE,dprocs=[]}
             (* Cong/AC is named but never user-excludable; SF-derived frags
                go through force_add so they override any active exclusion. *)


### PR DESCRIPTION
## Issue

Theorems passed in a tactic's or simpset's theorem list can be
*directives* rather than facts: `AC`, `Cong`, `Excl`, `ExclSF`, `FRAG`,
`Req0`, `ReqD`, `Once`/`Ntimes`, `NoAsms`, `IgnAsm`, `Abbr` and label
references.  `markerLib` constructs most of them but offered no way to
enumerate or classify them.  Each consumer restated the part of the
vocabulary it happened to know:

- `simpLib.process_tags` had its own `is_AC`/`is_Cong` head tests plus
  two hand-rolled extraction loops for `Excl`/`ExclSF` and `FRAG`.
- `markerLib.dest_tacmarked` knew only the tactic-level directives
  (`NoAsms`, `IgnAsm`, `Abbr`, labels).
- `mk_require_tac` knew only `Req0`/`ReqD`.

Nothing tied these together, and a directive that reached a consumer
which did not know it was not rejected: it fell through as an ordinary
rewrite.  The failure is silent and directional.  Concretely, on
`develop`:

```sml
SIMP_CONV bool_ss [Req0 (ASSUME “q”)] “q”;
(* [q, marker$Req0] |- q <=> T *)
```

The `marker$Req0` hypothesis is carried into the result and nothing
ever discharges it.  `SIMP_RULE` behaves the same way.  `NoAsms` and
`IgnAsm` became vacuous rewrites (`NoAsms <=> T`).  Every tactic entry
point strips these markers before the simpset layer, so the leak only
shows up at the conversion/rule level, but there it is undetectable
without inspecting hypotheses.

A second, independent instance surfaced while pinning the fix:
`BoundedRewrites.DEST_BOUNDED` searched the hypothesis set with
`aconv bounded_tm o rator`, which raises on any hypothesis that is not
an application.  So for a theorem with a variable hypothesis,

```sml
Once (ASSUME “p:bool”)
```

was silently treated as unbounded by the rewriter and its `BOUNDED`
hypothesis leaked into every rewrite result.

Adding a directive obliged nobody to touch any list, so nothing
detected either omission at compile time.  A downstream branch
(`isabelle-tactics`) already hit the classical-rule variant of this,
where an unrecognised directive is added to a claset as a logical rule.

## Fix

`markerLib` now owns the vocabulary as a closed datatype:

```sml
datatype directive =
    DAC of thm * thm | DCong of thm
  | DExcl of string | DExclSF of string | DFRAG of string
  | DReq0 of thm | DReqD of thm | DBounded of thm * int
  | DNoAsms | DIgnAsm of string | DAbbr of string | DLabel of string
val dest_directive : thm -> directive option
val is_directive   : thm -> bool
```

Hypothesis-carried wrappers (`Req0`, `ReqD`, bounds) are reported before
the payload's own head, so consumers strip them first.
`dest_tacmarked` is now a projection of `dest_directive`, so there is a
single recogniser.

`simpLib.process_tags` becomes one fold over the datatype with an
explicit policy for every constructor:

- `Cong`/`AC`/`Excl`/`ExclSF`/`FRAG`: honoured as before.
- `Req0`/`ReqD`: refused with a `process_tags` error.  Every tactic
  strips them via `mk_require_tac` before reaching here, so one that
  arrives can only corrupt the result.
- `NoAsms`/`IgnAsm`/`Abbr`/labels: dropped.  These are the tactic
  layer's, but `FULL_SIMP_TAC` legitimately lets them reach `SIMP_RULE`
  for the assumptions, so they cannot be errors.
- `Once`/`Ntimes`: passed through; the rewriter honours them.

Because the type is closed, a consumer that dispatches with `case`
gets a non-exhaustive-match warning when a constructor is added, which
is the compile-time check that was missing.  `simpLib`'s private
`is_AC`, `is_Cong`, `extract_excls` and `extract_frags` are removed.

`DEST_BOUNDED` now tests `is_comb` before taking the rator.

## Tests

- `src/marker/selftest.sml`: every constructor is recognised with the
  identity and payload its consumer needs; wrapper ordering
  (`Req0 (Cong th)`); five non-directives (including a plain reflexive
  equation and an equation over a `marker$` constant) are rejected.
- `src/simp/src/selftest.sml`: `SIMP_CONV` refuses `Req0`/`ReqD` and
  leaves the term unchanged for `NoAsms`/`IgnAsm`.
- `src/1/selftest.sml`: `DEST_BOUNDED` finds the bound past a variable
  hypothesis (fails against the old code).
