### PR TITLE
computeLib: a no-progress conversion falls through to the next rule

### DIFF
--- a/help/Docfiles/computeLib.CBV_CONV.smd
+++ b/help/Docfiles/computeLib.CBV_CONV.smd
@@ -35,7 +35,11 @@ there is at least one implication then also add `P1 ⇒ P2 ⇒ ... ⇒ t ⇔ T`.
 It is also possible to add conversions to a simplification set with
 `add_conv`. The only restriction is that a constant (`c`) and an arity
 (`n`) must be provided. The conversion will be called only on terms in
-which `c` is applied to `n` arguments.
+which `c` is applied to `n` arguments. A conversion that makes no
+progress on such a term, whether by failing, by raising `UNCHANGED`, or
+by returning a reflexive theorem, is skipped and the remaining rules for
+`c` are tried; its result is otherwise evaluated further in the same
+compset.
 
 Two theorem "preprocessors" are provided to control the strictness of
 the arguments of a constant. `lazyfy_thm` has pattern variables on the

--- a/src/compute/src/computeLib.sml
+++ b/src/compute/src/computeLib.sml
@@ -287,7 +287,9 @@ fun CBVn_CONV n rws t =
 
 (*---------------------------------------------------------------------------
  * Adding an arbitrary conv. The conversion result is wrapped with from_term
- * at invocation time in reduce_cst, using the current compset.
+ * at invocation time in reduce_cst, using the current compset. A conv that
+ * fails, raises UNCHANGED or returns a reflexive theorem makes no progress
+ * and reduce_cst moves on to the constant's remaining rules.
  *---------------------------------------------------------------------------*)
 
 fun add_conv (cst,arity,conv) rws = add_extern (cst,arity,conv) rws;

--- a/src/compute/src/equations.sml
+++ b/src/compute/src/equations.sml
@@ -174,16 +174,28 @@ fun reduce_cst rws (th,{Head, Args, Rws=Try{Hcst,Rws=Rewrite rls,Tail},Skip}) =
      handle No_match
      => reduce_cst rws (th,{Head=Head,Args=Args,Rws=Tail,Skip=Skip}))
   | reduce_cst rws (th,{Head, Args, Rws=Try{Hcst,Rws=Conv conv,Tail},Skip}) =
-    (let
-       val thm = conv (rhs (concl th))
-       val (_, dt) = from_term(rws, [], rhs (concl thm))
-       val cl = mk_clos([], dt)
-       val mk_thm = K (TRANS th thm)
-     in
-       (true, rhs (concl thm), cl, [], mk_thm)
-     end
-     handle HOL_ERR _
-     => reduce_cst rws (th,{Head=Head,Args=Args,Rws=Tail,Skip=Skip}))
+    let
+      fun next () = reduce_cst rws (th,{Head=Head,Args=Args,Rws=Tail,Skip=Skip})
+      val t = rhs (concl th)
+    in
+      (let
+         val thm = conv t
+         val t' = rhs (concl thm)
+         (* A conversion reports no progress by failing, by raising
+            UNCHANGED, or by returning |- t = t.  All three move on to the
+            next rule: `t'` would otherwise be recompiled and sent through
+            this same chain again, so a reflexive result never terminates. *)
+         val _ = if aconv t t' then raise No_match else ()
+         val (_, dt) = from_term(rws, [], t')
+         val cl = mk_clos([], dt)
+         val mk_thm = K (TRANS th thm)
+       in
+         (true, t', cl, [], mk_thm)
+       end
+       handle HOL_ERR _ => next ()
+            | Conv.UNCHANGED => next ()
+            | No_match => next ())
+    end
   | reduce_cst _ (th,cst) =
     (false, rhs (concl th), CST cst, [], K th)
 

--- a/src/compute/src/selftest.sml
+++ b/src/compute/src/selftest.sml
@@ -193,3 +193,41 @@ in
   OK()
 end
 handle HOL_ERR e => die ("set_skip after copy failed: " ^ message_of e)
+
+(* Registered conversions: a conversion that makes no progress must fall
+   through to the constant's remaining rules rather than be retried on
+   its own (reflexive) result, or escape CBV_CONV (UNCHANGED). *)
+local
+  val conj = boolSyntax.conjunction
+  fun capped calls conv t =
+      (calls := !calls + 1;
+       if !calls > 10 then raise Fail "CBV_CONV loops on the result"
+       else conv t)
+  fun compset_with conv thms =
+      computeLib.new_compset []
+        |> computeLib.add_conv (conj, 2, conv)
+        |> computeLib.add_thms thms
+  fun check name conv thms tm expected ncalls =
+      let
+        val _ = tprint name
+        val calls = ref 0
+        val cs = compset_with (capped calls conv) thms
+        val th = computeLib.CBV_CONV cs tm
+                 handle Fail m => (die m; raise Fail m)
+      in
+        if aconv (rhs (concl th)) expected andalso !calls = ncalls then OK()
+        else die ("got " ^ thm_to_string th ^ " after " ^
+                  Int.toString (!calls) ^ " calls")
+      end
+in
+val _ = check "Checking a reflexive add_conv result is not retried"
+              REFL [] “T /\ p” “T /\ p” 1
+val _ = check "Checking a reflexive add_conv result falls through to rewrites"
+              REFL [boolTheory.AND_CLAUSES] “T /\ p” “p:bool” 1
+val _ = check "Checking an add_conv raising UNCHANGED falls through to rewrites"
+              (fn _ => raise Conv.UNCHANGED) [boolTheory.AND_CLAUSES]
+              “T /\ p” “p:bool” 1
+val _ = check "Checking a progressing add_conv result is used"
+              (Rewrite.REWRITE_CONV [boolTheory.AND_CLAUSES]) []
+              “T /\ p” “p:bool” 1
+end

--- a/src/real/RealField.sml
+++ b/src/real/RealField.sml
@@ -446,33 +446,24 @@ val sgn_tm = “real_sgn :real -> real”;
 val max_tm = “max :real -> real -> real”;
 val min_tm = “min :real -> real -> real”;
 
-(* computeLib retries reflexive results and does not catch UNCHANGED.
-   CHANGED_CONV converts both no-progress cases to the HOL_ERR it expects. *)
-fun add_reduce_conv entry compset =
-  let
-    val (operator, arity, conv) = entry
-  in
-    computeLib.add_conv (operator, arity, CHANGED_CONV conv) compset
-  end
-
 fun real_rat_compset () =
   reduceLib.num_compset
-  |> add_reduce_conv (leq_tm,     2, REAL_RAT_LE_CONV)
-  |> add_reduce_conv (less_tm,    2, REAL_RAT_LT_CONV)
-  |> add_reduce_conv (geq_tm,     2, REAL_RAT_GE_CONV)
-  |> add_reduce_conv (greater_tm, 2, REAL_RAT_GT_CONV)
-  |> add_reduce_conv (real_eq_tm, 2, REAL_RAT_EQ_CONV)
-  |> add_reduce_conv (negate_tm,  1, REAL_RAT_NEG_CONV)
-  |> add_reduce_conv (sgn_tm,     1, REAL_RAT_SGN_CONV)
-  |> add_reduce_conv (absval_tm,  1, REAL_RAT_ABS_CONV)
-  |> add_reduce_conv (inv_tm,     1, REAL_RAT_INV_CONV)
-  |> add_reduce_conv (plus_tm,    2, REAL_RAT_ADD_CONV)
-  |> add_reduce_conv (minus_tm,   2, REAL_RAT_SUB_CONV)
-  |> add_reduce_conv (mult_tm,    2, REAL_RAT_MUL_CONV)
-  |> add_reduce_conv (div_tm,     2, REAL_RAT_DIV_CONV)
-  |> add_reduce_conv (exp_tm,     2, REAL_RAT_POW_CONV)
-  |> add_reduce_conv (max_tm,     2, REAL_RAT_MAX_CONV)
-  |> add_reduce_conv (min_tm,     2, REAL_RAT_MIN_CONV)
+  |> computeLib.add_conv (leq_tm,     2, REAL_RAT_LE_CONV)
+  |> computeLib.add_conv (less_tm,    2, REAL_RAT_LT_CONV)
+  |> computeLib.add_conv (geq_tm,     2, REAL_RAT_GE_CONV)
+  |> computeLib.add_conv (greater_tm, 2, REAL_RAT_GT_CONV)
+  |> computeLib.add_conv (real_eq_tm, 2, REAL_RAT_EQ_CONV)
+  |> computeLib.add_conv (negate_tm,  1, REAL_RAT_NEG_CONV)
+  |> computeLib.add_conv (sgn_tm,     1, REAL_RAT_SGN_CONV)
+  |> computeLib.add_conv (absval_tm,  1, REAL_RAT_ABS_CONV)
+  |> computeLib.add_conv (inv_tm,     1, REAL_RAT_INV_CONV)
+  |> computeLib.add_conv (plus_tm,    2, REAL_RAT_ADD_CONV)
+  |> computeLib.add_conv (minus_tm,   2, REAL_RAT_SUB_CONV)
+  |> computeLib.add_conv (mult_tm,    2, REAL_RAT_MUL_CONV)
+  |> computeLib.add_conv (div_tm,     2, REAL_RAT_DIV_CONV)
+  |> computeLib.add_conv (exp_tm,     2, REAL_RAT_POW_CONV)
+  |> computeLib.add_conv (max_tm,     2, REAL_RAT_MAX_CONV)
+  |> computeLib.add_conv (min_tm,     2, REAL_RAT_MIN_CONV)
 
 val REAL_RAT_REDUCE_CONV =
   (* ensure that REDUCE_CONV will look at all of a term, even


### PR DESCRIPTION
## Issue

A conversion registered with `computeLib.add_conv` was deemed to have
made progress whenever it did not raise `HOL_ERR`. Two consequences:

1. **A reflexive result makes `CBV_CONV` diverge.** In `reduce_cst`
   (`src/compute/src/equations.sml`, the `Conv` case) the `reduced_p`
   flag was unconditionally `true`. `cbv_wk` then reaches `prove_ants`,
   whose empty-antecedent arm re-enters `cbv_wk` with `from_term` of the
   conversion's result, i.e. the identical term recompiled against the
   full compset, and the same stack. The rule chain restarts at the head
   rather than resuming at `Tail`, so the conversion is called again on
   the same term, forever. The failure mode is a hang with no diagnostic.

2. **A conversion raising `UNCHANGED` escapes `CBV_CONV`.** `UNCHANGED`
   is not a `HOL_ERR`, so the handler that moves on to the next rule did
   not see it and the exception propagated out of the whole evaluation.
   Anything built from `ALL_CONV` or `TRY_CONV` was therefore unusable as
   a registered conversion.

The contract "a registered conversion must change the term or fail with
`HOL_ERR`" was enforced by nothing and documented nowhere. `add_conv` and
`add_convs` are used at over a hundred sites outside `src/compute`
(`reduceLib`, `intReduce`, `ratReduce`, `bitstringLib`, `binary_ieeeLib`,
`patriciaLib`, `sptreeLib`, `quantHeuristicsLib`, ...) plus every
user-built compset, each on the honour system.

The live symptom was `RealField.REAL_RAT_REDUCE_CONV`, which did not
terminate on any term containing a non-integral rational literal:
`REAL_RAT_DIV_CONV` rewrites `x / y` to `x * inv y` and back, so on a
literal already in lowest terms it returns `|- 1/3 = 1/3`. Commit
cf808e983 stopped that by wrapping every `real_rat_compset` entry in
`CHANGED_CONV`, a per-compset workaround that left the class of bug
intact for every other compset. `quantHeuristicsLibBase` registers
`QCONV QUANT_SIMP_CONV`, which manufactures exactly the reflexive
theorem that looped, so it was the next candidate.

Minimal reproduction (any compset that knows the constant; the rules
are irrelevant):

```sml
val cs = computeLib.new_compset [arithmeticTheory.ADD_CLAUSES]
val _  = computeLib.add_conv (numSyntax.suc_tm, 1, REFL) cs
val _  = computeLib.CBV_CONV cs ``SUC (x:num)``   (* hangs *)
```

## Fix

`reduce_cst` now treats three outcomes of a registered conversion
uniformly as "no progress" and moves on to the constant's remaining
rules:

- a raised `HOL_ERR` (as before);
- a raised `Conv.UNCHANGED`;
- a reflexive result, detected with `aconv` on the input and output
  terms.

Nothing that terminated before can depend on the old behaviour: any
path that received a reflexive result did not terminate, and any path
that received `UNCHANGED` aborted the evaluation.

`aconv` starts with a pointer-equality test, so `REFL`-derived results
are caught at no cost. `EVAL` on four numeric/list workloads (1s to
11.5s each, best of three, old versus new `equations.uo`) differed by
under 1% in both directions.

## Other changes

- `src/compute/src/selftest.sml`: rows for a reflexive result not being
  retried, a reflexive result falling through to rewrites, `UNCHANGED`
  falling through to rewrites, and a progressing result being used.
  With the fix reverted, the first row hits its call cap.
- `help/Docfiles/computeLib.CBV_CONV.smd` and the `add_conv` comment in
  `computeLib.sml` state the contract.
- `src/real/RealField.sml`: the `CHANGED_CONV` wrapper from cf808e983 is
  removed as redundant. The two `REAL_RAT_REDUCE_CONV` rows in
  `src/real/selftest.sml` now exercise the mechanism fix directly.
- Left alone: `CHANGED_CONV REAL_INT_NEG_CONV` in `RealArith.sml`
  (harmless) and `QCHANGED_CONV PMATCH_CLEANUP_CONV` in
  `patternMatchesLib.sml`, whose remaining gap the mechanism now covers.
